### PR TITLE
Fix incorrect comment order when popping session items

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -101,8 +101,8 @@ result = await Runner.run(
 print(f"Agent: {result.final_output}")
 
 # User wants to correct their question
-user_item = await session.pop_item()  # Remove user's question
 assistant_item = await session.pop_item()  # Remove agent's response
+user_item = await session.pop_item()  # Remove user's question
 
 # Ask a corrected question
 result = await Runner.run(


### PR DESCRIPTION
The previous comments incorrectly suggested that the user's question was removed before the assistant's response. This fix updates the comment order to reflect the actual sequence of the code execution.
