### PR TITLE
Consistently use "Python" in docstrings

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -76,7 +76,7 @@ class FuncSchema:
 
 @dataclass
 class FuncDocumentation:
-    """Contains metadata about a python function, extracted from its docstring."""
+    """Contains metadata about a Python function, extracted from its docstring."""
 
     name: str
     """The name of the function, via `__name__`."""
@@ -194,7 +194,7 @@ def function_schema(
     strict_json_schema: bool = True,
 ) -> FuncSchema:
     """
-    Given a python function, extracts a `FuncSchema` from it, capturing the name, description,
+    Given a Python function, extracts a `FuncSchema` from it, capturing the name, description,
     parameter descriptions, and other metadata.
 
     Args:
@@ -208,7 +208,7 @@ def function_schema(
             descriptions.
         strict_json_schema: Whether the JSON schema is in strict mode. If True, we'll ensure that
             the schema adheres to the "strict" standard the OpenAI API expects. We **strongly**
-            recommend setting this to True, as it increases the likelihood of the LLM providing
+            recommend setting this to True, as it increases the likelihood of the LLM producing
             correct JSON input.
 
     Returns:


### PR DESCRIPTION
Capitalized "Python" as it's a proper noun in function documentation.
Changed "providing" to "producing" for more accurate technical description of LLM behavior.

These minor documentation improvements enhance professionalism and technical accuracy while maintaining identical functionality.