### PR TITLE
fix: preserve legacy positional previous_response_id in Runner.run_streamed

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -317,11 +317,12 @@ class Runner:
         max_turns: int = DEFAULT_MAX_TURNS,
         hooks: RunHooks[TContext] | None = None,
         run_config: RunConfig | None = None,
-        error_handlers: RunErrorHandlers[TContext] | None = None,
         previous_response_id: str | None = None,
         auto_previous_response_id: bool = False,
         conversation_id: str | None = None,
         session: Session | None = None,
+        *,
+        error_handlers: RunErrorHandlers[TContext] | None = None,
     ) -> RunResultStreaming:
         """
         Run a workflow starting at the given agent in streaming mode.


### PR DESCRIPTION
This pull request fixes a backward-compatibility issue with https://github.com/openai/openai-agents-python/pull/2347 in Runner.run_streamed where legacy positional arguments could be interpreted incorrectly after parameter additions.

  - Updated src/agents/run.py to make error_handlers keyword-only (*), preserving the existing positional slot for previous_response_id.
  - Added a regression test in tests/test_agent_runner.py that exercises the legacy positional call pattern and asserts previous_response_id remains correctly populated while error_handlers stays None.