### PR TITLE
fix: handle output_text type in realtime text mode

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -571,7 +571,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                                 "transcript": part.get("transcript"),
                             }
                         )
-                    elif part.get("type") == "text":
+                    elif part.get("type") in ("text", "output_text"):
                         converted_content.append({"type": "text", "text": part.get("text")})
                 status = item.get("status")
                 if status not in ("in_progress", "completed", "incomplete"):


### PR DESCRIPTION
Fixes #2161

#### Description

 Realtime API's text mode sends content in `output_text` but the code only checked for `text`. This caused empty `AssistantMessageItem.content` in `RealtimeHistoryUpdated/RealtimeHistoryAdded` events.

#### Changes

  - Change `part.get("type") == "text"` to `part.get("type") in ("text", "output_text")` (as suggested in the issue)
  - Add a test for the same

#### Tests

All tests pass.