### PR TITLE
Raise error on more invalid function schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -54,7 +54,7 @@ def _ensure_strict_json_schema(
     elif (
         typ == "object"
         and "additionalProperties" in json_schema
-        and json_schema["additionalProperties"] is True
+        and json_schema["additionalProperties"]
     ):
         raise UserError(
             "additionalProperties should not be set for object types. This could be because "

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from enum import Enum
 from typing import Any, Literal
 
@@ -421,10 +422,20 @@ def test_var_keyword_dict_annotation():
     def func(**kwargs: dict[str, int]):
         return kwargs
 
-    fs = function_schema(func, use_docstring_info=False)
+    fs = function_schema(func, use_docstring_info=False, strict_json_schema=False)
 
     properties = fs.params_json_schema.get("properties", {})
     # The name of the field is "kwargs", and it's a JSON object i.e. a dict.
     assert properties.get("kwargs").get("type") == "object"
     # The values in the dict are integers.
     assert properties.get("kwargs").get("additionalProperties").get("type") == "integer"
+
+
+def test_schema_with_mapping_raises_strict_mode_error():
+    """A mapping type is not allowed in strict mode. Same for dicts. Ensure we raise a UserError."""
+
+    def func_with_mapping(test_one: Mapping[str, int]) -> str:
+        return "foo"
+
+    with pytest.raises(UserError):
+        function_schema(func_with_mapping)


### PR DESCRIPTION

Towards #345

## Summary:
Using a `dict` or `Mapping` isn't strict-mode compliant. But we were checking for the literal `True` whereas the value can also be an array, for example. Fix that.

## Test Plan:

Unit tests
