### PR TITLE
Retry: Add tool_name to ToolContext for generic tool handlers

### DIFF
--- a/docs/ref/tool_context.md
+++ b/docs/ref/tool_context.md
@@ -1,3 +1,0 @@
-# `Tool context`
-
-::: agents.tool_context

--- a/docs/ref/tool_context.md
+++ b/docs/ref/tool_context.md
@@ -1,0 +1,3 @@
+# `Tool context`
+
+::: agents.tool_context

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -180,7 +180,7 @@ Sometimes, you don't want to use a Python function as a tool. You can directly c
 -   `name`
 -   `description`
 -   `params_json_schema`, which is the JSON schema for the arguments
--   `on_invoke_tool`, which is an async function that receives the context and the arguments as a JSON string, and must return the tool output as a string.
+-   `on_invoke_tool`, which is an async function that receives a [`ToolContext`][agents.tool_context.ToolContext] and the arguments as a JSON string, and must return the tool output as a string.
 
 ```python
 from typing import Any

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -213,6 +213,23 @@ tool = FunctionTool(
 )
 ```
 
+### Tool context
+
+When `on_invoke_tool` is called, it receives a `ToolContext` instance. The object contains:
+
+- `context` – the context object you passed to `Runner.run()`.
+- `usage` – usage information for the run so far.
+- `tool_name` – the name of the tool being invoked.
+- `tool_call_id` – the ID of the tool call.
+
+You can access these fields inside your tool function:
+
+```python
+async def run_function(ctx: ToolContext[Any], args: str) -> str:
+    print("Tool invoked:", ctx.tool_name)
+    ...
+```
+
 ### Automatic argument and docstring parsing
 
 As mentioned before, we automatically parse the function signature to extract the schema for the tool, and we parse the docstring to extract descriptions for the tool and for individual arguments. Some notes on that:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -213,23 +213,6 @@ tool = FunctionTool(
 )
 ```
 
-### Tool context
-
-When `on_invoke_tool` is called, it receives a `ToolContext` instance. The object contains:
-
-- `context` – the context object you passed to `Runner.run()`.
-- `usage` – usage information for the run so far.
-- `tool_name` – the name of the tool being invoked.
-- `tool_call_id` – the ID of the tool call.
-
-You can access these fields inside your tool function:
-
-```python
-async def run_function(ctx: ToolContext[Any], args: str) -> str:
-    print("Tool invoked:", ctx.tool_name)
-    ...
-```
-
 ### Automatic argument and docstring parsing
 
 As mentioned before, we automatically parse the function signature to extract the schema for the tool, and we parse the docstring to extract descriptions for the tool and for individual arguments. Some notes on that:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ plugins:
                     - ref/lifecycle.md
                     - ref/items.md
                     - ref/run_context.md
+                    - ref/tool_context.md
                     - ref/usage.md
                     - ref/exceptions.md
                     - ref/guardrail.md

--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -549,7 +549,9 @@ class RunImpl:
         ) -> Any:
             with function_span(func_tool.name) as span_fn:
                 tool_context = ToolContext.from_agent_context(
-                    context_wrapper, func_tool.name, tool_call.call_id
+                    context_wrapper,
+                    tool_call.call_id,
+                    tool_call=tool_call,
                 )
                 if config.trace_include_sensitive_data:
                     span_fn.span_data.input = tool_call.arguments

--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -548,7 +548,9 @@ class RunImpl:
             func_tool: FunctionTool, tool_call: ResponseFunctionToolCall
         ) -> Any:
             with function_span(func_tool.name) as span_fn:
-                tool_context = ToolContext.from_agent_context(context_wrapper, tool_call.call_id)
+                tool_context = ToolContext.from_agent_context(
+                    context_wrapper, func_tool.name, tool_call.call_id
+                )
                 if config.trace_include_sensitive_data:
                     span_fn.span_data.input = tool_call.arguments
                 try:

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -250,7 +250,12 @@ class RealtimeSession(RealtimeModelListener):
             )
 
             func_tool = function_map[event.name]
-            tool_context = ToolContext.from_agent_context(self._context_wrapper, event.call_id)
+            tool_context = ToolContext(
+                context=self._context_wrapper.context,
+                usage=self._context_wrapper.usage,
+                tool_name=event.name,
+                tool_call_id=event.call_id,
+            )
             result = await func_tool.on_invoke_tool(tool_context, event.arguments)
 
             await self._model.send_tool_output(event, str(result), True)

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -293,7 +293,12 @@ class RealtimeSession(RealtimeModelListener):
             )
         elif event.name in handoff_map:
             handoff = handoff_map[event.name]
-            tool_context = ToolContext.from_agent_context(self._context_wrapper, event.call_id)
+            tool_context = ToolContext(
+                context=self._context_wrapper.context,
+                usage=self._context_wrapper.usage,
+                tool_name=event.name,
+                tool_call_id=event.call_id,
+            )
 
             # Execute the handoff to get the new agent
             result = await handoff.on_invoke_handoff(self._context_wrapper, event.arguments)

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field, fields
 from typing import Any
 
+from openai.types.responses import ResponseFunctionToolCall
+
 from .run_context import RunContextWrapper, TContext
 
 
@@ -24,7 +26,10 @@ class ToolContext(RunContextWrapper[TContext]):
 
     @classmethod
     def from_agent_context(
-        cls, context: RunContextWrapper[TContext], tool_name: str, tool_call_id: str
+        cls,
+        context: RunContextWrapper[TContext],
+        tool_call_id: str,
+        tool_call: ResponseFunctionToolCall | None = None,
     ) -> "ToolContext":
         """
         Create a ToolContext from a RunContextWrapper.
@@ -33,4 +38,5 @@ class ToolContext(RunContextWrapper[TContext]):
         base_values: dict[str, Any] = {
             f.name: getattr(context, f.name) for f in fields(RunContextWrapper) if f.init
         }
+        tool_name = tool_call.name if tool_call is not None else _assert_must_pass_tool_name()
         return cls(tool_name=tool_name, tool_call_id=tool_call_id, **base_values)

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -8,16 +8,23 @@ def _assert_must_pass_tool_call_id() -> str:
     raise ValueError("tool_call_id must be passed to ToolContext")
 
 
+def _assert_must_pass_tool_name() -> str:
+    raise ValueError("tool_name must be passed to ToolContext")
+
+
 @dataclass
 class ToolContext(RunContextWrapper[TContext]):
     """The context of a tool call."""
+
+    tool_name: str = field(default_factory=_assert_must_pass_tool_name)
+    """The name of the tool being invoked."""
 
     tool_call_id: str = field(default_factory=_assert_must_pass_tool_call_id)
     """The ID of the tool call."""
 
     @classmethod
     def from_agent_context(
-        cls, context: RunContextWrapper[TContext], tool_call_id: str
+        cls, context: RunContextWrapper[TContext], tool_name: str, tool_call_id: str
     ) -> "ToolContext":
         """
         Create a ToolContext from a RunContextWrapper.
@@ -26,4 +33,4 @@ class ToolContext(RunContextWrapper[TContext]):
         base_values: dict[str, Any] = {
             f.name: getattr(context, f.name) for f in fields(RunContextWrapper) if f.init
         }
-        return cls(tool_call_id=tool_call_id, **base_values)
+        return cls(tool_name=tool_name, tool_call_id=tool_call_id, **base_values)

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, fields
-from typing import Any
+from typing import Any, Optional
 
 from openai.types.responses import ResponseFunctionToolCall
 
@@ -29,7 +29,7 @@ class ToolContext(RunContextWrapper[TContext]):
         cls,
         context: RunContextWrapper[TContext],
         tool_call_id: str,
-        tool_call: ResponseFunctionToolCall | None = None,
+        tool_call: Optional[ResponseFunctionToolCall] = None,
     ) -> "ToolContext":
         """
         Create a ToolContext from a RunContextWrapper.

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -26,7 +26,9 @@ async def test_argless_function():
     tool = function_tool(argless_function)
     assert tool.name == "argless_function"
 
-    result = await tool.on_invoke_tool(ToolContext(context=None, tool_call_id="1"), "")
+    result = await tool.on_invoke_tool(
+        ToolContext(context=None, tool_name=tool.name, tool_call_id="1"), ""
+    )
     assert result == "ok"
 
 
@@ -39,11 +41,13 @@ async def test_argless_with_context():
     tool = function_tool(argless_with_context)
     assert tool.name == "argless_with_context"
 
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), "")
+    result = await tool.on_invoke_tool(ToolContext(None, tool_name=tool.name, tool_call_id="1"), "")
     assert result == "ok"
 
     # Extra JSON should not raise an error
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"a": 1}')
+    result = await tool.on_invoke_tool(
+        ToolContext(None, tool_name=tool.name, tool_call_id="1"), '{"a": 1}'
+    )
     assert result == "ok"
 
 
@@ -56,15 +60,19 @@ async def test_simple_function():
     tool = function_tool(simple_function, failure_error_function=None)
     assert tool.name == "simple_function"
 
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"a": 1}')
+    result = await tool.on_invoke_tool(
+        ToolContext(None, tool_name=tool.name, tool_call_id="1"), '{"a": 1}'
+    )
     assert result == 6
 
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"a": 1, "b": 2}')
+    result = await tool.on_invoke_tool(
+        ToolContext(None, tool_name=tool.name, tool_call_id="1"), '{"a": 1, "b": 2}'
+    )
     assert result == 3
 
     # Missing required argument should raise an error
     with pytest.raises(ModelBehaviorError):
-        await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), "")
+        await tool.on_invoke_tool(ToolContext(None, tool_name=tool.name, tool_call_id="1"), "")
 
 
 class Foo(BaseModel):
@@ -92,7 +100,9 @@ async def test_complex_args_function():
             "bar": Bar(x="hello", y=10),
         }
     )
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), valid_json)
+    result = await tool.on_invoke_tool(
+        ToolContext(None, tool_name=tool.name, tool_call_id="1"), valid_json
+    )
     assert result == "6 hello10 hello"
 
     valid_json = json.dumps(
@@ -101,7 +111,9 @@ async def test_complex_args_function():
             "bar": Bar(x="hello", y=10),
         }
     )
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), valid_json)
+    result = await tool.on_invoke_tool(
+        ToolContext(None, tool_name=tool.name, tool_call_id="1"), valid_json
+    )
     assert result == "3 hello10 hello"
 
     valid_json = json.dumps(
@@ -111,12 +123,16 @@ async def test_complex_args_function():
             "baz": "world",
         }
     )
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), valid_json)
+    result = await tool.on_invoke_tool(
+        ToolContext(None, tool_name=tool.name, tool_call_id="1"), valid_json
+    )
     assert result == "3 hello10 world"
 
     # Missing required argument should raise an error
     with pytest.raises(ModelBehaviorError):
-        await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"foo": {"a": 1}}')
+        await tool.on_invoke_tool(
+            ToolContext(None, tool_name=tool.name, tool_call_id="1"), '{"foo": {"a": 1}}'
+        )
 
 
 def test_function_config_overrides():
@@ -176,7 +192,9 @@ async def test_manual_function_tool_creation_works():
         assert tool.params_json_schema[key] == value
     assert tool.strict_json_schema
 
-    result = await tool.on_invoke_tool(ToolContext(None, tool_call_id="1"), '{"data": "hello"}')
+    result = await tool.on_invoke_tool(
+        ToolContext(None, tool_name=tool.name, tool_call_id="1"), '{"data": "hello"}'
+    )
     assert result == "hello_done"
 
     tool_not_strict = FunctionTool(
@@ -191,7 +209,8 @@ async def test_manual_function_tool_creation_works():
     assert "additionalProperties" not in tool_not_strict.params_json_schema
 
     result = await tool_not_strict.on_invoke_tool(
-        ToolContext(None, tool_call_id="1"), '{"data": "hello", "bar": "baz"}'
+        ToolContext(None, tool_name=tool_not_strict.name, tool_call_id="1"),
+        '{"data": "hello", "bar": "baz"}',
     )
     assert result == "hello_done"
 
@@ -202,7 +221,7 @@ async def test_function_tool_default_error_works():
         raise ValueError("test")
 
     tool = function_tool(my_func)
-    ctx = ToolContext(None, tool_call_id="1")
+    ctx = ToolContext(None, tool_name=tool.name, tool_call_id="1")
 
     result = await tool.on_invoke_tool(ctx, "")
     assert "Invalid JSON" in str(result)
@@ -226,7 +245,7 @@ async def test_sync_custom_error_function_works():
         return f"error_{error.__class__.__name__}"
 
     tool = function_tool(my_func, failure_error_function=custom_sync_error_function)
-    ctx = ToolContext(None, tool_call_id="1")
+    ctx = ToolContext(None, tool_name=tool.name, tool_call_id="1")
 
     result = await tool.on_invoke_tool(ctx, "")
     assert result == "error_ModelBehaviorError"
@@ -250,7 +269,7 @@ async def test_async_custom_error_function_works():
         return f"error_{error.__class__.__name__}"
 
     tool = function_tool(my_func, failure_error_function=custom_sync_error_function)
-    ctx = ToolContext(None, tool_call_id="1")
+    ctx = ToolContext(None, tool_name=tool.name, tool_call_id="1")
 
     result = await tool.on_invoke_tool(ctx, "")
     assert result == "error_ModelBehaviorError"

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -16,7 +16,7 @@ class DummyContext:
 
 
 def ctx_wrapper() -> ToolContext[DummyContext]:
-    return ToolContext(context=DummyContext(), tool_call_id="1")
+    return ToolContext(context=DummyContext(), tool_name="dummy", tool_call_id="1")
 
 
 @function_tool


### PR DESCRIPTION
This is a follow-up to pr #1043   The original changes were reverted due to missing updates in RealtimeSession, which caused runtime test failures.

This PR:

- Reapplies the `tool_name` and `tool_call_id` additions to `ToolContext`.
- Updates `RealtimeSession._handle_tool_call` to instantiate `ToolContext` with `tool_name=event.name` and `tool_call_id=event.call_id`.
- Adjusts tests as needed so that all 533 tests (including old-version Python 3.9) pass cleanly.

Closes #1030 