### PR TITLE
fix(agent): stricter validation for Agent.prompt type checking

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -28,6 +28,7 @@ from .run_context import RunContextWrapper, TContext
 from .tool import FunctionTool, FunctionToolResult, Tool, function_tool
 from .util import _transforms
 from .util._types import MaybeAwaitable
+from .prompts import Prompt, DynamicPromptFunction
 
 if TYPE_CHECKING:
     from .lifecycle import AgentHooks
@@ -267,12 +268,12 @@ class Agent(AgentBase, Generic[TContext]):
         if (
             self.prompt is not None
             and not callable(self.prompt)
-            and not hasattr(self.prompt, "get")
-        ):
-            raise TypeError(
-                f"Agent prompt must be a Prompt, DynamicPromptFunction, or None, "
-                f"got {type(self.prompt).__name__}"
-            )
+            and not isinstance(self.prompt, Prompt)
+       ):
+         raise TypeError(
+              f"Agent prompt must be a Prompt, DynamicPromptFunction, or None, "
+              f"got {type(self.prompt).__name__}"
+           )
 
         if not isinstance(self.handoffs, list):
             raise TypeError(f"Agent handoffs must be a list, got {type(self.handoffs).__name__}")


### PR DESCRIPTION
This PR improves the validation logic for the Agent.prompt field in agent.py.

🔧 Changes

⚫ Replaced hasattr(self.prompt, "get") check with a strict isinstance(self.prompt, Prompt) check.

⚫ Ensures only valid Prompt objects or DynamicPromptFunction (callable) are accepted.

⚫ Prevents invalid objects (e.g., dict with .get() method) from being mistakenly allowed.

✅ Why this matters

⚫ Increases type safety and prevents runtime errors when an invalid prompt object is passed.

⚫ Makes the behavior more predictable and aligned with the intended usage (Prompt | DynamicPromptFunction | None).