### PR TITLE
docs: clarify on_tool_start and on_tool_end hooks for local tools only

### DIFF
--- a/examples/basic/agent_lifecycle_example.py
+++ b/examples/basic/agent_lifecycle_example.py
@@ -28,6 +28,10 @@ class CustomAgentHooks(AgentHooks):
             f"### ({self.display_name}) {self.event_counter}: Agent {source.name} handed off to {agent.name}"
         )
 
+    # Note: The on_tool_start and on_tool_end hooks apply only to local tools.
+    # They do not include hosted tools that run on the OpenAI server side,
+    # such as WebSearchTool, FileSearchTool, CodeInterpreterTool, HostedMCPTool,
+    # or other built-in hosted tools.
     async def on_tool_start(self, context: RunContextWrapper, agent: Agent, tool: Tool) -> None:
         self.event_counter += 1
         print(

--- a/examples/basic/lifecycle_example.py
+++ b/examples/basic/lifecycle_example.py
@@ -70,6 +70,10 @@ class ExampleHooks(RunHooks):
             f"### {self.event_counter}: Agent {agent.name} ended with output {output}. Usage: {self._usage_to_str(context.usage)}"
         )
 
+    # Note: The on_tool_start and on_tool_end hooks apply only to local tools.
+    # They do not include hosted tools that run on the OpenAI server side,
+    # such as WebSearchTool, FileSearchTool, CodeInterpreterTool, HostedMCPTool,
+    # or other built-in hosted tools.
     async def on_tool_start(self, context: RunContextWrapper, agent: Agent, tool: Tool) -> None:
         self.event_counter += 1
         # While this type cast is not ideal,

--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -62,7 +62,7 @@ class RunHooksBase(Generic[TContext, TAgent]):
         agent: TAgent,
         tool: Tool,
     ) -> None:
-        """Called concurrently with tool invocation."""
+        """Called immediately before a local tool is invoked."""
         pass
 
     async def on_tool_end(
@@ -72,7 +72,7 @@ class RunHooksBase(Generic[TContext, TAgent]):
         tool: Tool,
         result: str,
     ) -> None:
-        """Called after a tool is invoked."""
+        """Called immediately after a local tool is invoked."""
         pass
 
 
@@ -113,7 +113,7 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         agent: TAgent,
         tool: Tool,
     ) -> None:
-        """Called concurrently with tool invocation."""
+        """Called immediately before a local tool is invoked."""
         pass
 
     async def on_tool_end(
@@ -123,7 +123,7 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         tool: Tool,
         result: str,
     ) -> None:
-        """Called after a tool is invoked."""
+        """Called immediately after a local tool is invoked."""
         pass
 
     async def on_llm_start(


### PR DESCRIPTION
This PR improves the doc comments for the `on_tool_start` and `on_tool_end` hooks.

Clarified that these hooks are for local tools only, and do not include hosted tools running on the OpenAI server side (e.g., `WebSearchTool`, `FileSearchTool`, `CodeInterpreterTool`, `HostedMCPTool`, etc.).

### Related Issues

- [https://github.com/openai/openai-agents-python/issues/778](https://github.com/openai/openai-agents-python/issues/778) rm-openai said: “I should document this better”, this PR addresses that note.
- [https://github.com/openai/openai-agents-python/issues/1889](https://github.com/openai/openai-agents-python/issues/1889)
- [https://github.com/openai/openai-agents-python/issues/2036](https://github.com/openai/openai-agents-python/issues/2036)