### PR TITLE
Handle exceptions in parallel agent runs to prevent early termination

### DIFF
--- a/examples/agent_patterns/parallelization.py
+++ b/examples/agent_patterns/parallelization.py
@@ -36,6 +36,7 @@ async def main():
                 spanish_agent,
                 msg,
             ),
+            return_exceptions=True,
         )
 
         outputs = [


### PR DESCRIPTION
**Problem**:
When running agents in parallel using `asyncio.gather`, any unhandled exception in one task (e.g., network error, agent crash) would immediately propagate and terminate the entire workflow, discarding all partial results.

**Example of Failure**:
```python
res_1, res_2, res_3 = await asyncio.gather(
    Runner.run(spanish_agent, msg),  # Fails with Exception
    Runner.run(spanish_agent, msg),
    Runner.run(spanish_agent, msg),
)
# All results are lost due to a single failure.
```

**Changes**:
- Added `return_exceptions=True` to `asyncio.gather()` to handle failures gracefully:
```python
  res_1, res_2, res_3 = await asyncio.gather(
      Runner.run(spanish_agent, msg),
      Runner.run(spanish_agent, msg),
      Runner.run(spanish_agent, msg),
      return_exceptions=True,
  )
```
- Exceptions are now captured as `Exception` objects in the results instead of being raised immediately.

**Benefits**:
- Ensures robustness: Partial results are preserved even if one or more tasks fail.
- Allows explicit error handling for failed tasks (e.g., logging, fallback logic).
- Prevents unnecessary re-runs of successful tasks when one task fails.

**Example Output Handling**:  
```python
outputs = [
    ItemHelpers.text_message_outputs(res_1.new_items) if not isinstance(res_1, Exception) else None,
    # ...similar for res_2, res_3
]
```