### PR TITLE
fixl: #1668 Handoffs with gpt-5* model + store=False + remove_all_tools fails due to 404 error response

### DIFF
--- a/src/agents/extensions/handoff_filters.py
+++ b/src/agents/extensions/handoff_filters.py
@@ -4,6 +4,7 @@ from ..handoffs import HandoffInputData
 from ..items import (
     HandoffCallItem,
     HandoffOutputItem,
+    ReasoningItem,
     RunItem,
     ToolCallItem,
     ToolCallOutputItem,
@@ -41,6 +42,7 @@ def _remove_tools_from_items(items: tuple[RunItem, ...]) -> tuple[RunItem, ...]:
             or isinstance(item, HandoffOutputItem)
             or isinstance(item, ToolCallItem)
             or isinstance(item, ToolCallOutputItem)
+            or isinstance(item, ReasoningItem)
         ):
             continue
         filtered_items.append(item)

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -25,6 +25,10 @@ def _get_message_input_item(content: str) -> TResponseInputItem:
     }
 
 
+def _get_reasoning_input_item() -> TResponseInputItem:
+    return {"id": "rid", "summary": [], "type": "reasoning"}
+
+
 def _get_function_result_input_item(content: str) -> TResponseInputItem:
     return {
         "call_id": "1",
@@ -169,6 +173,7 @@ def test_removes_tools_from_new_items_and_history():
     handoff_input_data = HandoffInputData(
         input_history=(
             _get_message_input_item("Hello1"),
+            _get_reasoning_input_item(),
             _get_function_result_input_item("World"),
             _get_message_input_item("Hello2"),
         ),
@@ -185,7 +190,7 @@ def test_removes_tools_from_new_items_and_history():
         run_context=RunContextWrapper(context=()),
     )
     filtered_data = remove_all_tools(handoff_input_data)
-    assert len(filtered_data.input_history) == 2
+    assert len(filtered_data.input_history) == 3
     assert len(filtered_data.pre_handoff_items) == 1
     assert len(filtered_data.new_items) == 1
 

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -1,4 +1,5 @@
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 
 from agents import Agent, HandoffInputData, RunContextWrapper
 from agents.extensions.handoff_filters import remove_all_tools
@@ -80,7 +81,7 @@ def _get_handoff_output_run_item(content: str) -> HandoffOutputItem:
 
 def _get_reasoning_output_run_item() -> ReasoningItem:
     return ReasoningItem(
-        agent=fake_agent(), raw_item={"id": "rid", "summary": [], "type": "reasoning"}
+        agent=fake_agent(), raw_item=ResponseReasoningItem(id="rid", summary=[], type="reasoning")
     )
 
 

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -5,6 +5,7 @@ from agents.extensions.handoff_filters import remove_all_tools
 from agents.items import (
     HandoffOutputItem,
     MessageOutputItem,
+    ReasoningItem,
     ToolCallOutputItem,
     TResponseInputItem,
 )
@@ -74,6 +75,12 @@ def _get_handoff_output_run_item(content: str) -> HandoffOutputItem:
         },
         source_agent=fake_agent(),
         target_agent=fake_agent(),
+    )
+
+
+def _get_reasoning_output_run_item() -> ReasoningItem:
+    return ReasoningItem(
+        agent=fake_agent(), raw_item={"id": "rid", "summary": [], "type": "reasoning"}
     )
 
 
@@ -165,10 +172,12 @@ def test_removes_tools_from_new_items_and_history():
             _get_message_input_item("Hello2"),
         ),
         pre_handoff_items=(
+            _get_reasoning_output_run_item(),
             _get_message_output_run_item("123"),
             _get_tool_output_run_item("456"),
         ),
         new_items=(
+            _get_reasoning_output_run_item(),
             _get_message_output_run_item("Hello"),
             _get_tool_output_run_item("World"),
         ),
@@ -187,11 +196,13 @@ def test_removes_handoffs_from_history():
             _get_handoff_input_item("World"),
         ),
         pre_handoff_items=(
+            _get_reasoning_output_run_item(),
             _get_message_output_run_item("Hello"),
             _get_tool_output_run_item("World"),
             _get_handoff_output_run_item("World"),
         ),
         new_items=(
+            _get_reasoning_output_run_item(),
             _get_message_output_run_item("Hello"),
             _get_tool_output_run_item("World"),
             _get_handoff_output_run_item("World"),


### PR DESCRIPTION
# Issue

When `store=False` and `handoff_filters.remove_all_tools` is used during a handoff, the filter currently removes: `HandoffCallItem` and   `HandoffOutputItem`... But it does **not** remove the corresponding `ReasoningItem`.

Since `store=False` means items are not persisted on the server side, the Responses API fails because the `ReasoningItem` is still present, but its referenced item has already been removed. This leads to a 404 error:

```
Error getting response: Error code: 404 - {'error': {'message': "Item with id 'rs_xxxx' not found. Items are not persisted when `store` is set to false. Try again with `store` set to true, or remove this item from your input.", 'type': 'invalid_request_error', 'param': 'input', 'code': None}}.
```

This PR fixes: https://github.com/openai/openai-agents-python/issues/1668

# Reproduction Example

```python
from agents import Agent, ModelSettings, Runner, handoff
from agents.extensions import handoff_filters

agent2 = Agent(
    name="Assistant 2",
    model="gpt-5-mini",
    instructions="You always respond politely.",
    model_settings=ModelSettings(store=False),
)

agent = Agent(
    name="Assistant",
    model="gpt-5-mini",
    instructions="Always hand off to the assistant2 agent.",
    model_settings=ModelSettings(store=False),
    handoffs=[handoff(agent2, input_filter=handoff_filters.remove_all_tools)],
)

result = Runner.run_sync(agent, "Tell me something about San Francisco.")
print(result.final_output)
```

# Solution

Updated `_remove_tools_from_items(...)` to also drop `ReasoningItem`.
This ensures that reasoning items are removed together with tool/handoff items, preventing API errors.

## Note

There is another function in the same file, `_remove_tool_types_from_input(...)`, which is for filtering the input history, and it intentionally does not remove reasoning items.

With store=False, removing it would also work without errors. 

However, with store=True, developers often reuse the previous round’s `to_input_list()` (containing message items that include IDs) and pass it into the Responses API. In this case, the server requires each message to be paired with its corresponding reasoning item. Removing reasoning in this path would cause errors such as: Item 'msg_xxxxx' of type 'message' was provided without its required 'reasoning' item: 'rs_xxxxxx'

For this reason, `_remove_tool_types_from_input(...)` intentionally keeps reasoning items.