### PR TITLE
Docs: Fix Guardrail definition to include both input and output validations

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -17,19 +17,19 @@ Input guardrails run in 3 steps:
 
 !!! Note
 
-    Input guardrails are intended to run on user input, so an agent's guardrails only run if the agent is the *first* agent. You might wonder, why is the `guardrails` property on the agent instead of passed to `Runner.run`? It's because guardrails tend to be related to the actual Agent - you'd run different guardrails for different agents, so colocating the code is useful for readability.
+    Input guardrails are intended to run on user input, so an agent's guardrails only run if the agent is the *first* agent. **In a sequence or chain of agents, the 'first agent' is the entry point – the agent that directly receives the initial user's input. Therefore, input guardrails only check this agent’s input.** You might wonder, why is the `guardrails` property on the agent instead of passed to `Runner.run`? It's because guardrails tend to be related to the actual Agent - you'd run different guardrails for different agents, so colocating the code is useful for readability.
 
 ## Output guardrails
 
 Output guardrails run in 3 steps:
 
-1. First, the guardrail receives the same input passed to the agent.
+1. First, the guardrail receives the same output passed to the agent.
 2. Next, the guardrail function runs to produce a [`GuardrailFunctionOutput`][agents.guardrail.GuardrailFunctionOutput], which is then wrapped in an [`OutputGuardrailResult`][agents.guardrail.OutputGuardrailResult]
 3. Finally, we check if [`.tripwire_triggered`][agents.guardrail.GuardrailFunctionOutput.tripwire_triggered] is true. If true, an [`OutputGuardrailTripwireTriggered`][agents.exceptions.OutputGuardrailTripwireTriggered] exception is raised, so you can appropriately respond to the user or handle the exception.
 
 !!! Note
 
-    Output guardrails are intended to run on the final agent output, so an agent's guardrails only run if the agent is the *last* agent. Similar to the input guardrails, we do this because guardrails tend to be related to the actual Agent - you'd run different guardrails for different agents, so colocating the code is useful for readability.
+    Output guardrails are intended to run on the final agent output, so an agent's guardrails only run if the agent is the *last* agent. **In a sequence or chain of agents, the 'last agent' is the one that produces the final output returned to the user. Therefore, output guardrails only check this agent’s output.** Similar to the input guardrails, we do this because guardrails tend to be related to the actual Agent - you'd run different guardrails for different agents, so colocating the code is useful for readability.
 
 ## Tripwires
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -23,7 +23,7 @@ Input guardrails run in 3 steps:
 
 Output guardrails run in 3 steps:
 
-1. First, the guardrail receives the same output passed to the agent.
+1. First, the guardrail receives the same output produced by the agent.
 2. Next, the guardrail function runs to produce a [`GuardrailFunctionOutput`][agents.guardrail.GuardrailFunctionOutput], which is then wrapped in an [`OutputGuardrailResult`][agents.guardrail.OutputGuardrailResult]
 3. Finally, we check if [`.tripwire_triggered`][agents.guardrail.GuardrailFunctionOutput.tripwire_triggered] is true. If true, an [`OutputGuardrailTripwireTriggered`][agents.exceptions.OutputGuardrailTripwireTriggered] exception is raised, so you can appropriately respond to the user or handle the exception.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Here are the main features of the SDK:
 -   Agent loop: Built-in agent loop that handles calling tools, sending results to the LLM, and looping until the LLM is done.
 -   Python-first: Use built-in language features to orchestrate and chain agents, rather than needing to learn new abstractions.
 -   Handoffs: A powerful feature to coordinate and delegate between multiple agents.
--   Guardrails: Run input validations and checks in parallel to your agents, breaking early if the checks fail.
+-   Guardrails: Run input and output validations and checks in parallel to your agents, breaking early if the checks fail.
 -   Function tools: Turn any Python function into a tool, with automatic schema generation and Pydantic-powered validation.
 -   Tracing: Built-in tracing that lets you visualize, debug and monitor your workflows, as well as use the OpenAI suite of evaluation, fine-tuning and distillation tools.
 


### PR DESCRIPTION

**Summary:**
This PR updates the description of **Guardrails** in the OpenAI Agents SDK documentation to reflect that they apply to both input and output validations.

**Original Text:**

> Guardrails: Run input validations and checks in parallel to your agents, breaking early if the checks fail.

**Proposed Update:**

> Guardrails: Run input and output validations and checks in parallel to your agents, breaking early if the checks fail.

**Why this change is necessary:**
The original statement is incomplete and potentially misleading, as it only mentions input validations. However, the [[Agents SDK Guardrail Documentation](https://openai.github.io/openai-agents-python/guardrails/)] defines two distinct types of guardrails:

* `InputGuardrail`: Validates user input before it reaches the agent.
* `OutputGuardrail`: Validates the agent’s final output before it is returned to the user.

Both types of guardrails are critical for ensuring the safety and reliability of agent behavior. Additionally, both can trigger a `Tripwire` (e.g., `InputGuardrailTripwireTriggered`, `OutputGuardrailTripwireTriggered`) to halt execution when a validation fails—hence, the phrase “breaking early” applies to both.

**Impact:**
This correction improves clarity and accuracy, helping developers better understand the full lifecycle of guardrail checks in the SDK.

