### PR TITLE
Add message history API to agent run context for hook-driven conversation injections

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -50,6 +50,7 @@ from .handoffs import (
 from .items import (
     HandoffCallItem,
     HandoffOutputItem,
+    InjectedInputItem,
     ItemHelpers,
     MessageOutputItem,
     ModelResponse,
@@ -66,6 +67,7 @@ from .memory import (
     SessionABC,
     SQLiteSession,
 )
+from .message_history import MessageHistory
 from .model_settings import ModelSettings
 from .models.interface import Model, ModelProvider, ModelTracing
 from .models.multi_provider import MultiProvider
@@ -276,6 +278,7 @@ __all__ = [
     "RunItem",
     "HandoffCallItem",
     "HandoffOutputItem",
+    "InjectedInputItem",
     "ToolCallItem",
     "ToolCallOutputItem",
     "ReasoningItem",
@@ -287,6 +290,7 @@ __all__ = [
     "SQLiteSession",
     "OpenAIConversationsSession",
     "RunContextWrapper",
+    "MessageHistory",
     "TContext",
     "RunErrorDetails",
     "RunResult",

--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -154,6 +154,16 @@ class MessageOutputItem(RunItemBase[ResponseOutputMessage]):
 
 
 @dataclass
+class InjectedInputItem(RunItemBase[TResponseInputItem]):
+    """Represents a manually injected input item added via hooks."""
+
+    raw_item: TResponseInputItem
+    """The injected input item that should be treated as part of the conversation."""
+
+    type: Literal["injected_input_item"] = "injected_input_item"
+
+
+@dataclass
 class HandoffCallItem(RunItemBase[ResponseFunctionToolCall]):
     """Represents a tool call for a handoff from one agent to another."""
 
@@ -329,6 +339,7 @@ class MCPApprovalResponseItem(RunItemBase[McpApprovalResponse]):
 
 RunItem: TypeAlias = Union[
     MessageOutputItem,
+    InjectedInputItem,
     HandoffCallItem,
     HandoffOutputItem,
     ToolCallItem,

--- a/src/agents/message_history.py
+++ b/src/agents/message_history.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence as ABCSequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+if TYPE_CHECKING:
+    from .agent import Agent
+    from .items import InjectedInputItem, RunItem, TResponseInputItem
+else:  # pragma: no cover - runtime fallbacks to break import cycles
+    Agent = Any  # type: ignore[assignment]
+    InjectedInputItem = RunItem = TResponseInputItem = Any  # type: ignore[assignment]
+
+
+def _input_to_new_input_list(
+    value: str | TResponseInputItem | ABCSequence[TResponseInputItem],
+) -> list[TResponseInputItem]:
+    from .items import ItemHelpers
+
+    if isinstance(value, str):
+        return ItemHelpers.input_to_new_input_list(value)
+    if isinstance(value, list):
+        return ItemHelpers.input_to_new_input_list(value)
+    if isinstance(value, ABCSequence):
+        sequence_value = cast(Iterable[TResponseInputItem], value)
+        return ItemHelpers.input_to_new_input_list(list(sequence_value))
+    return ItemHelpers.input_to_new_input_list([value])
+
+
+InjectedMessageStage = Literal[
+    "agent_start",
+    "before_llm",
+    "after_llm",
+    "before_tool",
+    "after_tool",
+    "unspecified",
+]
+
+
+@dataclass
+class _StageMarker:
+    stage: InjectedMessageStage
+    call_id: str | None
+
+
+@dataclass
+class InjectedMessageRecord:
+    item: InjectedInputItem
+    stage: InjectedMessageStage
+    call_id: str | None
+    order: int
+
+
+@dataclass
+class MessageHistory:
+    """Tracks the conversation history visible to hooks and allows modifications."""
+
+    _original_input: str | list[TResponseInputItem] | None = None
+    _generated_items: list[RunItem] | None = None
+    _pending_injected_items: list[InjectedMessageRecord] = field(default_factory=list)
+    _next_turn_override: list[TResponseInputItem] | None = None
+    _live_input_buffer: list[TResponseInputItem] | None = field(default=None, repr=False)
+    _stage_markers: list[_StageMarker] = field(default_factory=list, repr=False)
+    _next_order: int = 0
+
+    def set_original_input(self, original_input: str | list[TResponseInputItem]) -> None:
+        """Update the original input reference for the current run."""
+
+        self._original_input = original_input
+
+    def bind_generated_items(self, generated_items: list[RunItem]) -> None:
+        """Bind the list of generated items accumulated so far."""
+
+        self._generated_items = generated_items
+
+    def get_messages(self) -> list[TResponseInputItem]:
+        """Return a snapshot of the current transcript, including pending injections."""
+
+        messages: list[TResponseInputItem] = []
+        if self._original_input is not None:
+            messages.extend(_input_to_new_input_list(self._original_input))
+        if self._generated_items:
+            messages.extend(item.to_input_item() for item in self._generated_items)
+        if self._pending_injected_items:
+            messages.extend(record.item.to_input_item() for record in self._pending_injected_items)
+        return messages
+
+    def add_message(
+        self,
+        *,
+        agent: Agent[Any],
+        message: str | TResponseInputItem | ABCSequence[TResponseInputItem],
+    ) -> None:
+        """Queue one or more messages to be appended to the history."""
+
+        from .items import InjectedInputItem
+
+        new_items = _input_to_new_input_list(message)
+        for item in new_items:
+            normalized = deepcopy(item)
+            injected_item = InjectedInputItem(agent=agent, raw_item=normalized)
+            stage = self._stage_markers[-1].stage if self._stage_markers else "unspecified"
+            call_id = self._stage_markers[-1].call_id if self._stage_markers else None
+            self._pending_injected_items.append(
+                InjectedMessageRecord(
+                    item=injected_item,
+                    stage=stage,
+                    call_id=call_id,
+                    order=self._next_order,
+                )
+            )
+            self._next_order += 1
+            if self._live_input_buffer is not None:
+                self._live_input_buffer.append(deepcopy(normalized))
+
+    def pending_input_items(self) -> list[TResponseInputItem]:
+        """Return pending injected messages as input items without clearing them."""
+
+        return [record.item.to_input_item() for record in self._pending_injected_items]
+
+    def flush_pending_items(self) -> list[InjectedMessageRecord]:
+        """Return and clear pending injected messages with metadata."""
+
+        pending = self._pending_injected_items
+        self._pending_injected_items = []
+        return pending
+
+    def override_next_turn(self, messages: ABCSequence[TResponseInputItem]) -> None:
+        """Replace the next model call's input history with a custom list."""
+
+        override_messages = [deepcopy(message) for message in messages]
+        self._next_turn_override = override_messages
+        if self._live_input_buffer is not None:
+            self._live_input_buffer.clear()
+            self._live_input_buffer.extend(deepcopy(message) for message in override_messages)
+
+    def consume_next_turn_override(self) -> list[TResponseInputItem] | None:
+        """Pop the next turn override if set."""
+
+        if self._next_turn_override is None:
+            return None
+        override = [deepcopy(message) for message in self._next_turn_override]
+        self._next_turn_override = None
+        return override
+
+    def clear(self) -> None:
+        """Reset all pending state."""
+
+        self._pending_injected_items.clear()
+        self._next_turn_override = None
+        self._live_input_buffer = None
+
+    def bind_live_input_buffer(self, buffer: list[TResponseInputItem]) -> None:
+        """Bind the live model input list so hook mutations apply immediately."""
+
+        self._live_input_buffer = buffer
+
+    def release_live_input_buffer(self) -> None:
+        """Stop tracking the live model input once the LLM call completes."""
+
+        self._live_input_buffer = None
+
+    def begin_injection_stage(
+        self, stage: InjectedMessageStage, call_id: str | None = None
+    ) -> _StageMarker:
+        marker = _StageMarker(stage=stage, call_id=call_id)
+        self._stage_markers.append(marker)
+        return marker
+
+    def end_injection_stage(self, marker: _StageMarker | None) -> None:
+        if marker is None:
+            return
+        if not self._stage_markers:
+            return
+        if self._stage_markers and self._stage_markers[-1] is marker:
+            self._stage_markers.pop()
+            return
+        try:
+            self._stage_markers.remove(marker)
+        except ValueError:
+            pass

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -3,6 +3,7 @@ from typing import Any, Generic
 
 from typing_extensions import TypeVar
 
+from .message_history import MessageHistory
 from .usage import Usage
 
 TContext = TypeVar("TContext", default=Any)
@@ -24,3 +25,6 @@ class RunContextWrapper(Generic[TContext]):
     """The usage of the agent run so far. For streamed responses, the usage will be stale until the
     last chunk of the stream is processed.
     """
+
+    message_history: MessageHistory = field(default_factory=MessageHistory)
+    """Mutable conversation history that hooks can inspect and update."""

--- a/tests/test_message_history.py
+++ b/tests/test_message_history.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any, cast
+
+import pytest
+
+from agents import Agent, Runner
+from agents.items import InjectedInputItem, TResponseInputItem
+from agents.lifecycle import AgentHooks, RunHooks
+from agents.run_context import RunContextWrapper
+from agents.stream_events import RunItemStreamEvent
+
+from .fake_model import FakeModel
+from .test_responses import (
+    get_function_tool,
+    get_function_tool_call,
+    get_text_message,
+)
+
+
+class MessageInjectionHooks(RunHooks):
+    def __init__(self, injected_text: str):
+        self.injected_text = injected_text
+
+    async def on_llm_start(
+        self,
+        context: RunContextWrapper[Any],
+        agent: Agent[Any],
+        _instructions: str | None,
+        _input_items: list[TResponseInputItem],
+    ) -> None:
+        context.message_history.add_message(agent=agent, message=self.injected_text)
+
+
+class OrderingAgentHooks(AgentHooks):
+    def __init__(self) -> None:
+        self.agent_start_text = "agent-start"
+        self.before_tool_text = "before-tool"
+        self.after_tool_text = "after-tool"
+
+    async def on_start(self, context: RunContextWrapper[Any], agent: Agent[Any]) -> None:
+        context.message_history.add_message(
+            agent=agent,
+            message={"role": "developer", "content": self.agent_start_text},
+        )
+
+    async def on_tool_start(
+        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
+    ) -> None:
+        context.message_history.add_message(
+            agent=agent,
+            message={"role": "developer", "content": self.before_tool_text},
+        )
+
+    async def on_tool_end(
+        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: Any
+    ) -> None:
+        context.message_history.add_message(
+            agent=agent,
+            message={"role": "developer", "content": self.after_tool_text},
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_hooks_can_inject_messages_into_llm_input() -> None:
+    hooks = MessageInjectionHooks("Moderator: cite your sources.")
+    model = FakeModel()
+    model.set_next_output([get_text_message("done")])
+
+    agent = Agent(name="editor", model=model)
+    result = await Runner.run(agent, input="original prompt", hooks=hooks)
+
+    assert model.last_turn_args["input"] == [
+        {"role": "user", "content": "original prompt"},
+        {"role": "user", "content": hooks.injected_text},
+    ]
+
+    injected_items = [item for item in result.new_items if isinstance(item, InjectedInputItem)]
+    assert injected_items
+
+    first_injected_raw = cast(MutableMapping[str, Any], injected_items[0].raw_item)
+    assert first_injected_raw["content"] == hooks.injected_text
+
+
+@pytest.mark.asyncio
+async def test_streamed_runs_emit_injected_input_items() -> None:
+    hooks = MessageInjectionHooks("Moderator: cite your sources.")
+    model = FakeModel()
+    model.set_next_output([get_text_message("done")])
+
+    agent = Agent(name="editor", model=model)
+    streamed_result = Runner.run_streamed(agent, input="streaming prompt", hooks=hooks)
+
+    events: list[RunItemStreamEvent] = []
+    async for event in streamed_result.stream_events():
+        if isinstance(event, RunItemStreamEvent):
+            events.append(event)
+
+    assert model.last_turn_args["input"] == [
+        {"role": "user", "content": "streaming prompt"},
+        {"role": "user", "content": hooks.injected_text},
+    ]
+
+    injected_items = [
+        item for item in streamed_result.new_items if isinstance(item, InjectedInputItem)
+    ]
+    assert injected_items
+    assert any(isinstance(event.item, InjectedInputItem) for event in events)
+
+
+def _find_index(items: list[TResponseInputItem], predicate) -> int:
+    for idx, item in enumerate(items):
+        if predicate(item):
+            return idx
+    raise AssertionError("predicate did not match any item")
+
+
+@pytest.mark.asyncio
+async def test_injected_messages_preserve_order_around_tool_calls() -> None:
+    tool = get_function_tool(name="helper", return_value="ok")
+    call_id = "call-123"
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call(tool.name, "{}", call_id=call_id)],
+            [get_text_message("done")],
+        ]
+    )
+
+    hooks = OrderingAgentHooks()
+    agent = Agent(name="tester", model=model, tools=[tool], hooks=hooks)
+    result = await Runner.run(agent, input="run")
+
+    transcript = result.to_input_list()
+    agent_start_idx = _find_index(
+        transcript,
+        lambda item: item.get("role") == "developer"
+        and item.get("content") == hooks.agent_start_text,
+    )
+    before_tool_idx = _find_index(
+        transcript,
+        lambda item: item.get("role") == "developer"
+        and item.get("content") == hooks.before_tool_text,
+    )
+    tool_output_idx = _find_index(
+        transcript,
+        lambda item: item.get("type") == "function_call_output" and item.get("call_id") == call_id,
+    )
+    after_tool_idx = _find_index(
+        transcript,
+        lambda item: item.get("role") == "developer"
+        and item.get("content") == hooks.after_tool_text,
+    )
+
+    assert agent_start_idx < before_tool_idx < tool_output_idx < after_tool_idx


### PR DESCRIPTION
## Summary

This PR introduces a `MessageHistory` abstraction on the agent run context so hooks can inspect and modify the effective conversation history seen by the model. Hooks can now inject additional messages, override the next turn’s input, and keep the transcript aligned with tool calls and streaming runs.

## Motivation

Hooks already let users observe the agent lifecycle, but they had no structured way to:

- see the full conversation as the model sees it,
- inject extra messages at precise points (e.g. before/after tools),
- or override the next model call input without rebuilding prompts by hand.

With `MessageHistory`, you can implement patterns such as:

- safety or policy layers that inject moderator / developer guidance,
- UX helpers that tell the LLM how many steps it has left or what phase of a workflow it is in,
- domain assistants that add contextual hints or metadata right before a tool call,
- teaching/tutoring flows that annotate tool results with explanations.

## Changes

- Added `MessageHistory` (`src/agents/message_history.py`):
  - Tracks original input, generated `RunItem`s and pending injected messages.
  - Exposes:
    - `get_messages()` to snapshot the current transcript,
    - `add_message(...)` to queue injected messages as `InjectedInputItem`s,
    - `override_next_turn(...)` to replace the next model call’s input,
    - stage markers around hooks and tools (`agent_start`, `before_llm`, `after_llm`, `before_tool`, `after_tool`).
- Extended `RunContextWrapper` with `message_history`, available in both `RunHooks` and `AgentHooks`.
- Integrated `MessageHistory` into `AgentRunner`:
  - Binds original input and generated items so hooks see the same history as the model.
  - Applies optional next-turn overrides (disallowed when using `conversation_id` / `previous_response_id`).
  - Appends pending injected messages to the model input.
  - Uses stage metadata to insert `InjectedInputItem`s before/after tool calls and around LLM calls.
- Added `InjectedInputItem` to `RunItem` so injected messages show up in `new_items` and streaming events.

## Example

A custom set of hooks can now:

- inject a developer message at agent start (e.g. global policy),
- add guidance before each LLM call (e.g. “only call one shell command at a time”, “you have 3 steps left”),
- add messages before and after each tool call (e.g. explain what the tool is doing or how to interpret its result).

For instance, a `ShellTool` example uses `context.message_history.add_message(...)` in `on_start`, `on_llm_start`, `on_tool_start` and `on_tool_end` to:

- enforce serialized shell usage,
- add instructions on how to create a CSV file,
- and surface all injected developer messages in `result.to_input_list()` alongside tool calls and outputs.

## Tests

- `tests/test_message_history.py`:
  - `test_run_hooks_can_inject_messages_into_llm_input`
  - `test_streamed_runs_emit_injected_input_items`
  - `test_injected_messages_preserve_order_around_tool_calls`

All tests pass with `make tests`.

Usage example:
```python
import asyncio
import os
from pathlib import Path

from agents import (
    Agent,
    AgentHooks,
    ModelSettings,
    Runner,
    RunContextWrapper,
    ShellCallOutcome,
    ShellCommandOutput,
    ShellCommandRequest,
    ShellResult,
    ShellTool,
    trace,
    Tool
)


class CustomAgentHooks(AgentHooks):
    def __init__(self, display_name: str):
        self.event_counter = 0
        self.display_name = display_name

    async def on_start(self, context, agent):
        self.event_counter += 1
        print(f"### ({self.display_name}) {self.event_counter}: Agent {agent.name} started.")
        context.message_history.add_message(
            agent=agent,
            message={
                    "role": "developer",
                    "content": f"This is developer message added at agent start {self.event_counter}.",
            },
        )


    async def on_llm_start(self, context, agent, system_prompt, input_items):
        context.message_history.add_message(
            agent=agent,
            message={
                    "role": "developer",
                    "content": (
                        f"This is developer message added before LLM call {self.event_counter}. "
                        "**Always call only one shell command at a time.** That means call shell for `ls` first, "
                        "wait for the result, then call shell for `date`, wait for the result, and so on. "
                        "YOU MUST FOLLOW THIS RULE STRICTLY!"
                    )
            },
        )

    async def on_llm_end(self, context, agent, response):
        context.message_history.add_message(
            agent=agent,
            message={
                    "role": "developer",
                    "content": f"This is developer message added after LLM call {self.event_counter}.",
            },
        )

    async def on_tool_start(
        self, context: RunContextWrapper, agent: Agent, tool: Tool
    ) -> None:
        self.event_counter += 1
        print(
            f"### ({self.display_name}) {self.event_counter}: Agent {agent.name} started tool {tool.name}"
        )

        context.message_history.add_message(
            agent=agent,
            message={
                    "role": "developer",
                    "content": f"This is developer message added before tool {tool.name} execution.",
            },
        )

    async def on_tool_end(
        self, context: RunContextWrapper, agent: Agent, tool: Tool, result: str
    ) -> None:
        self.event_counter += 1
        print(
            f"### ({self.display_name}) {self.event_counter}: Agent {agent.name} ended tool {tool.name} with result {result}"
        )

        context.message_history.add_message(
            agent=agent,
            message={
                    "role": "developer",
                    "content": (
                        f"This is developer message added after tool {tool.name} execution. "
                        "If the user ask you to create a tiny csv file with some data in it, "
                        "create a csv file with columns 'id' and 'value', and add 3 rows of sample data."
                    )
            },
        )

class ShellExecutor:
    """Executes shell commands with optional approval."""

    def __init__(self, cwd: Path | None = None):
        self.cwd = Path(cwd or Path.cwd())

    async def __call__(self, request: ShellCommandRequest) -> ShellResult:
        action = request.data.action

        outputs: list[ShellCommandOutput] = []
        for command in action.commands:
            proc = await asyncio.create_subprocess_shell(
                command,
                cwd=self.cwd,
                env=os.environ.copy(),
                stdout=asyncio.subprocess.PIPE,
                stderr=asyncio.subprocess.PIPE,
            )
            timed_out = False
            try:
                timeout = (action.timeout_ms or 0) / 1000 or None
                stdout_bytes, stderr_bytes = await asyncio.wait_for(
                    proc.communicate(), timeout=timeout
                )
            except asyncio.TimeoutError:
                proc.kill()
                stdout_bytes, stderr_bytes = await proc.communicate()
                timed_out = True

            stdout = stdout_bytes.decode("utf-8", errors="ignore")
            stderr = stderr_bytes.decode("utf-8", errors="ignore")
            outputs.append(
                ShellCommandOutput(
                    command=command,
                    stdout=stdout,
                    stderr=stderr,
                    outcome=ShellCallOutcome(
                        type="timeout" if timed_out else "exit",
                        exit_code=getattr(proc, "returncode", None),
                    ),
                )
            )

            if timed_out:
                break

        return ShellResult(
            output=outputs,
            provider_data={"working_directory": str(self.cwd)},
        )


with trace("shell_example"):
    agent = Agent(
        name="Shell Assistant",
        model="gpt-5.1",
        instructions=(
            "You can run shell commands using the shell tool. "
            "Keep responses concise and include command output when helpful."
        ),
        tools=[ShellTool(executor=ShellExecutor())],
        model_settings=ModelSettings(
            tool_choice="required",
            parallel_tool_calls=False
        ),
        hooks=CustomAgentHooks(display_name="Test Agent")
    )

    prompt = \
"""First, list files in the current directory using 'ls' command.
Then, show the current date using 'date' command.
After that create python file that creates a tiny csv file with some data in it.
Finally, show the data from the created csv file using 'cat' command. 
Provide results of each command in your response."""

    result = await Runner.run(agent, prompt)
    print(f"\nFinal response:\n{result.final_output}")
```

now result contains:
```
[{'content': "First, list files in the current directory using 'ls' command.\nThen, show the current date using 'date' command.\nAfter that create python file that creates a tiny csv file with some data in it.\nFinally, show the data from the created csv file using 'cat' command. \nProvide results of each command in your response.",
  'role': 'user'},
 {'role': 'developer',
  'content': 'This is developer message added at agent start 1.'},
 {'role': 'developer',
  'content': 'This is developer message added before LLM call 1. **Always call only one shell command at a time.** That means call shell for `ls` first, wait for the result, then call shell for `date`, wait for the result, and so on. YOU MUST FOLLOW THIS RULE STRICTLY!'},
 {'id': 'sh_0a6f7ea4569ac7de006924701d93bc819b8d5547a44df8c727',
  'action': {'commands': ['ls'],
   'max_output_length': 8802,
   'timeout_ms': None},
  'call_id': 'call_tskqGdnNwqunPxK9BRy8NRTP',
  'status': 'completed',
  'type': 'shell_call'},
 {'role': 'developer',
  'content': 'This is developer message added before tool shell execution.'},
 {'type': 'shell_call_output',
  'call_id': 'call_tskqGdnNwqunPxK9BRy8NRTP',
  'output': [{'stdout': 'sandbox.ipynb\n',
    'stderr': '',
    'outcome': {'type': 'exit', 'exit_code': 0}}]},
 {'role': 'developer',
  'content': "This is developer message added after tool shell execution. If the user ask you to create a tiny csv file with some data in it, create a csv file with columns 'id' and 'value', and add 3 rows of sample data."},
 {'role': 'developer',
  'content': 'This is developer message added after LLM call 1.'},
 {'role': 'developer',
  'content': 'This is developer message added before LLM call 3. **Always call only one shell command at a time.** That means call shell for `ls` first, wait for the result, then call shell for `date`, wait for the result, and so on. YOU MUST FOLLOW THIS RULE STRICTLY!'},
 {'id': 'sh_0a6f7ea4569ac7de006924701ef96c819ba49e872f8ff7bc96',
  'action': {'commands': ['date'],
   'max_output_length': 10240,
   'timeout_ms': None},
  'call_id': 'call_xpP3LmBozLhQtClp9HmOVJUm',
  'status': 'completed',
  'type': 'shell_call'},
 {'role': 'developer',
  'content': 'This is developer message added before tool shell execution.'},
 {'type': 'shell_call_output',
  'call_id': 'call_xpP3LmBozLhQtClp9HmOVJUm',
  'output': [{'stdout': 'Mon Nov 24 17:48:00 +03 2025\n',
    'stderr': '',
    'outcome': {'type': 'exit', 'exit_code': 0}}]},
 {'role': 'developer',
  'content': "This is developer message added after tool shell execution. If the user ask you to create a tiny csv file with some data in it, create a csv file with columns 'id' and 'value', and add 3 rows of sample data."},
 {'role': 'developer',
  'content': 'This is developer message added after LLM call 3.'},
 {'role': 'developer',
  'content': 'This is developer message added before LLM call 5. **Always call only one shell command at a time.** That means call shell for `ls` first, wait for the result, then call shell for `date`, wait for the result, and so on. YOU MUST FOLLOW THIS RULE STRICTLY!'},
 {'id': 'sh_0a6f7ea4569ac7de006924702223d0819bb1aeb94202d41b7c',
  'action': {'commands': ['python - << \'EOF\'\nimport csv\n\nfilename = \'data.csv\'\n\nrows = [\n    {\'id\': 1, \'value\': \'alpha\'},\n    {\'id\': 2, \'value\': \'beta\'},\n    {\'id\': 3, \'value\': \'gamma\'},\n]\n\nwith open(filename, \'w\', newline=\'\') as csvfile:\n    writer = csv.DictWriter(csvfile, fieldnames=[\'id\', \'value\'])\n    writer.writeheader()\n    writer.writerows(rows)\n\nprint(f"Created {filename} with sample data.")\nEOF'],
   'max_output_length': 10240,
   'timeout_ms': None},
  'call_id': 'call_jbIEb3453E4CAFrFwdYDxkSd',
  'status': 'completed',
  'type': 'shell_call'},
 {'role': 'developer',
  'content': 'This is developer message added before tool shell execution.'},
 {'type': 'shell_call_output',
  'call_id': 'call_jbIEb3453E4CAFrFwdYDxkSd',
  'output': [{'stdout': 'Created data.csv with sample data.\n',
    'stderr': '',
    'outcome': {'type': 'exit', 'exit_code': 0}}]},
 {'role': 'developer',
  'content': "This is developer message added after tool shell execution. If the user ask you to create a tiny csv file with some data in it, create a csv file with columns 'id' and 'value', and add 3 rows of sample data."},
 {'role': 'developer',
  'content': 'This is developer message added after LLM call 5.'},
 {'role': 'developer',
  'content': 'This is developer message added before LLM call 7. **Always call only one shell command at a time.** That means call shell for `ls` first, wait for the result, then call shell for `date`, wait for the result, and so on. YOU MUST FOLLOW THIS RULE STRICTLY!'},
 {'id': 'sh_0a6f7ea4569ac7de00692470246b3c819ba5fff00211b35d52',
  'action': {'commands': ['cat data.csv'],
   'max_output_length': 10240,
   'timeout_ms': None},
  'call_id': 'call_kAjmrvuXvuK6tHtz4TLIxun7',
  'status': 'completed',
  'type': 'shell_call'},
 {'role': 'developer',
  'content': 'This is developer message added before tool shell execution.'},
 {'type': 'shell_call_output',
  'call_id': 'call_kAjmrvuXvuK6tHtz4TLIxun7',
  'output': [{'stdout': 'id,value\r\n1,alpha\r\n2,beta\r\n3,gamma\r\n',
    'stderr': '',
    'outcome': {'type': 'exit', 'exit_code': 0}}]},
 {'role': 'developer',
  'content': "This is developer message added after tool shell execution. If the user ask you to create a tiny csv file with some data in it, create a csv file with columns 'id' and 'value', and add 3 rows of sample data."},
 {'role': 'developer',
  'content': 'This is developer message added after LLM call 7.'},
 {'role': 'developer',
  'content': 'This is developer message added before LLM call 9. **Always call only one shell command at a time.** That means call shell for `ls` first, wait for the result, then call shell for `date`, wait for the result, and so on. YOU MUST FOLLOW THIS RULE STRICTLY!'},
 {'id': 'msg_0a6f7ea4569ac7de0069247025b014819bbb4eaf0bc556cbef',
  'content': [{'annotations': [],
    'text': 'Here are the results of each step:\n\n1. `ls`\n   ```\n   sandbox.ipynb\n   ```\n\n2. `date`\n   ```\n   Mon Nov 24 17:48:00 +03 2025\n   ```\n\n3. Python script that creates the CSV file (executed via shell):\n   ```python\n   import csv\n\n   filename = \'data.csv\'\n\n   rows = [\n       {\'id\': 1, \'value\': \'alpha\'},\n       {\'id\': 2, \'value\': \'beta\'},\n       {\'id\': 3, \'value\': \'gamma\'},\n   ]\n\n   with open(filename, \'w\', newline=\'\') as csvfile:\n       writer = csv.DictWriter(csvfile, fieldnames=[\'id\', \'value\'])\n       writer.writeheader()\n       writer.writerows(rows)\n\n   print(f"Created {filename} with sample data.")\n   ```\n   Command output:\n   ```\n   Created data.csv with sample data.\n   ```\n\n4. `cat data.csv`\n   ```\n   id,value\n   1,alpha\n   2,beta\n   3,gamma\n   ```',
    'type': 'output_text',
    'logprobs': []}],
  'role': 'assistant',
  'status': 'completed',
  'type': 'message'},
 {'role': 'developer',
  'content': 'This is developer message added after LLM call 9.'}]
```