### PR TITLE
fix(tracing): propagate trace metadata to spans for processors

### DIFF
--- a/src/agents/tracing/spans.py
+++ b/src/agents/tracing/spans.py
@@ -178,6 +178,11 @@ class Span(abc.ABC, Generic[TSpanData]):
         """The API key to use when exporting this span."""
         pass
 
+    @property
+    def trace_metadata(self) -> dict[str, Any] | None:
+        """Trace-level metadata inherited by this span, if available."""
+        return None
+
 
 class NoOpSpan(Span[TSpanData]):
     """A no-op implementation of Span that doesn't record any data.
@@ -266,6 +271,7 @@ class SpanImpl(Span[TSpanData]):
         "_processor",
         "_span_data",
         "_tracing_api_key",
+        "_trace_metadata",
     )
 
     def __init__(
@@ -276,6 +282,7 @@ class SpanImpl(Span[TSpanData]):
         processor: TracingProcessor,
         span_data: TSpanData,
         tracing_api_key: str | None,
+        trace_metadata: dict[str, Any] | None = None,
     ):
         self._trace_id = trace_id
         self._span_id = span_id or util.gen_span_id()
@@ -287,6 +294,7 @@ class SpanImpl(Span[TSpanData]):
         self._prev_span_token: contextvars.Token[Span[TSpanData] | None] | None = None
         self._span_data = span_data
         self._tracing_api_key = tracing_api_key
+        self._trace_metadata = trace_metadata
 
     @property
     def trace_id(self) -> str:
@@ -355,6 +363,10 @@ class SpanImpl(Span[TSpanData]):
     @property
     def tracing_api_key(self) -> str | None:
         return self._tracing_api_key
+
+    @property
+    def trace_metadata(self) -> dict[str, Any] | None:
+        return self._trace_metadata
 
     def export(self) -> dict[str, Any] | None:
         return {


### PR DESCRIPTION
This pull request fixes trace metadata propagation so tracing processors can reliably access trace-level metadata from child spans. It adds trace_metadata on span objects, threads metadata inheritance through span creation paths (ambient trace, explicit trace parent, explicit span parent).

see also: https://github.com/openai/openai-agents-js/pull/964