### PR TITLE
Docs: Add missing docstring to `get_weather` function (in `forcing_tool_use.py`)

### DIFF
--- a/examples/agent_patterns/forcing_tool_use.py
+++ b/examples/agent_patterns/forcing_tool_use.py
@@ -44,6 +44,7 @@ class Weather(BaseModel):
 
 @function_tool
 def get_weather(city: str) -> Weather:
+    """Get the current weather information for a specified city."""
     print("[debug] get_weather called")
     return Weather(city=city, temperature_range="14-20C", conditions="Sunny with wind")
 


### PR DESCRIPTION
## Summary

Added a missing docstring to the `get_weather` function (in `agent_patterns/forcing_tool_use.py`) to improve code documentation and tool description.

## Problem

The `get_weather` function (tool) was missing a docstring, which is important for:
- Function documentation and code clarity
- Tool description that the LLM uses to understand when to call the tool
- Following Python best practices for function documentation

## Changes Made

Just added a clear and concise docstring to the `get_weather` function:
```python
@function_tool
def get_weather(city: str) -> Weather:
    """Get the current weather information for a specified city."""
    print("[debug] get_weather called")
    return Weather(city=city, temperature_range="14-20C", conditions="Sunny with wind")
```

This docstring provides a clear description of the function's purpose and helps both developers and LLMs understand when and how to use this tool.