### PR TITLE
docs: add documentation for extension feature EncryptedSession

### DIFF
--- a/docs/ref/extensions/memory/encrypt_session.md
+++ b/docs/ref/extensions/memory/encrypt_session.md
@@ -1,3 +1,3 @@
-# `Encrypt Session`
+# `EncryptedSession`
 
-::: agents.extensions.memory.encrypt_session
+::: agents.extensions.memory.encrypt_session.EncryptedSession

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ plugins:
                     - ref/extensions/handoff_prompt.md
                     - ref/extensions/litellm.md
                     - ref/extensions/memory/sqlalchemy_session.md
+                    - ref/extensions/memory/encrypt_session.md
 
         - locale: ja
           name: 日本語


### PR DESCRIPTION
# EncryptedSession Documentation

This PR adds documentation for the `EncryptedSession` extension feature in the sessions guide. Includes usage examples with SQLAlchemy integration and documents key features: transparent encryption, HKDF key derivation, TTL-based expiration.

Updates: navigation in mkdocs.yml and fixes the API reference to properly point to the `EncryptedSession` class.

reference to feature PR: https://github.com/openai/openai-agents-python/pull/1674