### PR TITLE
Docs: Add missing docstring to `get_weather` function (in `README.md`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ from agents import Agent, Runner, function_tool
 
 @function_tool
 def get_weather(city: str) -> str:
+    """Get the current weather for a given city."""
     return f"The weather in {city} is sunny."
 
 


### PR DESCRIPTION
## Summary

Added a missing docstring to the `get_weather` function (in `README.md`) in Functions example to improve code documentation and tool description.


## Problem

The `get_weather` function in `README.md` was missing a proper docstring, which is important for:

- Clear function documentation and readability
- Helping language models understand the tool's purpose and when to use it
- Following Python best practices for function documentation

## Changes Made

Added a concise, one-line docstring to the `get_weather` function in `README.md`:

```python
@function_tool
def get_weather(city: str) -> str:
    """Get the current weather for a given city."""
    return f"The weather in {city} is sunny."
```