### PR TITLE
fix: #1907 guardrails w/ turn_detection.interrupt_response: true

### DIFF
--- a/src/agents/realtime/model_inputs.py
+++ b/src/agents/realtime/model_inputs.py
@@ -95,6 +95,9 @@ class RealtimeModelSendToolOutput:
 class RealtimeModelSendInterrupt:
     """Send an interrupt to the model."""
 
+    force_response_cancel: bool = False
+    """Force sending a response.cancel event even if automatic cancellation is enabled."""
+
 
 @dataclass
 class RealtimeModelSendSessionUpdate:

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -704,7 +704,7 @@ class RealtimeSession(RealtimeModelListener):
             )
 
             # Interrupt the model
-            await self._model.send_event(RealtimeModelSendInterrupt())
+            await self._model.send_event(RealtimeModelSendInterrupt(force_response_cancel=True))
 
             # Send guardrail triggered message
             guardrail_names = [result.guardrail.get_name() for result in triggered_results]


### PR DESCRIPTION
This pull request resolves #1907 where guardrails for realtime agents do not work when turn_detection.interrupt_response: true