### PR TITLE
fix: #2155 DeepSeek reasoning_content missing in tool call messages

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -698,7 +698,16 @@ class Converter:
                     pending_thinking_blocks = reconstructed_thinking_blocks
 
                 # DeepSeek requires reasoning_content field in assistant messages with tool calls
-                elif model and "deepseek" in model.lower():
+                # Items may not all originate from DeepSeek, so need to check for model match.
+                # For backward compatibility, if provider_data is missing, ignore the check.
+                elif (
+                    model
+                    and "deepseek" in model.lower()
+                    and (
+                        (item_model and "deepseek" in item_model.lower())
+                        or item_provider_data == {}
+                    )
+                ):
                     summary_items = reasoning_item.get("summary", [])
                     if summary_items:
                         reasoning_texts = []

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -428,15 +428,20 @@ class Converter:
         result: list[ChatCompletionMessageParam] = []
         current_assistant_msg: ChatCompletionAssistantMessageParam | None = None
         pending_thinking_blocks: list[dict[str, str]] | None = None
+        pending_reasoning_content: str | None = None  # For DeepSeek reasoning_content
 
         def flush_assistant_message() -> None:
-            nonlocal current_assistant_msg
+            nonlocal current_assistant_msg, pending_reasoning_content
             if current_assistant_msg is not None:
                 # The API doesn't support empty arrays for tool_calls
                 if not current_assistant_msg.get("tool_calls"):
                     del current_assistant_msg["tool_calls"]
+                    # prevents stale reasoning_content from contaminating later turns
+                    pending_reasoning_content = None
                 result.append(current_assistant_msg)
                 current_assistant_msg = None
+            else:
+                pending_reasoning_content = None
 
         def ensure_assistant_message() -> ChatCompletionAssistantMessageParam:
             nonlocal current_assistant_msg, pending_thinking_blocks
@@ -579,6 +584,11 @@ class Converter:
             elif func_call := cls.maybe_function_tool_call(item):
                 asst = ensure_assistant_message()
 
+                # If we have pending reasoning content for DeepSeek, add it to the assistant message
+                if pending_reasoning_content:
+                    asst["reasoning_content"] = pending_reasoning_content  # type: ignore[typeddict-unknown-key]
+                    pending_reasoning_content = None  # Clear after using
+
                 # If we have pending thinking blocks, use them as the content
                 # This is required for Anthropic API tool calls with interleaved thinking
                 if pending_thinking_blocks:
@@ -686,6 +696,18 @@ class Converter:
                     # Store thinking blocks as pending for the next assistant message
                     # This preserves the original behavior
                     pending_thinking_blocks = reconstructed_thinking_blocks
+
+                # DeepSeek requires reasoning_content field in assistant messages with tool calls
+                elif model and "deepseek" in model.lower():
+                    summary_items = reasoning_item.get("summary", [])
+                    if summary_items:
+                        
+                        reasoning_texts = []
+                        for summary_item in summary_items:
+                            if isinstance(summary_item, dict) and summary_item.get("text"):
+                                reasoning_texts.append(summary_item["text"])
+                        if reasoning_texts:
+                            pending_reasoning_content = "\n".join(reasoning_texts)
 
             # 8) compaction items => reject for chat completions
             elif isinstance(item, dict) and item.get("type") == "compaction":

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -701,7 +701,6 @@ class Converter:
                 elif model and "deepseek" in model.lower():
                     summary_items = reasoning_item.get("summary", [])
                     if summary_items:
-                        
                         reasoning_texts = []
                         for summary_item in summary_items:
                             if isinstance(summary_item, dict) and summary_item.get("text"):

