### PR TITLE
Add a new GH Actions job to automatically update translated document pagse

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,47 @@
+name: "Update Translated Docs"
+
+# This GitHub Actions job automates the process of updating all translated document pages. Please note the following:
+# 1. The translation results may vary each time; some differences in detail are expected.
+# 2. When you add a new page to the left-hand menu, **make sure to manually update mkdocs.yml** to include the new item.
+# 3. If you switch to a different LLM (for example, from o3 to a newer model), be sure to conduct thorough testing before making the switch.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - mkdocs.yml
+
+jobs:
+  update-docs:
+    name: Build and Push Translated Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: make sync
+      - name: Build full docs
+        run: make build-full-docs
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "Update all translated document pages"
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
This pull request adds a new GitHub Actions job to automate the translation of document pages.
- Before this job can run, **OPENAI_API_KEY must be added to the project secrets.**
- It typically takes 8–10 minutes using the o3 model, so the job is configured to run only when there are changes under docs/ or in mkdocs.yml.
- The job commits and pushes the translated changes, but it does not deploy the documents to GitHub Pages. If we think it’s better to deploy the latest changes automatically as well, I’m happy to update the workflow. (Personally, I don’t think it’s necessary, since the changes will be deployed with the next deployment job execution)