### PR TITLE
Add installation instructions for OpenAI Agents SDK using UV

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ source env/bin/activate
 ```
 pip install openai-agents
 ```
+### Option 2: Install with UV  
+[`uv`](https://github.com/astral-sh/uv) is a modern package manager for Python that provides fast dependency resolution.  
+
+1. Initialize the directory with `uv`:  
+   ```
+   uv init --package sample_project
+   ```
+2. Install Agents SDK
+   ```
+   uv add openai-agents
+   ```
+
 
 ## Hello world example
 


### PR DESCRIPTION
This PR adds installation instructions for installing the OpenAI Agents SDK using [uv](https://github.com/astral-sh/uv), an alternative Python package manager.

**Changes:**

- Introduced a new section: "Option 2: Install with UV" under the "Get started" section.
- Provided commands to initialize a directory with uv and install openai-agents.
- Ensured formatting consistency with existing installation instructions.