### PR TITLE
fix: count `spans` and `traces` correctly

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -81,7 +81,17 @@ class BackendSpanExporter(TracingExporter):
         traces: list[dict[str, Any]] = []
         spans: list[dict[str, Any]] = []
 
-        data = [item.export() for item in items if item.export()]
+        # Categorize items into traces and spans
+        for item in items:
+            if hasattr(item, 'export') and callable(item.export):
+                export_data = item.export()
+                if export_data:
+                    if isinstance(item, Trace):
+                        traces.append(export_data)
+                    else:
+                        spans.append(export_data)
+
+        data = traces + spans
         payload = {"data": data}
 
         headers = {

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -78,9 +78,6 @@ class BackendSpanExporter(TracingExporter):
             logger.warning("OPENAI_API_KEY is not set, skipping trace export")
             return
 
-        traces: list[dict[str, Any]] = []
-        spans: list[dict[str, Any]] = []
-
         data = [item.export() for item in items if item.export()]
         payload = {"data": data}
 
@@ -100,7 +97,7 @@ class BackendSpanExporter(TracingExporter):
 
                 # If the response is successful, break out of the loop
                 if response.status_code < 300:
-                    logger.debug(f"Exported {len(traces)} traces, {len(spans)} spans")
+                    logger.debug(f"Exported {len(items)} items")
                     return
 
                 # If the response is a client error (4xx), we wont retry

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -81,17 +81,7 @@ class BackendSpanExporter(TracingExporter):
         traces: list[dict[str, Any]] = []
         spans: list[dict[str, Any]] = []
 
-        # Categorize items into traces and spans
-        for item in items:
-            if hasattr(item, 'export') and callable(item.export):
-                export_data = item.export()
-                if export_data:
-                    if isinstance(item, Trace):
-                        traces.append(export_data)
-                    else:
-                        spans.append(export_data)
-
-        data = traces + spans
+        data = [item.export() for item in items if item.export()]
         payload = {"data": data}
 
         headers = {


### PR DESCRIPTION
Closes #53 

Counts the number of `spans` and `traces` correctly to show the correct number in the debug logs.