### PR TITLE
fix: correct typos in general documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -10,7 +10,7 @@ from agents import set_default_openai_key
 set_default_openai_key("sk-...")
 ```
 
-Alternatively, you can also configure an OpenAI client to be used. By default, the SDK creates an `AsyncOpenAI` instance, using the API key from the environment variable or the default key set above. You can chnage this by using the [set_default_openai_client()][agents.set_default_openai_client] function.
+Alternatively, you can also configure an OpenAI client to be used. By default, the SDK creates an `AsyncOpenAI` instance, using the API key from the environment variable or the default key set above. You can change this by using the [set_default_openai_client()][agents.set_default_openai_client] function.
 
 ```python
 from openai import AsyncOpenAI

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -21,7 +21,7 @@ Input guardrails run in 3 steps:
 
 ## Output guardrails
 
-Output guardrailas run in 3 steps:
+Output guardrails run in 3 steps:
 
 1. First, the guardrail receives the same input passed to the agent.
 2. Next, the guardrail function runs to produce a [`GuardrailFunctionOutput`][agents.guardrail.GuardrailFunctionOutput], which is then wrapped in an [`OutputGuardrailResult`][agents.guardrail.OutputGuardrailResult]
@@ -33,7 +33,7 @@ Output guardrailas run in 3 steps:
 
 ## Tripwires
 
-If the input or output fails the guardrail, the Guardrail can signal this with a tripwire. As soon as we see a guardail that has triggered the tripwires, we immediately raise a `{Input,Output}GuardrailTripwireTriggered` exception and halt the Agent execution.
+If the input or output fails the guardrail, the Guardrail can signal this with a tripwire. As soon as we see a guardrail that has triggered the tripwires, we immediately raise a `{Input,Output}GuardrailTripwireTriggered` exception and halt the Agent execution.
 
 ## Implementing a guardrail
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -16,7 +16,7 @@ The Agents SDK includes built-in tracing, collecting a comprehensive record of e
     -   `trace_id`: A unique ID for the trace. Automatically generated if you don't pass one. Must have the format `trace_<32_alphanumeric>`.
     -   `group_id`: Optional group ID, to link multiple traces from the same conversation. For example, you might use a chat thread ID.
     -   `disabled`: If True, the trace will not be recorded.
-    -   `metadata`: Optiona metadata for the trace.
+    -   `metadata`: Optional metadata for the trace.
 -   **Spans** represent operations that have a start and end time. Spans have:
     -   `started_at` and `ended_at` timestamps.
     -   `trace_id`, to represent the trace they belong to


### PR DESCRIPTION
I updated some documentation typos:

- Corrected spelling in config.md: "chnage" -> "change"
- Fixed typo in guardrails.md: "guardrailas" -> "guardrails"
- Corrected spelling in tracing.md: "Optiona" -> "Optional"