### PR TITLE
Ensure MCP works when inputSchema.properties is missing

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -59,6 +59,11 @@ class MCPUtil:
         """Convert an MCP tool to an Agents SDK function tool."""
         invoke_func = functools.partial(cls.invoke_mcp_tool, server, tool)
         schema, is_strict = tool.inputSchema, False
+
+        # MCP spec doesn't require the inputSchema to have `properties`, but OpenAI spec does.
+        if "properties" not in schema:
+            schema["properties"] = {}
+
         if convert_schemas_to_strict:
             try:
                 schema = ensure_strict_json_schema(schema)


### PR DESCRIPTION
Resolves #449 - TLDR, [OpenAI's API](https://platform.openai.com/docs/api-reference/responses/create) expects the properties field to be present, whereas the MCP schema explicitly allows omitting the properties field. [MCP Spec](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-03-26/schema.json) 