### PR TITLE
Small fix for litellm model

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -5,7 +5,6 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any, Literal, cast, overload
 
-import litellm.types
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 from agents.exceptions import ModelBehaviorError


### PR DESCRIPTION
Small fix:

Removing `import litellm.types` as its outside the try except block for importing litellm so the import error message isn't displayed, and the line actually isn't needed. I was reproducing a GitHub issue and came across this in the process.