### PR TITLE
Fix Docstring Reference in 'ToolsToFinalOutputFunction' in 'agent.py'

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -44,7 +44,7 @@ ToolsToFinalOutputFunction: TypeAlias = Callable[
     MaybeAwaitable[ToolsToFinalOutputResult],
 ]
 """A function that takes a run context and a list of tool results, and returns a
-`ToolToFinalOutputResult`.
+`ToolsToFinalOutputResult`.
 """
 
 


### PR DESCRIPTION
### **Summary**
This pull request fixes docstring in `ToolsToFinalOutputFunction`, where `ToolToFinalOutputResult` was incorrectly referenced instead of `ToolsToFinalOutputResult`.

### **Changes Made**
- Updated the docstring of `ToolsToFinalOutputFunction` to correctly reference `ToolsToFinalOutputResult`.

### **Before**
```python
"""A function that takes a run context and a list of tool results, and returns a
`ToolToFinalOutputResult`.
"""
```

### **After**
```python
"""A function that takes a run context and a list of tool results, and returns a
`ToolsToFinalOutputResult`.
"""
```

### **Why This Change?**
- The incorrect reference could cause confusion for developers reading the code.
- This aligns the documentation with the actual return type of the function.

### **Checklist**
- [x] Verify correct reference to `ToolsToFinalOutputResult`
- [x] Ensure no functionality is affected

### **Testing**
This is a documentation-only change and does not affect runtime behavior.

### **Reviewer Notes**
- Please review for accuracy in documentation.
- No additional tests are needed since this is a non-functional change.