### PR TITLE
Fix streaming in chat completions

### DIFF
--- a/tests/test_openai_chatcompletions_stream.py
+++ b/tests/test_openai_chatcompletions_stream.py
@@ -107,6 +107,11 @@ async def test_stream_response_yields_events_for_text_content(monkeypatch) -> No
     assert isinstance(completed_resp.output[0].content[0], ResponseOutputText)
     assert completed_resp.output[0].content[0].text == "Hello"
 
+    assert completed_resp.usage, "usage should not be None"
+    assert completed_resp.usage.input_tokens == 7
+    assert completed_resp.usage.output_tokens == 5
+    assert completed_resp.usage.total_tokens == 12
+
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #63. Fixes the type errors with usage, which were hidden away by using model_copy. 

## Test plan

Added a unit test, which failed before and passes now.

Also ran stream_text.py, with chat completions.

