### PR TITLE
fix(chatcmpl): preserve text content when adding Anthropic thinking blocks to tool calls

### DIFF
--- a/tests/test_anthropic_thinking_blocks.py
+++ b/tests/test_anthropic_thinking_blocks.py
@@ -217,19 +217,26 @@ def test_anthropic_thinking_blocks_with_tool_calls():
         "Signature should be preserved in thinking block"
     )
 
-    first_content = content[1]
-    assert first_content.get("type") == "thinking", (
+    second_content = content[1]
+    assert second_content.get("type") == "thinking", (
         f"Second content must be 'thinking' type for Anthropic compatibility, "
-        f"but got '{first_content.get('type')}'"
+        f"but got '{second_content.get('type')}'"
     )
     expected_thinking = "We should use the city Tokyo as the city."
-    assert first_content.get("thinking") == expected_thinking, (
+    assert second_content.get("thinking") == expected_thinking, (
         "Thinking content should be preserved"
     )
     # Signature should also be preserved
-    assert first_content.get("signature") == "TestSignature456", (
+    assert second_content.get("signature") == "TestSignature456", (
         "Signature should be preserved in thinking block"
     )
+
+    last_content = content[2]
+    assert last_content.get("type") == "text", (
+        f"First content must be 'text' type but got '{last_content.get('type')}'"
+    )
+    expected_text = "I'll check the weather for you."
+    assert last_content.get("text") == expected_text, "Content text should be preserved"
 
     # Verify tool calls are preserved
     tool_calls = assistant_msg.get("tool_calls", [])


### PR DESCRIPTION
In the case of Anthropic Claude with extended thinking, this ensures that existing text content is properly converted to content array format before appending thinking blocks, preventing overwriting of original assistant message content.

This happens in a rare case where there is a (output text, thinking block, tool call) all in one response. Error message is like below:

```
litellm.BadRequestError: BedrockException - {"message":"The model returned the following errors: messages.1.content.49: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response."}
```

The error is misleading because the actual reason is because we didn't provide the text content along side the thinking blocks.

This rarely happens. (0.5%) But in our agent evaluation suite, this happens when doing agents handoffs to a reflection style agent.