### PR TITLE
[fix] use openai model provider as default

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -27,14 +27,19 @@ from .exceptions import (
     ModelBehaviorError,
     OutputGuardrailTripwireTriggered,
 )
-from .guardrail import InputGuardrail, InputGuardrailResult, OutputGuardrail, OutputGuardrailResult
+from .guardrail import (
+    InputGuardrail,
+    InputGuardrailResult,
+    OutputGuardrail,
+    OutputGuardrailResult,
+)
 from .handoffs import Handoff, HandoffInputFilter, handoff
 from .items import ItemHelpers, ModelResponse, RunItem, TResponseInputItem
 from .lifecycle import RunHooks
 from .logger import logger
 from .model_settings import ModelSettings
 from .models.interface import Model, ModelProvider
-from .models.multi_provider import MultiProvider
+from .models.openai_provider import OpenAIProvider
 from .result import RunResult, RunResultStreaming
 from .run_context import RunContextWrapper, TContext
 from .stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent
@@ -56,7 +61,7 @@ class RunConfig:
     agent. The model_provider passed in below must be able to resolve this model name.
     """
 
-    model_provider: ModelProvider = field(default_factory=MultiProvider)
+    model_provider: ModelProvider = field(default_factory=OpenAIProvider)
     """The model provider to use when looking up string model names. Defaults to OpenAI."""
 
     model_settings: ModelSettings | None = None


### PR DESCRIPTION
 This commit fix the error:

When set default openai client but not use `litellm` provider, would got `unknown prefix` error.

Another reason is many of the endpoints are already compatible with the OpenAI SDK/Openai api, I want use them without install litellm.

```python
client = AsyncOpenAI(
    base_url="https://integrate.api.nvidia.com/v1",
    api_key=os.getenv("NV_API_KEY"),
)
set_default_openai_client(client=client, use_for_tracing=False)
...
  agent = Agent(
      name="Assistant",
      instructions="You only respond in haikus.",
      model="meta/llama-4-scout-17b-16e-instruct",
      tools=[get_weather],
  )
```

Got Error:
```
openai-agents-python/src/agents/models/multi_provider.py", line 117, in _create_fallback_provider
    raise UserError(f"Unknown prefix: {prefix}")
agents.exceptions.UserError: Unknown prefix: meta
```
