### PR TITLE
fix: make trace_include_sensitive_data default to False for security

### DIFF
--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -28,7 +28,7 @@ DEFAULT_MAX_TURNS = 10
 
 def _default_trace_include_sensitive_data() -> bool:
     """Return the default for trace_include_sensitive_data based on environment."""
-    val = os.getenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", "true")
+    val = os.getenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", "false")
     return val.strip().lower() in ("1", "true", "yes", "on")
 
 

--- a/src/agents/voice/pipeline_config.py
+++ b/src/agents/voice/pipeline_config.py
@@ -22,9 +22,10 @@ class VoicePipelineConfig:
     tracing: TracingConfig | None = None
     """Tracing configuration for this pipeline."""
 
-    trace_include_sensitive_data: bool = True
-    """Whether to include sensitive data in traces. Defaults to `True`. This is specifically for the
-      voice pipeline, and not for anything that goes on inside your Workflow."""
+    trace_include_sensitive_data: bool = False
+    """Whether to include sensitive data in traces. Defaults to `False` for security. When enabled,
+      tool inputs/outputs and LLM generations may be exposed in traces. Only enable in trusted
+      environments."""
 
     trace_include_sensitive_audio_data: bool = True
     """Whether to include audio data in traces. Defaults to `True`."""

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -88,11 +88,11 @@ async def test_agent_model_object_is_used_when_present() -> None:
     assert result.final_output == "from-agent-object"
 
 
-def test_trace_include_sensitive_data_defaults_to_true_when_env_not_set(monkeypatch):
-    """By default, trace_include_sensitive_data should be True when the env is not set."""
+def test_trace_include_sensitive_data_defaults_to_false_when_env_not_set(monkeypatch):
+    """By default, trace_include_sensitive_data should be False for security when the env is not set."""
     monkeypatch.delenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", raising=False)
     config = RunConfig()
-    assert config.trace_include_sensitive_data is True
+    assert config.trace_include_sensitive_data is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

By default,  was set to , which meant sensitive data (tool inputs/outputs, LLM generations) was automatically included in traces without explicit user consent. This violates the security principle of "secure by default" and could lead to:

- **Accidental data leakage** of PII, secrets, or confidential information in production traces
- **Compliance violations** for organizations with strict data handling requirements
- **Security incidents** where developers unknowingly expose sensitive data

## Changes

This PR makes the SDK secure-by-default by changing the default value from  to :

1. **src/agents/run_config.py**: Changed  environment variable default from  to 
2. **src/agents/voice/pipeline_config.py**: Changed  default from  to  with improved documentation
3. **tests/test_run_config.py**: Updated test expectations to reflect new secure-by-default behavior

## Impact

- **Breaking change**: Users relying on the old default will need to explicitly opt-in by setting  or passing  to their config
- **Security improvement**: Prevents accidental exposure of sensitive data in production deployments
- **Total diff**: ~15 lines changed (well within the 10-100 line limit)

## Migration for existing users

Users who want to maintain the previous behavior can:



This change aligns with security best practices and protects users from unintentional data exposure.