### PR TITLE
Fix an error with make mypy on local machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint:
 
 .PHONY: mypy
 mypy: 
-	uv run mypy .
+	uv run mypy . --exclude site
 
 .PHONY: tests
 tests: 


### PR DESCRIPTION
```
uv run mypy .
site/scripts/generate_ref_files.py: error: Duplicate module named "generate_ref_files" (also at "./docs/scripts/generate_ref_files.py") site/scripts/generate_ref_files.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info site/scripts/generate_ref_files.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH Found 1 error in 1 file (errors prevented further checking) make: *** [mypy] Error 2
```