### PR TITLE
docs: clarify GuardrailFunctionOutput docstrings

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -22,13 +22,12 @@ class GuardrailFunctionOutput:
 
     output_info: Any
     """
-    Optional information about the guardrail's output. For example, the guardrail could include
-    information about the checks it performed and granular results.
+    Optional metadata about the guardrail's execution, such as details of checks performed or results.
     """
 
     tripwire_triggered: bool
     """
-    Whether the tripwire was triggered. If triggered, the agent's execution will be halted.
+    Whether the tripwire was triggered; if True, agent execution will halt.
     """
 
 


### PR DESCRIPTION
This update refines the inline documentation for the `GuardrailFunctionOutput` class by rewording the `output_info` and `tripwire_triggered` docstrings to be more concise and precise.
No code behavior or public API signatures have changed.