### PR TITLE
fix: make codex subprocess stream limit configurable and validate bounds

### DIFF
--- a/src/agents/extensions/experimental/codex/codex.py
+++ b/src/agents/extensions/experimental/codex/codex.py
@@ -30,6 +30,7 @@ class Codex:
         base_url: str | None = None,
         api_key: str | None = None,
         env: Mapping[str, str] | None = None,
+        codex_subprocess_stream_limit_bytes: int | None = None,
     ) -> None: ...
 
     def __init__(
@@ -40,12 +41,14 @@ class Codex:
         base_url: str | None | _UnsetType = _UNSET,
         api_key: str | None | _UnsetType = _UNSET,
         env: Mapping[str, str] | None | _UnsetType = _UNSET,
+        codex_subprocess_stream_limit_bytes: int | None | _UnsetType = _UNSET,
     ) -> None:
         kw_values = {
             "codex_path_override": codex_path_override,
             "base_url": base_url,
             "api_key": api_key,
             "env": env,
+            "codex_subprocess_stream_limit_bytes": codex_subprocess_stream_limit_bytes,
         }
         has_kwargs = any(value is not _UNSET for value in kw_values.values())
         if options is not None and has_kwargs:
@@ -59,6 +62,7 @@ class Codex:
         self._exec = CodexExec(
             executable_path=resolved_options.codex_path_override,
             env=_normalize_env(resolved_options),
+            subprocess_stream_limit_bytes=resolved_options.codex_subprocess_stream_limit_bytes,
         )
         self._options = resolved_options
 

--- a/src/agents/extensions/experimental/codex/codex_options.py
+++ b/src/agents/extensions/experimental/codex/codex_options.py
@@ -17,6 +17,8 @@ class CodexOptions:
     api_key: str | None = None
     # Environment variables for the Codex CLI process (do not inherit os.environ).
     env: Mapping[str, str] | None = None
+    # StreamReader byte limit used for Codex subprocess stdout/stderr pipes.
+    codex_subprocess_stream_limit_bytes: int | None = None
 
 
 def coerce_codex_options(

--- a/src/agents/extensions/experimental/codex/codex_tool.py
+++ b/src/agents/extensions/experimental/codex/codex_tool.py
@@ -425,6 +425,7 @@ def _resolve_codex_options(
         base_url=options.base_url,
         api_key=api_key,
         env=options.env,
+        codex_subprocess_stream_limit_bytes=options.codex_subprocess_stream_limit_bytes,
     )
 
 


### PR DESCRIPTION
This pull request fixes large Codex JSON-line stream failures by making the subprocess stream limit configurable while preserving a safe default. It adds codex_subprocess_stream_limit_bytes to CodexOptions/Codex(...), supports OPENAI_AGENTS_CODEX_SUBPROCESS_STREAM_LIMIT_BYTES, and resolves values with explicit option > env var > default (8 MiB). It also adds validation guardrails (64 KiB to 64 MiB) with clear UserErrors and updates Codex option resolution paths so the new setting is preserved through tool integration.

The change is backward-compatible: existing behavior remains unchanged unless users opt in to a custom value, and the default still handles larger single-line outputs than the prior asyncio default limit.