### PR TITLE
Fix typo in models.md

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -48,7 +48,7 @@ async def main():
     print(result.final_output)
 ```
 
-1.  Sets the the name of an OpenAI model directly.
+1.  Sets the name of an OpenAI model directly.
 2.  Provides a [`Model`][agents.models.interface.Model] implementation.
 
 ## Using other LLM providers

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,6 +1,6 @@
 # Models
 
-The Agents SDK comes with out of the box support for OpenAI models in two flavors:
+The Agents SDK comes with out-of-the-box support for OpenAI models in two flavors:
 
 -   **Recommended**: the [`OpenAIResponsesModel`][agents.models.openai_responses.OpenAIResponsesModel], which calls OpenAI APIs using the new [Responses API](https://platform.openai.com/docs/api-reference/responses).
 -   The [`OpenAIChatCompletionsModel`][agents.models.openai_chatcompletions.OpenAIChatCompletionsModel], which calls OpenAI APIs using the [Chat Completions API](https://platform.openai.com/docs/api-reference/chat).

--- a/docs/models.md
+++ b/docs/models.md
@@ -15,7 +15,7 @@ Within a single workflow, you may want to use different models for each agent. F
 
 !!!note
 
-    While our SDK supports both the [`OpenAIResponsesModel`][agents.models.openai_responses.OpenAIResponsesModel] and the[`OpenAIChatCompletionsModel`][agents.models.openai_chatcompletions.OpenAIChatCompletionsModel] shapes, we recommend using a single model shape for each workflow because the two shapes support a different set of features and tools. If your workflow requires mixing and matching model shapes, make sure that all the features you're using are available on both.
+    While our SDK supports both the [`OpenAIResponsesModel`][agents.models.openai_responses.OpenAIResponsesModel] and the [`OpenAIChatCompletionsModel`][agents.models.openai_chatcompletions.OpenAIChatCompletionsModel] shapes, we recommend using a single model shape for each workflow because the two shapes support a different set of features and tools. If your workflow requires mixing and matching model shapes, make sure that all the features you're using are available on both.
 
 ```python
 from agents import Agent, Runner, AsyncOpenAI, OpenAIChatCompletionsModel


### PR DESCRIPTION
"The Agents SDK comes with out of the box support" → "The Agents SDK comes with out-of-the-box support" (Hyphenate "out-of-the-box" as it's a compound adjective).

"Sets the the name of an OpenAI model directly." → "Sets the name of an OpenAI model directly." (Remove the duplicate "the").

"While our SDK supports both the [OpenAIResponsesModel][agents.models.openai_responses.OpenAIResponsesModel] and the[OpenAIChatCompletionsModel]" → "While our SDK supports both the [OpenAIResponsesModel][agents.models.openai_responses.OpenAIResponsesModel] and the [OpenAIChatCompletionsModel] (Add missing space after "the").