### PR TITLE
fix: enforce min trigger size=1 to prevent immediate exports

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -183,7 +183,7 @@ class BatchTraceProcessor(TracingProcessor):
         self._shutdown_event = threading.Event()
 
         # The queue size threshold at which we export immediately.
-        self._export_trigger_size = int(max_queue_size * export_trigger_ratio)
+        self._export_trigger_size = max(1, int(max_queue_size * export_trigger_ratio))
 
         # Track when we next *must* perform a scheduled export
         self._next_export_time = time.time() + self._schedule_delay


### PR DESCRIPTION
When max_queue_size is small (e.g., 1), max_queue_size * export_trigger_ratio could be less than 1, resulting in a zero trigger size. This would cause immediate exports after adding any item to the queue (since queue_size >= 0 is always true), defeating the purpose of batching. This change ensures the trigger size is at least 1 by using max(1, int(max_queue_size * export_trigger_ratio)).

**Fix**:  
```python
# Before (broken for small queues)
trigger_size = int(max_queue_size * export_trigger_ratio)

# After (fixed: min 1 item needed)
trigger_size = max(1, int(max_queue_size * export_trigger_ratio))
```

**Key change**:  
Added `max(1, ...)` to guarantee the trigger size is **never 0**, so batching works even for tiny queues.