### PR TITLE
fix(strict_schema): correct error message and replace runtime assert

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -57,7 +57,7 @@ def _ensure_strict_json_schema(
         and json_schema["additionalProperties"]
     ):
         raise UserError(
-            "additionalProperties should not be set for object types. This could be because "
+            "additionalProperties should be set to False for object types. This could be because "
             "you're using an older version of Pydantic, or because you configured additional "
             "properties to be allowed. If you really need this, update the function or output tool "
             "to not use a strict schema."
@@ -154,9 +154,8 @@ def resolve_ref(*, root: dict[str, object], ref: str) -> object:
     resolved = root
     for key in path:
         value = resolved[key]
-        assert is_dict(value), (
-            f"encountered non-dictionary entry while resolving {ref} - {resolved}"
-        )
+        if not is_dict(value):
+            raise ValueError(f"encountered non-dictionary entry while resolving {ref} - {resolved}")
         resolved = value
 
     return resolved


### PR DESCRIPTION
This commit addresses two critical issues in the strict schema validation:

1. **Corrected error message for additionalProperties**:
   - Changed the misleading error message from "additionalProperties should not be set" to "additionalProperties should be set to False"
   - This accurately reflects the requirement that object types must explicitly set `additionalProperties: false` rather than implying it shouldn't be set at all
   - Prevents confusion for users encountering this validation error

2. **Replaced dangerous assert with proper exception handling**:
   - Replaced the `assert is_dict(value)` statement with proper runtime validation
   - Now raises a `ValueError` with clear message instead of relying on `assert`
   - Ensures validation works properly in optimized Python environments (when run with `-O` flag)
   - Maintains the same error semantics while making the code production-safe

Both fixes maintain backward compatibility while improving error clarity and runtime safety.