### PR TITLE
Databricks MLflow tracing integration

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -101,7 +101,8 @@ To customize this default setup, to send traces to alternative or additional bac
 
 -   [Weights & Biases](https://weave-docs.wandb.ai/guides/integrations/openai_agents)
 -   [Arize-Phoenix](https://docs.arize.com/phoenix/tracing/integrations-tracing/openai-agents-sdk)
--   [MLflow](https://mlflow.org/docs/latest/tracing/integrations/openai-agent)
+-   [MLflow (self-hosted/OSS](https://mlflow.org/docs/latest/tracing/integrations/openai-agent)
+-   [MLflow (Databricks hosted](https://docs.databricks.com/aws/en/mlflow/mlflow-tracing#-automatic-tracing)
 -   [Braintrust](https://braintrust.dev/docs/guides/traces/integrations#openai-agents-sdk)
 -   [Pydantic Logfire](https://logfire.pydantic.dev/docs/integrations/llms/openai/#openai-agents)
 -   [AgentOps](https://docs.agentops.ai/v1/integrations/agentssdk)


### PR DESCRIPTION
Per discussions with @dmitri-openai , a PR to add a link to Databricks hosted MLflow for tracing integrations