### PR TITLE
Add custom_metadata property to all tool types

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -429,6 +429,7 @@ def function_tool(
     failure_error_function: ToolErrorFunction | None = None,
     strict_mode: bool = True,
     is_enabled: bool | Callable[[RunContextWrapper[Any], AgentBase], MaybeAwaitable[bool]] = True,
+    custom_metadata: dict[str, Any] | None = None,
 ) -> FunctionTool:
     """Overload for usage as @function_tool (no parentheses)."""
     ...
@@ -444,6 +445,7 @@ def function_tool(
     failure_error_function: ToolErrorFunction | None = None,
     strict_mode: bool = True,
     is_enabled: bool | Callable[[RunContextWrapper[Any], AgentBase], MaybeAwaitable[bool]] = True,
+    custom_metadata: dict[str, Any] | None = None,
 ) -> Callable[[ToolFunction[...]], FunctionTool]:
     """Overload for usage as @function_tool(...)."""
     ...
@@ -459,6 +461,7 @@ def function_tool(
     failure_error_function: ToolErrorFunction | None = default_tool_error_function,
     strict_mode: bool = True,
     is_enabled: bool | Callable[[RunContextWrapper[Any], AgentBase], MaybeAwaitable[bool]] = True,
+    custom_metadata: dict[str, Any] | None = None,
 ) -> FunctionTool | Callable[[ToolFunction[...]], FunctionTool]:
     """
     Decorator to create a FunctionTool from a function. By default, we will:
@@ -490,6 +493,7 @@ def function_tool(
         is_enabled: Whether the tool is enabled. Can be a bool or a callable that takes the run
             context and agent and returns whether the tool is enabled. Disabled tools are hidden
             from the LLM at runtime.
+    custom_metadata: Optional metadata to attach to the resulting tool instance.
     """
 
     def _create_function_tool(the_func: ToolFunction[...]) -> FunctionTool:
@@ -580,6 +584,7 @@ def function_tool(
             on_invoke_tool=_on_invoke_tool,
             strict_json_schema=strict_mode,
             is_enabled=is_enabled,
+            custom_metadata=custom_metadata,
         )
 
     # If func is actually a callable, we were used as @function_tool with no parentheses

--- a/tests/test_tool_custom_metadata.py
+++ b/tests/test_tool_custom_metadata.py
@@ -17,6 +17,7 @@ from agents.tool import (
     ImageGenerationTool,
     LocalShellCommandRequest,
     LocalShellTool,
+    function_tool,
     Tool,
     WebSearchTool,
 )
@@ -169,6 +170,26 @@ def test_custom_metadata_defaults_to_none(factory: Callable[[bool], Any]) -> Non
 def test_custom_metadata_can_be_provided(factory: Callable[[bool], Any]) -> None:
     tool = factory(True)
     assert tool.custom_metadata == {"key": "value"}
+
+
+def test_function_tool_decorator_allows_custom_metadata() -> None:
+    metadata = {"foo": "bar"}
+
+    @function_tool(custom_metadata=metadata)
+    def _decorated() -> str:
+        return "ok"
+
+    assert _decorated.custom_metadata is metadata
+
+
+def test_function_tool_direct_call_allows_custom_metadata() -> None:
+    metadata = {"alpha": "beta"}
+
+    def _fn() -> str:
+        return "ok"
+
+    tool = function_tool(_fn, custom_metadata=metadata)
+    assert tool.custom_metadata is metadata
 
 
 class _MetadataCapturingHooks(AgentHooks):


### PR DESCRIPTION
This pull request adds support for attaching optional custom metadata to all tool classes in `src/agents/tool.py`. This metadata can be used to store arbitrary information relevant to each tool instance and is accessible during tool execution, including via agent hooks. Comprehensive tests are included to verify default behavior, metadata assignment, and propagation to hooks.

**Why?**:
- Developers can add custom attributes to the defined tools that are custom to their implementation.
- For example in our architecture we define things like DisplayName and Icon in our tools for use in our Frontend. Here's what I'm doing today vs. after this PR is merged.

**Current**
```py
from agents.tool import function_tool
from typing import Optional, Literal, Union, TypeAlias

MarkdownLanguage: TypeAlias = Literal["python","sql","bash","json","markdown","text"]

class ToolMetadata(BaseModel):
    type: str
    default_open: bool = False
    input_language: Union[bool, MarkdownLanguage] = "json"
    output_language: MarkdownLanguage = "text"
    input_parameters: list[str] | None = None
    avatar: Optional[str] = None

    def apply_to_tool(self, tool: Tool, access_token: str | None = None) -> Tool:
        """Apply validated metadata to a tool instance (mutates in place)."""
        if access_token and isinstance(tool, HostedMCPTool):
            tool.tool_config.authorization = access_token
        
        for field_name in self.__class__.model_fields:
            value = getattr(self, field_name)
            if value is not None:
                setattr(tool, field_name, value)
        
        return tool

@function_tool
async def multiply_by_two(x: int) -> int:
    return x * 2

metadata = ToolMetadata(
    display_name="Math Tool",
    family="computation",
    avatar="calculator",
    input_language="python"
)
math_tool = metadata.apply_to_tool(multiply_by_two)
print(f"Configured Tool: {math_tool}")
print(f"Display Name: {math_tool.display_name}")
```

**New**
```py
class ToolMetadata(TypedDict):
    type: str
    default_open: bool = False
    input_language: Union[bool, MarkdownLanguage] = "json"
    output_language: MarkdownLanguage = "text"
    input_parameters: list[str] | None = None
    avatar: Optional[str] = None

metadata = ToolMetadata(
    display_name="Math Tool",
    family="computation",
    avatar="calculator",
    input_language="python"
)

@function_tool(custom_metadata=metadata)
async def multiply_by_two(x: int) -> int:
    return x * 2
```

**Custom metadata support for tools:**

* Added a `custom_metadata` field to all tool classes (`FunctionTool`, `FileSearchTool`, `WebSearchTool`, `ComputerTool`, `HostedMCPTool`, `CodeInterpreterTool`, `ImageGenerationTool`, `LocalShellTool`) in `src/agents/tool.py`, allowing arbitrary metadata to be attached to each tool instance. [[1]](diffhunk://#diff-aba0138fa4cf97145683b5d41be26c21b0416064547df729be66fd762aae8eafR188-R190) [[2]](diffhunk://#diff-aba0138fa4cf97145683b5d41be26c21b0416064547df729be66fd762aae8eafR217-R219) [[3]](diffhunk://#diff-aba0138fa4cf97145683b5d41be26c21b0416064547df729be66fd762aae8eafR240-R242) [[4]](diffhunk://#diff-aba0138fa4cf97145683b5d41be26c21b0416064547df729be66fd762aae8eafR260-R262) [[5]](diffhunk://#diff-aba0138fa4cf97145683b5d41be26c21b0416064547df729be66fd762aae8eafR328-R330) [[6]](diffhunk://#diff-aba0138fa4cf97145683b5d41be26c21b0416064547df729be66fd762aae8eafR343-R345) [[7]](diffhunk://#diff-aba0138fa4cf97145683b5d41be26c21b0416064547df729be66fd762aae8eafR358-R360) [[8]](diffhunk://#diff-aba0138fa4cf97145683b5d41be26c21b0416064547df729be66fd762aae8eafR392-R394)

**Testing and validation:**

* Added `tests/test_tool_custom_metadata.py` with tests to ensure that `custom_metadata` defaults to `None`, can be set, and is available in agent hooks during tool execution.