### PR TITLE
fix: #2291 silence LiteLLM serializer warnings in streaming (opt-in)

### DIFF
--- a/tests/models/test_litellm_logging_patch.py
+++ b/tests/models/test_litellm_logging_patch.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+pytest.importorskip("litellm")
+
+
+def test_litellm_logging_patch_env_var_controls_application(monkeypatch):
+    """Assert the serializer patch only applies when the env var is enabled."""
+    litellm_logging = importlib.import_module("litellm.litellm_core_utils.litellm_logging")
+    litellm_model = importlib.import_module("agents.extensions.models.litellm_model")
+
+    monkeypatch.delenv("OPENAI_AGENTS_ENABLE_LITELLM_SERIALIZER_PATCH", raising=False)
+    litellm_logging = importlib.reload(litellm_logging)
+    importlib.reload(litellm_model)
+
+    assert hasattr(
+        litellm_logging,
+        "_extract_response_obj_and_hidden_params",
+    ), "LiteLLM removed _extract_response_obj_and_hidden_params; revisit warning patch."
+    assert getattr(litellm_logging, "_openai_agents_patched_serializer_warnings", False) is False
+
+    monkeypatch.setenv("OPENAI_AGENTS_ENABLE_LITELLM_SERIALIZER_PATCH", "true")
+    litellm_logging = importlib.reload(litellm_logging)
+    importlib.reload(litellm_model)
+
+    assert getattr(litellm_logging, "_openai_agents_patched_serializer_warnings", False) is True


### PR DESCRIPTION
This pull request fixes LiteLLM Pydantic serializer warnings during streaming by adding an opt-in patch in src/agents/extensions/models/litellm_model.py that wraps LiteLLM’s private logging helper to serialize BaseModel instances with warnings disabled, and by adding a unit test in tests/models/test_litellm_logging_patch.py to assert the env var controls whether the patch is applied. It documents the LiteLLM issue context and the private-helper dependency risk, with guidance to remove the patch once LiteLLM resolves the underlying issue. This pull request resolves #2291.

Test script:
```python
import asyncio

from agents import Agent, ModelSettings, RunConfig, Runner


async def main() -> int:
    """Stream events from a Claude model via LiteLLM to validate warning suppression."""
    agent = Agent(
        name="claude-streaming-repro",
        model="litellm/anthropic/claude-sonnet-4-5-20250929",
        instructions="You are a helpful assistant. Keep responses brief.",
        model_settings=ModelSettings(temperature=0.7),
    )

    run_config = RunConfig(tracing_disabled=True)

    result = Runner.run_streamed(
        agent,
        input=[{"role": "user", "content": "Say hello in one sentence."}],
        run_config=run_config,
    )

    event_count = 0
    async for event in result.stream_events():
        event_count += 1
        print(f"Event {event_count}: {event.__class__.__name__}")

    print(f"Total events: {event_count}")
    return event_count


if __name__ == "__main__":
    asyncio.run(main())
```

before:
```
$ uv run python test.py
Event 1: AgentUpdatedStreamEvent
Event 2: RawResponsesStreamEvent
Event 3: RawResponsesStreamEvent
Event 4: RawResponsesStreamEvent
Event 5: RawResponsesStreamEvent
Event 6: RawResponsesStreamEvent
Event 7: RawResponsesStreamEvent
Event 8: RawResponsesStreamEvent
Event 9: RawResponsesStreamEvent
Event 10: RunItemStreamEvent
Total events: 10
/Users/seratch/code/openai-agents-python/.venv/lib/python3.12/site-packages/pydantic/main.py:464: UserWarning: Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(Expected 10 fields but got 5: Expected `Message` - serialized value may not be as expected [field_name='message', input_value=Message(content='Hello! H...er_specific_fields=None), input_type=Message])
  PydanticSerializationUnexpectedValue(Expected `StreamingChoices` - serialized value may not be as expected [field_name='choices', input_value=Choices(finish_reason='st...r_specific_fields=None)), input_type=Choices])
  return self.__pydantic_serializer__.to_python(
```

after with the opt-in env variable:
```
$ OPENAI_AGENTS_ENABLE_LITELLM_SERIALIZER_PATCH=1 uv run python test.py
Event 1: AgentUpdatedStreamEvent
Event 2: RawResponsesStreamEvent
Event 3: RawResponsesStreamEvent
Event 4: RawResponsesStreamEvent
Event 5: RawResponsesStreamEvent
Event 6: RawResponsesStreamEvent
Event 7: RawResponsesStreamEvent
Event 8: RawResponsesStreamEvent
Event 9: RawResponsesStreamEvent
Event 10: RunItemStreamEvent
Total events: 10
```