### PR TITLE
Add exclude_params feature to function_tool

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -100,7 +100,7 @@ for tool in agent.tools:
 
 1.  You can use any Python types as arguments to your functions, and the function can be sync or async.
 2.  Docstrings, if present, are used to capture descriptions and argument descriptions
-3.  Functions can optionally take the `context` (must be the first argument). You can also set overrides, like the name of the tool, description, which docstring style to use, etc.
+3.  Functions can optionally take the `context` (must be the first argument). You can also set overrides, like the name of the tool, description, which docstring style to use, and exclude specific parameters from the schema, etc.
 4.  You can pass the decorated functions to the list of tools.
 
 ??? note "Expand to see output"
@@ -283,6 +283,45 @@ async def run_my_agent() -> str:
 
     return str(result.final_output)
 ```
+
+## Excluding parameters from the schema
+
+Sometimes, you might want to exclude certain parameters from the JSON schema that's presented to the LLM, while still making them available to your function with their default values. This can be useful for:
+
+- Keeping implementation details hidden from the LLM
+- Simplifying the tool interface presented to the model
+- Maintaining backward compatibility when adding new parameters
+- Supporting internal parameters that should always use default values
+
+You can do this using the `exclude_params` parameter of the `@function_tool` decorator:
+
+```python
+from typing import Optional
+from agents import function_tool, RunContextWrapper
+
+@function_tool(exclude_params=["timestamp", "internal_id"])
+def search_database(
+    query: str,
+    limit: int = 10,
+    timestamp: Optional[str] = None,
+    internal_id: Optional[str] = None
+) -> str:
+    """
+    Search the database for records matching the query.
+    
+    Args:
+        query: The search query string
+        limit: Maximum number of results to return
+        timestamp: The timestamp to use for the search (hidden from schema)
+        internal_id: Internal tracking ID for telemetry (hidden from schema)
+    """
+    # Implementation...
+```
+
+In this example:
+- The LLM will only see `query` and `limit` parameters in the tool schema
+- `timestamp` and `internal_id` will be automatically set to their default values when the function runs
+- All excluded parameters must have default values (either `None` or a specific value)
 
 ## Handling errors in function tools
 


### PR DESCRIPTION
## Summary

This PR adds an `exclude_params` feature to `function_tool` and `function_schema`, allowing developers to hide specific parameters from the LLM while still making them available to the function with their default values.

## Motivation

When building AI agents for production systems, there's often a need to pass context-sensitive parameters (like timestamps, user IDs, or environment flags) to function tools without exposing these implementation details to the LLM. This is particularly important for evaluation scenarios where you want to ensure the agent behaves authentically without being influenced by "meta" parameters.

## Use Case: Incident Response Bot Evaluation

Our primary use case is an incident response bot that reacts to PagerDuty alerts and investigates root causes using tools like `search_slack`. During evaluation, we run the bot against historical incidents to measure its performance. However, we face a critical challenge:

**The Problem:**
- When evaluating on a 10-day-old incident, Slack contains messages posted *after* the incident occurred
- These messages often reveal the root cause that wasn't available during the actual incident
- The AI agent could "cheat" by accessing this future knowledge, making evaluations unrealistic

**The Solution:**
We need to pass a `timestamp` parameter to `search_slack` to filter results to only show messages available at incident time. However:
- Each incident in our evaluation dataset occurred at different times
- The timestamp parameter must be dynamically set per evaluation
- The LLM agent should remain unaware of this filtering - it should always believe it's triaging a "current" incident

**Example Implementation:**
```python
@function_tool(exclude_params=['timestamp'])
def search_slack(query: str, timestamp: str = None) -> Dict[str, Any]:
    """
    Search Slack messages for incident-related information.
    
    Args:
        query: Search query for Slack messages
        timestamp: Internal parameter for filtering messages (hidden from LLM)
    """
    # Filter messages to only show those before the timestamp
    # In evaluation: timestamp = incident_time
    # In production: timestamp = current_time
    return search_slack_with_time_filter(query, timestamp)
```

With `exclude_params=['timestamp']`, the LLM only sees:
```json
{
  "name": "search_slack",
  "parameters": {
    "type": "object", 
    "properties": {
      "query": {"type": "string", "description": "Search query for Slack messages"}
    },
    "required": ["query"]
  }
}
```

The agent calls `search_slack("API errors in payment service")` while the function receives both `query` and the pre-configured `timestamp`.

## Implementation Details

- **Added `exclude_params` parameter** to both `function_schema()` and `function_tool()` decorator
- **Parameter validation**: Ensures excluded parameters have default values (required for function execution)
- **Schema filtering**: Excluded parameters are removed from the JSON schema presented to the LLM
- **Backwards compatible**: Existing code continues to work unchanged
- **Comprehensive testing**: Added test coverage for various scenarios

## Files Changed

- `src/agents/function_schema.py`: Core schema generation logic
- `src/agents/tool.py`: function_tool decorator implementation  
- `docs/tools.md`: Documentation and examples
- `tests/test_function_schema.py`: Schema generation tests
- `tests/test_function_tool.py`: function_tool decorator tests

## Benefits

1. **Authentic evaluations**: Agents can't access future information during historical incident analysis
2. **Clean abstractions**: Implementation details stay hidden from LLM reasoning
3. **Flexible parameter injection**: Different contexts (eval vs prod) can inject different values
4. **Maintained agent behavior**: Agent code remains identical across environments
