### PR TITLE
Reorder hooks into chronological lifecycle order

### DIFF
--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -15,6 +15,10 @@ class RunHooksBase(Generic[TContext, TAgent]):
     override the methods you need.
     """
 
+    async def on_agent_start(self, context: RunContextWrapper[TContext], agent: TAgent) -> None:
+        """Called before the agent is invoked. Called each time the current agent changes."""
+        pass    
+    
     async def on_llm_start(
         self,
         context: RunContextWrapper[TContext],
@@ -34,28 +38,6 @@ class RunHooksBase(Generic[TContext, TAgent]):
         """Called immediately after the LLM call returns for this agent."""
         pass
 
-    async def on_agent_start(self, context: RunContextWrapper[TContext], agent: TAgent) -> None:
-        """Called before the agent is invoked. Called each time the current agent changes."""
-        pass
-
-    async def on_agent_end(
-        self,
-        context: RunContextWrapper[TContext],
-        agent: TAgent,
-        output: Any,
-    ) -> None:
-        """Called when the agent produces a final output."""
-        pass
-
-    async def on_handoff(
-        self,
-        context: RunContextWrapper[TContext],
-        from_agent: TAgent,
-        to_agent: TAgent,
-    ) -> None:
-        """Called when a handoff occurs."""
-        pass
-
     async def on_tool_start(
         self,
         context: RunContextWrapper[TContext],
@@ -73,6 +55,24 @@ class RunHooksBase(Generic[TContext, TAgent]):
         result: str,
     ) -> None:
         """Called after a tool is invoked."""
+        pass
+
+    async def on_handoff(
+        self,
+        context: RunContextWrapper[TContext],
+        from_agent: TAgent,
+        to_agent: TAgent,
+    ) -> None:
+        """Called when a handoff occurs."""
+        pass
+
+    async def on_agent_end(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: TAgent,
+        output: Any,
+    ) -> None:
+        """Called when the agent produces a final output."""
         pass
 
 
@@ -86,44 +86,6 @@ class AgentHooksBase(Generic[TContext, TAgent]):
     async def on_start(self, context: RunContextWrapper[TContext], agent: TAgent) -> None:
         """Called before the agent is invoked. Called each time the running agent is changed to this
         agent."""
-        pass
-
-    async def on_end(
-        self,
-        context: RunContextWrapper[TContext],
-        agent: TAgent,
-        output: Any,
-    ) -> None:
-        """Called when the agent produces a final output."""
-        pass
-
-    async def on_handoff(
-        self,
-        context: RunContextWrapper[TContext],
-        agent: TAgent,
-        source: TAgent,
-    ) -> None:
-        """Called when the agent is being handed off to. The `source` is the agent that is handing
-        off to this agent."""
-        pass
-
-    async def on_tool_start(
-        self,
-        context: RunContextWrapper[TContext],
-        agent: TAgent,
-        tool: Tool,
-    ) -> None:
-        """Called concurrently with tool invocation."""
-        pass
-
-    async def on_tool_end(
-        self,
-        context: RunContextWrapper[TContext],
-        agent: TAgent,
-        tool: Tool,
-        result: str,
-    ) -> None:
-        """Called after a tool is invoked."""
         pass
 
     async def on_llm_start(
@@ -143,6 +105,44 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         response: ModelResponse,
     ) -> None:
         """Called immediately after the agent receives the LLM response."""
+        pass    
+
+    async def on_tool_start(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: TAgent,
+        tool: Tool,
+    ) -> None:
+        """Called concurrently with tool invocation."""
+        pass
+
+    async def on_tool_end(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: TAgent,
+        tool: Tool,
+        result: str,
+    ) -> None:
+        """Called after a tool is invoked."""
+        pass
+
+    async def on_handoff(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: TAgent,
+        source: TAgent,
+    ) -> None:
+        """Called when the agent is being handed off to. The `source` is the agent that is handing
+        off to this agent."""
+        pass
+
+    async def on_end(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: TAgent,
+        output: Any,
+    ) -> None:
+        """Called when the agent produces a final output."""
         pass
 
 


### PR DESCRIPTION
## Summary
This PR defines correct lifecycle order of hooks for both `RunHooksBase` and `AgentHooksBase`, aligning with the logical execution flow of an agent run.

## Changes Made
I have simply **reordered the hooks** to reflect their chronological execution sequence during an agent run.

### RunHooksBase 
```
on_agent_start
on_llm_start
on_llm_end
on_tool_start
on_tool_end
on_handoff
on_agent_end
```



### AgentHooksBase 
```
on_start
on_llm_start
on_llm_end
on_tool_start
on_tool_end
on_handoff
on_end
```



## Enhancement
- Establishes a clear and **logical sequence** for hook execution.
- Improves developer understanding by reflecting the **actual lifecycle**:
  - **Start → LLM Call → Tool Call  → Handoff (if any) → End**

This ordering provides consistency and clarity to understand the correct agent execution flow.