### PR TITLE
Fix extended thinking bug by reordering tool messages

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -23,6 +23,7 @@ from openai.types.chat import (
     ChatCompletionChunk,
     ChatCompletionMessageCustomToolCall,
     ChatCompletionMessageFunctionToolCall,
+    ChatCompletionMessageParam,
 )
 from openai.types.chat.chat_completion_message import (
     Annotation,
@@ -267,6 +268,10 @@ class LitellmModel(Model):
             input, preserve_thinking_blocks=preserve_thinking_blocks
         )
 
+        # Fix for interleaved thinking bug: reorder messages to ensure tool_use comes before tool_result  # noqa: E501
+        if preserve_thinking_blocks:
+            converted_messages = self._fix_tool_message_ordering(converted_messages)
+
         if system_instructions:
             converted_messages.insert(
                 0,
@@ -378,6 +383,112 @@ class LitellmModel(Model):
             reasoning=model_settings.reasoning,
         )
         return response, ret
+
+    def _fix_tool_message_ordering(
+        self, messages: list[ChatCompletionMessageParam]
+    ) -> list[ChatCompletionMessageParam]:
+        """
+        Fix the ordering of tool messages to ensure tool_use messages come before tool_result messages.
+
+        This addresses the interleaved thinking bug where conversation histories may contain
+        tool results before their corresponding tool calls, causing Anthropic API to reject the request.
+        """  # noqa: E501
+        if not messages:
+            return messages
+
+        # Collect all tool calls and tool results
+        tool_call_messages = {}  # tool_id -> (index, message)
+        tool_result_messages = {}  # tool_id -> (index, message)
+        other_messages = []  # (index, message) for non-tool messages
+
+        for i, message in enumerate(messages):
+            if not isinstance(message, dict):
+                other_messages.append((i, message))
+                continue
+
+            role = message.get("role")
+
+            if role == "assistant" and message.get("tool_calls"):
+                # Extract tool calls from this assistant message
+                tool_calls = message.get("tool_calls", [])
+                if isinstance(tool_calls, list):
+                    for tool_call in tool_calls:
+                        if isinstance(tool_call, dict):
+                            tool_id = tool_call.get("id")
+                            if tool_id:
+                                # Create a separate assistant message for each tool call
+                                single_tool_msg = cast(dict[str, Any], message.copy())
+                                single_tool_msg["tool_calls"] = [tool_call]
+                                tool_call_messages[tool_id] = (
+                                    i,
+                                    cast(ChatCompletionMessageParam, single_tool_msg),
+                                )
+
+            elif role == "tool":
+                tool_call_id = message.get("tool_call_id")
+                if tool_call_id:
+                    tool_result_messages[tool_call_id] = (i, message)
+                else:
+                    other_messages.append((i, message))
+            else:
+                other_messages.append((i, message))
+
+        # Create the fixed message sequence
+        fixed_messages: list[ChatCompletionMessageParam] = []
+        used_indices = set()
+
+        # Add messages in their original order, but ensure tool_use → tool_result pairing
+        for i, original_message in enumerate(messages):
+            if i in used_indices:
+                continue
+
+            if not isinstance(original_message, dict):
+                fixed_messages.append(original_message)
+                used_indices.add(i)
+                continue
+
+            role = original_message.get("role")
+
+            if role == "assistant" and original_message.get("tool_calls"):
+                # Process each tool call in this assistant message
+                tool_calls = original_message.get("tool_calls", [])
+                if isinstance(tool_calls, list):
+                    for tool_call in tool_calls:
+                        if isinstance(tool_call, dict):
+                            tool_id = tool_call.get("id")
+                            if (
+                                tool_id
+                                and tool_id in tool_call_messages
+                                and tool_id in tool_result_messages
+                            ):
+                                # Add tool_use → tool_result pair
+                                _, tool_call_msg = tool_call_messages[tool_id]
+                                _, tool_result_msg = tool_result_messages[tool_id]
+
+                                fixed_messages.append(tool_call_msg)
+                                fixed_messages.append(tool_result_msg)
+
+                                # Mark both as used
+                                used_indices.add(tool_call_messages[tool_id][0])
+                                used_indices.add(tool_result_messages[tool_id][0])
+                            elif tool_id and tool_id in tool_call_messages:
+                                # Tool call without result - add just the tool call
+                                _, tool_call_msg = tool_call_messages[tool_id]
+                                fixed_messages.append(tool_call_msg)
+                                used_indices.add(tool_call_messages[tool_id][0])
+
+                used_indices.add(i)  # Mark original multi-tool message as used
+
+            elif role == "tool":
+                # Skip - these will be handled as part of tool pairs above
+                used_indices.add(i)
+
+            else:
+                # Regular message - add it normally
+                fixed_messages.append(original_message)
+                used_indices.add(i)
+
+        return fixed_messages
 
     def _remove_not_given(self, value: Any) -> Any:
         if isinstance(value, NotGiven):

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -533,7 +533,7 @@ class Converter:
 
                 if content_items and preserve_thinking_blocks:
                     # Reconstruct thinking blocks from content and signature
