### PR TITLE
Fix type placeholder convention

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -116,7 +116,7 @@ class AgentOutputSchema(AgentOutputSchemaBase):
                 raise UserError(
                     "Strict JSON schema is enabled, but the output type is not valid. "
                     "Either make the output type strict, "
-                    "or wrap your type with AgentOutputSchema(your_type, strict_json_schema=False)"
+                    "or wrap your type with AgentOutputSchema(YourType, strict_json_schema=False)"
                 ) from e
 
     def is_plain_text(self) -> bool:


### PR DESCRIPTION
Updated the error message to replace the placeholder `your_type` with `YourType`, removing the underscore and adopting PascalCase, which aligns with standard Python type naming conventions.