### PR TITLE
description_override is not properly used for function_schema.description

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -337,7 +337,8 @@ def function_schema(
     # 5. Return as a FuncSchema dataclass
     return FuncSchema(
         name=func_name,
-        description=description_override or doc_info.description if doc_info else None,
+        # Ensure description_override takes precedence even if docstring info is disabled.
+        description=description_override or (doc_info.description if doc_info else None),
         params_pydantic_model=dynamic_model,
         params_json_schema=json_schema,
         signature=sig,


### PR DESCRIPTION
Describe the bug
A clear and concise description of what the bug is.

In the function_schema method of the OpenAI Agents SDK, the following line:

```python
description=description_override or doc_info.description if doc_info else None
```

does not honor description_override when `use_docstring_info=False`. This happens because of operator precedence in Python. Without parentheses, the expression is interpreted as:

```python
description=(description_override or doc_info.description) if doc_info else None
```
So when doc_info is None, even if description_override is set, it falls back to None

Debug information
Python version (e.g. Python 3.10)
Repro steps

```python
from agents.function_schema import function_schema

def my_func():
    pass

schema = function_schema(
    my_func,
    description_override ="CustomDescription",
    use_docstring_info=False
)

print(schema.description) # Expected: "CustomDescription", Actual: None
```
Expected behavior

Even when use_docstring_info=False, if description_override is provided, it should be used for description.

Suggested Fix:
Update this line:
description=description_override or doc_info.description if doc_info else None
To this (with parentheses to enforce correct evaluation):
description=description_override or (doc_info.description if doc_info else None)