### PR TITLE
docs: clarify handoff() docs, callable not supported

### DIFF
--- a/src/agents/handoffs/__init__.py
+++ b/src/agents/handoffs/__init__.py
@@ -208,7 +208,7 @@ def handoff(
     """Create a handoff from an agent.
 
     Args:
-        agent: The agent to handoff to, or a function that returns an agent.
+        agent: The agent to handoff to.
         tool_name_override: Optional override for the name of the tool that represents the handoff.
         tool_description_override: Optional override for the description of the tool that
             represents the handoff.

--- a/src/agents/realtime/handoffs.py
+++ b/src/agents/realtime/handoffs.py
@@ -74,7 +74,7 @@ def realtime_handoff(
     """Create a handoff from a RealtimeAgent.
 
     Args:
-        agent: The RealtimeAgent to handoff to, or a function that returns a RealtimeAgent.
+        agent: The RealtimeAgent to handoff to.
         tool_name_override: Optional override for the name of the tool that represents the handoff.
         tool_description_override: Optional override for the description of the tool that
             represents the handoff.


### PR DESCRIPTION
Related issue: https://github.com/openai/openai-agents-python/issues/2115

The docs said that `handoff()` can accept a function that returns an agent, but this is not actually supported in the current code.

* The agent type hint does not include Callable.
* The runtime never calls a function to get an agent.
* There is no test that uses a function; all tests use Agent instances only.

This PR updates the docs to match the real behavior.

If callable support is needed, it will require more work and can be added in a separate PR in the future.
