### PR TITLE
docs: #2023 update readme to reflect commands required for developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ For voice support, install with the optional `voice` group: `pip install 'openai
 
 For Redis session support, install with the optional `redis` group: `pip install 'openai-agents[redis]'`.
 
+> [!NOTE]
+> **For developers working on this project:** When working within the `openai-agents-python` repository, use `pip install -e '.[voice]'` or `pip install -e '.[redis]'` to install the project in editable mode with optional dependencies, instead of installing from PyPI.
+
 ### uv
 
 If you're familiar with [uv](https://docs.astral.sh/uv/), using the tool would be even similar:
@@ -45,6 +48,9 @@ uv add openai-agents
 For voice support, install with the optional `voice` group: `uv add 'openai-agents[voice]'`.
 
 For Redis session support, install with the optional `redis` group: `uv add 'openai-agents[redis]'`.
+
+> [!NOTE]
+> **For developers working on this project:** When working within the `openai-agents-python` repository, use `uv sync --extra voice` or `uv sync --extra redis` instead of `uv add`, as the project cannot install itself as a dependency.
 
 ## Hello world example
 


### PR DESCRIPTION
### Summary

Fixes installation instructions in README.md for developers working on the `openai-agents-python` repository itself. The original instructions failed when developers tried to install optional dependencies (`voice` and `redis` extras) because:

1. **For `pip`**: `pip install 'openai-agents[voice]'` would install from PyPI instead of the local codebase, preventing developers from testing their changes.

2. **For `uv`**: `uv add 'openai-agents[voice]'` would attempt to add the project as its own dependency, which `uv` prevents with the error: "self-dependencies are not permitted without the `--dev` or `--optional` flags."

This PR adds developer-specific notes that clarify the correct commands:
- For `pip`: Use `pip install -e '.[voice]'` to install in editable mode from the local directory
- For `uv`: Use `uv sync --extra voice` to sync optional dependencies without adding the project as a dependency

The changes maintain backward compatibility—end users can still follow the original instructions, while developers now have clear guidance.

### Test plan

1. Verified that the existing installation commands still work for end users (they install from PyPI)
2. Tested that `uv sync --extra voice` works correctly in the repository
3. Verified that `pip install -e '.[voice]'` would work (editable install from local directory)
4. Confirmed that `uv add 'openai-agents[voice]'` fails with the expected error message when run inside the repository
5. Ran linting and formatting checks

### Issue number

#2023

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass