### PR TITLE
feat(repl): add preload_history support to run_demo_loop

### DIFF
--- a/docs/repl.md
+++ b/docs/repl.md
@@ -20,10 +20,10 @@ if __name__ == "__main__":
 To end this chat session, simply type `quit` or `exit` (and press Enter) or use the `Ctrl-D` keyboard shortcut.
 
 
-## Few-shot initialization with preload_history
+## Few-shot initialization with `preload_history`
 
-The run_demo_loop function also accepts an optional preload_history parameter. This allows you to initialize the session with example user/assistant turns, providing context before interactive input begins.  
-
+The `run_demo_loop` function accepts an optional `preload_history` parameter, which lets you seed the session with predefined user/assistant exchanges.  
+This enables few-shot prompting by giving the agent example interactions that establish context and behavior before the interactive session begins.
 
 ```python
 import asyncio
@@ -40,6 +40,7 @@ async def main() -> None:
 if __name__ == "__main__":
     asyncio.run(main())
 
-```  
+```
 
-When you run this example, the chat session starts with the provided conversation history, and the agent can continue the dialogue as if those exchanges had already occurred.
+When you run this example, the session begins with the provided history.
+The agent continues the conversation naturally, as if those exchanges had already taken place.

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -18,3 +18,28 @@ if __name__ == "__main__":
 `run_demo_loop` prompts for user input in a loop, keeping the conversation history between turns. By default, it streams model output as it is produced. When you run the example above, run_demo_loop starts an interactive chat session. It continuously asks for your input, remembers the entire conversation history between turns (so your agent knows what's been discussed) and automatically streams the agent's responses to you in real-time as they are generated.
 
 To end this chat session, simply type `quit` or `exit` (and press Enter) or use the `Ctrl-D` keyboard shortcut.
+
+
+## Few-shot initialization with preload_history
+
+The run_demo_loop function also accepts an optional preload_history parameter. This allows you to initialize the session with example user/assistant turns, providing context before interactive input begins.  
+
+
+```python
+import asyncio
+from agents import Agent, run_demo_loop
+
+async def main() -> None:
+    agent = Agent(name="Assistant", instructions="You are a helpful assistant.")
+    preload_history = [
+        {"role": "user", "content": "What's 2+2?"},
+        {"role": "assistant", "content": "2+2 equals 4."}
+    ]
+    await run_demo_loop(agent, preload_history=preload_history)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+```  
+
+When you run this example, the chat session starts with the provided conversation history, and the agent can continue the dialogue as if those exchanges had already occurred.

--- a/src/agents/repl.py
+++ b/src/agents/repl.py
@@ -6,14 +6,18 @@ from openai.types.responses.response_text_delta_event import ResponseTextDeltaEv
 
 from .agent import Agent
 from .items import TResponseInputItem
-from .result import RunResultBase
+from .result import RunResultBase, RunResultStreaming, RunResult
 from .run import Runner
 from .run_context import TContext
 from .stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent, RunItemStreamEvent
 
 
 async def run_demo_loop(
-    agent: Agent[Any], *, stream: bool = True, context: TContext | None = None
+    agent: Agent[Any], 
+    *, 
+    stream: bool = True, 
+    context: TContext | None = None,
+    preload_history: list[TResponseInputItem] | None = None,
 ) -> None:
     """Run a simple REPL loop with the given agent.
 
@@ -25,10 +29,47 @@ async def run_demo_loop(
         agent: The starting agent to run.
         stream: Whether to stream the agent output.
         context: Additional context information to pass to the runner.
+        preload_history: Optional list of conversation turns to initialize the
+            session with. Allows few-shot prompting by seeding the dialogue with
+            example user/assistant exchanges.
+
+            Example:
+                >>> preload_history = [
+                ...     {"role": "user", "content": "What's 2+2?"},
+                ...     {"role": "assistant", "content": "2+2 equals 4."}
+                ... ]
     """
 
     current_agent = agent
-    input_items: list[TResponseInputItem] = []
+    # Start history with few-shot examples if provided
+    input_items: list[TResponseInputItem] = preload_history[:] if preload_history else []
+    
+    # Run the preload through the agent once (so the context is fully established)
+    if input_items:
+        result: RunResultStreaming | RunResult
+        if stream:
+            result = Runner.run_streamed(current_agent, input=input_items, context=context)
+            async for event in result.stream_events():
+                if isinstance(event, RawResponsesStreamEvent):
+                    if isinstance(event.data, ResponseTextDeltaEvent):
+                        print(event.data.delta, end="", flush=True)
+                elif isinstance(event, RunItemStreamEvent):
+                    if event.item.type == "tool_call_item":
+                        print("\n[tool called]", flush=True)
+                    elif event.item.type == "tool_call_output_item":
+                        print(f"\n[tool output: {event.item.output}]", flush=True)
+                elif isinstance(event, AgentUpdatedStreamEvent):
+                    print(f"\n[Agent updated: {event.new_agent.name}]", flush=True)
+            print()
+        else:
+            result = await Runner.run(current_agent, input_items, context=context)
+            if result.final_output is not None:
+                print(result.final_output)
+
+        current_agent = result.last_agent
+        input_items = result.to_input_list()
+    
+    # Now enter REPL loop
     while True:
         try:
             user_input = input(" > ")
@@ -42,7 +83,6 @@ async def run_demo_loop(
 
         input_items.append({"role": "user", "content": user_input})
 
-        result: RunResultBase
         if stream:
             result = Runner.run_streamed(current_agent, input=input_items, context=context)
             async for event in result.stream_events():

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -26,3 +26,31 @@ async def test_run_demo_loop_conversation(monkeypatch, capsys):
         get_text_message("hello").model_dump(exclude_unset=True),
         get_text_input_item("How are you?"),
     ]
+
+
+
+@pytest.mark.asyncio
+async def test_run_demo_loop_with_preload_history(monkeypatch, capsys):
+    model = FakeModel()
+    model.add_multiple_turn_outputs([[get_text_message("ready")]])
+
+    agent = Agent(name="test", model=model)
+
+    # Preload with a sample exchange
+    preload_history = [
+        {"role": "user", "content": "What's 2+2?"},
+        {"role": "assistant", "content": "2+2 equals 4."},
+    ]
+
+    # User quits immediately (no extra turns)
+    inputs = iter(["quit"])
+    monkeypatch.setattr("builtins.input", lambda _=" > ": next(inputs))
+
+    await run_demo_loop(agent, stream=False, preload_history=preload_history)
+
+    output = capsys.readouterr().out
+    # Verify that model saw the preload in its input history
+    assert model.last_turn_args["input"][0]["content"] == "What's 2+2?"
+    assert model.last_turn_args["input"][1]["content"] == "2+2 equals 4."
+    # Verify model responded as configured
+    assert "ready" in output


### PR DESCRIPTION
### Summary
This PR introduces support for an optional `preload_history` parameter in the `run_demo_loop` function.  
It allows users to initialize a session with example user/assistant exchanges, enabling few-shot prompting.

### Changes
- Extended `run_demo_loop` to accept `preload_history`.
- Updated docstring and `docs/repl.md` with usage example.
- Added test (`test_run_demo_loop_with_preload_history`) to verify functionality.

### Motivation
Few-shot prompting is a common technique for shaping agent behavior.  
This update makes it easier to bootstrap interactive sessions with predefined examples.

### Testing
- Added a new test in `tests/test_repl.py` covering preload history.  
- Ran full test suite with `pytest`, all tests passed.


