### PR TITLE
Fix image_generator example error on Windows OS

### DIFF
--- a/examples/tools/image_generator.py
+++ b/examples/tools/image_generator.py
@@ -12,7 +12,7 @@ def open_file(path: str) -> None:
     if sys.platform.startswith("darwin"):
         subprocess.run(["open", path], check=False)  # macOS
     elif os.name == "nt":  # Windows
-        os.astartfile(path)  # type: ignore
+        os.startfile(path)
     elif os.name == "posix":
         subprocess.run(["xdg-open", path], check=False)  # Linux/Unix
     else:

--- a/examples/tools/image_generator.py
+++ b/examples/tools/image_generator.py
@@ -12,7 +12,7 @@ def open_file(path: str) -> None:
     if sys.platform.startswith("darwin"):
         subprocess.run(["open", path], check=False)  # macOS
     elif os.name == "nt":  # Windows
-        os.startfile(path)
+        os.startfile(path)  # type: ignore
     elif os.name == "posix":
         subprocess.run(["xdg-open", path], check=False)  # Linux/Unix
     else:


### PR DESCRIPTION
Due to the method name typo, it does not work on the OS.