### PR TITLE
Typo in parameter name

### DIFF
--- a/examples/mcp/filesystem_example/README.md
+++ b/examples/mcp/filesystem_example/README.md
@@ -21,6 +21,6 @@ It's only given access to the `sample_files` directory adjacent to the example, 
 Under the hood:
 
 1. The server is spun up in a subprocess, and exposes a bunch of tools like `list_directory()`, `read_file()`, etc.
-2. We add the server instance to the Agent via `mcp_agents`.
+2. We add the server instance to the Agent via `mcp_servers`.
 3. Each time the agent runs, we call out to the MCP server to fetch the list of tools via `server.list_tools()`.
 4. If the LLM chooses to use an MCP tool, we call the MCP server to run the tool via `server.run_tool()`.


### PR DESCRIPTION
Parameter name should be "mcp_servers", not "mcp_agents"