### PR TITLE
Format final story outline for better readability using textwrap

### DIFF
--- a/examples/agent_patterns/llm_as_a_judge.py
+++ b/examples/agent_patterns/llm_as_a_judge.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import textwrap
 import asyncio
+import textwrap
 from dataclasses import dataclass
 from typing import Literal
 

--- a/examples/agent_patterns/llm_as_a_judge.py
+++ b/examples/agent_patterns/llm_as_a_judge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import textwrap
 import asyncio
 from dataclasses import dataclass
 from typing import Literal
@@ -69,7 +70,8 @@ async def main() -> None:
 
             input_items.append({"content": f"Feedback: {result.feedback}", "role": "user"})
 
-    print(f"Final story outline: {latest_outline}")
+    print("Final story outline:")
+    print(textwrap.indent(latest_outline, "  "))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Problem:
The final story outline was printed as a single unformatted block, making it hard to read for multi-line or lengthy content.

Changes:
- Added `textwrap` import to enable line-based formatting.
- Replaced `print(f"Final story outline: {latest_outline}")` with:
```python
   print("Final story outline:")
   print(textwrap.indent(latest_outline, "  "))
```
- Ensures each line of the outline is indented by 2 spaces for visual clarity.

Benefits:
- Improves readability of multi-line outputs.
- Keeps the outline distinct from surrounding console logs.
- Safe to use since `latest_outline` is guaranteed to be a string before printing (set in the loop).