### PR TITLE
Fix typos and misspellings

### DIFF
--- a/docs/scripts/translate_docs.py
+++ b/docs/scripts/translate_docs.py
@@ -68,7 +68,7 @@ eng_to_non_eng_mapping = {
 }
 eng_to_non_eng_instructions = {
     "common": [
-        "* The term 'examples' must be code examples when the page mentions the code examples in the repo, it can be translated as either 'code exmaples' or 'sample code'.",
+        "* The term 'examples' must be code examples when the page mentions the code examples in the repo, it can be translated as either 'code examples' or 'sample code'.",
         "* The term 'primitives' can be translated as basic components.",
         "* When the terms 'instructions' and 'tools' are mentioned as API parameter names, they must be kept as is.",
         "* The terms 'temperature', 'top_p', 'max_tokens', 'presence_penalty', 'frequency_penalty' as parameter names must be kept as is.",

--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -131,7 +131,7 @@ def _detect_docstring_style(doc: str) -> DocstringStyle:
 
 @contextlib.contextmanager
 def _suppress_griffe_logging():
-    # Supresses warnings about missing annotations for params
+    # Suppresses warnings about missing annotations for params
     logger = logging.getLogger("griffe")
     previous_level = logger.getEffectiveLevel()
     logger.setLevel(logging.ERROR)

--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -168,7 +168,7 @@ class ResponseSpanData(SpanData):
 class HandoffSpanData(SpanData):
     """
     Represents a Handoff Span in the trace.
-    Includes source and desitnation agents.
+    Includes source and destination agents.
     """
 
     __slots__ = ("from_agent", "to_agent")

--- a/tests/test_agent_hooks.py
+++ b/tests/test_agent_hooks.py
@@ -224,7 +224,7 @@ class Foo(TypedDict):
 
 
 @pytest.mark.asyncio
-async def test_structed_output_non_streamed_agent_hooks():
+async def test_structured_output_non_streamed_agent_hooks():
     hooks = AgentHooksForTests()
     model = FakeModel()
     agent_1 = Agent(name="test_1", model=model)
@@ -295,7 +295,7 @@ async def test_structed_output_non_streamed_agent_hooks():
 
 
 @pytest.mark.asyncio
-async def test_structed_output_streamed_agent_hooks():
+async def test_structured_output_streamed_agent_hooks():
     hooks = AgentHooksForTests()
     model = FakeModel()
     agent_1 = Agent(name="test_1", model=model)


### PR DESCRIPTION
Detected typos using typos-cli (https://crates.io/crates/typos-cli). It detected "occured" in a string constant "handoff_occured" too, but I didn't change the part this time because it could be a minor breaking change.


Full outputs:
```
% typos .
error: `Supresses` should be `Suppresses`
  --> ./src/agents/function_schema.py:134:7
    |
134 |     # Supresses warnings about missing annotations for params
    |       ^^^^^^^^^
    |
error: `typ` should be `typo`, `type`
  --> ./src/agents/strict_schema.py:51:5
   |
51 |     typ = json_schema.get("type")
   |     ^^^
   |
error: `typ` should be `typo`, `type`
  --> ./src/agents/strict_schema.py:52:8
   |
52 |     if typ == "object" and "additionalProperties" not in json_schema:
   |        ^^^
   |
error: `typ` should be `typo`, `type`
  --> ./src/agents/strict_schema.py:55:9
   |
55 |         typ == "object"
   |         ^^^
   |
error: `occured` should be `occurred`
  --> ./src/agents/stream_events.py:34:18
   |
34 |         "handoff_occured",
   |                  ^^^^^^^
   |
error: `occured` should be `occurred`
  --> ./src/agents/_run_impl.py:723:69
    |
723 |                 event = RunItemStreamEvent(item=item, name="handoff_occured")
    |                                                                     ^^^^^^^
    |
error: `desitnation` should be `destination`
  --> ./src/agents/tracing/span_data.py:171:25
    |
171 |     Includes source and desitnation agents.
    |                         ^^^^^^^^^^^
    |
error: `exmaples` should be `examples`
  --> ./docs/scripts/translate_docs.py:71:145
   |
71 |         "* The term 'examples' must be code examples when the page mentions the code examples in the repo, it can be translated as either 'code exmaples' or 'sample code'.",
   |                                                                                                                                                 ^^^^^^^^
   |
error: `structed` should be `structured`
  --> ./tests/test_agent_hooks.py:227:16
    |
227 | async def test_structed_output_non_streamed_agent_hooks():
    |                ^^^^^^^^
    |
error: `structed` should be `structured`
  --> ./tests/test_agent_hooks.py:298:16
    |
298 | async def test_structed_output_streamed_agent_hooks():
    |                ^^^^^^^^
    |
```