### PR TITLE
fix: remove erroneous isinstance(agent, Tool) check in visualization

### DIFF
--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -4,7 +4,6 @@ import graphviz  # type: ignore
 
 from agents import Agent
 from agents.handoffs import Handoff
-from agents.tool import Tool
 
 
 def get_main_graph(agent: Agent) -> str:
@@ -139,7 +138,7 @@ def get_all_edges(
             "{agent.name}" -> "{handoff.name}";""")
             parts.append(get_all_edges(handoff, agent, visited))
 
-    if not agent.handoffs and not isinstance(agent, Tool):  # type: ignore
+    if not agent.handoffs:
         parts.append(f'"{agent.name}" -> "__end__";')
 
     return "".join(parts)


### PR DESCRIPTION
## Summary

Fixes #2397 

This PR fixes a `TypeError` that occurs on Python 3.12+ when calling `draw_graph()`:

```
TypeError: Subscripted generics cannot be used with class and instance checks
```

## Root Cause

The issue is on line 142 of `visualization.py`:

```python
if not agent.handoffs and not isinstance(agent, Tool):  # type: ignore
```

This code has two problems:

1. **Runtime error on Python 3.12+**: `Tool` is a `Union` type alias containing generic types (like `ComputerTool[Any]`). In Python 3.12+, using `isinstance()` with such types raises a `TypeError`.

2. **Logically incorrect**: The `agent` parameter is typed as `Agent`, which can never be an instance of `Tool` (a completely different type). This check always evaluated to `False` (when it didn't error), making it a no-op.

## Changes

- **Removed** the unnecessary `isinstance(agent, Tool)` check
- **Removed** the unused `from agents.tool import Tool` import
- **Added** two new test cases using real `Agent` objects (not mocks) to ensure the fix works and prevent regression

## Testing

Added tests:
- `test_draw_graph_with_real_agent_no_handoffs`: Tests agent without handoffs connects to `__end__`
- `test_draw_graph_with_real_agent_with_handoffs`: Tests parent/child agent graph generation

These tests use real `Agent` objects rather than mocks, which would have caught this bug earlier.