### PR TITLE
Document OpenAI Conversations session option

### DIFF
--- a/docs/ref/memory/openai_conversations_session.md
+++ b/docs/ref/memory/openai_conversations_session.md
@@ -1,0 +1,3 @@
+# `Openai Conversations Session`
+
+::: agents.memory.openai_conversations_session

--- a/docs/ref/memory/sqlite_session.md
+++ b/docs/ref/memory/sqlite_session.md
@@ -1,0 +1,3 @@
+# `Sqlite Session`
+
+::: agents.memory.sqlite_session

--- a/docs/ref/models/default_models.md
+++ b/docs/ref/models/default_models.md
@@ -1,0 +1,3 @@
+# `Default Models`
+
+::: agents.models.default_models

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -122,6 +122,27 @@ print(f"Agent: {result.final_output}")
 result = await Runner.run(agent, "Hello")
 ```
 
+### OpenAI Conversations API memory
+
+Use the [OpenAI Conversations API](https://platform.openai.com/docs/guides/conversational-agents/conversations-api) to persist
+conversation state without managing your own database. This is helpful when you already rely on OpenAI-hosted infrastructure
+for storing conversation history.
+
+```python
+from agents import OpenAIConversationsSession
+
+session = OpenAIConversationsSession()
+
+# Optionally resume a previous conversation by passing a conversation ID
+# session = OpenAIConversationsSession(conversation_id="conv_123")
+
+result = await Runner.run(
+    agent,
+    "Hello",
+    session=session,
+)
+```
+
 ### SQLite memory
 
 ```python
@@ -282,6 +303,7 @@ Use meaningful session IDs that help you organize conversations:
 -   Use in-memory SQLite (`SQLiteSession("session_id")`) for temporary conversations
 -   Use file-based SQLite (`SQLiteSession("session_id", "path/to/db.sqlite")`) for persistent conversations
 -   Use SQLAlchemy-powered sessions (`SQLAlchemySession("session_id", engine=engine, create_tables=True)`) for production systems with existing databases supported by SQLAlchemy
+-   Use OpenAI-hosted storage (`OpenAIConversationsSession()`) when you prefer to store history in the OpenAI Conversations API
 -   Consider implementing custom session backends for other production systems (Redis, Django, etc.) for more advanced use cases
 
 ### Session management
@@ -378,4 +400,5 @@ For detailed API documentation, see:
 
 -   [`Session`][agents.memory.Session] - Protocol interface
 -   [`SQLiteSession`][agents.memory.SQLiteSession] - SQLite implementation
+-   [`OpenAIConversationsSession`](ref/memory/openai_conversations_session.md) - OpenAI Conversations API implementation
 -   [`SQLAlchemySession`][agents.extensions.memory.sqlalchemy_session.SQLAlchemySession] - SQLAlchemy-powered implementation


### PR DESCRIPTION
## Summary
- document the OpenAI Conversations session option on the sessions guide
- link to the generated reference page for the OpenAI Conversations session implementation
- check in the generated reference stubs created during the docs build

## Testing
- make build-docs

------
https://chatgpt.com/codex/tasks/task_i_68b80232666c83209c185fb761150b60