### PR TITLE
fix: clarify multi-agent orchestration description

### DIFF
--- a/docs/multi_agent.md
+++ b/docs/multi_agent.md
@@ -27,7 +27,7 @@ This pattern is great when the task is open-ended and you want to rely on the in
 
 ## Orchestrating via code
 
-While orchestrating via LLM is powerful, orchestrating via LLM makes tasks more deterministic and predictable, in terms of speed, cost and performance. Common patterns here are:
+While orchestrating via LLM is powerful, orchestrating via code makes tasks more deterministic and predictable, in terms of speed, cost and performance. Common patterns here are:
 
 -   Using [structured outputs](https://platform.openai.com/docs/guides/structured-outputs) to generate well formed data that you can inspect with your code. For example, you might ask an agent to classify the task into a few categories, and then pick the next agent based on the category.
 -   Chaining multiple agents by transforming the output of one into the input of the next. You can decompose a task like writing a blog post into a series of steps - do research, write an outline, write the blog post, critique it, and then improve it.


### PR DESCRIPTION
I fixed a logical contradiction in multi_agent.md where "orchestrating via LLM" was incorrectly used twice in the same sentence under the "Orchestrating via code" heading.