### PR TITLE
Allow cancel out of the streaming result

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -75,7 +75,9 @@ class RunResultBase(abc.ABC):
 
     def to_input_list(self) -> list[TResponseInputItem]:
         """Creates a new input list, merging the original input with all the new items generated."""
-        original_items: list[TResponseInputItem] = ItemHelpers.input_to_new_input_list(self.input)
+        original_items: list[TResponseInputItem] = ItemHelpers.input_to_new_input_list(
+            self.input
+        )
         new_items = [item.to_input_item() for item in self.new_items]
 
         return original_items + new_items
@@ -153,7 +155,8 @@ class RunResultStreaming(RunResultBase):
         return self.current_agent
 
     def cancel(self) -> None:
-        """Cancels the streaming run, stopping all background tasks and marking the run as complete."""
+        """Cancels the streaming run, stopping all background tasks and marking the run as
+        complete."""
         self._cleanup_tasks()  # Cancel all running tasks
         self.is_complete = True  # Mark the run as complete to stop event streaming
 
@@ -204,13 +207,17 @@ class RunResultStreaming(RunResultBase):
 
     def _check_errors(self):
         if self.current_turn > self.max_turns:
-            self._stored_exception = MaxTurnsExceeded(f"Max turns ({self.max_turns}) exceeded")
+            self._stored_exception = MaxTurnsExceeded(
+                f"Max turns ({self.max_turns}) exceeded"
+            )
 
         # Fetch all the completed guardrail results from the queue and raise if needed
         while not self._input_guardrail_queue.empty():
             guardrail_result = self._input_guardrail_queue.get_nowait()
             if guardrail_result.output.tripwire_triggered:
-                self._stored_exception = InputGuardrailTripwireTriggered(guardrail_result)
+                self._stored_exception = InputGuardrailTripwireTriggered(
+                    guardrail_result
+                )
 
         # Check the tasks for any exceptions
         if self._run_impl_task and self._run_impl_task.done():

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -188,7 +188,6 @@ class RunResultStreaming(RunResultBase):
             try:
                 item = await self._event_queue.get()
             except asyncio.CancelledError:
-                self.cancel()  # Ensure tasks are cleaned up if the coroutine is cancelled
                 break
 
             if isinstance(item, QueueCompleteSentinel):

--- a/tests/test_cancel_streaming.py
+++ b/tests/test_cancel_streaming.py
@@ -1,0 +1,22 @@
+import pytest
+from openai.types.responses import ResponseTextDeltaEvent
+from agents import Agent, Runner
+
+
+@pytest.mark.asyncio
+async def test_joker_streamed_jokes_with_cancel():
+    agent = Agent(
+        name="Joker",
+        instructions="You are a helpful assistant.",
+    )
+
+    result = Runner.run_streamed(agent, input="Please tell me 5 jokes.")
+    num_visible_event = 0
+    
+    async for event in result.stream_events():
+        if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
+            num_visible_event += 1
+            if num_visible_event == 3:
+                result.cancel()
+    
+    assert num_visible_event == 3, f"Expected 3 visible events, but got {num_visible_event}"

--- a/tests/test_cancel_streaming.py
+++ b/tests/test_cancel_streaming.py
@@ -1,8 +1,8 @@
 import pytest
-from openai.types.responses import ResponseTextDeltaEvent
-from .fake_model import FakeModel
 
 from agents import Agent, Runner
+
+from .fake_model import FakeModel
 
 
 @pytest.mark.asyncio
@@ -14,7 +14,7 @@ async def test_joker_streamed_jokes_with_cancel():
     num_events = 0
     stop_after = 1  # There are two that the model gives back.
 
-    async for event in result.stream_events():
+    async for _event in result.stream_events():
         num_events += 1
         if num_events == 1:
             result.cancel()

--- a/tests/test_cancel_streaming.py
+++ b/tests/test_cancel_streaming.py
@@ -1,22 +1,22 @@
 import pytest
 from openai.types.responses import ResponseTextDeltaEvent
+from .fake_model import FakeModel
+
 from agents import Agent, Runner
 
 
 @pytest.mark.asyncio
 async def test_joker_streamed_jokes_with_cancel():
-    agent = Agent(
-        name="Joker",
-        instructions="You are a helpful assistant.",
-    )
+    model = FakeModel()
+    agent = Agent(name="Joker", model=model)
 
     result = Runner.run_streamed(agent, input="Please tell me 5 jokes.")
-    num_visible_event = 0
-    
+    num_events = 0
+    stop_after = 1  # There are two that the model gives back.
+
     async for event in result.stream_events():
-        if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
-            num_visible_event += 1
-            if num_visible_event == 3:
-                result.cancel()
-    
-    assert num_visible_event == 3, f"Expected 3 visible events, but got {num_visible_event}"
+        num_events += 1
+        if num_events == 1:
+            result.cancel()
+
+    assert num_events == 1, f"Expected {stop_after} visible events, but got {num_events}"


### PR DESCRIPTION
Fix for #574 

@rm-openai  I'm not sure how to add a test within the repo but I have pasted a test script below that seems to work 

```python
import asyncio
from openai.types.responses import ResponseTextDeltaEvent
from agents import Agent, Runner

async def main():
    agent = Agent(
        name="Joker",
        instructions="You are a helpful assistant.",
    )

    result = Runner.run_streamed(agent, input="Please tell me 5 jokes.")
    num_visible_event = 0
    async for event in result.stream_events():
        if event.type == "raw_response_event" and isinstance(event.data, ResponseTextDeltaEvent):
            print(event.data.delta, end="", flush=True)
            num_visible_event += 1
            print(num_visible_event)
            if num_visible_event == 3:
                result.cancel()


if __name__ == "__main__":
    asyncio.run(main())
````