### PR TITLE
Refactor: Update routing.py to use SQLiteSession for session management

### DIFF
--- a/examples/agent_patterns/routing.py
+++ b/examples/agent_patterns/routing.py
@@ -2,29 +2,11 @@ import asyncio
 import uuid
 
 from openai.types.responses import ResponseContentPartDoneEvent, ResponseTextDeltaEvent
+from agents import Agent, RawResponsesStreamEvent, Runner, trace, SQLiteSession
 
-from agents import Agent, RawResponsesStreamEvent, Runner, TResponseInputItem, trace
-
-"""
-This example shows the handoffs/routing pattern. The triage agent receives the first message, and
-then hands off to the appropriate agent based on the language of the request. Responses are
-streamed to the user.
-"""
-
-french_agent = Agent(
-    name="french_agent",
-    instructions="You only speak French",
-)
-
-spanish_agent = Agent(
-    name="spanish_agent",
-    instructions="You only speak Spanish",
-)
-
-english_agent = Agent(
-    name="english_agent",
-    instructions="You only speak English",
-)
+french_agent = Agent(name="french_agent", instructions="You only speak French")
+spanish_agent = Agent(name="spanish_agent", instructions="You only speak Spanish")
+english_agent = Agent(name="english_agent", instructions="You only speak English")
 
 triage_agent = Agent(
     name="triage_agent",
@@ -32,22 +14,38 @@ triage_agent = Agent(
     handoffs=[french_agent, spanish_agent, english_agent],
 )
 
-
 async def main():
-    # We'll create an ID for this conversation, so we can link each trace
     conversation_id = str(uuid.uuid4().hex[:16])
+    # Create a persistent session for this conversation
+    session = SQLiteSession(conversation_id, "conversation_history.db")
 
     msg = input("Hi! We speak French, Spanish and English. How can I help? ")
-    agent = triage_agent
-    inputs: list[TResponseInputItem] = [{"content": msg, "role": "user"}]
 
-    while True:
-        # Each conversation turn is a single trace. Normally, each input from the user would be an
-        # API request to your app, and you can wrap the request in a trace()
-        with trace("Routing example", group_id=conversation_id):
+    # We use a trace to track the full conversation
+    with trace("Routing example", group_id=conversation_id):
+        result = Runner.run_streamed(
+            triage_agent,
+            input=[{"content": msg, "role": "user"}],
+            session=session,  # Pass the session object here
+        )
+        async for event in result.stream_events():
+            if not isinstance(event, RawResponsesStreamEvent):
+                continue
+            data = event.data
+            if isinstance(data, ResponseTextDeltaEvent):
+                print(data.delta, end="", flush=True)
+            elif isinstance(data, ResponseContentPartDoneEvent):
+                print("\n")
+
+        while True:
+            print("\n")
+            user_msg = input("Enter a message: ")
+            
+            # The session automatically remembers the previous conversation
             result = Runner.run_streamed(
-                agent,
-                input=inputs,
+                result.current_agent,
+                input=[{"content": user_msg, "role": "user"}],
+                session=session,  # The session is now the source of history
             )
             async for event in result.stream_events():
                 if not isinstance(event, RawResponsesStreamEvent):
@@ -57,14 +55,6 @@ async def main():
                     print(data.delta, end="", flush=True)
                 elif isinstance(data, ResponseContentPartDoneEvent):
                     print("\n")
-
-        inputs = result.to_input_list()
-        print("\n")
-
-        user_msg = input("Enter a message: ")
-        inputs.append({"content": user_msg, "role": "user"})
-        agent = result.current_agent
-
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Refactor: Update routing.py to Use SQLiteSession
This pull request refactors the routing.py example to use the built-in SQLiteSession class for managing conversation history. The existing manual handling of the inputs list has been replaced with a more robust and scalable approach.

Why This Change?
The "Handoffs and routing" section aims to demonstrate a practical agentic pattern. Using the SQLiteSession primitive aligns this example with the SDK's recommended best practices for session management. This change:

Simplifies the code: It removes the need for manual message list management, making the core routing logic clearer and easier to follow.

Adds persistence: The example now correctly reflects how a real-world application would handle persistent conversation state, which is essential for multi-turn interactions.

Enhances robustness: The use of a dedicated session primitive makes the example more reliable and scalable.

This refactoring does not change the fundamental behavior of the example—the triage agent still correctly hands off the conversation to the appropriate language agent. Instead, it improves the underlying implementation, making the example a more accurate and valuable resource for developers.