### PR TITLE
docs: Enhance fetch_user_age tool: include UID and correct output format

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -38,7 +38,7 @@ class UserInfo:  # (1)!
 
 @function_tool
 async def fetch_user_age(wrapper: RunContextWrapper[UserInfo]) -> str:  # (2)!
-    return f"User {wrapper.context.name} is 47 years old"
+    return f"User {wrapper.context.name} (ID: {wrapper.context.uid}) is 47 years old"
 
 async def main():
     user_info = UserInfo(name="John", uid=123)
@@ -55,7 +55,7 @@ async def main():
     )
 
     print(result.final_output)  # (5)!
-    # The user John is 47 years old.
+    # User John (ID: 123) is 47 years old
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/docs/context.md
+++ b/docs/context.md
@@ -10,7 +10,7 @@ Context is an overloaded term. There are two main classes of context you might c
 This is represented via the [`RunContextWrapper`][agents.run_context.RunContextWrapper] class and the [`context`][agents.run_context.RunContextWrapper.context] property within it. The way this works is:
 
 1. You create any Python object you want. A common pattern is to use a dataclass or a Pydantic object.
-2. You pass that object to the various run methods (e.g. `Runner.run(..., **context=whatever**))`.
+2. You pass that object to the various run methods (e.g., `Runner.run(..., context=your_context_object)`).
 3. All your tool calls, lifecycle hooks etc will be passed a wrapper object, `RunContextWrapper[T]`, where `T` represents your context object type which you can access via `wrapper.context`.
 
 The **most important** thing to be aware of: every agent, tool function, lifecycle etc for a given agent run must use the same _type_ of context.

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -17,19 +17,19 @@ Input guardrails run in 3 steps:
 
 !!! Note
 
-    Input guardrails are intended to run on user input, so an agent's guardrails only run if the agent is the *first* agent. You might wonder, why is the `guardrails` property on the agent instead of passed to `Runner.run`? It's because guardrails tend to be related to the actual Agent - you'd run different guardrails for different agents, so colocating the code is useful for readability.
+    Input guardrails are intended to run on user input, so an agent's guardrails only run if the agent is the *first* agent. **In a sequence or chain of agents, the 'first agent' is the entry point – the agent that directly receives the initial user's input. Therefore, input guardrails only check this agent’s input.** You might wonder, why is the `guardrails` property on the agent instead of passed to `Runner.run`? It's because guardrails tend to be related to the actual Agent - you'd run different guardrails for different agents, so colocating the code is useful for readability.
 
 ## Output guardrails
 
 Output guardrails run in 3 steps:
 
-1. First, the guardrail receives the same input passed to the agent.
+1. First, the guardrail receives the same output passed to the agent.
 2. Next, the guardrail function runs to produce a [`GuardrailFunctionOutput`][agents.guardrail.GuardrailFunctionOutput], which is then wrapped in an [`OutputGuardrailResult`][agents.guardrail.OutputGuardrailResult]
 3. Finally, we check if [`.tripwire_triggered`][agents.guardrail.GuardrailFunctionOutput.tripwire_triggered] is true. If true, an [`OutputGuardrailTripwireTriggered`][agents.exceptions.OutputGuardrailTripwireTriggered] exception is raised, so you can appropriately respond to the user or handle the exception.
 
 !!! Note
 
-    Output guardrails are intended to run on the final agent output, so an agent's guardrails only run if the agent is the *last* agent. Similar to the input guardrails, we do this because guardrails tend to be related to the actual Agent - you'd run different guardrails for different agents, so colocating the code is useful for readability.
+    Output guardrails are intended to run on the final agent output, so an agent's guardrails only run if the agent is the *last* agent. **In a sequence or chain of agents, the 'last agent' is the one that produces the final output returned to the user. Therefore, output guardrails only check this agent’s output.** Similar to the input guardrails, we do this because guardrails tend to be related to the actual Agent - you'd run different guardrails for different agents, so colocating the code is useful for readability.
 
 ## Tripwires
 


### PR DESCRIPTION
**Background**
The existing `fetch_user_age` tool only displayed the user’s name and hard-coded age, and the printed comment was misleading. It also neglected the user’s unique identifier.

**Issue**

* Output string in `context.md` was inaccurate for given string in function `fetch_user_age`:

  ```python
  f"User {wrapper.context.name} is 47 years old"
  # The user John is 47 years old.
  ```

* The `uid` field of `UserInfo` was never used, reducing context completeness.

**Changes**

1. **Use `uid` in the tool’s response**
   Updated `fetch_user_age` to reference both `name` and `uid` from `wrapper.context`.

   ```diff
   - return f"User {wrapper.context.name} is 47 years old"
   + return f"User {wrapper.context.name} (ID: {wrapper.context.uid}) is 47 years old"
   ```
2. **Correct expected output in example**
   Adjusted the printed comment in `context.md` to match the new response format.

   ```diff
   - # The user John is 47 years old.
   + # User John (ID: 123) is 47 years old
   ```
---

These updates ensure the tool provides a more complete and accurate user context, improving both clarity and correctness.
