### PR TITLE
Allow previous_response_id to be passed to input guardrails

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -18,7 +18,10 @@ from .exceptions import (
 )
 from .guardrail import (
     GuardrailFunctionOutput,
+    InputGuardailInputs,
     InputGuardrail,
+    InputGuardrailFunction,
+    InputGuardrailFunctionLegacy,
     InputGuardrailResult,
     OutputGuardrail,
     OutputGuardrailResult,
@@ -174,6 +177,9 @@ __all__ = [
     "OutputGuardrail",
     "OutputGuardrailResult",
     "GuardrailFunctionOutput",
+    "InputGuardailInputs",
+    "InputGuardrailFunction",
+    "InputGuardrailFunctionLegacy",
     "input_guardrail",
     "output_guardrail",
     "handoff",

--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -688,10 +688,11 @@ class RunImpl:
         agent: Agent[Any],
         guardrail: InputGuardrail[TContext],
         input: str | list[TResponseInputItem],
+        previous_response_id: str | None,
         context: RunContextWrapper[TContext],
     ) -> InputGuardrailResult:
         with guardrail_span(guardrail.get_name()) as span_guardrail:
-            result = await guardrail.run(agent, input, context)
+            result = await guardrail.run(agent, input, context, previous_response_id)
             span_guardrail.span_data.triggered = result.output.tripwire_triggered
             return result
 

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -221,6 +221,7 @@ class Runner:
                                 starting_agent.input_guardrails
                                 + (run_config.input_guardrails or []),
                                 copy.deepcopy(input),
+                                previous_response_id,
                                 context_wrapper,
                             ),
                             cls._run_single_turn(
@@ -446,6 +447,7 @@ class Runner:
         agent: Agent[Any],
         guardrails: list[InputGuardrail[TContext]],
         input: str | list[TResponseInputItem],
+        previous_response_id: str | None,
         context: RunContextWrapper[TContext],
         streamed_result: RunResultStreaming,
         parent_span: Span[Any],
@@ -455,7 +457,9 @@ class Runner:
         # We'll run the guardrails and push them onto the queue as they complete
         guardrail_tasks = [
             asyncio.create_task(
-                RunImpl.run_single_input_guardrail(agent, guardrail, input, context)
+                RunImpl.run_single_input_guardrail(
+                    agent, guardrail, input, previous_response_id, context
+                )
             )
             for guardrail in guardrails
         ]
@@ -551,6 +555,7 @@ class Runner:
                             starting_agent,
                             starting_agent.input_guardrails + (run_config.input_guardrails or []),
                             copy.deepcopy(ItemHelpers.input_to_new_input_list(starting_input)),
+                            previous_response_id,
                             context_wrapper,
                             streamed_result,
                             current_span,
@@ -825,6 +830,7 @@ class Runner:
         agent: Agent[Any],
         guardrails: list[InputGuardrail[TContext]],
         input: str | list[TResponseInputItem],
+        previous_response_id: str | None,
         context: RunContextWrapper[TContext],
     ) -> list[InputGuardrailResult]:
         if not guardrails:
@@ -832,7 +838,9 @@ class Runner:
 
         guardrail_tasks = [
             asyncio.create_task(
-                RunImpl.run_single_input_guardrail(agent, guardrail, input, context)
+                RunImpl.run_single_input_guardrail(
+                    agent, guardrail, input, previous_response_id, context
+                )
             )
             for guardrail in guardrails
         ]

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -32,14 +32,20 @@ def get_sync_guardrail(triggers: bool, output_info: Any | None = None):
 async def test_sync_input_guardrail():
     guardrail = InputGuardrail(guardrail_function=get_sync_guardrail(triggers=False))
     result = await guardrail.run(
-        agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
     )
     assert not result.output.tripwire_triggered
     assert result.output.output_info is None
 
     guardrail = InputGuardrail(guardrail_function=get_sync_guardrail(triggers=True))
     result = await guardrail.run(
-        agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
     )
     assert result.output.tripwire_triggered
     assert result.output.output_info is None
@@ -48,7 +54,10 @@ async def test_sync_input_guardrail():
         guardrail_function=get_sync_guardrail(triggers=True, output_info="test")
     )
     result = await guardrail.run(
-        agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
     )
     assert result.output.tripwire_triggered
     assert result.output.output_info == "test"
@@ -70,14 +79,20 @@ def get_async_input_guardrail(triggers: bool, output_info: Any | None = None):
 async def test_async_input_guardrail():
     guardrail = InputGuardrail(guardrail_function=get_async_input_guardrail(triggers=False))
     result = await guardrail.run(
-        agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
     )
     assert not result.output.tripwire_triggered
     assert result.output.output_info is None
 
     guardrail = InputGuardrail(guardrail_function=get_async_input_guardrail(triggers=True))
     result = await guardrail.run(
-        agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
     )
     assert result.output.tripwire_triggered
     assert result.output.output_info is None
@@ -86,7 +101,10 @@ async def test_async_input_guardrail():
         guardrail_function=get_async_input_guardrail(triggers=True, output_info="test")
     )
     result = await guardrail.run(
-        agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
     )
     assert result.output.tripwire_triggered
     assert result.output.output_info == "test"
@@ -98,7 +116,10 @@ async def test_invalid_input_guardrail_raises_user_error():
         # Purposely ignoring type error
         guardrail = InputGuardrail(guardrail_function="foo")  # type: ignore
         await guardrail.run(
-            agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+            agent=Agent(name="test"),
+            input="test",
+            context=RunContextWrapper(context=None),
+            previous_response_id=None,
         )
 
 
