### PR TITLE
fix(agent-tool): preserve nested run cache across tool-call GC

### DIFF
--- a/src/agents/agent_tool_state.py
+++ b/src/agents/agent_tool_state.py
@@ -67,6 +67,8 @@ def record_agent_tool_run_result(
 ) -> None:
     """Store the nested agent run result by tool call identity."""
     tool_call_obj_id = id(tool_call)
+    # Clear any stale signature index if this object ID gets reused.
+    _drop_agent_tool_run_result(tool_call_obj_id)
     _agent_tool_run_results_by_obj[tool_call_obj_id] = run_result
     _index_agent_tool_run_result(tool_call, tool_call_obj_id)
 

--- a/tests/test_agent_tool_state.py
+++ b/tests/test_agent_tool_state.py
@@ -45,3 +45,136 @@ def test_agent_tool_result_survives_tool_call_gc_until_consumed() -> None:
     assert tool_state.peek_agent_tool_run_result(resume_tool_call) is nested_result
     assert tool_state.consume_agent_tool_run_result(resume_tool_call) is nested_result
     assert tool_state.peek_agent_tool_run_result(resume_tool_call) is None
+
+
+def test_record_clears_stale_signature_when_obj_id_is_reused() -> None:
+    tool_state._agent_tool_run_results_by_obj.clear()
+    tool_state._agent_tool_run_results_by_signature.clear()
+    tool_state._agent_tool_run_result_signature_by_obj.clear()
+
+    tool_call = make_function_tool_call(
+        "inner_tool",
+        call_id="new-call",
+        arguments='{"input":"hello"}',
+    )
+    obj_id = id(tool_call)
+
+    stale_signature = (
+        "old-call",
+        "inner_tool",
+        '{"input":"old"}',
+        "function_call",
+        "old-id",
+        "completed",
+    )
+    stale_result: Any = object()
+    new_result: Any = object()
+
+    tool_state._agent_tool_run_results_by_obj[obj_id] = stale_result
+    tool_state._agent_tool_run_result_signature_by_obj[obj_id] = stale_signature
+    tool_state._agent_tool_run_results_by_signature[stale_signature] = {obj_id}
+
+    tool_state.record_agent_tool_run_result(tool_call, new_result)
+
+    assert obj_id in tool_state._agent_tool_run_results_by_obj
+    assert tool_state._agent_tool_run_results_by_obj[obj_id] is new_result
+    assert stale_signature not in tool_state._agent_tool_run_results_by_signature
+
+
+def test_consume_peek_and_drop_direct_object_path() -> None:
+    tool_state._agent_tool_run_results_by_obj.clear()
+    tool_state._agent_tool_run_results_by_signature.clear()
+    tool_state._agent_tool_run_result_signature_by_obj.clear()
+
+    tool_call = make_function_tool_call(
+        "inner_tool",
+        call_id="direct-1",
+        arguments='{"input":"hello"}',
+    )
+    nested_result: Any = object()
+
+    tool_state.record_agent_tool_run_result(tool_call, nested_result)
+    assert tool_state.peek_agent_tool_run_result(tool_call) is nested_result
+    assert tool_state.consume_agent_tool_run_result(tool_call) is nested_result
+    assert tool_state.consume_agent_tool_run_result(tool_call) is None
+
+    tool_state.record_agent_tool_run_result(tool_call, nested_result)
+    tool_state.drop_agent_tool_run_result(tool_call)
+    assert tool_state.peek_agent_tool_run_result(tool_call) is None
+
+
+def test_signature_fallback_none_and_ambiguous_paths() -> None:
+    tool_state._agent_tool_run_results_by_obj.clear()
+    tool_state._agent_tool_run_results_by_signature.clear()
+    tool_state._agent_tool_run_result_signature_by_obj.clear()
+
+    tool_call = make_function_tool_call(
+        "inner_tool",
+        call_id="fallback-1",
+        arguments='{"input":"hello"}',
+    )
+    signature = tool_state._tool_call_signature(tool_call)
+
+    # No candidate IDs -> None paths.
+    assert tool_state.consume_agent_tool_run_result(tool_call) is None
+    assert tool_state.peek_agent_tool_run_result(tool_call) is None
+    tool_state.drop_agent_tool_run_result(tool_call)
+
+    # Multiple candidate IDs -> ambiguous, should return/perform no-op.
+    tool_state._agent_tool_run_results_by_signature[signature] = {101, 202}
+    fake_result_1: Any = object()
+    fake_result_2: Any = object()
+    tool_state._agent_tool_run_results_by_obj[101] = fake_result_1
+    tool_state._agent_tool_run_results_by_obj[202] = fake_result_2
+    tool_state._agent_tool_run_result_signature_by_obj[101] = signature
+    tool_state._agent_tool_run_result_signature_by_obj[202] = signature
+
+    assert tool_state.consume_agent_tool_run_result(tool_call) is None
+    assert tool_state.peek_agent_tool_run_result(tool_call) is None
+    tool_state.drop_agent_tool_run_result(tool_call)
+
+
+def test_drop_index_handles_missing_candidate_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signature = ("call", "name", "{}", "function_call", "id", "completed")
+
+    signature_by_obj = {7: signature}
+    monkeypatch.setattr(tool_state, "_agent_tool_run_result_signature_by_obj", signature_by_obj)
+    monkeypatch.setattr(tool_state, "_agent_tool_run_results_by_signature", None)
+    tool_state._drop_agent_tool_run_result(7)
+
+    signature_by_obj = {9: signature}
+    monkeypatch.setattr(tool_state, "_agent_tool_run_result_signature_by_obj", signature_by_obj)
+    monkeypatch.setattr(tool_state, "_agent_tool_run_results_by_signature", {})
+    tool_state._drop_agent_tool_run_result(9)
+
+
+def test_drop_removes_single_fallback_candidate() -> None:
+    tool_state._agent_tool_run_results_by_obj.clear()
+    tool_state._agent_tool_run_results_by_signature.clear()
+    tool_state._agent_tool_run_result_signature_by_obj.clear()
+
+    stored_call = make_function_tool_call(
+        "inner_tool",
+        call_id="drop-fallback",
+        arguments='{"input":"hello"}',
+    )
+    probe_call = make_function_tool_call(
+        "inner_tool",
+        call_id="drop-fallback",
+        arguments='{"input":"hello"}',
+    )
+
+    stored_id = id(stored_call)
+    signature = tool_state._tool_call_signature(stored_call)
+    nested_result: Any = object()
+    tool_state._agent_tool_run_results_by_obj[stored_id] = nested_result
+    tool_state._agent_tool_run_result_signature_by_obj[stored_id] = signature
+    tool_state._agent_tool_run_results_by_signature[signature] = {stored_id}
+
+    tool_state.drop_agent_tool_run_result(probe_call)
+
+    assert signature not in tool_state._agent_tool_run_results_by_signature
+    assert stored_id not in tool_state._agent_tool_run_result_signature_by_obj
+    assert stored_id not in tool_state._agent_tool_run_results_by_obj


