### PR TITLE
Fix guardrail trigger in input_guardrails.py

### DIFF
--- a/examples/agent_patterns/input_guardrails.py
+++ b/examples/agent_patterns/input_guardrails.py
@@ -53,7 +53,7 @@ async def math_guardrail(
 
     return GuardrailFunctionOutput(
         output_info=final_output,
-        tripwire_triggered=not final_output.is_math_homework,
+        tripwire_triggered=final_output.is_math_homework,
     )
 
 


### PR DESCRIPTION
Remove the `not` keyword from the `tripwire_triggered` parameter in the `math_guardrail` function in `examples/agent_patterns/input_guardrails.py`.

The not keyword prevented the guardrail from being triggered, which defeats the purpose of the example.

