### PR TITLE
Docs: Clarify installation instructions for uv tool in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For voice support, install with the optional `voice` group: `pip install 'openai
 
 ### uv
 
-If you're familiar with [uv](https://docs.astral.sh/uv/), using the tool would be even similar:
+If you're familiar with [uv](https://docs.astral.sh/uv/), using it to install OpenAI Agents SDK is just as straightforward:
 
 ```bash
 uv init


### PR DESCRIPTION
This PR updates the README to clarify the installation instructions for using the [uv](https://docs.astral.sh/uv/) tool when setting up the OpenAI Agents SDK.

Changes
- Rephrased the note under the uv section to make the installation process more explicit and clear.
- Updated the wording from “the tool would be even similar” to a clearer explanation that installing the OpenAI Agents SDK with uv is straightforward.

The previous wording was ambiguous (I'm not sure what "even similar" is referring to) and might confuse users unfamiliar with uv. This update improves clarity and makes the instructions easier to follow.