### PR TITLE
docs: correct step 1 of Output guardrails to use agent's output (#890)

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -11,7 +11,7 @@ There are two kinds of guardrails:
 
 Input guardrails run in 3 steps:
 
-1. First, the guardrail receives the same input passed to the agent.
+1. First, the guardrail receives the same output produced by the agent.
 2. Next, the guardrail function runs to produce a [`GuardrailFunctionOutput`][agents.guardrail.GuardrailFunctionOutput], which is then wrapped in an [`InputGuardrailResult`][agents.guardrail.InputGuardrailResult]
 3. Finally, we check if [`.tripwire_triggered`][agents.guardrail.GuardrailFunctionOutput.tripwire_triggered] is true. If true, an [`InputGuardrailTripwireTriggered`][agents.exceptions.InputGuardrailTripwireTriggered] exception is raised, so you can appropriately respond to the user or handle the exception.
 


### PR DESCRIPTION
This PR fixes a typo in the “Output guardrails run in 3 steps” section by updating step 1 to refer to the agent’s output rather than its input.

- Changed “First, the guardrail receives the same input passed to the agent.”
  to “First, the guardrail receives the same output produced by the agent.”

Closes openai/openai-agents-python#890
