### PR TITLE
Fix typo: Replace 'two' with 'three' in /docs/mcp.md

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -8,7 +8,7 @@ The Agents SDK has support for MCP. This enables you to use a wide range of MCP 
 
 ## MCP servers
 
-Currently, the MCP spec defines two kinds of servers, based on the transport mechanism they use:
+Currently, the MCP spec defines three kinds of servers, based on the transport mechanism they use:
 
 1. **stdio** servers run as a subprocess of your application. You can think of them as running "locally".
 2. **HTTP over SSE** servers run remotely. You connect to them via a URL.


### PR DESCRIPTION
The documentation in `docs/mcp.md` listed three server types (stdio, HTTP over SSE, Streamable HTTP) but incorrectly stated "two kinds of servers" in the heading. This PR fixes the numerical discrepancy. 

**Changes:** 

- Modified from "two kinds of servers" to "three kinds of servers". 
- File: `docs/mcp.md` (line 11). 
