### PR TITLE
Upgrade openai-python to 2.8.0 for GPT 5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.9"
 license = "MIT"
 authors = [{ name = "OpenAI", email = "support@openai.com" }]
 dependencies = [
-    "openai>=2.7.1,<3",
+    "openai>=2.8.0,<3",
     "pydantic>=2.12.3, <3",
     "griffe>=1.5.6, <2",
     "typing-extensions>=4.12.2, <5",

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -377,7 +377,7 @@ class Converter:
         elif tool_choice == "web_search":
             return {
                 # TODO: revist the type: ignore comment when ToolChoice is updated in the future
-                "type": "web_search",  # type: ignore [typeddict-item]
+                "type": "web_search",  # type: ignore[misc, return-value]
             }
         elif tool_choice == "web_search_preview":
             return {
@@ -398,7 +398,7 @@ class Converter:
         elif tool_choice == "mcp":
             # Note that this is still here for backwards compatibility,
             # but migrating to MCPToolChoice is recommended.
-            return {"type": "mcp"}  # type: ignore [typeddict-item]
+            return {"type": "mcp"}  # type: ignore[misc, return-value]
         else:
             return {
                 "type": "function",

--- a/uv.lock
+++ b/uv.lock
@@ -2002,7 +2002,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.7.1"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2014,9 +2014,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/a2/f4023c1e0c868a6a5854955b3374f17153388aed95e835af114a17eac95b/openai-2.7.1.tar.gz", hash = "sha256:df4d4a3622b2df3475ead8eb0fbb3c27fd1c070fa2e55d778ca4f40e0186c726", size = 595933, upload-time = "2025-11-04T06:07:23.069Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/0c/b9321e12f89e236f5e9a46346c30fb801818e22ba33b798a5aca84be895c/openai-2.8.0.tar.gz", hash = "sha256:4851908f6d6fcacbd47ba659c5ac084f7725b752b6bfa1e948b6fbfc111a6bad", size = 602412, upload-time = "2025-11-13T18:15:25.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/74/6bfc3adc81f6c2cea4439f2a734c40e3a420703bbcdc539890096a732bbd/openai-2.7.1-py3-none-any.whl", hash = "sha256:2f2530354d94c59c614645a4662b9dab0a5b881c5cd767a8587398feac0c9021", size = 1008780, upload-time = "2025-11-04T06:07:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e1/0a6560bab7fb7b5a88d35a505b859c6d969cb2fa2681b568eb5d95019dec/openai-2.8.0-py3-none-any.whl", hash = "sha256:ba975e347f6add2fe13529ccb94d54a578280e960765e5224c34b08d7e029ddf", size = 1022692, upload-time = "2025-11-13T18:15:23.621Z" },
 ]
 
 [[package]]
@@ -2105,7 +2105,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.67.4.post1,<2" },
     { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.11.0,<2" },
     { name = "numpy", marker = "python_full_version >= '3.10' and extra == 'voice'", specifier = ">=2.2.0,<3" },
-    { name = "openai", specifier = ">=2.7.1,<3" },
+    { name = "openai", specifier = ">=2.8.0,<3" },
     { name = "pydantic", specifier = ">=2.12.3,<3" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=7" },
     { name = "requests", specifier = ">=2.0,<3" },


### PR DESCRIPTION
This PR upgrades `openai-python` to 2.8.0 for GPT-5.1 support.

Resolved: https://github.com/openai/openai-agents-python/issues/2089 (reasoning effort "none" is now supported in gpt-5.1)

* All tests passed.
* `make mypy` shows different type-checking errors caused by the updated ToolChoice definition in 2.8.0, where the newly added `ToolChoiceApplyPatchParam` and `ToolChoiceShellParam` introduce additional TypedDict variants with the same structure as ToolChoiceTypesParam ([source code](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_create_params.py#L305)), leading to different type-checking behavior.