### PR TITLE
Add exempt-issue-labels to the issue triage GH Action job

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -21,6 +21,7 @@ jobs:
           days-before-pr-stale: 10
           days-before-pr-close: 7
           stale-pr-label: "stale"
+          exempt-issue-labels: "skip-stale"
           stale-pr-message: "This PR is stale because it has been open for 10 days with no activity."
           close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Like I did for the TypeScript SDK project (see https://github.com/openai/openai-agents-js/pull/97), we may want to have the labels to exclude the issues from auto-closing. Some of the issues that have been open for a while could just need time.