### PR TITLE
fix #2181 FunctionTool.strict_json_schema is missing when using Chat Completions API

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -598,6 +598,7 @@ class Converter:
                     "name": tool.name,
                     "description": tool.description or "",
                     "parameters": tool.params_json_schema,
+                    "strict": tool.strict_json_schema,
                 },
             }
 
@@ -614,5 +615,6 @@ class Converter:
                 "name": handoff.tool_name,
                 "description": handoff.tool_description,
                 "parameters": handoff.input_json_schema,
+                "strict": handoff.strict_json_schema,
             },
         }

--- a/tests/test_tool_converter.py
+++ b/tests/test_tool_converter.py
@@ -18,12 +18,21 @@ def test_to_openai_with_function_tool():
     result = Converter.tool_to_openai(tool)
 
     assert result["type"] == "function"
-    assert result["function"]["name"] == "some_function"
-    params = result.get("function", {}).get("parameters")
+    function_def = result["function"]
+    assert function_def["name"] == "some_function"
+    assert function_def["strict"] is True
+    params = function_def.get("parameters")
     assert params is not None
     properties = params.get("properties", {})
     assert isinstance(properties, dict)
     assert properties.keys() == {"a", "b"}
+
+
+def test_to_openai_respects_non_strict_function_tool():
+    tool = function_tool(some_function, strict_mode=False)
+    result = Converter.tool_to_openai(tool)
+
+    assert result["function"]["strict"] is False
 
 
 class Foo(BaseModel):
@@ -39,6 +48,7 @@ def test_convert_handoff_tool():
     assert result["type"] == "function"
     assert result["function"]["name"] == Handoff.default_tool_name(agent)
     assert result["function"].get("description") == Handoff.default_tool_description(agent)
+    assert result["function"].get("strict") is True
     params = result.get("function", {}).get("parameters")
     assert params is not None
 


### PR DESCRIPTION
This pull request resolves #2181; i've confirmed this works without any issues by running simple code snippets