### PR TITLE
Use head commit in docs workflow PR body

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -55,6 +55,10 @@ jobs:
         with:
           commit-message: "Update all translated document pages"
           title: "Update all translated document pages"
-          body: "Automated update of translated documentation"
+          body: |
+            Automated update of translated documentation.
+
+            Triggered by commit: [${{ github.event.head_commit.id }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.head_commit.id }}).
+            Message: `${{ github.event.head_commit.message }}`
           branch: update-translated-docs-${{ github.run_id }}
           delete-branch: true


### PR DESCRIPTION
### Summary
- include the triggering commit's details in the automated translated-docs PR description so reviewers can trace the source change.

### Test plan
- `make format`
- `make lint`
- `make mypy` *(fails: missing optional dependencies `numpy`, `litellm`, `sqlalchemy`)*
- `make tests` *(fails: missing optional dependencies `litellm`, `numpy`)*

------
https://chatgpt.com/codex/tasks/task_i_68b8be8c01808320bd82cc21fa05f310