### PR TITLE
Attach partial run data on errors

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -10,6 +10,7 @@ from .agent_output import AgentOutputSchema, AgentOutputSchemaBase
 from .computer import AsyncComputer, Button, Computer, Environment
 from .exceptions import (
     AgentsException,
+    ErrorRunData,
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
     ModelBehaviorError,
@@ -173,6 +174,7 @@ __all__ = [
     "Environment",
     "Button",
     "AgentsException",
+    "ErrorRunData",
     "InputGuardrailTripwireTriggered",
     "OutputGuardrailTripwireTriggered",
     "MaxTurnsExceeded",

--- a/src/agents/exceptions.py
+++ b/src/agents/exceptions.py
@@ -1,11 +1,34 @@
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from .agent import Agent
     from .guardrail import InputGuardrailResult, OutputGuardrailResult
+    from .items import ModelResponse, RunItem, TResponseInputItem
+    from .run_context import RunContextWrapper
+
+
+@dataclass
+class ErrorRunData:
+    """Data collected from an agent run when an exception occurs."""
+
+    input: str | list[TResponseInputItem]
+    new_items: list[RunItem]
+    raw_responses: list[ModelResponse]
+    last_agent: "Agent[Any]"
+    context_wrapper: "RunContextWrapper[Any]"
+    input_guardrail_results: list[InputGuardrailResult]
+    output_guardrail_results: list[OutputGuardrailResult]
 
 
 class AgentsException(Exception):
     """Base class for all exceptions in the Agents SDK."""
+
+    run_data: ErrorRunData | None
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+        self.run_data = None
 
 
 class MaxTurnsExceeded(AgentsException):
@@ -15,6 +38,7 @@ class MaxTurnsExceeded(AgentsException):
 
     def __init__(self, message: str):
         self.message = message
+        super().__init__(message)
 
 
 class ModelBehaviorError(AgentsException):
@@ -26,6 +50,7 @@ class ModelBehaviorError(AgentsException):
 
     def __init__(self, message: str):
         self.message = message
+        super().__init__(message)
 
 
 class UserError(AgentsException):
@@ -35,6 +60,7 @@ class UserError(AgentsException):
 
     def __init__(self, message: str):
         self.message = message
+        super().__init__(message)
 
 
 class InputGuardrailTripwireTriggered(AgentsException):

--- a/tests/test_error_run_data.py
+++ b/tests/test_error_run_data.py
@@ -1,0 +1,42 @@
+import json
+import pytest
+
+from agents import Agent, Runner, MaxTurnsExceeded, ErrorRunData
+from .fake_model import FakeModel
+from .test_responses import get_text_message, get_function_tool, get_function_tool_call
+
+
+@pytest.mark.asyncio
+async def test_run_error_includes_data():
+    model = FakeModel()
+    agent = Agent(name="test", model=model, tools=[get_function_tool("foo", "res")])
+    model.add_multiple_turn_outputs([
+        [get_text_message("1"), get_function_tool_call("foo", json.dumps({"a": "b"}))],
+        [get_text_message("done")],
+    ])
+    with pytest.raises(MaxTurnsExceeded) as exc:
+        await Runner.run(agent, input="hello", max_turns=1)
+    data = exc.value.run_data
+    assert isinstance(data, ErrorRunData)
+    assert data.last_agent == agent
+    assert len(data.raw_responses) == 1
+    assert len(data.new_items) > 0
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_error_includes_data():
+    model = FakeModel()
+    agent = Agent(name="test", model=model, tools=[get_function_tool("foo", "res")])
+    model.add_multiple_turn_outputs([
+        [get_text_message("1"), get_function_tool_call("foo", json.dumps({"a": "b"}))],
+        [get_text_message("done")],
+    ])
+    result = Runner.run_streamed(agent, input="hello", max_turns=1)
+    with pytest.raises(MaxTurnsExceeded) as exc:
+        async for _ in result.stream_events():
+            pass
+    data = exc.value.run_data
+    assert isinstance(data, ErrorRunData)
+    assert data.last_agent == agent
+    assert len(data.raw_responses) == 1
+    assert len(data.new_items) > 0


### PR DESCRIPTION
## Summary
- include an `ErrorRunData` dataclass and expose it
- record intermediate run state in `AgentsException`
- attach run data in `Runner.run`, streaming runner internals and result checks
- test that run data is included for aborted runs

## Testing
- `ruff check --quiet $(git ls-files '*.py')`
- `ruff format --quiet $(git ls-files '*.py')`
- `mypy .` *(fails: Could not connect to packages)*
- `make tests` *(fails: Could not connect to packages)*