### PR TITLE
fix: strip #2518 total_tokens from OpenAI tracing usage payloads

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -33,7 +33,6 @@ class BackendSpanExporter(TracingExporter):
         {
             "input_tokens",
             "output_tokens",
-            "total_tokens",
             "input_tokens_details",
             "output_tokens_details",
         }

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -316,14 +316,15 @@ def test_backend_span_exporter_sanitizes_generation_usage_for_openai_tracing(moc
     sent_payload = mock_client.return_value.post.call_args.kwargs["json"]["data"][0]
     sent_usage = sent_payload["span_data"]["usage"]
     assert "requests" not in sent_usage
+    assert "total_tokens" not in sent_usage
     assert sent_usage["input_tokens"] == 10
     assert sent_usage["output_tokens"] == 5
-    assert sent_usage["total_tokens"] == 15
     assert sent_usage["input_tokens_details"] == {"cached_tokens": 1}
     assert sent_usage["output_tokens_details"] == {"reasoning_tokens": 2}
 
     # Ensure the original exported object has not been mutated.
     assert "requests" in item.exported_payload["span_data"]["usage"]
+    assert item.exported_payload["span_data"]["usage"]["total_tokens"] == 15
     exporter.close()
 
 
@@ -400,7 +401,6 @@ def test_sanitize_for_openai_tracing_api_keeps_allowed_generation_usage():
             "usage": {
                 "input_tokens": 1,
                 "output_tokens": 2,
-                "total_tokens": 3,
                 "input_tokens_details": {"cached_tokens": 0},
                 "output_tokens_details": {"reasoning_tokens": 0},
             },


### PR DESCRIPTION
This pull request fixes OpenAI tracing export sanitization for generation spans by removing `total_tokens` from the usage payload sent to the OpenAI tracing ingest endpoint, which rejects that field with a 400 (`extra_forbidden`) error. It updates the OpenAI tracing usage allowlist in the backend span exporter and adjusts trace processor tests to assert that `total_tokens` is filtered from the outbound payload while the original exported payload remains unchanged.

This pull request resolves #2518. 