### PR TITLE
Fix _export_batches docstring to remove incorrect "threshold" reference

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -269,8 +269,7 @@ class BatchTraceProcessor(TracingProcessor):
 
     def _export_batches(self, force: bool = False):
         """Drains the queue and exports in batches. If force=True, export everything.
-        Otherwise, export up to `max_batch_size` repeatedly until the queue is empty or below a
-        certain threshold.
+        Otherwise, export up to `max_batch_size` repeatedly until the queue is completely empty.
         """
         while True:
             items_to_export: list[Span[Any] | Trace] = []


### PR DESCRIPTION
The docstring incorrectly mentioned "below a certain threshold" but the actual implementation drains the queue completely regardless of any threshold.