### PR TITLE
fix: #2061 handle invalid tool arguments JSON without crashing

### DIFF
--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -139,7 +139,7 @@ async def test_tool_call_error():
     agent = Agent(
         name="test_agent",
         model=model,
-        tools=[get_function_tool("foo", "tool_result", hide_errors=True)],
+        tools=[get_function_tool("foo", "tool_result")],
     )
 
     model.add_multiple_turn_outputs(

--- a/tests/test_tracing_errors_streamed.py
+++ b/tests/test_tracing_errors_streamed.py
@@ -148,7 +148,7 @@ async def test_tool_call_error():
     agent = Agent(
         name="test_agent",
         model=model,
-        tools=[get_function_tool("foo", "tool_result", hide_errors=True)],
+        tools=[get_function_tool("foo", "tool_result")],
     )
 
     model.add_multiple_turn_outputs(


### PR DESCRIPTION
This pull request fixes the tool execution flow to handle malformed JSON arguments gracefully instead of raising and crashing. It adds an early JSON parse check in `src/agents/_run_impl.py` to return a user-friendly tool output, while still emitting tool hooks and output guardrails, and records the parse error in tracing. Tests in `tests/test_tracing_errors.py` and `tests/test_tracing_errors_streamed.py` are updated to assert the new tool output and tracing payload.

Resolves #2061 
See also: https://github.com/openai/openai-agents-js/pull/887