### PR TITLE
Fix token usage attribute names in stream_response for streamed outputs

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -651,8 +651,8 @@ class Runner:
                 usage = (
                     Usage(
                         requests=1,
-                        input_tokens=event.response.usage.input_tokens,
-                        output_tokens=event.response.usage.output_tokens,
+                        input_tokens=event.response.usage.prompt_tokens,
+                        output_tokens=event.response.usage.completion_tokens,
                         total_tokens=event.response.usage.total_tokens,
                     )
                     if event.response.usage


### PR DESCRIPTION
This PR fixes an issue in the streaming response processing where the code incorrectly accessed non-existent attributes (input_tokens and output_tokens) on the Usage object. Instead, the correct property names (prompt_tokens and completion_tokens) should be used. see https://github.com/openai/openai-python/blob/v1.66.2/src/openai/types/completion_usage.py
fix bug metioned in #63 