### PR TITLE
Fix docstring formatting and add safe check for empty message content

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -66,7 +66,7 @@ class RunItemBase(Generic[T], abc.ABC):
     """The agent whose run caused this item to be generated."""
 
     raw_item: T
-    """The raw Responses item from the run. This will always be a either an output item (i.e.
+    """The raw Responses item from the run. This will always be either an output item (i.e.
     `openai.types.responses.ResponseOutputItem` or an input item
     (i.e. `openai.types.responses.ResponseInputItemParam`).
     """
@@ -243,6 +243,8 @@ class ItemHelpers:
         if not isinstance(message, ResponseOutputMessage):
             return ""
 
+        if not message.content:
+            return ""
         last_content = message.content[-1]
         if isinstance(last_content, ResponseOutputText):
             return last_content.text
@@ -255,6 +257,8 @@ class ItemHelpers:
     def extract_last_text(cls, message: TResponseOutputItem) -> str | None:
         """Extracts the last text content from a message, if any. Ignores refusals."""
         if isinstance(message, ResponseOutputMessage):
+            if not message.content:
+                return None
             last_content = message.content[-1]
             if isinstance(last_content, ResponseOutputText):
                 return last_content.text


### PR DESCRIPTION
Improved clarity in a multiline docstring in `RunItemBase` by correcting misplaced parentheses.

Also added guards in `ItemHelpers.extract_last_content` and `extract_last_text` to handle empty `message.content` safely and prevent potential `IndexError`.