### PR TITLE
fix: prevent race condition in listener iteration

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -266,7 +266,8 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
 
     async def _emit_event(self, event: RealtimeModelEvent) -> None:
         """Emit an event to the listeners."""
-        for listener in self._listeners:
+        # Copy list to avoid modification during iteration
+        for listener in list(self._listeners):
             await listener.on_event(event)
 
     async def _listen_for_messages(self):


### PR DESCRIPTION
## Summary
Fixed a race condition in `OpenAIRealtimeWebSocketModel._emit_event()` where the listeners list could be modified during async iteration, causing `RuntimeError: list changed size during iteration`.

## Problem
The `_emit_event()` method iterates over `self._listeners` while calling `await listener.on_event(event)`:

```python
for listener in self._listeners:  # Iteration
    await listener.on_event(event)  # Await point - yields control
```

During the `await`, other code (e.g., cleanup) can call `remove_listener()`, modifying the list mid-iteration.

**Crash scenario:**
1. Session emits event → `_emit_event()` starts iterating listeners
2. At `await listener.on_event()`, control returns to event loop
3. Cleanup runs → calls `remove_listener()` → modifies list
4. Control returns to iteration → RuntimeError

This is realistic because `remove_listener()` is called during session cleanup (session.py:761).

## Solution
Create a shallow copy of the listeners list before iteration:

```python
for listener in list(self._listeners):  # Copy prevents modification issues
    await listener.on_event(event)
```

This allows safe concurrent modifications without affecting the ongoing iteration.

## Testing
- All 23 existing tests in `tests/realtime/test_openai_realtime.py` pass
- No behavioral changes, only defensive coding

## Impact
- Prevents crashes during concurrent listener management
- Common in cleanup scenarios where session removes itself as listener
- Minimal performance impact (shallow copy of small list)