### PR TITLE
chore: ignore PyCharm .idea/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,7 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-#.idea/
+.idea/
 
 # Ruff stuff:
 .ruff_cache/


### PR DESCRIPTION
Uncomment .idea/ directory in .gitignore to ensure PyCharm IDE project configuration files are excluded from version control.