### PR DESCRIPTION
## Summary
Fixes #2487.

`agent.as_tool()` resume logic currently depends on an in-memory cache keyed by tool-call identity. That cache was tied to the original `tool_call` object lifetime via weakref callbacks. After serializing state and dropping the original `RunResult`, GC could clear the cache entry before resume, causing nested runs to restart and repeatedly pause on the same approval.

This PR decouples cache retention from `tool_call` GC and keeps entries until explicit consume/drop.

## Changes
- `src/agents/agent_tool_state.py`
  - Removed weakref-based auto-eviction for nested agent-tool run results.
  - Keep signature/object-id indexes and clear entries only on explicit consume/drop paths.
- `tests/test_agent_tool_state.py`
  - Added regression test proving nested result survives original tool-call GC and is still resumable by signature.
  - Updated shutdown-safety test for current globals.

## Validation
- `uv run --with ruff ruff check src/agents/agent_tool_state.py tests/test_agent_tool_state.py`
- `uv run mypy src/agents/agent_tool_state.py tests/test_agent_tool_state.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --with pytest pytest -q tests/test_agent_tool_state.py tests/test_agent_as_tool.py -k "rejected_nested_approval_resumes_run or agent_tool_result_survives_tool_call_gc_until_consumed"` (2 passed)
- Changed executable lines in touched source files are covered (100%; source changes are deletion-only).
