### PR TITLE
Feat/prompts caching

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -169,9 +169,9 @@ agent = Agent(
 
 ## Caching
 
-Every time an Agent runs, it calls `list_tools()` on the MCP server. This can be a latency hit, especially if the server is a remote server. To automatically cache the list of tools, you can pass `cache_tools_list=True` to [`MCPServerStdio`][agents.mcp.server.MCPServerStdio], [`MCPServerSse`][agents.mcp.server.MCPServerSse], and [`MCPServerStreamableHttp`][agents.mcp.server.MCPServerStreamableHttp]. You should only do this if you're certain the tool list will not change.
+Every time an Agent runs, it calls `list_tools()` and `list_prompts()` on the MCP server. This can be a latency hit, especially if the server is a remote server. To automatically cache the list of tools and prompts, you can pass `cache_tools_list=True` and `cache_prompts_list=True` to [`MCPServerStdio`][agents.mcp.server.MCPServerStdio], [`MCPServerSse`][agents.mcp.server.MCPServerSse], and [`MCPServerStreamableHttp`][agents.mcp.server.MCPServerStreamableHttp]. You should only do this if you're certain the tools and the prompts lists will not change.
 
-If you want to invalidate the cache, you can call `invalidate_tools_cache()` on the servers.
+If you want to invalidate the cache, you can call `invalidate_tools_cache()` and `invalidate_prompts_cache()` on the servers.
 
 ## End-to-end examples
 

--- a/examples/mcp/caching/README.md
+++ b/examples/mcp/caching/README.md
@@ -1,0 +1,13 @@
+# Caching Example
+
+This example show how to integrate tools and prompts caching using a Streamable HTTP server in [server.py](server.py).
+
+Run the example via:
+
+```
+uv run python examples/mcp/caching/main.py
+```
+
+## Details
+
+The example uses the `MCPServerStreamableHttp` class from `agents.mcp`. The server runs in a sub-process at `https://localhost:8000/mcp`.

--- a/examples/mcp/caching/main.py
+++ b/examples/mcp/caching/main.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 from typing import Any
 
-from mcp.types import ListPromptsResult
+from mcp.types import ListPromptsResult, MCPTool
 
 from agents import gen_trace_id, trace
 from agents.mcp import MCPServerStreamableHttp
@@ -18,8 +18,12 @@ async def run(mcp_server: MCPServerStreamableHttp):
     print("Cached tools names after invoking list_tools")
     await mcp_server.list_tools()
     cached_tools_list = mcp_server._tools_list
-    for tool in cached_tools_list:
-        print(f"name: {tool.name}")
+    if cached_tools_list:
+        for tool in cached_tools_list:
+            print(f"name: {tool.name}")
+
+    else:
+        print("Failed to cache list_prompts")
 
     print("Cached prompts before invoking list_prompts")
     print(mcp_server._prompts_list)

--- a/examples/mcp/caching/main.py
+++ b/examples/mcp/caching/main.py
@@ -10,19 +10,19 @@ from agents.mcp import MCPServerStreamableHttp
 
 
 async def run(mcp_server: MCPServerStreamableHttp):
-    print(f"Cached tools before invoking tool_list")
+    print("Cached tools before invoking tool_list")
     print(mcp_server._tools_list)
 
-    print(f"Cached tools names after invoking list_tools")
+    print("Cached tools names after invoking list_tools")
     await mcp_server.list_tools()
     cached_tools_list = mcp_server._tools_list
     for tool in cached_tools_list:
         print(f"name: {tool.name}")
 
-    print(f"Cached prompts before invoking list_prompts")
+    print("Cached prompts before invoking list_prompts")
     print(mcp_server._prompts_list)
 
-    print(f"\nCached prompts after invoking list_prompts")
+    print("\nCached prompts after invoking list_prompts")
     await mcp_server.list_prompts()
     cached_prompts_list = mcp_server._prompts_list
     for prompt in cached_prompts_list.prompts:

--- a/examples/mcp/caching/main.py
+++ b/examples/mcp/caching/main.py
@@ -1,0 +1,74 @@
+import asyncio
+import os
+import shutil
+import subprocess
+import time
+from typing import Any
+
+from agents import gen_trace_id, trace
+from agents.mcp import MCPServerStreamableHttp
+
+
+async def run(mcp_server: MCPServerStreamableHttp):
+    print(f"Cached tools before invoking tool_list")
+    print(mcp_server._tools_list)
+    await mcp_server.list_tools()
+    print(f"Cached tools names after invoking list_tools")
+    cached_tools_list = mcp_server._tools_list
+    for tool in cached_tools_list:
+        print(f"name: {tool.name}")
+
+    print(f"Cached prompts before invoking list_prompts")
+    print(mcp_server._prompts_list)
+    await mcp_server.list_prompts()
+    print(f"\nCached prompts after invoking list_prompts")
+    cached_prompts_list = mcp_server._prompts_list
+    for prompt in cached_prompts_list.prompts:
+        print(f"name: {prompt.name}")
+
+async def main():
+    async with MCPServerStreamableHttp(
+        name="Streamable HTTP Python Server",
+        cache_tools_list=True,
+        cache_prompts_list=True,
+        params={
+            "url": "http://localhost:8000/mcp",
+        },
+    ) as server:
+        trace_id = gen_trace_id()
+        with trace(workflow_name="Caching Example", trace_id=trace_id):
+            print(f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n")
+            await run(server)
+
+
+if __name__ == "__main__":
+    # Let's make sure the user has uv installed
+    if not shutil.which("uv"):
+        raise RuntimeError(
+            "uv is not installed. Please install it: https://docs.astral.sh/uv/getting-started/installation/"
+        )
+
+    # We'll run the Streamable HTTP server in a subprocess. Usually this would be a remote server, but for this
+    # demo, we'll run it locally at http://localhost:8000/mcp
+    process: subprocess.Popen[Any] | None = None
+    try:
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        server_file = os.path.join(this_dir, "server.py")
+
+        print("Starting Streamable HTTP server at http://localhost:8000/mcp ...")
+
+        # Run `uv run server.py` to start the Streamable HTTP server
+        process = subprocess.Popen(["uv", "run", server_file])
+        # Give it 3 seconds to start
+        time.sleep(3)
+
+        print("Streamable HTTP server started. Running example...\n\n")
+    except Exception as e:
+        print(f"Error starting Streamable HTTP server: {e}")
+        exit(1)
+
+    try:
+        asyncio.run(main())
+    finally:
+        if process:
+            process.terminate()

--- a/examples/mcp/caching/main.py
+++ b/examples/mcp/caching/main.py
@@ -5,6 +5,8 @@ import subprocess
 import time
 from typing import Any
 
+from mcp.types import ListPromptsResult
+
 from agents import gen_trace_id, trace
 from agents.mcp import MCPServerStreamableHttp
 
@@ -25,8 +27,11 @@ async def run(mcp_server: MCPServerStreamableHttp):
     print("Cached prompts after invoking list_prompts")
     await mcp_server.list_prompts()
     cached_prompts_list = mcp_server._prompts_list
-    for prompt in cached_prompts_list.prompts:
-        print(f"name: {prompt.name}")
+    if isinstance(cached_prompts_list, ListPromptsResult):
+        for prompt in cached_prompts_list.prompts:
+            print(f"name: {prompt.name}")
+    else:
+        print("Failed to cache list_prompts")
 
 async def main():
     async with MCPServerStreamableHttp(

--- a/examples/mcp/caching/main.py
+++ b/examples/mcp/caching/main.py
@@ -12,16 +12,18 @@ from agents.mcp import MCPServerStreamableHttp
 async def run(mcp_server: MCPServerStreamableHttp):
     print(f"Cached tools before invoking tool_list")
     print(mcp_server._tools_list)
-    await mcp_server.list_tools()
+
     print(f"Cached tools names after invoking list_tools")
+    await mcp_server.list_tools()
     cached_tools_list = mcp_server._tools_list
     for tool in cached_tools_list:
         print(f"name: {tool.name}")
 
     print(f"Cached prompts before invoking list_prompts")
     print(mcp_server._prompts_list)
-    await mcp_server.list_prompts()
+
     print(f"\nCached prompts after invoking list_prompts")
+    await mcp_server.list_prompts()
     cached_prompts_list = mcp_server._prompts_list
     for prompt in cached_prompts_list.prompts:
         print(f"name: {prompt.name}")

--- a/examples/mcp/caching/main.py
+++ b/examples/mcp/caching/main.py
@@ -5,8 +5,6 @@ import subprocess
 import time
 from typing import Any
 
-from mcp.types import ListPromptsResult, MCPTool
-
 from agents import gen_trace_id, trace
 from agents.mcp import MCPServerStreamableHttp
 
@@ -31,7 +29,7 @@ async def run(mcp_server: MCPServerStreamableHttp):
     print("Cached prompts after invoking list_prompts")
     await mcp_server.list_prompts()
     cached_prompts_list = mcp_server._prompts_list
-    if isinstance(cached_prompts_list, ListPromptsResult):
+    if cached_prompts_list:
         for prompt in cached_prompts_list.prompts:
             print(f"name: {prompt.name}")
     else:

--- a/examples/mcp/caching/main.py
+++ b/examples/mcp/caching/main.py
@@ -22,7 +22,7 @@ async def run(mcp_server: MCPServerStreamableHttp):
     print("Cached prompts before invoking list_prompts")
     print(mcp_server._prompts_list)
 
-    print("\nCached prompts after invoking list_prompts")
+    print("Cached prompts after invoking list_prompts")
     await mcp_server.list_prompts()
     cached_prompts_list = mcp_server._prompts_list
     for prompt in cached_prompts_list.prompts:

--- a/examples/mcp/caching/server.py
+++ b/examples/mcp/caching/server.py
@@ -1,0 +1,37 @@
+import random
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+# Create server
+mcp = FastMCP("Echo Server")
+
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers"""
+    print(f"[debug-server] add({a}, {b})")
+    return a + b
+
+
+@mcp.tool()
+def get_secret_word() -> str:
+    print("[debug-server] get_secret_word()")
+    return random.choice(["apple", "banana", "cherry"])
+
+
+@mcp.tool()
+def get_current_weather(city: str) -> str:
+    print(f"[debug-server] get_current_weather({city})")
+
+    endpoint = "https://wttr.in"
+    response = requests.get(f"{endpoint}/{city}")
+    return response.text
+
+@mcp.prompt()
+def system_prompt() -> str:
+    return "Use the tools to answer the questions."
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -305,7 +305,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             self._cache_dirty_prompts = False
             # Fetch the prompts from the server
             self._prompts_list = await self.session.list_prompts()
-            prompts = self._tools_list
+            prompts = self._prompts_list
 
         return prompts
 

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -91,18 +91,19 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         """
         Args:
             cache_tools_list: Whether to cache the tools list. If `True`, the tools list will be
-            cached and only fetched from the server once. If `False`, the tools list will be
-            fetched from the server on each call to `list_tools()`. The cache can be invalidated
-            by calling `invalidate_tools_cache()`. You should set this to `True` if you know the
-            server will not change its tools list, because it can drastically improve latency
-            (by avoiding a round-trip to the server every time).
+                cached and only fetched from the server once. If `False`, the tools list will be
+                fetched from the server on each call to `list_tools()`. The cache can be invalidated
+                by calling `invalidate_tools_cache()`. You should set this to `True` if you know the
+                server will not change its tools list, because it can drastically improve latency
+                (by avoiding a round-trip to the server every time).
 
-            cache_prompts_list: Whether to cache the prompts list. If `True`, the prompts list will be
-            cached and only fetched from the server once. If `False`, the prompts list will be
-            fetched from the server on each call to `list_prompts()`. The cache can be invalidated
-            by calling `invalidate_prompts_cache()`. You should set this to `True` if you know the
-            server will not change its prompts list, because it can drastically improve latency
-            (by avoiding a round-trip to the server every time).
+            cache_prompts_list: Whether to cache the prompts list. If `True`, the prompts list
+                will be cached and only fetched from the server once. If `False`, the prompts
+                list will be fetched from the server on each call to `list_prompts()`.
+                The cache can be invalidated by calling `invalidate_prompts_cache()`.
+                You should set this to `True` if you know the server will not change
+                its prompts list, because it can drastically improve latency
+                (by avoiding a round-trip to the server every time).
 
             client_session_timeout_seconds: the read timeout passed to the MCP ClientSession.
             tool_filter: The tool filter to use for filtering tools.
@@ -387,11 +388,12 @@ class MCPServerStdio(_MCPServerWithClientSession):
                 if you know the server will not change its tools list, because it can drastically
                 improve latency (by avoiding a round-trip to the server every time).
 
-            cache_prompts_list: Whether to cache the prompts list. If `True`, the prompts list will be
-                cached and only fetched from the server once. If `False`, the prompts list will be
-                fetched from the server on each call to `list_prompts()`. The cache can be invalidated
-                by calling `invalidate_prompts_cache()`. You should set this to `True` if you know the
-                server will not change its prompts list, because it can drastically improve latency
+            cache_prompts_list: Whether to cache the prompts list. If `True`, the prompts list
+                will be cached and only fetched from the server once. If `False`, the prompts
+                list will be fetched from the server on each call to `list_prompts()`.
+                The cache can be invalidated by calling `invalidate_prompts_cache()`.
+                You should set this to `True` if you know the server will not change
+                its prompts list, because it can drastically improve latency
                 (by avoiding a round-trip to the server every time).
 
             name: A readable name for the server. If not provided, we'll create one from the
@@ -480,11 +482,12 @@ class MCPServerSse(_MCPServerWithClientSession):
                 if you know the server will not change its tools list, because it can drastically
                 improve latency (by avoiding a round-trip to the server every time).
 
-            cache_prompts_list: Whether to cache the prompts list. If `True`, the prompts list will be
-                cached and only fetched from the server once. If `False`, the prompts list will be
-                fetched from the server on each call to `list_prompts()`. The cache can be invalidated
-                by calling `invalidate_prompts_cache()`. You should set this to `True` if you know the
-                server will not change its prompts list, because it can drastically improve latency
+            cache_prompts_list: Whether to cache the prompts list. If `True`, the prompts list
+                will be cached and only fetched from the server once. If `False`, the prompts
+                list will be fetched from the server on each call to `list_prompts()`.
+                The cache can be invalidated by calling `invalidate_prompts_cache()`.
+                You should set this to `True` if you know the server will not change
+                its prompts list, because it can drastically improve latency
                 (by avoiding a round-trip to the server every time).
 
             name: A readable name for the server. If not provided, we'll create one from the
@@ -575,11 +578,12 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 if you know the server will not change its tools list, because it can drastically
                 improve latency (by avoiding a round-trip to the server every time).
 
-            cache_prompts_list: Whether to cache the prompts list. If `True`, the prompts list will be
-                cached and only fetched from the server once. If `False`, the prompts list will be
-                fetched from the server on each call to `list_prompts()`. The cache can be invalidated
-                by calling `invalidate_prompts_cache()`. You should set this to `True` if you know the
-                server will not change its prompts list, because it can drastically improve latency
+            cache_prompts_list: Whether to cache the prompts list. If `True`, the prompts list
+                will be cached and only fetched from the server once. If `False`, the prompts
+                list will be fetched from the server on each call to `list_prompts()`.
+                The cache can be invalidated by calling `invalidate_prompts_cache()`.
+                You should set this to `True` if you know the server will not change
+                its prompts list, because it can drastically improve latency
                 (by avoiding a round-trip to the server every time).
 
             name: A readable name for the server. If not provided, we'll create one from the

--- a/tests/mcp/helpers.py
+++ b/tests/mcp/helpers.py
@@ -38,6 +38,7 @@ class _TestFilterServer(_MCPServerWithClientSession):
         # Initialize parent class properly to avoid type errors
         super().__init__(
             cache_tools_list=False,
+            cache_prompts_list=False,
             client_session_timeout_seconds=None,
             tool_filter=tool_filter,
         )

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -65,7 +65,7 @@ async def test_server_caching_tools_works(
 @pytest.mark.asyncio
 @patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
 @patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
-@patch("mcp.client.session.ClientSession.list_tools")
+@patch("mcp.client.session.ClientSession.list_prompts")
 async def test_server_caching_prompts_works(
     mock_list_prompts: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
 ):

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -69,8 +69,8 @@ async def test_server_caching_tools_works(
 async def test_server_caching_prompts_works(
     mock_list_prompts: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
 ):
-    """Test that if we turn caching on, the list of prompts is cached and not fetched from the server
-    on each call to `list_prompts()`.
+    """Test that if we turn caching on, the list of prompts is cached and not fetched
+    from the server on each call to `list_prompts()`.
     """
     server = MCPServerStdio(
         params={
@@ -98,15 +98,18 @@ async def test_server_caching_prompts_works(
         result_prompts = await server.list_prompts()
         assert result_prompts == prompts
 
-        assert mock_list_prompts.call_count == 1, "list_prompts() should not have been called again"
+        assert mock_list_prompts.call_count == 1, ("list_prompts() "
+                                                   "should not have been called again")
 
         # Invalidate the cache and call list_prompts() again
         server.invalidate_prompts_cache()
         result_prompts = await server.list_prompts()
         assert result_prompts == prompts
 
-        assert mock_list_prompts.call_count == 2, "list_prompts() should be called again"
+        assert mock_list_prompts.call_count == 2, ("list_prompts() "
+                                                   "should be called again")
 
-        # Without invalidating the cache, calling list_prompts() again should return the cached value
+        # Without invalidating the cache, calling list_prompts()
+        # again should return the cached value
         result_prompts = await server.list_prompts()
         assert result_prompts == prompts

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -84,19 +84,20 @@ async def test_server_caching_prompts_works(
         Prompt(name="prompt2"),
     ]
 
-    mock_list_prompts.return_value = ListPromptsResult(prompts=prompts)
+    list_prompts = ListPromptsResult(prompts=prompts)
+    mock_list_prompts.return_value = list_prompts
 
     async with server:
 
         # Call list_prompts() multiple times
         result_prompts = await server.list_prompts()
-        assert result_prompts == prompts
+        assert result_prompts == list_prompts
 
         assert mock_list_prompts.call_count == 1, "list_prompts() should have been called once"
 
         # Call list_prompts() again, should return the cached value
         result_prompts = await server.list_prompts()
-        assert result_prompts == prompts
+        assert result_prompts == list_prompts
 
         assert mock_list_prompts.call_count == 1, ("list_prompts() "
                                                    "should not have been called again")
@@ -104,7 +105,7 @@ async def test_server_caching_prompts_works(
         # Invalidate the cache and call list_prompts() again
         server.invalidate_prompts_cache()
         result_prompts = await server.list_prompts()
-        assert result_prompts == prompts
+        assert result_prompts == list_prompts
 
         assert mock_list_prompts.call_count == 2, ("list_prompts() "
                                                    "should be called again")
@@ -112,4 +113,4 @@ async def test_server_caching_prompts_works(
         # Without invalidating the cache, calling list_prompts()
         # again should return the cached value
         result_prompts = await server.list_prompts()
-        assert result_prompts == prompts
+        assert result_prompts == list_prompts

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -8,7 +8,11 @@ from agents.run_context import RunContextWrapper
 
 class CrashingClientSessionServer(_MCPServerWithClientSession):
     def __init__(self):
-        super().__init__(cache_tools_list=False, client_session_timeout_seconds=5)
+        super().__init__(
+            cache_tools_list=False,
+            cache_prompts_list=False,
+            client_session_timeout_seconds=5
+        )
         self.cleanup_called = False
 
     def create_streams(self):


### PR DESCRIPTION
Summary

Integrate prompts list caching in MCP Servers. This allows agents to fetch prompts from local memory when `cache_prompts_list` is set to `True`. Otherwise, every time an agent runs, it calls `list_prompts()` on the MCP Server.

Key changes:

- Updated the implementation of `list_prompts` in `_MCPServerWithClientSession` to integrate caching using the same design pattern as caching integration in `list_tools`.
- Created example that uses caching with working demonstration.
- Updated documentation with caching setting.
- Renamed test `test_server_caching_works` to `test_server_caching_prompts_works` in tests/mcp/test_caching.py.

Note: This PR does not implement caching in `get_prompt` which can be useful in certain situations.

Test plan

Unit tests: Added 1 unit test in tests/mcp/test_caching.py to cover prompts list caching.

Example verification: Created working example with MCP server and client.
All tests pass: 523/523 tests passing after adding optional dependencies


Checks

 [x] I've added new tests (if relevant)
 [x] I've added/updated the relevant documentation
 [x] I've run make lint and make format
 [x] I've made sure tests pass