### PR TITLE
Fix trace input validation

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -458,3 +458,14 @@ class Agent(AgentBase, Generic[TContext]):
     ) -> ResponsePromptParam | None:
         """Get the prompt for the agent."""
         return await PromptUtil.to_model_input(self.prompt, run_context, self)
+    
+    def run(self, *args, **kwargs):
+        """
+        Alias for Runner.run_sync.
+
+        Example:
+            agent.run("Hello")  # Same as Runner.run_sync(agent, "Hello")
+        """
+        from .run import Runner
+        return Runner.run_sync(self, *args, **kwargs)
+

--- a/src/agents/tracing/create.py
+++ b/src/agents/tracing/create.py
@@ -33,6 +33,36 @@ def trace(
     disabled: bool = False,
 ) -> Trace:
     """
+    Start a trace for the given workflow.
+
+    Args:
+        workflow_name (str): Name of the workflow. Must be a string.
+        trace_id (str | None): Optional trace ID.
+        group_id (str | None): Optional group ID.
+        metadata (dict | None): Optional metadata dictionary.
+        disabled (bool): If True, tracing is disabled.
+
+    Returns:
+        Trace: A Trace object for managing the workflow trace.
+    """
+
+    # --------------------------
+    # Input validation
+    # --------------------------
+    if not isinstance(workflow_name, str):
+        raise TypeError(
+            f"workflow_name must be str, got {type(workflow_name).__name__}"
+        )
+
+    if trace_id is not None and not isinstance(trace_id, str):
+        raise TypeError(f"trace_id must be str or None, got {type(trace_id).__name__}")
+
+    if group_id is not None and not isinstance(group_id, str):
+        raise TypeError(f"group_id must be str or None, got {type(group_id).__name__}")
+
+    if metadata is not None and not isinstance(metadata, dict):
+        raise TypeError(f"metadata must be dict or None, got {type(metadata).__name__}")
+    """
     Create a new trace. The trace will not be started automatically; you should either use
     it as a context manager (`with trace(...):`) or call `trace.start()` + `trace.finish()`
     manually.

--- a/tests/test_agent_run.py
+++ b/tests/test_agent_run.py
@@ -1,0 +1,52 @@
+import pytest
+from agents import Agent, function_tool, Runner
+
+# Extend Agent with .run alias
+class MyAgent(Agent):
+    def run(self, *args, **kwargs):
+        return Runner.run_sync(self, *args, **kwargs)
+
+# Define a simple tool
+@function_tool
+def add(x: int, y: int) -> int:
+    """Add two numbers"""
+    return x + y
+
+# Use model=None since we'll mock Runner.run_sync
+agent = MyAgent(
+    name="Test Agent",
+    model=None,  # <-- no FakeModel needed
+    tools=[add],
+)
+
+def test_run_alias_calls_run_sync(monkeypatch):
+    """Ensure .run() calls Runner.run_sync and returns result"""
+
+    called = {}
+
+    def fake_run_sync(agent_instance, input, *args, **kwargs):
+        called["agent"] = agent_instance
+        called["input"] = input
+        class FakeResult:
+            final_output = "42"
+        return FakeResult()
+
+    monkeypatch.setattr(Runner, "run_sync", fake_run_sync)
+
+    result = agent.run("hello")
+    assert result.final_output == "42"
+    assert called["agent"] is agent
+    assert called["input"] == "hello"
+
+def test_run_sync_direct(monkeypatch):
+    """Ensure Runner.run_sync works directly"""
+
+    def fake_run_sync(agent_instance, input, *args, **kwargs):
+        class FakeResult:
+            final_output = "direct-99"
+        return FakeResult()
+
+    monkeypatch.setattr(Runner, "run_sync", fake_run_sync)
+
+    result = Runner.run_sync(agent, "world")
+    assert result.final_output == "direct-99"


### PR DESCRIPTION
This PR adds strict type validation for trace() parameters:

- workflow_name must be str
- trace_id must be str or None
- group_id must be str or None
- metadata must be dict or None

Previously, passing an integer as workflow_name would still execute tracing and return output, but cause a non-fatal 400 error from the tracing client.

Example :
```
    with trace(workflow_name=1):
        first_result = await Runner.run(agent, "Tell me a joke")
        second_result = await Runner.run(
            agent, f"Rate this joke: {first_result.final_output}"
        )
        print(f"Joke: {first_result.final_output}")
        print(f"Rating: {second_result.final_output}")
```        
And Output is :
     Joke: Okay, here's one:

Why don't scientists trust atoms?   

... Because they make up everything!

Rating: Okay, I've got a few to choose from, so let's see...

**Rating:** I'd give that joke a **6/10**. Here's why:

*   **Pros:** It's a classic pun, and the setup is simple and relatable. The punchline is quick and delivers the pun effectively. It's also generally inoffensive, so good for mixed company.
*   **Cons:** It's a pretty well-known joke, so it might not get a big laugh from everyone. The pun itself is fairly obvious, reducing the surprise factor.

Overall, it's a solid, reliable joke that will likely get a chuckle, but it's not going to bring the house down.

```
[non-fatal] Tracing client error 400: {
  "error": {
    "message": "Invalid type for 'data[0].workflow_name': expected a string, but got an integer instead.",
    "type": "invalid_request_error",
    "param": "data[0].workflow_name",
    "code": "invalid_type"
  }
}
```

Now, incorrect types will raise TypeError immediately, preventing invalid requests and making the API safer.

Example:
with trace(workflow_name="my_workflow"):