### PR TITLE
Pr fix incomplete agent graphs when using handoff() function

### DIFF
--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -84,6 +84,9 @@ def get_all_nodes(
                 f"shape=box, style=filled, style=rounded, "
                 f"fillcolor=lightyellow, width=1.5, height=0.8];"
             )
+            if handoff.agent and handoff.agent.name not in visited:  
+                parts.append(get_all_nodes(handoff.agent, agent, visited))
+            
         if isinstance(handoff, Agent):
             if handoff.name not in visited:
                 parts.append(
@@ -134,6 +137,8 @@ def get_all_edges(
         if isinstance(handoff, Handoff):
             parts.append(f"""
             "{agent.name}" -> "{handoff.agent_name}";""")
+            if handoff.agent:  
+                parts.append(get_all_edges(handoff.agent, agent, visited)) 
         if isinstance(handoff, Agent):
             parts.append(f"""
             "{agent.name}" -> "{handoff.name}";""")

--- a/src/agents/handoffs.py
+++ b/src/agents/handoffs.py
@@ -118,7 +118,8 @@ class Handoff(Generic[TContext, TAgent]):
     """Whether the input JSON schema is in strict mode. We **strongly** recommend setting this to
     True, as it increases the likelihood of correct JSON input.
     """
-
+    agent: TAgent | None = None  
+    """Reference to the actual agent object for visualization purposes."""
     is_enabled: bool | Callable[[RunContextWrapper[Any], AgentBase[Any]], MaybeAwaitable[bool]] = (
         True
     )
@@ -280,5 +281,6 @@ def handoff(
         on_invoke_handoff=_invoke_handoff,
         input_filter=input_filter,
         agent_name=agent.name,
+        agent = agent,
         is_enabled=_is_enabled if callable(is_enabled) else is_enabled,
     )


### PR DESCRIPTION
**##Problem##**
The draw_graph function in _src/agents/extensions/visualization.py_ exhibits inconsistent behavior when visualizing agent chains. visualization.py:148-165 Currently, the visualization system only recursively traverses direct Agent references but fails to recursively traverse Handoff objects created by the handoff() function. visualization.md:15-21

This limitation causes incomplete visualizations where only the first few agents in a handoff chain are displayed, breaking the user's expectation that the complete agent workflow should be visible regardless of the handoff implementation method used.

**##Current Behavior:##**

Agent chains using direct Agent references: Complete visualization
Agent chains using handoff() function:  Incomplete visualization (stops after first handoff)
Root Cause
The visualization functions get_all_nodes() and get_all_edges() contain conditional logic that only triggers recursive traversal for isinstance(handoff, Agent) but not for isinstance(handoff, Handoff).

**##Solution##**
This PR implements a three-part fix to enable complete agent chain visualization:

Extend Handoff class: Add an optional agent field to store a reference to the target agent object for visualization purposes
Update handoff() function: Populate the agent reference when creating Handoff objects
Enhance visualization functions: Modify get_all_nodes() and get_all_edges() to recursively traverse Handoff objects when the agent reference is available
The solution maintains backward compatibility while enabling consistent visualization behavior across all handoff types.

**##Impact##**
This fix resolves a user experience inconsistency where developers using the recommended handoff() function received incomplete visualizations compared to those using direct agent references. visualization.md:94-105 The change ensures that all agent workflows are fully visualizable regardless of implementation approach.