--- a/tests/models/test_deepseek_reasoning_content.py
+++ b/tests/models/test_deepseek_reasoning_content.py
@@ -1,0 +1,236 @@
+import litellm
+import pytest
+from litellm.types.utils import ChatCompletionMessageToolCall, Choices, Function, Message, ModelResponse, Usage
+
+from agents.extensions.models.litellm_model import LitellmModel
+from agents.model_settings import ModelSettings
+from agents.models.chatcmpl_converter import Converter
+from agents.models.interface import ModelTracing
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_deepseek_reasoning_content_preserved_in_tool_calls(monkeypatch):
+    """
+    Ensure DeepSeek reasoning_content is preserved when converting items to messages.
+
+    DeepSeek requires reasoning_content field in assistant messages with tool_calls.
+    This test verifies that reasoning content from reasoning items is correctly
+    extracted and added to assistant messages during conversion.
+    """
+    # Capture the messages sent to the model
+    captured_calls: list[dict] = []
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        captured_calls.append({"model": model, "messages": messages, **kwargs})
+
+        # First call: model returns reasoning_content + tool_call
+        if len(captured_calls) == 1:
+            tool_call = ChatCompletionMessageToolCall(
+                id="call_123",
+                type="function",
+                function=Function(name="get_weather", arguments='{"city": "Tokyo"}'),
+            )
+            msg = Message(
+                role="assistant",
+                content=None,
+                tool_calls=[tool_call],
+            )
+            # DeepSeek adds reasoning_content to the message
+            msg.reasoning_content = "Let me think about getting the weather for Tokyo..."
+
+            choice = Choices(index=0, message=msg)
+            return ModelResponse(choices=[choice], usage=Usage(100, 50, 150))
+
+        # Second call: model returns final response
+        msg = Message(role="assistant", content="The weather in Tokyo is sunny.")
+        choice = Choices(index=0, message=msg)
+        return ModelResponse(choices=[choice], usage=Usage(100, 50, 150))
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+    model = LitellmModel(model="deepseek/deepseek-reasoner")
+
+    # First call: get the tool call response
+    first_response = await model.get_response(
+        system_instructions="You are a helpful assistant.",
+        input="What's the weather in Tokyo?",
+        model_settings=ModelSettings(),
+        tools=[],  # We'll simulate the tool response manually
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert len(first_response.output) >= 1
+
+    input_items = []
+    input_items.append({"role": "user", "content": "What's the weather in Tokyo?"})
+
+    for item in first_response.output:
+        if hasattr(item, "model_dump"):
+            input_items.append(item.model_dump())
+        else:
+            input_items.append(item)
+
+    input_items.append({
+        "type": "function_call_output",
+        "call_id": "call_123",
+        "output": "The weather in Tokyo is sunny.",
+    })
+
+    messages = Converter.items_to_messages(
+        input_items,
+        model="deepseek/deepseek-reasoner",
+    )
+
+    assistant_messages_with_tool_calls = [
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+
+    assert len(assistant_messages_with_tool_calls) > 0
+    assistant_msg = assistant_messages_with_tool_calls[0]
+    assert "reasoning_content" in assistant_msg
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_deepseek_reasoning_content_in_multi_turn_conversation(monkeypatch):
+    """
+    Verify reasoning_content is included in assistant messages during multi-turn conversations.
+
+    When DeepSeek returns reasoning_content with tool_calls, subsequent API calls must
+    include the reasoning_content field in the assistant message to avoid 400 errors.
+    """
+    captured_calls: list[dict] = []
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        captured_calls.append({"model": model, "messages": messages, **kwargs})
+
+        # First call: model returns reasoning_content + tool_call
+        if len(captured_calls) == 1:
+            tool_call = ChatCompletionMessageToolCall(
+                id="call_weather_123",
+                type="function",
+                function=Function(name="get_weather", arguments='{"city": "Tokyo"}'),
+            )
+            msg = Message(
+                role="assistant",
+                content=None,
+                tool_calls=[tool_call],
+            )
+            # DeepSeek adds reasoning_content
+            msg.reasoning_content = "I need to get the weather for Tokyo first."
+            choice = Choices(index=0, message=msg)
+            return ModelResponse(choices=[choice], usage=Usage(100, 50, 150))
+
+        # Second call: check if reasoning_content was in the request
+        # In real DeepSeek API, this would fail with 400 if reasoning_content is missing
+        msg = Message(role="assistant", content="Based on my findings, the weather in Tokyo is sunny.")
+        choice = Choices(index=0, message=msg)
+        return ModelResponse(choices=[choice], usage=Usage(100, 50, 150))
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+    model = LitellmModel(model="deepseek/deepseek-reasoner")
+
+    # First call
+    first_response = await model.get_response(
+        system_instructions="You are a helpful assistant.",
+        input="What's the weather in Tokyo?",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    input_items = []
+    input_items.append({"role": "user", "content": "What's the weather in Tokyo?"})
+
+    for item in first_response.output:
+        if hasattr(item, "model_dump"):
+            input_items.append(item.model_dump())
+        else:
+            input_items.append(item)
+
+    input_items.append({
+        "type": "function_call_output",
+        "call_id": "call_weather_123",
+        "output": "The weather in Tokyo is sunny and 22°C.",
+    })
+
+    await model.get_response(
+        system_instructions="You are a helpful assistant.",
+        input=input_items,
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert len(captured_calls) == 2
+
+    second_call_messages = captured_calls[1]["messages"]
+
+    assistant_with_tools = None
+    for msg in second_call_messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant" and msg.get("tool_calls"):
+            assistant_with_tools = msg
+            break
+
+    assert assistant_with_tools is not None
+    assert "reasoning_content" in assistant_with_tools
+
+
+def test_deepseek_reasoning_content_with_openai_chatcompletions_path():
+    """
+    Verify reasoning_content works when using OpenAIChatCompletionsModel.
+
+    This ensures the fix works for both LiteLLM and OpenAI ChatCompletions code paths.
+    """
+    from agents.models.chatcmpl_converter import Converter
+
+    input_items = [
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {
+            "id": "__fake_id__",
+            "summary": [{"text": "I need to check the weather in Paris.", "type": "summary_text"}],
+            "type": "reasoning",
+            "content": None,
+            "encrypted_content": None,
+            "status": None,
+            "provider_data": {"model": "deepseek-reasoner", "response_id": "chatcmpl-test"},
+        },
+        {
+            "arguments": '{"city": "Paris"}',
+            "call_id": "call_weather_456",
+            "name": "get_weather",
+            "type": "function_call",
+            "id": "__fake_id__",
+            "status": None,
+            "provider_data": {"model": "deepseek-reasoner"},
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_weather_456",
+            "output": "The weather in Paris is cloudy and 15°C.",
+        },
+    ]
+
+    messages = Converter.items_to_messages(
+        input_items,
+        model="deepseek-reasoner",
+    )
+
+    assistant_with_tools = None
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant" and msg.get("tool_calls"):
+            assistant_with_tools = msg
+            break
+
+    assert assistant_with_tools is not None
+    assert "reasoning_content" in assistant_with_tools
+    assert assistant_with_tools["reasoning_content"] == "I need to check the weather in Paris."

--- a/tests/test_agent_runner_sync.py
+++ b/tests/test_agent_runner_sync.py
@@ -9,9 +9,9 @@ from agents.run import AgentRunner
 
 
 @pytest.fixture
-def fresh_event_loop_policy() -> Generator[asyncio.AbstractEventLoopPolicy, None, None]:
+def fresh_event_loop_policy() -> Generator[Any, None, None]:
     policy_before = asyncio.get_event_loop_policy()
-    new_policy = asyncio.DefaultEventLoopPolicy()
+    new_policy = asyncio.DefaultEventLoopPolicy()  # type: ignore[attr-defined]
     asyncio.set_event_loop_policy(new_policy)
     try:
         yield new_policy

--- a/tests/test_agent_runner_sync.py
+++ b/tests/test_agent_runner_sync.py
@@ -9,9 +9,9 @@ from agents.run import AgentRunner
 
 
 @pytest.fixture
-def fresh_event_loop_policy() -> Generator[Any, None, None]:
+def fresh_event_loop_policy() -> Generator[asyncio.AbstractEventLoopPolicy, None, None]:
     policy_before = asyncio.get_event_loop_policy()
-    new_policy = asyncio.DefaultEventLoopPolicy()  # type: ignore[attr-defined]
+    new_policy = asyncio.DefaultEventLoopPolicy()
     asyncio.set_event_loop_policy(new_policy)
     try:
         yield new_policy


### PR DESCRIPTION
This PR fixes issue #2155 (400 error on tool calls due to missing `reasoning_content` in reconstructed assistant messages.)

**Root Cause**: When DeepSeek returns a response with `reasoning_content` and `tool_calls`, the SDK converts it to:
- A `ResponseReasoningItem` (stores reasoning in `summary` field)
- A `ResponseFunctionToolCall` (stores tool call)

On the next API call, `Converter.items_to_messages()` reconstructs the assistant message with tool calls, but was only handling reasoning content for Anthropic/Claude models (via thinking blocks), not DeepSeek.


**Solution**: The fix follows the same pattern as Anthropic's thinking blocks but uses DeepSeek's `reasoning_content` field instead. It:
1. Extracts reasoning text from the `summary` field when processing reasoning items for DeepSeek models
2. Stores it temporarily in `pending_reasoning_content`
3. Adds it to the assistant message when tool calls are processed


### Checks

- [x] I've added new tests 
- [x] I've run `make lint` and `make format` (linter shows only import resolution warnings, not code issues)
- [x] I've made sure tests pass


Note: The fix works for both code paths:
- **LiteLLM path**: When using `LitellmModel` with `model="deepseek/deepseek-reasoner"`
- **OpenAI ChatCompletions path**: When using `OpenAIChatCompletionsModel` with `model="deepseek-reasoner"` and DeepSeek's OpenAI-compatible endpoint