### PR TITLE
Replace undefined variable name in documentation code snippet

### DIFF
--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -78,7 +78,7 @@ async def main():
         # San Francisco
 
         # Second turn
-        new_input = output.to_input_list() + [{"role": "user", "content": "What state is it in?"}]
+        new_input = result.to_input_list() + [{"role": "user", "content": "What state is it in?"}]
         result = await Runner.run(agent, new_input)
         print(result.final_output)
         # California


### PR DESCRIPTION
Corrected the variable name from 'output' to 'result' in the code snippet in [running_agents.md](https://github.com/openai/openai-agents-python/blob/main/docs/running_agents.md)  to match the actual code usage.
the variable `output` was not defined and it is implying the variable `result` from the first run. 

# Previous:
```
async def main():
    agent = Agent(name="Assistant", instructions="Reply very concisely.")
    with trace(workflow_name="Conversation", group_id=thread_id):
        # First turn
        result = await Runner.run(agent, "What city is the Golden Gate Bridge in?")
        print(result.final_output)
        # San Francisco

        # Second turn
        new_input = output.to_input_list() + [{"role": "user", "content": "What state is it in?"}]
        result = await Runner.run(agent, new_input)
        print(result.final_output)
        # California
   ```
        
  # Updated:
  ```
  async def main():
    agent = Agent(name="Assistant", instructions="Reply very concisely.")

    with trace(workflow_name="Conversation", group_id=thread_id):
        # First turn
        result = await Runner.run(agent, "What city is the Golden Gate Bridge in?")
        print(result.final_output)
        # San Francisco

        # Second turn
        new_input = result.to_input_list() + [{"role": "user", "content": "What state is it in?"}]
        result = await Runner.run(agent, new_input)
        print(result.final_output)
        # California```