### PR TITLE
feat(app): add AdGen AI Platform scaffold, file uploads & campaign flow

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,43 @@
+# AdGen AI Platform — Internal Next.js App
+
+This folder contains a Next.js (App Router) + TypeScript + Tailwind CSS scaffold for the AdGen AI Platform. The app is intentionally UI-only at the moment — no business logic or external integrations exist yet.
+
+What was added:
+
+- App Router structure in `app/` with the full campaign flow: `campaigns/create`, `campaigns/[id]/formats`, `variations`, `select-variation`, `final`, and `view`.
+- Placeholder API route handlers under `app/api` (empty for now).
+- UI components in `components/` and types and DB schema placeholders in `lib/`.
+
+API endpoints (local file-backed, placeholders for real integrations):
+
+- POST /api/campaigns — create a campaign record. Body: { name, client }
+- POST /api/upload/logo — multipart/form-data: campaignId, file (single)
+- POST /api/upload/image — multipart/form-data: campaignId, file (single)
+- DELETE /api/upload/logo?id=ASSET_ID — delete logo asset and file
+- DELETE /api/upload/image?id=ASSET_ID — delete image asset and file
+
+Files are saved under app/public/uploads/campaigns/{campaignId}/logo and /images.
+
+Example (create campaign):
+
+```
+curl -X POST -H "Content-Type: application/json" -d '{"name":"My Campaign","client":"ACME"}' localhost:3000/api/campaigns
+```
+
+Example (upload):
+
+```
+curl -X POST -F "campaignId=<id>" -F "file=@./logo.png" localhost:3000/api/upload/logo
+```
+
+How to run locally (from inside this folder):
+
+```bash
+# install dependencies
+npm install
+
+# run dev
+npm run dev
+```
+
+Note: Depending on your host repo you might want to run this app in its own container or inside a monorepo workspace. This is an internal scaffold and intentionally contains no secrets or integrations.

--- a/app/app/api/campaigns/[id]/route.ts
+++ b/app/app/api/campaigns/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import { findCampaignById, findAssetsByCampaignId, updateCampaign } from '../../../../lib/db'
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const id = params.id
+  const campaign = findCampaignById(id)
+  if (!campaign) return NextResponse.json({ success: false, error: 'not found' }, { status: 404 })
+  const assets = findAssetsByCampaignId(id)
+  return NextResponse.json({ success: true, campaign, assets })
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const id = params.id
+  const payload = await req.json().catch(() => ({}))
+
+  // Allow updating name, client, status, formats
+  const allowed: any = {}
+  if (typeof payload.name === 'string') allowed.name = payload.name
+  if (typeof payload.client === 'string') allowed.client = payload.client
+  if (typeof payload.status === 'string') allowed.status = payload.status
+  if (Array.isArray(payload.formats)) allowed.formats = payload.formats
+
+  const updated = updateCampaign(id, allowed)
+  if (!updated) return NextResponse.json({ success: false, error: 'not found' }, { status: 404 })
+  return NextResponse.json({ success: true, campaign: updated })
+}

--- a/app/app/api/campaigns/[id]/variations/route.ts
+++ b/app/app/api/campaigns/[id]/variations/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { findCampaignById, findVariationsByCampaignId, insertVariation } from '../../../../../lib/db'
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const id = params.id
+  const campaign = findCampaignById(id)
+  if (!campaign) return NextResponse.json({ success: false, error: 'campaign not found' }, { status: 404 })
+  const variations = findVariationsByCampaignId(id)
+  return NextResponse.json({ success: true, variations })
+}
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const id = params.id
+  const campaign = findCampaignById(id)
+  if (!campaign) return NextResponse.json({ success: false, error: 'campaign not found' }, { status: 404 })
+
+  const payload = await req.json().catch(() => ({}))
+  const name = payload.name || `Variation ${new Date().toISOString()}`
+
+  const vId = crypto.randomUUID()
+  const previewUrl = payload.previewUrl || null
+  insertVariation({ id: vId, campaignId: id, name, previewUrl: previewUrl || undefined, created_at: new Date().toISOString() })
+
+  return NextResponse.json({ success: true, variation: { id: vId, campaignId: id, name, previewUrl } })
+}

--- a/app/app/api/campaigns/route.ts
+++ b/app/app/api/campaigns/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { insertCampaign } from '../../../lib/db'
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}))
+  const { name, client } = body
+  if (!name) {
+    return NextResponse.json({ success: false, error: 'Missing campaign name' }, { status: 400 })
+  }
+
+  const id = crypto.randomUUID()
+  const created_at = new Date().toISOString()
+
+  insertCampaign({ id, name, client, status: 'draft', created_at })
+
+  return NextResponse.json({ success: true, campaignId: id })
+}

