### PR TITLE
feat: add camb.ai integration for audio/speech tools and voice pipeline TTS

### DIFF
--- a/docs/ref/extensions/camb.md
+++ b/docs/ref/extensions/camb.md
@@ -1,0 +1,3 @@
+# `CambAI Tools`
+
+::: agents.extensions.camb

--- a/docs/ref/voice/models/camb_provider.md
+++ b/docs/ref/voice/models/camb_provider.md
@@ -1,0 +1,3 @@
+# `CambAIVoiceModelProvider`
+
+::: agents.voice.models.camb_model_provider

--- a/docs/ref/voice/models/camb_tts.md
+++ b/docs/ref/voice/models/camb_tts.md
@@ -1,0 +1,3 @@
+# `CambAI TTS`
+
+::: agents.voice.models.camb_tts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,10 +151,13 @@ plugins:
                     - ref/voice/models/openai_provider.md
                     - ref/voice/models/openai_stt.md
                     - ref/voice/models/openai_tts.md
+                    - ref/voice/models/camb_provider.md
+                    - ref/voice/models/camb_tts.md
                 - Extensions:
                     - ref/extensions/handoff_filters.md
                     - ref/extensions/handoff_prompt.md
                     - ref/extensions/litellm.md
+                    - ref/extensions/camb.md
                     - ref/extensions/memory/sqlalchemy_session.md
                     - ref/extensions/memory/encrypt_session.md
                     - ref/extensions/memory/advanced_sqlite_session.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ sqlalchemy = ["SQLAlchemy>=2.0", "asyncpg>=0.29.0"]
 encrypt = ["cryptography>=45.0, <46"]
 redis = ["redis>=7"]
 dapr = ["dapr>=1.16.0", "grpcio>=1.60.0"]
