### PR TITLE
Refine return types for OnHandoff callbacks to improve type safety

### DIFF
--- a/src/agents/handoffs.py
+++ b/src/agents/handoffs.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 # The handoff input type is the type of data passed when the agent is called via a handoff.
 THandoffInput = TypeVar("THandoffInput", default=Any)
 
-OnHandoffWithInput = Callable[[RunContextWrapper[Any], THandoffInput], Any]
-OnHandoffWithoutInput = Callable[[RunContextWrapper[Any]], Any]
+OnHandoffWithInput = Callable[[RunContextWrapper[Any], THandoffInput], Awaitable[None] | None]
+OnHandoffWithoutInput = Callable[[RunContextWrapper[Any]], Awaitable[None] | None]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Summary:
  - Refined OnHandoffWithInput and OnHandoffWithoutInput types to Awaitable[None] | None for better type safety.
  - Improved static analysis, autocomplete, and developer experience.
  - No functional changes, strictly a type-level enhancement.