### PR TITLE
Fix function_schema name override bug

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -223,7 +223,8 @@ def function_schema(
         doc_info = None
         param_descs = {}
 
-    func_name = name_override or doc_info.name if doc_info else func.__name__
+    # Ensure name_override takes precedence even if docstring info is disabled.
+    func_name = name_override or (doc_info.name if doc_info else func.__name__)
 
     # 2. Inspect function signature and get type hints
     sig = inspect.signature(func)

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -439,3 +439,15 @@ def test_schema_with_mapping_raises_strict_mode_error():
 
     with pytest.raises(UserError):
         function_schema(func_with_mapping)
+
+
+def test_name_override_without_docstring() -> None:
+    """name_override should be used even when not parsing docstrings."""
+
+    def foo(x: int) -> int:
+        return x
+
+    fs = function_schema(foo, use_docstring_info=False, name_override="custom")
+
+    assert fs.name == "custom"
+    assert fs.params_json_schema.get("title") == "custom_args"


### PR DESCRIPTION
## Summary
- ensure `name_override` is always used in `function_schema`
- test name override when docstring info is disabled

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_i_684f1cf885b08321b4dd3f4294e24ca2