### PR TITLE
spelled wiht to with

### DIFF
--- a/docs/realtime/guide.md
+++ b/docs/realtime/guide.md
@@ -15,7 +15,7 @@ Realtime agents allow for conversational flows, processing audio and text inputs
 
 The realtime system consists of several key components:
 
--   **RealtimeAgent**: An agent, configured wiht instructions, tools and handoffs.
+-   **RealtimeAgent**: An agent, configured with instructions, tools and handoffs.
 -   **RealtimeRunner**: Manages configuration. You can call `runner.run()` to get a session.
 -   **RealtimeSession**: A single interaction session. You typically create one each time a user starts a conversation, and keep it alive until the conversation is done.
 -   **RealtimeModel**: The underlying model interface (typically OpenAI's WebSocket implementation)


### PR DESCRIPTION
**“Fixed typo and clarified RealtimeAgent description: ‘with’ corrected from ‘wiht’.”**
