### PR TITLE
fix(agent-tools): inherit parent RunConfig when agent-as-tool is invoked

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -590,6 +590,9 @@ class Agent(AgentBase, Generic[TContext]):
                 raise ModelBehaviorError("Agent tool called with invalid input")
 
             resolved_max_turns = max_turns if max_turns is not None else DEFAULT_MAX_TURNS
+            resolved_run_config = run_config
+            if resolved_run_config is None and isinstance(context, ToolContext):
+                resolved_run_config = context.run_config
             if isinstance(context, ToolContext):
                 # Use a fresh ToolContext to avoid sharing approval state with parent runs.
                 nested_context = ToolContext(
@@ -600,6 +603,7 @@ class Agent(AgentBase, Generic[TContext]):
                     tool_arguments=context.tool_arguments,
                     tool_call=context.tool_call,
                     agent=context.agent,
+                    run_config=resolved_run_config,
                 )
                 if should_capture_tool_input:
                     nested_context.tool_input = params_data
@@ -697,7 +701,7 @@ class Agent(AgentBase, Generic[TContext]):
                         starting_agent=cast(Agent[Any], self),
                         input=resume_state or resolved_input,
                         context=None if resume_state is not None else cast(Any, nested_context),
-                        run_config=run_config,
+                        run_config=resolved_run_config,
                         max_turns=resolved_max_turns,
                         hooks=hooks,
                         previous_response_id=None
@@ -761,7 +765,7 @@ class Agent(AgentBase, Generic[TContext]):
                         starting_agent=cast(Agent[Any], self),
                         input=resume_state or resolved_input,
                         context=None if resume_state is not None else cast(Any, nested_context),
-                        run_config=run_config,
+                        run_config=resolved_run_config,
                         max_turns=resolved_max_turns,
                         hooks=hooks,
                         previous_response_id=None

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -821,6 +821,7 @@ async def execute_function_tool_calls(
                 tool_call.call_id,
                 tool_call=tool_call,
                 agent=agent,
+                run_config=config,
             )
             agent_hooks = agent.hooks
             if config.trace_include_sensitive_data:

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -100,6 +100,7 @@ class ToolContext(RunContextWrapper[TContext]):
         tool_call_id: str,
         tool_call: ResponseFunctionToolCall | None = None,
         agent: AgentBase[Any] | None = None,
+        *,
         run_config: RunConfig | None = None,
     ) -> ToolContext:
         """

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -11,6 +11,7 @@ from .usage import Usage
 if TYPE_CHECKING:
     from .agent import AgentBase
     from .items import TResponseInputItem
+    from .run_config import RunConfig
     from .run_context import _ApprovalRecord
 
 
@@ -48,6 +49,9 @@ class ToolContext(RunContextWrapper[TContext]):
     agent: AgentBase[Any] | None = None
     """The active agent for this tool call, when available."""
 
+    run_config: RunConfig | None = None
+    """The active run config for this tool call, when available."""
+
     def __init__(
         self,
         context: TContext,
@@ -58,6 +62,7 @@ class ToolContext(RunContextWrapper[TContext]):
         tool_call: ResponseFunctionToolCall | None = None,
         *,
         agent: AgentBase[Any] | None = None,
+        run_config: RunConfig | None = None,
         turn_input: list[TResponseInputItem] | None = None,
         _approvals: dict[str, _ApprovalRecord] | None = None,
         tool_input: Any | None = None,
@@ -86,6 +91,7 @@ class ToolContext(RunContextWrapper[TContext]):
         )
         self.tool_call = tool_call
         self.agent = agent
+        self.run_config = run_config
 
     @classmethod
     def from_agent_context(
@@ -94,6 +100,7 @@ class ToolContext(RunContextWrapper[TContext]):
         tool_call_id: str,
         tool_call: ResponseFunctionToolCall | None = None,
         agent: AgentBase[Any] | None = None,
+        run_config: RunConfig | None = None,
     ) -> ToolContext:
         """
         Create a ToolContext from a RunContextWrapper.
@@ -109,6 +116,9 @@ class ToolContext(RunContextWrapper[TContext]):
         tool_agent = agent
         if tool_agent is None and isinstance(context, ToolContext):
             tool_agent = context.agent
