### PR TITLE
Support for file_input content  (#fix 893)

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -19,6 +19,7 @@ from openai.types.chat import (
     ChatCompletionToolMessageParam,
     ChatCompletionUserMessageParam,
 )
+from openai.types.chat.chat_completion_content_part_param import File, FileFile
 from openai.types.chat.chat_completion_tool_param import ChatCompletionToolParam
 from openai.types.chat.completion_create_params import ResponseFormat
 from openai.types.responses import (
@@ -251,7 +252,8 @@ class Converter:
                     )
                 )
             elif isinstance(c, dict) and c.get("type") == "input_file":
-                raise UserError(f"File uploads are not supported for chat completions {c}")
+                out.append(File(type="file",
+                                file=FileFile(file_data=c.get("file_data"))))
             else:
                 raise UserError(f"Unknown content: {c}")
         return out


### PR DESCRIPTION
PDF and file upload are supported by litellm and various models. 

This PR enables them. 

fixes #893 