### PR TITLE
docs: Clarify the `is_enabled` parameter in `handoff()` documentation

### DIFF
--- a/docs/handoffs.md
+++ b/docs/handoffs.md
@@ -36,6 +36,7 @@ The [`handoff()`][agents.handoffs.handoff] function lets you customize things.
 -   `on_handoff`: A callback function executed when the handoff is invoked. This is useful for things like kicking off some data fetching as soon as you know a handoff is being invoked. This function receives the agent context, and can optionally also receive LLM generated input. The input data is controlled by the `input_type` param.
 -   `input_type`: The type of input expected by the handoff (optional).
 -   `input_filter`: This lets you filter the input received by the next agent. See below for more.
+-   `is_enabled`: Whether the handoff is enabled. This can be a boolean or a function that returns a boolean, allowing you to dynamically enable or disable the handoff at runtime.
 
 ```python
 from agents import Agent, handoff, RunContextWrapper


### PR DESCRIPTION
This pull request aims to improve the clarity and completeness of the `handoff()` function documentation.

Currently, the `handoff()` function documentation lists several parameters but omits the `is_enabled` parameter, which is present in the underlying source code. This can be confusing for developers trying to dynamically control handoff behavior.

This change adds `is_enabled` to the list of parameters in the documentation, making it easier for users to understand and utilize this feature.The addition will also align the documentation with the actual implementation, enhancing the overall user experience.