### PR TITLE
fix(events): correct spelling of "handoff_occurred" event name

### DIFF
--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -884,7 +884,7 @@ class RunImpl:
             elif isinstance(item, HandoffCallItem):
                 event = RunItemStreamEvent(item=item, name="handoff_requested")
             elif isinstance(item, HandoffOutputItem):
-                event = RunItemStreamEvent(item=item, name="handoff_occured")
+                event = RunItemStreamEvent(item=item, name="handoff_occurred")
             elif isinstance(item, ToolCallItem):
                 event = RunItemStreamEvent(item=item, name="tool_called")
             elif isinstance(item, ToolCallOutputItem):

--- a/src/agents/stream_events.py
+++ b/src/agents/stream_events.py
@@ -31,7 +31,7 @@ class RunItemStreamEvent:
     name: Literal[
         "message_output_created",
         "handoff_requested",
-        "handoff_occured",
+        "handoff_occurred",
         "tool_called",
         "tool_output",
         "reasoning_item_created",


### PR DESCRIPTION
## Description
Fixes a spelling error in the event name for handoff events, changing `handoff_occured` to `handoff_occurred` for consistency and correctness.

## Motivation and Context
Correct spelling improves code quality and developer experience. Consistency in event naming helps avoid confusion and potential bugs.

## Changes
- Renamed all instances of `handoff_occured` to `handoff_occurred` in the codebase.

## Breaking Changes
- This change is not backward compatible if any external code relied on the old event name.
