### PR TITLE
Fix set_api_key breaking cached property mechanism

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-set-api-key-cached-property
   pull_request:
     # All PRs, including stacked PRs
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-set-api-key-cached-property
   pull_request:
     # All PRs, including stacked PRs
 

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -69,9 +69,12 @@ class BackendSpanExporter(TracingExporter):
             api_key: The OpenAI API key to use. This is the same key used by the OpenAI Python
                 client.
         """
-        # We're specifically setting the underlying cached property as well
+        # Clear the cached property if it exists
+        if 'api_key' in self.__dict__:
+            del self.__dict__['api_key']
+
+        # Update the private attribute
         self._api_key = api_key
-        self.api_key = api_key
 
     @cached_property
     def api_key(self):

--- a/tests/tracing/test_set_api_key_fix.py
+++ b/tests/tracing/test_set_api_key_fix.py
@@ -1,0 +1,32 @@
+import os
+
+from agents.tracing.processors import BackendSpanExporter
+
+
+def test_set_api_key_preserves_env_fallback():
+    """Test that set_api_key doesn't break environment variable fallback."""
+    # Set up environment
+    original_key = os.environ.get("OPENAI_API_KEY")
+    os.environ["OPENAI_API_KEY"] = "env-key"
+
+    try:
+        exporter = BackendSpanExporter()
+
+        # Initially should use env var
+        assert exporter.api_key == "env-key"
+
+        # Set explicit key
+        exporter.set_api_key("explicit-key")
+        assert exporter.api_key == "explicit-key"
+
+        # Clear explicit key and verify env fallback works
+        exporter._api_key = None
+        if "api_key" in exporter.__dict__:
+            del exporter.__dict__["api_key"]
+        assert exporter.api_key == "env-key"
+
+    finally:
+        if original_key is None:
+            os.environ.pop("OPENAI_API_KEY", None)
+        else:
+            os.environ["OPENAI_API_KEY"] = original_key


### PR DESCRIPTION
## Problem  
The `BackendSpanExporter.set_api_key()` method was directly assigning to `self.api_key`, which created an instance attribute that permanently shadowed the `@cached_property`. This broke the environment variable fallback mechanism.  
  
## Solution  
- Clear the cached property if it exists before updating the private attribute  
- This preserves the intended fallback behavior to environment variables  
  
## Testing  
- Added test to verify environment variable fallback works after calling `set_api_key()`  
- Existing functionality remains unchanged