### PR TITLE
Fix #777 by handling MCPCall events in RunImpl

### DIFF
--- a/examples/hosted_mcp/approvals.py
+++ b/examples/hosted_mcp/approvals.py
@@ -48,7 +48,7 @@ async def main(verbose: bool, stream: bool):
         print(res.final_output)
 
     if verbose:
-        for item in result.new_items:
+        for item in res.new_items:
             print(item)
 
 

--- a/examples/hosted_mcp/simple.py
+++ b/examples/hosted_mcp/simple.py
@@ -34,7 +34,7 @@ async def main(verbose: bool, stream: bool):
         # The repository is primarily written in multiple languages, including Rust and TypeScript...
 
     if verbose:
-        for item in result.new_items:
+        for item in res.new_items:
             print(item)
 
 

--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -33,6 +33,7 @@ from openai.types.responses.response_output_item import (
     ImageGenerationCall,
     LocalShellCall,
     McpApprovalRequest,
+    McpCall,
     McpListTools,
 )
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem
@@ -456,6 +457,9 @@ class RunImpl:
                         )
             elif isinstance(output, McpListTools):
                 items.append(MCPListToolsItem(raw_item=output, agent=agent))
+            elif isinstance(output, McpCall):
+                items.append(ToolCallItem(raw_item=output, agent=agent))
+                tools_used.append("mcp")
             elif isinstance(output, ImageGenerationCall):
                 items.append(ToolCallItem(raw_item=output, agent=agent))
                 tools_used.append("image_generation")


### PR DESCRIPTION
This pull request resolves #777; If you think we should introduce a new item type for MCP call output, please let me know. As other hosted tools use this event, I believe using the same should be good to go tho.