### PR TITLE
Import Path Inconsistency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: MIT License",

--- a/src/agents/tracing/__init__.py
+++ b/src/agents/tracing/__init__.py
@@ -1,6 +1,6 @@
 import atexit
 
-from agents.tracing.provider import DefaultTraceProvider, TraceProvider
+from .provider import DefaultTraceProvider, TraceProvider
 
 from .create import (
     agent_span,


### PR DESCRIPTION
There's an inconsistent import style in the tracing module where one import uses an absolute path in line number 3 while all others use relative imports