### PR TITLE
docs: mention 'name' is required in Agent constructor . fix: mention 'name' as required in Agent init doc

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,6 +6,7 @@ Agents are the core building block in your apps. An agent is a large language mo
 
 The most common properties of an agent you'll configure are:
 
+-   `name`: A required string that identifies your agent.
 -   `instructions`: also known as a developer message or system prompt.
 -   `model`: which LLM to use, and optional `model_settings` to configure model tuning parameters like temperature, top_p, etc.
 -   `tools`: Tools that the agent can use to achieve its tasks.


### PR DESCRIPTION
## What

Updated the docs under `docs/agents.md` to clarify that the `name` argument is required when initializing an `Agent`.

## Why

Without this clarification, users get a confusing error:
`TypeError: Agent.__init__() missing 1 required positional argument: 'name'`

This matches the actual constructor in the source code and helps future devs avoid frustration.

## Reference

- Source: [`agent.py`](https://github.com/openai/openai-agents-python/blob/main/src/agents/agent.py)
