### PR TITLE
fix: making input_file's filename optional in code for supporting non-OpenAI models

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -293,17 +293,12 @@ class Converter:
                     raise UserError(
                         f"Only file_data is supported for input_file {casted_file_param}"
                     )
-                if "filename" not in casted_file_param or not casted_file_param["filename"]:
-                    raise UserError(f"filename must be provided for input_file {casted_file_param}")
-                out.append(
-                    File(
-                        type="file",
-                        file=FileFile(
-                            file_data=casted_file_param["file_data"],
-                            filename=casted_file_param["filename"],
-                        ),
-                    )
-                )
+                filedata = FileFile(file_data=casted_file_param["file_data"])
+
+                if "filename" in casted_file_param and casted_file_param["filename"]:
+                    filedata["filename"] = casted_file_param["filename"]
+
+                out.append(File(type="file", file=filedata))
             else:
                 raise UserError(f"Unknown content: {c}")
         return out


### PR DESCRIPTION
For input_file the  `filename` parameter was recently made required in https://github.com/openai/openai-agents-python/pull/1513. 
This conflicts with many models outside of OpenAI, which do not require it.

This PR makes `filename` optional again to improve compatibility across the ecosystem. 
For gpt* models, the server already handles missing filename errors, making the current client-side validation redundant.