### PR TITLE
chore: update test coverage rules to exclude tests/*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ coverage:
 	
 	uv run coverage run -m pytest
 	uv run coverage xml -o coverage.xml
-	uv run coverage report -m --fail-under=95
+	uv run coverage report -m --fail-under=85
 
 .PHONY: snapshots-fix
 snapshots-fix: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,8 @@ module = "sounddevice.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]
-source = ["tests", "src/agents"]
+source = ["src/agents"]
+omit = ["tests/*"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
This pull request adjusts the rules for test code coverage. The current settings include tests/* as well, and it makes the percentage number inaccurate. This change removes tests/* and set the requirement to 85% as the current actual number is 89%.