### PR TITLE
Tweak on guardrail docstrings

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -128,7 +128,7 @@ class InputGuardrail(Generic[TContext]):
 @dataclass
 class OutputGuardrail(Generic[TContext]):
     """Output guardrails are checks that run on the final output of an agent.
-    They can be used to check if the output passes certain validation criteria
+    They can be used to do check if the output passes certain validation criteria
 
     You can use the `@output_guardrail()` decorator to turn a function into an `OutputGuardrail`,
     or create an `OutputGuardrail` manually.

--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -78,8 +78,9 @@ class InputGuardrail(Generic[TContext]):
     You can use the `@input_guardrail()` decorator to turn a function into an `InputGuardrail`, or
     create an `InputGuardrail` manually.
 
-    Guardrails return a `GuardrailResult`. If `result.tripwire_triggered` is `True`, the agent
-    execution will immediately stop and an `InputGuardrailTripwireTriggered` exception will be raised
+    Guardrails return a `GuardrailResult`. If `result.tripwire_triggered` is `True`,
+    the agent's execution will immediately stop, and
+    an `InputGuardrailTripwireTriggered` exception will be raised
     """
 
     guardrail_function: Callable[

--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -79,7 +79,7 @@ class InputGuardrail(Generic[TContext]):
     create an `InputGuardrail` manually.
 
     Guardrails return a `GuardrailResult`. If `result.tripwire_triggered` is `True`, the agent
-    execution will immediately stop and a `InputGuardrailTripwireTriggered` exception will be raised
+    execution will immediately stop and an `InputGuardrailTripwireTriggered` exception will be raised
     """
 
     guardrail_function: Callable[
@@ -127,12 +127,12 @@ class InputGuardrail(Generic[TContext]):
 @dataclass
 class OutputGuardrail(Generic[TContext]):
     """Output guardrails are checks that run on the final output of an agent.
-    They can be used to do check if the output passes certain validation criteria
+    They can be used to check if the output passes certain validation criteria
 
     You can use the `@output_guardrail()` decorator to turn a function into an `OutputGuardrail`,
     or create an `OutputGuardrail` manually.
 
-    Guardrails return a `GuardrailResult`. If `result.tripwire_triggered` is `True`, a
+    Guardrails return a `GuardrailResult`. If `result.tripwire_triggered` is `True`, an
     `OutputGuardrailTripwireTriggered` exception will be raised.
     """
 
@@ -316,7 +316,7 @@ def output_guardrail(
     ) -> OutputGuardrail[TContext_co]:
         return OutputGuardrail(
             guardrail_function=f,
-            # Guardrail name defaults to function name when not specified (None).
+            # Guardrail name defaults to function's name when not specified (None).
             name=name if name else f.__name__,
         )
 


### PR DESCRIPTION
✅ The article usage is now grammatically correct with "an" before class names starting with vowel sounds
✅ The possessive form correctly uses "function's name" instead of "function name"
✅ The redundant word "do" has been removed from "to do check" → "to check"
✅ The line length violations (E501) have been resolved with proper docstring formatting
✅ Overall documentation now maintains professional consistency and grammatical accuracy