### PR TITLE
fix: Remove trailing commas causing tuple assignment in response cancellation

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -431,7 +431,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
             and session.audio is not None
             and session.audio.input is not None
             and session.audio.input.turn_detection is not None
-            and session.audio.input.turn_detection.interrupt_response is True,
+            and session.audio.input.turn_detection.interrupt_response is True
         )
         if not automatic_response_cancellation_enabled:
             await self._cancel_response()
@@ -616,7 +616,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                     and session.audio is not None
                     and session.audio.input is not None
                     and session.audio.input.turn_detection is not None
-                    and session.audio.input.turn_detection.interrupt_response is True,
+                    and session.audio.input.turn_detection.interrupt_response is True
                 )
                 if not automatic_response_cancellation_enabled:
                     await self._cancel_response()


### PR DESCRIPTION
Fixes #1951

## Problem
Trailing commas on lines 434 and 619 in `src/agents/realtime/openai_realtime.py` create single-element tuples instead of boolean values, breaking the response cancellation logic when `interrupt_response=False`.

## Root Cause
```python
# Buggy (creates tuple):
automatic_response_cancellation_enabled = (..., )  # type: tuple

# Python semantics:
(False,) → tuple, not (False,) → False (truthy)
```

This causes `_cancel_response()` to never be called when automatic response cancellation is disabled.

## Changes
- Removed trailing commas on lines 434 and 619
- Changes convert tuple assignments to proper boolean expressions

## Verification
- Created test demonstrating bug behavior
- Verified bug exists in code (2 occurrences)
- Applied fix and confirmed trailing commas removed
- All 23 realtime tests pass

## Impact
- Introduced in: PR #1646 (commit 9168348, 2025-09-12)
- Severity: CRITICAL - response cancellation completely broken for `interrupt_response=False`
- Test coverage gap: No existing tests for this scenario