### PR TITLE
docs: Add external documentation link to LocalShellTool docstring

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -264,7 +264,11 @@ LocalShellExecutor = Callable[[LocalShellCommandRequest], MaybeAwaitable[str]]
 
 @dataclass
 class LocalShellTool:
-    """A tool that allows the LLM to execute commands on a shell."""
+    """A tool that allows the LLM to execute commands on a shell.
+
+    For more details, see:
+    https://platform.openai.com/docs/guides/tools-local-shell
+    """
 
     executor: LocalShellExecutor
     """A function that executes a command on a shell."""


### PR DESCRIPTION
This pull request addresses the need for detailed documentation regarding the `LocalShellTool`.

Per the discussion in a previous pull request, it was decided that adding extensive details to the main documentation page would be too verbose. Instead, the recommended approach was to include a link to the detailed external documentation within the tool's docstring.

This change implements that decision by adding a direct link to the official guide in the `LocalShellTool` docstring. This approach keeps the primary documentation concise while providing a clear path for users to access in-depth information and security best practices for using the tool.