### PR TITLE
Fix: Clarify random_number function docstring for inclusive range

### DIFF
--- a/examples/basic/lifecycle_example.py
+++ b/examples/basic/lifecycle_example.py
@@ -56,7 +56,7 @@ hooks = ExampleHooks()
 
 @function_tool
 def random_number(max: int) -> int:
-    """Generate a random number up to the provided max."""
+    """Generate a random number from 0 to max (inclusive)."""
     return random.randint(0, max)
 
 


### PR DESCRIPTION
## Summary

Fixed an ambiguous docstring in the `random_number` function (in `lifecycle_example.py`) that could lead to confusion about whether the range is inclusive or exclusive of the maximum value.

## Problem

The random_number function docstring was ambiguous, using "up to the provided maximum" which could be interpreted as either inclusive or exclusive of the maximum value.

The implementation correctly uses `random.randint(0, max)` which generates numbers from 0 to max inclusive, matching the expected behavior based on usage in the example.

## Changes Made

Changed the docstring from:
```python
"Generate a random number up to the provided maximum."
```

To:
```python
"Generate a random number from 0 to max (inclusive)."
```

This makes the behavior explicit and eliminates potential confusion for developers using this function.