### PR TITLE
Avoid to run the Agent first step before Input guardrails finished

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -212,15 +212,14 @@ class Runner:
                     )
 
                     if current_turn == 1:
-                        input_guardrail_results, turn_result = await asyncio.gather(
-                            cls._run_input_guardrails(
+                        input_guardrail_results = await cls._run_input_guardrails(
                                 starting_agent,
                                 starting_agent.input_guardrails
                                 + (run_config.input_guardrails or []),
                                 copy.deepcopy(input),
                                 context_wrapper,
-                            ),
-                            cls._run_single_turn(
+                        )
+                        turn_result = await cls._run_single_turn(
                                 agent=current_agent,
                                 all_tools=all_tools,
                                 original_input=original_input,
@@ -230,7 +229,6 @@ class Runner:
                                 run_config=run_config,
                                 should_run_agent_start_hooks=should_run_agent_start_hooks,
                                 tool_use_tracker=tool_use_tracker,
-                            ),
                         )
                     else:
                         turn_result = await cls._run_single_turn(


### PR DESCRIPTION
The guardrail may trigger a Tripewire but the agent still run

In v0.0.7, the code runs the input guardrail task and the agent's first step together asynchronously. 

If the guardrail is in place to avoid a side effect from the Agent run, the agent may still do something unexpected.