### PR TITLE
Fix: Correct streaming order for ReasoningItem and RawResponsesStreamEvent events

### DIFF
--- a/tests/fastapi/test_streaming_context.py
+++ b/tests/fastapi/test_streaming_context.py
@@ -25,5 +25,17 @@ async def test_streaming_context():
             body = (await r.aread()).decode("utf-8")
             lines = [line for line in body.splitlines() if line]
             assert lines == snapshot(
-                ["agent_updated_stream_event", "raw_response_event", "run_item_stream_event"]
+                [
+                    "agent_updated_stream_event",
+                    "raw_response_event",  # ResponseCreatedEvent
+                    "raw_response_event",  # ResponseInProgressEvent
+                    "raw_response_event",  # ResponseOutputItemAddedEvent
+                    "raw_response_event",  # ResponseContentPartAddedEvent
+                    "raw_response_event",  # ResponseTextDeltaEvent
+                    "raw_response_event",  # ResponseTextDoneEvent
+                    "raw_response_event",  # ResponseContentPartDoneEvent
+                    "raw_response_event",  # ResponseOutputItemDoneEvent
+                    "raw_response_event",  # ResponseCompletedEvent
+                    "run_item_stream_event",  # MessageOutputItem
+                ]
             )

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -695,11 +695,16 @@ async def test_streaming_events():
     # Now lets check the events
 
     expected_item_type_map = {
-        "tool_call": 2,
+        # 3 tool_call_item events:
+        #   1. get_function_tool_call("foo", ...)
+        #   2. get_handoff_tool_call(agent_1) because handoffs are implemented via tool calls too
+        #   3. get_function_tool_call("bar", ...)
+        "tool_call": 3,
+        # Only 2 outputs, handoff tool call doesn't have corresponding tool_call_output event
         "tool_call_output": 2,
-        "message": 2,
-        "handoff": 1,
-        "handoff_output": 1,
+        "message": 2,  # get_text_message("a_message") + get_final_output_message(...)
+        "handoff": 1,  # get_handoff_tool_call(agent_1)
+        "handoff_output": 1,  # handoff_output_item
     }
 
     total_expected_item_count = sum(expected_item_type_map.values())

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -2,13 +2,38 @@ import asyncio
 import time
 
 import pytest
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseContentPartAddedEvent,
+    ResponseContentPartDoneEvent,
+    ResponseCreatedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseInProgressEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseReasoningSummaryPartAddedEvent,
+    ResponseReasoningSummaryPartDoneEvent,
+    ResponseReasoningSummaryTextDeltaEvent,
+    ResponseReasoningSummaryTextDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseTextDoneEvent,
+)
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
 
 from agents import Agent, HandoffCallItem, Runner, function_tool
 from agents.extensions.handoff_filters import remove_all_tools
 from agents.handoffs import handoff
+from agents.items import MessageOutputItem, ReasoningItem, ToolCallItem, ToolCallOutputItem
 
 from .fake_model import FakeModel
 from .test_responses import get_function_tool_call, get_handoff_tool_call, get_text_message
+
+
+def get_reasoning_item() -> ResponseReasoningItem:
+    return ResponseReasoningItem(
+        id="rid", type="reasoning", summary=[Summary(text="thinking", type="summary_text")]
+    )
 
 
 @function_tool
@@ -108,3 +133,150 @@ async def test_stream_events_main_with_handoff():
 
     assert handoff_requested_seen, "handoff_requested event not observed"
     assert agent_switched_to_english, "Agent did not switch to EnglishAgent"
