### PR TITLE
Added response cost in the Usage

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -107,7 +107,7 @@ class LitellmModel(Model):
                         input_tokens=response_usage.prompt_tokens,
                         output_tokens=response_usage.completion_tokens,
                         total_tokens=response_usage.total_tokens,
-                        cost=response._hidden_params.get("response_cost", 0.0)
+                        response_cost=response._hidden_params.get("response_cost", 0.0)
                     )
                     if response.usage
                     else Usage()

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -107,6 +107,7 @@ class LitellmModel(Model):
                         input_tokens=response_usage.prompt_tokens,
                         output_tokens=response_usage.completion_tokens,
                         total_tokens=response_usage.total_tokens,
+                        cost=response._hidden_params.get("response_cost", 0.0)
                     )
                     if response.usage
                     else Usage()

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -15,8 +15,12 @@ class Usage:
     total_tokens: int = 0
     """Total tokens sent and received, across all requests."""
 
+    cost: float = 0.0
+    """Total cost incurred, across all requests."""
+
     def add(self, other: "Usage") -> None:
         self.requests += other.requests if other.requests else 0
         self.input_tokens += other.input_tokens if other.input_tokens else 0
         self.output_tokens += other.output_tokens if other.output_tokens else 0
         self.total_tokens += other.total_tokens if other.total_tokens else 0
+        self.cost += other.cost if other.cost else 0

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -15,7 +15,7 @@ class Usage:
     total_tokens: int = 0
     """Total tokens sent and received, across all requests."""
 
-    cost: float = 0.0
+    response_cost: float = 0.0
     """Total cost incurred, across all requests."""
 
     def add(self, other: "Usage") -> None:
@@ -23,4 +23,4 @@ class Usage:
         self.input_tokens += other.input_tokens if other.input_tokens else 0
         self.output_tokens += other.output_tokens if other.output_tokens else 0
         self.total_tokens += other.total_tokens if other.total_tokens else 0
-        self.cost += other.cost if other.cost else 0
+        self.response_cost += other.response_cost if other.response_cost else 0


### PR DESCRIPTION
### Feature: Add Response Cost Tracking to Usage Class

This PR introduces a new attribute, response\_cost, to the Usage class to enable tracking of the total cost incurred from API responses. This addition enhances observability and cost management for developers using the OpenAI Agents SDK by making cost metrics available alongside existing usage metrics such as request count and token usage.

#### How it works:

* A new field, response\_cost: float = 0.0, is added to the Usage dataclass.
* The add() method has been updated to correctly accumulate the response\_cost from another Usage instance.
* This allows developers to easily aggregate and monitor financial cost metrics in tandem with usage data.

#### Example:

```python
usage_1 = Usage(requests=1, input_tokens=100, output_tokens=200, total_tokens=300, response_cost=0.012)
usage_2 = Usage(requests=2, input_tokens=150, output_tokens=250, total_tokens=400, response_cost=0.015)

usage_1.add(usage_2)

# usage_1 now reflects:
# requests: 3
# input_tokens: 250
# output_tokens: 450
# total_tokens: 700
# response_cost: 0.027
```

This addition is useful for developers needing cost-aware usage insights for budgeting, reporting, or scaling decisions.

Closes https://github.com/openai/openai-agents-python/issues/683
