### PR TITLE
docs: update GuardrailFunctionOutput docstrings for clarity

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -18,17 +18,18 @@ if TYPE_CHECKING:
 
 @dataclass
 class GuardrailFunctionOutput:
-    """The output of a guardrail function."""
+    """Encapsulates the result of a guardrail’s validation step."""
 
     output_info: Any
     """
-    Optional information about the guardrail's output. For example, the guardrail could include
-    information about the checks it performed and granular results.
+    Detailed metadata or diagnostics from the check,
+    for example which rules passed, which failed, and any metrics.
     """
 
     tripwire_triggered: bool
     """
-    Whether the tripwire was triggered. If triggered, the agent's execution will be halted.
+    Whether this check caused a hard stop.
+    If True, downstream execution must abort immediately.
     """
 
 


### PR DESCRIPTION
This PR refines the inline documentation for the `GuardrailFunctionOutput` class:
- Updates the class summary to “Encapsulates the result of a guardrail’s validation step.”
- Enhances the `output_info` field docstring to emphasize metadata and diagnostic examples (e.g., passed/failed rules, metrics).
- Clarifies the `tripwire_triggered` field docstring to explicitly describe the hard-stop behavior.

✓ Purely informational edits.
✓ No changes to type signatures or logic.
These improvements boost developer readability, auto-generated documentation, and tooling support without impacting runtime behavior.