### PR TITLE
feat: add agent field to ToolContext

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -820,6 +820,7 @@ async def execute_function_tool_calls(
                 context_wrapper,
                 tool_call.call_id,
                 tool_call=tool_call,
+                agent=agent,
             )
             agent_hooks = agent.hooks
             if config.trace_include_sensitive_data:

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -9,6 +9,7 @@ from .run_context import RunContextWrapper, TContext
 from .usage import Usage
 
 if TYPE_CHECKING:
+    from .agent import Agent
     from .items import TResponseInputItem
     from .run_context import _ApprovalRecord
 
@@ -44,6 +45,9 @@ class ToolContext(RunContextWrapper[TContext]):
     tool_call: ResponseFunctionToolCall | None = None
     """The tool call object associated with this invocation."""
 
+    agent: Agent[Any] | None = None
+    """The agent that is calling this tool, if available."""
+
     def __init__(
         self,
         context: TContext,
@@ -53,6 +57,7 @@ class ToolContext(RunContextWrapper[TContext]):
         tool_arguments: str | object = _MISSING,
         tool_call: ResponseFunctionToolCall | None = None,
         *,
+        agent: Agent[Any] | None = None,
         turn_input: list[TResponseInputItem] | None = None,
         _approvals: dict[str, _ApprovalRecord] | None = None,
         tool_input: Any | None = None,
@@ -80,6 +85,7 @@ class ToolContext(RunContextWrapper[TContext]):
             else cast(str, tool_call_id)
         )
         self.tool_call = tool_call
+        self.agent = agent
 
     @classmethod
     def from_agent_context(
@@ -87,6 +93,7 @@ class ToolContext(RunContextWrapper[TContext]):
         context: RunContextWrapper[TContext],
         tool_call_id: str,
         tool_call: ResponseFunctionToolCall | None = None,
+        agent: Agent[Any] | None = None,
     ) -> ToolContext:
         """
         Create a ToolContext from a RunContextWrapper.
@@ -105,6 +112,7 @@ class ToolContext(RunContextWrapper[TContext]):
             tool_call_id=tool_call_id,
             tool_arguments=tool_args,
             tool_call=tool_call,
+            agent=agent,
             **base_values,
         )
         return tool_context

--- a/tests/test_tool_context.py
+++ b/tests/test_tool_context.py
@@ -1,6 +1,7 @@
 import pytest
 from openai.types.responses import ResponseFunctionToolCall
 
+from agents import Agent
 from agents.run_context import RunContextWrapper
 from agents.tool_context import ToolContext
 from tests.utils.hitl import make_context_wrapper
@@ -36,3 +37,47 @@ def test_tool_context_from_agent_context_populates_fields() -> None:
     assert tool_ctx.tool_name == "test_tool"
     assert tool_ctx.tool_call_id == "call-123"
     assert tool_ctx.tool_arguments == '{"a": 1}'
+
+
+def test_tool_context_agent_none_by_default() -> None:
+    """Agent field defaults to None for backward compatibility."""
+    tool_call = ResponseFunctionToolCall(
+        type="function_call",
+        name="test_tool",
+        call_id="call-1",
+        arguments="{}",
+    )
+    ctx = make_context_wrapper()
+    tool_ctx = ToolContext.from_agent_context(ctx, tool_call_id="call-1", tool_call=tool_call)
+    assert tool_ctx.agent is None
+
+
+def test_tool_context_agent_from_agent_context() -> None:
+    """Agent is populated when passed to from_agent_context."""
+    agent = Agent(name="test-agent", instructions="do stuff")
+    tool_call = ResponseFunctionToolCall(
+        type="function_call",
+        name="test_tool",
+        call_id="call-2",
+        arguments="{}",
+    )
+    ctx = make_context_wrapper()
+    tool_ctx = ToolContext.from_agent_context(
+        ctx, tool_call_id="call-2", tool_call=tool_call, agent=agent
+    )
+    assert tool_ctx.agent is agent
+    assert tool_ctx.agent.name == "test-agent"
+
+
+def test_tool_context_agent_via_constructor() -> None:
+    """Agent is accessible when passed directly to the ToolContext constructor."""
+    agent = Agent(name="direct-agent", instructions="hi")
+    tool_ctx: ToolContext[dict[str, object]] = ToolContext(
+        context={},
+        tool_name="my_tool",
+        tool_call_id="call-3",
+        tool_arguments="{}",
+        agent=agent,
+    )
+    assert tool_ctx.agent is agent
+    assert tool_ctx.agent.name == "direct-agent"


### PR DESCRIPTION
## Summary

- Adds an optional `agent` field to `ToolContext` so tool implementations can inspect which agent is calling them
- Passes the `agent` through from `execute_function_tool_calls()` in `tool_execution.py`
- Adds test coverage for the new field

## Motivation

When using `Agent.as_tool()` to run parallel subagents, we want to designate specific context for each subagent. The problem is that when a tool runs inside a subagent, it needs to know which subagent it belongs to so it can read/write the correct branch.

Currently, `on_invoke_tool` only receives `ToolContext` with no agent reference. The agent *is* available in hooks (`on_tool_start`, `on_tool_end`) but is not forwarded to the tool itself. There doesn't appear to be an established pattern for a tool to discover which `Agent` instance it's running inside.

This PR adds the agent reference directly to `ToolContext`, consistent with how it's already passed to hooks.

## Backward compatibility

The `agent` field defaults to `None`, so no existing code breaks:
- It is a keyword-only `__init__` parameter, preserving positional constructor compatibility
- `from_agent_context` gains an optional `agent` keyword argument with default `None`
- `ToolContext` is a public API — users may construct it directly in tests without an agent

## Test plan

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make mypy` passes (no new errors)
- [x] All existing tests pass
- [x] New tests verify `agent` is `None` by default, populated via `from_agent_context`, and accessible via direct construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)