### PR TITLE
Ensure item.model_dump only contains JSON serializable types

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -116,7 +116,7 @@ class MCPUtil:
         if len(result.content) == 1:
             tool_output = result.content[0].model_dump_json()
         elif len(result.content) > 1:
-            tool_output = json.dumps([item.model_dump() for item in result.content])
+            tool_output = json.dumps([item.model_dump(mode="json") for item in result.content])
         else:
             logger.error(f"Errored MCP tool result: {result}")
             tool_output = "Error running tool."


### PR DESCRIPTION
The EmbeddedResource from MCP tool call contains a field with type AnyUrl that is not JSON-serializable. To avoid this exception, use item.model_dump(mode="json") to ensure a JSON-serializable return value.