### PR TITLE
feat: propagate tool description to ToolCallItem (#2379)

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -245,6 +245,9 @@ class ToolCallItem(RunItemBase[Any]):
 
     type: Literal["tool_call_item"] = "tool_call_item"
 
+    description: str | None = None
+    """Optional tool description if known at item creation time."""
+
 
 ToolCallOutputTypes: TypeAlias = Union[
     FunctionCallOutput,

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -111,6 +111,16 @@ class MCPServer(abc.ABC):
         """Invoke a tool on the server."""
         pass
 
+    @property
+    def cached_tools(self) -> list[MCPTool] | None:
+        """Return the most recently fetched tools list, if available.
+
+        Implementations may return `None` when tools have not been fetched yet or caching is
+        disabled.
+        """
+
+        return None
+
     @abc.abstractmethod
     async def list_prompts(
         self,
@@ -210,6 +220,10 @@ class MCPServer(abc.ABC):
 
 class _MCPServerWithClientSession(MCPServer, abc.ABC):
     """Base class for MCP servers that use a `ClientSession` to communicate with the server."""
+
+    @property
+    def cached_tools(self) -> list[MCPTool] | None:
+        return self._tools_list
 
     def __init__(
         self,

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -610,6 +610,8 @@ class RunState(Generic[TContext, TAgent]):
             result["target_agent"] = {"name": item.target_agent.name}
         if hasattr(item, "tool_name") and item.tool_name is not None:
             result["tool_name"] = item.tool_name
+        if hasattr(item, "description") and item.description is not None:
+            result["description"] = item.description
 
         return result
 
@@ -1985,7 +1987,11 @@ def _deserialize_items(
                 # Tool call items can be function calls, shell calls, apply_patch calls,
                 # MCP calls, etc. Check the type field to determine which type to deserialize as
                 raw_item_tool = _deserialize_tool_call_raw_item(normalized_raw_item)
-                result.append(ToolCallItem(agent=agent, raw_item=raw_item_tool))
+                # Preserve description if it was stored with the item
+                description = item_data.get("description")
+                result.append(
+                    ToolCallItem(agent=agent, raw_item=raw_item_tool, description=description)
+                )
 
             elif item_type == "tool_call_output_item":
                 # For tool call outputs, validate and convert the raw dict


### PR DESCRIPTION
### Summary

Add `description` field to `ToolCallItem` to expose tool descriptions for streaming UIs and observability.

- Add optional `description: str | None` field to `ToolCallItem`
- Populate from `FunctionTool.description` for `@function_tool` decorated functions
- Populate via `MCPServer.cached_tools` lookup for MCP tools
- Add `cached_tools` property to `MCPServer` base class
- Preserve through `RunState` serialization round-trips

### Motivation

When streaming tool calls to UIs, the tool name alone (e.g., `list_sites`) isn't user-friendly. This change makes the tool's description available at streaming time, enabling UIs to show "Listing organization sites with pagination..." instead of just the function name.

### Test plan

- Added serialization round-trip test for description field
- Verified both streaming and non-streaming paths populate the field
- All existing tests pass

### Issue number

Closes #2379