### PR TITLE
Bump LiteLLM to fix Vertex AI function calling with no-param tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Repository = "https://github.com/openai/openai-agents-python"
 [project.optional-dependencies]
 voice = ["numpy>=2.2.0, <3; python_version>='3.10'", "websockets>=15.0, <16"]
 viz = ["graphviz>=0.17"]
-litellm = ["litellm>=1.80.17, <2"]
+litellm = ["litellm>=1.81.0, <2"]
 realtime = ["websockets>=15.0, <16"]
 sqlalchemy = ["SQLAlchemy>=2.0", "asyncpg>=0.29.0"]
 encrypt = ["cryptography>=45.0, <46"]

--- a/uv.lock
+++ b/uv.lock
@@ -2250,7 +2250,7 @@ requires-dist = [
     { name = "graphviz", marker = "extra == 'viz'", specifier = ">=0.17" },
     { name = "griffe", specifier = ">=1.5.6,<2" },
     { name = "grpcio", marker = "extra == 'dapr'", specifier = ">=1.60.0" },
-    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80.17,<2" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.81.0,<2" },
     { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.11.0,<2" },
     { name = "numpy", marker = "python_full_version >= '3.10' and extra == 'voice'", specifier = ">=2.2.0,<3" },
     { name = "openai", specifier = ">=2.9.0,<3" },


### PR DESCRIPTION
Fixes a Vertex AI error that occurs within LiteLLM, where tools with no parameters (like `get_random_number()`) would fail with a BadRequestError about function declaration parameters schema needing to be type OBJECT.

Bumped LiteLLM dependency to 1.81.0 which handles this case properly. Related bug fix [here](https://github.com/BerriAI/litellm/pull/19103).

Error:
```
litellm.BadRequestError: Vertex_aiException BadRequestError - {
  "error": {
    "code": 400,
    "message": "Unable to submit request because `get_random_number` functionDeclaration parameters schema should be of type OBJECT. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling",
    "status": "INVALID_ARGUMENT"
  }
}
```

Repro Script:
```py
import asyncio
import random

from agents import Agent, Runner, function_tool


@function_tool
def get_random_number() -> int:
    """
    Returns a random number between 0 and 100.
    """
    return random.randint(0, 100)


agent = Agent(
    name="Assistant",
    model="litellm/vertex_ai/gemini-3-flash-preview",
    instructions="You are a helpful agent.",
    tools=[get_random_number],
)


async def main():
    result = await Runner.run(agent, input="Call the `get_random_number` tool")
    print(result.final_output)


if __name__ == "__main__":
    asyncio.run(main())
