### PR TITLE
fix(result): support Pydantic model_rebuild for RunResultStreaming

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -8,6 +8,9 @@ from collections.abc import AsyncIterator
 from dataclasses import InitVar, dataclass, field
 from typing import Any, Literal, TypeVar, cast
 
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
 from .agent import Agent
 from .agent_output import AgentOutputSchemaBase
 from .exceptions import (
@@ -123,6 +126,16 @@ class RunResultBase(abc.ABC):
 
     _trace_state: TraceState | None = field(default=None, init=False, repr=False)
     """Serialized trace metadata captured during the run."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        # RunResult objects are runtime values; schema generation should treat them as instances
+        # instead of recursively traversing internal dataclass annotations.
+        return core_schema.is_instance_schema(cls)
 
     @property
     @abc.abstractmethod

--- a/tests/test_result_cast.py
+++ b/tests/test_result_cast.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from agents import (
     Agent,
@@ -43,6 +43,16 @@ def create_run_result(
 
 class Foo(BaseModel):
     bar: int
+
+
+def test_run_result_streaming_supports_pydantic_model_rebuild() -> None:
+    class StreamingRunContainer(BaseModel):
+        query_id: str
+        run_stream: RunResultStreaming | None
+
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    StreamingRunContainer.model_rebuild()
 
 
 def _create_message(text: str) -> ResponseOutputMessage:


### PR DESCRIPTION
## Summary
Fixes Pydantic undefined-annotation errors when `RunResultStreaming` is used as a field type in a Pydantic model and `model_rebuild()` is called.

## What changed
- Added `RunResultBase.__get_pydantic_core_schema__` so run-result objects are treated as runtime instance types during Pydantic schema generation.
- Added a regression test for the reported pattern (`RunResultStreaming | None` + `ConfigDict(arbitrary_types_allowed=True)` + `model_rebuild()`).

## Why this works
Pydantic was recursively traversing internal dataclass annotations from `RunResultStreaming`, which triggers unresolved forward references like `Agent` in nested runtime types. Treating run results as instance types avoids recursive traversal while preserving normal runtime usage.

## Validation
- `uv run ruff check src/agents/result.py tests/test_result_cast.py`
- `uv run pytest tests/test_result_cast.py -q`
- `uv run pytest tests/test_source_compat_constructors.py -q`
- Manual repro script from the issue now succeeds (`MyModel.model_rebuild()` no longer raises).

Fixes #2127
