### PR TITLE
docs: Add `strict_json_schema` and `is_enabled` to `FunctionTool` docs

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -181,6 +181,8 @@ Sometimes, you don't want to use a Python function as a tool. You can directly c
 -   `description`
 -   `params_json_schema`, which is the JSON schema for the arguments
 -   `on_invoke_tool`, which is an async function that receives a [`ToolContext`][agents.tool_context.ToolContext] and the arguments as a JSON string, and must return the tool output as a string.
+-   `strict_json_schema`: Whether the JSON schema is in strict mode. It's recommended to set this to `True`.
+-   `is_enabled`: Whether the tool is enabled. This can be a boolean or a callable that takes the run context and agent, and returns whether the tool is enabled.
 
 ```python
 from typing import Any


### PR DESCRIPTION
This pull request improves the `FunctionTool` documentation by including two important parameters that were previously missing.

I've noticed that the `FunctionTool` class in the source code includes `strict_json_schema` and `is_enabled` parameters, but these were not listed in the "Custom function tools" section of the documentation.

This update adds these parameters to the documentation, providing a more complete and accurate reference for developers. This change will make it easier for users to understand the full capabilities of the `FunctionTool` and enhance the overall quality of the SDK's documentation.