### PR TITLE
Add default include of reasoning.encrypted_content for store=False to prevent reasoning errors

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -259,6 +259,10 @@ class OpenAIResponsesModel(Model):
         include_set: set[str] = set(converted_tools.includes)
         if model_settings.response_include is not None:
             include_set.update(model_settings.response_include)
+
+        if model_settings.store is False and model_settings.response_include is None:
+            include_set.add("reasoning.encrypted_content")
+
         if model_settings.top_logprobs is not None:
             include_set.add("message.output_text.logprobs")
         include = cast(list[ResponseIncludable], list(include_set))

--- a/tests/test_store_response_include.py
+++ b/tests/test_store_response_include.py
@@ -1,0 +1,50 @@
+import pytest
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from agents import ModelSettings, ModelTracing, OpenAIResponsesModel
+
+
+class DummyResponses:
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+
+        class DummyResponse:
+            id = "dummy"
+            output = []
+            usage = type(
+                "Usage",
+                (),
+                {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "input_tokens_details": InputTokensDetails(cached_tokens=0),
+                    "output_tokens_details": OutputTokensDetails(reasoning_tokens=0),
+                },
+            )()
+
+        return DummyResponse()
+
+
+class DummyClient:
+    def __init__(self):
+        self.responses = DummyResponses()
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_store_false_includes_encrypted_reasoning():
+    client = DummyClient()
+    model = OpenAIResponsesModel(model="gpt-5", openai_client=client)  # type: ignore
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(store=False),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+    include = set(client.responses.kwargs["include"])
+    assert "reasoning.encrypted_content" in include


### PR DESCRIPTION
## Issue

When using store=False without including reasoning.encrypted_content, any function calls (including handoff) that generate reasoning items will result in an error because the server does not persist reasoning items. This makes the Responses API difficult to use in practice.

I believe it would be better if `reasoning.encrypted_content` were included by default in this case, since in almost all scenarios the agent needs it when working with reasoning models and `store=False`.

Related issue: [openai/openai-agents-python#1668](https://github.com/openai/openai-agents-python/issues/1668)

## Reproducible Example

```python
from agents import Agent, Runner, function_tool, ModelSettings

@function_tool
def get_weather(city: str) -> str:
    return "hot"

agent = Agent(
    name="Test store false",
    instructions="You are a helpful assistant.",
    model="gpt-5-mini",
    tools=[get_weather],
    model_settings=ModelSettings(store=False)
)

result = Runner.run_sync(agent, input="What's the weather in Hsinchu?")

print(result.final_output)
```

This results in:

```
Error getting response: Error code: 404 - {'error': {'message': "Item with id 'rs_xxx' not found. Items are not persisted when `store` is set to false. Try again with `store` set to true, or remove this item from your input.", 'type': 'invalid_request_error', 'param': 'input', 'code': None}}. 
```

## Fix

- When `model_settings.response_include is None` **and** `model_settings.store is False`, automatically add `"reasoning.encrypted_content"` to the include set.
- This change makes it easier for developers using `gpt-5`, since they no longer need to worry about missing reasoning data when `store=False`.