### PR TITLE
Add extra request parameters `extra_query` and `extra_body`

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, fields, replace
 from typing import Literal
 
 from openai.types.shared import Reasoning
+from openai._types import Body, Query
 
 
 @dataclass
@@ -57,6 +58,14 @@ class ModelSettings:
     include_usage: bool | None = None
     """Whether to include usage chunk.
     Defaults to True if not provided."""
+
+    extra_query: Query | None = None
+    """Additional query fields to provide with the request.
+    Defaults to None if not provided."""
+
+    extra_body: Body | None = None
+    """Additional body fields to provide with the request.
+    Defaults to None if not provided."""
 
     def resolve(self, override: ModelSettings | None) -> ModelSettings:
         """Produce a new ModelSettings by overlaying any non-None values from the

--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, fields, replace
 from typing import Literal
 
-from openai.types.shared import Reasoning
 from openai._types import Body, Query
+from openai.types.shared import Reasoning
 
 
 @dataclass

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -540,6 +540,8 @@ class OpenAIChatCompletionsModel(Model):
             store=self._non_null_or_not_given(store),
             reasoning_effort=self._non_null_or_not_given(reasoning_effort),
             extra_headers=_HEADERS,
+            extra_query=model_settings.extra_query,
+            extra_body=model_settings.extra_body,
             metadata=self._non_null_or_not_given(model_settings.metadata),
         )
 

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -245,6 +245,8 @@ class OpenAIResponsesModel(Model):
             parallel_tool_calls=parallel_tool_calls,
             stream=stream,
             extra_headers=_HEADERS,
+            extra_query=model_settings.extra_query,
+            extra_body=model_settings.extra_body,
             text=response_format,
             store=self._non_null_or_not_given(model_settings.store),
             reasoning=self._non_null_or_not_given(model_settings.reasoning),


### PR DESCRIPTION
Added the possibility to pass `extra_query` and `extra_body` parameters when sending a request.
In this implementation I added the attributes to `ModelSettings` as suggested by @rm-openai in #487 .

I'll be happy to add some tests if you have any suggestions.