### PR TITLE
fix: handle omit type in `_remove_not_given()` for litellm model

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -500,7 +500,7 @@ class LitellmModel(Model):
         return fixed_messages
 
     def _remove_not_given(self, value: Any) -> Any:
-        if isinstance(value, (NotGiven, type(omit))):
+        if value is omit or isinstance(value, NotGiven):
             return None
         return value
 


### PR DESCRIPTION
When running the code example to use agents sdk with LiteLLM: https://openai.github.io/openai-agents-python/models/litellm/

I get the following error:
```
File "/Users/hareeshbahuleyan/Desktop/mzai_github/openai-agents-python/src/agents/extensions/models/litellm_model.py", line 99, in get_response
    response = await self._fetch_response(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hareeshbahuleyan/Desktop/mzai_github/openai-agents-python/src/agents/extensions/models/litellm_model.py", line 345, in _fetch_response
    ret = await litellm.acompletion(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hareeshbahuleyan/Desktop/mzai_github/openai-agents-python/.venv/lib/python3.11/site-packages/litellm/utils.py", line 1586, in wrapper_async
    raise e
  File "/Users/hareeshbahuleyan/Desktop/mzai_github/openai-agents-python/.venv/lib/python3.11/site-packages/litellm/utils.py", line 1437, in wrapper_async
    result = await original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hareeshbahuleyan/Desktop/mzai_github/openai-agents-python/.venv/lib/python3.11/site-packages/litellm/main.py", line 563, in acompletion
    raise exception_type(
          ^^^^^^^^^^^^^^^
  File "/Users/hareeshbahuleyan/Desktop/mzai_github/openai-agents-python/.venv/lib/python3.11/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 2306, in exception_type
    raise e  # it's already mapped
    ^^^^^^^
  File "/Users/hareeshbahuleyan/Desktop/mzai_github/openai-agents-python/.venv/lib/python3.11/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 539, in exception_type
    raise APIConnectionError(
litellm.exceptions.APIConnectionError: litellm.APIConnectionError: APIConnectionError: OpenAIException - Invalid tool choice, tool_choice=<openai.Omit object at 0x104a97c90>. Got=<class 'openai.Omit'>. Expecting str, or dict.
``` 

This PR attempts to handle the error thrown, in particular:
```
OpenAIException - Invalid tool choice, tool_choice=<openai.Omit object at 0x104a97c90>. Got=<class 'openai.Omit'>. Expecting str, or dict.
```