### PR TITLE
Add Advanced Reasoning section with depth parameter note

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -280,6 +280,19 @@ agent = Agent(
 )
 ```
 
+## Advanced Reasoning
+
+Agents can be configured to perform advanced reasoning using the `reasoning` parameter in `ModelSettings`.
+
+Key configurable options:
+
+- `strategy`: The reasoning strategy, e.g., `"tree_of_thoughts"` or `"step_by_step"`.
+- `depth`: The number of reasoning steps the model should perform.
+
+!!! note
+    The maximum value for `depth` is currently **not documented**. Contributors should refer to model-specific limits, and start with low values (like 2–3) to avoid excessively long computations or errors.
+
+
 !!! note
 
     To prevent infinite loops, the framework automatically resets `tool_choice` to "auto" after a tool call. This behavior is configurable via [`agent.reset_tool_choice`][agents.agent.Agent.reset_tool_choice]. The infinite loop is because tool results are sent to the LLM, which then generates another tool call because of `tool_choice`, ad infinitum.


### PR DESCRIPTION
### Summary
Added a new **"Advanced Reasoning"** section in `agents.md` explaining the `reasoning` parameter in `ModelSettings`.

### Details
- Introduced the `strategy` and `depth` options for advanced reasoning.
- Noted that the **maximum value for the `depth` parameter** is currently undocumented.
- Recommended that contributors start with **low values (like 2–3)** to avoid excessively long computations or errors.

### Motivation
This addition clarifies the usage of the `reasoning` parameter and helps contributors avoid unintended issues due to missing documentation about `depth`.
