### PR TITLE
fix(realtime): omit null audio formats in SIP call attach updates

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -1043,7 +1043,9 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 input_format_source = model_settings.get(
                     "input_audio_format", DEFAULT_MODEL_SETTINGS.get("input_audio_format")
                 )
-        audio_input_args["format"] = to_realtime_audio_format(input_format_source)
+        input_format = to_realtime_audio_format(input_format_source)
+        if input_format is not None:
+            audio_input_args["format"] = input_format
 
         if "noise_reduction" in input_audio_config:
             audio_input_args["noise_reduction"] = input_audio_config.get("noise_reduction")
@@ -1085,7 +1087,9 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 output_format_source = model_settings.get(
                     "output_audio_format", DEFAULT_MODEL_SETTINGS.get("output_audio_format")
                 )
-        audio_output_args["format"] = to_realtime_audio_format(output_format_source)
+        output_format = to_realtime_audio_format(output_format_source)
+        if output_format is not None:
+            audio_output_args["format"] = output_format
 
         if "speed" in output_audio_config:
             audio_output_args["speed"] = output_audio_config.get("speed")


### PR DESCRIPTION
## Summary

Fixes #2308 by avoiding `format: null` in `session.update` payloads when attaching to an existing SIP call via `call_id`.

In call-attach mode, `input_audio_format` / `output_audio_format` can be intentionally omitted. The SDK was still serializing these as explicit `null` values, which can cause the Realtime API to reject the update with errors like:

- `Invalid type for 'session.audio.input.format': expected an object, but got null`

## What changed

- In `OpenAIRealtimeWebSocketModel._get_session_config`:
  - only set `audio.input.format` if a non-null format can be converted.
  - only set `audio.output.format` if a non-null format can be converted.
- Added regression tests to verify:
  - with `call_id` and no explicit formats, update payload omits both format fields.
  - with explicit formats, payload still includes normalized `audio/pcmu` fields.

## Validation

- `uv run --with ruff ruff check src/agents/realtime/openai_realtime.py tests/realtime/test_realtime_model_settings.py`
- `uv run --with mypy mypy src/agents/realtime/openai_realtime.py tests/realtime/test_realtime_model_settings.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --with pytest pytest -q tests/realtime/test_realtime_model_settings.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --with coverage --with pytest coverage run -m pytest -q tests/realtime/test_realtime_model_settings.py`

Changed executable lines coverage (local):
- `src/agents/realtime/openai_realtime.py`: 100% (6/6)
