### PR TITLE
Enh - Use handoff_description as Default Fallback for Tool Description in as_tool() of agents

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -253,7 +253,7 @@ class Agent(AgentBase, Generic[TContext]):
 
         @function_tool(
             name_override=tool_name or _transforms.transform_string_function_style(self.name),
-            description_override=tool_description or "",
+            description_override=tool_description or self.handoff_description,
         )
         async def run_agent(context: RunContextWrapper, input: str) -> str:
             from .run import Runner


### PR DESCRIPTION
### Summary

Replaced the default fallback value for `description_override` in the `as_tool()` method of the `Agent` class from an empty string (`""`) to `self.handoff_description`. This ensures that when no explicit tool description is provided, the agent's `handoff_description` is used as a meaningful and human-readable default. This improves clarity, reduces the need for redundant arguments, and aligns with the DRY principle.

### Issue number

### Checks

- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
