### PR TITLE
Realtime: only update model settings from session

### DIFF
--- a/tests/realtime/test_runner.py
+++ b/tests/realtime/test_runner.py
@@ -1,18 +1,21 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from inline_snapshot import snapshot
 
 from agents.realtime.agent import RealtimeAgent
 from agents.realtime.config import RealtimeRunConfig, RealtimeSessionModelSettings
 from agents.realtime.model import RealtimeModel, RealtimeModelConfig
 from agents.realtime.runner import RealtimeRunner
 from agents.realtime.session import RealtimeSession
+from agents.tool import function_tool
 
 
 class MockRealtimeModel(RealtimeModel):
+    def __init__(self):
+        self.connect_args = None
+
     async def connect(self, options=None):
-        pass
+        self.connect_args = options
 
     def add_listener(self, listener):
         pass
@@ -53,7 +56,9 @@ def mock_model():
 
 
 @pytest.mark.asyncio
-async def test_run_creates_session_with_no_settings(mock_agent, mock_model):
+async def test_run_creates_session_with_no_settings(
+    mock_agent: Mock, mock_model: MockRealtimeModel
+):
     """Test that run() creates a session correctly if no settings are provided"""
     runner = RealtimeRunner(mock_agent, model=mock_model)
 
@@ -71,22 +76,17 @@ async def test_run_creates_session_with_no_settings(mock_agent, mock_model):
         assert call_args[1]["agent"] == mock_agent
         assert call_args[1]["context"] is None
 
-        # Verify model_config contains expected settings from agent
+        # With no settings provided, model_config should be None
         model_config = call_args[1]["model_config"]
-        assert model_config == snapshot(
-            {
-                "initial_model_settings": {
-                    "instructions": "Test instructions",
-                    "tools": [{"type": "function", "name": "test_tool"}],
-                }
-            }
-        )
+        assert model_config is None
 
         assert session == mock_session
 
 
 @pytest.mark.asyncio
