### PR TITLE
v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-agents"
-version = "0.4.2"
+version = "0.5.0"
 description = "OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1877,7 +1877,7 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "griffe" },


### PR DESCRIPTION
- add python 3.14 support (changed Runner#run_sync internals a lot for it)
- realtime agent runner's SIP support

Also:
- we should have the following ones in this release too
  - #1995
  - #1937
  - #2039

- optional:
  - #2028
  - #2007
  - #1986 
  - #1996 
  - #2014 
