### PR TITLE
Ensure that input_guardrails can block model/tools from running

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -97,6 +97,13 @@ class InputGuardrail(Generic[TContext]):
     function's name.
     """
 
+    block_downstream_calls: bool = True
+    """Whether this guardrail should block downstream calls until it completes.
+    If any input guardrail has this set to True, the initial model call and any
+    subsequent tool execution will be delayed until all blocking guardrails finish.
+    Defaults to True for backwards compatibility and safety.
+    """
+
     def get_name(self) -> str:
         if self.name:
             return self.name
@@ -209,6 +216,7 @@ def input_guardrail(
 def input_guardrail(
     *,
     name: str | None = None,
+    block_downstream_calls: bool = True,
 ) -> Callable[
     [_InputGuardrailFuncSync[TContext_co] | _InputGuardrailFuncAsync[TContext_co]],
     InputGuardrail[TContext_co],
@@ -221,6 +229,7 @@ def input_guardrail(
     | None = None,
     *,
     name: str | None = None,
+    block_downstream_calls: bool = True,
 ) -> (
     InputGuardrail[TContext_co]
     | Callable[
@@ -235,7 +244,7 @@ def input_guardrail(
         @input_guardrail
         def my_sync_guardrail(...): ...
 
-        @input_guardrail(name="guardrail_name")
+        @input_guardrail(name="guardrail_name", block_downstream_calls=False)
         async def my_async_guardrail(...): ...
     """
 
@@ -246,6 +255,7 @@ def input_guardrail(
             guardrail_function=f,
             # If not set, guardrail name uses the function’s name by default.
             name=name if name else f.__name__,
+            block_downstream_calls=block_downstream_calls,
         )
 
     if func is not None:

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -196,7 +196,11 @@ class RunResultStreaming(RunResultBase):
                 break
 
             try:
-                item = await self._event_queue.get()
+                # Avoid blocking forever if the background task errors before enqueuing.
+                item = await asyncio.wait_for(self._event_queue.get(), timeout=0.1)
+            except asyncio.TimeoutError:
+                # No item yet; re-check for stored exceptions and completion conditions.
+                continue
             except asyncio.CancelledError:
                 break
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -526,11 +526,13 @@ async def test_input_guardrail_tripwire_triggered_causes_exception():
             tripwire_triggered=True,
         )
 
-    agent = Agent(
-        name="test", input_guardrails=[InputGuardrail(guardrail_function=guardrail_function)]
-    )
     model = FakeModel()
     model.set_next_output([get_text_message("user_message")])
+    agent = Agent(
+        name="test",
+        input_guardrails=[InputGuardrail(guardrail_function=guardrail_function)],
+        model=model,
+    )
 
     with pytest.raises(InputGuardrailTripwireTriggered):
         await Runner.run(agent, input="user_message")
@@ -780,3 +782,213 @@ async def test_dynamic_tool_addition_run() -> None:
 
     assert executed["called"] is True
     assert result.final_output == "done"
