### PR TITLE
fix: fallback to function name for unnamed output_guardrail decorators

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -314,7 +314,11 @@ def output_guardrail(
     def decorator(
         f: _OutputGuardrailFuncSync[TContext_co] | _OutputGuardrailFuncAsync[TContext_co],
     ) -> OutputGuardrail[TContext_co]:
-        return OutputGuardrail(guardrail_function=f, name=name)
+        return OutputGuardrail(
+            guardrail_function=f,
+            # Guardrail name defaults to function name when not specified (None).
+            name=name if name else function.__name__,
+        )
 
     if func is not None:
         # Decorator was used without parentheses


### PR DESCRIPTION
**Overview:**
This PR improves the output_guardrail behavior by ensuring a valid name is always assigned to the guardrail, even when the decorator is used without parentheses or without explicitly providing a name.

**Problem:**
Previously, when the decorator @output_guardrail was used without a name (and without parentheses), the name attribute of the guardrail remained None. This resulted in issues during runtime — specifically, the guardrail name did not appear in result.input_guardrail_results, making it harder to trace or debug guardrail outputs.

While the OutputGuardrail.get_name() method correctly defaults to the function name when name is None, this method is not used inside the decorator. Hence, unless a name is provided explicitly, the OutputGuardrail instance holds None for its name internally.

**Solution:**
This PR updates the decorator logic to:

Automatically fallback to the function name if the name parameter is not provided.

Ensure that the guardrail always has a meaningful identifier, which improves downstream behavior such as logging, debugging, and result tracing.

**Example Behavior Before:**

@output_guardrail
def validate_output(...):
 Name remains None

**Example Behavior After:**

@output_guardrail
def validate_output(...):
Name becomes "validate_output" automatically

**Why it matters:**
This small change avoids hidden bugs or inconsistencies in downstream systems (like guardrail_results) that rely on guardrail names being defined. It also brings consistent behavior whether or not parentheses are used in the decorator.