### PR TITLE
docs: add minimal Agent instantiation example to docstring

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -163,6 +163,14 @@ class Agent(AgentBase, Generic[TContext]):
     Agents are generic on the context type. The context is a (mutable) object you create. It is
     passed to tool functions, handoffs, guardrails, etc.
 
+    Example:
+        from agents import Agent
+
+        agent = Agent(
+            name="example",
+            instructions="Say hello"
+        )
+
     See `AgentBase` for base parameters that are shared with `RealtimeAgent`s.
     """
 


### PR DESCRIPTION
### What this PR does
Adds a minimal, runnable example to the `Agent` docstring showing the recommended import path and basic instantiation.

### Why
New users often struggle with where to import `Agent` from and what the minimal setup looks like. This keeps the reference concise while improving clarity.

### Scope
- Docstring only
- No behavior changes
