### PR TITLE
Align make check with CI pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,20 @@ jobs:
       - name: Run lint
         run: make lint
 
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: make sync
+      - name: Run format check
+        run: make format-check
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ deploy-docs:
 	uv run mkdocs gh-deploy --force --verbose
 
 .PHONY: check
-check: format-check lint mypy tests
+check: format-check lint mypy coverage

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1034,7 +1034,6 @@ class AgentRunner:
         run_config: RunConfig,
         tool_use_tracker: AgentToolUseTracker,
     ) -> SingleStepResult:
-
         original_input = streamed_result.input
         pre_step_items = streamed_result.new_items
         event_queue = streamed_result._event_queue

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -70,8 +70,8 @@ class BackendSpanExporter(TracingExporter):
                 client.
         """
         # Clear the cached property if it exists
-        if 'api_key' in self.__dict__:
-            del self.__dict__['api_key']
+        if "api_key" in self.__dict__:
+            del self.__dict__["api_key"]
 
         # Update the private attribute
         self._api_key = api_key

--- a/tests/test_agent_clone_shallow_copy.py
+++ b/tests/test_agent_clone_shallow_copy.py
@@ -5,6 +5,7 @@ from agents import Agent, function_tool, handoff
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 
+
 def test_agent_clone_shallow_copy():
     """Test that clone creates shallow copy with tools.copy() workaround"""
     target_agent = Agent(name="Target")
@@ -16,9 +17,7 @@ def test_agent_clone_shallow_copy():
     )
 
     cloned = original.clone(
-        name="Cloned",
-        tools=original.tools.copy(),
-        handoffs=original.handoffs.copy()
+        name="Cloned", tools=original.tools.copy(), handoffs=original.handoffs.copy()
     )
 
     # Basic assertions

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -14,6 +14,7 @@ async def foo() -> str:
     await asyncio.sleep(3)
     return "success!"
 
+
 @pytest.mark.asyncio
 async def test_stream_events_main():
     model = FakeModel()


### PR DESCRIPTION
Noticed that `make check` fails locally due to formatting issues (ruff format --check), but CI passes just fine. Looks like the CI only runs lint/type/tests, but doesn’t actually check code formatting.

This PR syncs up the local `make check` command with the checks we run in CI.

- **Adds `format-check` to CI:** The CI will now fail if code isn't formatted correctly, which prevents surprises when pulling `main`.
- **Aligns `make check`:** Updates the `check` command to run `coverage` instead of just `tests`, so it matches the CI test step exactly.

Now, if it passes locally, it should pass in CI.