+
+
+@pytest.mark.asyncio
+async def test_blocking_input_guardrail_tripwire_prevents_model_call():
+    """Blocking input guardrails should prevent the initial model call if tripped."""
+    def guardrail_function(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    model = FakeModel()
+    model.set_next_output([get_text_message("should_not_be_called")])
+    agent = Agent(
+        name="test",
+        input_guardrails=[InputGuardrail(guardrail_function=guardrail_function)],
+        model=model,
+    )
+
+    with pytest.raises(InputGuardrailTripwireTriggered):
+        await Runner.run(agent, input="user_message")
+
+    # Ensure model was never invoked
+    assert model.last_turn_args == {}
+
+
+@pytest.mark.asyncio
+async def test_blocking_input_guardrail_delays_tool_execution():
+    """Test that blocking input guardrails delay tool execution until they complete."""
+    import asyncio
+
+    execution_order = []
+
+    # Create a slow blocking guardrail
+    async def slow_blocking_guardrail(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: Any
+    ) -> GuardrailFunctionOutput:
+        execution_order.append("guardrail_start")
+        await asyncio.sleep(0.1)  # Simulate slow guardrail
+        execution_order.append("guardrail_end")
+        return GuardrailFunctionOutput(
+            output_info="blocking_completed",
+            tripwire_triggered=False,
+        )
+
+    # Create a tool that tracks when it's called
+    @function_tool
+    async def test_tool() -> str:
+        execution_order.append("tool_executed")
+        return "tool_result"
+
+    # Create agent with blocking guardrail and tool
+    blocking_guardrail = InputGuardrail(
+        guardrail_function=slow_blocking_guardrail, block_downstream_calls=True
+    )
+
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        input_guardrails=[blocking_guardrail],
+        tools=[test_tool],
+        model=model,
+    )
+
+    # Model output that calls the tool
+    model.add_multiple_turn_outputs(
+        [[get_function_tool_call("test_tool", "{}")], [get_text_message("completed")]]
+    )
+
+    result = await Runner.run(agent, input="test input")
+
+    # Verify execution order: guardrail must complete before tool is executed
+    assert execution_order == ["guardrail_start", "guardrail_end", "tool_executed"]
+    assert result.final_output == "completed"
+    assert len(result.input_guardrail_results) == 1
+    assert result.input_guardrail_results[0].output.output_info == "blocking_completed"
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_input_guardrail_allows_parallel_tool_execution():
+    """Test that non-blocking input guardrails allow tool execution in parallel."""
+    import asyncio
+
+    execution_order = []
+    tool_started = asyncio.Event()
+
+    # Create a slow non-blocking guardrail
+    async def slow_non_blocking_guardrail(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: Any
+    ) -> GuardrailFunctionOutput:
+        execution_order.append("guardrail_start")
+        # Wait for tool to start before finishing
+        await tool_started.wait()
+        execution_order.append("guardrail_end")
+        return GuardrailFunctionOutput(
+            output_info="non_blocking_completed",
+            tripwire_triggered=False,
+        )
+
+    # Create a tool that signals when it starts
+    @function_tool
+    async def test_tool() -> str:
+        execution_order.append("tool_start")
+        tool_started.set()
+        await asyncio.sleep(0.05)  # Small delay
+        execution_order.append("tool_end")
+        return "tool_result"
+
+    # Create agent with non-blocking guardrail and tool
+    non_blocking_guardrail = InputGuardrail(
+        guardrail_function=slow_non_blocking_guardrail, block_downstream_calls=False
+    )
+
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        input_guardrails=[non_blocking_guardrail],
+        tools=[test_tool],
+        model=model,
+    )
+
+    # Model output that calls the tool
+    model.add_multiple_turn_outputs(
+        [[get_function_tool_call("test_tool", "{}")], [get_text_message("completed")]]
+    )
+
+    result = await Runner.run(agent, input="test input")
+
+    # Verify execution order: tool should start before guardrail finishes
+    assert execution_order == ["guardrail_start", "tool_start", "guardrail_end", "tool_end"]
+    assert result.final_output == "completed"
+    assert len(result.input_guardrail_results) == 1
+    assert result.input_guardrail_results[0].output.output_info == "non_blocking_completed"
+
+
+@pytest.mark.asyncio
+async def test_mixed_blocking_and_non_blocking_guardrails():
+    """Test behavior when both blocking and non-blocking guardrails are present."""
+    import asyncio
+
+    execution_order = []
+
+    # Create blocking and non-blocking guardrails
+    async def blocking_guardrail(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: Any
+    ) -> GuardrailFunctionOutput:
+        execution_order.append("blocking_start")
+        await asyncio.sleep(0.1)
+        execution_order.append("blocking_end")
+        return GuardrailFunctionOutput(
+            output_info="blocking_done",
+            tripwire_triggered=False,
+        )
+
+    async def non_blocking_guardrail(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: Any
+    ) -> GuardrailFunctionOutput:
+        execution_order.append("non_blocking_start")
+        await asyncio.sleep(0.15)  # Takes longer than blocking
+        execution_order.append("non_blocking_end")
+        return GuardrailFunctionOutput(
+            output_info="non_blocking_done",
+            tripwire_triggered=False,
+        )
+
+    @function_tool
+    async def test_tool() -> str:
+        execution_order.append("tool_executed")
+        return "tool_result"
+
+    # Create agent with both types of guardrails
+    blocking_gr = InputGuardrail(
+        guardrail_function=blocking_guardrail, block_downstream_calls=True
+    )
+    non_blocking_gr = InputGuardrail(
+        guardrail_function=non_blocking_guardrail, block_downstream_calls=False
+    )
+
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        input_guardrails=[blocking_gr, non_blocking_gr],
+        tools=[test_tool],
+        model=model,
+    )
+
+    model.add_multiple_turn_outputs(
+        [[get_function_tool_call("test_tool", "{}")], [get_text_message("completed")]]
+    )
+
+    result = await Runner.run(agent, input="test input")
+
+    # Expected execution order
+    # blocking guardrail run first because you need to wait for it to run
+    # subsequent runs
+    # then non-blocking guardrail runs
+    # then tool runs
+    # then non-blocking guardrail finishes
+    expected_execution_order = [
+        "blocking_start",
+        "blocking_end",
+        "non_blocking_start",
+        "tool_executed",
+        "non_blocking_end",
+    ]
+
+    # Check that the execution order is as expected
+    assert execution_order == expected_execution_order
+
+    assert result.final_output == "completed"
+    assert len(result.input_guardrail_results) == 2

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -260,3 +260,64 @@ async def test_output_guardrail_decorators():
     assert not result.output.tripwire_triggered
     assert result.output.output_info == "test_4"
     assert guardrail.get_name() == "Custom name"
