### PR TITLE
clarify Guardrail agent instructions and fix tripwire logic in homework_guardrail

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,12 @@ class HomeworkOutput(BaseModel):
 
 guardrail_agent = Agent(
     name="Guardrail check",
-    instructions="Check if the user is asking about homework.",
+    instructions=
+        """
+        - Determine if the user's input looks like a school-style homework question.
+        - Homework questions are typically about math, history, science, or similar academic subjects.
+        - If the input is educational or academic in nature, classify it as homework.
+        """,
     output_type=HomeworkOutput,
 )
 
@@ -113,7 +118,7 @@ async def homework_guardrail(ctx, agent, input_data):
     final_output = result.final_output_as(HomeworkOutput)
     return GuardrailFunctionOutput(
         output_info=final_output,
-        tripwire_triggered=not final_output.is_homework,
+        tripwire_triggered=final_output.is_homework,
     )
 ```
 


### PR DESCRIPTION
## fix: clarify and correct homework guardrail logic

### Description
This update expands and clarifies the definition of a “homework” question by changing the agent instructions from *“Check if the user is asking about homework”* to *“Determine if the user’s input looks like a school-style homework question (e.g., math, history, science, academic subjects).”*  

Additionally, the logic in `homework_guardrail` was fixed, updating  
`tripwire_triggered = not final_output.is_homework` → `tripwire_triggered = final_output.is_homework`.  

### Impact
- Ensures the guardrail now correctly triggers on homework-style inputs rather than the opposite.  
- Makes examples easier to understand.  
- Guarantees the guardrail behaves as intended, effectively preventing homework-style queries.  
