### PR TITLE
Fix handoff transfer message JSON

### DIFF
--- a/src/agents/handoffs.py
+++ b/src/agents/handoffs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Generic, cast, overload
@@ -99,8 +100,7 @@ class Handoff(Generic[TContext]):
     """
 
     def get_transfer_message(self, agent: Agent[Any]) -> str:
-        base = f"{{'assistant': '{agent.name}'}}"
-        return base
+        return json.dumps({"assistant": agent.name})
 
     @classmethod
     def default_tool_name(cls, agent: Agent[Any]) -> str:

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import pytest
@@ -276,3 +277,10 @@ def test_handoff_input_schema_is_strict():
         "additionalProperties" in obj.input_json_schema
         and not obj.input_json_schema["additionalProperties"]
     ), "Input schema should be strict and have additionalProperties=False"
+
+
+def test_get_transfer_message_is_valid_json() -> None:
+    agent = Agent(name="foo")
+    obj = handoff(agent)
+    transfer = obj.get_transfer_message(agent)
+    assert json.loads(transfer) == {"assistant": agent.name}


### PR DESCRIPTION
## Summary
- ensure `Handoff.get_transfer_message` emits valid JSON
- test transfer message validity

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_i_68432f925b048324a16878d28e850841