### PR TITLE
 Enable previous_response_id chaining for internal calls on the first turn

### DIFF
--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -143,25 +143,16 @@ from openai import AsyncOpenAI
 client = AsyncOpenAI()
 
 async def main():
-    # Create a server-managed conversation
-    conversation = await client.conversations.create()
-    conv_id = conversation.id    
-
     agent = Agent(name="Assistant", instructions="Reply very concisely.")
 
-    # First turn
-    result1 = await Runner.run(agent, "What city is the Golden Gate Bridge in?", conversation_id=conv_id)
-    print(result1.final_output)
-    # San Francisco
+    # Create a server-managed conversation
+    conversation = await client.conversations.create()
+    conv_id = conversation.id
 
-    # Second turn reuses the same conversation_id
-    result2 = await Runner.run(
-        agent,
-        "What state is it in?",
-        conversation_id=conv_id,
-    )
-    print(result2.final_output)
-    # California
+    while True:
+        user_input = input("You: ")
+        result = await Runner.run(agent, user_input, conversation_id=conv_id)
+        print(f"Assistant: {result.final_output}")
 ```
 
 #### 2. Using `previous_response_id`
@@ -174,21 +165,22 @@ from agents import Agent, Runner
 async def main():
     agent = Agent(name="Assistant", instructions="Reply very concisely.")
 
-    # First turn
-    result1 = await Runner.run(agent, "What city is the Golden Gate Bridge in?")
-    print(result1.final_output)
-    # San Francisco
+    previous_response_id = None
 
-    # Second turn, chained to the previous response
-    result2 = await Runner.run(
-        agent,
-        "What state is it in?",
-        previous_response_id=result1.last_response_id,
-    )
-    print(result2.final_output)
-    # California
+    while True:
+        user_input = input("You: ")
+
+        # Setting auto_previous_response_id=True enables response chaining automatically
+        # for the first turn, even when there's no actual previous response ID yet.
+        result = await Runner.run(
+            agent,
+            user_input,
+            previous_response_id=previous_response_id,
+            auto_previous_response_id=True,
+        )
+        previous_response_id = result.last_response_id
+        print(f"Assistant: {result.final_output}")
 ```
-
 
 ## Long running agents & human-in-the-loop
 


### PR DESCRIPTION
Resolved issue: https://github.com/openai/openai-agents-python/issues/2124

Relative Issue: [https://github.com/openai/openai-agents-python/issues/2020#issuecomment-3567846339](https://github.com/openai/openai-agents-python/issues/2020#issuecomment-3567846339) (reported in a comment)
Relative PR: [https://github.com/openai/openai-agents-python/pull/1827](https://github.com/openai/openai-agents-python/pull/1827)

This PR enables `previous_response_id` chaining during internal function calls inside the first turn, even though no real `previous_response_id` exists yet.

Only the first turn is special-cased; once the first real `response_id` is obtained, all subsequent turns behave normally.

## Background

Currently, `previous_response_id` chaining only enables when a real previous response ID is explicitly provided. This works fine for subsequent turns, but it has a limitation:

For the first turn of a brand-new conversation, there is no existing `previous_response_id`. As a result, there is no way to tell the SDK that internal function calls can use `previous_response_id` chaining.

## Solution

Introduce a special flag value:

```
previous_response_id = "" # or name it as any other string
```

Setting "" makes the internal function calls inside the first turn use proper response chaining.

## Example usage:

```python
previous_response_id = ""

while True:
    user_input = input()
    result = await Runner.run(
        agent,
        user_input, 
        previous_response_id=previous_response_id
    )
    previous_response_id = result.last_response_id
```

## Alternative solution

"" is just one idea. We can rename it to any other string.

If the empty string is undesirable, an explicit parameter could be added:

```python
previous_response_id = None

while True:
    user_input = input()
    result = await Runner.run(
        agent,
        user_input,
        previous_response_id = previous_response_id,
        enable_internal_previous_response_chaining=True,
    )    
    previous_response_id = result.last_response_id
```

However, this introduces an extra API parameter solely for this feature and feels a little verbose.  
I am open to switching to this approach if preferred.