@@ -210,14 +231,20 @@ def decorated_named_input_guardrail(
 async def test_input_guardrail_decorators():
     guardrail = decorated_input_guardrail
     result = await guardrail.run(
-        agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        agent=Agent(name="test"),
+        input="test",
+        previous_response_id=None,
+        context=RunContextWrapper(context=None),
     )
     assert not result.output.tripwire_triggered
     assert result.output.output_info == "test_1"
 
     guardrail = decorated_named_input_guardrail
     result = await guardrail.run(
-        agent=Agent(name="test"), input="test", context=RunContextWrapper(context=None)
+        agent=Agent(name="test"),
+        input="test",
+        previous_response_id=None,
+        context=RunContextWrapper(context=None),
     )
     assert not result.output.tripwire_triggered
     assert result.output.output_info == "test_2"

--- a/tests/guardrails/test_new_input_guardrails.py
+++ b/tests/guardrails/test_new_input_guardrails.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agents import (
+    Agent,
+    GuardrailFunctionOutput,
+    InputGuardailInputs,
+    InputGuardrail,
+    RunContextWrapper,
+    TResponseInputItem,
+)
+from agents.guardrail import input_guardrail
+
+
+def get_sync_guardrail(triggers: bool, output_info: Any | None = None):
+    def sync_guardrail(context: RunContextWrapper[Any], inputs: InputGuardailInputs):
+        assert inputs.agent is not None
+        assert inputs.input is not None
+
+        return GuardrailFunctionOutput(
+            output_info=output_info,
+            tripwire_triggered=triggers,
+        )
+
+    return sync_guardrail
+
+
+@pytest.mark.asyncio
+async def test_sync_input_guardrail():
+    guardrail = InputGuardrail(guardrail_function=get_sync_guardrail(triggers=False))
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
+    )
+    assert not result.output.tripwire_triggered
+    assert result.output.output_info is None
+
+    guardrail = InputGuardrail(guardrail_function=get_sync_guardrail(triggers=True))
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
+    )
+    assert result.output.tripwire_triggered
+    assert result.output.output_info is None
+
+    guardrail = InputGuardrail(
+        guardrail_function=get_sync_guardrail(triggers=True, output_info="test")
+    )
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
+    )
+    assert result.output.tripwire_triggered
+    assert result.output.output_info == "test"
+
+
+def get_async_input_guardrail(triggers: bool, output_info: Any | None = None):
+    async def async_guardrail(context: RunContextWrapper[Any], inputs: InputGuardailInputs):
+        assert inputs.agent is not None
+        assert inputs.input is not None
+
+        return GuardrailFunctionOutput(
+            output_info=output_info,
+            tripwire_triggered=triggers,
+        )
+
+    return async_guardrail
+
+
+@pytest.mark.asyncio
+async def test_async_input_guardrail():
+    guardrail = InputGuardrail(guardrail_function=get_async_input_guardrail(triggers=False))
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
+    )
+    assert not result.output.tripwire_triggered
+    assert result.output.output_info is None
+
+    guardrail = InputGuardrail(guardrail_function=get_async_input_guardrail(triggers=True))
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
+    )
+    assert result.output.tripwire_triggered
+    assert result.output.output_info is None
+
+    guardrail = InputGuardrail(
+        guardrail_function=get_async_input_guardrail(triggers=True, output_info="test")
+    )
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        context=RunContextWrapper(context=None),
+        previous_response_id=None,
+    )
+    assert result.output.tripwire_triggered
+    assert result.output.output_info == "test"
+
+
+@input_guardrail
+def decorated_input_guardrail(
+    context: RunContextWrapper[Any], inputs: InputGuardailInputs
+) -> GuardrailFunctionOutput:
+    assert inputs.agent is not None
+    assert inputs.input is not None
+
+    return GuardrailFunctionOutput(
+        output_info="test_1",
+        tripwire_triggered=False,
+    )
+
+
+@input_guardrail(name="Custom name")
+def decorated_named_input_guardrail(
+    context: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+) -> GuardrailFunctionOutput:
+    return GuardrailFunctionOutput(
+        output_info="test_2",
+        tripwire_triggered=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_input_guardrail_decorators():
+    guardrail = decorated_input_guardrail
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        previous_response_id=None,
+        context=RunContextWrapper(context=None),
+    )
+    assert not result.output.tripwire_triggered
+    assert result.output.output_info == "test_1"
+
+    guardrail = decorated_named_input_guardrail
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        previous_response_id=None,
+        context=RunContextWrapper(context=None),
+    )
+    assert not result.output.tripwire_triggered
+    assert result.output.output_info == "test_2"
+    assert guardrail.get_name() == "Custom name"
+
+
+@input_guardrail
+def guardrail_with_previous_response_id(
+    context: RunContextWrapper[Any], inputs: InputGuardailInputs
+) -> GuardrailFunctionOutput:
+    assert inputs.agent is not None
+    assert inputs.input is not None
+    assert inputs.previous_response_id is not None
+    return GuardrailFunctionOutput(
+        output_info="test_3",
+        tripwire_triggered=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_guardrail_with_previous_response_id():
+    guardrail = guardrail_with_previous_response_id
+    result = await guardrail.run(
+        agent=Agent(name="test"),
+        input="test",
+        previous_response_id="test",
+        context=RunContextWrapper(context=None),
+    )
+    assert not result.output.tripwire_triggered
+    assert result.output.output_info == "test_3"


### PR DESCRIPTION
Input guardrails are expected to run on the full input, so passing the `previous_response_id` along. For back-compat, introducing a new signature for the guardrail. Using a dataclass for the inputs so we can extend in the future easily.