### PR TITLE
Add AgentHookContext with turn_input for agent hooks

### DIFF
--- a/examples/basic/agent_lifecycle_example.py
+++ b/examples/basic/agent_lifecycle_example.py
@@ -4,7 +4,15 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from agents import Agent, AgentHooks, RunContextWrapper, Runner, Tool, function_tool
+from agents import (
+    Agent,
+    AgentHookContext,
+    AgentHooks,
+    RunContextWrapper,
+    Runner,
+    Tool,
+    function_tool,
+)
 
 
 class CustomAgentHooks(AgentHooks):
@@ -12,9 +20,12 @@ class CustomAgentHooks(AgentHooks):
         self.event_counter = 0
         self.display_name = display_name
 
-    async def on_start(self, context: RunContextWrapper, agent: Agent) -> None:
+    async def on_start(self, context: AgentHookContext, agent: Agent) -> None:
         self.event_counter += 1
-        print(f"### ({self.display_name}) {self.event_counter}: Agent {agent.name} started")
+        # Access the turn_input from the context to see what input the agent received
+        print(
+            f"### ({self.display_name}) {self.event_counter}: Agent {agent.name} started with turn_input: {context.turn_input}"
+        )
 
     async def on_end(self, context: RunContextWrapper, agent: Agent, output: Any) -> None:
         self.event_counter += 1

