### PR TITLE
docs: fix code typo in `for` loop

### DIFF
--- a/docs/ko/usage.md
+++ b/docs/ko/usage.md
@@ -58,7 +58,7 @@ SDK 는 `request_usage_entries` 에서 각 API 요청의 사용량을 자동으�
 ```python
 result = await Runner.run(agent, "What's the weather in Tokyo?")
 
-for request in enumerate(result.context_wrapper.usage.request_usage_entries):
+for i, request in enumerate(result.context_wrapper.usage.request_usage_entries):
     print(f"Request {i + 1}: {request.input_tokens} in, {request.output_tokens} out")
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,7 @@ The SDK automatically tracks usage for each API request in `request_usage_entrie
 ```python
 result = await Runner.run(agent, "What's the weather in Tokyo?")
 
-for request in enumerate(result.context_wrapper.usage.request_usage_entries):
+for i, request in enumerate(result.context_wrapper.usage.request_usage_entries):
     print(f"Request {i + 1}: {request.input_tokens} in, {request.output_tokens} out")
 ```
 

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -58,7 +58,7 @@ SDK 会自动在 `request_usage_entries` 中跟踪每个 API 请求的用量，�
 ```python
 result = await Runner.run(agent, "What's the weather in Tokyo?")
 
-for request in enumerate(result.context_wrapper.usage.request_usage_entries):
+for i, request in enumerate(result.context_wrapper.usage.request_usage_entries):
     print(f"Request {i + 1}: {request.input_tokens} in, {request.output_tokens} out")
 ```
 


### PR DESCRIPTION
fixes the following code typo

```diff
- for request in enumerate(result.context_wrapper.usage.request_usage_entries):
+ for i, request in enumerate(result.context_wrapper.usage.request_usage_entries):
    print(f"Request {i + 1}: {request.input_tokens} in, {request.output_tokens} out")
```