### PR TITLE
Fix typo in assertion message for handoff function

### DIFF
--- a/src/agents/handoffs.py
+++ b/src/agents/handoffs.py
@@ -168,7 +168,7 @@ def handoff(
         input_filter: a function that filters the inputs that are passed to the next agent.
     """
     assert (on_handoff and input_type) or not (on_handoff and input_type), (
-        "You must provide either both on_input and input_type, or neither"
+        "You must provide either both on_handoff and input_type, or neither"
     )
     type_adapter: TypeAdapter[Any] | None
     if input_type is not None:


### PR DESCRIPTION
### Overview

This PR fixes a typo in the assert statement within the `handoff` function in `handoffs.py`, changing `'on_input'` to `'on_handoff`' for accuracy and clarity.   

### Changes

- Corrected the word “on_input” to “on_handoff” in the docstring.

### Motivation

Clear and correct documentation improves code readability and reduces confusion for users and contributors.

### Checklist

- [x] I have reviewed the docstring after making the change.
- [x] No functionality is affected.
- [x] The change follows the repository’s contribution guidelines.