### PR TITLE
fix(run): fail fast on incompatible handoff settings with server conversation

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import warnings
-from typing import Union, cast
+from typing import Any, Union, cast
 
 from typing_extensions import Unpack
 
@@ -410,6 +410,21 @@ class AgentRunner:
         if run_config is None:
             run_config = RunConfig()
 
+        def validate_conversation_settings(active_agent_for_validation: Agent[Any]) -> None:
+            validate_session_conversation_settings(
+                session,
+                conversation_id=conversation_id,
+                previous_response_id=previous_response_id,
+                auto_previous_response_id=auto_previous_response_id,
+            )
+            validate_server_conversation_handoff_settings(
+                active_agent_for_validation,
+                run_config,
+                conversation_id=conversation_id,
+                previous_response_id=previous_response_id,
+                auto_previous_response_id=auto_previous_response_id,
+            )
+
         is_resumed_state = isinstance(input, RunState)
         run_state: RunState[TContext] | None = None
         starting_input = input if not is_resumed_state else None
@@ -433,18 +448,8 @@ class AgentRunner:
                 previous_response_id=previous_response_id,
                 auto_previous_response_id=auto_previous_response_id,
             )
-            validate_session_conversation_settings(
-                session,
-                conversation_id=conversation_id,
-                previous_response_id=previous_response_id,
-                auto_previous_response_id=auto_previous_response_id,
-            )
-            validate_server_conversation_handoff_settings(
-                run_state._current_agent if run_state._current_agent else starting_agent,
-                run_config,
-                conversation_id=conversation_id,
-                previous_response_id=previous_response_id,
-                auto_previous_response_id=auto_previous_response_id,
+            validate_conversation_settings(
+                run_state._current_agent if run_state._current_agent else starting_agent
             )
             starting_input = run_state._original_input
             original_user_input = copy_input_items(run_state._original_input)
@@ -461,19 +466,7 @@ class AgentRunner:
             raw_input = cast(Union[str, list[TResponseInputItem]], input)
             original_user_input = raw_input
 
-            validate_session_conversation_settings(
-                session,
-                conversation_id=conversation_id,
-                previous_response_id=previous_response_id,
-                auto_previous_response_id=auto_previous_response_id,
-            )
-            validate_server_conversation_handoff_settings(
-                starting_agent,
-                run_config,
-                conversation_id=conversation_id,
-                previous_response_id=previous_response_id,
-                auto_previous_response_id=auto_previous_response_id,
-            )
+            validate_conversation_settings(starting_agent)
 
             server_manages_conversation = (
                 conversation_id is not None

--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -145,6 +145,8 @@ def _collect_handoff_edges(
                     continue
                 target_ref = handoff._agent_ref() if handoff._agent_ref is not None else None
                 if not isinstance(target_ref, Agent):
+                    # Still validate handoff-level settings even when target resolution is deferred.
+                    edges.append((current, handoff))
                     continue
                 target = target_ref
             else:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2131,6 +2131,26 @@ async def test_run_rejects_server_conversation_with_remove_all_tools_filter():
 
 
 @pytest.mark.asyncio
+async def test_run_rejects_server_conversation_with_unresolved_remove_all_tools_handoff():
+    model = FakeModel()
+    delegate = Agent(name="delegate", model=model)
+    unresolved_handoff = handoff(delegate, input_filter=remove_all_tools)
+    unresolved_handoff._agent_ref = None
+    triage = Agent(
+        name="triage",
+        model=model,
+        handoffs=[unresolved_handoff],
+    )
+
+    with pytest.raises(UserError, match="Server-managed conversation"):
+        await Runner.run(
+            triage,
+            input="test",
+            conversation_id="conv-test",
+        )
+
+
+@pytest.mark.asyncio
 async def test_run_rejects_server_conversation_with_global_remove_all_tools_filter():
     model = FakeModel()
     delegate = Agent(name="delegate", model=model)


### PR DESCRIPTION
## Summary
This PR adds an early validation guard for server-managed conversations to prevent unsupported handoff combinations from reaching the model API.

When `conversation_id`, `previous_response_id`, or `auto_previous_response_id` is used, the SDK now raises a `UserError` if handoff settings require local history/tool-state rewriting that the server-managed flow cannot support.

Specifically, it rejects:
- `nest_handoff_history=True` (when no input filter is set on that handoff)
- `remove_all_tools` (handoff-local or global `run_config.handoff_input_filter`)

## Why
Issue: `#2151`

With server-managed conversation, these handoff options can produce invalid or conflicting assumptions about what is sent to downstream turns. The current behavior fails late. This change fails fast with a clear error message before execution starts.

## Changes
- Added `validate_server_conversation_handoff_settings(...)` in `agent_runner_helpers`.
- Added graph traversal that handles both shorthand `Agent` handoffs and explicit `Handoff` entries.
- Invoked validation in both `Runner.run` and `Runner.run_streamed`:
  - resumed and non-resumed paths
- Added focused tests for:
  - nested handoff history + server-managed conversation
  - handoff-local `remove_all_tools`
  - global `run_config.handoff_input_filter=remove_all_tools`
  - streamed/non-streamed + resumed/non-resumed paths

## Validation
- `uv run ruff check src/agents/run_internal/agent_runner_helpers.py src/agents/run.py tests/test_agent_runner.py`
- `uv run mypy src/agents/run_internal/agent_runner_helpers.py src/agents/run.py tests/test_agent_runner.py`
- `env -u all_proxy -u ALL_PROXY -u http_proxy -u HTTP_PROXY -u https_proxy -u HTTPS_PROXY uv run pytest tests/test_agent_runner.py -k "server_conversation" -q`
- `env -u all_proxy -u ALL_PROXY -u http_proxy -u HTTP_PROXY -u https_proxy -u HTTPS_PROXY uv run pytest tests/test_agent_runner.py -q`
- `env -u all_proxy -u ALL_PROXY -u http_proxy -u HTTP_PROXY -u https_proxy -u HTTPS_PROXY uv run python -m trace --count --coverdir /tmp/openai_agents_2151_trace --module pytest tests/test_agent_runner.py -k "server_conversation" -q`

Trace output confirms the newly added validation paths in `src/agents/run_internal/agent_runner_helpers.py` and their call sites in `src/agents/run.py` are exercised.
