### PR TITLE
Fix: filename not provided in chatcmpl_converter.py

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -271,11 +271,16 @@ class Converter:
                     raise UserError(
                         f"Only file_data is supported for input_file {casted_file_param}"
                     )
+                if "filename" not in casted_file_param or not casted_file_param["filename"]:
+                    raise UserError(
+                        f"filename must be provided for input_file {casted_file_param}"
+                    )
                 out.append(
                     File(
                         type="file",
                         file=FileFile(
                             file_data=casted_file_param["file_data"],
+                            filename=casted_file_param["filename"],
                         ),
                     )
                 )


### PR DESCRIPTION
When a file is provided in base64 encoding, only the `file_data` part is converted to the chat completion API format. 
However, now without the `filename` field, OpenAI returns
```openai.BadRequestError: Error code: 400 - {'error': {'message': "Missing required parameter: 'messages[1].content[1].file.file_id'.", 'type': 'invalid_request_error', 'param': 'messages[1].content[1].file.file_id', 'code': 'missing_required_parameter'}}```