### PR TITLE
Added cached_tokens to the usage monitoring.

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -106,6 +106,7 @@ class LitellmModel(Model):
                     Usage(
                         requests=1,
                         input_tokens=response_usage.prompt_tokens,
+                        cached_tokens=response.usage.prompt_tokens_details.cached_tokens,
                         output_tokens=response_usage.completion_tokens,
                         total_tokens=response_usage.total_tokens,
                     )

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -83,6 +83,7 @@ class OpenAIChatCompletionsModel(Model):
                 Usage(
                     requests=1,
                     input_tokens=response.usage.prompt_tokens,
+                    cached_tokens=response.usage.prompt_tokens_details.cached_tokens,
                     output_tokens=response.usage.completion_tokens,
                     total_tokens=response.usage.total_tokens,
                 )

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -96,6 +96,7 @@ class OpenAIResponsesModel(Model):
                     Usage(
                         requests=1,
                         input_tokens=response.usage.input_tokens,
+                        cached_tokens=response.usage.input_tokens_details.cached_tokens,
                         output_tokens=response.usage.output_tokens,
                         total_tokens=response.usage.total_tokens,
                     )

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -684,6 +684,7 @@ class Runner:
                     Usage(
                         requests=1,
                         input_tokens=event.response.usage.input_tokens,
+                        cached_tokens=event.response.usage.input_tokens_details.cached_tokens,
                         output_tokens=event.response.usage.output_tokens,
                         total_tokens=event.response.usage.total_tokens,
                     )

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -9,6 +9,9 @@ class Usage:
     input_tokens: int = 0
     """Total input tokens sent, across all requests."""
 
+    cached_tokens: int = 0
+    """Total cached tokens sent, across all requests."""
+
     output_tokens: int = 0
     """Total output tokens received, across all requests."""
 
@@ -18,5 +21,6 @@ class Usage:
     def add(self, other: "Usage") -> None:
         self.requests += other.requests if other.requests else 0
         self.input_tokens += other.input_tokens if other.input_tokens else 0
+        self.cached_tokens += other.cached_tokens if other.cached_tokens else 0
         self.output_tokens += other.output_tokens if other.output_tokens else 0
         self.total_tokens += other.total_tokens if other.total_tokens else 0


### PR DESCRIPTION
**1.**: Added cached tokens to the Usage class and "add" function.
**2.**: Extracted cached_tokens from the LLM response and appended it to the Usage object.
**Note**: This change is only made when pairing the Agents SDK with the responses API (not the chat-completions).

cached_tokens is now accessible via the llm_output.raw_responses[n].usage, where n is the response index.