### PR TITLE
Realtime: enable a playback tracker

### DIFF
--- a/src/agents/realtime/__init__.py
+++ b/src/agents/realtime/__init__.py
@@ -47,6 +47,8 @@ from .model import (
     RealtimeModel,
     RealtimeModelConfig,
     RealtimeModelListener,
+    RealtimePlaybackState,
+    RealtimePlaybackTracker,
 )
 from .model_events import (
     RealtimeConnectionStatus,
@@ -139,6 +141,8 @@ __all__ = [
     "RealtimeModel",
     "RealtimeModelConfig",
     "RealtimeModelListener",
+    "RealtimePlaybackTracker",
+    "RealtimePlaybackState",
     # Model Events
     "RealtimeConnectionStatus",
     "RealtimeModelAudioDoneEvent",

--- a/src/agents/realtime/_default_tracker.py
+++ b/src/agents/realtime/_default_tracker.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._util import calculate_audio_length_ms
+from .config import RealtimeAudioFormat
+
+
+@dataclass
+class ModelAudioState:
+    initial_received_time: datetime
+    audio_length_ms: float
+
+
+class ModelAudioTracker:
+    def __init__(self) -> None:
+        # (item_id, item_content_index) -> ModelAudioState
+        self._states: dict[tuple[str, int], ModelAudioState] = {}
+        self._last_audio_item: tuple[str, int] | None = None
+
+    def set_audio_format(self, format: RealtimeAudioFormat) -> None:
+        """Called when the model wants to set the audio format."""
+        self._format = format
+
+    def on_audio_delta(self, item_id: str, item_content_index: int, audio_bytes: bytes) -> None:
+        """Called when an audio delta is received from the model."""
+        ms = calculate_audio_length_ms(self._format, audio_bytes)
+        new_key = (item_id, item_content_index)
+
+        self._last_audio_item = new_key
+        if new_key not in self._states:
+            self._states[new_key] = ModelAudioState(datetime.now(), ms)
+        else:
+            self._states[new_key].audio_length_ms += ms
+
+    def on_interrupted(self) -> None:
+        """Called when the audio playback has been interrupted."""
+        self._last_audio_item = None
+
+    def get_state(self, item_id: str, item_content_index: int) -> ModelAudioState | None:
+        """Called when the model wants to get the current playback state."""
+        return self._states.get((item_id, item_content_index))
+
+    def get_last_audio_item(self) -> tuple[str, int] | None:
+        """Called when the model wants to get the last audio item ID and content index."""
+        return self._last_audio_item

--- a/src/agents/realtime/_util.py
+++ b/src/agents/realtime/_util.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .config import RealtimeAudioFormat
+
+
+def calculate_audio_length_ms(format: RealtimeAudioFormat | None, audio_bytes: bytes) -> float:
+    if format and format.startswith("g711"):
+        return (len(audio_bytes) / 8000) * 1000
+    return (len(audio_bytes) / 24 / 2) * 1000

--- a/src/agents/realtime/model.py
+++ b/src/agents/realtime/model.py
@@ -6,11 +6,93 @@ from typing import Callable
 from typing_extensions import NotRequired, TypedDict
 
 from ..util._types import MaybeAwaitable
+from ._util import calculate_audio_length_ms
 from .config import (
+    RealtimeAudioFormat,
     RealtimeSessionModelSettings,
 )
 from .model_events import RealtimeModelEvent
 from .model_inputs import RealtimeModelSendEvent
+
+
+class RealtimePlaybackState(TypedDict):
+    current_item_id: str | None
+    """The item ID of the current item being played."""
+
+    current_item_content_index: int | None
+    """The index of the current item content being played."""
+
+    elapsed_ms: float | None
+    """The number of milliseconds of audio that have been played."""
+
+
+class RealtimePlaybackTracker:
+    """If you have custom playback logic or expect that audio is played with delays or at different
+    speeds, create an instance of RealtimePlaybackTracker and pass it to the session. You are
+    responsible for tracking the audio playback progress and calling `on_play_bytes` or
+    `on_play_ms` when the user has played some audio."""
+
+    def __init__(self) -> None:
+        self._format: RealtimeAudioFormat | None = None
+        # (item_id, item_content_index)
+        self._current_item: tuple[str, int] | None = None
+        self._elapsed_ms: float | None = None
+
+    def on_play_bytes(self, item_id: str, item_content_index: int, bytes: bytes) -> None:
+        """Called by you when you have played some audio.
+
+        Args:
+            item_id: The item ID of the audio being played.
+            item_content_index: The index of the audio content in `item.content`
+            bytes: The audio bytes that have been fully played.
+        """
+        ms = calculate_audio_length_ms(self._format, bytes)
+        self.on_play_ms(item_id, item_content_index, ms)
+
+    def on_play_ms(self, item_id: str, item_content_index: int, ms: float) -> None:
+        """Called by you when you have played some audio.
+
+        Args:
+            item_id: The item ID of the audio being played.
+            item_content_index: The index of the audio content in `item.content`
+            ms: The number of milliseconds of audio that have been played.
+        """
+        if self._current_item != (item_id, item_content_index):
+            self._current_item = (item_id, item_content_index)
+            self._elapsed_ms = ms
+        else:
+            assert self._elapsed_ms is not None
+            self._elapsed_ms += ms
+
+    def on_interrupted(self) -> None:
+        """Called by the model when the audio playback has been interrupted."""
+        self._current_item = None
+        self._elapsed_ms = None
+
+    def set_audio_format(self, format: RealtimeAudioFormat) -> None:
+        """Will be called by the model to set the audio format.
+
+        Args:
+            format: The audio format to use.
+        """
+        self._format = format
+
+    def get_state(self) -> RealtimePlaybackState:
+        """Will be called by the model to get the current playback state."""
+        if self._current_item is None:
+            return {
+                "current_item_id": None,
+                "current_item_content_index": None,
+                "elapsed_ms": None,
+            }
+        assert self._elapsed_ms is not None
+
+        item_id, item_content_index = self._current_item
+        return {
+            "current_item_id": item_id,
+            "current_item_content_index": item_content_index,
+            "elapsed_ms": self._elapsed_ms,
+        }
 
 
 class RealtimeModelListener(abc.ABC):
@@ -38,6 +120,18 @@ class RealtimeModelConfig(TypedDict):
 
     initial_model_settings: NotRequired[RealtimeSessionModelSettings]
     """The initial model settings to use when connecting."""
+
+    playback_tracker: NotRequired[RealtimePlaybackTracker]
+    """The playback tracker to use when tracking audio playback progress. If not set, the model will
+    use a default implementation that assumes audio is played immediately, at realtime speed.
+
+    A playback tracker is useful for interruptions. The model generates audio much faster than
+    realtime playback speed. So if there's an interruption, its useful for the model to know how
+    much of the audio has been played by the user. In low-latency scenarios, it's fine to assume
+    that audio is played back immediately at realtime speed. But in scenarios like phone calls or
+    other remote interactions, you can set a playback tracker that lets the model know when audio
+    is played to the user.
+    """
 
 
 class RealtimeModel(abc.ABC):

--- a/tests/realtime/test_agent.py
+++ b/tests/realtime/test_agent.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from agents import RunContextWrapper

--- a/tests/realtime/test_conversion_helpers.py
+++ b/tests/realtime/test_conversion_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 from unittest.mock import Mock
 

--- a/tests/realtime/test_playback_tracker.py
+++ b/tests/realtime/test_playback_tracker.py
@@ -1,0 +1,112 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agents.realtime._default_tracker import ModelAudioTracker
+from agents.realtime.model import RealtimePlaybackTracker
+from agents.realtime.model_inputs import RealtimeModelSendInterrupt
+from agents.realtime.openai_realtime import OpenAIRealtimeWebSocketModel
+
+
+class TestPlaybackTracker:
+    """Test playback tracker functionality for interrupt timing."""
+
+    @pytest.fixture
+    def model(self):
+        """Create a fresh model instance for each test."""
+        return OpenAIRealtimeWebSocketModel()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_timing_with_custom_playback_tracker(self, model):
+        """Test interrupt uses custom playback tracker elapsed time instead of default timing."""
+
+        # Create custom tracker and set elapsed time
+        custom_tracker = RealtimePlaybackTracker()
+        custom_tracker.set_audio_format("pcm16")
+        custom_tracker.on_play_ms("item_1", 1, 500.0)  # content_index 1, 500ms played
+
+        # Set up model with custom tracker directly
+        model._playback_tracker = custom_tracker
+
+        # Mock send_raw_message to capture interrupt
+        model._send_raw_message = AsyncMock()
+
+        # Send interrupt
+
+        await model._send_interrupt(RealtimeModelSendInterrupt())
+
+        # Should use custom tracker's 500ms elapsed time
+        model._send_raw_message.assert_called_once()
+        call_args = model._send_raw_message.call_args[0][0]
+        assert call_args.audio_end_ms == 500
+
+    @pytest.mark.asyncio
+    async def test_interrupt_skipped_when_no_audio_playing(self, model):
+        """Test interrupt returns early when no audio is currently playing."""
+        model._send_raw_message = AsyncMock()
+
+        # No audio playing (default state)
+
+        await model._send_interrupt(RealtimeModelSendInterrupt())
+
+        # Should not send any interrupt message
+        model._send_raw_message.assert_not_called()
+
+    def test_audio_state_accumulation_across_deltas(self):
+        """Test ModelAudioTracker accumulates audio length across multiple deltas."""
+
+        tracker = ModelAudioTracker()
+        tracker.set_audio_format("pcm16")
+
+        # Send multiple deltas for same item
+        tracker.on_audio_delta("item_1", 0, b"test")  # 4 bytes
+        tracker.on_audio_delta("item_1", 0, b"more")  # 4 bytes
+
+        state = tracker.get_state("item_1", 0)
+        assert state is not None
+        # Should accumulate: 8 bytes / 24 / 2 * 1000 = 166.67ms
+        expected_length = (8 / 24 / 2) * 1000
+        assert abs(state.audio_length_ms - expected_length) < 0.01
+
+    def test_state_cleanup_on_interruption(self):
+        """Test both trackers properly reset state on interruption."""
+
+        # Test ModelAudioTracker cleanup
+        model_tracker = ModelAudioTracker()
+        model_tracker.set_audio_format("pcm16")
+        model_tracker.on_audio_delta("item_1", 0, b"test")
+        assert model_tracker.get_last_audio_item() == ("item_1", 0)
+
+        model_tracker.on_interrupted()
+        assert model_tracker.get_last_audio_item() is None
+
+        # Test RealtimePlaybackTracker cleanup
+        playback_tracker = RealtimePlaybackTracker()
+        playback_tracker.on_play_ms("item_1", 0, 100.0)
+
+        state = playback_tracker.get_state()
+        assert state["current_item_id"] == "item_1"
+        assert state["elapsed_ms"] == 100.0
+
+        playback_tracker.on_interrupted()
+        state = playback_tracker.get_state()
+        assert state["current_item_id"] is None
+        assert state["elapsed_ms"] is None
+
+    def test_audio_length_calculation_with_different_formats(self):
+        """Test calculate_audio_length_ms handles g711 and PCM formats correctly."""
+        from agents.realtime._util import calculate_audio_length_ms
+
+        # Test g711 format (8kHz)
+        g711_bytes = b"12345678"  # 8 bytes
+        g711_length = calculate_audio_length_ms("g711_ulaw", g711_bytes)
+        assert g711_length == 1  # (8 / 8000) * 1000
+
+        # Test PCM format (24kHz, default)
+        pcm_bytes = b"test"  # 4 bytes
+        pcm_length = calculate_audio_length_ms("pcm16", pcm_bytes)
+        assert pcm_length == (4 / 24 / 2) * 1000  # ~83.33ms
+
+        # Test None format (defaults to PCM)
+        none_length = calculate_audio_length_ms(None, pcm_bytes)
+        assert none_length == pcm_length


### PR DESCRIPTION
So far, we've been assuming that audio is played:
- immediately (i.e. with 0 delay/latency)
- at realtime

This causes issues with our interrupt tracking. The model wants to know how much audio the user has actually heard. For example in a phone call agent, this wouldn't work (bc theres a delay of a few hundred ms between model sending audio and the user hearing it). This PR allows you to pass a playback tracker.






---
[//]: # (BEGIN SAPLING FOOTER)
* #1252
* #1216
* #1243
* __->__ #1242