### PR TITLE
ci: make format required (devs should run `make format` before committing)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: make sync
+      - name: Verify formatting
+        run: make format-check
       - name: Run lint
         run: make lint
 


### PR DESCRIPTION
we seem to sometimes be merging commits with failures on format

Another future enhancement is create a pre-commit file 