### PR TITLE
Clarify provider-agnostic wording in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenAI Agents SDK
 
-The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows. It is provider-agnostic, supporting the OpenAI Responses and Chat Completions APIs, as well as 100+ other LLMs.
+The OpenAI Agents SDK is a lightweight yet powerful framework for building multi-agent workflows. It works with multiple AI providers, supporting the OpenAI Responses and Chat Completions APIs, as well as 100+ other LLMs.
 
 <img src="https://cdn.openai.com/API/docs/images/orchestration.png" alt="Image of the Agents Tracing UI" style="max-height: 803px;">
 


### PR DESCRIPTION
Rephrased the sentence for better readability:
From: "It is provider-agnostic, supporting the OpenAI Responses and Chat Completions APIs, as well as 100+ other LLMs."
To: "It works with multiple AI providers, supporting the OpenAI Responses and Chat Completions APIs, as well as 100+ other LLMs."
