### PR TITLE
Make example prompt consistent with Quick-start context

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -85,7 +85,7 @@ Let's check that the workflow runs and the triage agent correctly routes between
 from agents import Runner
 
 async def main():
-    result = await Runner.run(triage_agent, "What is the capital of France?")
+    result = await Runner.run(triage_agent, "who was the first president of the united states?")
     print(result.final_output)
 ```
 


### PR DESCRIPTION
The goal of this doc is to provide an example where the triage agent can hand off the question to either a math tutor or a history tutor. However, the example prompt here has nothing to do with history or math; as a result, agent handoff will be skipped, which might confuse Agent SDK beginners. 

Also, in the "Put it all together" section, the prompt used is different from the example prompt here. 

This commit is updating the example prompt to be a history-related question, making it consistent with the section below.