### PR TITLE
docs: fix UserContext example

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -34,6 +34,7 @@ Agents are generic on their `context` type. Context is a dependency-injection to
 ```python
 @dataclass
 class UserContext:
+    name: str
     uid: str
     is_pro_user: bool
 

--- a/docs/ja/agents.md
+++ b/docs/ja/agents.md
@@ -38,6 +38,7 @@ agent = Agent(
 ```python
 @dataclass
 class UserContext:
+    name: str
     uid: str
     is_pro_user: bool
 

--- a/docs/scripts/generate_ref_files.py
+++ b/docs/scripts/generate_ref_files.py
@@ -31,6 +31,7 @@ def md_target(py_path: Path) -> Path:
     rel = py_path.relative_to(SRC_ROOT).with_suffix(".md")
     return DOCS_ROOT / rel
 
+
 def pretty_title(last_segment: str) -> str:
     """
     Convert a module/file segment like 'tool_context' to 'Tool Context'.
@@ -38,6 +39,7 @@ def pretty_title(last_segment: str) -> str:
     """
     cleaned = last_segment.replace("_", " ").replace("-", " ")
     return capwords(cleaned)
+
 
 # ---- Main ------------------------------------------------------------
 


### PR DESCRIPTION
## Fix documentation inconsistency in UserContext example

### Problem
The documentation in docs/agents.md & docs/ja/agents.md contained an inconsistency where the dynamic_instructions function referenced context.context.name, but the UserContext dataclass only defined uid and is_pro_user fields. This would cause a runtime AttributeError when users tried to follow the example.

### Solution
- Added the missing name: str field to the UserContext dataclass to match what the dynamic_instructions function expects.

### Changes Made
- Added name: str field to the UserContext dataclass in the Context section
- Maintained consistency between the dataclass definition and the dynamic instructions example
- Fixed formatting issues in related files

### Testing
✅ Code formatting passes (make format-check)
✅ Documentation example is now consistent and functional
✅ No runtime errors when following the example
✅ Verified locally: Ran make serve-docs and confirmed the documentation renders correctly with the fix(make serve-docs)

### Issue number
Fixes https://github.com/openai/openai-agents-python/issues/1262