### PR TITLE
fix: #2204 Convert tool execution exception to runtime error

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -493,7 +493,12 @@ class RealtimeSession(RealtimeModelListener):
                 )
             )
         else:
-            raise ModelBehaviorError(f"Tool {event.name} not found")
+            await self._put_event(
+                RealtimeError(
+                    info=self._event_info,
+                    error={"message": f"Tool {event.name} not found"},
+                )
+            )
 
     @classmethod
     def _get_new_history(

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from typing_extensions import assert_never
 
 from ..agent import Agent
-from ..exceptions import ModelBehaviorError, UserError
+from ..exceptions import UserError
 from ..handoffs import Handoff
 from ..logger import logger
 from ..run_context import RunContextWrapper, TContext


### PR DESCRIPTION
This PR fixes #2204 the issue I opened a while ago.

This fix changes "exception raise" to "runtime error message trigger" when an unregistered tool is triggered to be executed by the real-time model.