### PR TITLE
gpt 4.5-preview is removed, use gpt-4.1

### DIFF
--- a/examples/financial_research_agent/agents/writer_agent.py
+++ b/examples/financial_research_agent/agents/writer_agent.py
@@ -29,6 +29,6 @@ class FinancialReportData(BaseModel):
 writer_agent = Agent(
     name="FinancialWriterAgent",
     instructions=WRITER_PROMPT,
-    model="gpt-4.1-2025-04-14",
+    model="gpt-4.1",
     output_type=FinancialReportData,
 )

--- a/examples/financial_research_agent/agents/writer_agent.py
+++ b/examples/financial_research_agent/agents/writer_agent.py
@@ -29,6 +29,6 @@ class FinancialReportData(BaseModel):
 writer_agent = Agent(
     name="FinancialWriterAgent",
     instructions=WRITER_PROMPT,
-    model="gpt-4.5-preview-2025-02-27",
+    model="gpt-4.1-2025-04-14",
     output_type=FinancialReportData,
 )


### PR DESCRIPTION
The Financial Research Agent example is broken because it uses the model `gpt-4.5-preview-2025-02-27`. This model has been [removed and is no longer available](https://platform.openai.com/docs/deprecations#2025-04-14-gpt-4-5-preview).

This change follows the recommendation to replace gpt-4.5-preview with gpt-4.1.