+
+
+@input_guardrail(block_downstream_calls=False)
+def non_blocking_input_guardrail(
+    context: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+) -> GuardrailFunctionOutput:
+    return GuardrailFunctionOutput(
+        output_info="non_blocking",
+        tripwire_triggered=False,
+    )
+
+
+@input_guardrail(block_downstream_calls=True)
+def blocking_input_guardrail(
+    context: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+) -> GuardrailFunctionOutput:
+    return GuardrailFunctionOutput(
+        output_info="blocking",
+        tripwire_triggered=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_input_guardrail_block_downstream_calls_parameter():
+    """Test that the block_downstream_calls parameter is properly set."""
+    # Test decorator with block_downstream_calls=False
+    guardrail = non_blocking_input_guardrail
+    assert guardrail.block_downstream_calls is False
+
+    # Test decorator with block_downstream_calls=True (explicit)
+    guardrail = blocking_input_guardrail
+    assert guardrail.block_downstream_calls is True
+
+    # Test default behavior (should be True)
+    @input_guardrail
+    def default_guardrail(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info="default", tripwire_triggered=False)
+
+    assert default_guardrail.block_downstream_calls is True
+
+
+@pytest.mark.asyncio
+async def test_input_guardrail_manual_creation_with_block_downstream_calls():
+    """Test creating InputGuardrail manually with block_downstream_calls parameter."""
+
+    def test_func(context, agent, input):
+        return GuardrailFunctionOutput(output_info="test", tripwire_triggered=False)
+
+    # Test explicit True
+    guardrail = InputGuardrail(guardrail_function=test_func, block_downstream_calls=True)
+    assert guardrail.block_downstream_calls is True
+
+    # Test explicit False
+    guardrail = InputGuardrail(guardrail_function=test_func, block_downstream_calls=False)
+    assert guardrail.block_downstream_calls is False
+
+    # Test default (should be True)
+    guardrail = InputGuardrail(guardrail_function=test_func)
+    assert guardrail.block_downstream_calls is True

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -506,11 +506,13 @@ def guardrail_function(
 
 @pytest.mark.asyncio
 async def test_guardrail_error():
-    agent = Agent(
-        name="test", input_guardrails=[InputGuardrail(guardrail_function=guardrail_function)]
-    )
     model = FakeModel()
     model.set_next_output([get_text_message("some_message")])
+    agent = Agent(
+        name="test",
+        input_guardrails=[InputGuardrail(guardrail_function=guardrail_function)],
+        model=model,
+    )
 
     with pytest.raises(InputGuardrailTripwireTriggered):
         await Runner.run(agent, input="user_message")

--- a/tests/test_tracing_errors_streamed.py
+++ b/tests/test_tracing_errors_streamed.py
@@ -543,10 +543,7 @@ async def test_input_guardrail_error():
                         "type": "agent",
                         "error": {
                             "message": "Guardrail tripwire triggered",
-                            "data": {
-                                "guardrail": "input_guardrail_function",
-                                "type": "input_guardrail",
-                            },
+                            "data": {"guardrail": "input_guardrail_function"},
                         },
                         "data": {"name": "test", "handoffs": [], "tools": [], "output_type": "str"},
                         "children": [


### PR DESCRIPTION
## Summary

- This PR has been started from #931 but due to too many conflicts with `main` branch it has been redone from scratch. It should close #889 and #991 
- Add optional blocking behavior for input guardrails so they can either gate the first model call and tool execution
or run in parallel.
- Fix a streaming hang by adding a short timeout when reading the event queue so guardrail tripwires and background
task errors surface even if no model events are produced.

## Motivation

- Some guardrails must run before any downstream LLM/tool activity (e.g., safety tripwires), while others can run
concurrently (e.g., telemetry or advisory checks). Previously, all input guardrails ran in parallel with the first
model call, which meant tripwires could trigger after downstream actions had already started.
- In streaming mode, if a blocking guardrail triggers before the model produces any events, the consumer could hang
awaiting events that never arrive.

## Key Changes

- Input Guardrails API:
    - src/agents/guardrail.py
    - Add `block_downstream_calls: bool = True` to `InputGuardrail`.
    - Extend `@input_guardrail` decorator with `block_downstream_calls` (default `True` for safety/back-compat).
- Runner (non-streamed):
    - src/agents/run.py
    - On first turn, separate input guardrails into blocking vs non-blocking.
    - If any blocking guardrails exist:
      - Await them to complete before the first model call and tool execution.
      - Run non-blocking guardrails concurrently with the model call/tools.
    - If none blocking:
      - Run all guardrails concurrently with the model call/tools as before.
    - Helpers:
      - `_separate_blocking_guardrails(...)`: returns `(blocking, non_blocking)`.
      - `_get_model_response_only(...)`: obtains the model response without executing tools.
      - `_execute_tools_from_model_response(...)`: runs tool execution/side effects from a model response.
- Runner (streamed):
    - src/agents/run.py
    - On first turn, run blocking guardrails to completion first and push their results to the guardrail queue. If a
tripwire triggers, the run task exits and the stream consumer detects the error.
    - Start non-blocking guardrails in the background queue (or all guardrails if none are blocking).
    - Append guardrail results to `RunResultStreaming.input_guardrail_results` to avoid overwriting.
- Streaming Hang Fix (important):
    - src/agents/result.py
    - In `RunResultStreaming.stream_events()`, wrap `self._event_queue.get()` in a short timeout:
      - `item = await asyncio.wait_for(self._event_queue.get(), timeout=0.1)`
      - On `TimeoutError`, loop continues and re-checks for stored exceptions and guardrail tripwires.
    - Why: If a blocking input guardrail triggers before any model events are streamed, the event queue may stay empty
forever. The timeout wakes the loop to:
      - Drain `_input_guardrail_queue` and raise `InputGuardrailTripwireTriggered`.
      - Detect exceptions stored from the background run task (e.g., tripwire raised) and surface them.
    - Effect: Prevents indefinite hangs when there are no model events. Normal streaming behavior is unchanged; the
consumer still yields events as they arrive.
- Tests:
    - Add tests covering:
    - Blocking guardrail prevents the first model call.
    - Blocking guardrail delays tool execution until completion.
    - Non-blocking guardrail allows parallel tool execution with tools.
    - Mixed blocking and non-blocking ordering.
    - Streamed: blocking guardrail prevents starting model streaming.
- Small adjustments in existing tests to attach a model when asserting model behavior.

## Behavior

- Default behavior is unchanged for existing users: guardrails default to block_downstream_calls=True, preserving the
safest behavior.
- Opt-in parallelism: set block_downstream_calls=False to allow a guardrail to run concurrently with the first model
call/tools.
- Streaming never hangs waiting for model events that never come due to early guardrail tripwires.
    - When idle (no events), the loop wakes 10 times/second to re-check errors, which is lightweight and ensures
responsiveness.

## Tests

- Unit tests added/updated; run with make tests.
- Specific reproduction fixed: tests/
test_agent_runner_streamed.py::test_input_guardrail_tripwire_triggered_causes_exception_streamed previously hung; with
the timeout it surfaces the tripwire and exits as expected.

## Files Touched

- src/agents/guardrail.py: New flag + decorator param.
- src/agents/run.py: Guardrail separation, gating logic, streamed behavior, helper methods, accumulate results.
- src/agents/result.py: Short timeout in stream_events() to avoid hangs.
- tests/*: New and adjusted tests.