### PR TITLE
Fix a bug where the default behavior of loading the debug flag differs from the documentation

### DIFF
--- a/src/agents/_debug.py
+++ b/src/agents/_debug.py
@@ -1,17 +1,28 @@
 import os
 
 
-def _debug_flag_enabled(flag: str) -> bool:
+def _debug_flag_enabled(flag: str, default: bool = False) -> bool:
     flag_value = os.getenv(flag)
-    return flag_value is not None and (flag_value == "1" or flag_value.lower() == "true")
+    if flag_value is None:
+        return default
+    else:
+        return flag_value == "1" or flag_value.lower() == "true"
 
 
-DONT_LOG_MODEL_DATA = _debug_flag_enabled("OPENAI_AGENTS_DONT_LOG_MODEL_DATA")
+def _load_dont_log_model_data() -> bool:
+    return _debug_flag_enabled("OPENAI_AGENTS_DONT_LOG_MODEL_DATA", default=True)
+
+
+def _load_dont_log_tool_data() -> bool:
+    return _debug_flag_enabled("OPENAI_AGENTS_DONT_LOG_TOOL_DATA", default=True)
+
+
+DONT_LOG_MODEL_DATA = _load_dont_log_model_data()
 """By default we don't log LLM inputs/outputs, to prevent exposing sensitive information. Set this
 flag to enable logging them.
 """
 
-DONT_LOG_TOOL_DATA = _debug_flag_enabled("OPENAI_AGENTS_DONT_LOG_TOOL_DATA")
+DONT_LOG_TOOL_DATA = _load_dont_log_tool_data()
 """By default we don't log tool call inputs/outputs, to prevent exposing sensitive information. Set
 this flag to enable logging them.
 """

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,54 @@
+import os
+from unittest.mock import patch
+
+from agents._debug import _load_dont_log_model_data, _load_dont_log_tool_data
+
+
+@patch.dict(os.environ, {})
+def test_dont_log_model_data():
+    assert _load_dont_log_model_data() is True
+
+
+@patch.dict(os.environ, {"OPENAI_AGENTS_DONT_LOG_MODEL_DATA": "0"})
+def test_dont_log_model_data_0():
+    assert _load_dont_log_model_data() is False
+
+
+@patch.dict(os.environ, {"OPENAI_AGENTS_DONT_LOG_MODEL_DATA": "1"})
+def test_dont_log_model_data_1():
+    assert _load_dont_log_model_data() is True
+
+
+@patch.dict(os.environ, {"OPENAI_AGENTS_DONT_LOG_MODEL_DATA": "true"})
+def test_dont_log_model_data_true():
+    assert _load_dont_log_model_data() is True
+
+
+@patch.dict(os.environ, {"OPENAI_AGENTS_DONT_LOG_MODEL_DATA": "false"})
+def test_dont_log_model_data_false():
+    assert _load_dont_log_model_data() is False
+
+
+@patch.dict(os.environ, {})
+def test_dont_log_tool_data():
+    assert _load_dont_log_tool_data() is True
+
+
+@patch.dict(os.environ, {"OPENAI_AGENTS_DONT_LOG_TOOL_DATA": "0"})
+def test_dont_log_tool_data_0():
+    assert _load_dont_log_tool_data() is False
+
+
+@patch.dict(os.environ, {"OPENAI_AGENTS_DONT_LOG_TOOL_DATA": "1"})
+def test_dont_log_tool_data_1():
+    assert _load_dont_log_tool_data() is True
+
+
+@patch.dict(os.environ, {"OPENAI_AGENTS_DONT_LOG_TOOL_DATA": "true"})
+def test_dont_log_tool_data_true():
+    assert _load_dont_log_tool_data() is True
+
+
+@patch.dict(os.environ, {"OPENAI_AGENTS_DONT_LOG_TOOL_DATA": "false"})
+def test_dont_log_tool_data_false():
+    assert _load_dont_log_tool_data() is False


### PR DESCRIPTION
DONT_LOG_MODEL_DATA and DONT_LOG_TOOL_DATA constants' default values differ from the behaviors clearly stated in the documentation (code comments).