### PR TITLE
fix(voice): keep trace active until pipeline processing completes

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -265,6 +265,7 @@ class StreamedAudioResult:
 
     async def stream(self) -> AsyncIterator[VoiceStreamEvent]:
         """Stream the events and audio data as they're generated."""
+        saw_session_end = False
         while True:
             try:
                 event = await self._queue.get()
@@ -278,7 +279,17 @@ class StreamedAudioResult:
                 break
             yield event
             if event.type == "voice_stream_event_lifecycle" and event.event == "session_ended":
+                saw_session_end = True
                 break
+
+        # On the normal completion path, let the producer task finish gracefully so any active
+        # trace context can emit `trace_end` before we run cleanup.
+        if (
+            saw_session_end
+            and self.text_generation_task is not None
+            and not self.text_generation_task.done()
+        ):
+            await asyncio.shield(self.text_generation_task)
 
         self._check_errors()
         self._cleanup_tasks()

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+
 import numpy as np
 import numpy.typing as npt
 import pytest
+
+from tests.testing_processor import fetch_events
 
 try:
     from agents.voice import AudioInput, TTSModelSettings, VoicePipeline, VoicePipelineConfig
@@ -177,3 +181,71 @@ async def test_voicepipeline_transform_data() -> None:
         "session_ended",
     ]
     await fake_tts.verify_audio("out_1", audio_chunks[0], dtype=np.int16)
+
+
+class _BlockingWorkflow(FakeWorkflow):
+    def __init__(self, gate: asyncio.Event):
+        super().__init__()
+        self._gate = gate
+
+    async def run(self, _: str):
+        await self._gate.wait()
+        yield "out_1"
+
+
+class _OnStartYieldThenFailWorkflow(FakeWorkflow):
+    async def on_start(self):
+        yield "intro"
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_trace_not_finished_before_single_turn_completes() -> None:
+    fake_stt = FakeSTT(["first"])
+    fake_tts = FakeTTS()
+    gate = asyncio.Event()
+    workflow = _BlockingWorkflow(gate)
+    config = VoicePipelineConfig(tts_settings=TTSModelSettings(buffer_size=1))
+    pipeline = VoicePipeline(
+        workflow=workflow, stt_model=fake_stt, tts_model=fake_tts, config=config
+    )
+
+    audio_input = AudioInput(buffer=np.zeros(2, dtype=np.int16))
+    result = await pipeline.run(audio_input)
+    await asyncio.sleep(0)
+
+    events_before_unblock = fetch_events()
+    assert "trace_start" in events_before_unblock
+    assert "trace_end" not in events_before_unblock
+
+    gate.set()
+    await extract_events(result)
+    assert fetch_events()[-1] == "trace_end"
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_trace_finishes_after_multi_turn_processing() -> None:
+    fake_stt = FakeSTT(["first", "second"])
+    workflow = FakeWorkflow([["out_1"], ["out_2"]])
+    fake_tts = FakeTTS()
+    pipeline = VoicePipeline(workflow=workflow, stt_model=fake_stt, tts_model=fake_tts)
+
+    streamed_audio_input = await FakeStreamedAudioInput.get(count=2)
+    result = await pipeline.run(streamed_audio_input)
+    await extract_events(result)
+    assert fetch_events()[-1] == "trace_end"
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_multi_turn_on_start_exception_does_not_abort() -> None:
+    fake_stt = FakeSTT(["first"])
+    workflow = _OnStartYieldThenFailWorkflow([["out_1"]])
+    fake_tts = FakeTTS()
+    pipeline = VoicePipeline(workflow=workflow, stt_model=fake_stt, tts_model=fake_tts)
+
+    streamed_audio_input = await FakeStreamedAudioInput.get(count=1)
+    result = await pipeline.run(streamed_audio_input)
+    events, _ = await extract_events(result)
+
+    assert events[-1] == "session_ended"
+    assert "error" not in events


### PR DESCRIPTION
## Summary
- move `TraceCtxManager` scope into the background tasks for both single-turn and multi-turn voice pipeline execution so the trace stays open for the full async lifecycle
- avoid canceling the producer task immediately after `session_ended`; wait for graceful producer completion first so `trace_end` can be emitted reliably
- add voice pipeline regression tests for:
  - trace not finishing early in single-turn mode
  - trace ending after multi-turn processing
  - `on_start()` intro/exception path continuing without aborting the session

## Root Cause
`VoicePipeline` previously entered `TraceCtxManager` only around task creation, then returned immediately. This ended the trace before async processing finished, causing subsequent spans to be emitted after trace closure.

## Testing
- `uv run ruff check src/agents/voice/pipeline.py src/agents/voice/result.py tests/voice/test_pipeline.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --extra voice pytest tests/voice/test_pipeline.py -q`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --extra voice coverage run -m pytest tests/voice/test_pipeline.py -q`
- changed-line coverage check: `src/agents/voice/pipeline.py` and `src/agents/voice/result.py` are both 100%

Fixes #2470
