### PR TITLE
fix(realtime): include tool arguments in RealtimeToolStart/RealtimeToolEnd events

### DIFF
--- a/src/agents/realtime/events.py
+++ b/src/agents/realtime/events.py
@@ -69,6 +69,10 @@ class RealtimeToolStart:
     """The agent that updated."""
 
     tool: Tool
+    """The tool being called."""
+
+    arguments: str
+    """The arguments passed to the tool as a JSON string."""
 
     info: RealtimeEventInfo
     """Common info for all events, such as the context."""

--- a/src/agents/realtime/events.py
+++ b/src/agents/realtime/events.py
@@ -90,6 +90,9 @@ class RealtimeToolEnd:
     tool: Tool
     """The tool that was called."""
 
+    arguments: str
+    """The arguments passed to the tool as a JSON string."""
+
     output: Any
     """The output of the tool call."""
 

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -411,6 +411,7 @@ class RealtimeSession(RealtimeModelListener):
                     info=self._event_info,
                     tool=function_map[event.name],
                     agent=agent,
+                    arguments=event.arguments,
                 )
             )
 

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -437,6 +437,7 @@ class RealtimeSession(RealtimeModelListener):
                     tool=func_tool,
                     output=result,
                     agent=agent,
+                    arguments=event.arguments,
                 )
             )
         elif event.name in handoff_map:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -994,6 +994,7 @@ class TestToolCallExecution:
         assert tool_end_event.tool == mock_function_tool
         assert tool_end_event.output == "function_result"
         assert tool_end_event.agent == mock_agent
+        assert tool_end_event.arguments == '{"param": "value"}'
 
     @pytest.mark.asyncio
     async def test_function_tool_with_multiple_tools_available(self, mock_model, mock_agent):
@@ -1143,6 +1144,11 @@ class TestToolCallExecution:
         tool_start_event = await session._event_queue.get()
         assert isinstance(tool_start_event, RealtimeToolStart)
         assert tool_start_event.arguments == complex_args
+
+        # Verify tool_end event includes arguments
+        tool_end_event = await session._event_queue.get()
+        assert isinstance(tool_end_event, RealtimeToolEnd)
+        assert tool_end_event.arguments == complex_args
 
     @pytest.mark.asyncio
     async def test_tool_call_with_custom_call_id(self, mock_model, mock_agent, mock_function_tool):

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -986,6 +986,7 @@ class TestToolCallExecution:
         assert isinstance(tool_start_event, RealtimeToolStart)
         assert tool_start_event.tool == mock_function_tool
         assert tool_start_event.agent == mock_agent
+        assert tool_start_event.arguments == '{"param": "value"}'
 
         # Check tool end event
         tool_end_event = await session._event_queue.get()
@@ -1111,6 +1112,7 @@ class TestToolCallExecution:
         assert session._event_queue.qsize() == 1
         tool_start_event = await session._event_queue.get()
         assert isinstance(tool_start_event, RealtimeToolStart)
+        assert tool_start_event.arguments == "{}"
 
         # But no tool output should have been sent and no end event queued
         assert len(mock_model.sent_tool_outputs) == 0
@@ -1133,9 +1135,14 @@ class TestToolCallExecution:
 
         await session._handle_tool_call(tool_call_event)
 
-        # Verify arguments were passed correctly
+        # Verify arguments were passed correctly to tool
         call_args = mock_function_tool.on_invoke_tool.call_args
         assert call_args[0][1] == complex_args
+
+        # Verify tool_start event includes arguments
+        tool_start_event = await session._event_queue.get()
+        assert isinstance(tool_start_event, RealtimeToolStart)
+        assert tool_start_event.arguments == complex_args
 
     @pytest.mark.asyncio
     async def test_tool_call_with_custom_call_id(self, mock_model, mock_agent, mock_function_tool):


### PR DESCRIPTION
## What I changed  
I added an `arguments` field to `RealtimeToolStart` events so developers can see the parameters passed when a tool is invoked.  
The `tool_end` event already exposes the tool’s output, so adding arguments makes the start and end events more consistent and useful.

## What I did  
1. **Added the `arguments` field** to the `RealtimeToolStart` dataclass in `events.py`.  
   It’s stored as a JSON string, following the same convension used by the model layer.  
2. **Updated the event emission logic** in `session.py` to include the arguments from the tool call event.  
3. **Extended the test suit** to check that `arguments` are correctly included — covering normal, empty, and nested JSON cases.

## Testing  
All existing realtime tests passed (156/156).  
The new tests verify that arguments are properly included in all scenerios.

This is a simple, low-risk update that fits cleanly into the existing structure of the codebase.  

Fixes #1663