### PR TITLE
Add session parameter to run_demo_loop; update run_sync function parameter documentation

### DIFF
--- a/src/agents/repl.py
+++ b/src/agents/repl.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
 
+from . import Session
 from .agent import Agent
 from .items import TResponseInputItem
 from .result import RunResultBase
@@ -13,7 +14,7 @@ from .stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent, Run
 
 
 async def run_demo_loop(
-    agent: Agent[Any], *, stream: bool = True, context: TContext | None = None
+    agent: Agent[Any], *, stream: bool = True, context: TContext | None = None, session: Session | None = None
 ) -> None:
     """Run a simple REPL loop with the given agent.
 
@@ -25,6 +26,7 @@ async def run_demo_loop(
         agent: The starting agent to run.
         stream: Whether to stream the agent output.
         context: Additional context information to pass to the runner.
+        session: The Session to manage conversation history.
     """
 
     current_agent = agent
@@ -44,7 +46,7 @@ async def run_demo_loop(
 
         result: RunResultBase
         if stream:
-            result = Runner.run_streamed(current_agent, input=input_items, context=context)
+            result = Runner.run_streamed(current_agent, input=input_items, context=context, session=session)
             async for event in result.stream_events():
                 if isinstance(event, RawResponsesStreamEvent):
                     if isinstance(event.data, ResponseTextDeltaEvent):

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -383,6 +383,7 @@ class Runner:
             previous_response_id: The ID of the previous response, if using OpenAI models via the
                 Responses API, this allows you to skip passing in input from the previous turn.
             conversation_id: The ID of the stored conversation, if any.
+            session: The Session to manage conversation history.
         Returns:
             A result object that contains data about the run, as well as a method to stream events.
         """


### PR DESCRIPTION
- Add `session` parameter to run_demo_loop for conversation history management.
- Updated the documentation for the `session` parameter in the run_streamed function to clearly explain its purpose.