### PR TITLE
Make the TTS voices type exportable

### DIFF
--- a/src/agents/voice/__init__.py
+++ b/src/agents/voice/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "STTModelSettings",
     "TTSModel",
     "TTSModelSettings",
+    "TTSVoice",
     "VoiceModelProvider",
     "StreamedAudioResult",
     "SingleAgentVoiceWorkflow",

--- a/src/agents/voice/__init__.py
+++ b/src/agents/voice/__init__.py
@@ -7,6 +7,7 @@ from .model import (
     STTModelSettings,
     TTSModel,
     TTSModelSettings,
+    TTSVoice,
     VoiceModelProvider,
 )
 from .models.openai_model_provider import OpenAIVoiceModelProvider

--- a/src/agents/voice/model.py
+++ b/src/agents/voice/model.py
@@ -14,13 +14,13 @@ DEFAULT_TTS_INSTRUCTIONS = (
 )
 DEFAULT_TTS_BUFFER_SIZE = 120
 
-TTSVoice = Literal["alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"] | None
+TTSVoice = Literal["alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"]
 """Exportable type for the TTSModelSettings voice enum"""
 
 @dataclass
 class TTSModelSettings:
     """Settings for a TTS model."""
-    voice: TTSVoice = None
+    voice: TTSVoice | None = None
     """
     The voice to use for the TTS model. If not provided, the default voice for the respective model
     will be used.

--- a/src/agents/voice/model.py
+++ b/src/agents/voice/model.py
@@ -18,10 +18,8 @@ DEFAULT_TTS_BUFFER_SIZE = 120
 @dataclass
 class TTSModelSettings:
     """Settings for a TTS model."""
-
-    voice: (
-        Literal["alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"] | None
-    ) = None
+    TTSVoiceType = Literal["alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"] | None
+    voice: TTSVoiceType = None
     """
     The voice to use for the TTS model. If not provided, the default voice for the respective model
     will be used.

--- a/src/agents/voice/model.py
+++ b/src/agents/voice/model.py
@@ -14,12 +14,13 @@ DEFAULT_TTS_INSTRUCTIONS = (
 )
 DEFAULT_TTS_BUFFER_SIZE = 120
 
+TTSVoice = Literal["alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"] | None
+"""Exportable type for the TTSModelSettings voice enum"""
 
 @dataclass
 class TTSModelSettings:
     """Settings for a TTS model."""
-    TTSVoiceType = Literal["alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"] | None
-    voice: TTSVoiceType = None
+    voice: TTSVoice = None
     """
     The voice to use for the TTS model. If not provided, the default voice for the respective model
     will be used.


### PR DESCRIPTION
When using the voice agent in typed code, it is suboptimal and error prone to type the TTS voice variables in your code independently.

With this commit we are making the type exportable so that developers can just use that and be future-proof.

Example of usage in code:

```
DEFAULT_TTS_VOICE: TTSModelSettings.TTSVoice = "alloy"

...

tts_voice: TTSModelSettings.TTSVoice = DEFAULT_TTS_VOICE 

...

output = await VoicePipeline(
  workflow=workflow,
  config=VoicePipelineConfig(
  tts_settings=TTSModelSettings(
    buffer_size=512,
    transform_data=transform_data,
    voice=tts_voice,
    instructions=tts_instructions,
  ))
).run(audio_input)
```