### PR TITLE
add Traccia integration link to tracing documentation

### DIFF
--- a/docs/ja/tracing.md
+++ b/docs/ja/tracing.md
@@ -164,3 +164,4 @@ await Runner.run(
 -   [LangDB AI](https://docs.langdb.ai/getting-started/working-with-agent-frameworks/working-with-openai-agents-sdk)
 -   [Agenta](https://docs.agenta.ai/observability/integrations/openai-agents)
 -   [PostHog](https://posthog.com/docs/llm-analytics/installation/openai-agents)
+-   [Traccia](https://traccia.ai/docs/integrations/openai-agents)

--- a/docs/ko/tracing.md
+++ b/docs/ko/tracing.md
@@ -164,3 +164,4 @@ await Runner.run(
 -   [LangDB AI](https://docs.langdb.ai/getting-started/working-with-agent-frameworks/working-with-openai-agents-sdk)
 -   [Agenta](https://docs.agenta.ai/observability/integrations/openai-agents)
 -   [PostHog](https://posthog.com/docs/llm-analytics/installation/openai-agents)
+-   [Traccia](https://traccia.ai/docs/integrations/openai-agents)

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -162,3 +162,4 @@ await Runner.run(
 -   [LangDB AI](https://docs.langdb.ai/getting-started/working-with-agent-frameworks/working-with-openai-agents-sdk)
 -   [Agenta](https://docs.agenta.ai/observability/integrations/openai-agents)
 -   [PostHog](https://posthog.com/docs/llm-analytics/installation/openai-agents)
+-   [Traccia](https://traccia.ai/docs/integrations/openai-agents)

--- a/docs/zh/tracing.md
+++ b/docs/zh/tracing.md
@@ -164,3 +164,4 @@ await Runner.run(
 -   [LangDB AI](https://docs.langdb.ai/getting-started/working-with-agent-frameworks/working-with-openai-agents-sdk)
 -   [Agenta](https://docs.agenta.ai/observability/integrations/openai-agents)
 -   [PostHog](https://posthog.com/docs/llm-analytics/installation/openai-agents)
+-   [Traccia](https://traccia.ai/docs/integrations/openai-agents)


### PR DESCRIPTION
Hello from Traccia!

Traccia now supports tracing agents made with OpenAI Agents SDK - [Documentation](https://traccia.ai/docs/integrations/openai-agents)

[Traccia Release v0.1.6](https://github.com/traccia-ai/traccia/releases/tag/v0.1.6)