### PR TITLE
visualize the complete Agent Loop with an interactive UML

### DIFF
--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -83,7 +83,9 @@ async def main():
         print(result.final_output)
         # California
 ```
-
+## Agent loop deep diagram
+![image](https://github.com/user-attachments/assets/3b085816-6173-4fee-a936-5016e1c81755)
+[Download PDF](https://github.com/panaversity/learn-agentic-ai/blob/main/01_ai_agents_first/15_run_lifecycle/Agent_loop.pdf)
 ## Exceptions
 
 The SDK raises exceptions in certain cases. The full list is in [`agents.exceptions`][]. As an overview:


### PR DESCRIPTION
#### 🤔 Why we need this

The “Agent Loop” is the SDK’s most complex subsystem:

1. It spans \~2 000 lines across `run.py`, guardrails, hand-offs, and streaming helpers.
2. Contributors often ask *“Where do guardrails fire?”* or *“How does the Runner decide between tool-calls and hand-offs?”*

A single picture out-ranks a thousand words; the diagram turns that spaghetti into a map:

```
Runner ──▶ Agent ──▶ Model ──▷ Response
  ▲           │           │
  │           ▼           ▼
Guardrails ◀──┘     Tool-Calls / Handoffs
```