### PR TITLE
fix: restore replay compatibility for run context approvals and guardrail execution

### DIFF
--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -9,10 +9,16 @@ from .usage import Usage
 
 if TYPE_CHECKING:
     from .items import ToolApprovalItem, TResponseInputItem
+else:
+    # Keep runtime annotations resolvable for TypeAdapter users (e.g., Temporal's
+    # Pydantic data converter) without importing items.py and introducing cycles.
+    ToolApprovalItem = Any
+    TResponseInputItem = Any
 
 TContext = TypeVar("TContext", default=Any)
 
 
+@dataclass(eq=False)
 class _ApprovalRecord:
     """Tracks approval/rejection state for a tool.
 
@@ -20,12 +26,8 @@ class _ApprovalRecord:
     or lists of call IDs when approval is scoped to specific tool calls.
     """
 
-    approved: bool | list[str]
-    rejected: bool | list[str]
-
-    def __init__(self):
-        self.approved = []
-        self.rejected = []
+    approved: bool | list[str] = field(default_factory=list)
+    rejected: bool | list[str] = field(default_factory=list)
 
 
 @dataclass(eq=False)


### PR DESCRIPTION
This pull request fixes durable-agent regressions introduced by runtime behavior changes in `src/agents/run.py` and `src/agents/run_context.py`, while keeping current main-branch intent intact.

- Updates `RunContextWrapper` approval storage internals to remain Pydantic-schema-compatible when decoded in durable agent activities, by making `_ApprovalRecord` a dataclass with explicit serializable fields.
- Keeps runtime-safe annotation fallbacks for `ToolApprovalItem`/`TResponseInputItem` so Temporal’s type-adapter path can resolve types without import-cycle issues.
- Refactors first-turn parallel input-guardrail/model execution in `src/agents/run.py` to avoid race-driven `FIRST_COMPLETED` branching and use a deterministic join path, while preserving existing tripwire persistence behavior.
