### PR TITLE
fix(tracing): truncate oversized span input/output for OpenAI ingest

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -261,12 +261,17 @@ class BackendSpanExporter(TracingExporter):
         if isinstance(value, str):
             return self._truncate_string_for_json_limit(value, max_bytes)
 
-        preview = str(value)
-        if len(preview) > 512:
-            preview = preview[:512] + self._OPENAI_TRACING_STRING_TRUNCATION_SUFFIX
+        type_name = type(value).__name__
+        preview = f"<{type_name} truncated>"
+        if isinstance(value, dict):
+            preview = f"<{type_name} len={len(value)} truncated>"
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            preview = f"<{type_name} len={len(value)} truncated>"
+        elif isinstance(value, (bytes, bytearray, memoryview)):
+            preview = f"<{type_name} bytes={len(value)} truncated>"
         return {
             "truncated": True,
-            "original_type": type(value).__name__,
+            "original_type": type_name,
             "preview": preview,
         }
 


### PR DESCRIPTION
## Summary
Fixes #260 by making OpenAI tracing sanitization fail-safe for oversized `span_data.input` / `span_data.output` payloads.

## What changed
- Extended `_sanitize_for_openai_tracing_api` to also sanitize `input` and `output` fields (not just generation usage keys).
- Added byte-size based truncation helpers:
  - Strings are truncated with a stable suffix (`... [truncated]`) while staying under the ingest limit.
  - Non-string oversized payloads are replaced with a compact metadata object (`truncated`, `original_type`, `preview`).
- Kept behavior endpoint-aware: sanitization is only applied for the OpenAI tracing ingest endpoint, existing custom endpoint behavior is unchanged.

## Tests
- `uv run ruff check src/agents/tracing/processors.py tests/test_trace_processor.py`
- `uv run mypy src/agents/tracing/processors.py tests/test_trace_processor.py`
- `uv run pytest tests/test_trace_processor.py -q`
- `make format-check`

Added test coverage for:
- large string truncation
- large non-string replacement
- custom endpoint passthrough
- unchanged small input path
- helper edge-cases (`within limit`, `suffix too large`)
