### PR TITLE
Mark handoff span as errored when multiple handoffs are requested

### DIFF
--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -244,7 +244,18 @@ async def test_multiple_handoff_doesnt_error():
                                 },
                             },
                             {"type": "generation"},
-                            {"type": "handoff", "data": {"from_agent": "test", "to_agent": "test"}},
+                            {"type": "handoff",
+                             "data": {"from_agent": "test", "to_agent": "test"},
+                             "error": {
+                                    "data": {
+                                        "requested_agents": [
+                                            "test",
+                                            "test",
+                                        ],
+                                    },
+                                    "message": "Multiple handoffs requested",
+                                },
+                             },
                         ],
                     },
                     {
@@ -372,7 +383,19 @@ async def test_handoffs_lead_to_correct_agent_spans():
                             {"type": "generation"},
                             {
                                 "type": "handoff",
-                                "data": {"from_agent": "test_agent_3", "to_agent": "test_agent_1"},
+                                "data": {
+                                    "from_agent": "test_agent_3",
+                                    "to_agent": "test_agent_1"
+                                },
+                                "error": {
+                                    "data": {
+                                        "requested_agents": [
+                                            "test_agent_1",
+                                            "test_agent_2",
+                                        ],
+                                    },
+                                    "message": "Multiple handoffs requested",
+                                },
                             },
                         ],
                     },

--- a/tests/test_tracing_errors_streamed.py
+++ b/tests/test_tracing_errors_streamed.py
@@ -262,7 +262,14 @@ async def test_multiple_handoff_doesnt_error():
                                 },
                             },
                             {"type": "generation"},
-                            {"type": "handoff", "data": {"from_agent": "test", "to_agent": "test"}},
+                            {
+                                "type": "handoff",
+                                "data": {"from_agent": "test", "to_agent": "test"},
+                                "error": {
+                                    "data": {"requested_agents": ["test", "test"]},
+                                    "message": "Multiple handoffs requested",
+                                },
+                            },
                         ],
                     },
                     {
@@ -396,6 +403,10 @@ async def test_handoffs_lead_to_correct_agent_spans():
                             {"type": "generation"},
                             {
                                 "type": "handoff",
+                                "error": {
+                                    "message": "Multiple handoffs requested",
+                                    "data": {"requested_agents": ["test_agent_1", "test_agent_2"]},
+                                },
                                 "data": {"from_agent": "test_agent_3", "to_agent": "test_agent_1"},
                             },
                         ],


### PR DESCRIPTION
Also includes the set of requested agents in the error data.
<img width="968" alt="image" src="https://github.com/user-attachments/assets/0c5c2e81-08f7-445c-bbb0-3e169ef744a5" />
