### PR TITLE
Implement agent test generator UI

### DIFF
--- a/examples/hackathon/agent_extensions.py
+++ b/examples/hackathon/agent_extensions.py
@@ -1,13 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
 from agents.agent import Agent
-from examples.hackathon.types import TestCase
+from examples.hackathon.types import ScoringConfig, TestCase
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    pass
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
-def add_method(cls):
-    def decorator(func):
+def add_method(cls: type[Any]) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
         setattr(cls, func.__name__, func)
         return func
+
     return decorator
 
+
 @add_method(Agent)
-def generate_tests(self, test_cases: list[TestCase]):
-    pass
+def generate_tests(self, test_cases: list[TestCase]) -> None:
+    """Launch a Streamlit app to view and edit test cases."""
+
+    try:
+        import importlib
+
+        st = importlib.import_module("streamlit")
+    except Exception as exc:  # pragma: no cover - streamlit may not be installed
+        raise ImportError("streamlit is required to use 'generate_tests'") from exc
+
+    if "test_cases" not in st.session_state:
+        st.session_state.test_cases = [replace(tc) for tc in test_cases]
+
+    st.title(f"Tests for {self.name}")
+
+    for idx, case in enumerate(st.session_state.test_cases):
+        with st.expander(case.name, expanded=True):
+            case.name = st.text_input(
+                "Name",
+                value=case.name,
+                key=f"name_{idx}",
+            )
+            case.scenario = st.text_area(
+                "Scenario",
+                value=case.scenario,
+                key=f"scenario_{idx}",
+            )
+
+            scoring = case.scoring_config
+            scoring.ground_truth = st.text_area(
+                "Ground truth",
+                value=str(scoring.ground_truth or ""),
+                key=f"ground_{idx}",
+            )
+            scoring.criteria = st.text_area(
+                "Criteria",
+                value=scoring.criteria or "",
+                key=f"criteria_{idx}",
+            )
+            scoring.type = st.selectbox(
+                "Type",
+                [
+                    "tool_name",
+                    "tool_argument",
+                    "handoff",
+                    "model_graded",
+                    None,
+                ],
+                index=[
+                    "tool_name",
+                    "tool_argument",
+                    "handoff",
+                    "model_graded",
+                    None,
+                ].index(scoring.type),
+                key=f"type_{idx}",
+            )
+
+    st.divider()
+    st.header("Add new test case")
+    new_name = st.text_input("New test name", key="new_name")
+    new_scenario = st.text_area("New test scenario", key="new_scenario")
+    if st.button("Add Test Case"):
+        st.session_state.test_cases.append(
+            TestCase(
+                name=new_name or f"test-{len(st.session_state.test_cases) + 1}",
+                scenario=new_scenario,
+                scoring_config=ScoringConfig(),
+                agent_to_test=self,
+            )
+        )
+        st.experimental_rerun()
+
+    test_cases[:] = st.session_state.test_cases

--- a/examples/hackathon/conversation_generator.py
+++ b/examples/hackathon/conversation_generator.py
@@ -2,6 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
+from typing import cast
 
 from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
@@ -16,11 +17,13 @@ from agents.memory.session import SQLiteSession
 
 client = AsyncOpenAI()
 
+
 @dataclass
 class TestCase:
     name: str
     scenario: str
     agent_to_test: Agent
+
 
 # Iput:Takes a custom test scenario, and a user_prompt
 # Output: A user_agent that simulates a human user, and can be used to generate a conversation with the agent
@@ -31,9 +34,10 @@ def generate_simulated_user(scenario: str, user_prompt: str) -> Agent:
         You are playing the role of a human that is interacting with an AI agent. You will be provided the conversation history so far. Follow the below scenario and respond with the next appropriate response that the human would give.
         Scenario: {scenario}
         """),
-        model="o3"
+        model="o3",
     )
     return agent
+
 
 def generate_simulated_agent(scenario: str, agent_to_test: Agent) -> Agent:
     simulated_agent = agent_to_test.clone()
@@ -49,40 +53,53 @@ def generate_simulated_agent(scenario: str, agent_to_test: Agent) -> Agent:
     """
     return simulated_agent
 
+
 class ValidationStatus(Enum):
     COMPLETE = "complete"
     INCOMPLETE = "incomplete"
     INVALID = "invalid"
 
