### PR TITLE
Use `max_completion_tokens` param for OpenAI Chat Completion API

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -244,7 +244,7 @@ class OpenAIChatCompletionsModel(Model):
             top_p=self._non_null_or_not_given(model_settings.top_p),
             frequency_penalty=self._non_null_or_not_given(model_settings.frequency_penalty),
             presence_penalty=self._non_null_or_not_given(model_settings.presence_penalty),
-            max_tokens=self._non_null_or_not_given(model_settings.max_tokens),
+            max_completion_tokens=self._non_null_or_not_given(model_settings.max_tokens),
             tool_choice=tool_choice,
             response_format=response_format,
             parallel_tool_calls=parallel_tool_calls,


### PR DESCRIPTION
The current implementation uses `max_tokens` param for OpenAI Chat Completions API, tho according to [the docs](https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens) this parameter is deprecated and we should use `max_completion_tokens`.

<img width="646" alt="image" src="https://github.com/user-attachments/assets/1eadd313-f178-4bd2-ae6e-04ad6be2f216" />


## Changes

- use `max_completion_tokens` param for setting max output tokens for OpenAI Chat Completions