--- a/examples/basic/lifecycle_example.py
+++ b/examples/basic/lifecycle_example.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from agents import (
     Agent,
+    AgentHookContext,
     AgentHooks,
     RunContextWrapper,
     RunHooks,
@@ -21,10 +22,11 @@ from agents.tool_context import ToolContext
 class LoggingHooks(AgentHooks[Any]):
     async def on_start(
         self,
-        context: RunContextWrapper[Any],
+        context: AgentHookContext[Any],
         agent: Agent[Any],
     ) -> None:
-        print(f"#### {agent.name} is starting.")
+        # Access the turn_input from the context to see what input the agent received
+        print(f"#### {agent.name} is starting with turn_input: {context.turn_input}")
 
     async def on_end(
         self,
@@ -42,10 +44,11 @@ class ExampleHooks(RunHooks):
     def _usage_to_str(self, usage: Usage) -> str:
         return f"{usage.requests} requests, {usage.input_tokens} input tokens, {usage.output_tokens} output tokens, {usage.total_tokens} total tokens"
 
-    async def on_agent_start(self, context: RunContextWrapper, agent: Agent) -> None:
+    async def on_agent_start(self, context: AgentHookContext, agent: Agent) -> None:
         self.event_counter += 1
+        # Access the turn_input from the context to see what input the agent received
         print(
-            f"### {self.event_counter}: Agent {agent.name} started. Usage: {self._usage_to_str(context.usage)}"
+            f"### {self.event_counter}: Agent {agent.name} started. turn_input: {context.turn_input}. Usage: {self._usage_to_str(context.usage)}"
         )
 
     async def on_llm_start(

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -77,7 +77,7 @@ from .prompts import DynamicPromptFunction, GenerateDynamicPromptData, Prompt
 from .repl import run_demo_loop
 from .result import RunResult, RunResultStreaming
 from .run import RunConfig, Runner
-from .run_context import RunContextWrapper, TContext
+from .run_context import AgentHookContext, RunContextWrapper, TContext
 from .stream_events import (
     AgentUpdatedStreamEvent,
     RawResponsesStreamEvent,
@@ -291,6 +291,7 @@ __all__ = [
     "SessionABC",
     "SQLiteSession",
     "OpenAIConversationsSession",
+    "AgentHookContext",
     "RunContextWrapper",
     "TContext",
     "RunErrorDetails",

--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -4,7 +4,7 @@ from typing_extensions import TypeVar
 
 from .agent import Agent, AgentBase
 from .items import ModelResponse, TResponseInputItem
-from .run_context import RunContextWrapper, TContext
+from .run_context import AgentHookContext, RunContextWrapper, TContext
 from .tool import Tool
 
 TAgent = TypeVar("TAgent", bound=AgentBase, default=AgentBase)
@@ -34,17 +34,28 @@ class RunHooksBase(Generic[TContext, TAgent]):
         """Called immediately after the LLM call returns for this agent."""
         pass
 
-    async def on_agent_start(self, context: RunContextWrapper[TContext], agent: TAgent) -> None:
-        """Called before the agent is invoked. Called each time the current agent changes."""
+    async def on_agent_start(self, context: AgentHookContext[TContext], agent: TAgent) -> None:
+        """Called before the agent is invoked. Called each time the current agent changes.
+
+        Args:
+            context: The agent hook context.
+            agent: The agent that is about to be invoked.
+        """
         pass
 
     async def on_agent_end(
         self,
-        context: RunContextWrapper[TContext],
+        context: AgentHookContext[TContext],
         agent: TAgent,
         output: Any,
     ) -> None:
-        """Called when the agent produces a final output."""
+        """Called when the agent produces a final output.
+
+        Args:
+            context: The agent hook context.
+            agent: The agent that produced the output.
+            output: The final output produced by the agent.
+        """
         pass
 
     async def on_handoff(
@@ -83,18 +94,29 @@ class AgentHooksBase(Generic[TContext, TAgent]):
     Subclass and override the methods you need.
     """
 
-    async def on_start(self, context: RunContextWrapper[TContext], agent: TAgent) -> None:
+    async def on_start(self, context: AgentHookContext[TContext], agent: TAgent) -> None:
         """Called before the agent is invoked. Called each time the running agent is changed to this
-        agent."""
+        agent.
+
+        Args:
+            context: The agent hook context.
+            agent: This agent instance.
+        """
         pass
 
     async def on_end(
         self,
-        context: RunContextWrapper[TContext],
+        context: AgentHookContext[TContext],
         agent: TAgent,
         output: Any,
     ) -> None:
-        """Called when the agent produces a final output."""
+        """Called when the agent produces a final output.
+
+        Args:
+            context: The agent hook context.
+            agent: This agent instance.
+            output: The final output produced by the agent.
+        """
         pass
 
     async def on_handoff(

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass, field
-from typing import Any, Generic
+from typing import TYPE_CHECKING, Any, Generic
 
 from typing_extensions import TypeVar
 
 from .usage import Usage
+
+if TYPE_CHECKING:
+    from .items import TResponseInputItem
 
 TContext = TypeVar("TContext", default=Any)
 
@@ -24,3 +27,11 @@ class RunContextWrapper(Generic[TContext]):
     """The usage of the agent run so far. For streamed responses, the usage will be stale until the
     last chunk of the stream is processed.
     """
+
+
+@dataclass(eq=False)
+class AgentHookContext(RunContextWrapper[TContext]):
+    """Context passed to agent hooks (on_start, on_end)."""
+
+    turn_input: "list[TResponseInputItem]" = field(default_factory=list)
+    """The input items for the current turn."""

--- a/tests/test_agent_llm_hooks.py
+++ b/tests/test_agent_llm_hooks.py
@@ -7,7 +7,7 @@ from agents.agent import Agent
 from agents.items import ItemHelpers, ModelResponse, TResponseInputItem
 from agents.lifecycle import AgentHooks
 from agents.run import Runner
-from agents.run_context import RunContextWrapper, TContext
+from agents.run_context import AgentHookContext, RunContextWrapper, TContext
 from agents.tool import Tool
 
 from .fake_model import FakeModel
@@ -24,7 +24,7 @@ class AgentHooksForTests(AgentHooks):
     def reset(self):
         self.events.clear()
 
-    async def on_start(self, context: RunContextWrapper[TContext], agent: Agent[TContext]) -> None:
+    async def on_start(self, context: AgentHookContext[TContext], agent: Agent[TContext]) -> None:
         self.events["on_start"] += 1
 
     async def on_end(


### PR DESCRIPTION
Based on the idea discussed in https://github.com/openai/openai-agents-python/issues/2180#issuecomment-3677509756, this PR proposes a concrete implementation.

It adds `turn_input` to the agent hook context and resolved:  https://github.com/openai/openai-agents-js/pull/765

The implementation introduces a new `AgentHookContext`.

It covers the following hooks:

* AgentHooks: `on_start` and `on_end`
* RunHooks: `on_agent_start` and `on_agent_end`

This change does not modify the hook parameter list, so it should not introduce breaking changes. 

`AgentHookContext` is simply a subclass extension of `RunContextWrapper`, similar to how `ToolContext` works for tool hooks.

If this extensibility pattern is acceptable, we can further extend other hook contexts via `RunContextWrapper` subclasses when needed, for example `ComputerActionContext` and `ShellActionContext`.