### PR TITLE
fix: Improve tracing shutdown safety

### DIFF
--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -14,6 +14,15 @@ from .spans import NoOpSpan, Span, SpanImpl, TSpanData
 from .traces import NoOpTrace, Trace, TraceImpl
 
 
+def _safe_debug(message: str) -> None:
+    """Best-effort debug logging that tolerates closed streams during shutdown."""
+    try:
+        logger.debug(message)
+    except Exception:
+        # Avoid noisy shutdown errors when the underlying stream is already closed.
+        return
+
+
 class SynchronousMultiTracingProcessor(TracingProcessor):
     """
     Forwards all calls to a list of TracingProcessors, in order of registration.
@@ -83,7 +92,7 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
         Called when the application stops.
         """
         for processor in self._processors:
-            logger.debug(f"Shutting down trace processor {processor}")
+            _safe_debug(f"Shutting down trace processor {processor}")
             try:
                 processor.shutdown()
             except Exception as e:
@@ -306,7 +315,7 @@ class DefaultTraceProvider(TraceProvider):
             return
 
         try:
-            logger.debug("Shutting down trace provider")
+            _safe_debug("Shutting down trace provider")
             self._multi_processor.shutdown()
         except Exception as e:
             logger.error(f"Error shutting down trace provider: {e}")


### PR DESCRIPTION
This pull request resolves the potential errors with tracing providers when streams are already closed:

```
--- Logging error ---
Traceback (most recent call last):
  File "uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/logging/__init__.py", line 1163, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "openai-agents-python/src/agents/tracing/provider.py", line 309, in shutdown
    logger.debug("Shutting down trace provider")
Message: 'Shutting down trace provider'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/logging/__init__.py", line 1163, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "openai-agents-python/src/agents/tracing/provider.py", line 310, in shutdown
    self._multi_processor.shutdown()
  File "openai-agents-python/src/agents/tracing/provider.py", line 86, in shutdown
    logger.debug(f"Shutting down trace processor {processor}")
Message: 'Shutting down trace processor <tests.testing_processor.SpanProcessorForTests object at 0x10d54dca0>'
Arguments: ()
```
