### PR TITLE
Add input validation to prevent empty user messages in translation example

### DIFF
--- a/examples/agent_patterns/parallelization.py
+++ b/examples/agent_patterns/parallelization.py
@@ -20,6 +20,8 @@ translation_picker = Agent(
 
 async def main():
     msg = input("Hi! Enter a message, and we'll translate it to Spanish.\n\n")
+    if not msg.strip():
+        raise ValueError("Input message cannot be empty.")
 
     # Ensure the entire workflow is a single trace
     with trace("Parallel translation"):
@@ -37,7 +39,6 @@ async def main():
                 msg,
             ),
         )
-
         outputs = [
             ItemHelpers.text_message_outputs(res_1.new_items),
             ItemHelpers.text_message_outputs(res_2.new_items),


### PR DESCRIPTION
Problem:
The script allows empty or whitespace-only input from the user, which results in unnecessary agent executions and invalid translations.

Changes:
- Added input validation to check if the user input is empty or whitespace-only.
- If invalid, raises `ValueError` with a clear message: `"Input message cannot be empty."`
- Prevents downstream agent execution when input is invalid.

```python
msg = input("Hi! Enter a message, and we'll translate it to Spanish.\n\n")
if not msg.strip():
    raise ValueError("Input message cannot be empty.")
```

Benefits:
- Ensures only valid, non-empty input triggers agent workflows.
- Improves user experience by failing early with a descriptive error.
- Avoids unnecessary API calls or agent runs for invalid inputs.