### PR TITLE
chore: add release PR labeling and milestone fallback

### DIFF
--- a/.github/workflows/release-pr-update.yml
+++ b/.github/workflows/release-pr-update.yml
@@ -82,3 +82,25 @@ jobs:
           set -euo pipefail
           git push --force-with-lease origin "$RELEASE_BRANCH"
           gh pr edit "$PR_NUMBER" --body-file release-review.md
+          milestone_name="$(python - <<'PY'
+          import os
+          import re
+
+          branch = os.environ.get("RELEASE_BRANCH", "")
+          version = branch.replace("release/v", "", 1)
+          match = re.match(r"^(\d+)\.(\d+)", version)
+          if not match:
+              print("")
+          else:
+              print(f"{match.group(1)}.{match.group(2)}.x")
+          PY
+          )"
+          if [ -n "$milestone_name" ]; then
+            if ! gh pr edit "$PR_NUMBER" --add-label "project" --milestone "$milestone_name"; then
+              echo "PR label/milestone update failed; continuing without changes." >&2
+            fi
+          else
+            if ! gh pr edit "$PR_NUMBER" --add-label "project"; then
+              echo "PR label update failed; continuing without changes." >&2
+            fi
+          fi

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -113,14 +113,51 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
+          set -euo pipefail
           head_branch="release/v${RELEASE_VERSION}"
+          milestone_name="$(python - <<'PY'
+          import os
+          import re
+
+          version = os.environ.get("RELEASE_VERSION", "")
+          match = re.match(r"^(\d+)\.(\d+)", version)
+          if not match:
+              print("")
+          else:
+              print(f"{match.group(1)}.{match.group(2)}.x")
+          PY
+          )"
           pr_number="$(gh pr list --head "$head_branch" --base "main" --json number --jq '.[0].number // empty')"
           if [ -z "$pr_number" ]; then
-            gh pr create \
-              --title "Release ${RELEASE_VERSION}" \
-              --body-file pr-body.md \
-              --base "main" \
+            create_args=(
+              --title "Release ${RELEASE_VERSION}"
+              --body-file pr-body.md
+              --base "main"
               --head "$head_branch"
+              --label "project"
+            )
+            if [ -n "$milestone_name" ]; then
+              create_args+=(--milestone "$milestone_name")
+            fi
+            if ! gh pr create "${create_args[@]}"; then
+              echo "PR create with label/milestone failed; retrying without them." >&2
+              gh pr create \
+                --title "Release ${RELEASE_VERSION}" \
+                --body-file pr-body.md \
+                --base "main" \
+                --head "$head_branch"
+            fi
           else
-            gh pr edit "$pr_number" --title "Release ${RELEASE_VERSION}" --body-file pr-body.md
+            edit_args=(
+              --title "Release ${RELEASE_VERSION}"
+              --body-file pr-body.md
+              --add-label "project"
+            )
+            if [ -n "$milestone_name" ]; then
+              edit_args+=(--milestone "$milestone_name")
+            fi
+            if ! gh pr edit "$pr_number" "${edit_args[@]}"; then
+              echo "PR edit with label/milestone failed; retrying without them." >&2
+              gh pr edit "$pr_number" --title "Release ${RELEASE_VERSION}" --body-file pr-body.md
+            fi
           fi


### PR DESCRIPTION
This pull request updates the release PR workflows to apply the project label and X.Y.x milestone derived from the release version, while allowing the workflow to continue when those assignments fail. It adds retry/fallback logic for create/edit flows in .github/workflows/release-pr.yml and a best-effort label/milestone update in .github/workflows/release-pr-update.yml without blocking the job.