### PR TITLE
Add metadata to ModelSettings

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -40,6 +40,9 @@ class ModelSettings:
     max_tokens: int | None = None
     """The maximum number of output tokens to generate."""
 
+    metadata: dict[str, str] | None = None
+    """Metadata to include with the model response call."""
+
     store: bool | None = None
     """Whether to store the generated model response for later retrieval.
     Defaults to True if not provided."""

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -537,6 +537,7 @@ class OpenAIChatCompletionsModel(Model):
             stream_options={"include_usage": True} if stream else NOT_GIVEN,
             store=store,
             extra_headers=_HEADERS,
+            metadata=model_settings.metadata,
         )
 
         if isinstance(ret, ChatCompletion):

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -247,6 +247,7 @@ class OpenAIResponsesModel(Model):
             extra_headers=_HEADERS,
             text=response_format,
             store=self._non_null_or_not_given(model_settings.store),
+            metadata=model_settings.metadata,
         )
 
     def _get_client(self) -> AsyncOpenAI:


### PR DESCRIPTION
Allows metadata to be supplied to the `responses.create` call. This can, for example, be used to connect response logs to traces groups by passing the group_id.