### PR TITLE
Added mcp tool filtering and unit test

### DIFF
--- a/tests/mcp/test_allowed_tools.py
+++ b/tests/mcp/test_allowed_tools.py
@@ -1,0 +1,56 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from mcp.types import ListToolsResult, Tool as MCPTool
+
+from agents.mcp import MCPServerStdio
+
+from .helpers import DummyStreamsContextManager, tee
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_server_allowed_tools(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    """Test that if we specified allowed tools, the list of tools is reduced and contains only
+    the allowed ones on each call to `list_tools()`.
+    """
+    allowed_tools = ["tool1", "tool3"]
+    server = MCPServerStdio(
+        params={
+            "command": tee,
+        },
+        cache_tools_list=True,
+        allowed_tools=allowed_tools
+    )
+
+    all_tools = [
+        MCPTool(name="tool1", inputSchema={}),
+        MCPTool(name="tool2", inputSchema={}),
+        MCPTool(name="tool3", inputSchema={}),
+        MCPTool(name="tool4", inputSchema={}),
+    ]
+
+    mock_list_tools.return_value = ListToolsResult(tools=all_tools)
+
+    async with server:
+        tools = await server.list_tools()
+
+        # Check it returns only the number of allowed tools
+        assert len(tools) == len(allowed_tools)
+        # Check it returns exactly only the allowed tools
+        assert {tool.name for tool in tools} == set(allowed_tools)
+
+        # Call list_tools() again, should use cached filtered results
+        tools = await server.list_tools()
+        assert len(tools) == len(allowed_tools)
+        assert {tool.name for tool in tools} == set(allowed_tools)
+
+        # Invalidate cache and verify filtering still works
+        server.invalidate_tools_cache()
+        tools = await server.list_tools()
+        assert len(tools) == len(allowed_tools)
+        assert {tool.name for tool in tools} == set(allowed_tools)


### PR DESCRIPTION
### Summary

Considering multiple requests to add this feature #830, #851 , I added a parameter to MCP servers to filter out some tools.
Let me know if you want to implement something in a different way and if I have to update the documentation.

### Test plan

I added a unit test to check that only the allowed tools are returned by the server.

### Issue number

It should close #830 and #851 .

### Checks

- [ ✅] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [✅ ] I've run `make lint` and `make format`
- [✅ ] I've made sure tests pass