### PR TITLE
Add documentation for MCP tool use with Agents SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ As a result, the mental model for the agent loop is:
 
 The Agents SDK is designed to be highly flexible, allowing you to model a wide range of LLM workflows including deterministic flows, iterative loops, and more. See examples in [`examples/agent_patterns`](examples/agent_patterns).
 
+### Model Context Protocol
+
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is not currently supported natively in the Agents SDK. However, you can use third-party extensions, such as [openai-agents-mcp](https://pypi.org/project/openai-agents-mcp/), to enable Agents to access tools exposed by MCP servers.
+
 ## Tracing
 
 The Agents SDK automatically traces your agent runs, making it easy to track and debug the behavior of your agents. Tracing is extensible by design, supporting custom spans and a wide variety of external destinations, including [Logfire](https://logfire.pydantic.dev/docs/integrations/llms/openai/#openai-agents), [AgentOps](https://docs.agentops.ai/v1/integrations/agentssdk), [Braintrust](https://braintrust.dev/docs/guides/traces/integrations#openai-agents-sdk), [Scorecard](https://docs.scorecard.io/docs/documentation/features/tracing#openai-agents-sdk-integration), and [Keywords AI](https://docs.keywordsai.co/integration/development-frameworks/openai-agent). For more details about how to customize or disable tracing, see [Tracing](http://openai.github.io/openai-agents-python/tracing), which also includes a larger list of [external tracing processors](http://openai.github.io/openai-agents-python/tracing/#external-tracing-processors-list).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -218,6 +218,10 @@ As mentioned before, we automatically parse the function signature to extract th
 
 The code for the schema extraction lives in [`agents.function_schema`][].
 
+## Model Context Protocol servers as tools
+
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) servers are not currently supported natively in the Agents SDK. However, you can use third-party extensions, such as [openai-agents-mcp](https://pypi.org/project/openai-agents-mcp/), to enable Agents to access tools exposed by MCP servers.
+
 ## Agents as tools
 
 In some workflows, you may want a central agent to orchestrate a network of specialized agents, instead of handing off control. You can do this by modeling agents as tools.


### PR DESCRIPTION
This change resolves the discussion from #40 by making [openai-agents-mcp](https://pypi.org/project/openai-agents-mcp/) an extension package for Agents SDK. Adding some targeted documentation for those looking to use Agents SDK with MCP to point them to the third-party extension (such as folks in #23)

How Verified:
* make sync
* make build-docs
* make serve-docs
* ensured all hyperlinks work

<img width="1513" alt="image" src="https://github.com/user-attachments/assets/ca4a27f0-5ad2-4ed1-8b5e-e201b264f6bf" />
