### PR TITLE
feat(mcp): add meta argument to call_tool method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "typing-extensions>=4.12.2, <5",
     "requests>=2.0, <3",
     "types-requests>=2.0, <3",
-    "mcp>=1.11.0, <2; python_version >= '3.10'",
+    "mcp>=1.19.0,<2 ; python_full_version >= '3.10'",
 ]
 classifiers = [
     "Typing :: Typed",

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -79,7 +79,12 @@ class MCPServer(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         """Invoke a tool on the server."""
         pass
 
@@ -402,7 +407,12 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 f"The server may have disconnected."
             ) from e
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         """Invoke a tool on the server."""
         if not self.session:
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
@@ -410,7 +420,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         assert session is not None
 
         try:
-            return await self._run_with_retries(lambda: session.call_tool(tool_name, arguments))
+            return await self._run_with_retries(
+                lambda: session.call_tool(tool_name, arguments, meta=meta)
+            )
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
             raise UserError(

--- a/tests/mcp/helpers.py
+++ b/tests/mcp/helpers.py
@@ -72,6 +72,8 @@ class FakeMCPServer(MCPServer):
         self.tools: list[MCPTool] = tools or []
         self.tool_calls: list[str] = []
         self.tool_results: list[str] = []
+        self.tool_arguments: list[dict[str, Any] | None] = []
+        self.tool_metas: list[dict[str, Any] | None] = []
         self.tool_filter = tool_filter
         self._server_name = server_name
         self._custom_content: list[Content] | None = None
@@ -96,8 +98,15 @@ class FakeMCPServer(MCPServer):
 
         return tools
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         self.tool_calls.append(tool_name)
+        self.tool_arguments.append(arguments)
+        self.tool_metas.append(meta)
         self.tool_results.append(f"result_{tool_name}_{json.dumps(arguments)}")
 
         # Allow testing custom content scenarios

--- a/tests/mcp/test_mcp_server_manager.py
+++ b/tests/mcp/test_mcp_server_manager.py
@@ -33,7 +33,12 @@ class TaskBoundServer(MCPServer):
     ) -> list[MCPTool]:
         raise NotImplementedError
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         raise NotImplementedError
 
     async def list_prompts(self) -> ListPromptsResult:
@@ -69,7 +74,12 @@ class FlakyServer(MCPServer):
     ) -> list[MCPTool]:
         raise NotImplementedError
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         raise NotImplementedError
 
     async def list_prompts(self) -> ListPromptsResult:
@@ -104,7 +114,12 @@ class CleanupAwareServer(MCPServer):
     ) -> list[MCPTool]:
         raise NotImplementedError
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         raise NotImplementedError
 
     async def list_prompts(self) -> ListPromptsResult:
@@ -132,7 +147,12 @@ class CancelledServer(MCPServer):
     ) -> list[MCPTool]:
         raise NotImplementedError
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         raise NotImplementedError
 
     async def list_prompts(self) -> ListPromptsResult:

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -109,7 +109,12 @@ async def test_mcp_invoke_bad_json_errors(caplog: pytest.LogCaptureFixture):
 
 
 class CrashingFakeMCPServer(FakeMCPServer):
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None):
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ):
         raise Exception("Crash!")
 
 
@@ -367,7 +372,12 @@ class StructuredContentTestServer(FakeMCPServer):
         self._test_content = content
         self._test_structured_content = structured_content
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         """Return test result with specified content and structured content."""
         self.tool_calls.append(tool_name)
 

--- a/tests/mcp/test_prompt_server.py
+++ b/tests/mcp/test_prompt_server.py
@@ -63,7 +63,12 @@ class FakeMCPPromptServer(MCPServer):
     async def list_tools(self, run_context=None, agent=None):
         return []
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None = None):
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+        meta: dict[str, Any] | None = None,
+    ):
         raise NotImplementedError("This fake server doesn't support tools")
 
     @property

