### PR TITLE
Add missing guardrail exception import to quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -95,7 +95,6 @@ You can define custom guardrails to run on the input or output.
 
 ```python
 from agents import GuardrailFunctionOutput, Agent, Runner
-from agents.exceptions import InputGuardrailTripwireTriggered
 from pydantic import BaseModel
 
 
@@ -169,11 +168,19 @@ triage_agent = Agent(
 )
 
 async def main():
-    result = await Runner.run(triage_agent, "who was the first president of the united states?")
-    print(result.final_output)
+    # Example 1: History question
+    try:
+        result = await Runner.run(triage_agent, "who was the first president of the united states?")
+        print(result.final_output)
+    except InputGuardrailTripwireTriggered as e:
+        print("Guardrail blocked this input:", e)
 
-    result = await Runner.run(triage_agent, "what is life")
-    print(result.final_output)
+    # Example 2: General/philosophical question
+    try:
+        result = await Runner.run(triage_agent, "What is the meaning of life?")
+        print(result.final_output)
+    except InputGuardrailTripwireTriggered as e:
+        print("Guardrail blocked this input:", e)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -95,7 +95,9 @@ You can define custom guardrails to run on the input or output.
 
 ```python
 from agents import GuardrailFunctionOutput, Agent, Runner
+from agents.exceptions import InputGuardrailTripwireTriggered
 from pydantic import BaseModel
+
 
 class HomeworkOutput(BaseModel):
     is_homework: bool
@@ -122,6 +124,7 @@ Let's put it all together and run the entire workflow, using handoffs and the in
 
 ```python
 from agents import Agent, InputGuardrail, GuardrailFunctionOutput, Runner
+from agents.exceptions import InputGuardrailTripwireTriggered
 from pydantic import BaseModel
 import asyncio
 


### PR DESCRIPTION
docs: add missing InputGuardrailTripwireTriggered import to quickstart example

Fixes NameError when handling guardrail exceptions by including the required import in the docs.