### PR TITLE
Fix CI failure in `make old_version_tests`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,5 +84,7 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: make sync
+      - name: Install Python 3.9 dependencies
+        run: UV_PROJECT_ENVIRONMENT=.venv_39 uv sync --all-extras --all-packages --group dev
       - name: Run tests
         run: make old_version_tests


### PR DESCRIPTION
The `old_version_tests` target was failing in CI because it creates a separate Python 3.9 environment (`.venv_39`) that doesn't inherit dependencies from the main environment. Some tests import from modules that require optional dependencies.

I just added a step to explicitly install all dependencies for the Python 3.9 environment before running the tests.