### PR TITLE
Add Makefile check rule to run all the linters and checkers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ format:
 	uv run ruff format
 	uv run ruff check --fix
 
+.PHONY: format-check
+format-check:
+	uv run ruff format --check
+
 .PHONY: lint
 lint: 
 	uv run ruff check
@@ -55,5 +59,5 @@ serve-docs:
 deploy-docs:
 	uv run mkdocs gh-deploy --force --verbose
 
-	
-	
+.PHONY: check
+check: format-check lint mypy tests

--- a/README.md
+++ b/README.md
@@ -171,9 +171,15 @@ make sync
 2. (After making changes) lint/test
 
 ```
+make check # run tests linter and typechecker
+```
+
+Or to run them individually:
+```
 make tests  # run tests
 make mypy   # run typechecker
 make lint   # run linter
+make format-check # run style checker
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
It adds a Makefile rule `check` to run all linters and checkers in a single command. 

With only `make check`  instead of 3-4 commands, it can help to forget one of them before pushing a PR. 
