### PR TITLE
Duplicate Classifier in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Issue: "Intended Audience :: Developers" appears twice in the classifiers list. Line Number 20 and Line Number 26 Fix: Removed the duplicate classifier entry