### PR TITLE
Fix parallel_tool_calls when False

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -208,7 +208,9 @@ class OpenAIResponsesModel(Model):
         list_input = ItemHelpers.input_to_new_input_list(input)
 
         parallel_tool_calls = (
-            True if model_settings.parallel_tool_calls and tools and len(tools) > 0 else NOT_GIVEN
+            True if model_settings.parallel_tool_calls and tools and len(tools) > 0
+            else False if model_settings.parallel_tool_calls is False
+            else NOT_GIVEN
         )
 
         tool_choice = Converter.convert_tool_choice(model_settings.tool_choice)


### PR DESCRIPTION
Currently, when we set `parallel_tool_calls=False` in the `model_settings`, the responses API is called with `parallel_tool_calls == NotGiven`, which defaults to true on the Response API side (https://platform.openai.com/docs/api-reference/responses/create#responses-create-parallel_tool_calls).

This PR attempts to fix that.

```
agent = Agent(
    ...,
    model_settings=ModelSettings(
        parallel_tool_calls=False,
    ),
)
```