### PR TITLE
fix: #2007 TypeError object of type 'Omit' has no len()

### DIFF
--- a/tests/models/test_kwargs_functionality.py
+++ b/tests/models/test_kwargs_functionality.py
@@ -1,6 +1,7 @@
 import litellm
 import pytest
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
+from openai import Omit, omit
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.completion_usage import CompletionUsage
@@ -123,6 +124,9 @@ async def test_openai_chatcompletions_kwargs_forwarded(monkeypatch):
 
     # Verify regular parameters are still passed
     assert captured["temperature"] == 0.7
+
+    assert all(not isinstance(value, Omit) for value in captured.values())
+    assert omit not in captured.values()
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
This pull request aims to resolve #2007; this approach may look like a kind of workaround, which might should be done on the openai pakcage side, but if 3rd party integrations (e.g., commonly used proxy library of openai for monitoring etc.) do not expect the new `omit` object to come, removing them on the Agents SDK side should make sense at least in the short term. We may want to do the same for Responses API, but I'd like to hold off doing so for now.