### PR TITLE
docs: Fix typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ When you call `Runner.run()`, we run a loop until we get a final output.
 2. The LLM returns a response, which may include tool calls.
 3. If the response has a final output (see below for the more on this), we return it and end the loop.
 4. If the response has a handoff, we set the agent to the new agent and go back to step 1.
-5. We process the tool calls (if any) and append the tool responses messsages. Then we go to step 1.
+5. We process the tool calls (if any) and append the tool responses messages. Then we go to step 1.
 
 There is a `max_turns` parameter that you can use to limit the number of times the loop executes.
 

--- a/docs/results.md
+++ b/docs/results.md
@@ -32,7 +32,7 @@ The [`new_items`][agents.result.RunResultBase.new_items] property contains the n
 
 -   [`MessageOutputItem`][agents.items.MessageOutputItem] indicates a message from the LLM. The raw item is the message generated.
 -   [`HandoffCallItem`][agents.items.HandoffCallItem] indicates that the LLM called the handoff tool. The raw item is the tool call item from the LLM.
--   [`HandoffOutputItem`][agents.items.HandoffOutputItem] indicates that a handoff occured. The raw item is the tool response to the handoff tool call. You can also access the source/target agents from the item.
+-   [`HandoffOutputItem`][agents.items.HandoffOutputItem] indicates that a handoff occurred. The raw item is the tool response to the handoff tool call. You can also access the source/target agents from the item.
 -   [`ToolCallItem`][agents.items.ToolCallItem] indicates that the LLM invoked a tool.
 -   [`ToolCallOutputItem`][agents.items.ToolCallOutputItem] indicates that a tool was called. The raw item is the tool response. You can also access the tool output from the item.
 -   [`ReasoningItem`][agents.items.ReasoningItem] indicates a reasoning item from the LLM. The raw item is the reasoning generated.

--- a/examples/research_bot/README.md
+++ b/examples/research_bot/README.md
@@ -21,5 +21,5 @@ If you're building your own research bot, some ideas to add to this are:
 
 1. Retrieval: Add support for fetching relevant information from a vector store. You could use the File Search tool for this.
 2. Image and file upload: Allow users to attach PDFs or other files, as baseline context for the research.
-3. More planning and thinking: Models often produce better results given more time to think. Improve the planning process to come up with a better plan, and add an evaluation step so that the model can choose to improve it's results, search for more stuff, etc.
+3. More planning and thinking: Models often produce better results given more time to think. Improve the planning process to come up with a better plan, and add an evaluation step so that the model can choose to improve its results, search for more stuff, etc.
 4. Code execution: Allow running code, which is useful for data analysis.


### PR DESCRIPTION
I updated some documentation typos:

- Corrected spelling of "messages" in README.md **("messsages" → "messages")**
- Fixed "occurred" spelling in results.md **("occured" → "occurred")**
- Corrected "it's" to "its" in research_bot README **("it's" → "its")**