+        tool_run_config = run_config
+        if tool_run_config is None and isinstance(context, ToolContext):
+            tool_run_config = context.run_config
 
         tool_context = cls(
             tool_name=tool_name,
@@ -116,6 +126,7 @@ class ToolContext(RunContextWrapper[TContext]):
             tool_arguments=tool_args,
             tool_call=tool_call,
             agent=tool_agent,
+            run_config=tool_run_config,
             **base_values,
         )
         return tool_context

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -389,6 +389,114 @@ async def test_agent_as_tool_custom_output_extractor(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
+async def test_agent_as_tool_inherits_parent_run_config_when_not_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = Agent(name="inherits_config_agent")
+    parent_run_config = RunConfig(model="gpt-4.1-mini")
+
+    class DummyResult:
+        def __init__(self) -> None:
+            self.final_output = "ok"
+
+    async def fake_run(
+        cls,
+        starting_agent,
+        input,
+        *,
+        context,
+        max_turns,
+        hooks,
+        run_config,
+        previous_response_id,
+        conversation_id,
+        session,
+    ):
+        assert starting_agent is agent
+        assert input == "hello"
+        assert isinstance(context, ToolContext)
+        assert run_config is parent_run_config
+        assert context.run_config is parent_run_config
+        return DummyResult()
+
+    monkeypatch.setattr(Runner, "run", classmethod(fake_run))
+
+    tool = cast(
+        FunctionTool,
+        agent.as_tool(
+            tool_name="inherits_config_tool",
+            tool_description="inherit config",
+        ),
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="inherits_config_tool",
+        tool_call_id="call_inherit",
+        tool_arguments='{"input":"hello"}',
+        run_config=parent_run_config,
+    )
+
+    output = await tool.on_invoke_tool(tool_context, '{"input":"hello"}')
+
+    assert output == "ok"
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_explicit_run_config_overrides_parent_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = Agent(name="override_config_agent")
+    parent_run_config = RunConfig(model="gpt-4.1-mini")
+    explicit_run_config = RunConfig(model="gpt-4.1")
+
+    class DummyResult:
+        def __init__(self) -> None:
+            self.final_output = "ok"
+
+    async def fake_run(
+        cls,
+        starting_agent,
+        input,
+        *,
+        context,
+        max_turns,
+        hooks,
+        run_config,
+        previous_response_id,
+        conversation_id,
+        session,
+    ):
+        assert starting_agent is agent
+        assert input == "hello"
+        assert isinstance(context, ToolContext)
+        assert run_config is explicit_run_config
+        assert context.run_config is explicit_run_config
+        return DummyResult()
+
+    monkeypatch.setattr(Runner, "run", classmethod(fake_run))
+
+    tool = cast(
+        FunctionTool,
+        agent.as_tool(
+            tool_name="override_config_tool",
+            tool_description="override config",
+            run_config=explicit_run_config,
+        ),
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="override_config_tool",
+        tool_call_id="call_override",
+        tool_arguments='{"input":"hello"}',
+        run_config=parent_run_config,
+    )
+
+    output = await tool.on_invoke_tool(tool_context, '{"input":"hello"}')
+
+    assert output == "ok"
+
+
+@pytest.mark.asyncio
 async def test_agent_as_tool_structured_input_sets_tool_input(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
This fixes a bug where an agent used as a tool could ignore the parent run's `RunConfig` (notably custom `model_provider`) unless a separate `run_config` was explicitly passed to `Agent.as_tool(...)`.

## What changed
- Added `run_config` to `ToolContext` so tool invocations can carry run-level configuration metadata.
- In function tool execution, pass the active run `config` into `ToolContext.from_agent_context(...)`.
- In `Agent.as_tool(...)`:
  - if `run_config` is explicitly provided, keep using it;
  - otherwise inherit `run_config` from the parent `ToolContext` when available.
- Added regression tests for:
  - inheriting parent `run_config` when `as_tool(run_config=None)`;
  - explicit `run_config` overriding parent context;
  - function tool contexts receiving the active `RunConfig`.

## Why this is safe
- Backward compatibility is preserved: explicit `run_config` behavior remains unchanged.
- Existing code paths without nested agent tools are unaffected.
- The change is additive (`ToolContext.run_config` defaults to `None`).

## Validation
- `uv run --with ruff ruff check src/agents/agent.py src/agents/tool_context.py src/agents/run_internal/tool_execution.py tests/test_agent_as_tool.py tests/test_tool_context.py tests/test_run_step_execution.py`
- `uv run --with pytest --with socksio pytest -q tests/test_tool_context.py tests/test_agent_as_tool.py tests/test_run_step_execution.py`
- `uv run --with mypy --with socksio mypy src/agents/agent.py src/agents/tool_context.py src/agents/run_internal/tool_execution.py tests/test_tool_context.py tests/test_agent_as_tool.py tests/test_run_step_execution.py`
- Targeted trace coverage run to confirm modified paths were exercised.
