### PR TITLE
Add ProviderError exception and handle missing LLM response

### DIFF
--- a/src/agents/exceptions.py
+++ b/src/agents/exceptions.py
@@ -61,3 +61,7 @@ class OutputGuardrailTripwireTriggered(AgentsException):
         super().__init__(
             f"Guardrail {guardrail_result.guardrail.__class__.__name__} triggered tripwire"
         )
+
+
+class ProviderError(AgentsException):
+    """Exception raised when the provider fails."""

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -12,6 +12,7 @@ from openai.types.responses import Response
 
 from .. import _debug
 from ..agent_output import AgentOutputSchemaBase
+from ..exceptions import ProviderError
 from ..handoffs import Handoff
 from ..items import ModelResponse, TResponseInputItem, TResponseStreamEvent
 from ..logger import logger
@@ -69,6 +70,9 @@ class OpenAIChatCompletionsModel(Model):
                 tracing,
                 stream=False,
             )
+
+            if not getattr(response, "choices", None):
+                raise ProviderError(f"LLM provider error: {getattr(response, 'error', 'unknown')}")
 
             if _debug.DONT_LOG_MODEL_DATA:
                 logger.debug("Received model response")
@@ -252,7 +256,7 @@ class OpenAIChatCompletionsModel(Model):
             stream_options=self._non_null_or_not_given(stream_options),
             store=self._non_null_or_not_given(store),
             reasoning_effort=self._non_null_or_not_given(reasoning_effort),
-            extra_headers={ **HEADERS, **(model_settings.extra_headers or {}) },
+            extra_headers={**HEADERS, **(model_settings.extra_headers or {})},
             extra_query=model_settings.extra_query,
             extra_body=model_settings.extra_body,
             metadata=self._non_null_or_not_given(model_settings.metadata),


### PR DESCRIPTION
This commit introduces a new ProviderError exception to handle cases where the LLM provider response lacks the expected 'choices' attribute. It ensures more robust error handling and improves the reliability of the system by catching and raising explicit errors for invalid responses.

Fixes #604 