### PR TITLE
feat: add custom stream events support for tool functions

### DIFF
--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Generic
+from typing import Any, Awaitable, Callable, Generic, Mapping, Optional
 
 from typing_extensions import TypeVar
 
@@ -24,3 +24,25 @@ class RunContextWrapper(Generic[TContext]):
     """The usage of the agent run so far. For streamed responses, the usage will be stale until the
     last chunk of the stream is processed.
     """
+
+    # Internal emitter for streaming custom tool events; set by the Runner in streaming mode.
+    _emit_fn: Optional[Callable[[Any], Awaitable[None]]] = field(default=None, repr=False)
+    # Current agent reference for constructing RunItem wrappers; set by the Runner.
+    _current_agent: Any = field(default=None, repr=False)
+
+    async def emit_event(self, event: Mapping[str, Any]) -> None:
+        """
+        Emit a developer-defined event dict via the run's main stream.
+        The dict should include at least a 'type' key. The event will be forwarded
+        as a RunItemStreamEvent(name='tool_event', item.raw_item=event).
+
+        No-op if not in streaming mode.
+        """
+        if not self._emit_fn or not isinstance(event, Mapping) or not event.get("type"):
+            return
+        # Lazy import to avoid circular dependencies at module import time
+        from .items import ToolCallItem
+        from .stream_events import RunItemStreamEvent
+
+        item = ToolCallItem(raw_item=dict(event), agent=self._current_agent)
+        await self._emit_fn(RunItemStreamEvent(name="tool_event", item=item))

--- a/src/agents/stream_events.py
+++ b/src/agents/stream_events.py
@@ -39,6 +39,8 @@ class RunItemStreamEvent:
         "mcp_approval_requested",
         "mcp_approval_response",
         "mcp_list_tools",
+        # Custom tool events emitted by tools via RunContextWrapper.emit_event
+        "tool_event",
     ]
     """The name of the event."""
 


### PR DESCRIPTION
This adds support to add custom streaming events from within tool functions to e.g. send progress update messages for long running tools without breaking changes.

- No behavior change for existing tools; the new emit_event() method is opt-in.
- Non-streamed runs simply no-op emit_event (no emitter is set).
- Minimal surface change; no new stream types introduced.

This addition solves issue #1333 and could be used for #692 and  #661 

### Changes:

- src/agents/stream_events.py
  - Extended RunItemStreamEvent.name to accept "tool_event" so we can reuse RunItemStreamEvent without new types.
- src/agents/run_context.py
  - Added an internal emitter and current agent fields to RunContextWrapper:
  - Added async def emit_event(self, event: Mapping[str, Any]) -> None:
- src/agents/run.py
    - After creating RunResultStreaming and context_wrapper, wired an async _emit that enqueues to
    - Kept context_wrapper._current_agent updated each turn.

### How to use (inside tools):

1. In any tool function (receives ToolContext, which inherits RunContextWrapper), you can now do:

```python
await ctx.emit_event({"type": "data-my_tool.step", "data": {"message": "Working..."}})
```

2. The event flows through the SDK’s stream as a RunItemStreamEvent with name "tool_event" and item.raw_item. You can than forward that event as is to your stream consumer.

3. From your stream consumer re-yield these events:

```python
result = Runner.run_streamed(...)
async for event in result.stream_events():
    if event.type == "run_item_stream_event" and event.name == "tool_event":
        yield event.item.raw_item
```