### PR TITLE
Feat: Expose MCP message handler configuration

### DIFF
--- a/tests/mcp/test_message_handler.py
+++ b/tests/mcp/test_message_handler.py
@@ -1,0 +1,110 @@
+import contextlib
+
+import anyio
+import pytest
+from mcp.shared.message import SessionMessage
+from mcp.types import InitializeResult
+
+from agents.mcp.server import (
+    MCPServerSse,
+    MCPServerStreamableHttp,
+    MCPServerStdio,
+    _MCPServerWithClientSession,
+)
+from mcp.client.session import MessageHandlerFnT
+
+
+class _StubClientSession:
+    """Stub ClientSession that records the configured message handler."""
+
+    def __init__(
+        self,
+        read_stream,
+        write_stream,
+        read_timeout_seconds,
+        *,
+        message_handler=None,
+        **_: object,
+    ) -> None:
+        self.message_handler = message_handler
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def initialize(self) -> InitializeResult:
+        return InitializeResult(
+            protocolVersion="2024-11-05",
+            capabilities={},
+            serverInfo={"name": "stub", "version": "1.0"},
+        )
+
+
+class _MessageHandlerTestServer(_MCPServerWithClientSession):
+    def __init__(self, handler: MessageHandlerFnT | None):
+        super().__init__(
+            cache_tools_list=False,
+            client_session_timeout_seconds=None,
+            message_handler=handler,
+        )
+
+    def create_streams(self):
+        @contextlib.asynccontextmanager
+        async def _streams():
+            send_stream, recv_stream = anyio.create_memory_object_stream[SessionMessage | Exception](
+                1
+            )
+            try:
+                yield recv_stream, send_stream, None
+            finally:
+                await recv_stream.aclose()
+                await send_stream.aclose()
+
+        return _streams()
+
+    @property
+    def name(self) -> str:
+        return "test-server"
+
+
+@pytest.mark.asyncio
+async def test_client_session_receives_message_handler(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _recording_client_session(*args, **kwargs):
+        session = _StubClientSession(*args, **kwargs)
+        captured["message_handler"] = session.message_handler
+        return session
+
+    monkeypatch.setattr("agents.mcp.server.ClientSession", _recording_client_session)
+
+    async def handler(message: SessionMessage) -> None:
+        del message
+
+    server = _MessageHandlerTestServer(handler)
+
+    try:
+        await server.connect()
+    finally:
+        await server.cleanup()
+
+    assert captured["message_handler"] is handler
+
+
+@pytest.mark.parametrize(
+    "server_cls, params",
+    [
+        (MCPServerSse, {"url": "https://example.com"}),
+        (MCPServerStreamableHttp, {"url": "https://example.com"}),
+        (MCPServerStdio, {"command": "python"}),
+    ],
+)
+def test_message_handler_propagates_to_server_base(server_cls, params):
+    def handler(message: SessionMessage) -> None:
+        del message
+
+    server = server_cls(params, message_handler=handler)
+
+    assert server.message_handler is handler


### PR DESCRIPTION
Exposed the optional MCP message_handler, letting each transport surface the hook and ensuring the base session forwards it on.