--- a/app/app/api/generate-campaign/route.ts
+++ b/app/app/api/generate-campaign/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Placeholder API endpoint for generating a complete campaign.
+ * Expected to accept a request that defines campaign specs and returns a job handle.
+ */
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}))
+
+  // No integration here yet — return a fixed placeholder
+  return NextResponse.json({
+    status: 'accepted',
+    message: 'Campaign generation request accepted (placeholder).',
+    received: body,
+    campaignId: 'camp_placeholder_123'
+  })
+}

--- a/app/app/api/generate-variations/route.ts
+++ b/app/app/api/generate-variations/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Placeholder API endpoint for generating variations.
+ * In the future this will enqueue a job and call out to external n8n workflows, return a job id and status.
+ * For now it returns a stubbed response showing the expected contract.
+ */
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}))
+
+  // This is intentionally a placeholder
+  return NextResponse.json({
+    status: 'queued',
+    message: 'Variation generation request received (placeholder).',
+    received: body,
+    jobId: 'job_placeholder_123'
+  })
+}

--- a/app/app/api/upload/image/route.ts
+++ b/app/app/api/upload/image/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { insertAsset, deleteAssetById, findCampaignById } from '../../../../lib/db'
+import { saveFile, deleteFile } from '../../../../lib/storage'
+
+const MAX_BYTES = 20 * 1024 * 1024 // 20MB
+const ALLOWED = ['.png', '.jpg', '.jpeg', '.webp', '.svg']
+
+function extFromFilename(name: string) {
+  const idx = name.lastIndexOf('.')
+  return idx === -1 ? '' : name.slice(idx).toLowerCase()
+}
+
+export async function POST(req: Request) {
+  const fd = await req.formData()
+  const campaignId = fd.get('campaignId')?.toString() || ''
+  const file = fd.get('file') as File | null
+
+  if (!campaignId) return NextResponse.json({ success: false, error: 'campaignId required' }, { status: 400 })
+  const campaign = findCampaignById(campaignId)
+  if (!campaign) return NextResponse.json({ success: false, error: 'campaign not found' }, { status: 404 })
+
+  if (!file) return NextResponse.json({ success: false, error: 'file required' }, { status: 400 })
+
+  const filename = (file as any).name || 'upload'
+  const ext = extFromFilename(filename)
+  if (!ALLOWED.includes(ext)) return NextResponse.json({ success: false, error: 'file type not allowed' }, { status: 400 })
+
+  const buffer = Buffer.from(await (file as File).arrayBuffer())
+  if (buffer.byteLength > MAX_BYTES) return NextResponse.json({ success: false, error: 'file too large' }, { status: 400 })
+
+  const unique = `${crypto.randomUUID()}${ext}`
+  const url = saveFile(buffer, campaignId, 'image', unique)
+
+  const assetId = crypto.randomUUID()
+  insertAsset({ id: assetId, campaignId, type: 'image', file_url: url, file_type: ext, created_at: new Date().toISOString() })
+
+  return NextResponse.json({ success: true, file_url: url, asset_id: assetId })
+}
+
+export async function DELETE(req: Request) {
+  const url = new URL(req.url)
+  const id = url.searchParams.get('id')
+  if (!id) return NextResponse.json({ success: false, error: 'id required' }, { status: 400 })
+
+  const asset = deleteAssetById(id)
+  if (!asset) return NextResponse.json({ success: false, error: 'asset not found' }, { status: 404 })
+
+  // delete file
+  const fileName = asset.file_url.split('/').pop() || ''
+  deleteFile(asset.campaignId, 'image', fileName)
+
+  return NextResponse.json({ success: true })
+}

