### PR TITLE
Add missing docstrings to function_tool examples in model_providers

### DIFF
--- a/examples/model_providers/custom_example_agent.py
+++ b/examples/model_providers/custom_example_agent.py
@@ -3,7 +3,13 @@ import os
 
 from openai import AsyncOpenAI
 
-from agents import Agent, OpenAIChatCompletionsModel, Runner, function_tool, set_tracing_disabled
+from agents import (
+    Agent,
+    OpenAIChatCompletionsModel,
+    Runner,
+    function_tool,
+    set_tracing_disabled,
+)
 
 BASE_URL = os.getenv("EXAMPLE_BASE_URL") or ""
 API_KEY = os.getenv("EXAMPLE_API_KEY") or ""
@@ -33,7 +39,8 @@ set_tracing_disabled(disabled=True)
 
 
 @function_tool
-def get_weather(city: str):
+def get_weather(city: str) -> str:
+    """Get the current weather information for a specified city."""
     print(f"[debug] getting weather for {city}")
     return f"The weather in {city} is sunny."
 

--- a/examples/model_providers/custom_example_global.py
+++ b/examples/model_providers/custom_example_global.py
@@ -42,7 +42,8 @@ set_tracing_disabled(disabled=True)
 
 
 @function_tool
-def get_weather(city: str):
+def get_weather(city: str) -> str:
+    """Get the current weather information for a specified city."""
     print(f"[debug] getting weather for {city}")
     return f"The weather in {city} is sunny."
 

--- a/examples/model_providers/custom_example_provider.py
+++ b/examples/model_providers/custom_example_provider.py
@@ -42,20 +42,27 @@ set_tracing_disabled(disabled=True)
 
 class CustomModelProvider(ModelProvider):
     def get_model(self, model_name: str | None) -> Model:
-        return OpenAIChatCompletionsModel(model=model_name or MODEL_NAME, openai_client=client)
+        return OpenAIChatCompletionsModel(
+            model=model_name or MODEL_NAME, openai_client=client
+        )
 
 
 CUSTOM_MODEL_PROVIDER = CustomModelProvider()
 
 
 @function_tool
-def get_weather(city: str):
+def get_weather(city: str) -> str:
+    """Get the current weather information for a specified city."""
     print(f"[debug] getting weather for {city}")
     return f"The weather in {city} is sunny."
 
 
 async def main():
-    agent = Agent(name="Assistant", instructions="You only respond in haikus.", tools=[get_weather])
+    agent = Agent(
+        name="Assistant",
+        instructions="You only respond in haikus.",
+        tools=[get_weather],
+    )
 
     # This will use the custom model provider
     result = await Runner.run(

--- a/examples/model_providers/litellm_auto.py
+++ b/examples/model_providers/litellm_auto.py
@@ -17,7 +17,8 @@ set_tracing_disabled(disabled=True)
 
 
 @function_tool
-def get_weather(city: str):
+def get_weather(city: str) -> str:
+    """Get the current weather information for a specified city."""
     print(f"[debug] getting weather for {city}")
     return f"The weather in {city} is sunny."
 

--- a/examples/model_providers/litellm_provider.py
+++ b/examples/model_providers/litellm_provider.py
@@ -18,7 +18,8 @@ set_tracing_disabled(disabled=True)
 
 
 @function_tool
-def get_weather(city: str):
+def get_weather(city: str) -> str:
+    """Get the current weather information for a specified city."""
     print(f"[debug] getting weather for {city}")
     return f"The weather in {city} is sunny."
 


### PR DESCRIPTION
Added missing docstrings to `@function_tool` decorated functions in the model_providers example files to improve LLM agent tool understanding.

## Changes
- Added descriptive docstrings to function tools in 5 model provider example files
- Added return type annotations for consistency
- No functional changes - documentation improvement only

## Why this matters
The OpenAI Agents SDK uses function docstrings to generate tool descriptions that help LLMs understand when and how to use tools. The [official documentation](https://openai.github.io/openai-agents-python/tools/) states that "Tool description will be taken from the docstring of the function."

Without proper docstrings, developers following these examples may create tools that agents struggle to use effectively.

## Files changed
- `examples/model_providers/custom_example_agent.py`
- `examples/model_providers/custom_example_global.py`
- `examples/model_providers/custom_example_provider.py`  
- `examples/model_providers/litellm_auto.py`
- `examples/model_providers/litellm_provider.py`

## Testing
All existing functionality remains unchanged. These are documentation-only improvements to example files.