### PR TITLE
agent-as-tool-examples.py

### DIFF
--- a/examples/agent_patterns/agents_as_tools.py
+++ b/examples/agent_patterns/agents_as_tools.py
@@ -3,7 +3,7 @@ import asyncio
 from agents import Agent, ItemHelpers, MessageOutputItem, Runner, trace
 
 """
-This example shows the agents-as-tools pattern. The frontline agent receives a user message and
+This examples shows the agents-as-tools pattern. The frontline agent receives a user message and
 then picks which agents to call, as tools. In this case, it picks from a set of translation
 agents.
 """


### PR DESCRIPTION
This repository contains Python examples demonstrating the agent-as-tool pattern using the Agents SDK. It includes two examples designed to showcase how agents can be used as tools within a main agent, maintaining a professional standard while being beginner-friendly.