### PR TITLE
fix: #2426 persist streamed run-again tool items to session

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -946,6 +946,12 @@ async def start_streaming(
                     if streamed_result._state is not None:
                         streamed_result._state._current_step = NextStepRunAgain()
 
+                    await _save_stream_items_with_count(
+                        turn_session_items,
+                        turn_result.model_response.response_id,
+                        store_setting,
+                    )
+
                     if streamed_result._cancel_mode == "after_turn":  # type: ignore[comparison-overlap]
                         streamed_result.is_complete = True
                         streamed_result._event_queue.put_nowait(QueueCompleteSentinel())


### PR DESCRIPTION
This pull request resolves #2426: a streamed session persistence gap where `Runner.run_streamed` did not save tool call items when the turn ended with `NextStepRunAgain`, causing follow-up turns to miss prior tool execution context (for example, repeated tool calls in multi-turn flows, including handoff scenarios). 

The streamed loop now persists turn session items in the run-again path, aligning behavior with non-streaming `Runner.run`.  A regression test that verifies both `function_call` and `function_call_output` are stored in session history for streamed tool-call turns is also added. 
