### PR TITLE
Fix handling of text_message_outputs output structure in parallel translation example

### DIFF
--- a/examples/agent_patterns/parallelization.py
+++ b/examples/agent_patterns/parallelization.py
@@ -39,9 +39,9 @@ async def main():
         )
 
         outputs = [
-            ItemHelpers.text_message_outputs(res_1.new_items),
-            ItemHelpers.text_message_outputs(res_2.new_items),
-            ItemHelpers.text_message_outputs(res_3.new_items),
+            " ".join(ItemHelpers.text_message_outputs(res_1.new_items)),
+            " ".join(ItemHelpers.text_message_outputs(res_2.new_items)),
+            " ".join(ItemHelpers.text_message_outputs(res_3.new_items)),
         ]
 
         translations = "\n\n".join(outputs)


### PR DESCRIPTION
**Problem**:
The code assumed `ItemHelpers.text_message_outputs()` returned a single string per result (e.g., `"Hola mundo"`), but it actually returns a **list of strings** (e.g., `["Hola", "Mundo"]`). This caused a `TypeError` when joining outputs.

**Example of Failure**:
```python
outputs = [
    ["Hola", "Mundo"],  # From text_message_outputs
    ["Buenos días"],
    ["Cómo estás"],
]
translations = "\n\n".join(outputs)  # ❌ TypeError: can't join list to str
```

**Changes**:
- Wrap `text_message_outputs(...)` with `" ".join(...)` to safely flatten each agent’s output into a single string:
```python
  outputs = [
      " ".join(ItemHelpers.text_message_outputs(res_1.new_items)),
      " ".join(ItemHelpers.text_message_outputs(res_2.new_items)),
      " ".join(ItemHelpers.text_message_outputs(res_3.new_items)),
  ]
```

**Benefits**:
- Prevents `TypeError` by ensuring all outputs are strings.
- Maintains consistent formatting for the final joined output.
- Makes the example robust and easier to understand for users.

This change ensures the parallel translation workflow works reliably, even when agent outputs vary in structure.