### PR TITLE
fix(handoffs): avoid orphan reasoning items when nesting handoff history

### DIFF
--- a/src/agents/handoffs/history.py
+++ b/src/agents/handoffs/history.py
@@ -32,6 +32,9 @@ _conversation_history_end = _DEFAULT_CONVERSATION_HISTORY_END
 _SUMMARY_ONLY_INPUT_TYPES = {
     "function_call",
     "function_call_output",
+    # Raw reasoning items require a following item in Responses API input and can become
+    # invalid when forwarded across handoffs as standalone items.
+    "reasoning",
 }
 
 


### PR DESCRIPTION
## Summary
- fix `nest_handoff_history` so standalone `reasoning` items are summarized but not forwarded as raw input items
- keep `new_items` unchanged for session persistence while filtering only next-agent model input
- add regression tests for reasoning filtering and tool-approval filtering paths

## Why
With `RunConfig(nest_handoff_history=True)`, forwarding a raw `reasoning` item can produce Responses API 400 errors (`...reasoning... without its required following item`).

## Changes
- add `"reasoning"` to `_SUMMARY_ONLY_INPUT_TYPES` in `src/agents/handoffs/history.py`
- add tests in `tests/test_extension_filters.py`:
  - `test_nest_handoff_history_does_not_forward_raw_reasoning_items`
  - `test_nest_handoff_history_skips_tool_approval_items`
  - `test_parse_summary_line_rejects_blank_lines`

## Validation
- `uv run --with ruff ruff check src/agents/handoffs/history.py tests/test_extension_filters.py`
- `uv run --with mypy mypy src/agents/handoffs/history.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --with pytest pytest tests/test_extension_filters.py -q`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --with pytest pytest tests/test_run_step_processing.py -q`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --with pytest --with pytest-cov pytest tests/test_extension_filters.py tests/test_run_step_processing.py --cov=agents.handoffs.history --cov-report=term-missing -q`
  - coverage: `src/agents/handoffs/history.py` = **100%**

Fixes #2503
