### PR TITLE
Fix spelling, grammar, and minor formatting issues in running agents documentation

### DIFF
--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -23,7 +23,7 @@ Read more in the [results guide](results.md).
 
 ## The agent loop
 
-When you use the run method in `Runner`, you pass in a starting agent and input. The input can either be a string (which is considered a user message), or a list of input items, which are the items in the OpenAI Response API.
+When you use the run method in `Runner`, you pass in a starting agent and input. The input can either be a string (which is considered a user message), or a list of input items, which are the items in the OpenAI Responses API.
 
 The runner then runs a loop:
 


### PR DESCRIPTION
**Problem**:
The documentation for agent execution contains several minor but distracting issues:
- Verb tense mismatch ("outputs produces" → "outputs produced")
- Optional inconsistencies in code examples (haiku punctuation, undefined `thread_id`)

**Changes**:
1. **Grammar/Spelling Fixes**
- Changed `"outputs produces"` → `"outputs produced"`   (corrected past-tense verb agreement)

2. **Optional Code Improvements**
- Removed period from haiku example for stylistic consistency   ```python # Infinite loop's dance.  →  # Infinite loop's dance ```
- Added explicit `thread_id` definition in manual conversation example   ```python thread_id = "thread_123"  # Example thread ID ```
