### PR TITLE
Fix RealtimeModel reference

### DIFF
--- a/docs/ref/realtime/model.md
+++ b/docs/ref/realtime/model.md
@@ -1,0 +1,3 @@
+# `Model`
+
+::: agents.realtime.model

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ plugins:
                     - ref/realtime/session.md
                     - ref/realtime/events.md
                     - ref/realtime/config.md
+                    - ref/realtime/model.md
                 - Voice:
                     - ref/voice/pipeline.md
                     - ref/voice/workflow.md


### PR DESCRIPTION
## Summary
- document `agents.realtime.model` so the RealtimeModel link works
- include the new file in the documentation navigation

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_i_687fadfee88883219240b56e5abba76a