### PR TITLE
fix: restore MCPUtil.to_function_tool legacy call compatibility

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -228,13 +228,15 @@ class MCPServer(abc.ABC):
     def _get_needs_approval_for_tool(
         self,
         tool: MCPTool,
-        agent: AgentBase,
+        agent: AgentBase | None,
     ) -> bool | Callable[[RunContextWrapper[Any], dict[str, Any], str], Awaitable[bool]]:
         """Return a FunctionTool.needs_approval value for a given MCP tool."""
 
         policy = self._needs_approval_policy
 
         if callable(policy):
+            if agent is None:
+                return False
 
             async def _needs_approval(
                 run_context: RunContextWrapper[Any], _args: dict[str, Any], _call_id: str

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -299,7 +299,7 @@ class MCPUtil:
 
         needs_approval: (
             bool | Callable[[RunContextWrapper[Any], dict[str, Any], str], Awaitable[bool]]
-        ) = server._get_needs_approval_for_tool(tool, agent) if agent is not None else False
+        ) = server._get_needs_approval_for_tool(tool, agent)
 
         return FunctionTool(
             name=tool.name,

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -291,8 +291,8 @@ async def test_mcp_tool_timeout_handling():
 
 
 @pytest.mark.asyncio
-async def test_to_function_tool_legacy_call_without_agent_is_supported():
-    """Legacy three-argument to_function_tool calls should remain valid."""
+async def test_to_function_tool_legacy_call_without_agent_uses_server_policy():
+    """Legacy three-argument to_function_tool calls should honor server policy."""
 
     server = FakeMCPServer(require_approval="always")
     server.add_tool("legacy_tool", {})
@@ -304,8 +304,8 @@ async def test_to_function_tool_legacy_call_without_agent_is_supported():
         convert_schemas_to_strict=False,
     )
 
-    # v0.7.x behavior: direct conversion did not enable approval gating.
-    assert function_tool.needs_approval is False
+    # Legacy calls should still respect server-level approval settings.
+    assert function_tool.needs_approval is True
 
     tool_context = ToolContext(
         context=None,


### PR DESCRIPTION
This pull request fixes a backward-compatibility regression with #636 in MCP tool conversion by restoring support for the legacy three-argument MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict) call form.