### PR TITLE
fix: use ResponseOutputRefusal for refusal content part added event

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -309,12 +309,10 @@ class ChatCmplStreamHandler:
                     yield ResponseContentPartAddedEvent(
                         content_index=state.refusal_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
-                        part=ResponseOutputText(
-                            text="",
-                            type="output_text",
-                            annotations=[],
+                        output_index=(1 if state.reasoning_content_index_and_output else 0),
+                        part=ResponseOutputRefusal(
+                            refusal="",
+                            type="refusal",
                         ),
                         type="response.content_part.added",
                         sequence_number=sequence_number.get_and_increment(),


### PR DESCRIPTION
In the refusal handling branch, the `ResponseContentPartAddedEvent` was incorrectly using `ResponseOutputText` as the `part` payload.
This violates the OpenAI Agents protocol, which requires refusal content to be represented by `ResponseOutputRefusal` so that downstream consumers can access the `.refusal` field.

This change updates the `part` field to use `ResponseOutputRefusal(refusal="", type="refusal")`, ensuring type consistency with both the accumulated state and the corresponding `ResponseContentPartDoneEvent`.

Additionally, the `output_index` calculation is slightly improved for clarity by explicitly using `(1 if state.reasoning_content_index_and_output else 0)` instead of a boolean expression, though the primary fix is the payload type correction.