### PR TITLE
Correct error message for invalid output types with strict JSON schema

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -114,9 +114,9 @@ class AgentOutputSchema(AgentOutputSchemaBase):
                 self._output_schema = ensure_strict_json_schema(self._output_schema)
             except UserError as e:
                 raise UserError(
-                  "Strict JSON schema is enabled, but the output type is not valid. "
-                  "Either use a dataclass, Pydantic model, or TypedDict, "
-                  "or wrap your type with AgentOutputSchema(your_type, strict_json_schema=False)"
+                    "Strict JSON schema is enabled, but the output type is not valid. "
+                    "Either use a dataclass, Pydantic model, or TypedDict, "
+                    "or wrap your type with AgentOutputSchema(your_type, strict_json_schema=False)"
                 ) from e
 
     def is_plain_text(self) -> bool:

--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -114,9 +114,9 @@ class AgentOutputSchema(AgentOutputSchemaBase):
                 self._output_schema = ensure_strict_json_schema(self._output_schema)
             except UserError as e:
                 raise UserError(
-                    "Strict JSON schema is enabled, but the output type is not valid. "
-                    "Either make the output type strict, or pass output_schema_strict=False to "
-                    "your Agent()"
+                  "Strict JSON schema is enabled, but the output type is not valid. "
+                  "Either use a dataclass, Pydantic model, or TypedDict, "
+                  "or wrap your type with AgentOutputSchema(your_type, strict_json_schema=False)"
                 ) from e
 
     def is_plain_text(self) -> bool:


### PR DESCRIPTION
### Problem
1. **Incorrect parameter reference**: Suggests passing `output_schema_strict=False` to `Agent()`, but this parameter doesn't exist
2. **Vague guidance**: The phrase "make the output type strict" doesn't explain HOW to make types strict

### Solution
Updated the error message to provide accurate, actionable guidance:

**Before:**
```
"Either make the output type strict, or pass output_schema_strict=False to your Agent()"
```

**After:**
```
"Either use a dataclass, Pydantic model, or TypedDict, or wrap your type with AgentOutputSchema(your_type, strict_json_schema=False)"
```