### PR TITLE
feat(viz): draw MCP servers

### DIFF
--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -15,13 +15,17 @@ pip install "openai-agents[viz]"
 You can generate an agent visualization using the `draw_graph` function. This function creates a directed graph where:
 
 - **Agents** are represented as yellow boxes.
+- **MCP Servers** are represented as grey boxes.
 - **Tools** are represented as green ellipses.
 - **Handoffs** are directed edges from one agent to another.
 
 ### Example Usage
 
 ```python
+import os
+
 from agents import Agent, function_tool
+from agents.mcp.server import MCPServerStdio
 from agents.extensions.visualization import draw_graph
 
 @function_tool
@@ -38,11 +42,22 @@ english_agent = Agent(
     instructions="You only speak English",
 )
 
+current_dir = os.path.dirname(os.path.abspath(__file__))
+samples_dir = os.path.join(current_dir, "sample_files")
+mcp_server = MCPServerStdio(
+    name="Filesystem Server, via npx",
+    params={
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", samples_dir],
+    },
+)
+
 triage_agent = Agent(
     name="Triage agent",
     instructions="Handoff to the appropriate agent based on the language of the request.",
     handoffs=[spanish_agent, english_agent],
     tools=[get_weather],
+    mcp_servers=[mcp_server],
 )
 
 draw_graph(triage_agent)
@@ -60,9 +75,11 @@ The generated graph includes:
 - A **start node** (`__start__`) indicating the entry point.
 - Agents represented as **rectangles** with yellow fill.
 - Tools represented as **ellipses** with green fill.
+- MCP Servers represented as **rectangles** with grey fill.
 - Directed edges indicating interactions:
   - **Solid arrows** for agent-to-agent handoffs.
   - **Dotted arrows** for tool invocations.
+  - **Dashed arrows** for MCP server invocations.
 - An **end node** (`__end__`) indicating where execution terminates.
 
 ## Customizing the Graph

--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -71,6 +71,12 @@ def get_all_nodes(
             f"fillcolor=lightgreen, width=0.5, height=0.3];"
         )
 
+    for mcp_server in agent.mcp_servers:
+        parts.append(
+            f'"{mcp_server.name}" [label="{mcp_server.name}", shape=box, style=filled, '
+            f"fillcolor=lightgrey, width=1, height=0.5];"
+        )
+
     for handoff in agent.handoffs:
         if isinstance(handoff, Handoff):
             parts.append(
@@ -118,6 +124,11 @@ def get_all_edges(
         parts.append(f"""
         "{agent.name}" -> "{tool.name}" [style=dotted, penwidth=1.5];
         "{tool.name}" -> "{agent.name}" [style=dotted, penwidth=1.5];""")
+
+    for mcp_server in agent.mcp_servers:
+        parts.append(f"""
+        "{agent.name}" -> "{mcp_server.name}" [style=dashed, penwidth=1.5];
+        "{mcp_server.name}" -> "{agent.name}" [style=dashed, penwidth=1.5];""")
 
     for handoff in agent.handoffs:
         if isinstance(handoff, Handoff):


### PR DESCRIPTION
### Summary

Add nodes and edges for MCP servers in agent visualization. I'm open to suggestions to modify the style of visualizations.

### Checks

- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass

Example graph with MCP server:
<img width="735" height="401" alt="automobile_agent_graph" src="https://github.com/user-attachments/assets/c27777bd-eaf2-471b-b231-a058203ad218" />
