### PR TITLE
Fix typos and update async for loop variable

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -210,7 +210,7 @@ class Agent(AgentBase, Generic[TContext]):
         The final output will be the output of the first matching tool call. The LLM does not
         process the result of the tool call.
     - A function: If you pass a function, it will be called with the run context and the list of
-      tool results. It must return a `ToolToFinalOutputResult`, which determines whether the tool
+      tool results. It must return a `ToolsToFinalOutputResult`, which determines whether the tool
       calls result in a final output.
 
       NOTE: This configuration is specific to FunctionTools. Hosted tools, such as file search,

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -200,7 +200,7 @@ MCPToolApprovalFunction = Callable[
 @dataclass
 class HostedMCPTool:
     """A tool that allows the LLM to use a remote MCP server. The LLM will automatically list and
-    call tools, without requiring a a round trip back to your code.
+    call tools, without requiring a round trip back to your code.
     If you want to run MCP servers locally via stdio, in a VPC or other non-publicly-accessible
     environment, or you just prefer to run tool calls locally, then you can instead use the servers
     in `agents.mcp` and pass `Agent(mcp_servers=[...])` to the agent."""

--- a/tests/test_session_exceptions.py
+++ b/tests/test_session_exceptions.py
@@ -123,7 +123,7 @@ class TestSessionExceptions:
         async with session:
             # Try to iterate and expect exception
             with pytest.raises(ValueError, match="Test error"):
-                async for _event in session:
+                async for _ in session:
                     pass  # Should never reach here
 
         # Verify cleanup occurred


### PR DESCRIPTION
this PR fixes typos in docstrings and updates the async for loop variable in the test as per review feedback.
fixed typo: ToolToFinalOutputResult -> ToolsToFinalOutputResult
removed duplicate 'a' in docstring
changed async for loop variable from _event to _ in test_session_exceptions.py