+
+
+@pytest.mark.asyncio
+async def test_complete_streaming_events():
+    """Verify all streaming event types are emitted in correct order.
+
+    Tests the complete event sequence including:
+    - Reasoning items with summary events
+    - Function call with arguments delta/done events
+    - Message output with content_part and text delta/done events
+    """
+    model = FakeModel()
+    agent = Agent(
+        name="TestAgent",
+        model=model,
+        tools=[foo],
+    )
+
+    model.add_multiple_turn_outputs(
+        [
+            [
+                get_reasoning_item(),
+                get_function_tool_call("foo", '{"arg": "value"}'),
+            ],
+            [get_text_message("Final response")],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="Hello")
+
+    events = []
+    async for event in result.stream_events():
+        events.append(event)
+
+    assert len(events) == 27, f"Expected 27 events but got {len(events)}"
+
+    # Event 0: agent_updated_stream_event
+    assert events[0].type == "agent_updated_stream_event"
+    assert events[0].new_agent.name == "TestAgent"
+
+    # Event 1: ResponseCreatedEvent (first turn started)
+    assert events[1].type == "raw_response_event"
+    assert isinstance(events[1].data, ResponseCreatedEvent)
+
+    # Event 2: ResponseInProgressEvent
+    assert events[2].type == "raw_response_event"
+    assert isinstance(events[2].data, ResponseInProgressEvent)
+
+    # Event 3: ResponseOutputItemAddedEvent (reasoning item)
+    assert events[3].type == "raw_response_event"
+    assert isinstance(events[3].data, ResponseOutputItemAddedEvent)
+
+    # Event 4: ResponseReasoningSummaryPartAddedEvent
+    assert events[4].type == "raw_response_event"
+    assert isinstance(events[4].data, ResponseReasoningSummaryPartAddedEvent)
+
+    # Event 5: ResponseReasoningSummaryTextDeltaEvent
+    assert events[5].type == "raw_response_event"
+    assert isinstance(events[5].data, ResponseReasoningSummaryTextDeltaEvent)
+
+    # Event 6: ResponseReasoningSummaryTextDoneEvent
+    assert events[6].type == "raw_response_event"
+    assert isinstance(events[6].data, ResponseReasoningSummaryTextDoneEvent)
+
+    # Event 7: ResponseReasoningSummaryPartDoneEvent
+    assert events[7].type == "raw_response_event"
+    assert isinstance(events[7].data, ResponseReasoningSummaryPartDoneEvent)
+
+    # Event 8: ResponseOutputItemDoneEvent (reasoning item)
+    assert events[8].type == "raw_response_event"
+    assert isinstance(events[8].data, ResponseOutputItemDoneEvent)
+
+    # Event 9: ReasoningItem run_item_stream_event
+    assert events[9].type == "run_item_stream_event"
+    assert events[9].name == "reasoning_item_created"
+    assert isinstance(events[9].item, ReasoningItem)
+
+    # Event 10: ResponseOutputItemAddedEvent (function call)
+    assert events[10].type == "raw_response_event"
+    assert isinstance(events[10].data, ResponseOutputItemAddedEvent)
+
+    # Event 11: ResponseFunctionCallArgumentsDeltaEvent
+    assert events[11].type == "raw_response_event"
+    assert isinstance(events[11].data, ResponseFunctionCallArgumentsDeltaEvent)
+
+    # Event 12: ResponseFunctionCallArgumentsDoneEvent
+    assert events[12].type == "raw_response_event"
+    assert isinstance(events[12].data, ResponseFunctionCallArgumentsDoneEvent)
+
+    # Event 13: ResponseOutputItemDoneEvent (function call)
+    assert events[13].type == "raw_response_event"
+    assert isinstance(events[13].data, ResponseOutputItemDoneEvent)
+
+    # Event 14: ToolCallItem run_item_stream_event
+    assert events[14].type == "run_item_stream_event"
+    assert events[14].name == "tool_called"
+    assert isinstance(events[14].item, ToolCallItem)
+
+    # Event 15: ResponseCompletedEvent (first turn ended)
+    assert events[15].type == "raw_response_event"
+    assert isinstance(events[15].data, ResponseCompletedEvent)
+
+    # Event 16: ToolCallOutputItem run_item_stream_event
+    assert events[16].type == "run_item_stream_event"
+    assert events[16].name == "tool_output"
+    assert isinstance(events[16].item, ToolCallOutputItem)
+
+    # Event 17: ResponseCreatedEvent (second turn started)
+    assert events[17].type == "raw_response_event"
+    assert isinstance(events[17].data, ResponseCreatedEvent)
+
+    # Event 18: ResponseInProgressEvent
+    assert events[18].type == "raw_response_event"
+    assert isinstance(events[18].data, ResponseInProgressEvent)
+
+    # Event 19: ResponseOutputItemAddedEvent
+    assert events[19].type == "raw_response_event"
+    assert isinstance(events[19].data, ResponseOutputItemAddedEvent)
+
+    # Event 20: ResponseContentPartAddedEvent
+    assert events[20].type == "raw_response_event"
+    assert isinstance(events[20].data, ResponseContentPartAddedEvent)
+
+    # Event 21: ResponseTextDeltaEvent
+    assert events[21].type == "raw_response_event"
+    assert isinstance(events[21].data, ResponseTextDeltaEvent)
+
+    # Event 22: ResponseTextDoneEvent
+    assert events[22].type == "raw_response_event"
+    assert isinstance(events[22].data, ResponseTextDoneEvent)
+
+    # Event 23: ResponseContentPartDoneEvent
+    assert events[23].type == "raw_response_event"
+    assert isinstance(events[23].data, ResponseContentPartDoneEvent)
+
+    # Event 24: ResponseOutputItemDoneEvent
+    assert events[24].type == "raw_response_event"
+    assert isinstance(events[24].data, ResponseOutputItemDoneEvent)
+
+    # Event 25: ResponseCompletedEvent (second turn ended)
+    assert events[25].type == "raw_response_event"
+    assert isinstance(events[25].data, ResponseCompletedEvent)
+
+    # Event 26: MessageOutputItem run_item_stream_event
+    assert events[26].type == "run_item_stream_event"
+    assert events[26].name == "message_output_created"
+    assert isinstance(events[26].item, MessageOutputItem)


### PR DESCRIPTION
## Issues

This PR fixes incorrect streaming order for `ReasoningItem` and `RawResponsesStreamEvent`:

1. `RawResponsesStreamEvent` should be emitted ASAP.  

    This behavior was accidentally broken in https://github.com/openai/openai-agents-python/pull/1300, which changed the original correct ordering.
    
2. `ReasoningItem` should be emitted right after its  ```response.output_item.done``` event, rather than being delayed until after `response.completed`.  This issue was reported in https://github.com/openai/openai-agents-python/issues/1767#issuecomment-3319824140

## Solution

1. **Move raw event emission earlier**  

    Restored the correct ordering by moving `RawResponsesStreamEvent` to the top of the handler.

2. **Emit `ReasoningItem` earlier**  
   
    Applied the exact same approach as in PR #1300 for early emission of `ToolCallItem`, also applying it to ensure that `ReasoningItem` is emitted right after its `ResponseOutputItemDoneEvent`.
    
   Code intentionally not refactored for DRYness to keep the diff explicit and review-friendly. Refactoring can be done later after test code are merged.
        
3. **Add comprehensive unit tests**
    
   Extended `FakeModel` to fully simulate detailed streaming sequence and added tests verifying the exact event order, ensuring future changes won’t reintroduce regressions. 
   
   For reference, here is a real example script that calls the OpenAI API, along with the corresponding 27 test events:  https://gist.github.com/ihower/b6d9fe9b72b02c5131e210e2202b31b7

## Related

- Fixes: https://github.com/openai/openai-agents-python/issues/1767#issuecomment-3319824140
- Fixes: https://github.com/openai/openai-agents-python/issues/583
- Related: https://github.com/openai/openai-agents-python/pull/1300