### PR TITLE
Fixes #71: Added support for max_tokens in ModelSettings

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -19,6 +19,7 @@ class ModelSettings:
     tool_choice: Literal["auto", "required", "none"] | str | None = None
     parallel_tool_calls: bool | None = False
     truncation: Literal["auto", "disabled"] | None = None
+    max_tokens: int | None = None
 
     def resolve(self, override: ModelSettings | None) -> ModelSettings:
         """Produce a new ModelSettings by overlaying any non-None values from the
@@ -33,4 +34,5 @@ class ModelSettings:
             tool_choice=override.tool_choice or self.tool_choice,
             parallel_tool_calls=override.parallel_tool_calls or self.parallel_tool_calls,
             truncation=override.truncation or self.truncation,
+            max_tokens=override.max_tokens or self.max_tokens,
         )

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -509,6 +509,7 @@ class OpenAIChatCompletionsModel(Model):
             stream=stream,
             stream_options={"include_usage": True} if stream else NOT_GIVEN,
             extra_headers=_HEADERS,
+            max_tokens=self._non_null_or_not_given(model_settings.max_tokens),
         )
 
         if isinstance(ret, ChatCompletion):


### PR DESCRIPTION
Fixes #71

This PR adds support for `max_tokens` in `ModelSettings`. This was previously missing, causing issues with models that require an explicit max_tokens value.