### PR TITLE
Handle LiteLLM's json_tool_call addition for structured outputs

### DIFF
--- a/examples/model_providers/litellm_auto.py
+++ b/examples/model_providers/litellm_auto.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 
-from agents import Agent, Runner, function_tool, set_tracing_disabled
+from pydantic import BaseModel
+
+from agents import Agent, ModelSettings, Runner, function_tool, set_tracing_disabled
 
 """This example uses the built-in support for LiteLLM. To use this, ensure you have the
 ANTHROPIC_API_KEY environment variable set.
@@ -10,11 +12,17 @@ ANTHROPIC_API_KEY environment variable set.
 
 set_tracing_disabled(disabled=True)
 
+# import logging
+# logging.basicConfig(level=logging.DEBUG)
 
 @function_tool
 def get_weather(city: str):
     print(f"[debug] getting weather for {city}")
     return f"The weather in {city} is sunny."
+
+class Result(BaseModel):
+    output_text: str
+    tool_results: list[str]
 
 
 async def main():
@@ -24,6 +32,8 @@ async def main():
         # We prefix with litellm/ to tell the Runner to use the LitellmModel
         model="litellm/anthropic/claude-3-5-sonnet-20240620",
         tools=[get_weather],
+        model_settings=ModelSettings(tool_choice="required"),
+        output_type=Result,
     )
 
     result = await Runner.run(agent, "What's the weather in Tokyo?")


### PR DESCRIPTION
This pull request improves the interoperability with LiteLLM for structured output use cases (at least with Claude models). I found that LiteLLM could append non-existent tool called "json_tool_call" to handle JSON schema response format. Currently, Agents SDK raises an exception telling the "json_tool_call" tool does not exist, but allowing this tool use simply enables the use case without any issues. I think it's okay for us to add additional logic like this PR does. It's safe and does not break anything.