### PR TITLE
Add Previous/Next Navigation to MkDocs Footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,8 @@ theme:
         - navigation.expand
         # Enables annotations in code blocks
         - content.code.annotate
+        # Enables previous/next buttons
+        - navigation.footer
     palette:
         primary: black
     logo: assets/logo.svg


### PR DESCRIPTION
- Enabled `navigation.footer` in `mkdocs.yml` to add previous/next navigation at the bottom of each page.