### PR TITLE
add get_tool_call_name method to extract tool name from ToolCallItem

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -248,3 +248,8 @@ class ItemHelpers:
             "output": output,
             "type": "function_call_output",
         }
+    
+    @classmethod
+    def get_tool_call_name(cls, tool_call: ToolCallItem) -> str:
+        """Returns the tool name from a ToolCallItem."""
+        return tool_call.raw_item.name

--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -253,3 +253,10 @@ class ItemHelpers:
     def get_tool_call_name(cls, tool_call: ToolCallItem) -> str:
         """Returns the tool name from a ToolCallItem."""
         return tool_call.raw_item.name
+    
+    @classmethod
+    def tool_response_output(
+        cls, tool_call: ToolCallOutputItem
+    ):
+        """Extracts and returns the output from a ToolCallOutputItem."""
+        return tool_call.output


### PR DESCRIPTION
Adds a utility method get_tool_call_name to extract the name of a tool from a ToolCallItem. Useful for identifying which tool was invoked during agent execution.