### PR TITLE
fix: isolate nested agent-tool resume cache by RunState scope

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -9,6 +9,7 @@ from typing_extensions import Unpack
 
 from . import _debug
 from .agent import Agent
+from .agent_tool_state import set_agent_tool_state_scope
 from .exceptions import (
     AgentsException,
     InputGuardrailTripwireTriggered,
@@ -555,6 +556,7 @@ class AgentRunner:
                 session_items = []
                 model_responses = []
                 context_wrapper = ensure_context_wrapper(context)
+                set_agent_tool_state_scope(context_wrapper, None)
                 run_state = RunState(
                     context=context_wrapper,
                     original_input=original_input,
@@ -1458,6 +1460,7 @@ class AgentRunner:
                 auto_previous_response_id=auto_previous_response_id,
             )
             context_wrapper = ensure_context_wrapper(context)
+            set_agent_tool_state_scope(context_wrapper, None)
             # input_for_state is the same as input_for_result here
             input_for_state = input_for_result
             run_state = RunState(

--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from ..agent import Agent
+from ..agent_tool_state import set_agent_tool_state_scope
 from ..exceptions import UserError
 from ..guardrail import InputGuardrailResult
 from ..items import ModelResponse, RunItem, ToolApprovalItem, TResponseInputItem
@@ -141,10 +142,12 @@ def resolve_resumed_context(
     """Return the context wrapper for a resumed run, overriding when provided."""
     if context is not None:
         context_wrapper = ensure_context_wrapper(context)
+        set_agent_tool_state_scope(context_wrapper, run_state._agent_tool_state_scope_id)
         run_state._context = context_wrapper
         return context_wrapper
     if run_state._context is None:
         run_state._context = ensure_context_wrapper(context)
+    set_agent_tool_state_scope(run_state._context, run_state._agent_tool_state_scope_id)
     return run_state._context
 
 

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -194,10 +194,11 @@ def function_rejection_item(
     tool_call: Any,
     *,
     rejection_message: str = REJECTION_MESSAGE,
+    scope_id: str | None = None,
 ) -> ToolCallOutputItem:
     """Build a ToolCallOutputItem representing a rejected function tool call."""
     if isinstance(tool_call, ResponseFunctionToolCall):
-        drop_agent_tool_run_result(tool_call)
+        drop_agent_tool_run_result(tool_call, scope_id=scope_id)
     return ToolCallOutputItem(
         output=rejection_message,
         raw_item=ItemHelpers.tool_call_output_item(tool_call, rejection_message),

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from openai.types.responses import ResponseFunctionToolCall
 
+from .agent_tool_state import get_agent_tool_state_scope, set_agent_tool_state_scope
 from .run_context import RunContextWrapper, TContext
 from .usage import Usage
 
@@ -130,4 +131,5 @@ class ToolContext(RunContextWrapper[TContext]):
             run_config=tool_run_config,
             **base_values,
         )
+        set_agent_tool_state_scope(tool_context, get_agent_tool_state_scope(context))
         return tool_context

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -1840,16 +1840,24 @@ class TestDeserializeHelpers:
         del first_result
         gc.collect()
 
-        restored_state = await RunState.from_json(outer_agent, state_json)
-        restored_interruptions = restored_state.get_interruptions()
-        assert len(restored_interruptions) == 1
-        restored_state.approve(restored_interruptions[0])
+        restored_state_one = await RunState.from_json(outer_agent, state_json)
+        restored_state_two = await RunState.from_json(outer_agent, state_json)
 
-        resumed_result = await Runner.run(outer_agent, restored_state)
+        restored_interruptions_one = restored_state_one.get_interruptions()
+        restored_interruptions_two = restored_state_two.get_interruptions()
+        assert len(restored_interruptions_one) == 1
+        assert len(restored_interruptions_two) == 1
+        restored_state_one.approve(restored_interruptions_one[0])
+        restored_state_two.approve(restored_interruptions_two[0])
 
-        assert resumed_result.final_output == "outer-complete"
-        assert resumed_result.interruptions == []
-        assert tool_calls == ["hello"]
+        resumed_result_one = await Runner.run(outer_agent, restored_state_one)
+        resumed_result_two = await Runner.run(outer_agent, restored_state_two)
+
+        assert resumed_result_one.final_output == "outer-complete"
+        assert resumed_result_one.interruptions == []
+        assert resumed_result_two.final_output == "outer-complete"
+        assert resumed_result_two.interruptions == []
+        assert tool_calls == ["hello", "hello"]
 
     async def test_json_decode_error_handling(self):
         """Test that invalid JSON raises appropriate error."""


### PR DESCRIPTION
This pull request fixes cross-state interference when nested agent-tool interruption state is restored from JSON multiple times in the same process. The agent-tool pending result cache is now scoped per restored `RunState`, and the scope is propagated through resume execution paths and `ToolContext` creation so cache lookup/consume/drop always stays within the correct run-state boundary. It also updates `RunState` nested-state serialization/deserialization to use the scoped cache consistently, and extends regression coverage to verify two independently restored states from the same payload can both be approved and resumed successfully.