### PR TITLE
fix(responses): include text.format when verbosity set for plain-text responses

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -299,9 +299,12 @@ class OpenAIResponsesModel(Model):
             if response_format is not omit:
                 response_format["verbosity"] = model_settings.verbosity  # type: ignore [index]
             else:
-                # When no output_schema is present, text needs an explicit format key.
-                # Use the plain text format with verbosity to produce a valid `text` payload.
-                response_format = {"format": "text", "verbosity": model_settings.verbosity}
+                # When no output_schema is present, `text` needs an explicit format object.
+                # Use the plain text format object with verbosity to produce a valid `text` payload.
+                response_format = {
+                    "format": {"type": "text"},
+                    "verbosity": model_settings.verbosity,
+                }
 
         stream_param: Literal[True] | Omit = True if stream else omit
 


### PR DESCRIPTION
When model_settings.verbosity was set and no output schema was provided, the code previously built response_format = {"verbosity": ...} which is an invalid `text` payload for the Responses API.

The Responses API expects a `text` object to include a `format` field (for plain text use "format": "text").

This patch ensures a valid payload is sent by using:
  {"format": "text", "verbosity": <value>}
  
Impact:
- Prevents 400/BadRequest errors when callers use verbosity with plain text responses (no JSON schema).
- Backwards compatible for callers that already use output_schema.
