### PR TITLE
Fix TypeError when instantiating ChatCompletionMessageToolCallParam due to typing.Union

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -440,14 +440,16 @@ class Converter:
                 asst = ensure_assistant_message()
                 tool_calls = list(asst.get("tool_calls", []))
                 arguments = func_call["arguments"] if func_call["arguments"] else "{}"
-                new_tool_call = ChatCompletionMessageToolCallParam(
-                    id=func_call["call_id"],
-                    type="function",
-                    function={
+                # Workaround for openai-python bug where ChatCompletionMessageToolCallParam is a typing.Union and can't be instantiated directly.
+                # Use dict instead, as it's compatible with the API.
+                new_tool_call = {
+                    "id": func_call["call_id"],
+                     "type": "function",
+                      "function": {
                         "name": func_call["name"],
-                        "arguments": arguments,
-                    },
-                )
+                        "arguments": func_call["arguments"],
+                },
+            }
                 tool_calls.append(new_tool_call)
                 asst["tool_calls"] = tool_calls
             # 5) function call output => tool message


### PR DESCRIPTION
This fixes the error "TypeError: Cannot instantiate typing.Union" that happens in recent openai-python versions (e.g., 1.99.3+). The param type is a Union, so it can't be created directly. Changed to use a dict, which works with the API.

Tested with my own agent code that was failing—now it runs fine without downgrading openai.

Related to openai/openai-python issues like #2529 or #2541 (if they exist; I couldn't find exact matches, but similar problems reported).

Thanks!