### PR TITLE
fix: preserve latest session tool outputs and keep orphan calls in non-resume input prep

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -35,6 +35,7 @@ __all__ = [
     "normalize_resumed_input",
     "fingerprint_input_item",
     "deduplicate_input_items",
+    "deduplicate_input_items_preferring_latest",
     "function_rejection_item",
     "shell_rejection_item",
     "apply_patch_rejection_item",
@@ -174,6 +175,15 @@ def deduplicate_input_items(items: Sequence[TResponseInputItem]) -> list[TRespon
         seen_keys.add(dedupe_key)
         deduplicated.append(item)
     return deduplicated
+
+
+def deduplicate_input_items_preferring_latest(
+    items: Sequence[TResponseInputItem],
+) -> list[TResponseInputItem]:
+    """Deduplicate by stable identifiers while keeping the latest occurrence."""
+    # deduplicate_input_items keeps the first item per dedupe key. Reverse twice so that
+    # the latest item in the original order wins for duplicate IDs/call_ids.
+    return list(reversed(deduplicate_input_items(list(reversed(items)))))
 
 
 def function_rejection_item(

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -78,7 +78,7 @@ from .guardrails import (
 from .items import (
     REJECTION_MESSAGE,
     copy_input_items,
-    deduplicate_input_items,
+    deduplicate_input_items_preferring_latest,
     ensure_input_item_format,
     normalize_input_items_for_api,
     normalize_resumed_input,
@@ -1109,7 +1109,7 @@ async def run_single_turn_streamed(
         system_instructions=system_prompt,
     )
     if isinstance(filtered.input, list):
-        filtered.input = deduplicate_input_items(filtered.input)
+        filtered.input = deduplicate_input_items_preferring_latest(filtered.input)
     if server_conversation_tracker is not None:
         logger.debug(
             "filtered.input has %s items; ids=%s",
@@ -1418,7 +1418,7 @@ async def get_new_response(
         system_instructions=system_prompt,
     )
     if isinstance(filtered.input, list):
-        filtered.input = deduplicate_input_items(filtered.input)
+        filtered.input = deduplicate_input_items_preferring_latest(filtered.input)
 
     if server_conversation_tracker is not None:
         server_conversation_tracker.mark_input_as_sent(filtered.input)


### PR DESCRIPTION
This pull request fixes duplicate tool-output handling (caused by #2230) so the latest item wins consistently when entries share the same stable identifier (for example call_id). It addresses a regression where older session/history outputs could silently override newer outputs, causing model input and persisted session state to diverge from the latest tool result.

This pull request updates deduplication behavior in runtime paths that prepare model input (call_model_input_filter for both non-streamed and streamed runs) and in session persistence (save_result_to_session), and adds a shared latest-wins helper for internal item deduplication. It also keeps resume and non-resume behavior aligned for orphan tool-call normalization to avoid interruption-dependent context drift.
