### PR TITLE
Fix: Ensure output_guardrail provides function name instead of defaulting to None

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -310,7 +310,8 @@ def output_guardrail(
     def decorator(
         f: _OutputGuardrailFuncSync[TContext_co] | _OutputGuardrailFuncAsync[TContext_co],
     ) -> OutputGuardrail[TContext_co]:
-        return OutputGuardrail(guardrail_function=f, name=name)
+        #Updating default name None to the function name of guardrail_function if no name is provided.
+        return OutputGuardrail(guardrail_function=f, name=name if name else f.__name__)
 
     if func is not None:
         # Decorator was used without parentheses


### PR DESCRIPTION
This PR improves the output_guardrail feature by ensuring that a valid function name is always provided. Previously, if the name attribute was missing, it defaulted to None. This change introduces a fallback name to avoid unexpected behavior or errors in downstream processes.

