### PR TITLE
Fix: Remove ID from reasoning items when store is set to False

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1868,7 +1868,7 @@ class AgentRunner:
                 store_setting = item.agent.model_settings.store
                 if store_setting is False and "id" in input_item:
                     # Remove the instance-specific IDs to enable load balancing
-                    input_item = {k: v for k, v in input_item.items() if k != "id"} # type: ignore[assignment]
+                    input_item = {k: v for k, v in input_item.items() if k != "id"}  # type: ignore[assignment]
             new_items_as_input.append(input_item)
 
         # Save all items from this turn


### PR DESCRIPTION
### Summary

Fixes session management for OpenAI Responses API when using Zero Data Retention (`store=False`) with load-balanced instances. Previously, reasoning item IDs were saved to sessions, causing "reasoning item not found" errors when subsequent requests were routed to different OpenAI instances.

**Problem:**
When using the OpenAI Responses API with `store=False` (ZDR mode) and reasoning enabled (`response_include=["reasoning.encrypted_content"]`), the API returns reasoning items with instance-specific IDs (e.g., `rs_07162bf5faaac0660...`). These IDs are temporary references to reasoning content stored in the memory of the specific OpenAI instance that generated them. When the SDK's session management saves these items to persistent storage and replays them in a subsequent request, if that request is load-balanced to a different OpenAI instance, the new instance cannot resolve the ID, resulting in an error.

**Root Cause:**
Even with `store=False`, OpenAI assigns instance-specific IDs to reasoning items. These IDs act as cryptographic references to encrypted reasoning content temporarily held in the memory of the specific instance. The `encrypted_content` field, however, is universally decryptable by any OpenAI instance using shared internal keys.

**Solution:**
Modified `_save_result_to_session()` in `src/agents/run.py` to conditionally strip the `id` field from reasoning items when `store=False` before persisting them to session storage. This ensures that only portable information (the `encrypted_content`) is saved.

The fix:
- Checks if a reasoning item has `store=False` set in the agent's model settings
- Strips the instance-specific `id` field before saving to session
- Preserves the `encrypted_content` field, which is universally decryptable
- Keeps IDs intact when `store=True` or `None` (default), as those reference valid server-side conversation state

### Issue number

Closes #2063 

### User Scenario

**Before Fix:**
```
Turn 1 → Instance A → Returns reasoning{id: rs_A123, encrypted_content: xxx}
         ↓
Session saves both id and encrypted_content
         ↓
Turn 2 → Instance B → Receives id: rs_A123 → ❌ Error: "reasoning item not found"
```

**After Fix:**
```
Turn 1 → Instance A → Returns reasoning{id: rs_A123, encrypted_content: xxx}
         ↓
Session saves ONLY encrypted_content (id stripped)
         ↓
Turn 2 → Instance B → Receives only encrypted_content → ✅ Success: decrypts and continues
```

The chosen approach balances correctness, backward compatibility, and minimal API surface changes.