### PR TITLE
Refactor tracing provider

### DIFF
--- a/src/agents/tracing/__init__.py
+++ b/src/agents/tracing/__init__.py
@@ -1,6 +1,6 @@
 import atexit
 
-from agents.tracing.provider import TraceProvider
+from agents.tracing.provider import DefaultTraceProvider
 
 from .create import (
     agent_span,
@@ -107,7 +107,7 @@ def set_tracing_export_api_key(api_key: str) -> None:
     default_exporter().set_api_key(api_key)
 
 
-set_trace_provider(TraceProvider())
+set_trace_provider(DefaultTraceProvider())
 # Add the default processor, which exports traces and spans to the backend in batches. You can
 # change the default behavior by either:
 # 1. calling add_trace_processor(), which adds additional processors, or


### PR DESCRIPTION
## Summary
- make `TraceProvider` an abstract base class
- introduce `DefaultTraceProvider` for the default implementation

## Testing
- `make mypy`
- `make tests`
- `make format` *(fails: Could not connect, are you offline?)*
- `make lint` *(fails: Could not connect, are you offline?)*

------
https://chatgpt.com/codex/tasks/task_i_6849b96b8cc083209312411e2045ee3d