### PR TITLE
Removed lines to avoid duplicate output in REPL utility

### DIFF
--- a/src/agents/repl.py
+++ b/src/agents/repl.py
@@ -5,7 +5,7 @@ from typing import Any
 from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
 
 from .agent import Agent
-from .items import ItemHelpers, TResponseInputItem
+from .items import TResponseInputItem
 from .result import RunResultBase
 from .run import Runner
 from .stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent, RunItemStreamEvent
@@ -50,9 +50,6 @@ async def run_demo_loop(agent: Agent[Any], *, stream: bool = True) -> None:
                         print("\n[tool called]", flush=True)
                     elif event.item.type == "tool_call_output_item":
                         print(f"\n[tool output: {event.item.output}]", flush=True)
-                    elif event.item.type == "message_output_item":
-                        message = ItemHelpers.text_message_output(event.item)
-                        print(message, end="", flush=True)
                 elif isinstance(event, AgentUpdatedStreamEvent):
                     print(f"\n[Agent updated: {event.new_agent.name}]", flush=True)
             print()


### PR DESCRIPTION
In the REPL utility, the final output was printed after the streaming, causing a duplication issue.

I only removed the lines within the stream mode that printed the final output. It should not affect any other use case of the utility.

It solves a comment done in #784 .