### PR TITLE
fix: AdvcancedSQLiteSession conversation branching from turn number

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -815,7 +815,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                             ms.tool_name
                         FROM message_structure ms
                         WHERE ms.session_id = ? AND ms.branch_id = ?
-                        AND ms.branch_turn_number < ?
+                        AND ms.branch_turn_number <= ?
                         ORDER BY ms.sequence_number
                     """,
                         (self.session_id, self._current_branch_id, from_turn_number),


### PR DESCRIPTION
- So far if e.g. from_turn_number=3 is passed, only turns 1 and 2 are copied, not 3
- This is unintuitive because the function is called branch_from_turn() and I would expect the passed turn to be copied as well
- It is also limiting in that it doesn't allow branching from the last turn in the conversation (_validate_turn() raises an error if from_turn_number=n+1 is passed in an n-turn conversation, so users would have to hack their way around it by adding a dummy message as n+1st turn in order to copy the first n turns)
- In case we're preventing branching from the latest turn on purpose for some reason please let me know
- if so, what would be the preferred way to fork a conversation from the latest message? (My use case is that I want to produce multiple alternative messages from the same conversation history)