### PR TITLE
docs: add community session implementations section

### DIFF
--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -429,13 +429,13 @@ result = await Runner.run(
 
 ## Community session implementations
 
-The community has built session implementations for other frameworks:
+The community has developed additional session implementations:
 
-| Package | Description | Install |
-|---------|-------------|---------|
-| [openai-django-sessions](https://pypi.org/project/openai-django-sessions/) | Django ORM-based sessions for any Django-supported database (PostgreSQL, MySQL, SQLite) | `pip install openai-django-sessions` |
+| Package | Description |
+|---------|-------------|
+| [openai-django-sessions](https://pypi.org/project/openai-django-sessions/) | Django ORM-based sessions for any Django-supported database (PostgreSQL, MySQL, SQLite, and more) |
 
-If you've built a session implementation, consider opening a PR to add it here!
+If you've built a session implementation, please feel free to submit a documentation PR to add it here!
 
 ## API Reference
 


### PR DESCRIPTION
## Summary

This PR adds a "Community session implementations" section to the Sessions documentation page, making it easier for users to discover third-party session backends.

The documentation currently mentions "Consider implementing custom session backends for other production systems (Redis, Django, etc.)" but doesn't provide a place to discover community implementations.

## Changes

- Added a new "Community session implementations" section before the API Reference
- Created a table format for listing packages with description and install command
- Added initial entry: [openai-django-sessions](https://pypi.org/project/openai-django-sessions/) for Django ORM-based sessions

## Preview

The new section looks like:

| Package | Description | Install |
|---------|-------------|---------|
| [openai-django-sessions](https://pypi.org/project/openai-django-sessions/) | Django ORM-based sessions for any Django-supported database (PostgreSQL, MySQL, SQLite) | `pip install openai-django-sessions` |

This encourages community contributions by inviting others to open PRs to add their implementations.