### PR TITLE
refactor: reduce unnecessary task cancel

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -216,5 +216,3 @@ class RunResultStreaming(RunResultBase):
 
         if self._output_guardrails_task and not self._output_guardrails_task.done():
             self._output_guardrails_task.cancel()
-            self._output_guardrails_task.cancel()
-            self._output_guardrails_task.cancel()


### PR DESCRIPTION
Removed duplicate calls to `self._output_guardrails_task.cancel()` in the `_cleanup_tasks` method.