### PR TITLE
add overwrite mechanism for stream_options

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -54,6 +54,10 @@ class ModelSettings:
     """Whether to store the generated model response for later retrieval.
     Defaults to True if not provided."""
 
+    include_usage: bool | None = None
+    """Whether to include usage chunk.
+    Defaults to True if not provided."""
+
     def resolve(self, override: ModelSettings | None) -> ModelSettings:
         """Produce a new ModelSettings by overlaying any non-None values from the
         override on top of this instance."""

--- a/tests/test_openai_chatcompletions.py
+++ b/tests/test_openai_chatcompletions.py
@@ -282,7 +282,7 @@ async def test_fetch_response_stream(monkeypatch) -> None:
     # Check OpenAI client was called for streaming
     assert completions.kwargs["stream"] is True
     assert completions.kwargs["store"] is NOT_GIVEN
-    assert completions.kwargs["stream_options"] == {"include_usage": True}
+    assert completions.kwargs["stream_options"] is NOT_GIVEN
     # Response is a proper openai Response
     assert isinstance(response, Response)
     assert response.id == FAKE_RESPONSES_ID


### PR DESCRIPTION
fix issue https://github.com/openai/openai-agents-python/issues/442

below is an example to overwrite include_usage


```
    result = Runner.run_streamed(
        agent,
        "Write a haiku about recursion in programming.",
        run_config=RunConfig(
            model_provider=CUSTOM_MODEL_PROVIDER,
            model_settings=ModelSettings(include_usage=True)
        ),
    )
```
