### PR TITLE
fix: convert litellm response with reasoning content to openai message

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import AsyncIterator
-from typing import Any, Literal, Optional, cast, overload
+from typing import Any, Literal, cast, overload
 
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
@@ -50,7 +50,7 @@ class InternalChatCompletionMessage(ChatCompletionMessage):
     An internal subclass to carry reasoning_content without modifying the original model.
     """
 
-    reasoning_content: Optional[str] = None
+    reasoning_content: str
 
 
 class LitellmModel(Model):

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -36,6 +36,7 @@ from openai.types.responses import (
     ResponseOutputRefusal,
     ResponseOutputText,
     ResponseReasoningItem,
+    ResponseReasoningItemParam,
 )
 from openai.types.responses.response_input_param import FunctionCallOutput, ItemReference, Message
 from openai.types.responses.response_reasoning_item import Summary
@@ -208,6 +209,12 @@ class Converter:
             and item.get("role") == "assistant"
         ):
             return cast(ResponseOutputMessageParam, item)
+        return None
+
+    @classmethod
+    def maybe_reasoning_message(cls, item: Any) -> ResponseReasoningItemParam | None:
+        if isinstance(item, dict) and item.get("type") == "reasoning":
+            return cast(ResponseReasoningItemParam, item)
         return None
 
     @classmethod
@@ -459,7 +466,11 @@ class Converter:
                     f"Encountered an item_reference, which is not supported: {item_ref}"
                 )
 
-            # 7) If we haven't recognized it => fail or ignore
+            # 7) reasoning message => not handled
+            elif cls.maybe_reasoning_message(item):
+                pass
+
+            # 8) If we haven't recognized it => fail or ignore
             else:
                 raise UserError(f"Unhandled item type or structure: {item}")
 


### PR DESCRIPTION
### 1. Description

This PR fixes an issue where reasoning content from models accessed via LiteLLM was not being correctly parsed into the `ChatCompletionMessage` format. This was particularly noticeable when using reasoning models.

### 2. Context

I am using the `openai-agents-python` library in my project, and it has been incredibly helpful. Thank you for building such a great tool!

My setup uses `litellm` to interface with `gemini-2.5-pro`. I noticed that while the agent could receive a response, the reasoning(thinking) from the Gemini model was lost during the conversion process from the LiteLLM response format to the OpenAI `ChatCompletionMessage` object.

I saw that PR #871 made progress on a similar issue, but it seems the specific response structure from LiteLLM still requires a small adaptation. This fix adds the necessary logic to ensure that these responses are handled.

**Relates to:** #871

### 3. Key Changes

- `LitellmConverter.convert_message_to_openai`: add `reasoing_content`
-  `Converter.items_to_messages`: just pass the reasoning item

