### PR TITLE
Add explicit content=None to assistant tool-call messages in Chat Completions converter

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -393,6 +393,7 @@ class Converter:
             nonlocal current_assistant_msg, pending_thinking_blocks
             if current_assistant_msg is None:
                 current_assistant_msg = ChatCompletionAssistantMessageParam(role="assistant")
+                current_assistant_msg["content"] = None
                 current_assistant_msg["tool_calls"] = []
 
             return current_assistant_msg

--- a/tests/test_openai_chatcompletions_converter.py
+++ b/tests/test_openai_chatcompletions_converter.py
@@ -370,6 +370,11 @@ def test_tool_call_conversion():
     tool_msg = messages[0]
     assert tool_msg["role"] == "assistant"
     assert tool_msg.get("content") is None
+
+    # Verify the content key exists in the message even when it is None.
+    # This is for Chat Completions API compatibility.
+    assert "content" in tool_msg, "content key should be present in assistant message"
+
     tool_calls = list(tool_msg.get("tool_calls", []))
     assert len(tool_calls) == 1
 


### PR DESCRIPTION
Resolved: https://github.com/openai/openai-agents-python/issues/2237

This PR ensures that assistant messages with tool calls include an explicit `content` key with the value `None` when using the Chat Completions API.

## Background

When using the Chat Completions API, assistant messages that contain tool calls are currently sent back to the server without a `content` key.

Current behavior:
```json
{
  "role": "assistant",
  "tool_calls": [...]
}
````

Expected behavior:

```json
{
  "role": "assistant",
  "content": null,
  "tool_calls": [...]
}
```


## Why keep the `content` key even when it is `None`?

In the Chat Completions API, assistant messages that trigger function or tool calls include `"content": null`.
(i.e., the returned message did contain the `content` field, even when it is null).

When sending messages back to the server, this structure should stay the same.

This is also shown in official examples. For example, in the OpenAI Cookbook:

[https://github.com/openai/openai-cookbook/blob/bceb1173eb4b8ffb620279dd36c1e2942860f89a/examples/How_to_call_functions_with_chat_models.ipynb](https://github.com/openai/openai-cookbook/blob/bceb1173eb4b8ffb620279dd36c1e2942860f89a/examples/How_to_call_functions_with_chat_models.ipynb)

```python
messages.append(chat_response.choices[0].message.to_dict())
```

This sends the full assistant message, including `"content": None`, back to the Chat Completions API.

Currently, the SDK drops the `content` key during the conversion from Responses API items to Chat Completions messages.
This PR adds it back. 

If an assistant message has a non-None content value, this change does not overwrite or modify it. The content key is only added when it is missing.

## Impact

* No behavior change for OpenAI’s official API. This actually better matches the behavior of the Chat Completions API and how the openai-python library is used in practice.
* Improves compatibility with third-party Chat Completions servers that use stricter message validation.
