### PR TITLE
Realtime: run guardrails without blockign event loop

### DIFF
--- a/src/agents/realtime/events.py
+++ b/src/agents/realtime/events.py
@@ -197,6 +197,7 @@ class RealtimeGuardrailTripped:
 
     type: Literal["guardrail_tripped"] = "guardrail_tripped"
 
+
 RealtimeSessionEvent: TypeAlias = Union[
     RealtimeAgentStartEvent,
     RealtimeAgentEndEvent,


### PR DESCRIPTION
Guardrails were blocking the event loop. Now, they run as a separate task. 




---
[//]: # (BEGIN SAPLING FOOTER)
* #1112
* #1111
* #1107
* #1106
* __->__ #1104