### PR TITLE
examples(research_bot): Add space to INSTRUCTIONS

### DIFF
--- a/examples/research_bot/agents/search_agent.py
+++ b/examples/research_bot/agents/search_agent.py
@@ -2,11 +2,11 @@ from agents import Agent, WebSearchTool
 from agents.model_settings import ModelSettings
 
 INSTRUCTIONS = (
-    "You are a research assistant. Given a search term, you search the web for that term and"
-    "produce a concise summary of the results. The summary must 2-3 paragraphs and less than 300"
-    "words. Capture the main points. Write succinctly, no need to have complete sentences or good"
-    "grammar. This will be consumed by someone synthesizing a report, so its vital you capture the"
-    "essence and ignore any fluff. Do not include any additional commentary other than the summary"
+    "You are a research assistant. Given a search term, you search the web for that term and "
+    "produce a concise summary of the results. The summary must 2-3 paragraphs and less than 300 "
+    "words. Capture the main points. Write succinctly, no need to have complete sentences or good "
+    "grammar. This will be consumed by someone synthesizing a report, so its vital you capture the "
+    "essence and ignore any fluff. Do not include any additional commentary other than the summary "
     "itself."
 )
 


### PR DESCRIPTION
Thanks to awesome example `research_bot`

Fix andproduce and goodgrammar (and so on)

```python
>>> from examples.research_bot.agents import search_agent
>>> print(search_agent.INSTRUCTIONS)
You are a research assistant. Given a search term, you search the web for that term andproduce a concise summary of the results. The summary must 2-3 paragraphs and less than 300words. Capture the main points. Write succinctly, no need to have complete sentences or goodgrammar. This will be consumed by someone synthesizing a report, so its vital you capture theessence and ignore any fluff. Do not include any additional commentary other than the summaryitself.
```