### PR TITLE
Remove duplicate dependency definition of pynput

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dev = [
     "pynput",
     "types-pynput",
     "sounddevice",
-    "pynput",
     "textual",
     "websockets",
     "graphviz",


### PR DESCRIPTION
`pynput` is in the pyproject.toml file twice, as you can see on line 54.

The uv.lock file doesn't change.