### PR TITLE
Fix timeout handling for zero-millisecond values

### DIFF
--- a/examples/tools/local_shell.py
+++ b/examples/tools/local_shell.py
@@ -15,7 +15,7 @@ def shell_executor(request: LocalShellCommandRequest) -> str:
             env={**os.environ, **args.env} if args.env else os.environ,
             capture_output=True,
             text=True,
-            timeout=(args.timeout_ms / 1000) if args.timeout_ms else None,
+            timeout=(args.timeout_ms / 1000) if args.timeout_ms is not None else None,
         )
         return completed.stdout + completed.stderr
 


### PR DESCRIPTION
Previously, when `timeout_ms` was explicitly set to `0`, the condition `if args.timeout_ms` evaluated to `False` (since `0` is falsy), causing the timeout to be treated as `None` (no timeout). This violated the intended behavior where `0` should mean "time out immediately."

The fix changes the check to `if args.timeout_ms is not None`, ensuring that:
- `timeout_ms=0` correctly results in a `0.0` second timeout
- `timeout_ms=None` (or unset) still results in no timeout
- All other positive values work as before

This aligns the implementation with standard `subprocess.run()` timeout semantics and prevents unintended indefinite command execution.