### PR TITLE
docs: improve Agent context documentation with runnable example

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -32,17 +32,23 @@ agent = Agent(
 Agents are generic on their `context` type. Context is a dependency-injection tool: it's an object you create and pass to `Runner.run()`, that is passed to every agent, tool, handoff etc, and it serves as a grab bag of dependencies and state for the agent run. You can provide any Python object as the context.
 
 ```python
+from dataclasses import dataclass
+from agents import Agent
+
 @dataclass
 class UserContext:
     name: str
     uid: str
     is_pro_user: bool
 
-    async def fetch_purchases() -> list[Purchase]:
-        return ...
+    async def fetch_purchases(self) -> list[str]:
+        # Example async method returning a list of purchase (mock)
+        return ["purchase1", "purchase2"]
 
+# Create an agent with a typed context (UserContext)
 agent = Agent[UserContext](
-    ...,
+    name="Contextual Agent",
+    instructions="Use context info.",
 )
 ```
 


### PR DESCRIPTION
This PR enhances the Agent documentation by adding a minimal, runnable example demonstrating how to define a typed context using a dataclass.

The example clarifies:

- How to define a UserContext class with async methods
- How to create an Agent instance parameterized by this context type
- Basic usage patterns for developers new to the SDK

This addition aims to reduce onboarding friction by providing clear, executable snippets inline with existing documentation standards.

Looking forward to feedback and happy to improve further!