### PR TITLE
fix: Fix compaction run item typing and lifecycle handling

### DIFF
--- a/src/agents/_run_impl.py
+++ b/src/agents/_run_impl.py
@@ -542,7 +542,7 @@ class RunImpl:
                 shell_calls.append(ToolRunShellCall(tool_call=output, shell_tool=shell_tool))
                 continue
             if output_type == "compaction":
-                items.append(CompactionItem(raw_item=cast(dict[str, Any], output), agent=agent))
+                items.append(CompactionItem(raw_item=cast(TResponseInputItem, output), agent=agent))
                 continue
             if output_type == "apply_patch_call":
                 items.append(ToolCallItem(raw_item=cast(Any, output), agent=agent))

--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -328,20 +328,14 @@ class MCPApprovalResponseItem(RunItemBase[McpApprovalResponse]):
 
 
 @dataclass
-class CompactionItem:
+class CompactionItem(RunItemBase[TResponseInputItem]):
     """Represents a compaction item from responses.compact."""
-
-    agent: Agent[Any]
-    """The agent whose run caused this item to be generated."""
-
-    raw_item: dict[str, Any]
-    """The raw compaction item containing encrypted_content."""
 
     type: Literal["compaction_item"] = "compaction_item"
 
     def to_input_item(self) -> TResponseInputItem:
         """Converts this item into an input item suitable for passing to the model."""
-        return cast(TResponseInputItem, self.raw_item)
+        return self.raw_item
 
 
 RunItem: TypeAlias = Union[


### PR DESCRIPTION
This pull request is a follow-up for https://github.com/openai/openai-agents-python/pull/2224 It fixes compaction item handling so compaction outputs now subclass the standard RunItem base and carry the correct input-item type, ensuring agent references can be released consistently and type checks stay strict. It also aligns _run_impl construction of compaction items with the canonical TResponseInputItem shape to prevent mypy mismatches.