### PR TITLE
Fix typo on Agent documentation

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -27,7 +27,7 @@ class Agent(Generic[TContext]):
     """An agent is an AI model configured with instructions, tools, guardrails, handoffs and more.
 
     We strongly recommend passing `instructions`, which is the "system prompt" for the agent. In
-    addition, you can pass `description`, which is a human-readable description of the agent, used
+    addition, you can pass `handoff_description`, which is a human-readable description of the agent, used
     when the agent is used inside tools/handoffs.
 
     Agents are generic on the context type. The context is a (mutable) object you create. It is


### PR DESCRIPTION
Argument name is not description but handoff_description