### PR TITLE
Fix: Eliminate unreachable type check in function tool call handling

### DIFF
--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -490,9 +490,6 @@ class RunImpl:
                 continue
 
             # At this point we know it's a function tool call
-            if not isinstance(output, ResponseFunctionToolCall):
-                continue
-
             tools_used.append(output.name)
 
             # Handoffs


### PR DESCRIPTION
## Summary

Eliminate a redundant type validation in the tool call response logic. The extra check was unreachable and served no purpose, making the code misleading and harder to read.

## Problem

The code contained a redundant type check that was logically impossible to reach:

```python
elif not isinstance(output, ResponseFunctionToolCall):
    logger.warning(f"Unexpected output type, ignoring: {type(output)}")
    continue

# At this point we know it's a function tool call
if not isinstance(output, ResponseFunctionToolCall):  # This check can never be reached
    continue
```

The second type check (lines 495-497) could never be executed because:
- If `output` is NOT a `ResponseFunctionToolCall`, the first check would have already caused a `continue` and skipped the rest of the loop
- If `output` is a `ResponseFunctionToolCall`, the second check would always be false

## Changes Made

Removed the redundant and unreachable type check, leaving only the necessary logic:

```python
elif not isinstance(output, ResponseFunctionToolCall):
    logger.warning(f"Unexpected output type, ignoring: {type(output)}")
    continue

# At this point we know it's a function tool call
tools_used.append(output.name)
```

This improves code clarity and eliminates dead code that could confuse developers and static analysis tools.