### PR TITLE
Fix: Change CompletionUsage attribute names in streaming responses

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -651,8 +651,8 @@ class Runner:
                 usage = (
                     Usage(
                         requests=1,
-                        input_tokens=event.response.usage.input_tokens,
-                        output_tokens=event.response.usage.output_tokens,
+                        input_tokens=event.response.usage.prompt_tokens,
+                        output_tokens=event.response.usage.completion_tokens,
                         total_tokens=event.response.usage.total_tokens,
                     )
                     if event.response.usage

--- a/tests/test_usage_mapping.py
+++ b/tests/test_usage_mapping.py
@@ -1,0 +1,30 @@
+"""Test file to verify the fix for the CompletionUsage issue."""
+import pytest
+from openai.types.completion_usage import CompletionUsage
+
+from agents.usage import Usage
+
+
+def test_completion_usage_mapping():
+    """Test that Usage correctly maps from CompletionUsage's attributes."""
+    # Create a CompletionUsage object with the OpenAI SDK's attribute names
+    completion_usage = CompletionUsage(
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30
+    )
+    
+    # Create Usage object using the attributes from CompletionUsage
+    # This simulates what happens in run.py that we fixed
+    usage = Usage(
+        requests=1,
+        input_tokens=completion_usage.prompt_tokens,  # This was the fix
+        output_tokens=completion_usage.completion_tokens,  # This was the fix
+        total_tokens=completion_usage.total_tokens,
+    )
+    
+    # Verify the attributes were correctly mapped
+    assert usage.requests == 1
+    assert usage.input_tokens == 10
+    assert usage.output_tokens == 20
+    assert usage.total_tokens == 30 


### PR DESCRIPTION
This PR fixes #124 

## Issue
When streaming responses with certain models like Gemini or using OpenAI chat completions, the following error occurs:
`AttributeError: 'CompletionUsage' object has no attribute 'input_tokens'`

This happens because in streaming mode, the code in `run.py` tries to access `input_tokens` and `output_tokens` on the `CompletionUsage` object, but the OpenAI SDK uses `prompt_tokens` and `completion_tokens` instead.

## Solution
- Modified `run.py` to use the correct attribute names (`prompt_tokens` instead of `input_tokens` and `completion_tokens` instead of `output_tokens`) when creating a `Usage` object from a `CompletionUsage` object in streaming mode

## Testing
Added a test file `test_usage_mapping.py` that verifies the attribute mapping works correctly, ensuring compatibility between OpenAI SDK's CompletionUsage and the agents SDK's Usage class.
