### PR TITLE
docs: clarify usage of `name` and `instructions` fields in Agent constructor Fix agent docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ print(result.final_output)
 
 (_For Jupyter notebook users, see [hello_world_jupyter.ipynb](examples/basic/hello_world_jupyter.ipynb)_)
 
+### Note on `name` vs `instructions`
+
+- `name` is a **required** parameter used to identify your agent internally (for logs, tracing, handoffs, etc.), **but it is not passed to the LLM**.
+- `instructions` is an **optional** parameter, but it **is sent to the LLM** as a system prompt to define how the agent should behave.
+
+
 ## Handoffs example
 
 ```python

--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ print(result.final_output)
 
 (_For Jupyter notebook users, see [hello_world_jupyter.ipynb](examples/basic/hello_world_jupyter.ipynb)_)
 
+### Note on `name` vs `instructions`
+
+- `name` is a **required** parameter used to identify your agent internally (for logs, tracing, handoffs, etc.), **but it is not passed to the LLM**.
+- `instructions` is an **optional** parameter, but it **is sent to the LLM** as a system prompt to define how the agent should behave.
+
+
+
 ## Handoffs example
 
 ```python

--- a/README.md
+++ b/README.md
@@ -168,12 +168,6 @@ print(result.final_output)
 
 (_For Jupyter notebook users, see [hello_world_jupyter.ipynb](examples/basic/hello_world_jupyter.ipynb)_)
 
-### Note on `name` vs `instructions`
-
-- `name` is a **required** parameter used to identify your agent internally (for logs, tracing, handoffs, etc.), **but it is not passed to the LLM**.
-- `instructions` is an **optional** parameter, but it **is sent to the LLM** as a system prompt to define how the agent should behave.
-
-
 ## Handoffs example
 
 ```python


### PR DESCRIPTION
This pull request improves the documentation by clarifying the difference between the name and instructions parameters in the Agent constructor.
These small additions help new users better understand how to define their agent’s identity and behavior.