### PR TITLE
Add error function example in tools

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -320,3 +320,18 @@ When you create a function tool via `@function_tool`, you can pass a `failure_er
 -   If you explicitly pass `None`, then any tool call errors will be re-raised for you to handle. This could be a `ModelBehaviorError` if the model produced invalid JSON, or a `UserError` if your code crashed, etc.
 
 If you are manually creating a `FunctionTool` object, then you must handle errors inside the `on_invoke_tool` function.
+
+```python
+def sync_error_handler(ctx: RunContextWrapper[Any], error: Exception) -> str:
+    """Custom error handler that provides a formatted error message."""
+    return f"An error occurred: {error.__class__.__name__} - {str(error)}"
+
+@function_tool(failure_error_function=sync_error_handler)
+def get_latest_news():
+    """Get the latest news from the web."""
+    # This function might fail due to network issues, API limits, etc.
+    raise ConnectionError("Failed to connect to news service")
+
+# The error handler will be called if the tool fails
+# and will return: "An error occurred: ConnectionError - Failed to connect to news service"
+```

--- a/src/agents/handoffs.py
+++ b/src/agents/handoffs.py
@@ -119,9 +119,9 @@ class Handoff(Generic[TContext, TAgent]):
     True, as it increases the likelihood of correct JSON input.
     """
 
-    is_enabled: bool | Callable[
-        [RunContextWrapper[Any], AgentBase[Any]], MaybeAwaitable[bool]
-    ] = True
+    is_enabled: bool | Callable[[RunContextWrapper[Any], AgentBase[Any]], MaybeAwaitable[bool]] = (
+        True
+    )
     """Whether the handoff is enabled. Either a bool or a Callable that takes the run context and
     agent and returns whether the handoff is enabled. You can use this to dynamically enable/disable
     a handoff based on your context/state."""

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1034,7 +1034,6 @@ class AgentRunner:
         run_config: RunConfig,
         tool_use_tracker: AgentToolUseTracker,
     ) -> SingleStepResult:
-
         original_input = streamed_result.input
         pre_step_items = streamed_result.new_items
         event_queue = streamed_result._event_queue

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -70,8 +70,8 @@ class BackendSpanExporter(TracingExporter):
                 client.
         """
         # Clear the cached property if it exists
-        if 'api_key' in self.__dict__:
-            del self.__dict__['api_key']
+        if "api_key" in self.__dict__:
+            del self.__dict__["api_key"]
 
         # Update the private attribute
         self._api_key = api_key

--- a/tests/test_agent_clone_shallow_copy.py
+++ b/tests/test_agent_clone_shallow_copy.py
@@ -5,6 +5,7 @@ from agents import Agent, function_tool, handoff
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 
+
 def test_agent_clone_shallow_copy():
     """Test that clone creates shallow copy with tools.copy() workaround"""
     target_agent = Agent(name="Target")
@@ -16,9 +17,7 @@ def test_agent_clone_shallow_copy():
     )
 
     cloned = original.clone(
-        name="Cloned",
-        tools=original.tools.copy(),
-        handoffs=original.handoffs.copy()
+        name="Cloned", tools=original.tools.copy(), handoffs=original.handoffs.copy()
     )
 
     # Basic assertions

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -14,6 +14,7 @@ async def foo() -> str:
     await asyncio.sleep(3)
     return "success!"
 
+
 @pytest.mark.asyncio
 async def test_stream_events_main():
     model = FakeModel()


### PR DESCRIPTION
**Fixes #1367 - Add code example for custom error handling in function tools**

Adds a practical code example demonstrating how to use the `failure_error_function parameter` with `@function_tool `decorator. The example shows:
- How to create a custom error handler function
- How to apply it to a function tool using the decorator
- Expected behavior when the tool fails

This addresses the need for better documentation around error handling in function tools, making it easier for developers to implement custom error responses for their tools.
