### PR TITLE
Make the optional dependency installation compatible with zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ source env/bin/activate
 pip install openai-agents
 ```
 
-For voice support, install with the optional `voice` group: `pip install openai-agents[voice]`.
+For voice support, install with the optional `voice` group: `pip install 'openai-agents[voice]'`.
 
 ## Hello world example
 

--- a/docs/voice/quickstart.md
+++ b/docs/voice/quickstart.md
@@ -5,7 +5,7 @@
 Make sure you've followed the base [quickstart instructions](../quickstart.md) for the Agents SDK, and set up a virtual environment. Then, install the optional voice dependencies from the SDK:
 
 ```bash
-pip install openai-agents[voice]
+pip install 'openai-agents[voice]'
 ```
 
 ## Concepts

--- a/src/agents/voice/imports.py
+++ b/src/agents/voice/imports.py
@@ -5,7 +5,7 @@ try:
 except ImportError as _e:
     raise ImportError(
         "`numpy` + `websockets` are required to use voice. You can install them via the optional "
-        "dependency group: `pip install openai-agents[voice]`."
+        "dependency group: `pip install 'openai-agents[voice]'`."
     ) from _e
 
 __all__ = ["np", "npt", "websockets"]


### PR DESCRIPTION
When you run `pip install openai-agents[voice]` on zsh, it results in the following error:
```
zsh: no matches found: openai-agents[voice]
```

This pull request resolves the issue for zsh users, and as far as I know, this quotation should work for any shell envs and operating systems.