### PR TITLE
v0.6.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-agents"
-version = "0.6.5"
+version = "0.6.6"
 description = "OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -2167,7 +2167,7 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "griffe" },


### PR DESCRIPTION
### Release readiness review (v0.6.5 -> TARGET f3f69c21a582e70ae95524556c16c2b25f108c74)

This is a release readiness report done by `$final-release-review` skill.

### Diff

https://github.com/openai/openai-agents-python/compare/v0.6.5...f3f69c21a582e70ae95524556c16c2b25f108c74

### Release call:
- GREEN LIGHT TO SHIP Additive features and regression fixes with extensive new tests; remaining risks are contained and opt-in.

### Scope summary:
- 86 files changed (+4690/-183); key areas touched: `src/agents/memory` (compaction + SQLite ordering), `src/agents/realtime` (interrupt/truncation handling), `src/agents/tracing` (env-disable behavior), `src/agents/extensions/models` (LiteLLM patch), plus large test and example updates.

### Risk assessment (ordered by impact):
1) Realtime interruption now sends explicit truncation events
   - Risk: MODERATE. Client-side `conversation.item.truncate` may be emitted even when the server also truncates, which could yield duplicated truncation or mismatched history for some realtime sessions.
   - Files: `src/agents/realtime/openai_realtime.py`, `src/agents/realtime/_util.py`, `tests/realtime/test_openai_realtime.py`
2) Automatic compaction after each turn for compaction-aware sessions
   - Risk: LOW. Adds an extra Responses API call and can surface compaction failures as run errors for users who opt into compaction-aware sessions (or custom sessions implementing `run_compaction`).
   - Files: `src/agents/run.py`, `src/agents/memory/openai_responses_compaction_session.py`, `src/agents/_run_impl.py`, `src/agents/items.py`, `src/agents/models/chatcmpl_converter.py`
3) SQLiteSession history ordering now uses row id instead of created_at
   - Risk: LOW. Conversation history order may shift for users depending on `created_at` ordering or non-monotonic timestamps.
   - Files: `src/agents/memory/sqlite_session.py`
4) Optional LiteLLM serializer patch hooks private API
   - Risk: LOW. If `OPENAI_AGENTS_ENABLE_LITELLM_SERIALIZER_PATCH=true` and LiteLLM internals change, logging/serialization could fail.
   - Files: `src/agents/extensions/models/litellm_model.py`, `pyproject.toml`

### Notes:
- BASE_TAG `v0.6.5` from origin tags; TARGET `f3f69c21a582e70ae95524556c16c2b25f108c74` (origin/main).
- Working tree clean; no local verification run (assume CI green).
- Suggested spot checks: `uv run pytest -k compaction tests/memory/test_openai_responses_compaction_session.py` and `uv run pytest -k realtime tests/realtime/test_openai_realtime.py`.