-async def test_run_creates_session_with_settings_only_in_init(mock_agent, mock_model):
+async def test_run_creates_session_with_settings_only_in_init(
+    mock_agent: Mock, mock_model: MockRealtimeModel
+):
     """Test that it creates a session with the right settings if they are provided only in init"""
     config = RealtimeRunConfig(
         model_settings=RealtimeSessionModelSettings(model_name="gpt-4o-realtime", voice="nova")
@@ -99,28 +99,19 @@ async def test_run_creates_session_with_settings_only_in_init(mock_agent, mock_m
 
         _ = await runner.run()
 
-        # Verify session was created with config overrides
+        # Verify session was created - runner no longer processes settings
         call_args = mock_session_class.call_args
         model_config = call_args[1]["model_config"]
 
-        # Should have agent settings plus config overrides
-        assert model_config == snapshot(
-            {
-                "initial_model_settings": {
-                    "instructions": "Test instructions",
-                    "tools": [{"type": "function", "name": "test_tool"}],
-                    "model_name": "gpt-4o-realtime",
-                    "voice": "nova",
-                }
-            }
-        )
+        # Runner should pass None for model_config when none provided to run()
+        assert model_config is None
 
 
 @pytest.mark.asyncio
 async def test_run_creates_session_with_settings_in_both_init_and_run_overrides(
-    mock_agent, mock_model
+    mock_agent: Mock, mock_model: MockRealtimeModel
 ):
-    """Test settings in both init and run() - init should override run()"""
+    """Test settings provided in run() parameter are passed through"""
     init_config = RealtimeRunConfig(
         model_settings=RealtimeSessionModelSettings(model_name="gpt-4o-realtime", voice="nova")
     )
@@ -138,26 +129,18 @@ async def test_run_creates_session_with_settings_in_both_init_and_run_overrides(
 
         _ = await runner.run(model_config=run_model_config)
 
-        # Verify run() settings override init settings
+        # Verify run() model_config is passed through as-is
         call_args = mock_session_class.call_args
         model_config = call_args[1]["model_config"]
 
-        # Should have agent settings, then init config, then run config overrides
-        assert model_config == snapshot(
-            {
-                "initial_model_settings": {
-                    "voice": "nova",
-                    "input_audio_format": "pcm16",
-                    "instructions": "Test instructions",
-                    "tools": [{"type": "function", "name": "test_tool"}],
-                    "model_name": "gpt-4o-realtime",
-                }
-            }
-        )
+        # Runner should pass the model_config from run() parameter directly
+        assert model_config == run_model_config
 
 
 @pytest.mark.asyncio
-async def test_run_creates_session_with_settings_only_in_run(mock_agent, mock_model):
+async def test_run_creates_session_with_settings_only_in_run(
+    mock_agent: Mock, mock_model: MockRealtimeModel
+):
     """Test settings provided only in run()"""
     runner = RealtimeRunner(mock_agent, model=mock_model)
 
@@ -173,26 +156,16 @@ async def test_run_creates_session_with_settings_only_in_run(mock_agent, mock_mo
 
         _ = await runner.run(model_config=run_model_config)
 
-        # Verify run() settings are applied
+        # Verify run() model_config is passed through as-is
         call_args = mock_session_class.call_args
         model_config = call_args[1]["model_config"]
 
-        # Should have agent settings plus run() settings
-        assert model_config == snapshot(
-            {
-                "initial_model_settings": {
-                    "model_name": "gpt-4o-realtime-preview",
-                    "voice": "shimmer",
-                    "modalities": ["text", "audio"],
-                    "instructions": "Test instructions",
-                    "tools": [{"type": "function", "name": "test_tool"}],
-                }
-            }
-        )
+        # Runner should pass the model_config from run() parameter directly
+        assert model_config == run_model_config
 
 
 @pytest.mark.asyncio
-async def test_run_with_context_parameter(mock_agent, mock_model):
+async def test_run_with_context_parameter(mock_agent: Mock, mock_model: MockRealtimeModel):
     """Test that context parameter is passed through to session"""
     runner = RealtimeRunner(mock_agent, model=mock_model)
     test_context = {"user_id": "test123"}
@@ -208,17 +181,69 @@ async def test_run_with_context_parameter(mock_agent, mock_model):
 
 
 @pytest.mark.asyncio
-async def test_get_model_settings_with_none_values(mock_model):
-    """Test _get_model_settings handles None values from agent properly"""
+async def test_run_with_none_values_from_agent_does_not_crash(mock_model: MockRealtimeModel):
+    """Test that runner handles agents with None values without crashing"""
     agent = Mock(spec=RealtimeAgent)
     agent.get_system_prompt = AsyncMock(return_value=None)
     agent.get_all_tools = AsyncMock(return_value=None)
 
     runner = RealtimeRunner(agent, model=mock_model)
 
-    with patch("agents.realtime.runner.RealtimeSession"):
-        await runner.run()
+    with patch("agents.realtime.runner.RealtimeSession") as mock_session_class:
+        mock_session = Mock(spec=RealtimeSession)
+        mock_session_class.return_value = mock_session
 
-        # Should not crash and agent methods should be called
-        agent.get_system_prompt.assert_called_once()
-        agent.get_all_tools.assert_called_once()
+        session = await runner.run()
+
+        # Should not crash and return session
+        assert session == mock_session
+        # Runner no longer calls agent methods directly - session does that
+        agent.get_system_prompt.assert_not_called()
+        agent.get_all_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tool_and_handoffs_are_correct(mock_model: MockRealtimeModel):
+    @function_tool
+    def tool_one():
+        return "result_one"
+
+    agent_1 = RealtimeAgent(
+        name="one",
+        instructions="instr_one",
+    )
+    agent_2 = RealtimeAgent(
+        name="two",
+        instructions="instr_two",
+        tools=[tool_one],
+        handoffs=[agent_1],
+    )
+
+    session = RealtimeSession(
+        model=mock_model,
+        agent=agent_2,
+        context=None,
+        model_config=None,
+        run_config=None,
+    )
+
+    async with session:
+        pass
+
+    # Assert that the model.connect() was called with the correct settings
+    connect_args = mock_model.connect_args
+    assert connect_args is not None
+    assert isinstance(connect_args, dict)
+    initial_model_settings = connect_args["initial_model_settings"]
+    assert initial_model_settings is not None
+    assert isinstance(initial_model_settings, dict)
+    assert initial_model_settings["instructions"] == "instr_two"
+    assert len(initial_model_settings["tools"]) == 1
+    tool = initial_model_settings["tools"][0]
+    assert tool.name == "tool_one"
+
+    handoffs = initial_model_settings["handoffs"]
+    assert len(handoffs) == 1
+    handoff = handoffs[0]
+    assert handoff.tool_name == "transfer_to_one"
+    assert handoff.agent_name == "one"

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1206,3 +1206,116 @@ class TestGuardrailFunctionality:
         guardrail_events = [e for e in events if isinstance(e, RealtimeGuardrailTripped)]
         assert len(guardrail_events) == 1
         assert len(guardrail_events[0].guardrail_results) == 2
+
+
+class TestModelSettingsIntegration:
+    """Test suite for model settings integration in RealtimeSession."""
+
+    @pytest.mark.asyncio
+    async def test_session_gets_model_settings_from_agent_during_connection(self):
+        """Test that session properly gets model settings from agent during __aenter__."""
+        # Create mock model that records the config passed to connect()
+        mock_model = Mock(spec=RealtimeModel)
+        mock_model.connect = AsyncMock()
+        mock_model.add_listener = Mock()
+        
+        # Create agent with specific settings
+        agent = Mock(spec=RealtimeAgent)
+        agent.get_system_prompt = AsyncMock(return_value="Test agent instructions")
+        agent.get_all_tools = AsyncMock(return_value=[{"type": "function", "name": "test_tool"}])
+        agent.handoffs = []
+        
+        session = RealtimeSession(mock_model, agent, None)
+        
+        # Connect the session
+        await session.__aenter__()
+        
+        # Verify model.connect was called with settings from agent
+        mock_model.connect.assert_called_once()
+        connect_config = mock_model.connect.call_args[0][0]
+        
+        initial_settings = connect_config["initial_model_settings"]
+        assert initial_settings["instructions"] == "Test agent instructions"
+        assert initial_settings["tools"] == [{"type": "function", "name": "test_tool"}]
+        assert initial_settings["handoffs"] == []
+        
+        await session.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio  
+    async def test_model_config_overrides_agent_settings(self):
+        """Test that initial_model_settings from model_config override agent settings."""
+        mock_model = Mock(spec=RealtimeModel)
+        mock_model.connect = AsyncMock()
+        mock_model.add_listener = Mock()
+        
+        agent = Mock(spec=RealtimeAgent)
+        agent.get_system_prompt = AsyncMock(return_value="Agent instructions")
+        agent.get_all_tools = AsyncMock(return_value=[{"type": "function", "name": "agent_tool"}])
+        agent.handoffs = []
+        
+        # Provide model config with overrides
+        model_config = {
+            "initial_model_settings": {
+                "instructions": "Override instructions",
+                "voice": "nova",
+                "model_name": "gpt-4o-realtime"
+            }
+        }
+        
+        session = RealtimeSession(mock_model, agent, None, model_config=model_config)
+        
+        await session.__aenter__()
+        
+        # Verify overrides were applied
+        connect_config = mock_model.connect.call_args[0][0]
+        initial_settings = connect_config["initial_model_settings"]
+        
+        # Should have override values
+        assert initial_settings["instructions"] == "Override instructions" 
+        assert initial_settings["voice"] == "nova"
+        assert initial_settings["model_name"] == "gpt-4o-realtime"
+        # Should still have agent tools since not overridden
+        assert initial_settings["tools"] == [{"type": "function", "name": "agent_tool"}]
+        
+        await session.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_handoffs_are_included_in_model_settings(self):
+        """Test that handoffs from agent are properly processed into model settings."""
+        mock_model = Mock(spec=RealtimeModel)
+        mock_model.connect = AsyncMock()
+        mock_model.add_listener = Mock()
+        
+        # Create agent with handoffs
+        agent = Mock(spec=RealtimeAgent)
+        agent.get_system_prompt = AsyncMock(return_value="Agent with handoffs")
+        agent.get_all_tools = AsyncMock(return_value=[])
+        
+        # Create a mock handoff
+        handoff_agent = Mock(spec=RealtimeAgent)
+        handoff_agent.name = "handoff_target"
+        
+        mock_handoff = Mock(spec=Handoff)
+        mock_handoff.tool_name = "transfer_to_specialist"
+        mock_handoff.is_enabled = True
+        
+        agent.handoffs = [handoff_agent]  # Agent handoff
+        
+        # Mock the _get_handoffs method since it's complex  
+        with pytest.MonkeyPatch().context() as m:
+            async def mock_get_handoffs(cls, agent, context_wrapper):
+                return [mock_handoff]
+            
+            m.setattr("agents.realtime.session.RealtimeSession._get_handoffs", mock_get_handoffs)
+            
+            session = RealtimeSession(mock_model, agent, None)
+            
+            await session.__aenter__()
+            
+            # Verify handoffs were included
+            connect_config = mock_model.connect.call_args[0][0]
+            initial_settings = connect_config["initial_model_settings"]
+            
+            assert initial_settings["handoffs"] == [mock_handoff]
+            
+            await session.__aexit__(None, None, None)

--- a/tests/test_session_exceptions.py
+++ b/tests/test_session_exceptions.py
@@ -90,6 +90,8 @@ def fake_agent():
     """Create a fake agent for testing."""
     agent = Mock()
     agent.get_all_tools = AsyncMock(return_value=[])
+    agent.get_system_prompt = AsyncMock(return_value="test instructions")
+    agent.handoffs = []
     return agent
 
 


### PR DESCRIPTION

### Summary:
Was running into bugs. Because the model settings were being set from both runner and session, and that was causing issues. Among other things, handoffs were broken because the runner wasn't reading them, and the session wasn't setting them in the connect() call.

### Test Plan:
Unit tests.
