### PR TITLE
Fix incorrect slot name on `SpeechSpanData` 

### DIFF
--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -236,7 +236,7 @@ class TranscriptionSpanData(SpanData):
 
 
 class SpeechSpanData(SpanData):
-    __slots__ = ("input", "output", "model", "model_config", "first_byte_at")
+    __slots__ = ("input", "output", "model", "model_config", "first_content_at")
 
     def __init__(
         self,


### PR DESCRIPTION
Slot had inconsistent name. 

`"first_byte_at"` -> `"first_content_at"`