### PR TITLE
Fixed name coercion for int and boolean in Agent class with passing t…

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -24,6 +24,10 @@ from .tool import FunctionTool, FunctionToolResult, Tool, function_tool
 from .util import _transforms
 from .util._types import MaybeAwaitable
 
+# Pydantic ke liye import add kiya
+from pydantic import BaseModel, Field
+from typing import Union
+
 if TYPE_CHECKING:
     from .lifecycle import AgentHooks
     from .mcp import MCPServer
@@ -135,6 +139,12 @@ class Agent(AgentBase, Generic[TContext]):
 
     See `AgentBase` for base parameters that are shared with `RealtimeAgent`s.
     """
+
+    name: str = field(default=..., metadata={"description": "Agent name as string, can be provided as int or bool which will be converted to string"})
+    
+    def __post_init__(self):
+        if not isinstance(self.name, str):
+            self.name = str(self.name)
 
     instructions: (
         str

--- a/tests/test_agent_name.py
+++ b/tests/test_agent_name.py
@@ -1,0 +1,14 @@
+import pytest
+from src.agents import Agent
+def test_agent_name_types():
+    # String name
+    agent1 = Agent(name="Test", instructions="Test", model="gpt-4o")
+    assert agent1.name == "Test"
+    
+    # Integer name
+    agent2 = Agent(name=123, instructions="Test", model="gpt-4o")
+    assert agent2.name == "123"
+    
+    # Boolean name
+    agent3 = Agent(name=True, instructions="Test", model="gpt-4o")
+    assert agent3.name == "True"


### PR DESCRIPTION
### Description
Added support for `int` and `boolean` types for the `Agent` `name` parameter using `__post_init__` for string coercion. Changes:
- Updated `agent.py` to convert `int` and `boolean` to `str` using `__post_init__`.
- Added tests in `test_agent_name.py` to verify `str`, `int`, and `bool` names.

### Testing
- Ran `pytest tests/test_agent_name.py` successfully (1 passed).

### Checklist
- [x] Code changes
- [x] Tests added