### PR TITLE
Add uv as an alternative Python environment setup option for issue #884

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,21 @@ Explore the [examples](examples) directory to see the SDK in action, and read ou
 
 1. Set up your Python environment
 
-```
+- Option A: Using venv (traditional method)
+```bash
 python -m venv env
-source env/bin/activate
+source env/bin/activate  # On Windows: env\Scripts\activate
+```
+
+- Option B: Using uv (recommended)
+```bash
+uv venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 ```
 
 2. Install Agents SDK
 
-```
+```bash
 pip install openai-agents
 ```
 


### PR DESCRIPTION
- Add Option A (venv) and Option B (uv) in Get started section
- Mark uv as recommended to align with development workflow
- Include Windows activation commands for both options
- Resolves #884