### PR TITLE
Fix #892 by adding proper tool description in context.md

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -38,7 +38,8 @@ class UserInfo:  # (1)!
 
 @function_tool
 async def fetch_user_age(wrapper: RunContextWrapper[UserInfo]) -> str:  # (2)!
-    return f"User {wrapper.context.name} is 47 years old"
+    """Fetch the age of the user. Call this function to get user's age information."""
+    return f"The user {wrapper.context.name} is 47 years old"
 
 async def main():
     user_info = UserInfo(name="John", uid=123)


### PR DESCRIPTION
### Summary

This pull request fixes [issue #892](https://github.com/openai/openai-agents-python/issues/892) by adding a missing docstring to the `fetch_user_age` tool function in `docs/context.md`.

### Problem

Many non-OpenAI LLMs (such as Claude, Gemini, Mistral, etc.) are unable to use the `fetch_user_age` function because it lacks a docstring. As a result, they return responses like:

> "I cannot determine the user's age because the available tools lack the ability to fetch user-specific information."

### Changes Made

- Added a one-line docstring to the `fetch_user_age` function
- Improved return statement to match expected tool output

```python
@function_tool
async def fetch_user_age(wrapper: RunContextWrapper[UserInfo]) -> str:
    """Fetch the age of the user. Call this function to get user's age information."""
    return f"The user {wrapper.context.name} is 47 years old"