### PR TITLE
Fix as_tool returning blank string on early tool termination

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -13,7 +13,6 @@ from typing_extensions import NotRequired, TypeAlias, TypedDict
 from .agent_output import AgentOutputSchemaBase
 from .guardrail import InputGuardrail, OutputGuardrail
 from .handoffs import Handoff
-from .items import ItemHelpers
 from .logger import logger
 from .mcp import MCPUtil
 from .model_settings import ModelSettings
@@ -417,7 +416,7 @@ class Agent(AgentBase, Generic[TContext]):
             description_override=tool_description or "",
             is_enabled=is_enabled,
         )
-        async def run_agent(context: RunContextWrapper, input: str) -> str:
+        async def run_agent(context: RunContextWrapper, input: str) -> Any:
             from .run import DEFAULT_MAX_TURNS, Runner
 
             resolved_max_turns = max_turns if max_turns is not None else DEFAULT_MAX_TURNS
@@ -436,7 +435,7 @@ class Agent(AgentBase, Generic[TContext]):
             if custom_output_extractor:
                 return await custom_output_extractor(output)
 
-            return ItemHelpers.text_message_outputs(output.new_items)
+            return output.final_output
 
         return run_agent
 

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -225,30 +225,15 @@ async def test_agent_as_tool_is_enabled_preserves_other_params():
 
 
 @pytest.mark.asyncio
-async def test_agent_as_tool_returns_concatenated_text(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Agent tool should use default text aggregation when no custom extractor is provided."""
+async def test_agent_as_tool_returns_final_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Agent tool should return final_output when no custom extractor is provided."""
 
     agent = Agent(name="storyteller")
-
-    message = ResponseOutputMessage(
-        id="msg_1",
-        role="assistant",
-        status="completed",
-        type="message",
-        content=[
-            ResponseOutputText(
-                annotations=[],
-                text="Hello world",
-                type="output_text",
-                logprobs=[],
-            )
-        ],
-    )
 
     result = type(
         "DummyResult",
         (),
-        {"new_items": [MessageOutputItem(agent=agent, raw_item=message)]},
+        {"final_output": "Hello world"},
     )()
 
     async def fake_run(


### PR DESCRIPTION
Resolved: https://github.com/openai/openai-agents-python/issues/2110

This PR fixes a bug where using `Agent.as_tool` together with `tool_use_behavior` causes the lead agent to receive blank string whenever the tool terminates early.

This issue affects not only the case described in https://github.com/openai/openai-agents-python/issues/2110 (ToolsToFinalOutputResult), but also `stop_on_first_tool` and `StopAtTools`.

## Root Cause

`as_tool` currently returns:

    ItemHelpers.text_message_outputs(output.new_items)

This function only extracts text from `output.new_items`. But when a tool stops early, `new_items` contains no text messages, so the return value becomes an blank string `""`.

## Solution

Return `final_output` instead.  It already handles early tool-return scenarios correctly.

## Behavior Changes

1. `text_message_outputs(output.new_items)` includes the final assistant message and any intermediate preamble assistant messages.

   * Switching to `final_output` removes these preambles. Only final assistant message.
   * I think this is fine and reasonable because:

     1. preamble messages are rare unless explicitly prompted
     2. preambles are intended for human readability during tool-calling explanations, and they unnecessarily consume the lead agent’s context window
     3. when preambles exist and the tool terminates early, `text_message_outputs(output.new_items)` would return the preambles, not actual tool result, which is incorrect anyway.

2. `final_output` may be structured output instead of a plain string.

   * This aligns with the new tool-call behavior, where tool outputs are no longer restricted to text value and can be structured data (i.e. image or files)

## Repro Code

```
from agents import Agent, function_tool, Runner
from agents.agent import ToolsToFinalOutputResult
import random

@function_tool
def generate_random_number_tool() -> int:
    return random.randint(0, 100)


random_number_agent = Agent(
    name="Sub Agent",
    instructions="You are a helpful assistant that generate_random_number_tool",
    model="gpt-5-mini",
    tools=[generate_random_number_tool],
    tool_use_behavior="stop_on_first_tool"
)

main_agent = Agent(
    name="Main Agent",
    instructions="You are a helpful assistant. Must use the random_number_tool to generate a random number. If tool ouput is empty, just say N/A",
    model="gpt-5-mini",
    tools=[random_number_agent.as_tool(tool_name="random_number_tool", tool_description="A tool that generates a random number.")],
)


result = Runner.run_sync(main_agent, "What is the random number?")
print(result.final_output)

```

Before fix: You will get "N/A" instead of a random number