### PR TITLE
feat: add ToolOutputTrimmer for smart context management

### DIFF
--- a/src/agents/extensions/__init__.py
+++ b/src/agents/extensions/__init__.py
@@ -1,0 +1,3 @@
+from .tool_output_trimmer import ToolOutputTrimmer
+
+__all__ = ["ToolOutputTrimmer"]

--- a/src/agents/extensions/memory/__init__.py
+++ b/src/agents/extensions/memory/__init__.py
@@ -22,8 +22,6 @@ if TYPE_CHECKING:
     from .redis_session import RedisSession
     from .sqlalchemy_session import SQLAlchemySession
 
-from .tool_output_trimmer import ToolOutputTrimmer
-
 __all__: list[str] = [
     "AdvancedSQLiteSession",
     "AsyncSQLiteSession",
@@ -33,7 +31,6 @@ __all__: list[str] = [
     "EncryptedSession",
     "RedisSession",
     "SQLAlchemySession",
-    "ToolOutputTrimmer",
 ]
 
 

--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -8,7 +8,7 @@ bulky tool outputs from older turns while keeping recent turns at full fidelity.
 Usage::
 
     from agents import RunConfig
-    from agents.extensions.memory import ToolOutputTrimmer
+    from agents.extensions import ToolOutputTrimmer
 
     config = RunConfig(
         call_model_input_filter=ToolOutputTrimmer(
@@ -32,7 +32,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ...run_config import CallModelData, ModelInputData
+    from ..run_config import CallModelData, ModelInputData
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class ToolOutputTrimmer:
         from old turns. Does NOT mutate the original items — creates shallow copies when
         needed.
         """
-        from ...run_config import ModelInputData as _ModelInputData
+        from ..run_config import ModelInputData as _ModelInputData
 
         model_data = data.model_data
         items = model_data.input

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agents.extensions.memory.tool_output_trimmer import ToolOutputTrimmer
+from agents.extensions.tool_output_trimmer import ToolOutputTrimmer
 from agents.run_config import CallModelData, ModelInputData
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a built-in `ToolOutputTrimmer` class that implements `CallModelInputFilter` — a sliding-window filter that surgically trims large tool outputs from older conversation turns while keeping recent turns at full fidelity.

Closes #2467. Related: #177, #1494.

### What it does

- Derives turn boundaries from user messages (no explicit turn structure needed)
- Only targets `function_call_output` items in old turns — preserves user/assistant messages and `function_call` items
- Resolves tool names via `call_id` mapping for informative summaries
- Skips trimming when the summary would exceed the original size
- Validates all parameters at construction (`recent_turns >= 1`, `max_output_chars >= 1`, `preview_chars >= 0`)
- Never mutates the original input list

### Usage

```python
from agents import RunConfig
from agents.memory import ToolOutputTrimmer

config = RunConfig(
    call_model_input_filter=ToolOutputTrimmer(
        recent_turns=2,
        max_output_chars=500,
        preview_chars=200,
        trimmable_tools={"search", "execute_code"},
    ),
)
```

### Files changed

| File | Change |
|------|--------|
| `src/agents/memory/tool_output_trimmer.py` | New — `ToolOutputTrimmer` dataclass (170 lines) |
| `src/agents/memory/__init__.py` | Export `ToolOutputTrimmer` |
| `src/agents/__init__.py` | Export `ToolOutputTrimmer` |
| `tests/memory/test_tool_output_trimmer.py` | 30 tests across 6 test classes |

## Test plan

- [x] `make format` — clean
- [x] `make lint` — clean
- [x] `make mypy` — 0 new errors
- [x] `make tests` — 1888 passed, 4 skipped, 0 failures (no regressions)
- [x] 30 dedicated tests covering defaults, validation, boundary detection, trimming behavior, sliding window, and edge cases