### PR TITLE
fix: Enforce string type for Agent 'name' parameter

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -94,6 +94,10 @@ class AgentBase(Generic[TContext]):
     mcp_config: MCPConfig = field(default_factory=lambda: MCPConfig())
     """Configuration for MCP servers."""
 
+    def __post_init__(self):
+        if not isinstance(self.name, str):
+            raise TypeError(f"The 'name' property must be a string, but received a {type(self.name).__name__}.")
+
     async def get_mcp_tools(self, run_context: RunContextWrapper[TContext]) -> list[Tool]:
         """Fetches the available tools from the MCP servers."""
         convert_schemas_to_strict = self.mcp_config.get("convert_schemas_to_strict", False)


### PR DESCRIPTION
This Pull Request addresses an inconsistency between the documentation and the runtime behavior of the `Agent` class.

**The issue identified:**
* The documentation for the `Agent` class states that the `name` property is a `required string`.
* However, the code did not strictly enforce this, allowing non-string values (e.g., integers) to be passed without raising an error. This could lead to unexpected behavior in downstream components and creates confusion for developers.

**The solution:**
* A runtime check has been added to the `__post_init__` method of the `AgentBase` class.
* This check now strictly enforces that the `name` parameter must be a string, raising a `TypeError` if an invalid type is provided.

**Why this is important:**
* **Consistency:** The code now accurately reflects what is stated in the documentation, making the SDK more reliable.
* **Clarity:** Developers will receive an immediate and clear error message if they attempt to use an incorrect type, significantly