### PR TITLE
feat: Ignore reasoning items in chat completion converter

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -302,7 +302,11 @@ class Converter:
             return current_assistant_msg
 
         for item in items:
-            # 1) Check easy input message
+                        # 1) Ignore reasoning items, which are not sent to the LLM.
+            if isinstance(item, dict) and item.get("type") == "reasoning":
+                continue
+
+            # 2) Check easy input message
             if easy_msg := cls.maybe_easy_input_message(item):
                 role = easy_msg["role"]
                 content = easy_msg["content"]

--- a/tests/test_openai_chatcompletions_converter.py
+++ b/tests/test_openai_chatcompletions_converter.py
@@ -428,3 +428,17 @@ def test_assistant_messages_in_history():
     assert messages[1]["content"] == "Hello?"
     assert messages[2]["role"] == "user"
     assert messages[2]["content"] == "What was my Name?"
+
+
+def test_items_to_messages_ignores_reasoning_item() -> None:
+    """
+    A `reasoning` item in the input should be ignored, resulting in an empty
+    message list if it's the only item.
+    """
+    reasoning_item: TResponseInputItem = {
+        "type": "reasoning",
+        "reasoning": "Thinking about what to do...",  # type: ignore
+    }
+    messages = Converter.items_to_messages([reasoning_item])
+    assert len(messages) == 0
+


### PR DESCRIPTION
This change modifies the ChatCompletion converter to explicitly ignore items of type 'reasoning'. These items are internal to the agent's thought process and should not be sent to the language model as part of the conversation history.

A corresponding unit test has been added to ensure that these items are correctly filtered out.