### PR TITLE
Add a meta attribute to the base function class

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -308,6 +308,7 @@ class MCPUtil:
             on_invoke_tool=invoke_func,
             strict_json_schema=is_strict,
             needs_approval=needs_approval,
+            meta=tool.meta,
         )
 
     @staticmethod

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -277,6 +277,9 @@ class FunctionTool:
     timeout_error_function: ToolErrorFunction | None = None
     """Optional formatter for timeout errors when timeout_behavior is "error_as_result"."""
 
+    meta: dict[str, Any] | None = None
+    """Optional metadata for the tool."""
+
     _is_agent_tool: bool = field(default=False, init=False, repr=False)
     """Internal flag indicating if this tool is an agent-as-tool."""
 


### PR DESCRIPTION
## Problem

When using MCP function calls, we lose the metadata attached. 

## Note

This is changing the core function class so open to comments on a better setup