+camb = ["camb-sdk>=1.0.0"]
 
 [dependency-groups]
 dev = [
@@ -119,6 +120,10 @@ disallow_untyped_calls = false
 
 [[tool.mypy.overrides]]
 module = "sounddevice.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "camb.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/src/agents/extensions/__init__.py
+++ b/src/agents/extensions/__init__.py
@@ -1,3 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from .tool_output_trimmer import ToolOutputTrimmer
 
-__all__ = ["ToolOutputTrimmer"]
+if TYPE_CHECKING:
+    from .camb import CambAITools
+
+__all__ = ["CambAITools", "ToolOutputTrimmer"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "CambAITools":
+        try:
+            from .camb import CambAITools  # noqa: F401
+
+            return CambAITools
+        except ModuleNotFoundError as e:
+            raise ImportError(
+                "CambAITools requires the 'camb' extra. "
+                "Install it with: pip install 'openai-agents[camb]'"
+            ) from e
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/agents/extensions/camb.py
+++ b/src/agents/extensions/camb.py
@@ -1,0 +1,682 @@
+"""camb.ai toolkit for the OpenAI Agents SDK.
+
+Provides 9 audio/speech tools powered by camb.ai:
+- Text-to-Speech (TTS)
+- Translation
+- Transcription
+- Translated TTS
+- Voice Cloning
+- Voice Listing
+- Voice Creation from Description
+- Text-to-Sound generation
+- Audio Separation
+
+These tools can be used with any Agent by calling ``CambAITools().get_tools()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+import tempfile
+from os import getenv
+from typing import Any
+
+from agents.tool import FunctionTool, function_tool
+
+
+class CambAITools:
+    """Toolkit that exposes camb.ai audio/speech services as agent tools.
+
+    Each enabled service is returned as a :class:`FunctionTool` instance that
+    agents can call.  The underlying ``camb`` SDK is imported lazily so that
+    installing the extra is only required when the toolkit is actually used.
+
+    Args:
+        api_key: camb.ai API key.  Falls back to ``CAMB_API_KEY`` env var.
+        timeout: Request timeout in seconds.
+        max_poll_attempts: Maximum number of polling attempts for async tasks.
+        poll_interval: Seconds between polling attempts.
+        enable_tts: Enable the text-to-speech tool.
+        enable_translation: Enable the translation tool.
+        enable_transcription: Enable the transcription tool.
+        enable_translated_tts: Enable the translated TTS tool.
+        enable_voice_clone: Enable the voice cloning tool.
+        enable_voice_list: Enable the voice listing tool.
+        enable_voice_from_description: Enable the voice-from-description tool.
+        enable_text_to_sound: Enable the text-to-sound tool.
+        enable_audio_separation: Enable the audio separation tool.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        timeout: float = 60.0,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+        enable_tts: bool = True,
+        enable_translation: bool = True,
+        enable_transcription: bool = True,
+        enable_translated_tts: bool = True,
+        enable_voice_clone: bool = True,
+        enable_voice_list: bool = True,
+        enable_voice_from_description: bool = True,
+        enable_text_to_sound: bool = True,
+        enable_audio_separation: bool = True,
+    ) -> None:
+        self._api_key = api_key or getenv("CAMB_API_KEY")
+        if not self._api_key:
+            raise ValueError(
+                "CAMB_API_KEY not set. Please set the CAMB_API_KEY environment variable "
+                "or pass api_key to CambAITools."
+            )
+
+        self._timeout = timeout
+        self._max_poll_attempts = max_poll_attempts
+        self._poll_interval = poll_interval
+        self._client: Any = None  # Lazy AsyncCambAI
+
+        self._enable_tts = enable_tts
+        self._enable_translation = enable_translation
+        self._enable_transcription = enable_transcription
+        self._enable_translated_tts = enable_translated_tts
+        self._enable_voice_clone = enable_voice_clone
+        self._enable_voice_list = enable_voice_list
+        self._enable_voice_from_description = enable_voice_from_description
+        self._enable_text_to_sound = enable_text_to_sound
+        self._enable_audio_separation = enable_audio_separation
+
+    def _get_client(self) -> Any:
+        """Return a lazily-initialised ``AsyncCambAI`` client."""
+        if self._client is None:
+            try:
+                from camb.client import AsyncCambAI
+            except ImportError as e:
+                raise ImportError(
+                    "The 'camb' package is required. Install it with: "
+                    "pip install 'openai-agents[camb]'"
+                ) from e
+            self._client = AsyncCambAI(api_key=self._api_key, timeout=self._timeout)
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _poll_async(self, get_status_fn: Any, task_id: Any, *, run_id: Any = None) -> Any:
+        """Poll a camb.ai async task until completion."""
+        for _ in range(self._max_poll_attempts):
+            status = await get_status_fn(task_id, run_id=run_id)
+            if hasattr(status, "status"):
+                val = status.status
+                if val in ("completed", "SUCCESS"):
+                    return status
+                if val in ("failed", "FAILED", "error"):
+                    raise RuntimeError(f"Task failed: {getattr(status, 'error', 'Unknown error')}")
+            await asyncio.sleep(self._poll_interval)
+        raise TimeoutError(
+            f"Task {task_id} did not complete within "
+            f"{self._max_poll_attempts * self._poll_interval}s"
+        )
+
+    @staticmethod
+    def _detect_audio_format(data: bytes, content_type: str = "") -> str:
+        """Detect audio format from raw bytes or content-type header."""
+        if data.startswith(b"RIFF"):
+            return "wav"
+        if data.startswith((b"\xff\xfb", b"\xff\xfa", b"ID3")):
+            return "mp3"
+        if data.startswith(b"fLaC"):
+            return "flac"
+        if data.startswith(b"OggS"):
+            return "ogg"
+        ct = content_type.lower()
+        for key, fmt in [
+            ("wav", "wav"),
+            ("wave", "wav"),
+            ("mpeg", "mp3"),
+            ("mp3", "mp3"),
+            ("flac", "flac"),
+            ("ogg", "ogg"),
+        ]:
+            if key in ct:
+                return fmt
+        return "pcm"
+
+    @staticmethod
+    def _add_wav_header(pcm_data: bytes) -> bytes:
+        """Wrap raw PCM data with a WAV header."""
+        sr, ch, bps = 24000, 1, 16
+        byte_rate = sr * ch * bps // 8
+        block_align = ch * bps // 8
+        data_size = len(pcm_data)
+        header = struct.pack(
+            "<4sI4s4sIHHIIHH4sI",
+            b"RIFF",
+            36 + data_size,
+            b"WAVE",
+            b"fmt ",
+            16,
+            1,
+            ch,
+            sr,
+            byte_rate,
+            block_align,
+            bps,
+            b"data",
+            data_size,
+        )
+        return header + pcm_data
+
+    @staticmethod
+    def _save_audio(data: bytes, suffix: str = ".wav") -> str:
+        """Save audio bytes to a temp file and return the path."""
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+            f.write(data)
+            return f.name
+
+    @staticmethod
+    def _gender_str(g: int) -> str:
+        """Convert numeric gender code to a human-readable string."""
+        return {0: "not_specified", 1: "male", 2: "female", 9: "not_applicable"}.get(g, "unknown")
+
+    @staticmethod
+    def _format_transcription(transcription: Any) -> str:
+        """Format a transcription result as a JSON string."""
+        out: dict[str, Any] = {
+            "text": getattr(transcription, "text", ""),
+            "segments": [],
+            "speakers": [],
+        }
+        if hasattr(transcription, "segments"):
+            for seg in transcription.segments:
+                out["segments"].append(
+                    {
+                        "start": getattr(seg, "start", 0),
+                        "end": getattr(seg, "end", 0),
+                        "text": getattr(seg, "text", ""),
+                        "speaker": getattr(seg, "speaker", None),
+                    }
+                )
+        if hasattr(transcription, "speakers"):
+            out["speakers"] = list(transcription.speakers)
+        elif out["segments"]:
+            out["speakers"] = list({s["speaker"] for s in out["segments"] if s.get("speaker")})
+        return json.dumps(out, indent=2)
+
+    def _format_voices(self, voices: Any) -> str:
+        """Format a list of voice objects as a JSON string."""
+        out: list[dict[str, Any]] = []
+        for v in voices:
+            if isinstance(v, dict):
+                out.append(
+                    {
+                        "id": v.get("id"),
+                        "name": v.get("voice_name", v.get("name", "Unknown")),
+                        "gender": self._gender_str(v.get("gender", 0)),
+                        "age": v.get("age"),
+                        "language": v.get("language"),
+                    }
+                )
+            else:
+                out.append(
+                    {
+                        "id": getattr(v, "id", None),
+                        "name": getattr(v, "voice_name", getattr(v, "name", "Unknown")),
+                        "gender": self._gender_str(getattr(v, "gender", 0)),
+                        "age": getattr(v, "age", None),
+                        "language": getattr(v, "language", None),
+                    }
+                )
+        return json.dumps(out, indent=2)
+
+    def _format_separation(self, sep: Any) -> str:
+        """Format an audio separation result as a JSON string."""
+        out: dict[str, Any] = {"vocals": None, "background": None, "status": "completed"}
+        for attr, key in [
+            ("vocals_url", "vocals"),
+            ("vocals", "vocals"),
+            ("voice_url", "vocals"),
+            ("background_url", "background"),
+            ("background", "background"),
+            ("instrumental_url", "background"),
+        ]:
+            val = getattr(sep, attr, None)
+            if val and out[key] is None:
+                if isinstance(val, bytes):
+                    out[key] = self._save_audio(val, f"_{key}.wav")
+                else:
+                    out[key] = val
+        return json.dumps(out, indent=2)
+
+    @staticmethod
+    def _extract_translation(result: Any) -> str:
+        """Extract translated text from an SDK result."""
+        if hasattr(result, "__iter__") and not isinstance(result, (str, bytes)):
+            parts: list[str] = []
+            for chunk in result:
+                if hasattr(chunk, "text"):
+                    parts.append(chunk.text)
+                elif isinstance(chunk, str):
+                    parts.append(chunk)
+            return "".join(parts)
+        if hasattr(result, "text"):
+            return str(result.text)
+        return str(result)
+
+    # ------------------------------------------------------------------
+    # get_tools — build and return FunctionTool instances
+    # ------------------------------------------------------------------
+
+    def get_tools(self) -> list[FunctionTool]:
+        """Return the enabled tools as a list of :class:`FunctionTool` instances."""
+        tools: list[FunctionTool] = []
+
+        if self._enable_tts:
+            tools.append(self._make_tts_tool())
+        if self._enable_translation:
+            tools.append(self._make_translate_tool())
+        if self._enable_transcription:
+            tools.append(self._make_transcribe_tool())
+        if self._enable_translated_tts:
+            tools.append(self._make_translated_tts_tool())
+        if self._enable_voice_clone:
+            tools.append(self._make_clone_voice_tool())
+        if self._enable_voice_list:
+            tools.append(self._make_list_voices_tool())
+        if self._enable_voice_from_description:
+            tools.append(self._make_voice_from_description_tool())
+        if self._enable_text_to_sound:
+            tools.append(self._make_text_to_sound_tool())
+        if self._enable_audio_separation:
+            tools.append(self._make_audio_separation_tool())
+
+        return tools
+
+    # ------------------------------------------------------------------
+    # Individual tool builders
+    # ------------------------------------------------------------------
+
+    def _make_tts_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_tts(
+            text: str,
+            language: str = "en-us",
+            voice_id: int = 147320,
+            speech_model: str = "mars-flash",
+            user_instructions: str | None = None,
+        ) -> str:
+            """Convert text to speech using camb.ai.
+
+            Supports 140+ languages and multiple voice models.  The audio is
+            saved to a temporary file and the file path is returned.
+
+            Args:
+                text: Text to convert to speech (3-3000 characters).
+                language: BCP-47 language code (e.g. 'en-us', 'fr-fr').
+                voice_id: Voice ID.  Use camb_list_voices to find voices.
+                speech_model: Model: 'mars-flash', 'mars-pro', 'mars-instruct'.
+                user_instructions: Instructions for mars-instruct model.
+            """
+            from camb import StreamTtsOutputConfiguration
+
+            client = toolkit._get_client()
+            kwargs: dict[str, Any] = {
+                "text": text,
+                "language": language,
+                "voice_id": voice_id,
+                "speech_model": speech_model,
+                "output_configuration": StreamTtsOutputConfiguration(format="wav"),
+            }
+            if user_instructions and speech_model == "mars-instruct":
+                kwargs["user_instructions"] = user_instructions
+
+            chunks: list[bytes] = []
+            async for chunk in client.text_to_speech.tts(**kwargs):
+                chunks.append(chunk)
+            return toolkit._save_audio(b"".join(chunks), ".wav")
+
+        return function_tool(camb_tts, name_override="camb_tts")
+
+    def _make_translate_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_translate(
+            text: str,
+            source_language: int,
+            target_language: int,
+            formality: int | None = None,
+        ) -> str:
+            """Translate text between 140+ languages using camb.ai.
+
+            Provide integer language codes: 1=English, 2=Spanish, 3=French, 4=German,
+            5=Italian, 6=Portuguese, 7=Dutch, 8=Russian, 9=Japanese, 10=Korean,
+            11=Chinese.
+
+            Args:
+                text: Text to translate.
+                source_language: Source language code (integer).
+                target_language: Target language code (integer).
+                formality: Optional formality level: 1=formal, 2=informal.
+            """
+            from camb.core.api_error import ApiError
+
+            client = toolkit._get_client()
+            kwargs: dict[str, Any] = {
+                "text": text,
+                "source_language": source_language,
+                "target_language": target_language,
+            }
+            if formality:
+                kwargs["formality"] = formality
+
+            try:
+                result = await client.translation.translation_stream(**kwargs)
+                return toolkit._extract_translation(result)
+            except ApiError as e:
+                if e.status_code == 200 and e.body:
+                    return str(e.body)
+                raise
+
+        return function_tool(camb_translate, name_override="camb_translate")
+
+    def _make_transcribe_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_transcribe(
+            language: int,
+            audio_url: str | None = None,
+            audio_file_path: str | None = None,
+        ) -> str:
+            """Transcribe audio to text with speaker identification using camb.ai.
+
+            Supports audio URLs or local file paths.  Returns JSON with full transcription
+            text, timed segments, and speaker labels.
+
+            Args:
+                language: Language code (integer).  1=English, 2=Spanish, 3=French, etc.
+                audio_url: URL of the audio file to transcribe.
+                audio_file_path: Local file path to the audio file.
+            """
+            client = toolkit._get_client()
+            kwargs: dict[str, Any] = {"language": language}
+
+            if audio_url:
+                import httpx
+
+                async with httpx.AsyncClient() as http:
+                    resp = await http.get(audio_url)
+                    resp.raise_for_status()
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                    tmp.write(resp.content)
+                    tmp_path = tmp.name
+                with open(tmp_path, "rb") as f:
+                    kwargs["media_file"] = f
+                    result = await client.transcription.create_transcription(**kwargs)
+            elif audio_file_path:
+                with open(audio_file_path, "rb") as f:
+                    kwargs["media_file"] = f
+                    result = await client.transcription.create_transcription(**kwargs)
+            else:
+                return json.dumps({"error": "Provide either audio_url or audio_file_path"})
+
+            task_id = result.task_id
+            status = await toolkit._poll_async(
+                client.transcription.get_transcription_task_status, task_id
+            )
+            transcription = await client.transcription.get_transcription_result(status.run_id)
+            return toolkit._format_transcription(transcription)
+
+        return function_tool(camb_transcribe, name_override="camb_transcribe")
+
+    def _make_translated_tts_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_translated_tts(
+            text: str,
+            source_language: int,
+            target_language: int,
+            voice_id: int = 147320,
+            formality: int | None = None,
+        ) -> str:
+            """Translate text and convert to speech in one step using camb.ai.
+
+            Returns the file path to the generated audio file.
+
+            Args:
+                text: Text to translate and speak.
+                source_language: Source language code (integer).
+                target_language: Target language code (integer).
+                voice_id: Voice ID for TTS output.
+                formality: Optional formality: 1=formal, 2=informal.
+            """
+            import httpx
+
+            client = toolkit._get_client()
+            kwargs: dict[str, Any] = {
+                "text": text,
+                "voice_id": voice_id,
+                "source_language": source_language,
+                "target_language": target_language,
+            }
+            if formality:
+                kwargs["formality"] = formality
+
+            result = await client.translated_tts.create_translated_tts(**kwargs)
+            status = await toolkit._poll_async(
+                client.translated_tts.get_translated_tts_task_status, result.task_id
+            )
+
+            # Fetch the audio via the run_id result endpoint.
+            run_id = getattr(status, "run_id", None)
+            audio_data = b""
+            fmt = "pcm"
+            if run_id:
+                client_wrapper = getattr(client, "_client_wrapper", None)
+                if client_wrapper and hasattr(client_wrapper, "base_url"):
+                    url = f"{client_wrapper.base_url}/tts-result/{run_id}"
+                else:
+                    url = f"https://client.camb.ai/apis/tts-result/{run_id}"
+
+                async with httpx.AsyncClient() as http:
+                    resp = await http.get(url, headers={"x-api-key": toolkit._api_key or ""})
+                    if resp.status_code == 200:
+                        audio_data = resp.content
+                        fmt = toolkit._detect_audio_format(
+                            audio_data, resp.headers.get("content-type", "")
+                        )
+
+            if fmt == "pcm" and audio_data:
+                audio_data = toolkit._add_wav_header(audio_data)
+                fmt = "wav"
+
+            ext = {"wav": ".wav", "mp3": ".mp3", "flac": ".flac", "ogg": ".ogg"}.get(fmt, ".wav")
+            return toolkit._save_audio(audio_data, ext)
+
+        return function_tool(camb_translated_tts, name_override="camb_translated_tts")
+
+    def _make_clone_voice_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_clone_voice(
+            voice_name: str,
+            audio_file_path: str,
+            gender: int,
+            description: str | None = None,
+            age: int | None = None,
+            language: int | None = None,
+        ) -> str:
+            """Clone a voice from an audio sample using camb.ai.
+
+            Creates a custom voice from a 2+ second audio sample that can be used with
+            camb_tts and camb_translated_tts.
+
+            Args:
+                voice_name: Name for the new cloned voice.
+                audio_file_path: Path to audio file (minimum 2 seconds).
+                gender: Gender: 1=Male, 2=Female, 0=Not Specified, 9=Not Applicable.
+                description: Optional description of the voice.
+                age: Optional age of the voice.
+                language: Optional language code for the voice.
+            """
+            client = toolkit._get_client()
+            with open(audio_file_path, "rb") as f:
+                kwargs: dict[str, Any] = {
+                    "voice_name": voice_name,
+                    "gender": gender,
+                    "file": f,
+                }
+                if description:
+                    kwargs["description"] = description
+                if age:
+                    kwargs["age"] = age
+                if language:
+                    kwargs["language"] = language
+                result = await client.voice_cloning.create_custom_voice(**kwargs)
+
+            out: dict[str, Any] = {
+                "voice_id": getattr(result, "voice_id", getattr(result, "id", None)),
+                "voice_name": voice_name,
+                "status": "created",
+            }
+            if hasattr(result, "message"):
+                out["message"] = result.message
+            return json.dumps(out, indent=2)
+
+        return function_tool(camb_clone_voice, name_override="camb_clone_voice")
+
+    def _make_list_voices_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_list_voices() -> str:
+            """List all available voices from camb.ai.
+
+            Returns voice IDs, names, genders, ages, and languages.  Use the voice ID
+            with camb_tts or camb_translated_tts.
+            """
+            client = toolkit._get_client()
+            voices = await client.voice_cloning.list_voices()
+            return toolkit._format_voices(voices)
+
+        return function_tool(camb_list_voices, name_override="camb_list_voices")
+
+    def _make_voice_from_description_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_voice_from_description(
+            text: str,
+            voice_description: str,
+        ) -> str:
+            """Generate a synthetic voice from a detailed text description using camb.ai.
+
+            Provide sample text the voice will speak and a detailed description of the
+            desired voice (minimum 100 characters / 18+ words).  Include details like
+            accent, tone, age, gender, speaking style, etc.
+
+            Args:
+                text: Sample text the generated voice will speak.
+                voice_description: Detailed description of the desired voice (min 100 chars).
+            """
+            client = toolkit._get_client()
+            result = await client.text_to_voice.create_text_to_voice(
+                text=text, voice_description=voice_description
+            )
+            status = await toolkit._poll_async(
+                client.text_to_voice.get_text_to_voice_status, result.task_id
+            )
+            voice_result = await client.text_to_voice.get_text_to_voice_result(status.run_id)
+
+            out: dict[str, Any] = {
+                "previews": getattr(voice_result, "previews", []),
+                "status": "completed",
+            }
+            return json.dumps(out, indent=2)
+
+        return function_tool(
+            camb_voice_from_description, name_override="camb_voice_from_description"
+        )
+
+    def _make_text_to_sound_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_text_to_sound(
+            prompt: str,
+            duration: float | None = None,
+            audio_type: str | None = None,
+        ) -> str:
+            """Generate sounds, music, or soundscapes from text descriptions using camb.ai.
+
+            Describe the sound or music you want and the tool will generate it.  Returns
+            the file path to the generated audio file.
+
+            Args:
+                prompt: Description of the sound or music to generate.
+                duration: Optional duration in seconds.
+                audio_type: Optional type: 'music' or 'sound'.
+            """
+            client = toolkit._get_client()
+            kwargs: dict[str, Any] = {"prompt": prompt}
+            if duration:
+                kwargs["duration"] = duration
+            if audio_type:
+                kwargs["audio_type"] = audio_type
+
+            result = await client.text_to_audio.create_text_to_audio(**kwargs)
+            status = await toolkit._poll_async(
+                client.text_to_audio.get_text_to_audio_status, result.task_id
+            )
+
+            chunks: list[bytes] = []
+            async for chunk in client.text_to_audio.get_text_to_audio_result(status.run_id):
+                chunks.append(chunk)
+            return toolkit._save_audio(b"".join(chunks), ".wav")
+
+        return function_tool(camb_text_to_sound, name_override="camb_text_to_sound")
+
+    def _make_audio_separation_tool(self) -> FunctionTool:
+        toolkit = self
+
+        async def camb_audio_separation(
+            audio_url: str | None = None,
+            audio_file_path: str | None = None,
+        ) -> str:
+            """Separate vocals/speech from background audio using camb.ai.
+
+            Provide either an audio URL or a local file path.  Returns JSON with paths
+            to the separated vocals and background audio files.
+
+            Args:
+                audio_url: URL of the audio file to separate.
+                audio_file_path: Local file path to the audio file.
+            """
+            client = toolkit._get_client()
+            kwargs: dict[str, Any] = {}
+
+            if audio_url:
+                import httpx
+
+                async with httpx.AsyncClient() as http:
+                    resp = await http.get(audio_url)
+                    resp.raise_for_status()
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                    tmp.write(resp.content)
+                    tmp_path = tmp.name
+                with open(tmp_path, "rb") as f:
+                    kwargs["media_file"] = f
+                    result = await client.audio_separation.create_audio_separation(**kwargs)
+            elif audio_file_path:
+                with open(audio_file_path, "rb") as f:
+                    kwargs["media_file"] = f
+                    result = await client.audio_separation.create_audio_separation(**kwargs)
+            else:
+                return json.dumps({"error": "Provide either audio_url or audio_file_path"})
+
+            status = await toolkit._poll_async(
+                client.audio_separation.get_audio_separation_status, result.task_id
+            )
+            sep = await client.audio_separation.get_audio_separation_run_info(status.run_id)
+            return toolkit._format_separation(sep)
+
+        return function_tool(camb_audio_separation, name_override="camb_audio_separation")

--- a/src/agents/voice/__init__.py
+++ b/src/agents/voice/__init__.py
@@ -10,6 +10,8 @@ from .model import (
     TTSVoice,
     VoiceModelProvider,
 )
+from .models.camb_model_provider import CambAIVoiceModelProvider
+from .models.camb_tts import CambAITTSModel
 from .models.openai_model_provider import OpenAIVoiceModelProvider
 from .models.openai_stt import OpenAISTTModel, OpenAISTTTranscriptionSession
 from .models.openai_tts import OpenAITTSModel
@@ -26,6 +28,8 @@ from .workflow import (
 
 __all__ = [
     "AudioInput",
+    "CambAITTSModel",
+    "CambAIVoiceModelProvider",
     "StreamedAudioInput",
     "STTModel",
     "STTModelSettings",

--- a/src/agents/voice/models/camb_model_provider.py
+++ b/src/agents/voice/models/camb_model_provider.py
@@ -1,0 +1,66 @@
+"""camb.ai voice model provider.
+
+Provides a :class:`VoiceModelProvider` that creates :class:`CambAITTSModel`
+instances.  camb.ai does not offer a speech-to-text service, so
+:meth:`get_stt_model` always raises :class:`NotImplementedError`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..model import STTModel, TTSModel, VoiceModelProvider
+from .camb_tts import CambAITTSModel
+
+DEFAULT_TTS_MODEL = "mars-flash"
+
+
+class CambAIVoiceModelProvider(VoiceModelProvider):
+    """A :class:`VoiceModelProvider` backed by camb.ai.
+
+    Args:
+        api_key: camb.ai API key.  Falls back to ``CAMB_API_KEY`` env var.
+        camb_client: An optional pre-built ``AsyncCambAI`` instance.
+        voice_id: Default voice identifier used by all returned TTS models.
+        language: Default BCP-47 language code (e.g. ``"en-us"``).
+        user_instructions: Instructions forwarded when using ``mars-instruct``.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        camb_client: Any | None = None,
+        voice_id: int = 147320,
+        language: str = "en-us",
+        user_instructions: str | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._camb_client = camb_client
+        self._voice_id = voice_id
+        self._language = language
+        self._user_instructions = user_instructions
+
+    def get_stt_model(self, model_name: str | None) -> STTModel:
+        """camb.ai does not provide a speech-to-text model.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError("camb.ai does not provide a speech-to-text model.")
+
+    def get_tts_model(self, model_name: str | None) -> TTSModel:
+        """Return a :class:`CambAITTSModel` for the given model name.
+
+        Args:
+            model_name: Model name (e.g. ``"mars-flash"``, ``"mars-pro"``).
+                Falls back to ``"mars-flash"`` when ``None``.
+        """
+        return CambAITTSModel(
+            model=model_name or DEFAULT_TTS_MODEL,
+            camb_client=self._camb_client,
+            api_key=self._api_key,
+            voice_id=self._voice_id,
+            language=self._language,
+            user_instructions=self._user_instructions,
+        )

--- a/src/agents/voice/models/camb_tts.py
+++ b/src/agents/voice/models/camb_tts.py
@@ -1,0 +1,128 @@
+"""camb.ai MARS text-to-speech model for the voice pipeline.
+
+Streams PCM s16le audio chunks via the ``AsyncCambAI`` SDK, suitable for use
+in a :class:`VoicePipeline`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from ..model import TTSModel, TTSModelSettings
+
+# Model-specific sample rates (Hz).
+MODEL_SAMPLE_RATES: dict[str, int] = {
+    "mars-flash": 22050,
+    "mars-pro": 48000,
+    "mars-instruct": 22050,
+}
+
+
+def _get_aligned_audio(buffer: bytes) -> tuple[bytes, bytes]:
+    """Split *buffer* into 2-byte-aligned audio and a remainder."""
+    aligned_size = (len(buffer) // 2) * 2
+    return buffer[:aligned_size], buffer[aligned_size:]
+
+
+class CambAITTSModel(TTSModel):
+    """A text-to-speech model backed by camb.ai's MARS family.
+
+    This model streams PCM audio (s16le, mono) and is designed to be used as the
+    ``tts_model`` argument to :class:`VoicePipeline`.
+
+    Args:
+        model: Model name — ``"mars-flash"`` (fast, 22.05 kHz),
+            ``"mars-pro"`` (high quality, 48 kHz), or ``"mars-instruct"``
+            (follows *user_instructions*, 22.05 kHz).
+        camb_client: An optional pre-built ``AsyncCambAI`` instance.  When
+            omitted a new client is created lazily using *api_key*.
+        api_key: camb.ai API key.  Falls back to ``CAMB_API_KEY`` env var.
+        voice_id: Numeric voice identifier.
+        language: BCP-47 language code (e.g. ``"en-us"``, ``"fr-fr"``).
+        user_instructions: Instructions forwarded to the ``mars-instruct``
+            model only.
+    """
+
+    def __init__(
+        self,
+        model: str = "mars-flash",
+        *,
+        camb_client: Any | None = None,
+        api_key: str | None = None,
+        voice_id: int = 147320,
+        language: str = "en-us",
+        user_instructions: str | None = None,
+    ) -> None:
+        self._model = model
+        self._camb_client = camb_client
+        self._api_key = api_key
+        self._voice_id = voice_id
+        self._language = language
+        self._user_instructions = user_instructions
+        self._sample_rate = MODEL_SAMPLE_RATES.get(model, 22050)
+
+    def _get_client(self) -> Any:
+        """Return a lazily-initialised ``AsyncCambAI`` client."""
+        if self._camb_client is None:
+            try:
+                from camb.client import AsyncCambAI
+            except ImportError as e:
+                raise ImportError(
+                    "The 'camb' package is required. Install it with: "
+                    "pip install 'openai-agents[camb]'"
+                ) from e
+            self._camb_client = AsyncCambAI(api_key=self._api_key)
+        return self._camb_client
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def sample_rate(self) -> int:
+        """The native sample rate of the model."""
+        return self._sample_rate
+
+    async def run(self, text: str, settings: TTSModelSettings) -> AsyncIterator[bytes]:
+        """Stream PCM audio for *text*.
+
+        Args:
+            text: The text to convert to speech.
+            settings: TTS model settings (voice pipeline level).
+
+        Yields:
+            2-byte-aligned PCM s16le audio chunks.
+        """
+        try:
+            from camb import StreamTtsOutputConfiguration
+        except ImportError as e:
+            raise ImportError(
+                "The 'camb' package is required. Install it with: pip install 'openai-agents[camb]'"
+            ) from e
+
+        client = self._get_client()
+
+        tts_kwargs: dict[str, Any] = {
+            "text": text,
+            "voice_id": self._voice_id,
+            "language": self._language,
+            "speech_model": self._model,
+            "output_configuration": StreamTtsOutputConfiguration(format="pcm_s16le"),
+        }
+        if self._model == "mars-instruct" and self._user_instructions:
+            tts_kwargs["user_instructions"] = self._user_instructions
+
+        audio_buffer = b""
+        async for chunk in client.text_to_speech.tts(**tts_kwargs):
+            if chunk:
+                audio_buffer += chunk
+                aligned_audio, audio_buffer = _get_aligned_audio(audio_buffer)
+                if aligned_audio:
+                    yield aligned_audio
+
+        # Yield any remaining complete samples.
+        if len(audio_buffer) >= 2:
+            aligned_audio, _ = _get_aligned_audio(audio_buffer)
+            if aligned_audio:
+                yield aligned_audio

--- a/uv.lock
+++ b/uv.lock
@@ -254,6 +254,22 @@ wheels = [
 ]
 
 [[package]]
+name = "camb-sdk"
+version = "1.5.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "websocket-client" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/f9/4d3f62909f62f98556e09958f40934abf226289f55a43e149dfc426dc1cf/camb_sdk-1.5.8.tar.gz", hash = "sha256:4ace563accb6aab35d2a4dce53789c98d8809a8c48806a69d0873fc8b0361300", size = 83508, upload-time = "2026-01-27T14:55:49.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/2d/e7aeef5d5f48205020d153f4a6ffb39d8971fca78b2cc64fdf0a36ceeb12/camb_sdk-1.5.8-py3-none-any.whl", hash = "sha256:7e1a4764376791ab7cccc27014cdfb691b8c73eecdcaeb01457f506ffd3425be", size = 152371, upload-time = "2026-01-27T14:55:45.637Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1883,6 +1899,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+camb = [
+    { name = "camb-sdk" },
+]
 dapr = [
     { name = "dapr" },
     { name = "grpcio" },
@@ -1946,6 +1965,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", marker = "extra == 'sqlalchemy'", specifier = ">=0.29.0" },
+    { name = "camb-sdk", marker = "extra == 'camb'", specifier = ">=1.0.0" },
     { name = "cryptography", marker = "extra == 'encrypt'", specifier = ">=45.0,<46" },
     { name = "dapr", marker = "extra == 'dapr'", specifier = ">=1.16.0" },
     { name = "graphviz", marker = "extra == 'viz'", specifier = ">=0.17" },
@@ -1964,7 +1984,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'realtime'", specifier = ">=15.0,<16" },
     { name = "websockets", marker = "extra == 'voice'", specifier = ">=15.0,<16" },
 ]
-provides-extras = ["voice", "viz", "litellm", "realtime", "sqlalchemy", "encrypt", "redis", "dapr"]
+provides-extras = ["voice", "viz", "litellm", "realtime", "sqlalchemy", "encrypt", "redis", "dapr", "camb"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3315,6 +3335,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `CambAITools` extension providing 9 audio/speech agent tools (TTS, translation, transcription, translated TTS, voice cloning, voice listing, voice-from-description, text-to-sound, audio separation) powered by the camb.ai SDK
- Adds `CambAIVoiceModelProvider` and `CambAITTSModel` for streaming PCM TTS in the voice pipeline, supporting mars-flash, mars-pro, and mars-instruct models
- Adds `camb` as an optional dependency (`pip install openai-agents[camb]`)
- Adds API reference documentation for all new modules