### PR TITLE
fix: ensure chatgpt.openOnStartup setting is included in VSCode configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "chatgpt.openOnStartup": false
 }


### PR DESCRIPTION
### Summary

<!-- Please give a short summary of the change and the problem this solves. -->

### Test plan

<!-- Please explain how this was tested -->

### Issue number

<!-- For example: "Closes #1234" -->

### Checks

- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [ ] I've made sure tests pass
