### PR TITLE
Fix instructions not being applied

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -622,9 +622,6 @@ class RealtimeSession(RealtimeModelListener):
         # Start with run config model settings as base
         run_config_settings = self._run_config.get("model_settings", {})
         updated_settings: RealtimeSessionModelSettings = run_config_settings.copy()
-        # Apply starting settings (from model config) next
-        if starting_settings:
-            updated_settings.update(starting_settings)
 
         instructions, tools, handoffs = await asyncio.gather(
             agent.get_system_prompt(self._context_wrapper),
@@ -634,6 +631,10 @@ class RealtimeSession(RealtimeModelListener):
         updated_settings["instructions"] = instructions or ""
         updated_settings["tools"] = tools or []
         updated_settings["handoffs"] = handoffs or []
+
+        # Apply starting settings (from model config) next
+        if starting_settings:
+            updated_settings.update(starting_settings)
 
         disable_tracing = self._run_config.get("tracing_disabled", False)
         if disable_tracing:


### PR DESCRIPTION
```
        runner = RealtimeRunner(
            starting_agent=RealtimeAgent(
                name="realtime agent",
                tools=tools,
            )
        )
        model_config = {"initial_model_settings": {"instructions": "Specific instructions"}}
        await runner.run(model_config = model_cfg)
```
I would assume we first create the runner with an agent.  
And then when actually running we can add specific instructions.  
Currently these instructions are ignored.