--- a/uv.lock
+++ b/uv.lock
@@ -1609,7 +1609,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.12.4"
+version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
@@ -1624,9 +1624,9 @@ dependencies = [
     { name = "starlette", marker = "python_full_version >= '3.10'" },
     { name = "uvicorn", marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/88/f6cb7e7c260cd4b4ce375f2b1614b33ce401f63af0f49f7141a2e9bf0a45/mcp-1.12.4.tar.gz", hash = "sha256:0765585e9a3a5916a3c3ab8659330e493adc7bd8b2ca6120c2d7a0c43e034ca5", size = 431148, upload-time = "2025-08-07T20:31:18.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/2b/916852a5668f45d8787378461eaa1244876d77575ffef024483c94c0649c/mcp-1.19.0.tar.gz", hash = "sha256:213de0d3cd63f71bc08ffe9cc8d4409cc87acffd383f6195d2ce0457c021b5c1", size = 444163, upload-time = "2025-10-24T01:11:15.839Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/68/316cbc54b7163fa22571dcf42c9cc46562aae0a021b974e0a8141e897200/mcp-1.12.4-py3-none-any.whl", hash = "sha256:7aa884648969fab8e78b89399d59a683202972e12e6bc9a1c88ce7eda7743789", size = 160145, upload-time = "2025-08-07T20:31:15.69Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a3/3e71a875a08b6a830b88c40bc413bff01f1650f1efe8a054b5e90a9d4f56/mcp-1.19.0-py3-none-any.whl", hash = "sha256:f5907fe1c0167255f916718f376d05f09a830a215327a3ccdd5ec8a519f2e572", size = 170105, upload-time = "2025-10-24T01:11:14.151Z" },
 ]
 
 [[package]]
@@ -2251,7 +2251,7 @@ requires-dist = [
     { name = "griffe", specifier = ">=1.5.6,<2" },
     { name = "grpcio", marker = "extra == 'dapr'", specifier = ">=1.60.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.81.0,<2" },
-    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.11.0,<2" },
+    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.19.0,<2" },
     { name = "numpy", marker = "python_full_version >= '3.10' and extra == 'voice'", specifier = ">=2.2.0,<3" },
     { name = "openai", specifier = ">=2.9.0,<3" },
     { name = "pydantic", specifier = ">=2.12.3,<3" },


### PR DESCRIPTION
### Summary

This PR adds an optional `meta` parameter to `MCPServer.call_tool()` method, enabling users to pass metadata with MCP tool call requests.

**Motivation:**

The MCP protocol supports a `_meta` field in tool call requests (see [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/basic#general-fields)), which allows clients to include additional context such as progress tokens, request IDs, or custom tracking information. Currently, the Agents SDK's `MCPServer.call_tool()` method does not expose this capability, preventing users from leveraging this feature when invoking MCP tools.

This change aligns the SDK with the full MCP protocol capabilities and enables use cases like:
- Passing progress tokens for long-running tool operations
- Including request correlation IDs for debugging/tracing
- Forwarding user context or locale information to MCP servers

**Changes:**
- Add `meta: dict[str, Any] | None = None` parameter to `MCPServer.call_tool()` abstract method
- Update `_MCPServerWithClientSession` implementation to pass `meta` to the underlying `session.call_tool()`
- Update all test mocks to include the `meta` parameter
- Bump `mcp` dependency from `>=1.11.0` to `>=1.19.0` (minimum version with native `meta` support in `ClientSession.call_tool()`)

### Test plan

- Added 3 new tests for `meta` parameter:
  - `test_call_tool_passes_meta_to_session` - verifies meta is correctly passed
  - `test_call_tool_passes_none_meta_to_session` - verifies default None behavior
  - `test_call_tool_with_meta_retries_preserves_meta` - verifies meta is preserved across retries
- All 95 MCP tests pass
- Ran `make format`, `make lint`, `make mypy`, `make tests`

### Issue number

Closes #2367

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass