### PR TITLE
Docs: Add missing docstring to how_many_jokes tool

### DIFF
--- a/examples/basic/stream_items.py
+++ b/examples/basic/stream_items.py
@@ -6,6 +6,7 @@ from agents import Agent, ItemHelpers, Runner, function_tool
 
 @function_tool
 def how_many_jokes() -> int:
+    """Return a random integer of jokes to tell between 1 and 10 (inclusive)."""
     return random.randint(1, 10)
 
 


### PR DESCRIPTION
## Summary

Added a missing docstring to the `how_many_jokes` function in the `stream_items` example to improve code documentation and tool description.

## Problem

The `how_many_jokes` function was missing a docstring, which is important for:
- Function documentation and code clarity
- Tool description that the LLM uses to understand when to call the tool
- Following Python best practices for function documentation

## Changes Made

Added a clear and precise docstring to the `how_many_jokes` function:
```python
def how_many_jokes() -> int:
    """Return a random integer of jokes to tell between 1 and 10 (inclusive)."""
    return random.randint(1, 10)
```

The docstring provides a clear description of the function's purpose and helps both developers and LLMs understand when and how to use this tool.