### PR TITLE
Add Agents SDK DBOS integration to the docs for long-running agents and human-in-the-loop

### DIFF
--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -219,6 +219,10 @@ You can use the Agents SDK [Temporal](https://temporal.io/) integration to run d
 You can use the Agents SDK [Restate](https://restate.dev/) integration for lightweight, durable agents, including human approval, handoffs, and session management. The integration requires Restate's single-binary runtime as a dependency, and supports running agents as processes/containers or serverless functions.
 Read the [overview](https://www.restate.dev/blog/durable-orchestration-for-ai-agents-with-restate-and-openai-sdk) or view the [docs](https://docs.restate.dev/ai) for more details.
 
+### DBOS
+
+You can use the Agents SDK [DBOS](https://dbos.dev/) integration to run reliable agents that preserves progress across failures and restarts. It supports long-running agents, human-in-the-loop workflows, and handoffs. It supports both sync and async methods. The integration requires only a SQLite or Postgres database. View the integration [repo](https://github.com/dbos-inc/dbos-openai-agents) and the [docs](https://docs.dbos.dev/integrations/openai-agents) for more details.
+
 ## Exceptions
 
 The SDK raises exceptions in certain cases. The full list is in [`agents.exceptions`][]. As an overview:


### PR DESCRIPTION
This PR updates the docs to mention DBOS OpenAI Agents integration for long-running and human-in-the-loop agents. Closes #1711

DBOS is a durable execution library, where its only dependency is a database (SQLite or Postgres).

The integration adds a `DBOSRunner` as a drop-in replacement for `Runner`, which allows agents to be executed from DBOS workflows and persists LLM calls so they can be deterministically replayed after failures or restarts.

Example (async):

```python
@function_tool
@DBOS.step()
async def get_weather(city: str) -> str:
    ...

agent = Agent(name="weather", tools=[get_weather])

# Call the agent from a DBOS workflow
@DBOS.workflow()
async def run_agent(user_input: str) -> str:
    result = await DBOSRunner.run(agent, user_input)
    return str(result.final_output)
```

DBOS also supports a synchronous execution model:

```python
@function_tool
@DBOS.step()
def get_weather(city: str) -> str:
    ...

agent = Agent(name="weather", tools=[get_weather])

# Call the agent from a DBOS workflow
@DBOS.workflow()
def run_agent(user_input: str) -> str:
    result = DBOSRunner.run_sync(agent, user_input)
    return str(result.final_output)
```

Links:

* Integration repo: https://github.com/dbos-inc/dbos-openai-agents
* DBOS docs: https://docs.dbos.dev/integrations/openai-agents