### PR TITLE
docs(examples): use UserLocation dataclass in WebSearchTool example

### DIFF
--- a/examples/tools/web_search.py
+++ b/examples/tools/web_search.py
@@ -1,13 +1,21 @@
 import asyncio
 
-from agents import Agent, Runner, WebSearchTool, trace
-
+from agents import Agent, Runner, WebSearchTool, UserLocation, trace
 
 async def main():
     agent = Agent(
         name="Web searcher",
         instructions="You are a helpful agent.",
-        tools=[WebSearchTool(user_location={"type": "approximate", "city": "New York"})],
+        tools=[
+            WebSearchTool(
+                user_location=UserLocation(
+                    type="approximate",
+                    city="New York"
+                ),
+                # Feel free to adjust how much context the tool retrieves:
+                # search_context_size="medium",
+            )
+        ],
     )
 
     with trace("Web search example"):
@@ -16,8 +24,7 @@ async def main():
             "search the web for 'local sports news' and give me 1 interesting update in a sentence.",
         )
         print(result.final_output)
-        # The New York Giants are reportedly pursuing quarterback Aaron Rodgers after his ...
-
-
+        # Now this _will_ be localized to New York!
+    
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
This update refines the `examples/web_search.py` snippet to instantiate `WebSearchTool.user_location` with the proper `UserLocation` dataclass rather than a raw `dict`. This change improves type safety, editor autocompletion, and future‑proofs the example against any additional `UserLocation` fields.

See the official docs for `WebSearchTool` and its `user_location` parameter here: [https://openai.github.io/openai-agents-python/ref/tool/#agents.tool.WebSearchTool](https://openai.github.io/openai-agents-python/ref/tool/#agents.tool.WebSearchTool)