### PR TITLE
Add tests for Agent default model settings when using GPT-5

### DIFF
--- a/tests/models/test_default_models.py
+++ b/tests/models/test_default_models.py
@@ -1,6 +1,8 @@
 import os
 from unittest.mock import patch
 
+from agents import Agent
+from agents.model_settings import ModelSettings
 from agents.models import (
     get_default_model,
     get_default_model_settings,
@@ -21,7 +23,7 @@ def test_default_model_env_gpt_5():
     assert get_default_model() == "gpt-5"
     assert is_gpt_5_default() is True
     assert gpt_5_reasoning_settings_required(get_default_model()) is True
-    assert get_default_model_settings().reasoning.effort == "low"  # type: ignore [union-attr]
+    assert get_default_model_settings().reasoning.effort == "low"  # type: ignore[union-attr]
 
 
 @patch.dict(os.environ, {"OPENAI_DEFAULT_MODEL": "gpt-5-mini"})
@@ -29,7 +31,7 @@ def test_default_model_env_gpt_5_mini():
     assert get_default_model() == "gpt-5-mini"
     assert is_gpt_5_default() is True
     assert gpt_5_reasoning_settings_required(get_default_model()) is True
-    assert get_default_model_settings().reasoning.effort == "low"  # type: ignore [union-attr]
+    assert get_default_model_settings().reasoning.effort == "low"  # type: ignore[union-attr]
 
 
 @patch.dict(os.environ, {"OPENAI_DEFAULT_MODEL": "gpt-5-nano"})
@@ -37,7 +39,7 @@ def test_default_model_env_gpt_5_nano():
     assert get_default_model() == "gpt-5-nano"
     assert is_gpt_5_default() is True
     assert gpt_5_reasoning_settings_required(get_default_model()) is True
-    assert get_default_model_settings().reasoning.effort == "low"  # type: ignore [union-attr]
+    assert get_default_model_settings().reasoning.effort == "low"  # type: ignore[union-attr]
 
 
 @patch.dict(os.environ, {"OPENAI_DEFAULT_MODEL": "gpt-5-chat-latest"})
@@ -54,3 +56,20 @@ def test_default_model_env_gpt_4o():
     assert is_gpt_5_default() is False
     assert gpt_5_reasoning_settings_required(get_default_model()) is False
     assert get_default_model_settings().reasoning is None
+
+
+@patch.dict(os.environ, {"OPENAI_DEFAULT_MODEL": "gpt-5"})
+def test_agent_uses_gpt_5_default_model_settings():
+    """Agent should inherit GPT-5 default model settings."""
+    agent = Agent(name="test")
+    assert agent.model is None
+    assert agent.model_settings.reasoning.effort == "low"  # type: ignore[union-attr]
+    assert agent.model_settings.verbosity == "low"
+
+
+@patch.dict(os.environ, {"OPENAI_DEFAULT_MODEL": "gpt-5"})
+def test_agent_resets_model_settings_for_non_gpt_5_models():
+    """Agent should reset default GPT-5 settings when using a non-GPT-5 model."""
+    agent = Agent(name="test", model="gpt-4o")
+    assert agent.model == "gpt-4o"
+    assert agent.model_settings == ModelSettings()


### PR DESCRIPTION
## Summary
- test Agent inherits GPT-5 default model settings
- ensure non-GPT-5 models reset default GPT-5 settings

## Testing
- `make format`
- `make lint`
- `make mypy`
- `OPENAI_API_KEY=dummy make tests`


------
https://chatgpt.com/codex/tasks/task_i_68a92726d6bc83208337e5b8c2228631