### PR TITLE
Fixed a bug for "detail" attribute in input image

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -234,7 +234,7 @@ class Converter:
                         type="image_url",
                         image_url={
                             "url": casted_image_param["image_url"],
-                            "detail": casted_image_param.get("detail", None),
+                            "detail": casted_image_param.get("detail", "auto"),
                         },
                     )
                 )

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -234,7 +234,7 @@ class Converter:
                         type="image_url",
                         image_url={
                             "url": casted_image_param["image_url"],
-                            "detail": casted_image_param["detail"],
+                            "detail": casted_image_param.get("detail", None),
                         },
                     )
                 )


### PR DESCRIPTION
When an input image is given as input, the code tries to access the 'detail' key, that may not be present as noted in #159.

With this pull request, now it tries to access the key, otherwise set the value to `None`.
@pakrym-oai  or @rm-openai let me know if you want any changes.