### PR TITLE
fix: track request count when streaming fails mid-request (fixes #1973)

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1299,7 +1299,9 @@ class AgentRunner:
 
                             reasoning_item = ReasoningItem(raw_item=output_item, agent=agent)
                             streamed_result._event_queue.put_nowait(
-                                RunItemStreamEvent(item=reasoning_item, name="reasoning_item_created")
+                                RunItemStreamEvent(
+                                    item=reasoning_item, name="reasoning_item_created"
+                                )
                             )
         except Exception:
             # Track that a request was made, even if we didn't get usage info from the response

--- a/tests/test_usage_tracking_on_error.py
+++ b/tests/test_usage_tracking_on_error.py
@@ -100,7 +100,7 @@ async def test_usage_tracking_multi_turn_with_error():
 
     from agents.usage import Usage
 
-    from .test_responses import get_function_tool, get_function_tool_call, get_text_message
+    from .test_responses import get_function_tool, get_function_tool_call
 
     model = FakeModel()
 


### PR DESCRIPTION
## Summary

This PR fixes issue #1973 where usage tracking was completely lost when streaming fails mid-request.

## Problem

When streaming fails (API errors, connection drops, context window exceeded, etc.), usage tracking was completely lost. The issue occurs because usage is only accumulated when `ResponseCompletedEvent` arrives. If the model provider raises an exception before yielding `ResponseCompletedEvent`, the async for loop exits without ever updating usage.

### Why This Happens

In `src/agents/run.py` line 1254-1272, usage is only tracked when we receive `ResponseCompletedEvent`:

```python
if isinstance(event, ResponseCompletedEvent):
    usage = Usage(...)
    context_wrapper.usage.add(usage)
```

If an error occurs before this event (e.g., connection drops, rate limits, context window exceeded), the loop exits and no usage is recorded at all.

## Solution

Wrap the streaming loop in try-except to ensure at least the **request count** is tracked when streaming fails:

```python
try:
    async for event in model.stream_response(...):
        # existing logic
except Exception:
    if final_response is None:
        context_wrapper.usage.add(Usage(requests=1))
    raise
```

This approach:
- ✅ Tracks that a request was made (important for monitoring and cost estimation)
- ✅ Doesn't introduce new dependencies (no tiktoken needed)
- ✅ Preserves existing behavior for successful streaming
- ✅ Accurately reflects unavailable data (token counts stay at 0)

While we cannot estimate token counts without introducing dependencies or making model-specific assumptions, tracking the request count provides valuable information for:
- Monitoring API call frequency
- Debugging failed requests  
- Cost estimation (users know a request was made)

## Changes

**src/agents/run.py**:
- Added try-except around streaming loop (lines 1237-1310)
- Tracks request count on exception if no response received
- Preserves existing behavior for successful streaming

**tests/test_usage_tracking_on_error.py** (new file):
- Test request tracking on streaming error
- Test normal usage tracking still works
- Test multi-turn scenarios with error

## Testing

All tests pass:
```bash
pytest tests/test_usage_tracking_on_error.py -v
# 3 passed

pytest tests/test_cancel_streaming.py tests/test_agent_runner_streamed.py -v  
# 29 passed
```

Fixes #1973