### PR TITLE
fix(core): avoid noisy pydantic serialization warnings for model_dump items

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -119,6 +119,8 @@ def fingerprint_input_item(item: Any, *, ignore_ids_for_matching: bool = False) 
         payload: Any
         if hasattr(item, "model_dump"):
             payload = _model_dump_without_warnings(item)
+            if payload is None:
+                return None
         elif isinstance(item, dict):
             payload = dict(item)
             if ignore_ids_for_matching:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -50,6 +50,7 @@ from agents.run_config import _default_trace_include_sensitive_data
 from agents.run_internal.items import (
     drop_orphan_function_calls,
     ensure_input_item_format,
+    fingerprint_input_item,
     normalize_input_items_for_api,
     normalize_resumed_input,
 )
@@ -328,6 +329,14 @@ def testnormalize_input_items_for_api_preserves_provider_data():
     assert first["provider_data"] == {"trace": "keep"}
     assert second["role"] == "user"
     assert second["provider_data"] == {"trace": "remove"}
+
+
+def test_fingerprint_input_item_returns_none_when_model_dump_fails():
+    class _BrokenModelDump:
+        def model_dump(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("model_dump failed")
+
+    assert fingerprint_input_item(_BrokenModelDump()) is None
 
 
 def test_server_conversation_tracker_tracks_previous_response_id():


### PR DESCRIPTION
## Summary
- suppress pydantic serializer warnings when coercing model objects to API input dicts
- add a safe fallback path for model_dump-compatible objects that do not accept the `warnings` argument
- add regression coverage for `container_file_citation`-style payloads to ensure warning-free normalization

## Problem
`ensure_input_item_format` / input item normalization can emit noisy `PydanticSerializationUnexpectedValue` warnings for mixed/legacy annotation payloads (for example `container_file_citation` variants). This muddies logs and affects common `final_output`/history handling workflows.

## Fix
- introduced `_model_dump_without_warnings(...)` in `src/agents/run_internal/items.py`
- switched coercion paths to use this helper in both `_coerce_to_dict` and `fingerprint_input_item`
- helper first tries `model_dump(exclude_unset=True, warnings=False)` and falls back to `model_dump(exclude_unset=True)` for compatibility

## Tests
- `uv run ruff check src/agents/run_internal/items.py tests/test_agent_runner.py`
- `uv run mypy . --exclude site`
- `uv run pytest tests/test_agent_runner.py -k "ensure_api_input_item" -q`
- `uv run coverage run -m pytest tests/test_agent_runner.py -k "ensure_api_input_item" -q && uv run coverage report -m src/agents/run_internal/items.py`

Fixes #772
