### PR TITLE
docs: Improve type safety in code examples using `TContext`

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -53,7 +53,7 @@ import json
 
 from typing_extensions import TypedDict, Any
 
-from agents import Agent, FunctionTool, RunContextWrapper, function_tool
+from agents import Agent, FunctionTool, RunContextWrapper, function_tool, TContext
 
 
 class Location(TypedDict):
@@ -73,7 +73,7 @@ async def fetch_weather(location: Location) -> str:
 
 
 @function_tool(name_override="fetch_data")  # (3)!
-def read_file(ctx: RunContextWrapper[Any], path: str, directory: str | None = None) -> str:
+def read_file(ctx: RunContextWrapper[TContext], path: str, directory: str | None = None) -> str:
     """Read the contents of a file.
 
     Args:

--- a/examples/agent_patterns/forcing_tool_use.py
+++ b/examples/agent_patterns/forcing_tool_use.py
@@ -14,6 +14,7 @@ from agents import (
     ToolsToFinalOutputFunction,
     ToolsToFinalOutputResult,
     function_tool,
+    TContext
 )
 
 """
@@ -49,7 +50,7 @@ def get_weather(city: str) -> Weather:
 
 
 async def custom_tool_use_behavior(
-    context: RunContextWrapper[Any], results: list[FunctionToolResult]
+    context: RunContextWrapper[TContext], results: list[FunctionToolResult]
 ) -> ToolsToFinalOutputResult:
     weather: Weather = results[0].output
     return ToolsToFinalOutputResult(


### PR DESCRIPTION
This pull request aims to improve the type safety and clarity of code examples throughout the documentation.

The core change is replacing the generic `Any` type with `TContext` wherever `RunContextWrapper` is used. This modification is crucial because it:

-   Provides a more accurate and robust demonstration of the SDK's context system.
-   Aligns the code examples with best practices for type hinting in Python.
-   Enhances the overall readability and quality of the documentation. 


This change will serve as a strong reference for new and experienced developers alike, helping them write more type-safe and reliable agent code.