### PR TITLE
fix: filter reasoning items from nested handoff input

### DIFF
--- a/src/agents/handoffs/history.py
+++ b/src/agents/handoffs/history.py
@@ -32,6 +32,8 @@ _conversation_history_end = _DEFAULT_CONVERSATION_HISTORY_END
 _SUMMARY_ONLY_INPUT_TYPES = {
     "function_call",
     "function_call_output",
+    # Reasoning items can become orphaned after other summarized items are filtered.
+    "reasoning",
 }
 
 


### PR DESCRIPTION
This pull request fixes a bug where `nest_handoff_history=True` could forward a raw `reasoning` item during handoff turns after related items were summarized out, producing orphan reasoning input and a 400 error from the Responses API. It updates `src/agents/handoffs/history.py` to treat `reasoning` as summary-only so reasoning context remains in the conversation summary but is not sent as a raw handoff input item.

This pull request also adds focused regression tests in `tests/test_handoff_history_duplication.py`, `tests/test_agent_runner.py`, and `tests/test_agent_runner_streamed.py` to verify filtering behavior for pre-handoff reasoning, non-streamed handoff execution, and streamed handoff execution.

This pull request resolves #2503.