### PR TITLE
feat: add Shodh-Memory session example for cognitive memory persistence

### DIFF
--- a/examples/memory/shodh_session_example.py
+++ b/examples/memory/shodh_session_example.py
@@ -18,6 +18,7 @@ Note: This example requires the shodh-memory server to be running externally.
 
 import asyncio
 import os
+import uuid
 
 from agents import Agent, Runner
 
@@ -33,6 +34,9 @@ except ImportError:
 SHODH_API_KEY = os.environ.get("SHODH_API_KEY", "test-key")
 SHODH_SERVER = os.environ.get("SHODH_SERVER_URL", "http://localhost:3030")
 
+# Unique run ID to isolate state per execution — avoids stale results on reruns.
+RUN_ID = uuid.uuid4().hex[:8]
+
 
 async def session_example():
     """Demonstrate persistent conversation memory across agent runs."""
@@ -46,9 +50,9 @@ async def session_example():
     # shodh-memory applies biological memory dynamics: memories strengthen
     # with repeated access (Hebbian learning) and decay naturally over time.
     session = ShodhSession(
-        session_id="shodh_demo_123",
+        session_id=f"shodh_demo_{RUN_ID}",
         server_url=SHODH_SERVER,
-        user_id="demo-agent",
+        user_id=f"demo-agent-{RUN_ID}",
         api_key=SHODH_API_KEY,
     )
 
@@ -110,9 +114,9 @@ async def session_example():
     # Session isolation — different session_id, separate history.
     print("\n=== Session Isolation Demo ===")
     other_session = ShodhSession(
-        session_id="shodh_demo_456",
+        session_id=f"shodh_other_{RUN_ID}",
         server_url=SHODH_SERVER,
-        user_id="demo-agent",
+        user_id=f"demo-agent-{RUN_ID}",
         api_key=SHODH_API_KEY,
     )
     await other_session.clear_session()
@@ -142,7 +146,7 @@ async def tools_example():
 
     tools = ShodhTools(
         server_url=SHODH_SERVER,
-        user_id="demo-agent",
+        user_id=f"demo-tools-{RUN_ID}",
         api_key=SHODH_API_KEY,
     )
 


### PR DESCRIPTION
## Summary

Adds an example in `examples/memory/` demonstrating [Shodh-Memory](https://github.com/varun29ankuS/shodh-memory) as a session backend for the OpenAI Agents SDK. Unlike existing session examples (SQLite, Redis, Dapr) that store raw conversation turns, Shodh-Memory provides **cognitive memory** — memories strengthen with repeated access via Hebbian learning, decay naturally over time following biological curves, and are indexed in a knowledge graph for semantic retrieval.

The example demonstrates both:
- **`ShodhSession`** — drop-in `Session` protocol implementation for automatic conversation persistence with cognitive processing
- **`ShodhTools`** — 8 `FunctionTool` instances for explicit memory operations (remember, recall, forget, context summary, proactive context, todos)

## Why this matters

The `examples/memory/` folder currently has 14 session backends, all focused on short-term conversation history storage. There are no examples of **long-term persistent memory with semantic search and knowledge graphs** — which is the gap real production agents hit when they need to remember across sessions, learn user preferences over time, or manage tasks.

Shodh-Memory runs as a single local binary (~15MB, no Docker or external DB needed), making it accessible for developers to try immediately.

## Test plan

- [ ] `python examples/memory/shodh_session_example.py` runs successfully with shodh-memory server
- [ ] Example follows existing `examples/memory/` patterns (async main, session isolation demo)
- [ ] No changes to core library code