+
 class ValidationResult(BaseModel):
-    validation_status: ValidationStatus = Field(description="""Whether the conversation is valid according to the scenario.
+    validation_status: ValidationStatus = Field(
+        description="""Whether the conversation is valid according to the scenario.
     Mark it complete if the conversation is valid according to the scenario.
     Mark it incomplete if the conversation is following the scenario so far, but further back and forths are needed to complete the scenario.
     Mark it invalid if the conversation has deviated from the scenario.
-    """)
-    explanation: str = Field(description="The explanation for the validation status. If the conversation is valid according to the scenario, explain why. If the conversation is invalid according to the scenario, explain why. If the conversation is incomplete according to the scenario, explain why.")
+    """
+    )
+    explanation: str = Field(
+        description="The explanation for the validation status. If the conversation is valid according to the scenario, explain why. If the conversation is invalid according to the scenario, explain why. If the conversation is incomplete according to the scenario, explain why."
+    )
+
 
 # Input: Takes a custom test scenario, and a conversation
 # Output: Returns ValidationResult
 async def validate_conversation(scenario: str, session: SQLiteSession) -> ValidationStatus:
-    agent = Agent(name="Scenario Validator", instructions=dedent("""
+    agent = Agent(
+        name="Scenario Validator",
+        instructions=dedent("""
     You are a scenario validator. You are given a scenario and a conversation. You need to validate if the conversation is valid according to the scenario.
     """),
-    output_type=ValidationResult
+        output_type=ValidationResult,
     )
 
-    input=dedent(f"""
+    input = dedent(f"""
     Scenario: {scenario}
     Conversation: {await session.get_items()}
     """)
 
     result = await Runner.run(agent, input=input)
-    return result.final_output.validation_status
+    validation = cast(ValidationResult, result.final_output)
+    return validation.validation_status
+
 
 # Input: Takes a custom test scenario, an agent, and a user agent
 # Output: A conversation with the agent and the user_prompt
 # Note: there should be another agent that validates the scenario has not been violated after every turn by the user_agent
-async def generate_conversation(test_scenario: TestCase, agent_to_test: Agent, user_agent: Agent) -> list[TResponseInputItem]:
+async def generate_conversation(
+    test_scenario: TestCase, agent_to_test: Agent, user_agent: Agent
+) -> list[TResponseInputItem]:
     session = SQLiteSession(test_scenario.name)
 
     while True:
@@ -91,19 +108,28 @@ async def generate_conversation(test_scenario: TestCase, agent_to_test: Agent, u
 
         validation_result = await validate_conversation(test_scenario.scenario, session)
         if validation_result is ValidationStatus.COMPLETE:
-           return await session.get_items()
+            return await session.get_items()
         elif validation_result is ValidationStatus.INVALID:
             print("Conversation violated the scenario. Exiting...")
             break
 
+    return await session.get_items()
+
+
 async def main():
-    manager_agent = Agent(name="Manager Agent", instructions=dedent("""
+    manager_agent = Agent(
+        name="Manager Agent",
+        instructions=dedent("""
     You are a manager. You will always introduce yourself as the manager.
-    """))
-    customer_service_agent = Agent(name="Customer Service Agent", instructions=dedent("""
+    """),
+    )
+    customer_service_agent = Agent(
+        name="Customer Service Agent",
+        instructions=dedent("""
     You are a customer service agent. You are helpful and friendly. Only handoff to a manager if the user requests it or is becoming angry.
     """),
-    handoffs=[manager_agent])
+        handoffs=[manager_agent],
+    )
 
     scenarios = [
         TestCase(
@@ -113,7 +139,7 @@ async def main():
             2. Agent asks for order ID
             3. User does not answer the question and instead gets angry and requests to speak to a manager
             """),
-            agent_to_test=customer_service_agent
+            agent_to_test=customer_service_agent,
         ),
     ]
 
@@ -125,6 +151,7 @@ async def main():
             print("Conversation Completed\n", conversation)
 
         # client.evals.create()
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
### Summary
- implement a Streamlit UI for editing test cases via `Agent.generate_tests`
- fix example type hints so mypy passes

### Test plan
- `make format`
- `make lint`
- `make mypy`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_i_687fdd6a04848325904a8efb71898fbb