### PR TITLE
Add Galileo to external tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -115,3 +115,4 @@ To customize this default setup, to send traces to alternative or additional bac
 -   [Langfuse](https://langfuse.com/docs/integrations/openaiagentssdk/openai-agents)
 -   [Langtrace](https://docs.langtrace.ai/supported-integrations/llm-frameworks/openai-agents-sdk)
 -   [Okahu-Monocle](https://github.com/monocle2ai/monocle)
+-   [Galileo](https://v2docs.galileo.ai/integrations/openai-agent-integration#openai-agent-integration)


### PR DESCRIPTION
Use [Galileo SDK ](https://galileo.ai) to trace your agents

Python SDK code:
https://github.com/rungalileo/galileo-python/blob/main/src/galileo/handlers/openai_agents.py

![Screenshot 2025-04-03 at 04 40 24](https://github.com/user-attachments/assets/ff703f0b-b1fa-4dbf-ae8c-38df2a01c511)
