### PR TITLE
docs: fix typo in connectors.py

### DIFF
--- a/examples/hosted_mcp/connectors.py
+++ b/examples/hosted_mcp/connectors.py
@@ -13,7 +13,7 @@ from agents import Agent, HostedMCPTool, Runner
 async def main(verbose: bool, stream: bool):
     # 1. Visit https://developers.google.com/oauthplayground/
     # 2. Input https://www.googleapis.com/auth/calendar.events as the required scope
-    # 3. Grab the acccess token starting with "ya29."
+    # 3. Grab the access token starting with "ya29."
     authorization = os.environ["GOOGLE_CALENDAR_AUTHORIZATION"]
     agent = Agent(
         name="Assistant",


### PR DESCRIPTION
### Summary

This pull request fixes a small typo in a comment within the examples/hosted_mcp/connectors.py file. The word "acccess" has been corrected to "access".

### Test plan

No need - this is a documentation change in a comment only.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant) - No need
- [x] I've added/updated the relevant documentation - This is a documentation update  
- [x] I've run `make lint` and `make format` - No functional code changes
- [x] I've made sure tests pass - No need for comment change