### PR TITLE
Improve the loading of OPENAI_AGENTS_DISABLE_TRACING

### DIFF
--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -198,7 +198,7 @@ class DefaultTraceProvider(TraceProvider):
         self._multi_processor = SynchronousMultiTracingProcessor()
         # Lazily read env flag on first use to honor env set after import but before first trace.
         self._env_disabled: bool | None = None
-        self._manual_disabled = False
+        self._manual_disabled: bool | None = None
         self._disabled = False
 
     def register_processor(self, processor: TracingProcessor):
@@ -236,7 +236,8 @@ class DefaultTraceProvider(TraceProvider):
         """Refresh disabled flag from cached env value and manual override.
 
         The env flag is read once on first use to avoid surprises mid-run; further env
-        changes are ignored unless the manual flag is set via set_disabled.
+        changes are ignored after the manual flag is set via set_disabled, which always
+        takes precedence over the env value.
         """
         if self._env_disabled is None:
             self._env_disabled = os.environ.get(
@@ -245,7 +246,10 @@ class DefaultTraceProvider(TraceProvider):
                 "true",
                 "1",
             )
-        self._disabled = self._env_disabled or self._manual_disabled
+        if self._manual_disabled is None:
+            self._disabled = bool(self._env_disabled)
+        else:
+            self._disabled = self._manual_disabled
 
     def time_iso(self) -> str:
         """Return the current time in ISO 8601 format."""

--- a/tests/tracing/test_tracing_env_disable.py
+++ b/tests/tracing/test_tracing_env_disable.py
@@ -40,3 +40,17 @@ def test_manual_override_after_cache(monkeypatch):
     provider.set_disabled(False)
     enabled = provider.create_trace("enabled")
     assert isinstance(enabled, TraceImpl)
+
+
+def test_manual_override_env_disable(monkeypatch):
+    """Manual enable can override env disable flag."""
+    monkeypatch.setenv("OPENAI_AGENTS_DISABLE_TRACING", "1")
+    provider = DefaultTraceProvider()
+
+    env_disabled = provider.create_trace("env_disabled")
+    assert isinstance(env_disabled, NoOpTrace)
+
+    provider.set_disabled(False)
+    reenabled = provider.create_trace("reenabled")
+
+    assert isinstance(reenabled, TraceImpl)


### PR DESCRIPTION
This pull request improves when to load OPENAI_AGENTS_DISABLE_TRACING env variable. It used to be loaded when the DefaultTraceProvider class is imported, but now it loads the env variable when staring the trace provider for the first time at runtime.