### PR TITLE
Support parallel_tool_calls=False for ChatCompletion API

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -500,7 +500,11 @@ class OpenAIChatCompletionsModel(Model):
             span.span_data.input = converted_messages
 
         parallel_tool_calls = (
-            True if model_settings.parallel_tool_calls and tools and len(tools) > 0 else NOT_GIVEN
+            True
+            if model_settings.parallel_tool_calls and tools and len(tools) > 0
+            else False
+            if model_settings.parallel_tool_calls is False
+            else NOT_GIVEN
         )
         tool_choice = _Converter.convert_tool_choice(model_settings.tool_choice)
         response_format = _Converter.convert_response_format(output_schema)


### PR DESCRIPTION
The current ChatCompletion API supports only `parallel_tool_calls=True` or `parallel_tool_calls=NOT_GIVEN`
This PR is to support setting `parallel_tool_calls=False`, a common requirement in controlling agent tool use patterns (e.g. ensuring one tool call at the time, to facilitate desired tool calling sequence).

I followed the merged [PR#333](https://github.com/openai/openai-agents-python/pull/333) for consistency.


