### PR TITLE
Add parentheses for clarity in exit handler

### DIFF
--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -183,7 +183,7 @@ class TraceImpl(Trace):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(reset_current=exc_type is not GeneratorExit)
+        self.finish(reset_current=(exc_type is not GeneratorExit))
 
     def export(self) -> dict[str, Any] | None:
         return {


### PR DESCRIPTION
Added parentheses around the boolean expression in `__exit__` to make the evaluation order explicit. This improves readability while maintaining identical functionality.