### PR TITLE
test(function_schema): add tests for enforce_type_annotations behavior

### DIFF
--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -451,3 +451,37 @@ def test_name_override_without_docstring() -> None:
 
     assert fs.name == "custom"
     assert fs.params_json_schema.get("title") == "custom_args"
+
+# Tests for, "enforce_type_annotations" update inside "function_schema.py"
+def test_unannotated_function_with_enforcement():
+    """Test enforcement raises error for unannotated parameters"""
+    def my_func(x): ...
+    
+    with pytest.raises(ValueError) as exc_info:
+        function_schema(my_func, enforce_type_annotations=True)
+    
+    assert "Parameter 'x' must be type-annotated" in str(exc_info.value)
+
+
+def test_unannotated_function_without_enforcement():
+    """Test fallback to Any when enforcement is off"""
+    def my_func(x): ...
+    
+    schema = function_schema(my_func, enforce_type_annotations=False)
+    assert schema.params_json_schema["properties"]["x"]["type"] == "any"
+
+
+def test_annotated_function_works_with_enforcement():
+    """Test basic type hints work with enforcement"""
+    def my_func(x: int): ...
+    
+    schema = function_schema(my_func, enforce_type_annotations=True)
+    assert schema.params_json_schema["properties"]["x"]["type"] == "integer"
+
+
+def test_positional_args_backward_compatibility():
+    """Ensure old positional args still work"""
+    def my_func(x: int): ...
+    
+    schema = function_schema(my_func, "sphinx", enforce_type_annotations=False)
+    assert schema.name == "my_func"


### PR DESCRIPTION
Adds 4 new tests to validate enforce_type_annotations:

- Enforcement: Checks if unannotated functions raise errors.
- Fallback: Confirms unannotated parameters default to Any when disabled.
- Compatibility: Ensures positional args (e.g., function_schema(my_func, "sphinx")) still work.

See Updated Code:
https://github.com/openai/openai-agents-python/blob/main/src/agents/function_schema.py