### PR TITLE
Enforce max_output_length for shell tool outputs

### DIFF
--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -326,3 +326,49 @@ async def test_shell_tool_action_can_request_zero_max_output_length() -> None:
     assert raw_item["max_output_length"] == 0
     assert raw_item["output"][0]["stdout"] == ""
     assert raw_item["output"][0]["stderr"] == ""
+
+
+@pytest.mark.asyncio
+async def test_shell_tool_action_negative_max_output_length_clamps_to_zero() -> None:
+    shell_tool = ShellTool(
+        executor=lambda request: ShellResult(
+            output=[
+                ShellCommandOutput(
+                    stdout="0123456789",
+                    stderr="abcdef",
+                    outcome=ShellCallOutcome(type="exit", exit_code=0),
+                )
+            ],
+        )
+    )
+
+    tool_call = {
+        "type": "shell_call",
+        "id": "shell_call",
+        "call_id": "call_shell",
+        "status": "completed",
+        "action": {
+            "commands": ["echo hi"],
+            "timeout_ms": 1000,
+            "max_output_length": -5,
+        },
+    }
+
+    tool_run = ToolRunShellCall(tool_call=tool_call, shell_tool=shell_tool)
+    agent = Agent(name="shell-agent", tools=[shell_tool])
+    context_wrapper: RunContextWrapper[Any] = RunContextWrapper(context=None)
+
+    result = await ShellAction.execute(
+        agent=agent,
+        call=tool_run,
+        hooks=RunHooks[Any](),
+        context_wrapper=context_wrapper,
+        config=RunConfig(),
+    )
+
+    assert isinstance(result, ToolCallOutputItem)
+    assert result.output == ""
+    raw_item = cast(dict[str, Any], result.raw_item)
+    assert raw_item["max_output_length"] == 0
+    assert raw_item["output"][0]["stdout"] == ""
+    assert raw_item["output"][0]["stderr"] == ""


### PR DESCRIPTION
### Motivation

- Prevent overly large shell outputs from overflowing SDK/Responses API limits by making `max_output_length` actually enforceable. 
- Support both structured `ShellResult` outputs and simple string outputs so tool authors can limit payload size from either side. 

### Description

- Use the action `max_output_length` or the executor-returned `ShellResult.max_output_length` to determine truncation and store the resolved value in the raw payload. 
- Add `_truncate_shell_outputs` to trim structured `ShellCommandOutput` entries across `stdout` and `stderr`, and truncate the rendered `output_text` to `max_output_length`. 
- Apply truncation for both `ShellResult` and plain string executor returns, and include the resolved `max_output_length` in `raw_item`. 
- Modified files: `src/agents/_run_impl.py` and added a unit test in `tests/test_shell_tool.py`.

### Testing

- Ran the repository verification script `bash .codex/skills/verify-changes/scripts/run.sh` which runs formatting, linting, type-checking, and the test suite. 
- `make format` and linting passed with no remaining issues. 
- `mypy` completed without errors. 
- Test suite outcome: `1186 passed, 4 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6964ee5842548327bae2f9dedd862663)