### PR TITLE
fix: add call_id to function_call item if it doesn't have one (Gemini use case)

### DIFF
--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -546,7 +546,6 @@ class RunImpl:
 
             # Add call_id to function tool call if it doesn't have one
             output = add_function_tool_call_id_if_missing(output)
-            tools_used.append(output.name)
 
             tools_used.append(output.name)
 


### PR DESCRIPTION
I found that when using models like Gemini, the `call_id` in `function_call` item is empty. This causes difficulty in accurately matching `function_call` and `function_call_output` during parallel tool calling.
To address this, I added a check and filling for missing `call_id` values in `src/agents/_run_impl.py`. The `call_id` format follows the GPT series models’ convention — a 22-character random string ID with a prefix `call_`.