### PR TITLE
fix(examples): make sure audio playback finishes

### DIFF
--- a/examples/voice/static/main.py
+++ b/examples/voice/static/main.py
@@ -1,6 +1,8 @@
 import asyncio
 import random
 
+import numpy as np
+
 from agents import Agent, function_tool
 from agents.extensions.handoff_prompt import prompt_with_handoff_instructions
 from agents.voice import (
@@ -77,6 +79,9 @@ async def main():
                 print("Received audio")
             elif event.type == "voice_stream_event_lifecycle":
                 print(f"Received lifecycle event: {event.event}")
+
+        # Add 1 second of silence to the end of the stream to avoid cutting off the last audio.
+        player.add_audio(np.zeros(24000 * 1, dtype=np.int16))
 
 
 if __name__ == "__main__":

--- a/examples/voice/static/util.py
+++ b/examples/voice/static/util.py
@@ -62,6 +62,7 @@ class AudioPlayer:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        self.stream.stop()  # wait for the stream to finish
         self.stream.close()
 
     def add_audio(self, audio_data: npt.NDArray[np.int16]):


### PR DESCRIPTION
Previously the stream was closing as soon as all the audio was added but didn't wait for it to be finished. Additionally the audio might seem chopped off if there is no additional silence so this PR also adds one second of silence before exiting the program.