### PR TITLE
fix: await cancelled websocket task to prevent resource leak

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -516,6 +516,10 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
             self._websocket = None
         if self._websocket_task:
             self._websocket_task.cancel()
+            try:
+                await self._websocket_task
+            except asyncio.CancelledError:
+                pass
             self._websocket_task = None
 
     async def _cancel_response(self) -> None:


### PR DESCRIPTION
## Summary
Fixed a resource leak in the `OpenAIRealtimeWebSocketModel.close()` method where the websocket task was cancelled but not awaited, potentially leaving dangling resources.

## Problem
When `close()` was called, the code would:
1. Cancel `self._websocket_task`
2. Immediately set it to `None`

This could lead to:
- Resource leaks (unclosed connections, file descriptors)
- Python warnings: "Task was destroyed but it is pending!"
- Memory leaks from unreleased task resources

## Solution
Now properly awaits the cancelled task with exception handling:
```python
self._websocket_task.cancel()
try:
    await self._websocket_task
except asyncio.CancelledError:
    pass
self._websocket_task = None
```

This ensures the task is fully cleaned up before being discarded.

## Testing
- All 23 existing tests in `tests/realtime/test_openai_realtime.py` pass
- No behavioral changes, only proper cleanup

## Impact
- Prevents resource leaks in realtime sessions
- Eliminates potential "pending task" warnings
- Follows asyncio best practices for task cancellation