### PR TITLE
docs: fix typo in docstring for is_strict_json_schema method

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -38,7 +38,7 @@ class AgentOutputSchemaBase(abc.ABC):
     @abc.abstractmethod
     def is_strict_json_schema(self) -> bool:
         """Whether the JSON schema is in strict mode. Strict mode constrains the JSON schema
-        features, but guarantees valis JSON. See here for details:
+        features, but guarantees valid JSON. See here for details:
         https://platform.openai.com/docs/guides/structured-outputs#supported-schemas
         """
         pass


### PR DESCRIPTION
### Overview

This PR fixes a small typo in the docstring of the `is_strict_json_schema` abstract method of the `AgentOutputSchemaBase` class in `agent_output.py`.   

### Changes

- Corrected the word “valis” to “valid” in the docstring.

### Motivation

Clear and correct documentation improves code readability and reduces confusion for users and contributors.

### Checklist

- [x] I have reviewed the docstring after making the change.
- [x] No functionality is affected.
- [x] The change follows the repository’s contribution guidelines.
