### PR TITLE
Fix: call `_fix_tool_message_ordering` for all Anthropic models

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -269,7 +269,7 @@ class LitellmModel(Model):
         )
 
         # Fix for interleaved thinking bug: reorder messages to ensure tool_use comes before tool_result  # noqa: E501
-        if 'anthropic' in self.model.lower():
+        if 'anthropic' in self.model.lower() or 'claude' in self.model.lower():
             converted_messages = self._fix_tool_message_ordering(converted_messages)
 
         if system_instructions:


### PR DESCRIPTION
Resolves #1935

Fixed `_fix_tool_message_ordering()` to run for all Anthropic models instead of only when reasoning is enabled.