### PR TITLE
fix(typo): 'handoff_occured' to 'handoff_occurred'

### DIFF
--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -720,7 +720,7 @@ class RunImpl:
             elif isinstance(item, HandoffCallItem):
                 event = RunItemStreamEvent(item=item, name="handoff_requested")
             elif isinstance(item, HandoffOutputItem):
-                event = RunItemStreamEvent(item=item, name="handoff_occured")
+                event = RunItemStreamEvent(item=item, name="handoff_occurred")
             elif isinstance(item, ToolCallItem):
                 event = RunItemStreamEvent(item=item, name="tool_called")
             elif isinstance(item, ToolCallOutputItem):

--- a/src/agents/stream_events.py
+++ b/src/agents/stream_events.py
@@ -31,7 +31,7 @@ class RunItemStreamEvent:
     name: Literal[
         "message_output_created",
         "handoff_requested",
-        "handoff_occured",
+        "handoff_occurred",
         "tool_called",
         "tool_output",
         "reasoning_item_created",


### PR DESCRIPTION
Fixed a typo in "handoff_occured" in RunItemStreamEvent.