### PR TITLE
fix: Apply strict JSON schema validation in FunctionTool constructor

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -24,6 +24,7 @@ from .function_schema import DocstringStyle, function_schema
 from .items import RunItem
 from .logger import logger
 from .run_context import RunContextWrapper
+from .strict_schema import ensure_strict_json_schema
 from .tool_context import ToolContext
 from .tracing import SpanError
 from .util import _error_tracing
@@ -92,6 +93,10 @@ class FunctionTool:
     """Whether the tool is enabled. Either a bool or a Callable that takes the run context and agent
     and returns whether the tool is enabled. You can use this to dynamically enable/disable a tool
     based on your context/state."""
+
+    def __post_init__(self):
+        if self.strict_json_schema:
+            self.params_json_schema = ensure_strict_json_schema(self.params_json_schema)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Fixes an issue where directly created `FunctionTool` objects fail with OpenAI's Responses API due to missing `additionalProperties: false` in the JSON schema, while the `@function_tool` decorator works correctly.

## Problem
The documentation example for creating `FunctionTool` objects directly fails with:
```
Error code: 400 - {'error': {'message': "Invalid schema for function 'process_user': In context=(), 'additionalProperties' is required to be supplied and to be false.", 'type': 'invalid_request_error', 'param': 'tools[0].parameters', 'code': 'invalid_function_parameters'}}
```

This creates an inconsistency between `FunctionTool` and `@function_tool` behavior, both of which have `strict_json_schema=True` by default.

## Solution
- Added `__post_init__` method to `FunctionTool` dataclass
- Automatically applies `ensure_strict_json_schema()` when `strict_json_schema=True`
- Makes behavior consistent with `@function_tool` decorator
- Maintains backward compatibility

## Testing
The fix can be verified by running the reproduction case from the issue:

```python
from typing import Any
from pydantic import BaseModel
from agents import RunContextWrapper, FunctionTool, Agent, Runner

class FunctionArgs(BaseModel):
    username: str
    age: int

async def run_function(ctx: RunContextWrapper[Any], args: str) -> str:
    parsed = FunctionArgs.model_validate_json(args)
    return f"{parsed.username} is {parsed.age} years old"

# This now works without manual ensure_strict_json_schema() call
tool = FunctionTool(
    name="process_user",
    description="Processes extracted user data",
    params_json_schema=FunctionArgs.model_json_schema(),
    on_invoke_tool=run_function,
)

agent = Agent(
    name="Test Agent",
    instructions="You are a test agent",
    tools=[tool]
)

result = Runner.run_sync(agent, "Process user data for John who is 30 years old")
```
