### PR TITLE
fix: materialize iterable input history in ItemHelpers.input_to_new_input_list

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -57,6 +57,7 @@ from .tool import (
     ValidToolOutputPydanticModelsTypeAdapter,
 )
 from .usage import Usage
+from .util._json import _to_dump_compatible
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -531,7 +532,7 @@ class ItemHelpers:
                     "role": "user",
                 }
             ]
-        return input.copy()
+        return cast(list[TResponseInputItem], _to_dump_compatible(input))
 
     @classmethod
     def text_message_outputs(cls, items: list[RunItem]) -> str:


### PR DESCRIPTION
This pull request fixes conversation-history replay paths that could preserve Pydantic `ValidatorIterator` objects in input items. When users persisted and reloaded `to_input_list()` history (for example with custom Redis workflows), validated payloads could retain iterator-backed fields and become difficult to serialize or inspect. The change updates `ItemHelpers.input_to_new_input_list` to normalize list inputs through `_to_dump_compatible`, ensuring nested iterable fields are materialized into JSON-friendly structures before reuse. Tests were updated to cover the validated-input scenario and assert the resulting payload is dump-compatible.