### PR TITLE
Enable developers to initialize built-in tools in a simpler way

### DIFF
--- a/examples/hosted_mcp/approvals.py
+++ b/examples/hosted_mcp/approvals.py
@@ -27,7 +27,6 @@ async def main(verbose: bool, stream: bool):
         tools=[
             HostedMCPTool(
                 tool_config={
-                    "type": "mcp",
                     "server_label": "gitmcp",
                     "server_url": "https://gitmcp.io/openai/codex",
                     "require_approval": "always",

--- a/examples/hosted_mcp/simple.py
+++ b/examples/hosted_mcp/simple.py
@@ -13,7 +13,6 @@ async def main(verbose: bool, stream: bool):
         tools=[
             HostedMCPTool(
                 tool_config={
-                    "type": "mcp",
                     "server_label": "gitmcp",
                     "server_url": "https://gitmcp.io/openai/codex",
                     "require_approval": "never",

--- a/examples/tools/code_interpreter.py
+++ b/examples/tools/code_interpreter.py
@@ -7,11 +7,7 @@ async def main():
     agent = Agent(
         name="Code interpreter",
         instructions="You love doing math.",
-        tools=[
-            CodeInterpreterTool(
-                tool_config={"type": "code_interpreter", "container": {"type": "auto"}},
-            )
-        ],
+        tools=[CodeInterpreterTool(tool_config={"container": {"type": "auto"}})],
     )
 
     with trace("Code interpreter example"):

--- a/examples/tools/image_generator.py
+++ b/examples/tools/image_generator.py
@@ -23,11 +23,7 @@ async def main():
     agent = Agent(
         name="Image generator",
         instructions="You are a helpful agent.",
-        tools=[
-            ImageGenerationTool(
-                tool_config={"type": "image_generation", "quality": "low"},
-            )
-        ],
+        tools=[ImageGenerationTool(tool_config={"quality": "low"})],
     )
 
     with trace("Image generation example"):

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -193,6 +193,10 @@ class HostedMCPTool:
     def name(self):
         return "hosted_mcp"
 
+    def __post_init__(self):
+        if "type" not in self.tool_config:
+            self.tool_config["type"] = "mcp"
+
 
 @dataclass
 class CodeInterpreterTool:
@@ -204,6 +208,10 @@ class CodeInterpreterTool:
     @property
     def name(self):
         return "code_interpreter"
+
+    def __post_init__(self):
+        if "type" not in self.tool_config:
+            self.tool_config["type"] = "code_interpreter"
 
 
 @dataclass
@@ -217,6 +225,10 @@ class ImageGenerationTool:
     def name(self):
         return "image_generation"
 
+    def __post_init__(self):
+        if "type" not in self.tool_config:
+            self.tool_config["type"] = "image_generation"
+
 
 @dataclass
 class LocalShellCommandRequest:
@@ -227,6 +239,10 @@ class LocalShellCommandRequest:
 
     data: LocalShellCall
     """The data from the local shell tool call."""
+
+    def __post_init__(self):
+        if "type" not in self.data:
+            self.data["type"] = "local_shell_call"
 
 
 LocalShellExecutor = Callable[[LocalShellCommandRequest], MaybeAwaitable[str]]


### PR DESCRIPTION
This pull request enhances the tool data classes to enable developers to omit the required "type" property. Passing the property works too, so this does not bring any breaking changes. (for context, I received feedback from a customer that passing the similar name when initializing these classes looks quite redundant)