--- a/app/app/api/upload/logo/route.ts
+++ b/app/app/api/upload/logo/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { insertAsset, deleteAssetById, findCampaignById } from '../../../../lib/db'
+import { saveFile, deleteFile } from '../../../../lib/storage'
+
+const MAX_BYTES = 20 * 1024 * 1024 // 20MB
+const ALLOWED = ['.png', '.jpg', '.jpeg', '.webp', '.svg']
+
+function extFromFilename(name: string) {
+  const idx = name.lastIndexOf('.')
+  return idx === -1 ? '' : name.slice(idx).toLowerCase()
+}
+
+export async function POST(req: Request) {
+  const fd = await req.formData()
+  const campaignId = fd.get('campaignId')?.toString() || ''
+  const file = fd.get('file') as File | null
+
+  if (!campaignId) return NextResponse.json({ success: false, error: 'campaignId required' }, { status: 400 })
+  const campaign = findCampaignById(campaignId)
+  if (!campaign) return NextResponse.json({ success: false, error: 'campaign not found' }, { status: 404 })
+
+  if (!file) return NextResponse.json({ success: false, error: 'file required' }, { status: 400 })
+
+  const filename = (file as any).name || 'upload'
+  const ext = extFromFilename(filename)
+  if (!ALLOWED.includes(ext)) return NextResponse.json({ success: false, error: 'file type not allowed' }, { status: 400 })
+
+  const buffer = Buffer.from(await (file as File).arrayBuffer())
+  if (buffer.byteLength > MAX_BYTES) return NextResponse.json({ success: false, error: 'file too large' }, { status: 400 })
+
+  const unique = `${crypto.randomUUID()}${ext}`
+  const url = saveFile(buffer, campaignId, 'logo', unique)
+
+  const assetId = crypto.randomUUID()
+  insertAsset({ id: assetId, campaignId, type: 'logo', file_url: url, file_type: ext, created_at: new Date().toISOString() })
+
+  return NextResponse.json({ success: true, file_url: url, asset_id: assetId })
+}
+
+export async function DELETE(req: Request) {
+  const url = new URL(req.url)
+  const id = url.searchParams.get('id')
+  if (!id) return NextResponse.json({ success: false, error: 'id required' }, { status: 400 })
+
+  const asset = deleteAssetById(id)
+  if (!asset) return NextResponse.json({ success: false, error: 'asset not found' }, { status: 404 })
+
+  // delete file
+  const fileName = asset.file_url.split('/').pop() || ''
+  deleteFile(asset.campaignId, 'logo', fileName)
+
+  return NextResponse.json({ success: true })
+}

--- a/app/app/api/variations/[id]/route.ts
+++ b/app/app/api/variations/[id]/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { deleteVariationById } from '../../../../lib/db'
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const id = params.id
+  const deleted = deleteVariationById(id)
+  if (!deleted) return NextResponse.json({ success: false, error: 'not found' }, { status: 404 })
+  return NextResponse.json({ success: true })
+}

