### PR TITLE
Fix visualize graph filename to without extension.

### DIFF
--- a/docs/ja/visualization.md
+++ b/docs/ja/visualization.md
@@ -81,7 +81,7 @@ draw_graph(triage_agent).view()
 デフォルトでは、`draw_graph` はグラフをインラインで表示します。ファイルとして保存するには、ファイル名を指定します:
 
 ```python
-draw_graph(triage_agent, filename="agent_graph.png")
+draw_graph(triage_agent, filename="agent_graph")
 ```
 
 これにより、作業ディレクトリに `agent_graph.png` が生成されます。

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -78,9 +78,7 @@ draw_graph(triage_agent).view()
 By default, `draw_graph` displays the graph inline. To save it as a file, specify a filename:
 
 ```python
-draw_graph(triage_agent, filename="agent_graph.png")
+draw_graph(triage_agent, filename="agent_graph")
 ```
 
 This will generate `agent_graph.png` in the working directory.
-
-

--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -132,6 +132,6 @@ def draw_graph(agent: Agent, filename: Optional[str] = None) -> graphviz.Source:
     graph = graphviz.Source(dot_code)
 
     if filename:
-        graph.render(filename, format="png")
+        graph.render(filename, format="png", cleanup=True)
 
     return graph


### PR DESCRIPTION
Only the file name is needed since graphviz's `render()` automatically adds the file extension.
Also, unnecessary .gv (.dot) files are output, so the `cleanup=True` option has been modified to prevent them from being saved.