### PR TITLE
fix(example): Replace non-existent model with a valid OpenAI model

### DIFF
--- a/examples/tools/computer_use.py
+++ b/examples/tools/computer_use.py
@@ -28,7 +28,7 @@ async def main():
                 instructions="You are a helpful agent.",
                 tools=[ComputerTool(computer)],
                 # Use the computer using model, and set truncation to auto because its required
-                model="computer-use-preview-2025-02-04",
+                model="computer-use-preview-2025-03-11",
                 model_settings=ModelSettings(truncation="auto"),
             )
             result = await Runner.run(agent, "Search for SF sports news and summarize.")

--- a/tests/examples/tools/computer_use.py
+++ b/tests/examples/tools/computer_use.py
@@ -28,7 +28,7 @@ async def main():
                 instructions="You are a helpful agent.",
                 tools=[ComputerTool(computer)],
                 # Use the computer using model, and set truncation to auto because its required
-                model="computer-use-preview-2025-02-04",
+                model="computer-use-preview-2025-03-11",
                 model_settings=ModelSettings(truncation="auto"),
             )
             result = await Runner.run(agent, "Search for SF sports news and summarize.")


### PR DESCRIPTION
This pull request resolves the following issue:

```
openai.NotFoundError: Error code: 404 - {'error': {'message': 'The model computer-use-preview-2025-02-04 does not exist or you do not have access to it.', 'type': 'invalid_request_error', 'param': None, 'code': 'model_not_found'}}
```


The example has been updated to reference an existing and accessible OpenAI model.  
This change ensures the example code functions correctly when executed.
