### PR TITLE
Update `computer-use` example to support simultaneous key presses

### DIFF
--- a/examples/tools/computer_use.py
+++ b/examples/tools/computer_use.py
@@ -148,9 +148,11 @@ class LocalPlaywrightComputer(AsyncComputer):
         await self.page.mouse.move(x, y)
 
     async def keypress(self, keys: list[str]) -> None:
-        for key in keys:
-            mapped_key = CUA_KEY_TO_PLAYWRIGHT_KEY.get(key.lower(), key)
-            await self.page.keyboard.press(mapped_key)
+        mapped_keys = [CUA_KEY_TO_PLAYWRIGHT_KEY.get(key.lower(), key) for key in keys]
+        for key in mapped_keys:
+            await self.page.keyboard.down(key)
+        for key in reversed(mapped_keys):
+            await self.page.keyboard.up(key)
 
     async def drag(self, path: list[tuple[int, int]]) -> None:
         if not path:


### PR DESCRIPTION
### Summary

Updated the `computer-use` example to support simultaneous key presses.  
The current implementation presses and releases keys one at a time, which prevents combo inputs like copy (CTRL+C) from working correctly.

### Test plan

N/A

### Issue number

N/A

### Checks

- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [ ] I've made sure tests pass