--- a/app/app/campaigns/[id]/final/page.tsx
+++ b/app/app/campaigns/[id]/final/page.tsx
@@ -1,0 +1,16 @@
+export default function FinalizePage({ params }: { params: { id: string } }) {
+  return (
+    <div>
+      <div className="mb-4 text-sm text-slate-500">Finalize specs and confirm your campaign. This step will later trigger orchestration to downstream systems.</div>
+
+      <div className="border rounded p-4">
+        <div className="font-semibold">Deliverables</div>
+        <ul className="text-sm text-slate-700 mt-2 list-disc pl-5">
+          <li>OOH banner sizes</li>
+          <li>Social static + video</li>
+          <li>Print ready PDFs</li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/app/app/campaigns/[id]/formats/page.tsx
+++ b/app/app/campaigns/[id]/formats/page.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import React, { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+const ALL_FORMATS = [
+  { id: 'ooh', label: 'OOH', description: 'Outdoor, billboards and transit.' },
+  { id: 'social', label: 'Social', description: 'Static and short video specs.' },
+  { id: 'print', label: 'Print', description: 'Magazines and posters.' },
+  { id: 'dooh', label: 'DOOH', description: 'Digital out-of-home specific formats.' },
+]
+
+export default function FormatsPage({ params }: { params: { id: string } }) {
+  const id = params.id
+  const [loading, setLoading] = useState(true)
+  const [campaign, setCampaign] = useState<any | null>(null)
+  const [assets, setAssets] = useState<any[]>([])
+  const [selected, setSelected] = useState<string[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+    fetch(`/api/campaigns/${id}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (!json?.success) throw new Error(json?.error || 'fetch failed')
+        setCampaign(json.campaign)
+        setAssets(json.assets || [])
+        setSelected(json.campaign?.formats || [])
+      })
+      .catch((e: any) => setError(e?.message || String(e)))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  function toggleFormat(key: string) {
+    setSelected((s) => (s.includes(key) ? s.filter((x) => x !== key) : [...s, key]))
+  }
+
+  async function save() {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/campaigns/${id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ formats: selected }) })
+      const json = await res.json()
+      if (!json?.success) throw new Error(json?.error || 'save failed')
+      setCampaign(json.campaign)
+    } catch (e: any) {
+      setError(e?.message || String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const logo = assets.find((a) => a.type === 'logo')
+  const images = assets.filter((a) => a.type === 'image')
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-sm text-slate-500">Choose the creative formats this campaign should generate.</div>
+          <div className="text-xs text-slate-400 mt-1">Campaign: <span className="font-medium">{campaign?.name || id}</span></div>
+        </div>
+        <div className="text-sm">
+          <Link href={`/campaigns/${id}/variations`} className={`px-3 py-2 border rounded ${selected.length === 0 ? 'opacity-50 pointer-events-none' : 'bg-indigo-600 text-white'}`}>Next: Variations</Link>
+        </div>
+      </div>
+
+      {loading && <div className="text-sm text-slate-500">Loading campaign…</div>}
+      {error && <div className="text-sm text-red-600">{error}</div>}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="col-span-2">
+          <div className="bg-white p-4 rounded border">
+            <div className="mb-3 font-semibold">Select formats</div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {ALL_FORMATS.map((f) => (
+                <label key={f.id} className={`border rounded p-3 flex items-start gap-3 ${selected.includes(f.id) ? 'ring-2 ring-indigo-200' : ''}`}>
+                  <input type="checkbox" checked={selected.includes(f.id)} onChange={() => toggleFormat(f.id)} />
+                  <div>
+                    <div className="font-semibold">{f.label}</div>
+                    <div className="text-xs text-slate-500">{f.description}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+
+            <div className="mt-4 flex items-center gap-3 justify-end">
+              <button onClick={save} className={`px-3 py-2 rounded border ${saving ? 'opacity-50 pointer-events-none' : 'bg-indigo-600 text-white'}`}>Save</button>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="bg-white p-4 rounded border">
+            <div className="font-semibold mb-2">Uploaded assets</div>
+            {logo ? (
+              <div className="mb-4">
+                <div className="text-xs text-slate-500">Logo</div>
+                <div className="mt-2 border rounded p-2 flex items-center justify-center bg-slate-50">
+                  <img src={logo.file_url} alt="logo" style={{ maxHeight: 140 }} />
+                </div>
+              </div>
+            ) : (
+              <div className="text-xs text-slate-400 mb-4">No logo uploaded</div>
+            )}
+
+            <div>
+              <div className="text-xs text-slate-500">Images</div>
+              {images.length === 0 ? (
+                <div className="mt-2 text-xs text-slate-400">No images uploaded</div>
+              ) : (
+                <div className="mt-2 grid grid-cols-2 gap-2">
+                  {images.map((a) => (
+                    <div key={a.id} className="border rounded p-1 flex items-center justify-center">
+                      <img src={a.file_url} alt="img" style={{ width: '100%', height: 80, objectFit: 'cover' }} />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/app/campaigns/[id]/layout.tsx
+++ b/app/app/campaigns/[id]/layout.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import Link from 'next/link'
+
+export default function CampaignLayout({ children, params }: { children: React.ReactNode; params: { id: string } }) {
+  const { id } = params
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="bg-white shadow rounded-md p-6">
+        <div className="flex items-start justify-between gap-6">
+          <div>
+            <div className="text-sm text-slate-500">Campaign</div>
+            <div className="text-lg font-semibold">{id} — Campaign workflow</div>
+          </div>
+          <div className="flex items-center gap-3 text-sm text-slate-600">
+            <Link href={`/campaigns/${id}/formats`} className="px-3 py-2 border rounded">Formats</Link>
+            <Link href={`/campaigns/${id}/variations`} className="px-3 py-2 border rounded">Variations</Link>
+            <Link href={`/campaigns/${id}/final`} className="px-3 py-2 border rounded">Finalize</Link>
+            <Link href={`/campaigns/${id}/view`} className="px-3 py-2 bg-indigo-600 text-white rounded">View</Link>
+          </div>
+        </div>
+
+        <div className="mt-6">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/app/app/campaigns/[id]/page.tsx
+++ b/app/app/campaigns/[id]/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function CampaignRoot({ params }: { params: { id: string } }) {
+  return (
+    <div>
+      <div className="p-4 border rounded text-sm text-slate-700">Start your campaign workflow. Use the navigation buttons to move between steps.</div>
+
+      <div className="mt-4 flex gap-3">
+        <Link href={`/campaigns/${params.id}/formats`} className="px-3 py-2 bg-indigo-600 text-white rounded">Choose formats</Link>
+        <Link href={`/campaigns/${params.id}/variations`} className="px-3 py-2 border rounded">Create variations</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/app/campaigns/[id]/select-variation/page.tsx
+++ b/app/app/campaigns/[id]/select-variation/page.tsx
@@ -1,0 +1,12 @@
+export default function SelectVariation({ params }: { params: { id: string } }) {
+  return (
+    <div>
+      <div className="text-sm text-slate-500">Select the best variation(s) from the generated pool.</div>
+
+      <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="border rounded p-4">Variation A (preview)</div>
+        <div className="border rounded p-4">Variation B (preview)</div>
+      </div>
+    </div>
+  )
+}

--- a/app/app/campaigns/[id]/variations/page.tsx
+++ b/app/app/campaigns/[id]/variations/page.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import React, { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+export default function VariationsPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const [loading, setLoading] = useState(true)
+  const [campaign, setCampaign] = useState<any | null>(null)
+  const [assets, setAssets] = useState<any[]>([])
+  const [variations, setVariations] = useState<any[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    Promise.all([
+      fetch(`/api/campaigns/${id}`).then((r) => r.json()),
+      fetch(`/api/campaigns/${id}/variations`).then((r) => r.json()),
+    ])
+      .then(([cresp, vres]) => {
+        if (!cresp?.success) throw new Error(cresp?.error || 'failed to fetch campaign')
+        if (!vres?.success) throw new Error(vres?.error || 'failed to fetch variations')
+        setCampaign(cresp.campaign)
+        setAssets(cresp.assets || [])
+        setVariations(vres.variations || [])
+      })
+      .catch((e: any) => setError(e?.message || String(e)))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  async function createVariation() {
+    setError(null)
+    if (!campaign) return setError('campaign not loaded')
+    setCreating(true)
+    try {
+      // For now, create a placeholder variation that picks first image as preview if any
+      const preview = assets[0]?.file_url || null
+      const res = await fetch(`/api/campaigns/${id}/variations`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: `Var ${new Date().toLocaleString()}`, previewUrl: preview }) })
+      const json = await res.json()
+      if (!json?.success) throw new Error(json?.error || 'create failed')
+      setVariations((s) => [json.variation, ...s])
+    } catch (e: any) {
+      setError(e?.message || String(e))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function removeVariation(idToDelete: string) {
+    setError(null)
+    try {
+      const res = await fetch(`/api/variations/${idToDelete}`, { method: 'DELETE' })
+      const json = await res.json()
+      if (!json?.success) throw new Error(json?.error || 'delete failed')
+      setVariations((s) => s.filter((v) => v.id !== idToDelete))
+    } catch (e: any) {
+      setError(e?.message || String(e))
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-sm text-slate-500">Create variations for different audiences, sizes and channels.</div>
+          <div className="text-xs text-slate-400 mt-1">Campaign: <span className="font-medium">{campaign?.name || id}</span></div>
+        </div>
+        <div className="flex items-center gap-3 text-sm">
+          <Link href={`/campaigns/${id}/formats`} className="px-3 py-2 border rounded">Back: Formats</Link>
+          <Link href={`/campaigns/${id}/select-variation`} className={`px-3 py-2 border rounded ${variations.length === 0 ? 'opacity-50 pointer-events-none' : 'bg-indigo-600 text-white'}`}>Next: Select variation</Link>
+        </div>
+      </div>
+
+      {loading && <div className="text-sm text-slate-500">Loading…</div>}
+      {error && <div className="text-sm text-red-600">{error}</div>}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="col-span-2">
+          <div className="bg-white p-4 rounded border">
+            <div className="flex items-center justify-between">
+              <div className="font-semibold">Variations</div>
+              <div className="text-sm">
+                <button onClick={createVariation} className={`px-3 py-1 rounded border ${creating ? 'opacity-50 pointer-events-none' : 'bg-indigo-600 text-white'}`}>{creating ? 'Creating…' : 'Create Variation (placeholder)'}</button>
+              </div>
+            </div>
+
+            {variations.length === 0 ? (
+              <div className="mt-6 text-sm text-slate-400">No variations yet. Click create to add a placeholder variation.</div>
+            ) : (
+              <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {variations.map((v) => (
+                  <div key={v.id} className="border rounded p-3 bg-white">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="font-semibold">{v.name}</div>
+                        <div className="text-xs text-slate-400">{new Date(v.created_at).toLocaleString()}</div>
+                      </div>
+                      <div className="flex items-center gap-2 text-sm">
+                        <button onClick={() => removeVariation(v.id)} className="text-xs text-red-600 border px-2 py-1 rounded">Delete</button>
+                      </div>
+                    </div>
+
+                    {v.previewUrl ? (
+                      <div className="mt-3 border rounded p-2 flex items-center justify-center bg-slate-50">
+                        <img src={v.previewUrl} alt={v.name} style={{ maxHeight: 140 }} />
+                      </div>
+                    ) : (
+                      <div className="mt-3 text-xs text-slate-400">No preview available</div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <div className="bg-white p-4 rounded border">
+            <div className="font-semibold mb-2">Campaign assets</div>
+            <div className="text-xs text-slate-500 mb-2">These assets were uploaded for this campaign and can be used as previews for generated variations.</div>
+
+            <div className="space-y-3">
+              {assets.length === 0 && <div className="text-xs text-slate-400">No uploaded assets</div>}
+              {assets.map((a) => (
+                <div key={a.id} className="border p-2 rounded flex items-center gap-3">
+                  <div style={{ width: 56, height: 56, overflow: 'hidden' }} className="bg-slate-50 rounded">
+                    <img src={a.file_url} alt={a.file_url} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                  </div>
+                  <div className="text-xs text-slate-600">{a.type.toUpperCase()} • {a.file_type}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/app/campaigns/[id]/view/page.tsx
+++ b/app/app/campaigns/[id]/view/page.tsx
@@ -1,0 +1,17 @@
+export default function CampaignView({ params }: { params: { id: string } }) {
+  return (
+    <div className="space-y-4">
+      <div className="text-sm text-slate-500">Campaign view — overview of deliverables, status and audit trails.</div>
+
+      <div className="border rounded p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="font-semibold">Campaign details</div>
+            <div className="text-xs text-slate-500 mt-1">Status: Draft</div>
+          </div>
+          <div className="text-xs text-slate-400">ID: {params.id}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/app/campaigns/create/page.tsx
+++ b/app/app/campaigns/create/page.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import React, { useRef, useState } from 'react'
+import Link from 'next/link'
+
+type Asset = { id: string; url: string }
+
+const ACCEPTED = ['image/png', 'image/jpg', 'image/jpeg', 'image/webp', 'image/svg+xml']
+const MAX_BYTES = 20 * 1024 * 1024
+
+export default function CreateCampaign() {
+  const [name, setName] = useState('')
+  const [client, setClient] = useState('')
+  const [campaignId, setCampaignId] = useState<string | null>(null)
+  const [logo, setLogo] = useState<Asset | null>(null)
+  const [images, setImages] = useState<Asset[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loadingCreate, setLoadingCreate] = useState(false)
+  const logoRef = useRef<HTMLInputElement | null>(null)
+  const imagesRef = useRef<HTMLInputElement | null>(null)
+
+  async function createCampaign() {
+    setError(null)
+    if (!name) return setError('Campaign name is required')
+    setLoadingCreate(true)
+    try {
+      const res = await fetch('/api/campaigns', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name, client }) })
+      const json = await res.json()
+      if (!json?.success) throw new Error(json?.error || 'Failed to create')
+      setCampaignId(json.campaignId)
+    } catch (e: any) {
+      setError(e.message || String(e))
+    } finally {
+      setLoadingCreate(false)
+    }
+  }
+
+  async function upload(type: 'logo' | 'image', file: File) {
+    setError(null)
+    if (!campaignId) return setError('Create or select a campaign first')
+    if (!ACCEPTED.includes(file.type)) return setError('Unsupported file type')
+    if (file.size > MAX_BYTES) return setError('File too large (max 20MB)')
+
+    try {
+      const fd = new FormData()
+      fd.append('campaignId', campaignId)
+      fd.append('file', file, file.name)
+      const endpoint = type === 'logo' ? '/api/upload/logo' : '/api/upload/image'
+      const res = await fetch(endpoint, { method: 'POST', body: fd })
+      const json = await res.json()
+      if (!json?.success) throw new Error(json?.error || 'Upload failed')
+
+      const asset = { id: json.asset_id, url: json.file_url }
+      if (type === 'logo') setLogo(asset)
+      else setImages((s) => [asset, ...s])
+    } catch (e: any) {
+      setError(e.message || String(e))
+    }
+  }
+
+  async function handleLogoInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (file) upload('logo', file)
+    e.currentTarget.value = ''
+  }
+
+  async function handleImagesInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files || [])
+    for (const f of files) {
+      await upload('image', f)
+    }
+    e.currentTarget.value = ''
+  }
+
+  function onDropFactory(type: 'logo' | 'image') {
+    return async function (e: React.DragEvent<HTMLDivElement>) {
+      e.preventDefault()
+      if (!campaignId) return setError('Create or select a campaign first')
+      const items = Array.from(e.dataTransfer.files || [])
+      for (const f of items) await upload(type, f)
+    }
+  }
+
+  async function removeAsset(type: 'logo' | 'image', id: string) {
+    setError(null)
+    try {
+      const endpoint = type === 'logo' ? `/api/upload/logo?id=${encodeURIComponent(id)}` : `/api/upload/image?id=${encodeURIComponent(id)}`
+      const res = await fetch(endpoint, { method: 'DELETE' })
+      const json = await res.json()
+      if (!json?.success) throw new Error(json?.error || 'Delete failed')
+      if (type === 'logo') setLogo(null)
+      else setImages((s) => s.filter((a) => a.id !== id))
+    } catch (e: any) {
+      setError(e.message || String(e))
+    }
+  }
+
+  const nextDisabled = !logo || images.length < 1 || !campaignId
+
+  return (
+    <div className="max-w-4xl mx-auto bg-white p-6 rounded shadow">
+      <h2 className="text-xl font-semibold">Create a new Campaign</h2>
+      <p className="mt-2 text-sm text-slate-500">Fill the basic info first — a campaign record is created immediately and files can be uploaded to a dedicated folder on disk.</p>
+
+      <div className="mt-6 grid gap-4">
+        <label className="block">
+          <div className="text-sm font-medium">Campaign name</div>
+          <input value={name} onChange={(e) => setName(e.target.value)} type="text" className="mt-1 w-full border rounded px-3 py-2" placeholder="E.g. Spring Social Launch" />
+        </label>
+
+        <label className="block">
+          <div className="text-sm font-medium">Client name</div>
+          <input value={client} onChange={(e) => setClient(e.target.value)} type="text" className="mt-1 w-full border rounded px-3 py-2" placeholder="Brand or client" />
+        </label>
+
+        <div className="flex items-center justify-end gap-3 mt-2">
+          <Link href="/campaigns" className="px-3 py-2 border rounded">Cancel</Link>
+          {!campaignId ? (
+            <button onClick={createCampaign} className="px-3 py-2 bg-indigo-600 text-white rounded" disabled={loadingCreate}>{loadingCreate ? 'Creating…' : 'Create campaign'}</button>
+          ) : (
+            <div className="text-sm text-slate-500">Campaign created: <span className="font-medium">{campaignId}</span></div>
+          )}
+        </div>
+
+        {/* Upload areas */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+          <div>
+            <div className="text-sm font-semibold mb-2">Logo (single)</div>
+
+            <div onDrop={onDropFactory('logo')} onDragOver={(e) => e.preventDefault()} className="border-dashed border-2 rounded p-4 text-center">
+              <div className="text-xs text-slate-500">PNG, JPG, JPEG, WEBP, SVG — max 20MB</div>
+              <div className="mt-3 flex items-center justify-center gap-2">
+                <button onClick={() => logoRef.current?.click()} className="px-3 py-2 border rounded">Click to upload</button>
+                <div className="text-sm text-slate-400">or drag & drop a single logo file here</div>
+              </div>
+
+              <input ref={logoRef} type="file" accept="image/*" onChange={handleLogoInput} className="hidden" />
+            </div>
+
+            {logo && (
+              <div className="mt-4">
+                <div className="text-xs text-slate-500">Preview</div>
+                <div className="mt-2 border rounded p-4 w-full flex items-center justify-center bg-slate-50">
+                  <img src={logo.url} alt="logo" style={{ maxHeight: 140 }} />
+                </div>
+                <div className="mt-2 flex items-center gap-2">
+                  <button onClick={() => removeAsset('logo', logo.id)} className="px-2 py-1 text-sm border rounded text-red-600">Remove</button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div>
+            <div className="text-sm font-semibold mb-2">Images (multiple)</div>
+
+            <div onDrop={onDropFactory('image')} onDragOver={(e) => e.preventDefault()} className="border-dashed border-2 rounded p-4 text-center">
+              <div className="text-xs text-slate-500">PNG, JPG, JPEG, WEBP, SVG — max 20MB per file</div>
+              <div className="mt-3 flex items-center justify-center gap-2">
+                <button onClick={() => imagesRef.current?.click()} className="px-3 py-2 border rounded">Click to upload</button>
+                <div className="text-sm text-slate-400">or drag & drop multiple images</div>
+              </div>
+              <input multiple ref={imagesRef} type="file" accept="image/*" onChange={handleImagesInput} className="hidden" />
+            </div>
+
+            {images.length > 0 && (
+              <div className="mt-4">
+                <div className="text-xs text-slate-500">Previews</div>
+                <div className="mt-2 grid grid-cols-3 gap-2">
+                  {images.map((a) => (
+                    <div key={a.id} className="border rounded p-2 flex flex-col items-center">
+                      <img src={a.url} alt="img" className="object-cover h-20 w-full" />
+                      <div className="mt-2 flex items-center gap-2">
+                        <button onClick={() => removeAsset('image', a.id)} className="text-xs border px-2 py-1 rounded text-red-600">Remove</button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {error && <div className="mt-4 text-sm text-red-600">{error}</div>}
+
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <Link href="/campaigns" className="px-3 py-2 border rounded">Back to campaigns</Link>
+          <Link href={campaignId ? `/campaigns/${campaignId}/formats` : '#'} className={`px-3 py-2 bg-indigo-600 text-white rounded ${nextDisabled ? 'opacity-50 pointer-events-none' : ''}`}>Next: Choose Formats</Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/app/campaigns/page.tsx
+++ b/app/app/campaigns/page.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+
+export default function Campaigns() {
+  // Placeholder list view for campaigns
+  const sample = [
+    { id: 'abc123', name: 'Summer OOH Push' },
+    { id: 'xyz789', name: 'Holiday Social Teaser' },
+  ]
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="bg-white shadow rounded-md p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Campaigns</h2>
+          <Link href="/campaigns/create" className="text-indigo-600 font-semibold">Create new</Link>
+        </div>
+
+        <ul className="mt-5 divide-y">
+          {sample.map((c) => (
+            <li key={c.id} className="py-3 flex items-center justify-between">
+              <div>
+                <div className="font-medium">{c.name}</div>
+                <div className="text-xs text-slate-500">ID: {c.id}</div>
+              </div>
+              <div className="flex items-center gap-3">
+                <Link href={`/campaigns/${c.id}/view`} className="text-sm text-indigo-600">View</Link>
+                <Link href={`/campaigns/${c.id}/formats`} className="text-sm text-slate-600">Edit</Link>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #__next {
+  height: 100%;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,0 +1,36 @@
+import './globals.css'
+import React from 'react'
+
+export const metadata = {
+  title: 'AdGen AI Platform — Internal',
+  description: 'Internal scaffold for AdGen AI Platform — create and manage ad campaigns',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <div className="min-h-screen flex flex-col">
+          <header className="border-b bg-white">
+            <div className="max-w-8xl mx-auto px-6 py-4 flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-md flex items-center justify-center text-white font-semibold">AG</div>
+                <div className="text-lg font-semibold">AdGen AI Platform</div>
+              </div>
+              <nav className="text-sm text-slate-600 flex items-center gap-6">
+                <a href="/" className="hover:underline">Home</a>
+                <a href="/campaigns/create" className="text-indigo-600 font-semibold">Create Campaign</a>
+              </nav>
+            </div>
+          </header>
+
+          <main className="py-8 px-6 max-w-8xl mx-auto w-full">{children}</main>
+
+          <footer className="mt-auto border-t bg-white">
+            <div className="max-w-8xl mx-auto px-6 py-4 text-xs text-slate-500">Internal-only AdGen AI Platform • For development and testing only</div>
+          </footer>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+export default function Home() {
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="bg-white shadow-md rounded-md px-8 py-10">
+        <h1 className="text-2xl font-bold">AdGen AI Platform</h1>
+        <p className="mt-2 text-slate-600">Internal-only scaffold for building AI-powered OOH/DOOH/Social/Print ad campaigns.
+        This repository area contains the UI pages, components, lib, and API route placeholders for future integrations.</p>
+
+        <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <a className="p-4 border rounded hover:shadow-md" href="/campaigns/create">
+            <h3 className="font-semibold">Create a campaign</h3>
+            <p className="text-sm text-slate-500 mt-1">Step through the campaign creation workflow.</p>
+          </a>
+
+          <a className="p-4 border rounded hover:shadow-md" href="/campaigns">
+            <h3 className="font-semibold">View campaigns</h3>
+            <p className="text-sm text-slate-500 mt-1">Manage and explore existing campaigns (UI placeholder).</p>
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/CampaignCard.tsx
+++ b/app/components/CampaignCard.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function CampaignCard({ id, name, meta }: { id: string; name: string; meta?: string }) {
+  return (
+    <article className="border rounded p-4 shadow-sm hover:shadow-md">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-semibold">{name}</div>
+          {meta && <div className="text-xs text-slate-500 mt-1">{meta}</div>}
+        </div>
+        <div className="text-sm flex items-center gap-2">
+          <Link href={`/campaigns/${id}/view`} className="text-indigo-600">View</Link>
+          <Link href={`/campaigns/${id}/formats`} className="text-slate-600">Edit</Link>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Header() {
+  return (
+    <header className="border-b bg-white">
+      <div className="max-w-8xl mx-auto px-6 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-md flex items-center justify-center text-white font-semibold">AG</div>
+          <div className="text-lg font-semibold">AdGen AI Platform</div>
+        </div>
+
+        <nav className="text-sm text-slate-600 flex items-center gap-6">
+          <Link href="/">Home</Link>
+          <Link href="/campaigns/create" className="text-indigo-600 font-semibold">Create</Link>
+          <Link href="/campaigns">Campaigns</Link>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/app/components/Stepper.tsx
+++ b/app/components/Stepper.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export default function Stepper({ steps, active = 0 }: { steps: string[]; active?: number }) {
+  return (
+    <div className="flex items-center gap-3">
+      {steps.map((s, i) => (
+        <div key={s} className="flex items-center gap-3">
+          <div className={`w-8 h-8 rounded-full flex items-center justify-center ${i <= active ? 'bg-indigo-600 text-white' : 'bg-slate-100 text-slate-400'}`}>{i + 1}</div>
+          <div className={`text-sm ${i <= active ? 'text-slate-800' : 'text-slate-400'}`}>{s}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "adgen-ai-platform",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.0.0",
+    "typescript": "^5.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "^14.0.0"
+  }
+}

--- a/app/postcss.config.js
+++ b/app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/app/styles/README.md
+++ b/app/styles/README.md
@@ -1,0 +1,3 @@
+This folder contains stylesheet utilities and global style files for the AdGen AI Platform.
+
+Currently we use Tailwind through `app/globals.css`. Add modular CSS files here if needed.

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Add a full internal Next.js (App Router) TypeScript + Tailwind scaffold for the AdGen AI Platform. Includes local file-backed campaign creation, logo/images upload flow (public/uploads storage), DB file helpers, upload/delete API endpoints, and the initial Formats and Variations steps in the UI. This is an internal-only scaffold (no external integrations).