### PR TITLE
fix tool response handling in translation example

### DIFF
--- a/examples/agent_patterns/agents_as_tools.py
+++ b/examples/agent_patterns/agents_as_tools.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from agents import Agent, ItemHelpers, Runner, trace, ToolResponseItem
+from agents import Agent, ItemHelpers, Runner, trace
 
 """
 This example shows the agents-as-tools pattern. The frontline agent receives a user message and
@@ -63,11 +63,13 @@ async def main():
         orchestrator_result = await Runner.run(orchestrator_agent, msg)
 
         for item in orchestrator_result.new_items:
-            if isinstance(item, ToolResponseItem):
-                text = ItemHelpers.text_message_output(item.content)
-                if text:
+            text = ItemHelpers.text_message_output(item)
+            if text:
+                if hasattr(item, 'tool_name') and 'translate_to_' in getattr(item, 'tool_name', ''):
                     lang = item.tool_name.replace("translate_to_", "").capitalize()
                     print(f"  - {lang}: {text}")
+                else:
+                    print(f"  - Translation step: {text}")
 
         synthesizer_result = await Runner.run(
             synthesizer_agent, orchestrator_result.to_input_list()

--- a/examples/agent_patterns/agents_as_tools.py
+++ b/examples/agent_patterns/agents_as_tools.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from agents import Agent, ItemHelpers, MessageOutputItem, Runner, trace
+from agents import Agent, ItemHelpers, Runner, trace, ToolResponseItem
 
 """
 This example shows the agents-as-tools pattern. The frontline agent receives a user message and
@@ -63,10 +63,11 @@ async def main():
         orchestrator_result = await Runner.run(orchestrator_agent, msg)
 
         for item in orchestrator_result.new_items:
-            if isinstance(item, MessageOutputItem):
-                text = ItemHelpers.text_message_output(item)
+            if isinstance(item, ToolResponseItem):
+                text = ItemHelpers.text_message_output(item.content)
                 if text:
-                    print(f"  - Translation step: {text}")
+                    lang = item.tool_name.replace("translate_to_", "").capitalize()
+                    print(f"  - {lang}: {text}")
 
         synthesizer_result = await Runner.run(
             synthesizer_agent, orchestrator_result.to_input_list()


### PR DESCRIPTION
The agents_as_tools.py example was filtering on MessageOutputItem, but tool calls emit ToolResponseItem. Update the loop to check for ToolResponseItem and extract its inner content, so that intermediate translation steps are correctly printed via ItemHelpers.