-                    pending_thinking_blocks = []
+                    reconstructed_thinking_blocks = []
                     for content_item in content_items:
                         if (
                             isinstance(content_item, dict)
@@ -546,7 +546,11 @@ class Converter:
                             # Add signatures if available
                             if signatures:
                                 thinking_block["signature"] = signatures.pop(0)
-                            pending_thinking_blocks.append(thinking_block)
+                            reconstructed_thinking_blocks.append(thinking_block)
+
+                    # Store thinking blocks as pending for the next assistant message
+                    # This preserves the original behavior
+                    pending_thinking_blocks = reconstructed_thinking_blocks
 
             # 8) If we haven't recognized it => fail or ignore
             else:

--- a/tests/test_extended_thinking_message_order.py
+++ b/tests/test_extended_thinking_message_order.py
@@ -1,0 +1,293 @@
+"""Tests for the extended thinking message order bug fix in LitellmModel."""
+
+from __future__ import annotations
+
+from openai.types.chat import ChatCompletionMessageParam
+
+from agents.extensions.models.litellm_model import LitellmModel
+
+
+class TestExtendedThinkingMessageOrder:
+    """Test the _fix_tool_message_ordering method."""
+
+    def test_basic_reordering_tool_result_before_call(self):
+        """Test that a tool result appearing before its tool call gets reordered correctly."""
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Hello"},
+            {"role": "tool", "tool_call_id": "call_123", "content": "Result for call_123"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "Thanks"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        # Should reorder to: user, assistant+tool_call, tool_result, user
+        assert len(result) == 4
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert result[1]["tool_calls"][0]["id"] == "call_123"  # type: ignore
+        assert result[2]["role"] == "tool"
+        assert result[2]["tool_call_id"] == "call_123"
+        assert result[3]["role"] == "user"
+
+    def test_consecutive_tool_calls_get_separated(self):
+        """Test that consecutive assistant messages with tool calls get properly paired with results."""  # noqa: E501
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "test1", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "test2", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "Result 1"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "Result 2"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        # Should pair each tool call with its result immediately
+        assert len(result) == 5
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert result[1]["tool_calls"][0]["id"] == "call_1"  # type: ignore
+        assert result[2]["role"] == "tool"
+        assert result[2]["tool_call_id"] == "call_1"
+        assert result[3]["role"] == "assistant"
+        assert result[3]["tool_calls"][0]["id"] == "call_2"  # type: ignore
+        assert result[4]["role"] == "tool"
+        assert result[4]["tool_call_id"] == "call_2"
+
+    def test_unmatched_tool_results_preserved(self):
+        """Test that tool results without matching tool calls are preserved."""
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "Matched result"},
+            {"role": "tool", "tool_call_id": "call_orphan", "content": "Orphaned result"},
+            {"role": "user", "content": "End"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        # Should preserve the orphaned tool result
+        assert len(result) == 5
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert result[2]["role"] == "tool"
+        assert result[2]["tool_call_id"] == "call_1"
+        assert result[3]["role"] == "tool"  # Orphaned result preserved
+        assert result[3]["tool_call_id"] == "call_orphan"
+        assert result[4]["role"] == "user"
+
+    def test_tool_calls_without_results_preserved(self):
+        """Test that tool calls without results are still included."""
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "End"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        # Should preserve the tool call even without a result
+        assert len(result) == 3
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert result[1]["tool_calls"][0]["id"] == "call_1"  # type: ignore
+        assert result[2]["role"] == "user"
+
+    def test_correctly_ordered_messages_unchanged(self):
+        """Test that correctly ordered messages remain in the same order."""
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "Result"},
+            {"role": "assistant", "content": "Done"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        # Should remain exactly the same
+        assert len(result) == 4
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert result[1]["tool_calls"][0]["id"] == "call_1"  # type: ignore
+        assert result[2]["role"] == "tool"
+        assert result[2]["tool_call_id"] == "call_1"
+        assert result[3]["role"] == "assistant"
+
+    def test_multiple_tool_calls_single_message(self):
+        """Test assistant message with multiple tool calls gets split properly."""
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "test1", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "test2", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "Result 1"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "Result 2"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        # Should split the multi-tool message and pair each properly
+        assert len(result) == 5
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert len(result[1]["tool_calls"]) == 1  # type: ignore
+        assert result[1]["tool_calls"][0]["id"] == "call_1"  # type: ignore
+        assert result[2]["role"] == "tool"
+        assert result[2]["tool_call_id"] == "call_1"
+        assert result[3]["role"] == "assistant"
+        assert len(result[3]["tool_calls"]) == 1  # type: ignore
+        assert result[3]["tool_calls"][0]["id"] == "call_2"  # type: ignore
+        assert result[4]["role"] == "tool"
+        assert result[4]["tool_call_id"] == "call_2"
+
+    def test_empty_messages_list(self):
+        """Test that empty message list is handled correctly."""
+        messages: list[ChatCompletionMessageParam] = []
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        assert result == []
+
+    def test_no_tool_messages(self):
+        """Test that messages without tool calls are left unchanged."""
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "user", "content": "How are you?"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        assert result == messages
+
+    def test_complex_mixed_scenario(self):
+        """Test a complex scenario with various message types and orderings."""
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Start"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_out_of_order",
+                "content": "Out of order result",
+            },  # This comes before its call
+            {"role": "assistant", "content": "Regular response"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_out_of_order",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_normal",
+                        "type": "function",
+                        "function": {"name": "test2", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_normal", "content": "Normal result"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_orphan",
+                "content": "Orphaned result",
+            },  # No matching call
+            {"role": "user", "content": "End"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        # Should reorder properly while preserving all messages
+        assert len(result) == 8
+        assert result[0]["role"] == "user"  # Start
+        assert result[1]["role"] == "assistant"  # Regular response
+        assert result[2]["role"] == "assistant"  # call_out_of_order
+        assert result[2]["tool_calls"][0]["id"] == "call_out_of_order"  # type: ignore
+        assert result[3]["role"] == "tool"  # Out of order result (now properly paired)
+        assert result[3]["tool_call_id"] == "call_out_of_order"
+        assert result[4]["role"] == "assistant"  # call_normal
+        assert result[4]["tool_calls"][0]["id"] == "call_normal"  # type: ignore
+        assert result[5]["role"] == "tool"  # Normal result
+        assert result[5]["tool_call_id"] == "call_normal"
+        assert result[6]["role"] == "tool"  # Orphaned result (preserved)
+        assert result[6]["tool_call_id"] == "call_orphan"
+        assert result[7]["role"] == "user"  # End


### PR DESCRIPTION
Resolves #1797 

This fixes the issue where conversation histories with extended thinking could have tool_result messages appearing before their corresponding tool_use messages, causing Anthropic API rejections.

**What was happening:**
- Reasoning blocks between tool calls caused the converter to create malformed message sequences
- Multiple consecutive assistant messages with tool calls weren't getting paired with their results properly
- Anthropic API requires strict tool_use → tool_result ordering

**The fix:**
- Added `_fix_tool_message_ordering()` method that only activates when `preserve_thinking_blocks=True`
- Analyzes the entire conversation to identify tool call/result pairs
- Reconstructs messages ensuring proper tool_use → tool_result sequencing
- Handles edge cases like consecutive tool calls and misplaced results
- Non-breaking - only affects extended thinking scenarios

Repro script available in the original issue.