### PR TITLE
Store reference to original function when creating `FunctionTool`

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import inspect
 import json
 import weakref
@@ -244,8 +243,10 @@ class FunctionTool:
         if self.strict_json_schema:
             self.params_json_schema = ensure_strict_json_schema(self.params_json_schema)
 
+        # Dress the FunctionTool object with the name and docstring of the wrapped function
         if self._func:
-            functools.update_wrapper(self, self._func)
+            self.__name__ = self._func.__name__
+            self.__doc__ = self._func.__doc__
 
     def __call__(self, *args, **kwargs):
         if not self._func:

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.asyncio
 
 
 @function_tool
-async def _test_tool(query: str) -> str:
+async def test_tool(query: str) -> str:
     """A test tool for testing tool call tracking."""
     return f"Tool result for: {query}"
 
@@ -28,7 +28,7 @@ async def _test_tool(query: str) -> str:
 @pytest.fixture
 def agent() -> Agent:
     """Fixture for a basic agent with a fake model."""
-    return Agent(name="test", model=FakeModel(), tools=[_test_tool])
+    return Agent(name="test", model=FakeModel(), tools=[test_tool])
 
 
 @pytest.fixture
@@ -961,7 +961,7 @@ async def test_tool_execution_integration(agent: Agent):
         [
             {  # type: ignore
                 "type": "function_call",
-                "name": "_test_tool",
+                "name": "test_tool",
                 "arguments": '{"query": "test query"}',
                 "call_id": "call_123",
             }

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -188,6 +188,12 @@ async def test_complex_args_function():
         )
 
 
+def test_func_tool_name_doc_inheritance():
+    tool = function_tool(simple_function)
+    assert tool.__name__ == simple_function.__name__
+    assert tool.__doc__ == simple_function.__doc__
+
+
 def test_absent_func_tool():
     tool = function_tool(simple_function)
     kwargs = asdict(tool)


### PR DESCRIPTION
When `@function_tool`  is used, no reference to the original function is retained, which makes testing the function directly cumbersome. The original function is now just stored as an attribute of `FunctionTool`:

```python
@function_tool
def my_func(x: str, y: str) -> str:
  return x + y

# works like the original function
my_func.func('hello ', 'world!')
```

The alternative is to require users to define helper functions duplicating signatures and doc strings:
```python

# using double definitions instead
def _my_func(x: str, y: str) -> str:
  return x + y

@function_tool
def my_func(x: str, y: str) -> str:
  return _my_func(x, y)

```