### PR TITLE
Fix defaulting of tool_name and tool_description in Agent.as_tool()

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -230,11 +230,13 @@ class Agent(AgentBase, Generic[TContext]):
         return dataclasses.replace(self, **kwargs)
 
     def as_tool(
-        self,
-        tool_name: str | None,
-        tool_description: str | None,
-        custom_output_extractor: Callable[[RunResult], Awaitable[str]] | None = None,
-    ) -> Tool:
+    self,
+    tool_name: str | None = None,
+    tool_description: str | None = None,
+    custom_output_extractor: Callable[[RunResult], Awaitable[str]] | None = None,
+) -> Tool:
+        tool_name = tool_name or self.name
+        tool_description = tool_description or self.instructions
         """Transform this agent into a tool, callable by other agents.
 
         This is different from handoffs in two ways:


### PR DESCRIPTION
This PR fixes an issue where the `tool_name` and `tool_description` arguments in `Agent.as_tool()` were annotated as optional (`str | None`) but not given default values, which caused a runtime error when omitted.

Now both parameters default to the agent's name and instructions, respectively, as expected from the docstring and type hint.

Closes #1159 