### PR TITLE
[Bugfix] Fix wrong imports in examples

### DIFF
--- a/examples/reasoning_content/main.py
+++ b/examples/reasoning_content/main.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 from agents import ModelSettings
 from agents.models.interface import ModelTracing
 from agents.models.openai_provider import OpenAIProvider
-from agents.types import ResponseOutputRefusal, ResponseOutputText  # type: ignore
+from openai.types.responses import ResponseOutputRefusal, ResponseOutputText  # type: ignore
 
 MODEL_NAME = os.getenv("EXAMPLE_MODEL_NAME") or "deepseek-reasoner"
 

--- a/examples/reasoning_content/main.py
+++ b/examples/reasoning_content/main.py
@@ -13,10 +13,11 @@ import asyncio
 import os
 from typing import Any, cast
 
+from openai.types.responses import ResponseOutputRefusal, ResponseOutputText
+
 from agents import ModelSettings
 from agents.models.interface import ModelTracing
 from agents.models.openai_provider import OpenAIProvider
-from openai.types.responses import ResponseOutputRefusal, ResponseOutputText  # type: ignore
 
 MODEL_NAME = os.getenv("EXAMPLE_MODEL_NAME") or "deepseek-reasoner"
 


### PR DESCRIPTION
The current script gives

```
Traceback (most recent call last):
  File "/Users/xmxd289/code/openai-agents-python/examples/reasoning_content/main.py", line 19, in <module>
    from agents.types import ResponseOutputRefusal, ResponseOutputText  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'agents.types'
```

because it should be

`from openai.types.responses import ResponseOutputRefusal, ResponseOutputText`

rather than

`from agents.types import ResponseOutputRefusal, ResponseOutputText`