### PR TITLE
Fix session history duplication after PR #1550

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -411,7 +411,8 @@ class AgentRunner:
         if run_config is None:
             run_config = RunConfig()
 
-        # Prepare input with session if enabled
+        # Keep original user input separate from session-prepared input
+        original_user_input = input
         prepared_input = await self._prepare_input_with_session(input, session)
 
         tool_use_tracker = AgentToolUseTracker()
@@ -438,8 +439,8 @@ class AgentRunner:
             current_agent = starting_agent
             should_run_agent_start_hooks = True
 
-            # save the original input to the session if enabled
-            await self._save_result_to_session(session, original_input, [])
+            # save only the new user input to the session, not the combined history
+            await self._save_result_to_session(session, original_user_input, [])
 
             try:
                 while True:


### PR DESCRIPTION
Resolves #1699, and fixes session history duplication introduced in #1550. 

**Problem**:
When using sessions, the second `Runner.run()` call was saving combined input (history + new user input) instead of just the new user input, causing session history to be re-saved and duplicated.

**Root cause**:
Line 442 was saving `original_input` which contained the combined session history, not the actual user input.

**Fix**:
Separate `original_user_input` from `prepared_input` (which includes session history). Save only the new user input to prevent duplication.

```python
# Before:
prepared_input = await self._prepare_input_with_session(input, session)
await self._save_result_to_session(session, prepared_input, [])  # ❌ saves history too

# After:  
original_user_input = input
prepared_input = await self._prepare_input_with_session(input, session)
await self._save_result_to_session(session, original_user_input, [])  # ✅ saves only new input
```

**Verification**: Session items go from 6 → 4 in the same repro script as the original issue (2 turns × 2 items each, no duplicates).
