### PR TITLE
Simplify synthesizer agent input In agents_as_tool.py

### DIFF
--- a/examples/agent_patterns/agents_as_tools.py
+++ b/examples/agent_patterns/agents_as_tools.py
@@ -68,10 +68,15 @@ async def main():
                 if text:
                     print(f"  - Translation step: {text}")
 
-        synthesizer_result = await Runner.run(
-            synthesizer_agent, orchestrator_result.to_input_list()
+         # Create a simple input for the synthesizer agent combining user input and orchestrator's final output
+        synthesizer_input = (
+            f"Original Request: {msg}\n"
+            f"Orchestrator's Translation: {orchestrator_result.final_output}"
         )
 
+        synthesizer_result = await Runner.run(
+            synthesizer_agent, synthesizer_input, run_config=run_config
+        )
     print(f"\n\nFinal response:\n{synthesizer_result.final_output}")
 
 


### PR DESCRIPTION
### Feat: Simplify Synthesizer Agent Input for Enhanced Robustness

**Description:**
This pull request addresses a `TypeError: 'NoneType' object is not subscriptable` that was consistently observed when attempting to pass the detailed `orchestrator_result.to_input_list()` directly as input to the `synthesizer_agent`. The issue manifested within the `OpenAIChatCompletionsModel` when interacting with the Gemini API, suggesting a compatibility challenge in how the `agents` library processes complex, multi-turn conversation histories (including tool call details) for LLM input.

To resolve this and ensure stable operation, this change refactors the input mechanism for the `synthesizer_agent`. Instead of providing the full `to_input_list()`, the `synthesizer_agent` now receives a consolidated string composed of the original user message and the `orchestrator_result.final_output`. This simplified input provides the `synthesizer_agent` with the essential context required to "inspect translations, correct them if needed, and produce a final concatenated response" without encountering parsing errors related to the structured tool-call history.

This approach ensures the `synthesizer_agent` operates reliably while we continue to investigate the underlying `openai-agents` library behavior for direct `to_input_list()` consumption with Gemini API.

**Related Issue:**
[https://github.com/openai/openai-agents-python/issues/1732]

**Changes Made:**
-   Modified `main` function in `examples/agent_patterns/agents_as_tools.py`.
-   Introduced `synthesizer_input` variable to combine `msg` (original user input) and `orchestrator_result.final_output`.
-   Updated the `Runner.run` call for `synthesizer_agent` to use `synthesizer_input`.
-   Removed the `print(orchestrator_result.to_input_list())` line for cleaner output.