### PR TITLE
Add warning for agent names that transform into conflicting function names

### DIFF
--- a/src/agents/util/_transforms.py
+++ b/src/agents/util/_transforms.py
@@ -1,11 +1,21 @@
 import re
 
+from ..logger import logger
+
 
 def transform_string_function_style(name: str) -> str:
     # Replace spaces with underscores
     name = name.replace(" ", "_")
 
     # Replace non-alphanumeric characters with underscores
-    name = re.sub(r"[^a-zA-Z0-9]", "_", name)
+    transformed_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
 
-    return name.lower()
+    if transformed_name != name:
+        final_name = transformed_name.lower()
+        logger.warning(
+            f"Tool name {name!r} contains invalid characters for function calling and has been "
+            f"transformed to {final_name!r}. Please use only letters, digits, and underscores "
+            "to avoid potential naming conflicts."
+        )
+
+    return transformed_name.lower()


### PR DESCRIPTION
This PR adds a warning when agent names contain non-alphanumeric characters.  
Such names are converted to underscores (`_`) when used as default function names in handoff or `agent.as_tool`.

In these cases, non-English or symbolic names may turn into the same function name (e.g. `____`).  
The server does not raise an error, but handoffs will fail silently or tools may be overwritten.  
This is frustrating for developers when testing handoffs, as they will never be routed to the correct agent.

## Reproduction Example

```
from agents import Agent, ModelSettings, Runner, handoff

agent2 = Agent(
    name="風林火山 Agent",
    model="gpt-5-mini",
    instructions="You always answer: tree and mountain.",
)

agent3= Agent(
    name="疾風迅雷 Agent",
    model="gpt-5-mini",
    instructions="You always answer: wind and thunder.",
)

agent = Agent(
    name="Assistant",
    model="gpt-5-mini",
    instructions="You always hand off to the 風林火山 agent.",
    handoffs=[agent2, agent3],
)

result =  Runner.run_sync(agent, "Tell me something about speed.")


print(result.final_output)
```

![screenshot](https://github.com/user-attachments/assets/fcf94885-540e-4b4f-958e-a0368444ae6d)


## Example warning output

```
Tool name 'transfer_to_風林火山_Agent' contains invalid characters for function calling and has been transformed to 'transfer_to______agent'. Please use only letters, digits, and underscores to avoid potential naming conflicts.
Tool name 'transfer_to_疾風迅雷_Agent' contains invalid characters for function calling and has been transformed to 'transfer_to______agent'. Please use only letters, digits, and underscores to avoid potential naming conflicts.
```