### PR TITLE
docs: Add a type-safe example for custom `tool_use_behavior`

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -206,9 +206,9 @@ agent = Agent(
 - `ToolsToFinalOutputFunction`: A custom function that processes tool results and decides whether to stop or continue with the LLM.
 
 ```python
-from agents import Agent, Runner, function_tool, FunctionToolResult, RunContextWrapper
+from agents import Agent, Runner, function_tool, FunctionToolResult, RunContextWrapper, TContext
 from agents.agent import ToolsToFinalOutputResult
-from typing import List, Any
+from typing import List
 
 @function_tool
 def get_weather(city: str) -> str:
@@ -216,7 +216,7 @@ def get_weather(city: str) -> str:
     return f"The weather in {city} is sunny"
 
 def custom_tool_handler(
-    context: RunContextWrapper[Any],
+    context: RunContextWrapper[TContext],
     tool_results: List[FunctionToolResult]
 ) -> ToolsToFinalOutputResult:
     """Processes tool results to decide final output."""


### PR DESCRIPTION
This PR improves an existing documentation example by making it more type-safe.

The change replaces the generic `Any` type with `TContext` for the `RunContextWrapper` in the `custom_tool_handler` function. This provides a more accurate and robust example for developers, demonstrating a best practice for using the library's context system.

The improved example highlights:

-   Proper use of the generic `TContext` type.
-   Enhanced code clarity and type safety.
-   A strong reference for other developers to follow when implementing custom tool handlers.