### PR TITLE
Docs: Clarify that guardrails apply to both user input and agent output

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -115,7 +115,7 @@ Sometimes, you want to observe the lifecycle of an agent. For example, you may w
 
 ## Guardrails
 
-Guardrails allow you to run checks/validations on user input, in parallel to the agent running. For example, you could screen the user's input for relevance. Read more in the [guardrails](guardrails.md) documentation.
+Guardrails allow you to run checks/validations on user input in parallel to the agent running, and on the agent's output once it is produced. For example, you could screen the user's input and agent's output for relevance. Read more in the [guardrails](guardrails.md) documentation.
 
 ## Cloning/copying agents
 


### PR DESCRIPTION
## Summary

Clarified the OpenAI Agents SDK documentation on guardrails to indicate that they apply to both user input and the agent's output, preventing misunderstandings about their scope.

## Problem

The existing documentation stated:
> "Guardrails allow you to run checks/validations on user input, in parallel to the agent running. For example, you could screen the user's input for relevance."

This wording implied that guardrails are only applicable to **user input**, omitting the fact that they can also run on **agent output**. This could mislead developers into underutilizing guardrails for output validation and filtering.

## Changes Made

Updated the documentation sentence from:

> Guardrails allow you to run checks/validations on user input, in parallel to the agent running. For example, you could screen the user's input for relevance.

To:

> Guardrails allow you to run checks/validations on user input in parallel to the agent running, and on the agent's output once it is produced. For example, you could screen the user's input and agent's output for relevance.