### PR TITLE
refactor: Add runtime type validation for Agent 'instructions'Update agent.py

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -221,6 +221,14 @@ class Agent(AgentBase, Generic[TContext]):
     """Whether to reset the tool choice to the default value after a tool has been called. Defaults
     to True. This ensures that the agent doesn't enter an infinite loop of tool usage."""
 
+    def __post_init__(self):
+        if self.instructions is not None and not (
+        isinstance(self.instructions, str) or callable(self.instructions)
+    ):
+         raise TypeError(
+            f"The 'instructions' must be a string or a callable, but received {type(self.instructions).__name__}."
+        )
+
     def clone(self, **kwargs: Any) -> Agent[TContext]:
         """Make a copy of the agent, with the given arguments changed. For example, you could do:
         ```


### PR DESCRIPTION
This Pull Request improves the robustness of the Agent class by adding explicit runtime validation for the instructions parameter.

*The issue:*
* While the type hint for instructions is str | Callable | None, the current implementation does not prevent invalid types (e.g., integers, lists) from being passed, which could lead to unexpected behavior at a later stage.

*The solution:*
* A check has been added to the __post_init__ method of the Agent class.
* This check ensures that if instructions is provided (i.e., not None), it must be either a string or a callable object.
* A TypeError is now raised immediately if an incorrect type is used, providing clear feedback to the developer.

*Why this is important:*
* *Developer Experience:* This change provides immediate and helpful feedback to developers, preventing them from running into obscure errors later in their code.
* *Code Integrity:* It ensures that the instructions parameter always conforms to its expected type, which is critical for the reliable functioning of the agent.

This update aligns the runtime behavior of the Agent class with its stated type hints, making the code more predictable and easier to debug.