### PR TITLE
[doc] add mlflow tracing integration

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -93,6 +93,7 @@ To customize this default setup, to send traces to alternative or additional bac
 ## External tracing processors list
 
 -   [Arize-Phoenix](https://docs.arize.com/phoenix/tracing/integrations-tracing/openai-agents-sdk)
+-   [MLflow](https://mlflow.org/docs/latest/tracing/integrations/openai-agent)
 -   [Braintrust](https://braintrust.dev/docs/guides/traces/integrations#openai-agents-sdk)
 -   [Pydantic Logfire](https://logfire.pydantic.dev/docs/integrations/llms/openai/#openai-agents)
 -   [AgentOps](https://docs.agentops.ai/v1/integrations/agentssdk)


### PR DESCRIPTION
Hi team! Congrats on the new Agents SDK launch!

This PR adds MLflow to the tracing documentation, as it supports automatic tracing for OpenAI Agents SDK. It has also been supporting tracing for [Swarm](https://mlflow.org/docs/latest/tracing/integrations/swarm) as well, so it is fantastic that the new SDK offers built-in mechanism for 3P trace providers🙂

![image](https://github.com/user-attachments/assets/d36382da-dca1-4335-a915-ca94a994e26a)

