### PR TITLE
Add is_enabled to FunctionTool

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -181,7 +181,7 @@ class Runner:
 
             try:
                 while True:
-                    all_tools = await cls._get_all_tools(current_agent)
+                    all_tools = await cls._get_all_tools(current_agent, context_wrapper)
 
                     # Start an agent span if we don't have one. This span is ended if the current
                     # agent changes, or if the agent loop ends.
@@ -525,7 +525,7 @@ class Runner:
                 if streamed_result.is_complete:
                     break
 
-                all_tools = await cls._get_all_tools(current_agent)
+                all_tools = await cls._get_all_tools(current_agent, context_wrapper)
 
                 # Start an agent span if we don't have one. This span is ended if the current
                 # agent changes, or if the agent loop ends.
@@ -980,8 +980,10 @@ class Runner:
         return handoffs
 
     @classmethod
-    async def _get_all_tools(cls, agent: Agent[Any]) -> list[Tool]:
-        return await agent.get_all_tools()
+    async def _get_all_tools(
+        cls, agent: Agent[Any], context_wrapper: RunContextWrapper[Any]
+    ) -> list[Tool]:
+        return await agent.get_all_tools(context_wrapper)
 
     @classmethod
     def _get_model(cls, agent: Agent[Any], run_config: RunConfig) -> Model:

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -290,7 +290,7 @@ async def get_execute_result(
 
     processed_response = RunImpl.process_model_response(
         agent=agent,
-        all_tools=await agent.get_all_tools(),
+        all_tools=await agent.get_all_tools(context_wrapper or RunContextWrapper(None)),
         response=response,
         output_schema=output_schema,
         handoffs=handoffs,

--- a/tests/test_run_step_processing.py
+++ b/tests/test_run_step_processing.py
@@ -34,6 +34,10 @@ from .test_responses import (
 )
 
 
+def _dummy_ctx() -> RunContextWrapper[None]:
+    return RunContextWrapper(context=None)
+
+
 def test_empty_response():
     agent = Agent(name="test")
     response = ModelResponse(
@@ -83,7 +87,7 @@ async def test_single_tool_call():
         response=response,
         output_schema=None,
         handoffs=[],
-        all_tools=await agent.get_all_tools(),
+        all_tools=await agent.get_all_tools(_dummy_ctx()),
     )
     assert not result.handoffs
     assert result.functions and len(result.functions) == 1
@@ -111,7 +115,7 @@ async def test_missing_tool_call_raises_error():
             response=response,
             output_schema=None,
             handoffs=[],
-            all_tools=await agent.get_all_tools(),
+            all_tools=await agent.get_all_tools(_dummy_ctx()),
         )
 
 
@@ -140,7 +144,7 @@ async def test_multiple_tool_calls():
         response=response,
         output_schema=None,
         handoffs=[],
-        all_tools=await agent.get_all_tools(),
+        all_tools=await agent.get_all_tools(_dummy_ctx()),
     )
     assert not result.handoffs
     assert result.functions and len(result.functions) == 2
@@ -169,7 +173,7 @@ async def test_handoffs_parsed_correctly():
         response=response,
         output_schema=None,
         handoffs=[],
-        all_tools=await agent_3.get_all_tools(),
+        all_tools=await agent_3.get_all_tools(_dummy_ctx()),
     )
     assert not result.handoffs, "Shouldn't have a handoff here"
 
@@ -183,7 +187,7 @@ async def test_handoffs_parsed_correctly():
         response=response,
         output_schema=None,
         handoffs=Runner._get_handoffs(agent_3),
-        all_tools=await agent_3.get_all_tools(),
+        all_tools=await agent_3.get_all_tools(_dummy_ctx()),
     )
     assert len(result.handoffs) == 1, "Should have a handoff here"
     handoff = result.handoffs[0]
@@ -213,7 +217,7 @@ async def test_missing_handoff_fails():
             response=response,
             output_schema=None,
             handoffs=Runner._get_handoffs(agent_3),
-            all_tools=await agent_3.get_all_tools(),
+            all_tools=await agent_3.get_all_tools(_dummy_ctx()),
         )
 
 
@@ -236,7 +240,7 @@ async def test_multiple_handoffs_doesnt_error():
         response=response,
         output_schema=None,
         handoffs=Runner._get_handoffs(agent_3),
-        all_tools=await agent_3.get_all_tools(),
+        all_tools=await agent_3.get_all_tools(_dummy_ctx()),
     )
     assert len(result.handoffs) == 2, "Should have multiple handoffs here"
 
@@ -262,7 +266,7 @@ async def test_final_output_parsed_correctly():
         response=response,
         output_schema=Runner._get_output_schema(agent),
         handoffs=[],
-        all_tools=await agent.get_all_tools(),
+        all_tools=await agent.get_all_tools(_dummy_ctx()),
     )
 
 
@@ -288,7 +292,7 @@ async def test_file_search_tool_call_parsed_correctly():
         response=response,
         output_schema=None,
         handoffs=[],
-        all_tools=await agent.get_all_tools(),
+        all_tools=await agent.get_all_tools(_dummy_ctx()),
     )
     # The final item should be a ToolCallItem for the file search call
     assert any(
@@ -313,7 +317,7 @@ async def test_function_web_search_tool_call_parsed_correctly():
         response=response,
         output_schema=None,
         handoffs=[],
-        all_tools=await agent.get_all_tools(),
+        all_tools=await agent.get_all_tools(_dummy_ctx()),
     )
     assert any(
         isinstance(item, ToolCallItem) and item.raw_item is web_search_call
@@ -340,7 +344,7 @@ async def test_reasoning_item_parsed_correctly():
         response=response,
         output_schema=None,
         handoffs=[],
-        all_tools=await Agent(name="test").get_all_tools(),
+        all_tools=await Agent(name="test").get_all_tools(_dummy_ctx()),
     )
     assert any(
         isinstance(item, ReasoningItem) and item.raw_item is reasoning for item in result.new_items
@@ -409,7 +413,7 @@ async def test_computer_tool_call_without_computer_tool_raises_error():
             response=response,
             output_schema=None,
             handoffs=[],
-            all_tools=await Agent(name="test").get_all_tools(),
+            all_tools=await Agent(name="test").get_all_tools(_dummy_ctx()),
         )
 
 
@@ -437,7 +441,7 @@ async def test_computer_tool_call_with_computer_tool_parsed_correctly():
         response=response,
         output_schema=None,
         handoffs=[],
-        all_tools=await agent.get_all_tools(),
+        all_tools=await agent.get_all_tools(_dummy_ctx()),
     )
     assert any(
         isinstance(item, ToolCallItem) and item.raw_item is computer_call
@@ -468,7 +472,7 @@ async def test_tool_and_handoff_parsed_correctly():
         response=response,
         output_schema=None,
         handoffs=Runner._get_handoffs(agent_3),
-        all_tools=await agent_3.get_all_tools(),
+        all_tools=await agent_3.get_all_tools(_dummy_ctx()),
     )
     assert result.functions and len(result.functions) == 1
     assert len(result.handoffs) == 1, "Should have a handoff here"


### PR DESCRIPTION
### Summary:
Allows a user to do `function_tool(is_enabled=<some_callable>)`; the callable is called when the agent runs.

This allows you to dynamically enable/disable a tool based on the context/env. 

The meta-goal is to allow `Agent` to be effectively immutable. That enables some nice things down the line, and this allows you to dynamically modify the tools list without mutating the agent.

### Test Plan:
Unit tests

towards #767
