### PR TITLE
feat: Add list_tools method to Agent with logging & test cases & upda…

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -130,3 +130,29 @@ robot_agent = pirate_agent.clone(
     instructions="Write like a robot",
 )
 ```
+
+## Additional Methods
+
+### `get_system_prompt`
+
+The `get_system_prompt` method retrieves the system prompt for the agent. This can be a static string or dynamically generated instructions.
+
+```python
+system_prompt = await agent.get_system_prompt(context)
+print("System Prompt:", system_prompt)
+```
+
+- **Parameters**: 
+  - `run_context`: The context in which the agent is running.
+- **Returns**: A string representing the system prompt.
+
+### `list_tools`
+
+The `list_tools` method provides a list of all tools the agent has access to. This is useful for debugging and monitoring the agent's capabilities.
+
+```python
+tool_names = agent.list_tools()
+print("Tools:", tool_names)
+```
+
+- **Returns**: A list of tool names or descriptions. Logs a warning if no tools are available.

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -157,3 +157,15 @@ class Agent(Generic[TContext]):
             logger.error(f"Instructions must be a string or a function, got {self.instructions}")
 
         return None
+
+    def list_tools(self) -> list[str]:
+        """Get a list of all tools the agent has access to.
+
+        Returns:
+            A list of tool names. Logs a warning if no tools are available.
+        """
+        if not self.tools:
+            logger.warning(f"Agent '{self.name}' has no tools available.")
+            return []
+
+        return [tool.name for tool in self.tools]

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import BaseModel
 
-from agents import Agent, Handoff, RunContextWrapper, Runner, handoff
+from agents import Agent, Handoff, RunContextWrapper, Runner, handoff, FunctionTool
 
 
 @pytest.mark.asyncio
@@ -26,6 +26,29 @@ async def test_system_instructions():
     agent = agent.clone(instructions=async_instructions)
     assert await agent.get_system_prompt(context) == "async_123"
 
+def test_list_tools():
+    # Create some mock tools using FunctionTool
+    tool1 = FunctionTool(
+        name="Tool1",
+        description="A mock tool for testing",
+        params_json_schema={},
+        on_invoke_tool=lambda ctx, input: "output"
+    )
+    tool2 = FunctionTool(
+        name="Tool2",
+        description="Another mock tool for testing",
+        params_json_schema={},
+        on_invoke_tool=lambda ctx, input: "output"
+    )
+    
+    # Initialize the agent with these tools
+    agent = Agent(name="TestAgent", tools=[tool1, tool2])
+    
+    # Get the list of tool names
+    tool_names = agent.list_tools()
+    
+    # Assert that the tool names are as expected
+    assert tool_names == ["Tool1", "Tool2"]
 
 @pytest.mark.asyncio
 async def test_handoff_with_agents():


### PR DESCRIPTION

![Screenshot 2025-03-15 030440](https://github.com/user-attachments/assets/895ee436-c7ee-4fa3-9c67-ee10f454500a)
Added `list_tools` method to Agent class: This method returns a list of tools available to the agent, with logging for empty tool lists.

-Added a test case for `list_tools` method.

-Updated documentation of agents.md file to include this list_tools function.

-Also added the documentation for the get_system_prompt function.