### PR TITLE
fix: prevent ContextVar reset error in async streaming context.

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -186,7 +186,12 @@ class RunResultStreaming(RunResultBase):
             self._event_queue.task_done()
 
         if self._trace:
-            self._trace.finish(reset_current=True)
+            try:
+                self._trace.finish(reset_current=True)
+            except ValueError:
+                logger.warning("ContextVar reset failed — switching to reset_current=False")
+                self._trace.finish(reset_current=False)
+
 
         self._cleanup_tasks()
 


### PR DESCRIPTION
### Summary

This PR fixes a runtime error caused by an unexpected `reset_current` keyword argument passed to `Trace.finish()` within the `RunResultStreaming.stream_events()` method.

### What was the issue?

Currently, `stream_events()` calls:
refer #515

### Solution
Wrap the .finish(reset_current=True) call in a try/except block to fallback to a safe reset mode:
```python
if self._trace:
    try:
        self._trace.finish(reset_current=True)
    except ValueError:
        logger.warning("ContextVar reset failed — switching to reset_current=False")
        self._trace.finish(reset_current=False)
```

### 🧪 Testing
Tested with a minimal FastAPI + StreamingResponse setup. After this patch:

- The stream completes successfully.
- No ValueError is raised.
- Trace finalization still works.

### 📦 Affected file
`openai-agents-python\src\agents\result.py`

💬 Related Issue
This PR resolves the bug described in the issue: #515 