### PR TITLE
Add support to realtime API for setting "speed" of the models responses

### DIFF
--- a/src/agents/realtime/config.py
+++ b/src/agents/realtime/config.py
@@ -94,6 +94,9 @@ class RealtimeSessionModelSettings(TypedDict):
     voice: NotRequired[str]
     """The voice to use for audio output."""
 
+    speed: NotRequired[float]
+    """The speed of the model's responses."""
+
     input_audio_format: NotRequired[RealtimeAudioFormat]
     """The format for input audio streams."""
 

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -569,6 +569,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 or DEFAULT_MODEL_SETTINGS.get("model_name")
             ),
             voice=model_settings.get("voice", DEFAULT_MODEL_SETTINGS.get("voice")),
+            speed=model_settings.get("speed", None),
             modalities=model_settings.get("modalities", DEFAULT_MODEL_SETTINGS.get("modalities")),
             input_audio_format=model_settings.get(
                 "input_audio_format",


### PR DESCRIPTION
Unlike `openai-agents-js`, the python agents realtime sdk does not support setting the `speed` argument.

Since the underlying `openai.types.beta.realtime.Session` already supports the it, this is an easy fix.

This PR addresses that and enables settings speed as part of `RealtimeSessionModelSettings` just like it's javascript counterpart.