### PR TITLE
feat: #2367 add MCP tool meta resolver support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "typing-extensions>=4.12.2, <5",
     "requests>=2.0, <3",
     "types-requests>=2.0, <3",
-    "mcp>=1.11.0, <2; python_version >= '3.10'",
+    "mcp>=1.19.0, <2; python_version >= '3.10'",
 ]
 classifiers = [
     "Typing :: Typed",

--- a/src/agents/mcp/__init__.py
+++ b/src/agents/mcp/__init__.py
@@ -13,6 +13,8 @@ except ImportError:
     pass
 
 from .util import (
+    MCPToolMetaContext,
+    MCPToolMetaResolver,
     MCPUtil,
     ToolFilter,
     ToolFilterCallable,
@@ -31,6 +33,8 @@ __all__ = [
     "MCPServerStreamableHttpParams",
     "MCPServerManager",
     "MCPUtil",
+    "MCPToolMetaContext",
+    "MCPToolMetaResolver",
     "ToolFilter",
     "ToolFilterCallable",
     "ToolFilterContext",

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -14,7 +14,7 @@ class DummySession:
         self.call_tool_attempts = 0
         self.list_tools_attempts = 0
 
-    async def call_tool(self, tool_name, arguments):
+    async def call_tool(self, tool_name, arguments, meta=None):
         self.call_tool_attempts += 1
         if self.call_tool_attempts <= self.fail_call_tool:
             raise RuntimeError("call_tool failure")

--- a/tests/mcp/test_mcp_server_manager.py
+++ b/tests/mcp/test_mcp_server_manager.py
@@ -33,7 +33,12 @@ class TaskBoundServer(MCPServer):
     ) -> list[MCPTool]:
         raise NotImplementedError
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         raise NotImplementedError
 
     async def list_prompts(self) -> ListPromptsResult:
@@ -69,7 +74,12 @@ class FlakyServer(MCPServer):
     ) -> list[MCPTool]:
         raise NotImplementedError
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         raise NotImplementedError
 
     async def list_prompts(self) -> ListPromptsResult:
@@ -104,7 +114,12 @@ class CleanupAwareServer(MCPServer):
     ) -> list[MCPTool]:
         raise NotImplementedError
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         raise NotImplementedError
 
     async def list_prompts(self) -> ListPromptsResult:
@@ -132,7 +147,12 @@ class CancelledServer(MCPServer):
     ) -> list[MCPTool]:
         raise NotImplementedError
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None) -> CallToolResult:
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         raise NotImplementedError
 
     async def list_prompts(self) -> ListPromptsResult:

--- a/tests/mcp/test_prompt_server.py
+++ b/tests/mcp/test_prompt_server.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 from agents import Agent, Runner
-from agents.mcp import MCPServer
+from agents.mcp import MCPServer, MCPToolMetaResolver
 
 from ..fake_model import FakeModel
 from ..test_responses import get_text_message
@@ -12,7 +12,12 @@ from ..test_responses import get_text_message
 class FakeMCPPromptServer(MCPServer):
     """Fake MCP server for testing prompt functionality"""
 
-    def __init__(self, server_name: str = "fake_prompt_server"):
+    def __init__(
+        self,
+        server_name: str = "fake_prompt_server",
+        tool_meta_resolver: MCPToolMetaResolver | None = None,
+    ):
+        super().__init__(tool_meta_resolver=tool_meta_resolver)
         self.prompts: list[Any] = []
         self.prompt_results: dict[str, str] = {}
         self._server_name = server_name
@@ -63,7 +68,12 @@ class FakeMCPPromptServer(MCPServer):
     async def list_tools(self, run_context=None, agent=None):
         return []
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any] | None = None):
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+        meta: dict[str, Any] | None = None,
+    ):
         raise NotImplementedError("This fake server doesn't support tools")
 
     @property

--- a/uv.lock
+++ b/uv.lock
@@ -1609,7 +1609,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.12.4"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
@@ -1618,15 +1618,18 @@ dependencies = [
     { name = "jsonschema", marker = "python_full_version >= '3.10'" },
     { name = "pydantic", marker = "python_full_version >= '3.10'" },
     { name = "pydantic-settings", marker = "python_full_version >= '3.10'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.10'" },
     { name = "python-multipart", marker = "python_full_version >= '3.10'" },
     { name = "pywin32", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
     { name = "sse-starlette", marker = "python_full_version >= '3.10'" },
     { name = "starlette", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.10'" },
     { name = "uvicorn", marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/88/f6cb7e7c260cd4b4ce375f2b1614b33ce401f63af0f49f7141a2e9bf0a45/mcp-1.12.4.tar.gz", hash = "sha256:0765585e9a3a5916a3c3ab8659330e493adc7bd8b2ca6120c2d7a0c43e034ca5", size = 431148, upload-time = "2025-08-07T20:31:18.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/68/316cbc54b7163fa22571dcf42c9cc46562aae0a021b974e0a8141e897200/mcp-1.12.4-py3-none-any.whl", hash = "sha256:7aa884648969fab8e78b89399d59a683202972e12e6bc9a1c88ce7eda7743789", size = 160145, upload-time = "2025-08-07T20:31:15.69Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
 ]
 
 [[package]]
@@ -2251,7 +2254,7 @@ requires-dist = [
     { name = "griffe", specifier = ">=1.5.6,<2" },
     { name = "grpcio", marker = "extra == 'dapr'", specifier = ">=1.60.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.81.0,<2" },
-    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.11.0,<2" },
+    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.19.0,<2" },
     { name = "numpy", marker = "python_full_version >= '3.10' and extra == 'voice'", specifier = ">=2.2.0,<3" },
     { name = "openai", specifier = ">=2.9.0,<3" },
     { name = "pydantic", specifier = ">=2.12.3,<3" },
@@ -2665,6 +2668,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography", marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request resolves #2367

Here is a documentation draft:

If you need to attach MCP request metadata to tool calls, supply a `tool_meta_resolver` when constructing the server. The resolver receives an [`MCPToolMetaContext`][agents.mcp.MCPToolMetaContext] and returns a dict that is sent as MCP `_meta`.

```python
from agents import Agent, Runner
from agents.mcp import MCPToolMetaContext, MCPServerStreamableHttp

def resolve_meta(args: MCPToolMetaContext) -> dict[str, str]:
    return {"request_id": args.run_context.context["request_id"]}

async def main() -> None:
    async with MCPServerStreamableHttp(
        name="Streamable HTTP Server",
        params={"url": "http://localhost:8000/mcp"},
        tool_meta_resolver=resolve_meta,
    ) as server:
        agent = Agent(
            name="Assistant",
            instructions="Use MCP tools when helpful.",
            mcp_servers=[server],
        )
        await Runner.run(
            agent,
            "List available resources.",
            context={"request_id": "req-123"},
        )
```

Notes:

- The resolver runs before each MCP tool invocation during agent runs.
- If you pass explicit meta when calling `MCPUtil.invoke_mcp_tool`, it is merged over the resolver output.
- `list_tools()` does not accept metadata in the MCP Python SDK yet.
- If you call `server.call_tool` directly, pass `meta` yourself; the resolver is only used by the Agents SDK call path.