### PR TITLE
feat(voice)!: migrate STT streaming to match GA Realtime API

### DIFF
--- a/src/agents/tracing/spans.py
+++ b/src/agents/tracing/spans.py
@@ -22,6 +22,7 @@ class SpanError(TypedDict):
         message: A human-readable error description
         data: Optional dictionary containing additional error context
     """
+
     message: str
     data: dict[str, Any] | None
 

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -163,11 +163,16 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
         await self._websocket.send(
             json.dumps(
                 {
-                    "type": "transcription_session.update",
+                    "type": "session.update",
                     "session": {
-                        "input_audio_format": "pcm16",
-                        "input_audio_transcription": {"model": self._model},
-                        "turn_detection": self._turn_detection,
+                        "type": "transcription",
+                        "audio": {
+                            "input": {
+                                "format": {"type": "audio/pcm", "rate": 24000},
+                                "transcription": {"model": self._model},
+                                "turn_detection": self._turn_detection,
+                            }
+                        },
                     },
                 }
             )

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -115,10 +115,10 @@ async def test_session_connects_and_configures_successfully():
         assert headers.get("OpenAI-Beta") is None
         assert headers.get("OpenAI-Log-Session") == "1"
 
-        # Check that we sent a 'transcription_session.update' message
+        # Check that we sent a 'session.update' message
         sent_messages = [call.args[0] for call in mock_ws.send.call_args_list]
-        assert any('"type": "transcription_session.update"' in msg for msg in sent_messages), (
-            f"Expected 'transcription_session.update' in {sent_messages}"
+        assert any('"type": "session.update"' in msg for msg in sent_messages), (
+            f"Expected 'session.update' in {sent_messages}"
         )
 
         await session.close()


### PR DESCRIPTION
Fixes https://github.com/openai/openai-agents-python/issues/1755

#### Description

The streamed voice demo fails to run because the STT events have changed as part of Realtime GA.  
This PR migrates the STT voice model to be consistent with GA.
As such, this is a BREAKING change for those who want to use beta servers. 
 
#### Changes

1. Use GA event name `session.update` (instead of `transcription_session.update`) and GA session payload shape (like nested `audio.input` with PCM format object).
2. Update STT tests for the same.
3. Misc: Lint for `src/agents/tracing/spans.py`

### Tests

The demo works as expected and all tests/lint/type-checks pass.

