### PR TITLE
Add per-run tracing API key support

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,6 +38,18 @@ from agents import set_tracing_export_api_key
 set_tracing_export_api_key("sk-...")
 ```
 
+You can also set a tracing API key per run without changing the global exporter.
+
+```python
+from agents import Runner, RunConfig
+
+await Runner.run(
+    agent,
+    input="Hello",
+    run_config=RunConfig(tracing={"api_key": "sk-tracing-123"}),
+)
+```
+
 You can also disable tracing entirely by using the [`set_tracing_disabled()`][agents.set_tracing_disabled] function.
 
 ```python

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -121,6 +121,18 @@ agent = Agent(
 )
 ```
 
+If you only need a different tracing key for a single run, pass it via `RunConfig` instead of changing the global exporter.
+
+```python
+from agents import Runner, RunConfig
+
+await Runner.run(
+    agent,
+    input="Hello",
+    run_config=RunConfig(tracing={"api_key": "sk-tracing-123"}),
+)
+```
+
 ## Notes
 - View free traces at Openai Traces dashboard.
 
@@ -147,4 +159,3 @@ agent = Agent(
 -   [Portkey AI](https://portkey.ai/docs/integrations/agents/openai-agents)
 -   [LangDB AI](https://docs.langdb.ai/getting-started/working-with-agent-frameworks/working-with-openai-agents-sdk)
 -   [Agenta](https://docs.agenta.ai/observability/integrations/openai-agents)
-

--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -107,6 +107,7 @@ from .tool_guardrails import (
 from .tracing import (
     SpanError,
     Trace,
+    TracingConfig,
     function_span,
     get_current_trace,
     guardrail_span,
@@ -1515,6 +1516,7 @@ class TraceCtxManager:
         group_id: str | None,
         metadata: dict[str, Any] | None,
         disabled: bool,
+        tracing: TracingConfig | None = None,
     ):
         self.trace: Trace | None = None
         self.workflow_name = workflow_name
@@ -1522,6 +1524,7 @@ class TraceCtxManager:
         self.group_id = group_id
         self.metadata = metadata
         self.disabled = disabled
+        self.tracing = tracing
 
     def __enter__(self) -> TraceCtxManager:
         current_trace = get_current_trace()
@@ -1531,6 +1534,7 @@ class TraceCtxManager:
                 trace_id=self.trace_id,
                 group_id=self.group_id,
                 metadata=self.metadata,
+                tracing=self.tracing,
                 disabled=self.disabled,
             )
             self.trace.start(mark_as_current=True)

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -73,7 +73,7 @@ from .stream_events import (
 )
 from .tool import Tool, dispose_resolved_computers
 from .tool_guardrails import ToolInputGuardrailResult, ToolOutputGuardrailResult
-from .tracing import Span, SpanError, agent_span, get_current_trace, trace
+from .tracing import Span, SpanError, TracingConfig, agent_span, get_current_trace, trace
 from .tracing.span_data import AgentSpanData
 from .usage import Usage
 from .util import _coro, _error_tracing
@@ -225,6 +225,9 @@ class RunConfig:
     tracing_disabled: bool = False
     """Whether tracing is disabled for the agent run. If disabled, we will not trace the agent run.
     """
+
+    tracing: TracingConfig | None = None
+    """Tracing configuration for this run."""
 
     trace_include_sensitive_data: bool = field(
         default_factory=_default_trace_include_sensitive_data
@@ -575,6 +578,7 @@ class AgentRunner:
             trace_id=run_config.trace_id,
             group_id=run_config.group_id,
             metadata=run_config.trace_metadata,
+            tracing=run_config.tracing,
             disabled=run_config.tracing_disabled,
         ):
             current_turn = 0
@@ -902,6 +906,7 @@ class AgentRunner:
                 trace_id=run_config.trace_id,
                 group_id=run_config.group_id,
                 metadata=run_config.trace_metadata,
+                tracing=run_config.tracing,
                 disabled=run_config.tracing_disabled,
             )
         )

--- a/src/agents/tracing/__init__.py
+++ b/src/agents/tracing/__init__.py
@@ -1,5 +1,6 @@
 import atexit
 
+from .config import TracingConfig
 from .create import (
     agent_span,
     custom_span,
@@ -53,6 +54,7 @@ __all__ = [
     "set_trace_processors",
     "set_trace_provider",
     "set_tracing_disabled",
+    "TracingConfig",
     "trace",
     "Trace",
     "SpanError",

--- a/src/agents/tracing/config.py
+++ b/src/agents/tracing/config.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing_extensions import TypedDict
+
+
+class TracingConfig(TypedDict, total=False):
+    """Configuration for tracing export."""
+
+    api_key: str

--- a/src/agents/tracing/create.py
+++ b/src/agents/tracing/create.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from ..logger import logger
+from .config import TracingConfig
 from .setup import get_trace_provider
 from .span_data import (
     AgentSpanData,
@@ -30,6 +31,7 @@ def trace(
     trace_id: str | None = None,
     group_id: str | None = None,
     metadata: dict[str, Any] | None = None,
+    tracing: TracingConfig | None = None,
     disabled: bool = False,
 ) -> Trace:
     """
@@ -50,6 +52,7 @@ def trace(
         group_id: Optional grouping identifier to link multiple traces from the same conversation
             or process. For instance, you might use a chat thread ID.
         metadata: Optional dictionary of additional metadata to attach to the trace.
+        tracing: Optional tracing configuration for exporting this trace.
         disabled: If True, we will return a Trace but the Trace will not be recorded.
 
     Returns:
@@ -66,6 +69,7 @@ def trace(
         trace_id=trace_id,
         group_id=group_id,
         metadata=metadata,
+        tracing=tracing,
         disabled=disabled,
     )
 

--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -124,6 +124,12 @@ class Trace(abc.ABC):
         """
         pass
 
+    @property
+    @abc.abstractmethod
+    def tracing_api_key(self) -> str | None:
+        """The API key to use when exporting this trace and its spans."""
+        pass
+
 
 class NoOpTrace(Trace):
     """A no-op implementation of Trace that doesn't record any data.
@@ -193,6 +199,10 @@ class NoOpTrace(Trace):
         """
         return None
 
+    @property
+    def tracing_api_key(self) -> str | None:
+        return None
+
 
 NO_OP_TRACE = NoOpTrace()
 
@@ -205,6 +215,7 @@ class TraceImpl(Trace):
     __slots__ = (
         "_name",
         "_trace_id",
+        "_tracing_api_key",
         "group_id",
         "metadata",
         "_prev_context_token",
@@ -219,9 +230,11 @@ class TraceImpl(Trace):
         group_id: str | None,
         metadata: dict[str, Any] | None,
         processor: TracingProcessor,
+        tracing_api_key: str | None,
     ):
         self._name = name
         self._trace_id = trace_id or util.gen_trace_id()
+        self._tracing_api_key = tracing_api_key
         self.group_id = group_id
         self.metadata = metadata
         self._prev_context_token: contextvars.Token[Trace | None] | None = None
@@ -235,6 +248,10 @@ class TraceImpl(Trace):
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def tracing_api_key(self) -> str | None:
+        return self._tracing_api_key
 
     def start(self, mark_as_current: bool = False):
         if self._started:

--- a/src/agents/voice/pipeline.py
+++ b/src/agents/voice/pipeline.py
@@ -91,6 +91,7 @@ class VoicePipeline:
             trace_id=None,  # Automatically generated
             group_id=self.config.group_id,
             metadata=self.config.trace_metadata,
+            tracing=self.config.tracing,
             disabled=self.config.tracing_disabled,
         ):
             input_text = await self._process_audio_input(audio_input)
@@ -119,6 +120,7 @@ class VoicePipeline:
             trace_id=None,
             group_id=self.config.group_id,
             metadata=self.config.trace_metadata,
+            tracing=self.config.tracing,
             disabled=self.config.tracing_disabled,
         ):
             output = StreamedAudioResult(

--- a/src/agents/voice/pipeline_config.py
+++ b/src/agents/voice/pipeline_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from ..tracing import TracingConfig
 from ..tracing.util import gen_group_id
 from .model import STTModelSettings, TTSModelSettings, VoiceModelProvider
 from .models.openai_model_provider import OpenAIVoiceModelProvider
@@ -17,6 +18,9 @@ class VoicePipelineConfig:
 
     tracing_disabled: bool = False
     """Whether to disable tracing of the pipeline. Defaults to `False`."""
+
+    tracing: TracingConfig | None = None
+    """Tracing configuration for this pipeline."""
 
     trace_include_sensitive_data: bool = True
     """Whether to include sensitive data in traces. Defaults to `True`. This is specifically for the

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -20,6 +20,7 @@ def get_span(processor: TracingProcessor) -> SpanImpl[AgentSpanData]:
         parent_id=None,
         processor=processor,
         span_data=AgentSpanData(name="test_agent"),
+        tracing_api_key=None,
     )
 
 
@@ -31,6 +32,7 @@ def get_trace(processor: TracingProcessor) -> TraceImpl:
         group_id="test_session_id",
         metadata={},
         processor=processor,
+        tracing_api_key=None,
     )
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -401,3 +401,10 @@ async def test_noop_parent_is_noop_child():
     span_2.finish()
 
     assert span_2.export() is None
+
+
+def test_trace_and_spans_use_tracing_config_key():
+    with trace(workflow_name="test", tracing={"api_key": "tracing-key"}) as tr:
+        assert tr.tracing_api_key == "tracing-key"
+        with custom_span(name="span_with_key") as span:
+            assert span.tracing_api_key == "tracing-key"

--- a/tests/tracing/test_processor_api_key.py
+++ b/tests/tracing/test_processor_api_key.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Union, cast
+
 import pytest
 
 from agents.tracing.processors import BackendSpanExporter
+from agents.tracing.spans import Span
+from agents.tracing.traces import Trace
 
 
 @pytest.mark.asyncio
@@ -25,3 +32,46 @@ async def test_processor_api_key_from_env(monkeypatch):
     # If we set it afterwards, it should be the new value
     monkeypatch.setenv("OPENAI_API_KEY", "foo_bar_123")
     assert processor.api_key == "foo_bar_123"
+
+
+def test_exporter_uses_item_api_keys(monkeypatch):
+    class DummyItem:
+        def __init__(self, key: str | None, payload: dict[str, str]):
+            self.tracing_api_key = key
+            self._payload = payload
+
+        def export(self) -> dict[str, str]:
+            return self._payload
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(*, url, headers, json):
+        calls.append({"url": url, "headers": headers, "json": json})
+        return SimpleNamespace(status_code=200, text="ok")
+
+    exporter = BackendSpanExporter()
+    exporter.set_api_key("global-key")
+    monkeypatch.setattr(exporter, "_client", SimpleNamespace(post=fake_post))
+
+    exporter.export(
+        cast(
+            list[Union[Trace, Span[Any]]],
+            [
+                DummyItem("key-a", {"id": "a"}),
+                DummyItem(None, {"id": "b"}),
+                DummyItem("key-b", {"id": "c"}),
+            ],
+        )
+    )
+
+    assert len(calls) == 3
+    auth_by_first_item = {
+        tuple(entry["id"] for entry in call["json"]["data"]): call["headers"]["Authorization"]
+        for call in calls
+    }
+    assert ("a",) in auth_by_first_item
+    assert ("b",) in auth_by_first_item
+    assert ("c",) in auth_by_first_item
+    assert auth_by_first_item[("a",)] == "Bearer key-a"
+    assert auth_by_first_item[("c",)] == "Bearer key-b"
+    assert auth_by_first_item[("b",)] == "Bearer global-key"


### PR DESCRIPTION
Currently tracing uses a fixed global API key for all tracing. This makes it so you can't have different ones with different tracing API keys, despite the fact that LLM calls can actually have different API keys.

This PR (codex written) fixes that. Approach: introduce a `TracingConfig` passed through RunConfig/voice configs into trace creation, storing a per-run `tracing_api_key` on traces/spans. The backend exporter now groups batches by each item’s key (falling back to the global key), so mixed runs use the right header. Docs and tests cover the new per-run key flow.