### PR TITLE
Feat: Add StructuredSQLiteSession with conversation branching & usage tracking

### DIFF
--- a/examples/memory/advanced_structured_session_example.py
+++ b/examples/memory/advanced_structured_session_example.py
@@ -1,0 +1,191 @@
+"""
+Advanced example demonstrating conversation branching with StructuredSQLiteSession.
+
+This example shows how to use soft deletion for conversation editing/branching,
+allowing you to "undo" parts of a conversation and continue from any point.
+"""
+
+import asyncio
+
+from agents import Agent, Runner, function_tool
+from agents.extensions.memory import StructuredSQLiteSession
+
+
+@function_tool
+async def get_weather(city: str) -> str:
+    if city.strip().lower() == "new york":
+        return f"The weather in {city} is cloudy."
+    return f"The weather in {city} is sunny."
+
+
+async def main():
+    # Create an agent
+    agent = Agent(
+        name="Assistant",
+        instructions="Reply very concisely.",
+        tools=[get_weather],
+    )
+
+    # Create a structured session instance
+    session = StructuredSQLiteSession("conversation_advanced")
+
+    print("=== Advanced Structured Session: Conversation Branching ===")
+    print("This example demonstrates conversation editing and branching.\n")
+
+    # Build initial conversation
+    print("Building initial conversation...")
+
+    # Turn 1
+    print("Turn 1: User asks about Golden Gate Bridge")
+    result = await Runner.run(
+        agent,
+        "What city is the Golden Gate Bridge in?",
+        session=session,
+    )
+    print(f"Assistant: {result.final_output}")
+    await session.store_run_usage(result)
+
+    # Turn 2
+    print("Turn 2: User asks about weather")
+    result = await Runner.run(
+        agent,
+        "What's the weather in that city?",
+        session=session,
+    )
+    print(f"Assistant: {result.final_output}")
+    await session.store_run_usage(result)
+
+    # Turn 3
+    print("Turn 3: User asks about population")
+    result = await Runner.run(
+        agent,
+        "What's the population of that city?",
+        session=session,
+    )
+    print(f"Assistant: {result.final_output}")
+    await session.store_run_usage(result)
+
+    print("\n=== Original Conversation Complete ===")
+
+    # Show current conversation
+    print("Current conversation:")
+    current_items = await session.get_items()
+    for i, item in enumerate(current_items, 1):
+        role = str(item.get("role", item.get("type", "unknown")))
+        if item.get("type") == "function_call":
+            content = f"{item.get('name', 'unknown')}({item.get('arguments', '{}')})"
+        elif item.get("type") == "function_call_output":
+            content = str(item.get("output", ""))
+        else:
+            content = str(item.get("content", item.get("output", "")))
+        print(f"  {i}. {role}: {content}")
+
+    print(f"\nTotal items: {len(current_items)}")
+
+    # Demonstrate conversation branching
+    print("\n=== Conversation Branching Demo ===")
+    print("Let's say we want to edit the conversation from turn 2 onwards...")
+
+    # Soft delete from turn 2 to create a branch point
+    print("\nSoft deleting from turn 2 onwards to create branch point...")
+    deleted = await session.soft_delete_from_turn(2)
+    print(f"Deleted: {deleted}")
+
+    # Show only active items (turn 1 only)
+    active_items = await session.get_items()
+    print(f"Active items after deletion: {len(active_items)}")
+    print("Active conversation (turn 1 only):")
+    for i, item in enumerate(active_items, 1):
+        role = str(item.get("role", item.get("type", "unknown")))
+        if item.get("type") == "function_call":
+            content = f"{item.get('name', 'unknown')}({item.get('arguments', '{}')})"
+        elif item.get("type") == "function_call_output":
+            content = str(item.get("output", ""))
+        else:
+            content = str(item.get("content", item.get("output", "")))
+        print(f"  {i}. {role}: {content}")
+
+    # Create a new branch
+    print("\nCreating new conversation branch...")
+    print("Turn 2 (new branch): User asks about New York instead")
+    result = await Runner.run(
+        agent,
+        "Actually, what's the weather in New York instead?",
+        session=session,
+    )
+    print(f"Assistant: {result.final_output}")
+    await session.store_run_usage(result)
+
+    # Continue the new branch
+    print("Turn 3 (new branch): User asks about NYC attractions")
+    result = await Runner.run(
+        agent,
+        "What are some famous attractions in New York?",
+        session=session,
+    )
+    print(f"Assistant: {result.final_output}")
+    await session.store_run_usage(result)
+
+    # Show the new conversation
+    print("\n=== New Conversation Branch ===")
+    new_conversation = await session.get_items()
+    print("New conversation with branch:")
+    for i, item in enumerate(new_conversation, 1):
+        role = str(item.get("role", item.get("type", "unknown")))
+        if item.get("type") == "function_call":
+            content = f"{item.get('name', 'unknown')}({item.get('arguments', '{}')})"
+        elif item.get("type") == "function_call_output":
+            content = str(item.get("output", ""))
+        else:
+            content = str(item.get("content", item.get("output", "")))
+        print(f"  {i}. {role}: {content}")
+
+    # Show that we can still access the original branch
+    all_items = await session.get_items(include_inactive=True)
+    print(f"\nTotal items including inactive (original + new branch): {len(all_items)}")
+
+    print("\n=== Conversation Structure Analysis ===")
+    # Show conversation turns (active only)
+    conversation_turns = await session.get_conversation_by_turns()
+    print("Active conversation turns:")
+    for turn_num, items in conversation_turns.items():
+        print(f"  Turn {turn_num}: {len(items)} items")
+        for item in items:  # type: ignore
+            if item["tool_name"]:  # type: ignore
+                print(
+                    f"    - {item['type']} (tool: {item['tool_name']}) [active: {item['active']}]"  # type: ignore
+                )
+            else:
+                print(f"    - {item['type']} [active: {item['active']}]")  # type: ignore
+
+    # Show all conversation turns (including inactive)
+    all_conversation_turns = await session.get_conversation_by_turns(include_inactive=True)
+    print("\nAll conversation turns (including inactive):")
+    for turn_num, items in all_conversation_turns.items():
+        print(f"  Turn {turn_num}: {len(items)} items")
+        for item in items:  # type: ignore
+            status = "ACTIVE" if item["active"] else "INACTIVE"  # type: ignore
+            if item["tool_name"]:  # type: ignore
+                print(f"    - {item['type']} (tool: {item['tool_name']}) [{status}]")  # type: ignore
+            else:
+                print(f"    - {item['type']} [{status}]")
+
+    print("\n=== Reactivation Demo ===")
+    print("We can also reactivate the original conversation...")
+
+    # Reactivate the original conversation
+    reactivated = await session.reactivate_from_turn(2)
+    print(f"Reactivated: {reactivated}")
+
+    # Show all active items now
+    all_active = await session.get_items()
+    print(f"All active items after reactivation: {len(all_active)}")
+
+    print("\n=== Advanced Example Complete ===")
+    print("This demonstrates how soft deletion enables conversation editing/branching!")
+    print("You can 'undo' parts of a conversation and continue from any point.")
+    print("Perfect for building conversational AI systems with editing capabilities.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/memory/basic_structured_session_example.py
+++ b/examples/memory/basic_structured_session_example.py
@@ -1,0 +1,111 @@
+"""
+Basic example demonstrating structured session memory functionality.
+
+This example shows how to use StructuredSQLiteSession for conversation tracking
+with usage statistics and turn-based organization.
+"""
+
+import asyncio
+
+from agents import Agent, Runner, function_tool
+from agents.extensions.memory import StructuredSQLiteSession
+
+
+@function_tool
+async def get_weather(city: str) -> str:
+    if city.strip().lower() == "new york":
+        return f"The weather in {city} is cloudy."
+    return f"The weather in {city} is sunny."
+
+
+async def main():
+    # Create an agent
+    agent = Agent(
+        name="Assistant",
+        instructions="Reply very concisely.",
+        tools=[get_weather],
+    )
+
+    # Create a structured session instance
+    session = StructuredSQLiteSession("conversation_basic")
+
+    print("=== Basic Structured Session Example ===")
+    print("The agent will remember previous messages with structured tracking.\n")
+
+    # First turn
+    print("First turn:")
+    print("User: What city is the Golden Gate Bridge in?")
+    result = await Runner.run(
+        agent,
+        "What city is the Golden Gate Bridge in?",
+        session=session,
+    )
+    print(f"Assistant: {result.final_output}")
+    print(f"Usage: {result.context_wrapper.usage.total_tokens} tokens")
+
+    # Store usage data automatically
+    await session.store_run_usage(result)
+    print()
+
+    # Second turn - continuing the conversation
+    print("Second turn:")
+    print("User: What's the weather in that city?")
+    result = await Runner.run(
+        agent,
+        "What's the weather in that city?",
+        session=session,
+    )
+    print(f"Assistant: {result.final_output}")
+    print(f"Usage: {result.context_wrapper.usage.total_tokens} tokens")
+
+    # Store usage data automatically
+    await session.store_run_usage(result)
+    print()
+
+    print("=== Usage Tracking Demo ===")
+    session_usage = await session.get_session_usage()
+    if session_usage:
+        print("Session Usage (aggregated from turns):")
+        print(f"  Total requests: {session_usage['requests']}")
+        print(f"  Total tokens: {session_usage['total_tokens']}")
+        print(f"  Input tokens: {session_usage['input_tokens']}")
+        print(f"  Output tokens: {session_usage['output_tokens']}")
+        print(f"  Total turns: {session_usage['total_turns']}")
+
+        # Show usage by turn
+        turn_usage_list = await session.get_turn_usage()
+        if turn_usage_list and isinstance(turn_usage_list, list):
+            print("\nUsage by turn:")
+            for turn_data in turn_usage_list:
+                turn_num = turn_data["user_turn_number"]
+                tokens = turn_data["total_tokens"]
+                print(f"  Turn {turn_num}: {tokens} tokens")
+    else:
+        print("No usage data found.")
+
+    print("\n=== Structured Query Demo ===")
+    conversation_turns = await session.get_conversation_by_turns()
+    print("Conversation by turns:")
+    for turn_num, items in conversation_turns.items():
+        print(f"  Turn {turn_num}: {len(items)} items")
+        for item in items:
+            if item["tool_name"]:
+                print(f"    - {item['type']} (tool: {item['tool_name']})")
+            else:
+                print(f"    - {item['type']}")
+
+    # Show tool usage
+    tool_usage = await session.get_tool_usage()
+    if tool_usage:
+        print("\nTool usage:")
+        for tool_name, count, turn in tool_usage:
+            print(f"  {tool_name}: used {count} times in turn {turn}")
+    else:
+        print("\nNo tool usage found.")
+
+    print("\n=== Basic Example Complete ===")
+    print("Session provides structured tracking with usage analytics!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agents/extensions/memory/__init__.py
+++ b/src/agents/extensions/memory/__init__.py
@@ -9,7 +9,9 @@ used as a drop-in replacement for :class:`agents.memory.session.SQLiteSession`.
 from __future__ import annotations
 
 from .sqlalchemy_session import SQLAlchemySession  # noqa: F401
+from .structured_sqlite_session import StructuredSQLiteSession  # noqa: F401
 
 __all__: list[str] = [
     "SQLAlchemySession",
+    "StructuredSQLiteSession",
 ]

--- a/src/agents/extensions/memory/structured_sqlite_session.py
+++ b/src/agents/extensions/memory/structured_sqlite_session.py
@@ -1,0 +1,561 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+from agents.result import RunResult
+from agents.usage import Usage
+
+from ...items import TResponseInputItem
+from ...memory import SQLiteSession
+
+
+class StructuredSQLiteSession(SQLiteSession):
+    """SQLite session with simple structured metadata and soft deletion."""
+
+    ACTIVE = 1  # Message is active and visible in conversation
+    INACTIVE = 0  # Message is soft-deleted (hidden but preserved)
+
+    def __init__(self, session_id: str, db_path: str | Path = ":memory:", **kwargs):
+        super().__init__(session_id, db_path, **kwargs)
+        self._current_user_turn = 0
+        self._init_structure_tables()
+        self._initialize_turn_counter()
+
+    def _init_structure_tables(self):
+        """Add structure and usage tracking tables."""
+        conn = self._get_connection()
+
+        # Simple message structure with soft deletion and precise ordering
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS message_structure (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                message_type TEXT NOT NULL,
+                sequence_number INTEGER NOT NULL,
+                user_turn_number INTEGER,
+                tool_name TEXT,
+                is_active BOOLEAN DEFAULT 1,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                deactivated_at TIMESTAMP,
+                FOREIGN KEY (session_id) REFERENCES agent_sessions(session_id) ON DELETE CASCADE,
+                FOREIGN KEY (message_id) REFERENCES agent_messages(id) ON DELETE CASCADE
+            )
+        """)
+
+        # Turn-level usage tracking with full JSON details
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS turn_usage (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                user_turn_number INTEGER NOT NULL,
+                requests INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                total_tokens INTEGER DEFAULT 0,
+                input_tokens_details JSON,
+                output_tokens_details JSON,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (session_id) REFERENCES agent_sessions(session_id) ON DELETE CASCADE,
+                UNIQUE(session_id, user_turn_number)
+            )
+        """)
+
+        # Indexes
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_structure_session_seq
+            ON message_structure(session_id, sequence_number)
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_structure_active
+            ON message_structure(session_id, is_active)
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_structure_turn
+            ON message_structure(session_id, user_turn_number, is_active)
+        """)
+        # Compound index for optimal performance on get_items queries
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_structure_active_seq
+            ON message_structure(session_id, is_active, sequence_number)
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_turn_usage_session_turn
+            ON turn_usage(session_id, user_turn_number)
+        """)
+
+        conn.commit()
+
+    def _initialize_turn_counter(self):
+        """Initialize the turn counter based on existing database state."""
+        conn = self._get_connection()
+
+        # Get the highest user_turn_number for this session
+        cursor = conn.execute(
+            """
+            SELECT COALESCE(MAX(user_turn_number), 0)
+            FROM message_structure
+            WHERE session_id = ? AND is_active = 1
+        """,
+            (self.session_id,),
+        )
+        max_turn = cursor.fetchone()[0]
+        self._current_user_turn = max_turn
+
+    async def add_items(self, items: list[TResponseInputItem]) -> None:
+        # Add to base table first
+        await super().add_items(items)
+
+        # Extract structure metadata with precise sequencing
+        if items:
+            await self._add_structure_metadata(items)
+
+    async def store_run_usage(self, result: RunResult) -> None:
+        """Store usage data for the current conversation turn.
+
+        This is designed to be called after Runner.run() completes.
+        Session-level usage can be aggregated from turn data when needed.
+        """
+        try:
+            if result.context_wrapper.usage is not None:
+                # Only update turn-level usage - session usage is aggregated on demand
+                await self._update_turn_usage_internal(
+                    self._current_user_turn, result.context_wrapper.usage
+                )
+        except Exception as e:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.error(f"Failed to store usage for session {self.session_id}: {e}")
+
+    async def _add_structure_metadata(self, items: list[TResponseInputItem]) -> None:
+        """Extract structure metadata with microsecond precision ordering.
+
+        This method:
+        - Increments user turn counter for each user message encountered
+        - Assigns explicit sequence numbers for precise ordering
+        - Links messages to their database IDs for structure tracking
+        - Handles multiple user messages in a single batch correctly
+        """
+        try:
+            conn = self._get_connection()
+
+            # Get the IDs of messages we just inserted, in order
+            cursor = conn.execute(
+                f"SELECT id FROM {self.messages_table} "
+                f"WHERE session_id = ? ORDER BY id DESC LIMIT ?",
+                (self.session_id, len(items)),
+            )
+            message_ids = [row[0] for row in cursor.fetchall()]
+            message_ids.reverse()  # Match order of items
+
+            # Get current max sequence number
+            cursor = conn.execute(
+                """
+                SELECT COALESCE(MAX(sequence_number), 0)
+                FROM message_structure
+                WHERE session_id = ? AND is_active = 1
+            """,
+                (self.session_id,),
+            )
+            seq_start = cursor.fetchone()[0]
+
+            # Process items and assign turn numbers correctly
+            # Each user message starts a new turn, subsequent items belong to that turn
+            structure_data = []
+            current_turn = self._current_user_turn
+
+            for i, (item, msg_id) in enumerate(zip(items, message_ids)):
+                # If this is a user message, increment the turn counter
+                if self._is_user_message(item):
+                    current_turn += 1
+                    self._current_user_turn = current_turn
+
+                msg_type = self._classify_simple(item)
+                tool_name = self._extract_tool_name(item)
+
+                structure_data.append(
+                    (
+                        self.session_id,
+                        msg_id,
+                        msg_type,
+                        seq_start + i + 1,  # Explicit sequence
+                        current_turn,
+                        tool_name,
+                        self.ACTIVE,
+                    )
+                )
+
+            conn.executemany(
+                """
+                INSERT INTO message_structure
+                (session_id, message_id, message_type, sequence_number, user_turn_number, tool_name, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,  # noqa: E501
+                structure_data,
+            )
+            conn.commit()
+        except Exception as e:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.error(f"Failed to add structure metadata for session {self.session_id}: {e}")
+            # Don't re-raise - structure metadata is supplementary
+
+    def _classify_simple(self, item: TResponseInputItem) -> str:
+        """Simple classification."""
+        if isinstance(item, dict):
+            if item.get("role") == "user":
+                return "user"
+            elif item.get("role") == "assistant":
+                return "assistant"
+            elif item.get("type"):
+                return str(item.get("type"))
+        return "other"
+
+    def _extract_tool_name(self, item: TResponseInputItem) -> str | None:
+        """Extract tool name if this is a tool call/output."""
+        if isinstance(item, dict):
+            item_type = item.get("type")
+
+            # For MCP tools, try to extract from server_label if available
+            if item_type in {"mcp_call", "mcp_approval_request"} and "server_label" in item:
+                server_label = item.get("server_label")
+                tool_name = item.get("name")
+                if tool_name and server_label:
+                    return f"{server_label}.{tool_name}"
+                elif server_label:
+                    return str(server_label)
+                elif tool_name:
+                    return str(tool_name)
+
+            # For tool types without a 'name' field, derive from the type
+            elif item_type in {
+                "computer_call",
+                "file_search_call",
+                "web_search_call",
+                "code_interpreter_call",
+            }:
+                return item_type
+
+            # Most other tool calls have a 'name' field
+            elif "name" in item:
+                name = item.get("name")
+                return str(name) if name is not None else None
+
+        return None
+
+    def _is_user_message(self, item: TResponseInputItem) -> bool:
+        """Check if this is a user message."""
+        return isinstance(item, dict) and item.get("role") == "user"
+
+    async def get_items(
+        self, limit: int | None = None, include_inactive: bool = False
+    ) -> list[TResponseInputItem]:
+        """Get items, optionally including soft-deleted ones."""
+        if include_inactive:
+            # Use parent implementation for all items
+            return await super().get_items(limit)
+
+        # Filter to only active items
+        def _get_active_items_sync():
+            conn = self._get_connection()
+            with self._lock if self._is_memory_db else threading.Lock():
+                # Get active message IDs in correct order
+                if limit is None:
+                    cursor = conn.execute(
+                        """
+                        SELECT m.message_data
+                        FROM agent_messages m
+                        JOIN message_structure s ON m.id = s.message_id
+                        WHERE m.session_id = ? AND s.is_active = 1
+                        ORDER BY s.sequence_number ASC
+                    """,
+                        (self.session_id,),
+                    )
+                else:
+                    cursor = conn.execute(
+                        """
+                        SELECT m.message_data
+                        FROM agent_messages m
+                        JOIN message_structure s ON m.id = s.message_id
+                        WHERE m.session_id = ? AND s.is_active = 1
+                        ORDER BY s.sequence_number DESC
+                        LIMIT ?
+                    """,
+                        (self.session_id, limit),
+                    )
+
+                rows = cursor.fetchall()
+                if limit is not None:
+                    rows = list(reversed(rows))
+
+                items = []
+                for (message_data,) in rows:
+                    try:
+                        item = json.loads(message_data)
+                        items.append(item)
+                    except json.JSONDecodeError:
+                        continue
+                return items
+
+        return await asyncio.to_thread(_get_active_items_sync)
+
+    async def soft_delete_from_turn(self, user_turn_number: int) -> bool:
+        """Soft delete conversation from a specific user turn onwards."""
+        conn = self._get_connection()
+
+        cursor = conn.execute(
+            """
+            UPDATE message_structure
+            SET is_active = 0, deactivated_at = CURRENT_TIMESTAMP
+            WHERE session_id = ? AND user_turn_number >= ? AND is_active = 1
+        """,
+            (self.session_id, user_turn_number),
+        )
+
+        affected = cursor.rowcount
+        conn.commit()
+        return affected > 0
+
+    async def reactivate_from_turn(self, user_turn_number: int) -> bool:
+        """Reactivate soft-deleted conversation from a specific turn."""
+        conn = self._get_connection()
+
+        cursor = conn.execute(
+            """
+            UPDATE message_structure
+            SET is_active = 1, deactivated_at = NULL
+            WHERE session_id = ? AND user_turn_number >= ? AND is_active = 0
+        """,
+            (self.session_id, user_turn_number),
+        )
+
+        affected = cursor.rowcount
+        conn.commit()
+        return affected > 0
+
+    async def _update_turn_usage_internal(self, user_turn_number: int, usage_data: Usage) -> None:
+        """Internal method to update usage for a specific turn with full JSON details."""
+
+        def _update_sync():
+            conn = self._get_connection()
+
+            # Serialize token details as JSON
+            input_details_json = None
+            output_details_json = None
+
+            if hasattr(usage_data, "input_tokens_details") and usage_data.input_tokens_details:
+                try:
+                    input_details_json = json.dumps(usage_data.input_tokens_details.__dict__)
+                except (TypeError, ValueError) as e:
+                    import logging
+
+                    logger = logging.getLogger(__name__)
+                    logger.warning(f"Failed to serialize input tokens details: {e}")
+                    input_details_json = None
+
+            if hasattr(usage_data, "output_tokens_details") and usage_data.output_tokens_details:
+                try:
+                    output_details_json = json.dumps(usage_data.output_tokens_details.__dict__)
+                except (TypeError, ValueError) as e:
+                    import logging
+
+                    logger = logging.getLogger(__name__)
+                    logger.warning(f"Failed to serialize output tokens details: {e}")
+                    output_details_json = None
+
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO turn_usage
+                (session_id, user_turn_number, requests, input_tokens, output_tokens,
+                 total_tokens, input_tokens_details, output_tokens_details)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+                (
+                    self.session_id,
+                    user_turn_number,
+                    usage_data.requests or 0,
+                    usage_data.input_tokens or 0,
+                    usage_data.output_tokens or 0,
+                    usage_data.total_tokens or 0,
+                    input_details_json,
+                    output_details_json,
+                ),
+            )
+            conn.commit()
+
+        await asyncio.to_thread(_update_sync)
+
+    async def get_session_usage(self) -> dict[str, int] | None:
+        """Get current cumulative usage for this session by aggregating turn data."""
+
+        def _get_usage_sync():
+            conn = self._get_connection()
+            cursor = conn.execute(
+                """
+                SELECT
+                    SUM(requests) as total_requests,
+                    SUM(input_tokens) as total_input_tokens,
+                    SUM(output_tokens) as total_output_tokens,
+                    SUM(total_tokens) as total_total_tokens,
+                    COUNT(*) as total_turns
+                FROM turn_usage
+                WHERE session_id = ?
+            """,
+                (self.session_id,),
+            )
+
+            row = cursor.fetchone()
+            if row and row[0] is not None:
+                return {
+                    "requests": row[0] or 0,
+                    "input_tokens": row[1] or 0,
+                    "output_tokens": row[2] or 0,
+                    "total_tokens": row[3] or 0,
+                    "total_turns": row[4] or 0,
+                }
+            return None
+
+        return await asyncio.to_thread(_get_usage_sync)
+
+    async def get_conversation_by_turns(
+        self, include_inactive: bool = False
+    ) -> dict[int, list[dict[str, str | bool | None]]]:
+        """Get conversation grouped by user turns."""
+        conn = self._get_connection()
+
+        active_filter = "" if include_inactive else "AND is_active = 1"
+        cursor = conn.execute(
+            f"""
+            SELECT user_turn_number, message_type, tool_name, is_active
+            FROM message_structure
+            WHERE session_id = ? {active_filter}
+            ORDER BY sequence_number
+        """,  # noqa: E501
+            (self.session_id,),
+        )
+
+        turns: dict[int, list[dict[str, str | bool | None]]] = {}
+        for row in cursor.fetchall():
+            turn_num, msg_type, tool_name, is_active = row
+            if turn_num not in turns:
+                turns[turn_num] = []
+            turns[turn_num].append(
+                {"type": msg_type, "tool_name": tool_name, "active": bool(is_active)}
+            )
+        return turns
+
+    async def get_tool_usage(self, include_inactive: bool = False) -> list[tuple[str, int, int]]:
+        """Get all tool usage by turn."""
+        conn = self._get_connection()
+
+        active_filter = "" if include_inactive else "AND is_active = 1"
+        cursor = conn.execute(
+            f"""
+            SELECT tool_name, COUNT(*), user_turn_number
+            FROM message_structure
+            WHERE session_id = ? AND message_type IN (
+                'tool_call', 'function_call', 'computer_call', 'file_search_call',
+                'web_search_call', 'code_interpreter_call', 'custom_tool_call',
+                'mcp_call', 'mcp_approval_request'
+            ) {active_filter}
+            GROUP BY tool_name, user_turn_number
+            ORDER BY user_turn_number
+        """,  # noqa: E501
+            (self.session_id,),
+        )
+        return cursor.fetchall()
+
+    async def get_turn_usage(
+        self, user_turn_number: int | None = None
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        """Get usage statistics by turn with full JSON token details."""
+
+        def _get_turn_usage_sync():
+            conn = self._get_connection()
+
+            if user_turn_number is not None:
+                cursor = conn.execute(
+                    """
+                    SELECT requests, input_tokens, output_tokens, total_tokens,
+                           input_tokens_details, output_tokens_details
+                    FROM turn_usage
+                    WHERE session_id = ? AND user_turn_number = ?
+                """,
+                    (self.session_id, user_turn_number),
+                )
+                row = cursor.fetchone()
+                if row:
+                    # Parse JSON details if present
+                    input_details = None
+                    output_details = None
+
+                    if row[4]:  # input_tokens_details
+                        try:
+                            input_details = json.loads(row[4])
+                        except json.JSONDecodeError:
+                            pass
+
+                    if row[5]:  # output_tokens_details
+                        try:
+                            output_details = json.loads(row[5])
+                        except json.JSONDecodeError:
+                            pass
+
+                    return {
+                        "requests": row[0],
+                        "input_tokens": row[1],
+                        "output_tokens": row[2],
+                        "total_tokens": row[3],
+                        "input_tokens_details": input_details,
+                        "output_tokens_details": output_details,
+                    }
+                return {}
+            else:
+                cursor = conn.execute(
+                    """
+                    SELECT user_turn_number, requests, input_tokens, output_tokens,
+                           total_tokens, input_tokens_details, output_tokens_details
+                    FROM turn_usage
+                    WHERE session_id = ?
+                    ORDER BY user_turn_number
+                """,
+                    (self.session_id,),
+                )
+                results = []
+                for row in cursor.fetchall():
+                    # Parse JSON details if present
+                    input_details = None
+                    output_details = None
+
+                    if row[5]:  # input_tokens_details
+                        try:
+                            input_details = json.loads(row[5])
+                        except json.JSONDecodeError:
+                            pass
+
+                    if row[6]:  # output_tokens_details
+                        try:
+                            output_details = json.loads(row[6])
+                        except json.JSONDecodeError:
+                            pass
+
+                    results.append(
+                        {
+                            "user_turn_number": row[0],
+                            "requests": row[1],
+                            "input_tokens": row[2],
+                            "output_tokens": row[3],
+                            "total_tokens": row[4],
+                            "input_tokens_details": input_details,
+                            "output_tokens_details": output_details,
+                        }
+                    )
+                return results
+
+        return await asyncio.to_thread(_get_turn_usage_sync)

--- a/tests/extensions/memory/test_structured_sqlite_session.py
+++ b/tests/extensions/memory/test_structured_sqlite_session.py
@@ -2,9 +2,11 @@
 
 import tempfile
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import pytest
+
+pytest.importorskip("sqlalchemy")  # Skip tests if SQLAlchemy is not installed
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 from agents import Agent, Runner, TResponseInputItem, function_tool
@@ -44,7 +46,9 @@ def usage_data() -> Usage:
     )
 
 
-def create_mock_run_result(usage: Usage | None = None, agent: Agent | None = None) -> RunResult:
+def create_mock_run_result(
+    usage: Optional[Usage] = None, agent: Optional[Agent] = None
+) -> RunResult:
     """Helper function to create a mock RunResult for testing."""
     if agent is None:
         agent = Agent(name="test", model=FakeModel())

--- a/tests/extensions/memory/test_structured_sqlite_session.py
+++ b/tests/extensions/memory/test_structured_sqlite_session.py
@@ -1,0 +1,600 @@
+"""Tests for StructuredSQLiteSession functionality."""
+
+import tempfile
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from agents import Agent, Runner, TResponseInputItem, function_tool
+from agents.extensions.memory import StructuredSQLiteSession
+from agents.result import RunResult
+from agents.run_context import RunContextWrapper
+from agents.usage import Usage
+from tests.fake_model import FakeModel
+from tests.test_responses import get_text_message
+
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
+
+
+@function_tool
+async def test_tool(query: str) -> str:
+    """A test tool for testing tool call tracking."""
+    return f"Tool result for: {query}"
+
+
+@pytest.fixture
+def agent() -> Agent:
+    """Fixture for a basic agent with a fake model."""
+    return Agent(name="test", model=FakeModel(), tools=[test_tool])
+
+
+@pytest.fixture
+def usage_data() -> Usage:
+    """Fixture for test usage data."""
+    return Usage(
+        requests=1,
+        input_tokens=50,
+        output_tokens=30,
+        total_tokens=80,
+        input_tokens_details=InputTokensDetails(cached_tokens=10),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
+    )
+
+
+def create_mock_run_result(usage: Usage | None = None, agent: Agent | None = None) -> RunResult:
+    """Helper function to create a mock RunResult for testing."""
+    if agent is None:
+        agent = Agent(name="test", model=FakeModel())
+
+    if usage is None:
+        usage = Usage(
+            requests=1,
+            input_tokens=50,
+            output_tokens=30,
+            total_tokens=80,
+            input_tokens_details=InputTokensDetails(cached_tokens=10),
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
+        )
+
+    context_wrapper = RunContextWrapper(context=None, usage=usage)
+
+    return RunResult(
+        input="test input",
+        new_items=[],
+        raw_responses=[],
+        final_output="test output",
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+        context_wrapper=context_wrapper,
+        _last_agent=agent,
+    )
+
+
+async def test_structured_session_basic_functionality(agent: Agent):
+    """Test basic StructuredSQLiteSession functionality."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_structured.db"
+        session_id = "structured_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Test basic session operations work
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        await session.add_items(items)
+
+        # Get items and verify
+        retrieved = await session.get_items()
+        assert len(retrieved) == 2
+        assert retrieved[0].get("content") == "Hello"
+        assert retrieved[1].get("content") == "Hi there!"
+
+        session.close()
+
+
+async def test_message_structure_tracking(agent: Agent):
+    """Test that message structure is properly tracked."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_structure.db"
+        session_id = "structure_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Add various types of messages
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "What's 2+2?"},
+            {"type": "function_call", "name": "calculator", "arguments": '{"expression": "2+2"}'},  # type: ignore
+            {"type": "function_call_output", "output": "4"},  # type: ignore
+            {"role": "assistant", "content": "The answer is 4"},
+            {"type": "reasoning", "summary": [{"text": "Simple math", "type": "summary_text"}]},  # type: ignore
+        ]
+        await session.add_items(items)
+
+        # Get conversation structure
+        conversation_turns = await session.get_conversation_by_turns()
+        assert len(conversation_turns) == 1  # Should be one user turn
+
+        turn_1_items = conversation_turns[1]
+        assert len(turn_1_items) == 5
+
+        # Verify item types are classified correctly
+        item_types = [item["type"] for item in turn_1_items]
+        assert "user" in item_types
+        assert "function_call" in item_types
+        assert "function_call_output" in item_types
+        assert "assistant" in item_types
+        assert "reasoning" in item_types
+
+        session.close()
+
+
+async def test_tool_usage_tracking(agent: Agent):
+    """Test tool usage tracking functionality."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_tools.db"
+        session_id = "tools_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Add items with tool calls
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "Search for cats"},
+            {"type": "function_call", "name": "web_search", "arguments": '{"query": "cats"}'},  # type: ignore
+            {"type": "function_call_output", "output": "Found cat information"},  # type: ignore
+            {"type": "function_call", "name": "calculator", "arguments": '{"expression": "1+1"}'},  # type: ignore
+            {"type": "function_call_output", "output": "2"},  # type: ignore
+            {"role": "assistant", "content": "I found information about cats and calculated 1+1=2"},
+        ]
+        await session.add_items(items)
+
+        # Get tool usage
+        tool_usage = await session.get_tool_usage()
+        assert len(tool_usage) == 2  # Two different tools used
+
+        tool_names = {usage[0] for usage in tool_usage}
+        assert "web_search" in tool_names
+        assert "calculator" in tool_names
+
+        session.close()
+
+
+async def test_soft_deletion_functionality(agent: Agent):
+    """Test soft deletion and reactivation functionality."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_deletion.db"
+        session_id = "deletion_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Add multiple turns
+        turn_1_items: list[TResponseInputItem] = [
+            {"role": "user", "content": "First question"},
+            {"role": "assistant", "content": "First answer"},
+        ]
+        await session.add_items(turn_1_items)
+
+        turn_2_items: list[TResponseInputItem] = [
+            {"role": "user", "content": "Second question"},
+            {"role": "assistant", "content": "Second answer"},
+        ]
+        await session.add_items(turn_2_items)
+
+        turn_3_items: list[TResponseInputItem] = [
+            {"role": "user", "content": "Third question"},
+            {"role": "assistant", "content": "Third answer"},
+        ]
+        await session.add_items(turn_3_items)
+
+        # Verify all items are active
+        all_items = await session.get_items()
+        assert len(all_items) == 6
+
+        # Soft delete from turn 2 onwards
+        deleted = await session.soft_delete_from_turn(2)
+        assert deleted is True
+
+        # Verify only turn 1 items are active
+        active_items = await session.get_items()
+        assert len(active_items) == 2
+        assert active_items[0].get("content") == "First question"
+        assert active_items[1].get("content") == "First answer"
+
+        # Verify we can still get inactive items
+        all_items_including_inactive = await session.get_items(include_inactive=True)
+        assert len(all_items_including_inactive) == 6
+
+        # Test reactivation
+        reactivated = await session.reactivate_from_turn(2)
+        assert reactivated is True
+
+        # Verify all items are active again
+        all_active_again = await session.get_items()
+        assert len(all_active_again) == 6
+
+        session.close()
+
+
+async def test_usage_tracking_storage(agent: Agent, usage_data: Usage):
+    """Test usage data storage and retrieval."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_usage.db"
+        session_id = "usage_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Simulate adding items for turn 1 to increment turn counter
+        await session.add_items([{"role": "user", "content": "First turn"}])
+        run_result_1 = create_mock_run_result(usage_data)
+        await session.store_run_usage(run_result_1)
+
+        # Create different usage data for turn 2
+        usage_data_2 = Usage(
+            requests=2,
+            input_tokens=75,
+            output_tokens=45,
+            total_tokens=120,
+            input_tokens_details=InputTokensDetails(cached_tokens=20),
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=15),
+        )
+
+        # Simulate adding items for turn 2 to increment turn counter
+        await session.add_items([{"role": "user", "content": "Second turn"}])
+        run_result_2 = create_mock_run_result(usage_data_2)
+        await session.store_run_usage(run_result_2)
+
+        # Test session-level usage aggregation
+        session_usage = await session.get_session_usage()
+        assert session_usage is not None
+        assert session_usage["requests"] == 3  # 1 + 2
+        assert session_usage["total_tokens"] == 200  # 80 + 120
+        assert session_usage["input_tokens"] == 125  # 50 + 75
+        assert session_usage["output_tokens"] == 75  # 30 + 45
+        assert session_usage["total_turns"] == 2
+
+        # Test turn-level usage retrieval
+        turn_1_usage = await session.get_turn_usage(1)
+        assert isinstance(turn_1_usage, dict)
+        assert turn_1_usage["requests"] == 1
+        assert turn_1_usage["total_tokens"] == 80
+        assert turn_1_usage["input_tokens_details"]["cached_tokens"] == 10
+        assert turn_1_usage["output_tokens_details"]["reasoning_tokens"] == 5
+
+        turn_2_usage = await session.get_turn_usage(2)
+        assert isinstance(turn_2_usage, dict)
+        assert turn_2_usage["requests"] == 2
+        assert turn_2_usage["total_tokens"] == 120
+        assert turn_2_usage["input_tokens_details"]["cached_tokens"] == 20
+        assert turn_2_usage["output_tokens_details"]["reasoning_tokens"] == 15
+
+        # Test getting all turn usage
+        all_turn_usage = await session.get_turn_usage()
+        assert isinstance(all_turn_usage, list)
+        assert len(all_turn_usage) == 2
+        assert all_turn_usage[0]["user_turn_number"] == 1
+        assert all_turn_usage[1]["user_turn_number"] == 2
+
+        session.close()
+
+
+async def test_runner_integration_with_usage_tracking(agent: Agent):
+    """Test integration with Runner and automatic usage tracking pattern."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_integration.db"
+        session_id = "integration_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        async def store_session_usage(result: Any, session: StructuredSQLiteSession):
+            """Helper function to store usage after runner completes."""
+            try:
+                await session.store_run_usage(result)
+            except Exception:
+                # Ignore errors in test helper
+                pass
+
+        # Set up fake model responses
+        assert isinstance(agent.model, FakeModel)
+        fake_model = agent.model
+        fake_model.set_next_output([get_text_message("San Francisco")])
+
+        # First turn
+        result1 = await Runner.run(
+            agent,
+            "What city is the Golden Gate Bridge in?",
+            session=session,
+        )
+        assert result1.final_output == "San Francisco"
+        await store_session_usage(result1, session)
+
+        # Second turn
+        fake_model.set_next_output([get_text_message("California")])
+        result2 = await Runner.run(agent, "What state is it in?", session=session)
+        assert result2.final_output == "California"
+        await store_session_usage(result2, session)
+
+        # Verify conversation structure
+        conversation_turns = await session.get_conversation_by_turns()
+        assert len(conversation_turns) == 2
+
+        # Verify usage was tracked
+        session_usage = await session.get_session_usage()
+        assert session_usage is not None
+        assert session_usage["total_turns"] == 2
+        # FakeModel doesn't generate realistic usage data, so we just check structure exists
+        assert "requests" in session_usage
+        assert "total_tokens" in session_usage
+
+        session.close()
+
+
+async def test_sequence_ordering():
+    """Test that sequence ordering works correctly even with same timestamps."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_sequence.db"
+        session_id = "sequence_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Add multiple items quickly to test sequence ordering
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "Message 1"},
+            {"role": "assistant", "content": "Response 1"},
+            {"role": "user", "content": "Message 2"},
+            {"role": "assistant", "content": "Response 2"},
+        ]
+        await session.add_items(items)
+
+        # Get items and verify order is preserved
+        retrieved = await session.get_items()
+        assert len(retrieved) == 4
+        assert retrieved[0].get("content") == "Message 1"
+        assert retrieved[1].get("content") == "Response 1"
+        assert retrieved[2].get("content") == "Message 2"
+        assert retrieved[3].get("content") == "Response 2"
+
+        session.close()
+
+
+async def test_conversation_structure_with_multiple_turns():
+    """Test conversation structure tracking with multiple user turns."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_multi_turn.db"
+        session_id = "multi_turn_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Turn 1
+        turn_1: list[TResponseInputItem] = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        await session.add_items(turn_1)
+
+        # Turn 2
+        turn_2: list[TResponseInputItem] = [
+            {"role": "user", "content": "How are you?"},
+            {"type": "function_call", "name": "mood_check", "arguments": "{}"},  # type: ignore
+            {"type": "function_call_output", "output": "I'm good"},  # type: ignore
+            {"role": "assistant", "content": "I'm doing well!"},
+        ]
+        await session.add_items(turn_2)
+
+        # Turn 3
+        turn_3: list[TResponseInputItem] = [
+            {"role": "user", "content": "Goodbye"},
+            {"role": "assistant", "content": "See you later!"},
+        ]
+        await session.add_items(turn_3)
+
+        # Verify conversation structure
+        conversation_turns = await session.get_conversation_by_turns()
+        assert len(conversation_turns) == 3
+
+        # Turn 1 should have 2 items
+        assert len(conversation_turns[1]) == 2
+        assert conversation_turns[1][0]["type"] == "user"
+        assert conversation_turns[1][1]["type"] == "assistant"
+
+        # Turn 2 should have 4 items including tool calls
+        assert len(conversation_turns[2]) == 4
+        turn_2_types = [item["type"] for item in conversation_turns[2]]
+        assert "user" in turn_2_types
+        assert "function_call" in turn_2_types
+        assert "function_call_output" in turn_2_types
+        assert "assistant" in turn_2_types
+
+        # Turn 3 should have 2 items
+        assert len(conversation_turns[3]) == 2
+
+        session.close()
+
+
+async def test_empty_session_operations():
+    """Test operations on empty sessions."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_empty.db"
+        session_id = "empty_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Test getting items from empty session
+        items = await session.get_items()
+        assert len(items) == 0
+
+        # Test getting conversation from empty session
+        conversation = await session.get_conversation_by_turns()
+        assert len(conversation) == 0
+
+        # Test getting tool usage from empty session
+        tool_usage = await session.get_tool_usage()
+        assert len(tool_usage) == 0
+
+        # Test getting session usage from empty session
+        session_usage = await session.get_session_usage()
+        assert session_usage is None
+
+        # Test soft deletion on empty session
+        deleted = await session.soft_delete_from_turn(1)
+        assert deleted is False
+
+        session.close()
+
+
+async def test_json_serialization_edge_cases(usage_data: Usage):
+    """Test edge cases in JSON serialization of usage data."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_json.db"
+        session_id = "json_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Test with normal usage data (need to add user message first to create turn)
+        await session.add_items([{"role": "user", "content": "First test"}])
+        run_result_1 = create_mock_run_result(usage_data)
+        await session.store_run_usage(run_result_1)
+
+        # Test with None usage data
+        run_result_none = create_mock_run_result(None)
+        await session.store_run_usage(run_result_none)
+
+        # Test with usage data missing details
+        minimal_usage = Usage(
+            requests=1,
+            input_tokens=10,
+            output_tokens=5,
+            total_tokens=15,
+        )
+        await session.add_items([{"role": "user", "content": "Second test"}])
+        run_result_2 = create_mock_run_result(minimal_usage)
+        await session.store_run_usage(run_result_2)
+
+        # Verify we can retrieve the data
+        turn_1_usage = await session.get_turn_usage(1)
+        assert isinstance(turn_1_usage, dict)
+        assert turn_1_usage["requests"] == 1
+        assert turn_1_usage["input_tokens_details"]["cached_tokens"] == 10
+
+        turn_2_usage = await session.get_turn_usage(2)
+        assert isinstance(turn_2_usage, dict)
+        assert turn_2_usage["requests"] == 1
+        # Should have default values for minimal data (Usage class provides defaults)
+        assert turn_2_usage["input_tokens_details"]["cached_tokens"] == 0
+        assert turn_2_usage["output_tokens_details"]["reasoning_tokens"] == 0
+
+        session.close()
+
+
+async def test_session_isolation():
+    """Test that different session IDs maintain separate data."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_isolation.db"
+
+        session1 = StructuredSQLiteSession("session_1", db_path)
+        session2 = StructuredSQLiteSession("session_2", db_path)
+
+        # Add data to session 1
+        await session1.add_items([{"role": "user", "content": "Session 1 message"}])
+
+        # Add data to session 2
+        await session2.add_items([{"role": "user", "content": "Session 2 message"}])
+
+        # Verify isolation
+        session1_items = await session1.get_items()
+        session2_items = await session2.get_items()
+
+        assert len(session1_items) == 1
+        assert len(session2_items) == 1
+        assert session1_items[0].get("content") == "Session 1 message"
+        assert session2_items[0].get("content") == "Session 2 message"
+
+        # Test conversation structure isolation
+        session1_turns = await session1.get_conversation_by_turns()
+        session2_turns = await session2.get_conversation_by_turns()
+
+        assert len(session1_turns) == 1
+        assert len(session2_turns) == 1
+
+        session1.close()
+        session2.close()
+
+
+async def test_error_handling_in_usage_tracking(usage_data: Usage):
+    """Test that usage tracking errors don't break the main flow."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_errors.db"
+        session_id = "error_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Test normal operation
+        run_result = create_mock_run_result(usage_data)
+        await session.store_run_usage(run_result)
+
+        # Close the session to simulate database errors
+        session.close()
+
+        # This should not raise an exception (error should be caught)
+        await session.store_run_usage(run_result)
+
+
+async def test_tool_name_extraction():
+    """Test that tool names are correctly extracted from different item types."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_tool_names.db"
+        session_id = "tool_names_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Add items with different ways of specifying tool names
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "Use tools please"},  # Need user message to create turn
+            {"type": "function_call", "name": "search_web", "arguments": "{}"},  # type: ignore
+            {"type": "function_call_output", "tool_name": "search_web", "output": "result"},  # type: ignore
+            {"type": "function_call", "name": "calculator", "arguments": "{}"},  # type: ignore
+        ]
+        await session.add_items(items)
+
+        # Get conversation structure and verify tool names
+        conversation_turns = await session.get_conversation_by_turns()
+        turn_items = conversation_turns[1]
+
+        tool_items = [item for item in turn_items if item["tool_name"]]
+        tool_names = [item["tool_name"] for item in tool_items]
+
+        assert "search_web" in tool_names
+        assert "calculator" in tool_names
+
+        session.close()
+
+
+async def test_tool_execution_integration(agent: Agent):
+    """Test integration with actual tool execution."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_tool_integration.db"
+        session_id = "tool_integration_test"
+        session = StructuredSQLiteSession(session_id, db_path)
+
+        # Set up the fake model to trigger a tool call
+        fake_model = cast(FakeModel, agent.model)
+        fake_model.set_next_output(
+            [
+                {  # type: ignore
+                    "type": "function_call",
+                    "name": "test_tool",
+                    "arguments": '{"query": "test query"}',
+                    "call_id": "call_123",
+                }
+            ]
+        )
+
+        # Then set the final response
+        fake_model.set_next_output([get_text_message("Tool executed successfully")])
+
+        # Run the agent
+        result = await Runner.run(
+            agent,
+            "Please use the test tool",
+            session=session,
+        )
+
+        # Verify the tool was executed
+        assert "Tool result for: test query" in str(result.new_items)
+
+        # Verify tool usage was tracked
+        tool_usage = await session.get_tool_usage()
+        assert len(tool_usage) > 0
+
+        session.close()


### PR DESCRIPTION
This PR introduces `StructuredSQLiteSession` as a drop-in replacement for `SQLiteSession` with enhanced conversation management capabilities. Addresses #1385 and builds on the foundation from #1474.

### Key Features
- **Structured queries**: Get conversations by turns, tool usage analytics, etc.
- **Usage tracking**: Turn-level token usage with detailed breakdowns
- **Conversation branching**: Soft deletion allows "undoing" parts of conversations and continuing from any point

### New Table Schema
```sql
-- Message structure with soft deletion
message_structure (
    id, session_id, message_id, message_type, sequence_number,
    user_turn_number, tool_name, is_active, created_at, deactivated_at
)

-- Turn-level usage tracking  
turn_usage (
    id, session_id, user_turn_number, requests, input_tokens, 
    output_tokens, total_tokens, input_tokens_details, output_tokens_details
)
```

### Usage Pattern
Currently requires manual usage storage:
```python
result = await Runner.run(agent, "Hello", session=session)
await session.store_run_usage(result)  # Manual step
```
**Question**: Should usage storage be automatic? 

Currently users need to manually call `store_run_usage()` after each run to get the analytics features (turn-level token tracking, usage breakdowns, etc.). It works fine but could be better UX-wise.

However, since this is an extension feature, it shouldn't require changes to the core SDK (`run.py`). Making it automatic could be quite a complex change - as it could need to patch the runner itself, and potentially break the clean separation between core and extensions.

What's the preference here - keep the explicit manual approach or explore automatic storage despite the complexity?

### Testing Notes
Tests skip in `old_versions_test` due to sqlalchemy dependency in the same directory (same issue as #1357). The structured session itself doesn't need sqlalchemy, but the import path requires it.