### PR TITLE
feat: add Responses websocket model and stream_ws example

### DIFF
--- a/examples/basic/stream_ws.py
+++ b/examples/basic/stream_ws.py
@@ -1,0 +1,236 @@
+"""Responses websocket streaming example with function tools, agent-as-tool, and approval.
+
+This example shows a user-facing websocket workflow using
+`responses_websocket_session(...)`:
+- Streaming output (including reasoning summary deltas when available)
+- Regular function tools
+- An `Agent.as_tool(...)` specialist agent
+- HITL approval for a sensitive tool call
+- A follow-up turn using `previous_response_id` on the same trace
+
+Required environment variable:
+- `OPENAI_API_KEY`
+
+Optional environment variables:
+- `OPENAI_MODEL` (defaults to `gpt-5.2`)
+- `OPENAI_BASE_URL`
+- `OPENAI_WEBSOCKET_BASE_URL`
+- `EXAMPLES_INTERACTIVE_MODE=auto` (auto-approve HITL prompts for scripted runs)
+"""
+
+import asyncio
+import os
+from typing import Any
+
+from openai.types.shared import Reasoning
+
+from agents import (
+    Agent,
+    ModelSettings,
+    ResponsesWebSocketSession,
+    function_tool,
+    responses_websocket_session,
+    trace,
+)
+from examples.auto_mode import confirm_with_fallback
+
+
+@function_tool
+def lookup_order(order_id: str) -> dict[str, Any]:
+    """Return deterministic order data for the demo."""
+    orders = {
+        "ORD-1001": {
+            "order_id": "ORD-1001",
+            "status": "delivered",
+            "delivered_days_ago": 3,
+            "amount": 49.99,
+            "currency": "USD",
+            "item": "Wireless Mouse",
+        },
+        "ORD-2002": {
+            "order_id": "ORD-2002",
+            "status": "delivered",
+            "delivered_days_ago": 12,
+            "amount": 129.0,
+            "currency": "USD",
+            "item": "Keyboard",
+        },
+    }
+    return orders.get(
+        order_id,
+        {
+            "order_id": order_id,
+            "status": "unknown",
+            "delivered_days_ago": 999,
+            "amount": 0.0,
+            "currency": "USD",
+            "item": "unknown",
+        },
+    )
+
+
+@function_tool(needs_approval=True)
+def submit_refund(order_id: str, amount: float, reason: str) -> dict[str, Any]:
+    """Create a refund request. This tool requires approval."""
+    ticket = "RF-1001" if order_id == "ORD-1001" else f"RF-{order_id[-4:]}"
+    return {
+        "refund_ticket": ticket,
+        "order_id": order_id,
+        "amount": amount,
+        "reason": reason,
+        "status": "approved_pending_processing",
+    }
+
+
+def ask_approval(question: str) -> bool:
+    """Prompt for approval (or auto-approve in examples auto mode)."""
+    return confirm_with_fallback(f"[approval] {question} [y/N]: ", default=True)
+
+
+async def run_streamed_turn(
+    ws: ResponsesWebSocketSession,
+    agent: Agent[Any],
+    prompt: str,
+    *,
+    previous_response_id: str | None = None,
+) -> tuple[str, str]:
+    """Run one streamed turn and handle HITL approvals if needed."""
+    print(f"\nUser: {prompt}\n")
+
+    result = ws.run_streamed(
+        agent,
+        prompt,
+        previous_response_id=previous_response_id,
+    )
+    printed_reasoning = False
+    printed_output = False
+
+    while True:
+        async for event in result.stream_events():
+            if event.type == "raw_response_event":
+                raw = event.data
+                if raw.type == "response.reasoning_summary_text.delta":
+                    if not printed_reasoning:
+                        print("Reasoning:")
+                        printed_reasoning = True
+                    print(raw.delta, end="", flush=True)
+                elif raw.type == "response.output_text.delta":
+                    if printed_reasoning and not printed_output:
+                        print("\n")
+                    if not printed_output:
+                        print("Assistant:")
+                        printed_output = True
+                    print(raw.delta, end="", flush=True)
+                continue
+
+            if event.type != "run_item_stream_event":
+                continue
+
+            item = event.item
+            if item.type == "tool_call_item":
+                tool_name = getattr(item.raw_item, "name", "unknown")
+                tool_args = getattr(item.raw_item, "arguments", "")
+                print(f"\n[tool call] {tool_name}({tool_args})")
+            elif item.type == "tool_call_output_item":
+                print(f"[tool result] {item.output}")
+
+        if printed_reasoning or printed_output:
+            print("\n")
+
+        if not result.interruptions:
+            break
+
+        state = result.to_state()
+        for interruption in result.interruptions:
+            question = f"Approve {interruption.name} with args {interruption.arguments}?"
+            if ask_approval(question):
+                state.approve(interruption)
+            else:
+                state.reject(interruption)
+
+        result = ws.run_streamed(agent, state)
+
+    if result.last_response_id is None:
+        raise RuntimeError("The streamed run completed without a response_id.")
+
+    final_output = str(result.final_output)
+    print(f"response_id: {result.last_response_id}")
+    print(f"final_output: {final_output}\n")
+    return result.last_response_id, final_output
+
+
+async def main() -> None:
+    model_name = os.getenv("OPENAI_MODEL", "gpt-5.2-codex")
+    policy_agent = Agent(
+        name="RefundPolicySpecialist",
+        instructions=(
+            "You are a refund policy specialist. The policy is simple: orders delivered "
+            "within 7 days are eligible for a full refund, and older delivered orders "
+            "are not. Return a short answer with eligibility and a one-line reason."
+        ),
+        model=model_name,
+        model_settings=ModelSettings(max_tokens=120),
+    )
+
+    support_agent = Agent(
+        name="SupportAgent",
+        instructions=(
+            "You are a support agent. For refund requests, do this in order: "
+            "1) call lookup_order, 2) call refund_policy_specialist, 3) if the user "
+            "asked to proceed and the order is eligible, call submit_refund. "
+            "When asked for only the refund ticket, return only the ticket token "
+            "(for example RF-1001)."
+        ),
+        tools=[
+            lookup_order,
+            policy_agent.as_tool(
+                tool_name="refund_policy_specialist",
+                tool_description="Check refund eligibility and explain the policy decision.",
+            ),
+            submit_refund,
+        ],
+        model=model_name,
+        model_settings=ModelSettings(
+            max_tokens=200,
+            reasoning=Reasoning(effort="medium", summary="detailed"),
+        ),
+    )
+
+    try:
+        # You can skip this helper and call Runner.run_streamed(...) directly.
+        # It will still work, but each run will create/connect again unless you manually
+        # reuse the same RunConfig/provider. This helper makes that reuse easy across turns
+        # (and nested agent-as-tool runs) so the websocket connection can stay warm.
+        async with responses_websocket_session() as ws:
+            with trace("Responses WS support example") as current_trace:
+                print(f"Using model={model_name}")
+                print(f"trace_id={current_trace.trace_id}")
+
+                first_response_id, _ = await run_streamed_turn(
+                    ws,
+                    support_agent,
+                    (
+                        "Customer wants a refund for order ORD-1001 because the mouse arrived "
+                        "damaged. Please check the order, ask the refund policy specialist, and "
+                        "if it is eligible submit the refund. Reply with only the refund ticket."
+                    ),
+                )
+
+                await run_streamed_turn(
+                    ws,
+                    support_agent,
+                    "What refund ticket did you just create? Reply with only the ticket.",
+                    previous_response_id=first_response_id,
+                )
+    except RuntimeError as exc:
+        if "closed before any response events" in str(exc):
+            print(
+                "\nWebsocket mode closed before sending events. This usually means the "
+                "feature is not enabled for this account/model yet."
+            )
+            return
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -82,9 +82,10 @@ from .models.interface import Model, ModelProvider, ModelTracing
 from .models.multi_provider import MultiProvider
 from .models.openai_chatcompletions import OpenAIChatCompletionsModel
 from .models.openai_provider import OpenAIProvider
-from .models.openai_responses import OpenAIResponsesModel
+from .models.openai_responses import OpenAIResponsesModel, OpenAIResponsesWSModel
 from .prompts import DynamicPromptFunction, GenerateDynamicPromptData, Prompt
 from .repl import run_demo_loop
+from .responses_websocket_session import ResponsesWebSocketSession, responses_websocket_session
 from .result import RunResult, RunResultStreaming
 from .run import (
     ReasoningItemIdPolicy,
@@ -246,6 +247,15 @@ def set_default_openai_api(api: Literal["chat_completions", "responses"]) -> Non
     _config.set_default_openai_api(api)
 
 
+def set_default_openai_responses_transport(transport: Literal["http", "websocket"]) -> None:
+    """Set the default transport for OpenAI Responses API requests.
+
+    By default, the Responses API uses the HTTP transport. Set this to ``"websocket"`` to use
+    websocket transport when the OpenAI provider resolves a Responses model.
+    """
+    _config.set_default_openai_responses_transport(transport)
+
+
 def enable_verbose_stdout_logging():
     """Enables verbose logging to stdout. This is useful for debugging."""
     logger = logging.getLogger("openai.agents")
@@ -276,6 +286,7 @@ __all__ = [
     "MultiProvider",
     "OpenAIProvider",
     "OpenAIResponsesModel",
+    "OpenAIResponsesWSModel",
     "AgentOutputSchema",
     "AgentOutputSchemaBase",
     "Computer",
@@ -350,6 +361,7 @@ __all__ = [
     "RunErrorHandlers",
     "RunResult",
     "RunResultStreaming",
+    "ResponsesWebSocketSession",
     "RunConfig",
     "ReasoningItemIdPolicy",
     "ToolErrorFormatter",
@@ -446,6 +458,8 @@ __all__ = [
     "set_default_openai_key",
     "set_default_openai_client",
     "set_default_openai_api",
+    "set_default_openai_responses_transport",
+    "responses_websocket_session",
     "set_tracing_export_api_key",
     "enable_verbose_stdout_logging",
     "gen_trace_id",

--- a/src/agents/_config.py
+++ b/src/agents/_config.py
@@ -24,3 +24,11 @@ def set_default_openai_api(api: Literal["chat_completions", "responses"]) -> Non
         _openai_shared.set_use_responses_by_default(False)
     else:
         _openai_shared.set_use_responses_by_default(True)
+
+
+def set_default_openai_responses_transport(transport: Literal["http", "websocket"]) -> None:
+    if transport not in {"http", "websocket"}:
+        raise ValueError(
+            "Invalid OpenAI Responses transport. Expected one of: 'http', 'websocket'."
+        )
+    _openai_shared.set_default_openai_responses_transport(transport)

--- a/src/agents/models/_openai_shared.py
+++ b/src/agents/models/_openai_shared.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from openai import AsyncOpenAI
+
+OpenAIResponsesTransport = Literal["http", "websocket"]
 
 _default_openai_key: str | None = None
 _default_openai_client: AsyncOpenAI | None = None
 _use_responses_by_default: bool = True
+# Source of truth for the default Responses transport.
+_default_openai_responses_transport: OpenAIResponsesTransport = "http"
+# Backward-compatibility shim for internal code/tests that still mutate the legacy flag directly.
+_use_responses_websocket_by_default: bool = False
 
 
 def set_default_openai_key(key: str) -> None:
@@ -32,3 +40,29 @@ def set_use_responses_by_default(use_responses: bool) -> None:
 
 def get_use_responses_by_default() -> bool:
     return _use_responses_by_default
+
+
+def set_use_responses_websocket_by_default(use_responses_websocket: bool) -> None:
+    set_default_openai_responses_transport("websocket" if use_responses_websocket else "http")
+
+
+def get_use_responses_websocket_by_default() -> bool:
+    return get_default_openai_responses_transport() == "websocket"
+
+
+def set_default_openai_responses_transport(transport: OpenAIResponsesTransport) -> None:
+    global _default_openai_responses_transport
+    global _use_responses_websocket_by_default
+    _default_openai_responses_transport = transport
+    _use_responses_websocket_by_default = transport == "websocket"
+
+
+def get_default_openai_responses_transport() -> OpenAIResponsesTransport:
+    global _default_openai_responses_transport
+    # Respect direct writes to the legacy private flag (used in tests) by syncing on read.
+    legacy_transport: OpenAIResponsesTransport = (
+        "websocket" if _use_responses_websocket_by_default else "http"
+    )
+    if _default_openai_responses_transport != legacy_transport:
+        _default_openai_responses_transport = legacy_transport
+    return _default_openai_responses_transport

--- a/src/agents/models/interface.py
+++ b/src/agents/models/interface.py
@@ -36,6 +36,14 @@ class ModelTracing(enum.Enum):
 class Model(abc.ABC):
     """The base interface for calling an LLM."""
 
+    async def close(self) -> None:
+        """Release any resources held by the model.
+
+        Models that maintain persistent connections can override this. The default implementation
+        is a no-op.
+        """
+        return None
+
     @abc.abstractmethod
     async def get_response(
         self,
@@ -123,3 +131,11 @@ class ModelProvider(abc.ABC):
         Returns:
             The model.
         """
+
+    async def aclose(self) -> None:
+        """Release any resources held by the provider.
+
+        Providers that cache persistent models or network connections can override this. The
+        default implementation is a no-op.
+        """
+        return None

--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import os
+import weakref
+
 import httpx
 from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 
@@ -7,13 +11,15 @@ from . import _openai_shared
 from .default_models import get_default_model
 from .interface import Model, ModelProvider
 from .openai_chatcompletions import OpenAIChatCompletionsModel
-from .openai_responses import OpenAIResponsesModel
+from .openai_responses import OpenAIResponsesModel, OpenAIResponsesWSModel
 
 # This is kept for backward compatiblity but using get_default_model() method is recommended.
 DEFAULT_MODEL: str = "gpt-4o"
 
 
 _http_client: httpx.AsyncClient | None = None
+_WSModelCacheKey = tuple[str, bool]
+_WSLoopModelCache = dict[_WSModelCacheKey, Model]
 
 
 # If we create a new httpx client for each request, that would mean no sharing of connection pools,
@@ -31,10 +37,12 @@ class OpenAIProvider(ModelProvider):
         *,
         api_key: str | None = None,
         base_url: str | None = None,
+        websocket_base_url: str | None = None,
         openai_client: AsyncOpenAI | None = None,
         organization: str | None = None,
         project: str | None = None,
         use_responses: bool | None = None,
+        use_responses_websocket: bool | None = None,
     ) -> None:
         """Create a new OpenAI provider.
 
@@ -43,21 +51,27 @@ class OpenAIProvider(ModelProvider):
                 default API key.
             base_url: The base URL to use for the OpenAI client. If not provided, we will use the
                 default base URL.
+            websocket_base_url: The websocket base URL to use for the OpenAI client. If not
+                provided, we will use the OPENAI_WEBSOCKET_BASE_URL environment variable when set.
             openai_client: An optional OpenAI client to use. If not provided, we will create a new
                 OpenAI client using the api_key and base_url.
             organization: The organization to use for the OpenAI client.
             project: The project to use for the OpenAI client.
             use_responses: Whether to use the OpenAI responses API.
+            use_responses_websocket: Whether to use websocket transport for the OpenAI responses
+                API.
         """
         if openai_client is not None:
-            assert api_key is None and base_url is None, (
-                "Don't provide api_key or base_url if you provide openai_client"
+            assert api_key is None and base_url is None and websocket_base_url is None, (
+                "Don't provide api_key, base_url, or websocket_base_url if you provide "
+                "openai_client"
             )
             self._client: AsyncOpenAI | None = openai_client
         else:
             self._client = None
             self._stored_api_key = api_key
             self._stored_base_url = base_url
+            self._stored_websocket_base_url = websocket_base_url
             self._stored_organization = organization
             self._stored_project = project
 
@@ -66,13 +80,31 @@ class OpenAIProvider(ModelProvider):
         else:
             self._use_responses = _openai_shared.get_use_responses_by_default()
 
+        if use_responses_websocket is not None:
+            self._responses_transport: _openai_shared.OpenAIResponsesTransport = (
+                "websocket" if use_responses_websocket else "http"
+            )
+        else:
+            self._responses_transport = _openai_shared.get_default_openai_responses_transport()
+        # Backward-compatibility shim for internal tests/diagnostics that inspect the legacy flag.
+        self._use_responses_websocket = self._responses_transport == "websocket"
+
+        # Reuse websocket model wrappers so websocket transport can keep a persistent connection
+        # when callers pass model names as strings through a shared provider.
+        self._ws_model_cache_by_loop: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, _WSLoopModelCache
+        ] = weakref.WeakKeyDictionary()
+
     # We lazy load the client in case you never actually use OpenAIProvider(). Otherwise
     # AsyncOpenAI() raises an error if you don't have an API key set.
     def _get_client(self) -> AsyncOpenAI:
         if self._client is None:
             self._client = _openai_shared.get_default_openai_client() or AsyncOpenAI(
                 api_key=self._stored_api_key or _openai_shared.get_default_openai_key(),
-                base_url=self._stored_base_url,
+                base_url=self._stored_base_url or os.getenv("OPENAI_BASE_URL"),
+                websocket_base_url=(
+                    self._stored_websocket_base_url or os.getenv("OPENAI_WEBSOCKET_BASE_URL")
+                ),
                 organization=self._stored_organization,
                 project=self._stored_project,
                 http_client=shared_http_client(),
@@ -80,18 +112,122 @@ class OpenAIProvider(ModelProvider):
 
         return self._client
 
+    def _get_running_loop(self) -> asyncio.AbstractEventLoop | None:
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
+    async def _close_ws_models_for_loop(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        models: list[Model],
+        current_loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        if not models:
+            return
+        if loop is current_loop:
+            await self._close_models(models)
+            return
+        if loop.is_running():
+            for model in models:
+                future = asyncio.run_coroutine_threadsafe(model.close(), loop)
+                await asyncio.wrap_future(future)
+            return
+        # Do not run an inactive foreign loop on another thread. This also covers closed loops.
+        # Close from the current loop and rely on model-specific cross-loop cleanup fallbacks.
+        await self._close_models(models)
+
+    async def _close_models(self, models: list[Model]) -> None:
+        for model in models:
+            await model.close()
+
+    def _clear_ws_loop_cache_entry(
+        self, loop: asyncio.AbstractEventLoop, loop_cache: _WSLoopModelCache
+    ) -> None:
+        loop_cache.clear()
+        try:
+            del self._ws_model_cache_by_loop[loop]
+        except KeyError:
+            pass
+
+    def _collect_unique_cached_models(
+        self, loop_cache: _WSLoopModelCache, seen: set[int]
+    ) -> list[Model]:
+        models_to_close: list[Model] = []
+        for model in list(loop_cache.values()):
+            model_id = id(model)
+            if model_id in seen:
+                continue
+            seen.add(model_id)
+            models_to_close.append(model)
+        return models_to_close
+
+    def _prune_closed_ws_loop_caches(self) -> None:
+        """Drop websocket model cache entries for loops that are already closed."""
+        for loop, loop_cache in list(self._ws_model_cache_by_loop.items()):
+            if not loop.is_closed():
+                continue
+
+            for model in list(loop_cache.values()):
+                if isinstance(model, OpenAIResponsesWSModel):
+                    model._force_drop_websocket_connection_sync()
+
+            self._clear_ws_loop_cache_entry(loop, loop_cache)
+
     def get_model(self, model_name: str | None) -> Model:
         model_is_explicit = model_name is not None
         resolved_model_name = model_name if model_name is not None else get_default_model()
-
-        client = self._get_client()
-
-        return (
-            OpenAIResponsesModel(
-                model=resolved_model_name,
-                openai_client=client,
-                model_is_explicit=model_is_explicit,
-            )
-            if self._use_responses
-            else OpenAIChatCompletionsModel(model=resolved_model_name, openai_client=client)
+        cache_key: _WSModelCacheKey = (
+            resolved_model_name,
+            model_is_explicit,
         )
+        running_loop: asyncio.AbstractEventLoop | None = None
+        loop_cache: _WSLoopModelCache | None = None
+
+        use_websocket_transport = self._responses_transport == "websocket"
+        if self._use_responses and use_websocket_transport:
+            self._prune_closed_ws_loop_caches()
+            running_loop = self._get_running_loop()
+            loop_cache = (
+                self._ws_model_cache_by_loop.setdefault(running_loop, {})
+                if running_loop is not None
+                else None
+            )
+            if loop_cache is not None and (cached_model := loop_cache.get(cache_key)):
+                return cached_model
+        client = self._get_client()
+        model: Model
+
+        if not self._use_responses:
+            return OpenAIChatCompletionsModel(model=resolved_model_name, openai_client=client)
+
+        responses_model_type = (
+            OpenAIResponsesWSModel if use_websocket_transport else OpenAIResponsesModel
+        )
+        model = responses_model_type(
+            model=resolved_model_name,
+            openai_client=client,
+            model_is_explicit=model_is_explicit,
+        )
+        if use_websocket_transport:
+            if loop_cache is not None:
+                loop_cache[cache_key] = model
+        return model
+
+    async def aclose(self) -> None:
+        """Close any cached model resources held by this provider.
+
+        This primarily releases persistent websocket connections opened by
+        ``OpenAIResponsesWSModel`` instances. It intentionally does not close the
+        underlying ``AsyncOpenAI`` client because the SDK may be sharing the HTTP client
+        across providers/process-wide.
+        """
+        seen: set[int] = set()
+        current_loop = self._get_running_loop()
+        if current_loop is None:
+            return
+        for loop, loop_cache in list(self._ws_model_cache_by_loop.items()):
+            models_to_close = self._collect_unique_cached_models(loop_cache, seen)
+            await self._close_ws_models_for_loop(loop, models_to_close, current_loop)
+            self._clear_ws_loop_cache_entry(loop, loop_cache)

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import inspect
 import json
-from collections.abc import AsyncIterator, Mapping
+import weakref
+from collections.abc import AsyncIterator, Awaitable, Mapping
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Union, cast, overload
 
-from openai import APIStatusError, AsyncOpenAI, AsyncStream, Omit, omit
+import httpx
+from openai import AsyncOpenAI, NotGiven, Omit, omit
 from openai.types import ChatModel
 from openai.types.responses import (
     Response,
@@ -61,6 +67,89 @@ _HEADERS_OVERRIDE: ContextVar[dict[str, str] | None] = ContextVar(
 )
 
 
+def _json_dumps_default(value: Any) -> Any:
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump(mode="json", exclude_none=True)
+        except TypeError:
+            return model_dump()
+
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)
+
+    if isinstance(value, Enum):
+        return value.value
+
+    raise TypeError(f"Object of type {value.__class__.__name__} is not JSON serializable")
+
+
+def _is_openai_omitted_value(value: Any) -> bool:
+    return isinstance(value, (Omit, NotGiven))
+
+
+async def _refresh_openai_client_api_key_if_supported(client: Any) -> None:
+    """Refresh client auth if the current OpenAI SDK exposes a refresh hook."""
+    refresh_api_key = getattr(client, "_refresh_api_key", None)
+    if callable(refresh_api_key):
+        await refresh_api_key()
+
+
+def _construct_response_stream_event_from_payload(
+    payload: Mapping[str, Any],
+) -> ResponseStreamEvent:
+    """Parse websocket event payloads via the OpenAI SDK's internal type constructor."""
+    try:
+        from openai._models import construct_type
+    except Exception as exc:  # pragma: no cover - exercised only on SDK incompatibility
+        raise RuntimeError(
+            "Unable to parse Responses websocket events because the installed OpenAI SDK "
+            "does not expose the expected internal type constructor. Please upgrade this SDK "
+            "version pair or switch Responses transport back to HTTP."
+        ) from exc
+    return cast(
+        ResponseStreamEvent,
+        construct_type(type_=ResponseStreamEvent, value=dict(payload)),
+    )
+
+
+@dataclass(frozen=True)
+class _WebsocketRequestTimeouts:
+    lock: float | None
+    connect: float | None
+    send: float | None
+    recv: float | None
+
+
+class ResponsesWebSocketError(RuntimeError):
+    """Error raised for websocket transport error frames."""
+
+    def __init__(self, payload: Mapping[str, Any]):
+        event_type = str(payload.get("type") or "error")
+        self.event_type = event_type
+        self.payload = dict(payload)
+
+        error_data = payload.get("error")
+        error_obj = error_data if isinstance(error_data, Mapping) else {}
+        self.code = self._coerce_optional_str(error_obj.get("code"))
+        self.error_type = self._coerce_optional_str(error_obj.get("type"))
+        self.request_id = self._coerce_optional_str(
+            payload.get("request_id") or error_obj.get("request_id")
+        )
+        self.error_message = self._coerce_optional_str(error_obj.get("message"))
+
+        prefix = (
+            "Responses websocket error"
+            if event_type == "error"
+            else f"Responses websocket {event_type}"
+        )
+        super().__init__(f"{prefix}: {json.dumps(payload, default=_json_dumps_default)}")
+
+    @staticmethod
+    def _coerce_optional_str(value: Any) -> str | None:
+        return value if isinstance(value, str) else None
+
+
 class OpenAIResponsesModel(Model):
     """
     Implementation of `Model` that uses the OpenAI Responses API.
@@ -79,6 +168,31 @@ class OpenAIResponsesModel(Model):
 
     def _non_null_or_omit(self, value: Any) -> Any:
         return value if value is not None else omit
+
+    async def _maybe_aclose_async_iterator(self, iterator: Any) -> None:
+        aclose = getattr(iterator, "aclose", None)
+        if callable(aclose):
+            await aclose()
+            return
+
+        close = getattr(iterator, "close", None)
+        if callable(close):
+            close_result = close()
+            if inspect.isawaitable(close_result):
+                await close_result
+
+    def _schedule_async_iterator_close(self, iterator: Any) -> None:
+        task = asyncio.create_task(self._maybe_aclose_async_iterator(iterator))
+        task.add_done_callback(self._consume_background_cleanup_task_result)
+
+    @staticmethod
+    def _consume_background_cleanup_task_result(task: asyncio.Task[Any]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.debug(f"Background stream cleanup failed after cancellation: {exc}")
 
     async def get_response(
         self,
@@ -147,7 +261,7 @@ class OpenAIResponsesModel(Model):
                         },
                     )
                 )
-                request_id = e.request_id if isinstance(e, APIStatusError) else None
+                request_id = getattr(e, "request_id", None)
                 logger.error(f"Error getting response: {e}. (request_id: {request_id})")
                 raise
 
@@ -189,11 +303,43 @@ class OpenAIResponsesModel(Model):
                 )
 
                 final_response: Response | None = None
-
-                async for chunk in stream:
-                    if isinstance(chunk, ResponseCompletedEvent):
-                        final_response = chunk.response
-                    yield chunk
+                yielded_terminal_event = False
+                close_stream_in_background = False
+                try:
+                    async for chunk in stream:
+                        chunk_type = getattr(chunk, "type", None)
+                        if isinstance(chunk, ResponseCompletedEvent):
+                            final_response = chunk.response
+                        elif chunk_type in {
+                            "response.failed",
+                            "response.incomplete",
+                        }:
+                            terminal_response = getattr(chunk, "response", None)
+                            if isinstance(terminal_response, Response):
+                                final_response = terminal_response
+                        if chunk_type in {
+                            "response.completed",
+                            "response.failed",
+                            "response.incomplete",
+                            "response.error",
+                        }:
+                            yielded_terminal_event = True
+                        yield chunk
+                except asyncio.CancelledError:
+                    close_stream_in_background = True
+                    self._schedule_async_iterator_close(stream)
+                    raise
+                finally:
+                    if not close_stream_in_background:
+                        try:
+                            await self._maybe_aclose_async_iterator(stream)
+                        except Exception as exc:
+                            if yielded_terminal_event:
+                                logger.debug(
+                                    f"Ignoring stream cleanup error after terminal event: {exc}"
+                                )
+                            else:
+                                raise
 
                 if final_response and tracing.include_data():
                     span_response.span_data.response = final_response
@@ -224,7 +370,7 @@ class OpenAIResponsesModel(Model):
         conversation_id: str | None,
         stream: Literal[True],
         prompt: ResponsePromptParam | None = None,
-    ) -> AsyncStream[ResponseStreamEvent]: ...
+    ) -> AsyncIterator[ResponseStreamEvent]: ...
 
     @overload
     async def _fetch_response(
@@ -253,7 +399,36 @@ class OpenAIResponsesModel(Model):
         conversation_id: str | None = None,
         stream: Literal[True] | Literal[False] = False,
         prompt: ResponsePromptParam | None = None,
-    ) -> Response | AsyncStream[ResponseStreamEvent]:
+    ) -> Response | AsyncIterator[ResponseStreamEvent]:
+        response = await self._client.responses.create(
+            **self._build_response_create_kwargs(
+                system_instructions=system_instructions,
+                input=input,
+                model_settings=model_settings,
+                tools=tools,
+                output_schema=output_schema,
+                handoffs=handoffs,
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
+                stream=stream,
+                prompt=prompt,
+            )
+        )
+        return cast(Union[Response, AsyncIterator[ResponseStreamEvent]], response)
+
+    def _build_response_create_kwargs(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        previous_response_id: str | None = None,
+        conversation_id: str | None = None,
+        stream: bool = False,
+        prompt: ResponsePromptParam | None = None,
+    ) -> dict[str, Any]:
         list_input = ItemHelpers.input_to_new_input_list(input)
         list_input = _to_dump_compatible(list_input)
         list_input = self._remove_openai_responses_api_incompatible_fields(list_input)
@@ -324,33 +499,42 @@ class OpenAIResponsesModel(Model):
 
         stream_param: Literal[True] | Omit = True if stream else omit
 
-        response = await self._client.responses.create(
-            previous_response_id=self._non_null_or_omit(previous_response_id),
-            conversation=self._non_null_or_omit(conversation_id),
-            instructions=self._non_null_or_omit(system_instructions),
-            model=model_param,
-            input=list_input,
-            include=include,
-            tools=tools_param,
-            prompt=self._non_null_or_omit(prompt),
-            temperature=self._non_null_or_omit(model_settings.temperature),
-            top_p=self._non_null_or_omit(model_settings.top_p),
-            truncation=self._non_null_or_omit(model_settings.truncation),
-            max_output_tokens=self._non_null_or_omit(model_settings.max_tokens),
-            tool_choice=tool_choice_param,
-            parallel_tool_calls=parallel_tool_calls,
-            stream=cast(Any, stream_param),
-            extra_headers=self._merge_headers(model_settings),
-            extra_query=model_settings.extra_query,
-            extra_body=model_settings.extra_body,
-            text=response_format,
-            store=self._non_null_or_omit(model_settings.store),
-            prompt_cache_retention=self._non_null_or_omit(model_settings.prompt_cache_retention),
-            reasoning=self._non_null_or_omit(model_settings.reasoning),
-            metadata=self._non_null_or_omit(model_settings.metadata),
-            **extra_args,
-        )
-        return cast(Union[Response, AsyncStream[ResponseStreamEvent]], response)
+        create_kwargs: dict[str, Any] = {
+            "previous_response_id": self._non_null_or_omit(previous_response_id),
+            "conversation": self._non_null_or_omit(conversation_id),
+            "instructions": self._non_null_or_omit(system_instructions),
+            "model": model_param,
+            "input": list_input,
+            "include": include,
+            "tools": tools_param,
+            "prompt": self._non_null_or_omit(prompt),
+            "temperature": self._non_null_or_omit(model_settings.temperature),
+            "top_p": self._non_null_or_omit(model_settings.top_p),
+            "truncation": self._non_null_or_omit(model_settings.truncation),
+            "max_output_tokens": self._non_null_or_omit(model_settings.max_tokens),
+            "tool_choice": tool_choice_param,
+            "parallel_tool_calls": parallel_tool_calls,
+            "stream": cast(Any, stream_param),
+            "extra_headers": self._merge_headers(model_settings),
+            "extra_query": model_settings.extra_query,
+            "extra_body": model_settings.extra_body,
+            "text": response_format,
+            "store": self._non_null_or_omit(model_settings.store),
+            "prompt_cache_retention": self._non_null_or_omit(model_settings.prompt_cache_retention),
+            "reasoning": self._non_null_or_omit(model_settings.reasoning),
+            "metadata": self._non_null_or_omit(model_settings.metadata),
+        }
+        duplicate_extra_arg_keys = sorted(set(create_kwargs).intersection(extra_args))
+        if duplicate_extra_arg_keys:
+            if len(duplicate_extra_arg_keys) == 1:
+                key = duplicate_extra_arg_keys[0]
+                raise TypeError(
+                    f"responses.create() got multiple values for keyword argument '{key}'"
+                )
+            keys = ", ".join(repr(key) for key in duplicate_extra_arg_keys)
+            raise TypeError(f"responses.create() got multiple values for keyword arguments {keys}")
+        create_kwargs.update(extra_args)
+        return create_kwargs
 
     def _remove_openai_responses_api_incompatible_fields(self, list_input: list[Any]) -> list[Any]:
         """
@@ -409,6 +593,571 @@ class OpenAIResponsesModel(Model):
             **(model_settings.extra_headers or {}),
             **(_HEADERS_OVERRIDE.get() or {}),
         }
+
+
+class OpenAIResponsesWSModel(OpenAIResponsesModel):
+    """
+    Implementation of `Model` that uses the OpenAI Responses API over a websocket transport.
+
+    The websocket transport currently sends `response.create` frames and always streams events.
+    `get_response()` is implemented by consuming the streamed events until a terminal response
+    event is received.
+    """
+
+    def __init__(
+        self,
+        model: str | ChatModel,
+        openai_client: AsyncOpenAI,
+        *,
+        model_is_explicit: bool = True,
+    ) -> None:
+        super().__init__(
+            model=model, openai_client=openai_client, model_is_explicit=model_is_explicit
+        )
+        self._ws_connection: Any | None = None
+        self._ws_connection_identity: tuple[str, tuple[tuple[str, str], ...]] | None = None
+        self._ws_connection_loop_ref: weakref.ReferenceType[asyncio.AbstractEventLoop] | None = None
+        self._ws_request_lock: asyncio.Lock | None = None
+        self._ws_request_lock_loop_ref: weakref.ReferenceType[asyncio.AbstractEventLoop] | None = (
+            None
+        )
+        self._ws_client_close_generation = 0
+
+    def _get_ws_request_lock(self) -> asyncio.Lock:
+        running_loop = asyncio.get_running_loop()
+        if (
+            self._ws_request_lock is None
+            or self._ws_request_lock_loop_ref is None
+            or self._ws_request_lock_loop_ref() is not running_loop
+        ):
+            self._ws_request_lock = asyncio.Lock()
+            self._ws_request_lock_loop_ref = weakref.ref(running_loop)
+        return self._ws_request_lock
+
+    @overload
+    async def _fetch_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        stream: Literal[True],
+        prompt: ResponsePromptParam | None = None,
+    ) -> AsyncIterator[ResponseStreamEvent]: ...
+
+    @overload
+    async def _fetch_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        stream: Literal[False],
+        prompt: ResponsePromptParam | None = None,
+    ) -> Response: ...
+
+    async def _fetch_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        previous_response_id: str | None = None,
+        conversation_id: str | None = None,
+        stream: Literal[True] | Literal[False] = False,
+        prompt: ResponsePromptParam | None = None,
+    ) -> Response | AsyncIterator[ResponseStreamEvent]:
+        create_kwargs = self._build_response_create_kwargs(
+            system_instructions=system_instructions,
+            input=input,
+            model_settings=model_settings,
+            tools=tools,
+            output_schema=output_schema,
+            handoffs=handoffs,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            stream=True,
+            prompt=prompt,
+        )
+
+        if stream:
+            return self._iter_websocket_response_events(create_kwargs)
+
+        final_response: Response | None = None
+        terminal_event_type: str | None = None
+        async for event in self._iter_websocket_response_events(create_kwargs):
+            event_type = getattr(event, "type", None)
+            if isinstance(event, ResponseCompletedEvent):
+                final_response = event.response
+                terminal_event_type = event.type
+            elif event_type in {"response.incomplete", "response.failed"}:
+                terminal_event_type = cast(str, event_type)
+                terminal_response = getattr(event, "response", None)
+                if isinstance(terminal_response, Response):
+                    final_response = terminal_response
+
+        if final_response is None:
+            terminal_event_hint = (
+                f" Terminal event: `{terminal_event_type}`." if terminal_event_type else ""
+            )
+            raise RuntimeError(
+                "Responses websocket stream ended without a terminal response payload."
+                f"{terminal_event_hint}"
+            )
+
+        return final_response
+
+    async def _iter_websocket_response_events(
+        self, create_kwargs: dict[str, Any]
+    ) -> AsyncIterator[ResponseStreamEvent]:
+        request_timeout = create_kwargs.get("timeout", omit)
+        if _is_openai_omitted_value(request_timeout):
+            request_timeout = getattr(self._client, "timeout", None)
+        request_timeouts = self._get_websocket_request_timeouts(request_timeout)
+        request_close_generation = self._ws_client_close_generation
+        request_lock = self._get_ws_request_lock()
+        if request_timeouts.lock == 0 and not request_lock.locked():
+            # `wait_for(..., timeout=0)` can time out before an uncontended acquire runs.
+            await request_lock.acquire()
+        else:
+            await self._await_websocket_with_timeout(
+                request_lock.acquire(),
+                request_timeouts.lock,
+                "request lock wait",
+            )
+        try:
+            request_frame, ws_url, request_headers = await self._prepare_websocket_request(
+                create_kwargs
+            )
+            retry_pre_event_disconnect = True
+            while True:
+                connection = await self._await_websocket_with_timeout(
+                    self._ensure_websocket_connection(
+                        ws_url, request_headers, connect_timeout=request_timeouts.connect
+                    ),
+                    request_timeouts.connect,
+                    "connect",
+                )
+                received_any_event = False
+                yielded_terminal_event = False
+                sent_request_frame = False
+                try:
+                    # Once we begin awaiting `send()`, treat the request as potentially
+                    # transmitted to avoid replaying it on send/close races.
+                    sent_request_frame = True
+                    await self._await_websocket_with_timeout(
+                        connection.send(json.dumps(request_frame, default=_json_dumps_default)),
+                        request_timeouts.send,
+                        "send",
+                    )
+
+                    while True:
+                        frame = await self._await_websocket_with_timeout(
+                            connection.recv(),
+                            request_timeouts.recv,
+                            "receive",
+                        )
+                        if frame is None:
+                            raise RuntimeError(
+                                "Responses websocket connection closed before a terminal "
+                                "response event."
+                            )
+
+                        if isinstance(frame, bytes):
+                            frame = frame.decode("utf-8")
+
+                        payload = json.loads(frame)
+                        event_type = payload.get("type")
+
+                        if event_type == "error":
+                            raise ResponsesWebSocketError(payload)
+                        if event_type == "response.error":
+                            received_any_event = True
+                            raise ResponsesWebSocketError(payload)
+
+                        event = _construct_response_stream_event_from_payload(payload)
+                        received_any_event = True
+                        is_terminal_event = event_type in {
+                            "response.completed",
+                            "response.failed",
+                            "response.incomplete",
+                            "response.error",
+                        }
+                        if is_terminal_event:
+                            yielded_terminal_event = True
+                        yield event
+
+                        if is_terminal_event:
+                            return
+                except BaseException as exc:
+                    is_non_terminal_generator_exit = (
+                        isinstance(exc, GeneratorExit) and not yielded_terminal_event
+                    )
+                    if isinstance(exc, asyncio.CancelledError) or is_non_terminal_generator_exit:
+                        self._force_abort_websocket_connection(connection)
+                        self._clear_websocket_connection_state()
+                    elif not (yielded_terminal_event and isinstance(exc, GeneratorExit)):
+                        await self._drop_websocket_connection()
+
+                    is_pre_event_disconnect = (
+                        not received_any_event
+                        and isinstance(exc, Exception)
+                        and self._should_wrap_pre_event_websocket_disconnect(exc)
+                    )
+                    # Do not replay a request after the frame was sent; the server may already
+                    # be executing it even if no response event arrived yet.
+                    is_retryable_pre_event_disconnect = (
+                        is_pre_event_disconnect and not sent_request_frame
+                    )
+                    if (
+                        is_pre_event_disconnect
+                        and self._ws_client_close_generation != request_close_generation
+                    ):
+                        raise
+                    if retry_pre_event_disconnect and is_retryable_pre_event_disconnect:
+                        retry_pre_event_disconnect = False
+                        continue
+                    if is_pre_event_disconnect:
+                        raise RuntimeError(
+                            "Responses websocket connection closed before any response events "
+                            "were received. The feature may not be enabled for this account/model "
+                            "yet, or the server closed the connection."
+                        ) from exc
+                    raise
+        finally:
+            request_lock.release()
+
+    def _should_wrap_pre_event_websocket_disconnect(self, exc: Exception) -> bool:
+        if isinstance(exc, UserError):
+            return False
+        if isinstance(exc, ResponsesWebSocketError):
+            return False
+
+        if isinstance(exc, RuntimeError):
+            message = str(exc)
+            if message.startswith("Responses websocket error:"):
+                return False
+            return message.startswith(
+                "Responses websocket connection closed before a terminal response event."
+            )
+
+        exc_module = exc.__class__.__module__
+        exc_name = exc.__class__.__name__
+        return exc_module.startswith("websockets") and exc_name.startswith("ConnectionClosed")
+
+    def _get_websocket_request_timeouts(self, timeout: Any) -> _WebsocketRequestTimeouts:
+        if timeout is None or _is_openai_omitted_value(timeout):
+            return _WebsocketRequestTimeouts(lock=None, connect=None, send=None, recv=None)
+
+        if isinstance(timeout, httpx.Timeout):
+            return _WebsocketRequestTimeouts(
+                lock=None if timeout.pool is None else float(timeout.pool),
+                connect=None if timeout.connect is None else float(timeout.connect),
+                send=None if timeout.write is None else float(timeout.write),
+                recv=None if timeout.read is None else float(timeout.read),
+            )
+
+        if isinstance(timeout, (int, float)):
+            timeout_seconds = float(timeout)
+            return _WebsocketRequestTimeouts(
+                lock=timeout_seconds,
+                connect=timeout_seconds,
+                send=timeout_seconds,
+                recv=timeout_seconds,
+            )
+
+        return _WebsocketRequestTimeouts(lock=None, connect=None, send=None, recv=None)
+
+    async def _await_websocket_with_timeout(
+        self,
+        awaitable: Awaitable[Any],
+        timeout_seconds: float | None,
+        phase: str,
+    ) -> Any:
+        if timeout_seconds is None:
+            return await awaitable
+
+        if timeout_seconds == 0:
+            # `wait_for(..., timeout=0)` can time out before an immediately-ready awaitable runs.
+            task = asyncio.ensure_future(awaitable)
+            if not task.done():
+                await asyncio.sleep(0)
+            if task.done():
+                return task.result()
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            raise TimeoutError(
+                f"Responses websocket {phase} timed out after {timeout_seconds} seconds."
+            )
+
+        try:
+            return await asyncio.wait_for(awaitable, timeout=timeout_seconds)
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(
+                f"Responses websocket {phase} timed out after {timeout_seconds} seconds."
+            ) from exc
+
+    async def _prepare_websocket_request(
+        self, create_kwargs: dict[str, Any]
+    ) -> tuple[dict[str, Any], str, dict[str, str]]:
+        await _refresh_openai_client_api_key_if_supported(self._client)
+
+        request_kwargs = dict(create_kwargs)
+        extra_headers_raw = request_kwargs.pop("extra_headers", None)
+        if extra_headers_raw is None or _is_openai_omitted_value(extra_headers_raw):
+            extra_headers_raw = {}
+        extra_query = request_kwargs.pop("extra_query", None)
+        extra_body = request_kwargs.pop("extra_body", None)
+        # Request options like `timeout` are transport-level settings, not websocket
+        # `response.create` payload fields. They are applied separately when sending/receiving.
+        request_kwargs.pop("timeout", None)
+
+        if not isinstance(extra_headers_raw, Mapping):
+            raise UserError("Responses websocket extra headers must be a mapping.")
+
+        handshake_headers = self._merge_websocket_headers(extra_headers_raw)
+        ws_url = self._prepare_websocket_url(extra_query)
+
+        frame: dict[str, Any] = {"type": "response.create"}
+        for key, value in request_kwargs.items():
+            if _is_openai_omitted_value(value):
+                continue
+            frame[key] = value
+
+        frame["stream"] = True
+
+        if extra_body is not None and not _is_openai_omitted_value(extra_body):
+            if not isinstance(extra_body, Mapping):
+                raise UserError("Responses websocket extra_body must be a mapping.")
+            for key, value in extra_body.items():
+                if _is_openai_omitted_value(value):
+                    continue
+                frame[str(key)] = value
+
+        # Preserve websocket envelope fields regardless of `extra_body` contents.
+        frame["type"] = "response.create"
+        frame["stream"] = True
+
+        return frame, ws_url, handshake_headers
+
+    def _merge_websocket_headers(self, extra_headers: Mapping[str, Any]) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        for key, value in self._client.default_headers.items():
+            if _is_openai_omitted_value(value):
+                continue
+            headers[key] = str(value)
+
+        for key, value in extra_headers.items():
+            if isinstance(value, NotGiven):
+                continue
+            header_key = str(key)
+            for existing_key in list(headers):
+                if existing_key.lower() == header_key.lower():
+                    del headers[existing_key]
+            if isinstance(value, Omit):
+                continue
+            headers[header_key] = str(value)
+
+        return headers
+
+    def _prepare_websocket_url(self, extra_query: Any) -> str:
+        if self._client.websocket_base_url is not None:
+            base_url = httpx.URL(self._client.websocket_base_url)
+            ws_scheme = {"http": "ws", "https": "wss"}.get(base_url.scheme, base_url.scheme)
+            base_url = base_url.copy_with(scheme=ws_scheme)
+        else:
+            client_base_url = self._client.base_url
+            ws_scheme = {"http": "ws", "https": "wss"}.get(
+                client_base_url.scheme, client_base_url.scheme
+            )
+            base_url = client_base_url.copy_with(scheme=ws_scheme)
+
+        params: dict[str, Any] = dict(base_url.params)
+        default_query = getattr(self._client, "default_query", None)
+        if default_query is not None and not _is_openai_omitted_value(default_query):
+            if not isinstance(default_query, Mapping):
+                raise UserError("Responses websocket client default_query must be a mapping.")
+            for key, value in default_query.items():
+                query_key = str(key)
+                if isinstance(value, Omit):
+                    params.pop(query_key, None)
+                    continue
+                if isinstance(value, NotGiven):
+                    continue
+                params[query_key] = value
+
+        if extra_query is not None and not _is_openai_omitted_value(extra_query):
+            if not isinstance(extra_query, Mapping):
+                raise UserError("Responses websocket extra_query must be a mapping.")
+            for key, value in extra_query.items():
+                query_key = str(key)
+                if isinstance(value, Omit):
+                    params.pop(query_key, None)
+                    continue
+                if isinstance(value, NotGiven):
+                    continue
+                params[query_key] = value
+
+        path = base_url.path.rstrip("/") + "/responses"
+        return str(base_url.copy_with(path=path, params=params))
+
+    async def _ensure_websocket_connection(
+        self,
+        ws_url: str,
+        headers: Mapping[str, str],
+        *,
+        connect_timeout: float | None,
+    ) -> Any:
+        running_loop = asyncio.get_running_loop()
+        identity = (
+            ws_url,
+            tuple(sorted((str(key).lower(), str(value)) for key, value in headers.items())),
+        )
+
+        if self._ws_connection is not None and self._ws_connection_identity == identity:
+            if (
+                self._ws_connection_loop_ref is not None
+                and self._ws_connection_loop_ref() is running_loop
+                and self._is_websocket_connection_reusable(self._ws_connection)
+            ):
+                return self._ws_connection
+        if self._ws_connection is not None:
+            await self._drop_websocket_connection()
+        self._ws_connection = await self._open_websocket_connection(
+            ws_url,
+            headers,
+            connect_timeout=connect_timeout,
+        )
+        self._ws_connection_identity = identity
+        self._ws_connection_loop_ref = weakref.ref(running_loop)
+        return self._ws_connection
+
+    def _is_websocket_connection_reusable(self, connection: Any) -> bool:
+        try:
+            state = getattr(connection, "state", None)
+            state_name = getattr(state, "name", None)
+            if isinstance(state_name, str):
+                return state_name == "OPEN"
+
+            closed = getattr(connection, "closed", None)
+            if isinstance(closed, bool):
+                return not closed
+
+            is_open = getattr(connection, "open", None)
+            if isinstance(is_open, bool):
+                return is_open
+
+            close_code = getattr(connection, "close_code", None)
+            if close_code is not None:
+                return False
+        except Exception:
+            return False
+
+        return True
+
+    async def close(self) -> None:
+        """Close the persistent websocket connection, if one is open."""
+        self._ws_client_close_generation += 1
+        request_lock = self._get_current_loop_ws_request_lock()
+        if request_lock is not None and request_lock.locked():
+            if self._ws_connection is not None:
+                self._force_abort_websocket_connection(self._ws_connection)
+            self._clear_websocket_connection_state()
+            return
+
+        await self._drop_websocket_connection()
+
+    def _get_current_loop_ws_request_lock(self) -> asyncio.Lock | None:
+        if self._ws_request_lock is None or self._ws_request_lock_loop_ref is None:
+            return None
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
+        if self._ws_request_lock_loop_ref() is not running_loop:
+            return None
+
+        return self._ws_request_lock
+
+    def _force_abort_websocket_connection(self, connection: Any) -> None:
+        """Best-effort fallback for cross-loop cleanup when awaiting close() fails."""
+        try:
+            transport = getattr(connection, "transport", None)
+            if transport is not None:
+                abort = getattr(transport, "abort", None)
+                if callable(abort):
+                    abort()
+                    return
+                close_transport = getattr(transport, "close", None)
+                if callable(close_transport):
+                    close_transport()
+                    return
+        except Exception:
+            pass
+
+    def _force_drop_websocket_connection_sync(self) -> None:
+        """Synchronously abort and clear cached websocket state without awaiting close()."""
+        self._ws_client_close_generation += 1
+        if self._ws_connection is not None:
+            self._force_abort_websocket_connection(self._ws_connection)
+        self._clear_websocket_connection_state()
+        # Also clear the loop-bound lock so closed-loop models don't retain stale lock state.
+        self._ws_request_lock = None
+        self._ws_request_lock_loop_ref = None
+
+    def _clear_websocket_connection_state(self) -> None:
+        """Clear cached websocket connection metadata."""
+        self._ws_connection = None
+        self._ws_connection_identity = None
+        self._ws_connection_loop_ref = None
+
+    async def _drop_websocket_connection(self) -> None:
+        if self._ws_connection is None:
+            self._clear_websocket_connection_state()
+            return
+
+        try:
+            await self._ws_connection.close()
+        except Exception:
+            self._force_abort_websocket_connection(self._ws_connection)
+        finally:
+            self._clear_websocket_connection_state()
+
+    async def _open_websocket_connection(
+        self,
+        ws_url: str,
+        headers: Mapping[str, str],
+        *,
+        connect_timeout: float | None,
+    ) -> Any:
+        try:
+            from websockets.asyncio.client import connect
+        except ImportError as exc:
+            raise UserError(
+                "OpenAIResponsesWSModel requires the `websockets` package. "
+                "Install `websockets` or `openai[realtime]`."
+            ) from exc
+
+        return await connect(
+            ws_url,
+            user_agent_header=None,
+            additional_headers=dict(headers),
+            max_size=None,
+            open_timeout=connect_timeout,
+        )
 
 
 @dataclass

--- a/src/agents/responses_websocket_session.py
+++ b/src/agents/responses_websocket_session.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from .agent import Agent
+from .items import TResponseInputItem
+from .models.multi_provider import MultiProvider
+from .models.openai_provider import OpenAIProvider
+from .result import RunResult, RunResultStreaming
+from .run import Runner
+from .run_config import RunConfig
+from .run_state import RunState
+
+
+@dataclass(frozen=True)
+class ResponsesWebSocketSession:
+    """Helper that pins runs to a shared OpenAI websocket-capable provider."""
+
+    provider: OpenAIProvider
+    run_config: RunConfig
+
+    def __post_init__(self) -> None:
+        self._validate_provider_alignment()
+
+    def _validate_provider_alignment(self) -> MultiProvider:
+        model_provider = self.run_config.model_provider
+        if not isinstance(model_provider, MultiProvider):
+            raise TypeError(
+                "ResponsesWebSocketSession.run_config.model_provider must be a MultiProvider."
+            )
+        if model_provider.openai_provider is not self.provider:
+            raise ValueError(
+                "ResponsesWebSocketSession provider and run_config.model_provider are not aligned."
+            )
+        return model_provider
+
+    async def aclose(self) -> None:
+        """Close cached provider model resources (including websocket connections)."""
+        await self._validate_provider_alignment().aclose()
+
+    def _prepare_runner_kwargs(self, method_name: str, kwargs: Mapping[str, Any]) -> dict[str, Any]:
+        self._validate_provider_alignment()
+        if "run_config" in kwargs:
+            raise ValueError(
+                f"Do not pass `run_config` to ResponsesWebSocketSession.{method_name}()."
+            )
+        runner_kwargs = dict(kwargs)
+        runner_kwargs["run_config"] = self.run_config
+        return runner_kwargs
+
+    async def run(
+        self,
+        starting_agent: Agent[Any],
+        input: str | list[TResponseInputItem] | RunState[Any],
+        **kwargs: Any,
+    ) -> RunResult:
+        """Call ``Runner.run`` with the session's shared ``RunConfig``."""
+        runner_kwargs = self._prepare_runner_kwargs("run", kwargs)
+        return await Runner.run(starting_agent, input, **runner_kwargs)
+
+    def run_streamed(
+        self,
+        starting_agent: Agent[Any],
+        input: str | list[TResponseInputItem] | RunState[Any],
+        **kwargs: Any,
+    ) -> RunResultStreaming:
+        """Call ``Runner.run_streamed`` with the session's shared ``RunConfig``."""
+        runner_kwargs = self._prepare_runner_kwargs("run_streamed", kwargs)
+        return Runner.run_streamed(starting_agent, input, **runner_kwargs)
+
+
+@asynccontextmanager
+async def responses_websocket_session(
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    websocket_base_url: str | None = None,
+    organization: str | None = None,
+    project: str | None = None,
+) -> AsyncIterator[ResponsesWebSocketSession]:
+    """Create a shared OpenAI Responses websocket session for multiple Runner calls.
+
+    The helper returns a session object that injects one shared ``RunConfig`` backed by a
+    websocket-configured ``MultiProvider`` with one shared ``OpenAIProvider``. This preserves
+    prefix-based model routing (for example ``openai/gpt-4.1``) while keeping websocket
+    connections warm across turns and nested agent-as-tool runs that inherit the same
+    ``run_config``.
+
+    Drain or close streamed iterators before the context exits. Exiting the context while a
+    websocket request is still in flight may force-close the shared connection.
+    """
+    model_provider = MultiProvider(
+        openai_api_key=api_key,
+        openai_base_url=base_url,
+        openai_websocket_base_url=websocket_base_url,
+        openai_organization=organization,
+        openai_project=project,
+        openai_use_responses=True,
+        openai_use_responses_websocket=True,
+    )
+    provider = model_provider.openai_provider
+    session = ResponsesWebSocketSession(
+        provider=provider,
+        run_config=RunConfig(model_provider=model_provider),
+    )
+    try:
+        yield session
+    finally:
+        await session.aclose()
+
+
+__all__ = ["ResponsesWebSocketSession", "responses_websocket_session"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ def clear_openai_settings():
     _openai_shared._default_openai_key = None
     _openai_shared._default_openai_client = None
     _openai_shared._use_responses_by_default = True
+    _openai_shared.set_default_openai_responses_transport("http")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/models/test_map.py
+++ b/tests/models/test_map.py
@@ -1,4 +1,4 @@
-from agents import Agent, OpenAIResponsesModel, RunConfig
+from agents import Agent, MultiProvider, OpenAIResponsesModel, OpenAIResponsesWSModel, RunConfig
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.run_internal.run_loop import get_model
 
@@ -9,7 +9,7 @@ def test_no_prefix_is_openai():
     assert isinstance(model, OpenAIResponsesModel)
 
 
-def openai_prefix_is_openai():
+def test_openai_prefix_is_openai():
     agent = Agent(model="openai/gpt-4o", instructions="", name="test")
     model = get_model(agent, RunConfig())
     assert isinstance(model, OpenAIResponsesModel)
@@ -19,3 +19,37 @@ def test_litellm_prefix_is_litellm():
     agent = Agent(model="litellm/foo/bar", instructions="", name="test")
     model = get_model(agent, RunConfig())
     assert isinstance(model, LitellmModel)
+
+
+def test_no_prefix_can_use_openai_responses_websocket():
+    agent = Agent(model="gpt-4o", instructions="", name="test")
+    model = get_model(
+        agent,
+        RunConfig(model_provider=MultiProvider(openai_use_responses_websocket=True)),
+    )
+    assert isinstance(model, OpenAIResponsesWSModel)
+
+
+def test_openai_prefix_can_use_openai_responses_websocket():
+    agent = Agent(model="openai/gpt-4o", instructions="", name="test")
+    model = get_model(
+        agent,
+        RunConfig(model_provider=MultiProvider(openai_use_responses_websocket=True)),
+    )
+    assert isinstance(model, OpenAIResponsesWSModel)
+
+
+def test_multi_provider_passes_websocket_base_url_to_openai_provider(monkeypatch):
+    captured_kwargs = {}
+
+    class FakeOpenAIProvider:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+        def get_model(self, model_name):
+            raise AssertionError("This test only verifies constructor passthrough.")
+
+    monkeypatch.setattr("agents.models.multi_provider.OpenAIProvider", FakeOpenAIProvider)
+
+    MultiProvider(openai_websocket_base_url="wss://proxy.example.test/v1")
+    assert captured_kwargs["websocket_base_url"] == "wss://proxy.example.test/v1"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,21 @@
+import asyncio
+import gc
 import os
+import weakref
 
 import openai
 import pytest
 
-from agents import set_default_openai_api, set_default_openai_client, set_default_openai_key
+from agents import (
+    set_default_openai_api,
+    set_default_openai_client,
+    set_default_openai_key,
+    set_default_openai_responses_transport,
+)
+from agents.models import _openai_shared
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
-from agents.models.openai_responses import OpenAIResponsesModel
+from agents.models.openai_responses import OpenAIResponsesModel, OpenAIResponsesWSModel
 
 
 def test_cc_no_default_key_errors(monkeypatch):
@@ -62,3 +71,376 @@ def test_set_default_openai_api():
     assert isinstance(OpenAIProvider().get_model("gpt-4"), OpenAIResponsesModel), (
         "Should be responses model"
     )
+
+
+def test_set_default_openai_responses_transport():
+    set_default_openai_api("responses")
+
+    assert isinstance(OpenAIProvider().get_model("gpt-4"), OpenAIResponsesModel), (
+        "Default responses transport should be HTTP"
+    )
+
+    set_default_openai_responses_transport("websocket")
+    assert isinstance(OpenAIProvider().get_model("gpt-4"), OpenAIResponsesWSModel), (
+        "Should be websocket responses model"
+    )
+
+    set_default_openai_responses_transport("http")
+    assert isinstance(OpenAIProvider().get_model("gpt-4"), OpenAIResponsesModel), (
+        "Should switch back to HTTP responses model"
+    )
+
+
+def test_set_default_openai_responses_transport_rejects_invalid_value():
+    with pytest.raises(ValueError, match="Expected one of: 'http', 'websocket'"):
+        set_default_openai_responses_transport("ws")  # type: ignore[arg-type]
+
+
+def test_openai_provider_transport_override_beats_default():
+    set_default_openai_api("responses")
+    set_default_openai_responses_transport("websocket")
+
+    assert isinstance(
+        OpenAIProvider(use_responses=True, use_responses_websocket=False).get_model("gpt-4"),
+        OpenAIResponsesModel,
+    )
+    assert isinstance(
+        OpenAIProvider(use_responses=True, use_responses_websocket=True).get_model("gpt-4"),
+        OpenAIResponsesWSModel,
+    )
+
+
+def test_legacy_websocket_default_flag_syncs_transport_getter():
+    _openai_shared._use_responses_websocket_by_default = True
+    assert _openai_shared.get_default_openai_responses_transport() == "websocket"
+
+    _openai_shared._use_responses_websocket_by_default = False
+    assert _openai_shared.get_default_openai_responses_transport() == "http"
+
+
+def test_openai_provider_uses_base_urls_from_env(monkeypatch):
+    captured_kwargs: dict[str, object] = {}
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            self.api_key = kwargs.get("api_key")
+            self.base_url = kwargs.get("base_url")
+            self.websocket_base_url = kwargs.get("websocket_base_url")
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://proxy.example.test/v1")
+    monkeypatch.setenv("OPENAI_WEBSOCKET_BASE_URL", "wss://proxy.example.test/v1")
+    monkeypatch.setattr("agents.models.openai_provider.AsyncOpenAI", FakeAsyncOpenAI)
+
+    model = OpenAIProvider(use_responses=True).get_model("gpt-4")
+    assert isinstance(model, OpenAIResponsesModel)
+    assert captured_kwargs["base_url"] == "https://proxy.example.test/v1"
+    assert captured_kwargs["websocket_base_url"] == "wss://proxy.example.test/v1"
+
+
+def test_openai_provider_websocket_base_url_arg_overrides_env(monkeypatch):
+    captured_kwargs: dict[str, object] = {}
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            self.api_key = kwargs.get("api_key")
+            self.base_url = kwargs.get("base_url")
+            self.websocket_base_url = kwargs.get("websocket_base_url")
+
+    monkeypatch.setenv("OPENAI_WEBSOCKET_BASE_URL", "wss://env.example.test/v1")
+    monkeypatch.setattr("agents.models.openai_provider.AsyncOpenAI", FakeAsyncOpenAI)
+
+    model = OpenAIProvider(
+        use_responses=True,
+        websocket_base_url="wss://explicit.example.test/v1",
+    ).get_model("gpt-4")
+    assert isinstance(model, OpenAIResponsesModel)
+    assert captured_kwargs["websocket_base_url"] == "wss://explicit.example.test/v1"
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_reuses_websocket_model_instance_for_same_model_name():
+    provider = OpenAIProvider(use_responses=True, use_responses_websocket=True)
+
+    model1 = provider.get_model("gpt-4")
+    model2 = provider.get_model("gpt-4")
+
+    assert isinstance(model1, OpenAIResponsesWSModel)
+    assert model1 is model2
+
+
+def test_openai_provider_does_not_reuse_non_websocket_model_instances():
+    provider = OpenAIProvider(use_responses=True, use_responses_websocket=False)
+
+    model1 = provider.get_model("gpt-4")
+    model2 = provider.get_model("gpt-4")
+
+    assert isinstance(model1, OpenAIResponsesModel)
+    assert isinstance(model2, OpenAIResponsesModel)
+    assert model1 is not model2
+
+
+def test_openai_provider_does_not_reuse_websocket_model_without_running_loop():
+    class DummyAsyncOpenAI:
+        pass
+
+    provider = OpenAIProvider(
+        use_responses=True,
+        use_responses_websocket=True,
+        openai_client=DummyAsyncOpenAI(),  # type: ignore[arg-type]
+    )
+
+    model1 = provider.get_model("gpt-4")
+    model2 = provider.get_model("gpt-4")
+
+    assert isinstance(model1, OpenAIResponsesWSModel)
+    assert isinstance(model2, OpenAIResponsesWSModel)
+    assert model1 is not model2
+
+
+def test_openai_provider_scopes_websocket_model_cache_to_running_loop():
+    class DummyAsyncOpenAI:
+        pass
+
+    provider = OpenAIProvider(
+        use_responses=True,
+        use_responses_websocket=True,
+        openai_client=DummyAsyncOpenAI(),  # type: ignore[arg-type]
+    )
+
+    async def get_model():
+        return provider.get_model("gpt-4")
+
+    loop1 = asyncio.new_event_loop()
+    loop2 = asyncio.new_event_loop()
+    try:
+        model1 = loop1.run_until_complete(get_model())
+        model1_again = loop1.run_until_complete(get_model())
+        model2 = loop2.run_until_complete(get_model())
+    finally:
+        loop1.close()
+        loop2.close()
+        asyncio.set_event_loop(None)
+
+    assert isinstance(model1, OpenAIResponsesWSModel)
+    assert model1 is model1_again
+    assert model2 is not model1
+
+
+def test_openai_provider_websocket_loop_cache_does_not_keep_closed_loop_alive(monkeypatch):
+    class DummyAsyncOpenAI:
+        pass
+
+    class DummyWSConnection:
+        async def close(self) -> None:
+            return None
+
+    provider = OpenAIProvider(
+        use_responses=True,
+        use_responses_websocket=True,
+        openai_client=DummyAsyncOpenAI(),  # type: ignore[arg-type]
+    )
+
+    async def create_and_warm_model() -> OpenAIResponsesWSModel:
+        model = provider.get_model("gpt-4")
+        assert isinstance(model, OpenAIResponsesWSModel)
+
+        async def fake_open(
+            ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+        ) -> DummyWSConnection:
+            return DummyWSConnection()
+
+        monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+        model._get_ws_request_lock()
+        await model._ensure_websocket_connection(
+            "wss://example.test/v1/responses",
+            {},
+            connect_timeout=None,
+        )
+        return model
+
+    loop = asyncio.new_event_loop()
+    try:
+        model = loop.run_until_complete(create_and_warm_model())
+        loop_ref = weakref.ref(loop)
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+    del loop
+    gc.collect()
+
+    assert loop_ref() is None
+    assert list(provider._ws_model_cache_by_loop.items()) == []
+    # Keep a live reference to the model to ensure cache cleanup doesn't depend on model GC.
+    assert isinstance(model, OpenAIResponsesWSModel)
+
+
+def test_openai_provider_prunes_closed_loop_cache_with_live_ws_connection(monkeypatch):
+    class DummyAsyncOpenAI:
+        pass
+
+    abort_calls: list[str] = []
+
+    class DummyTransport:
+        def abort(self) -> None:
+            abort_calls.append("abort")
+
+    class PinningWSConnection:
+        def __init__(self, loop: asyncio.AbstractEventLoop):
+            self.loop = loop
+            self.transport = DummyTransport()
+
+        async def close(self) -> None:
+            raise AssertionError("Closed-loop cache pruning should not await websocket.close().")
+
+    provider = OpenAIProvider(
+        use_responses=True,
+        use_responses_websocket=True,
+        openai_client=DummyAsyncOpenAI(),  # type: ignore[arg-type]
+    )
+
+    async def create_and_warm_model() -> None:
+        model = provider.get_model("gpt-4")
+        assert isinstance(model, OpenAIResponsesWSModel)
+
+        async def fake_open(
+            ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+        ) -> PinningWSConnection:
+            return PinningWSConnection(asyncio.get_running_loop())
+
+        monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+        await model._ensure_websocket_connection(
+            "wss://example.test/v1/responses",
+            {},
+            connect_timeout=None,
+        )
+
+    async def get_model_on_current_loop() -> OpenAIResponsesWSModel:
+        model = provider.get_model("gpt-4")
+        assert isinstance(model, OpenAIResponsesWSModel)
+        return model
+
+    loop1 = asyncio.new_event_loop()
+    try:
+        loop1.run_until_complete(create_and_warm_model())
+        loop1_ref = weakref.ref(loop1)
+    finally:
+        loop1.close()
+        asyncio.set_event_loop(None)
+
+    del loop1
+    gc.collect()
+
+    # The cached websocket model's live connection pins the closed loop until provider cleanup runs.
+    assert loop1_ref() is not None
+
+    loop2 = asyncio.new_event_loop()
+    try:
+        loop2.run_until_complete(get_model_on_current_loop())
+    finally:
+        loop2.close()
+        asyncio.set_event_loop(None)
+
+    del loop2
+    gc.collect()
+
+    assert abort_calls == ["abort"]
+    assert loop1_ref() is None
+    assert all(not loop.is_closed() for loop in provider._ws_model_cache_by_loop)
+
+
+def test_openai_provider_aclose_closes_websocket_models_from_other_loops(monkeypatch):
+    class DummyAsyncOpenAI:
+        pass
+
+    provider = OpenAIProvider(
+        use_responses=True,
+        use_responses_websocket=True,
+        openai_client=DummyAsyncOpenAI(),  # type: ignore[arg-type]
+    )
+
+    async def get_model():
+        return provider.get_model("gpt-4")
+
+    closed_models: list[object] = []
+
+    async def fake_close(self):
+        closed_models.append(self)
+
+    monkeypatch.setattr(OpenAIResponsesWSModel, "close", fake_close)
+    monkeypatch.setattr(
+        "agents.models.openai_provider.asyncio.to_thread",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("provider.aclose() should not drive foreign loops in to_thread")
+        ),
+    )
+
+    loop1 = asyncio.new_event_loop()
+    loop2 = asyncio.new_event_loop()
+    try:
+        model1 = loop1.run_until_complete(get_model())
+        model2 = loop2.run_until_complete(get_model())
+
+        asyncio.run(provider.aclose())
+
+        model1_new = loop1.run_until_complete(get_model())
+        model2_again = loop2.run_until_complete(get_model())
+    finally:
+        loop1.close()
+        loop2.close()
+        asyncio.set_event_loop(None)
+
+    assert closed_models == [model1, model2] or closed_models == [model2, model1]
+    assert model1_new is not model1
+    assert model2_again is not model2
+
+
+def test_openai_provider_aclose_closes_websocket_models_when_original_loop_is_closed(monkeypatch):
+    class DummyAsyncOpenAI:
+        pass
+
+    provider = OpenAIProvider(
+        use_responses=True,
+        use_responses_websocket=True,
+        openai_client=DummyAsyncOpenAI(),  # type: ignore[arg-type]
+    )
+
+    async def get_model():
+        return provider.get_model("gpt-4")
+
+    loop = asyncio.new_event_loop()
+    try:
+        model = loop.run_until_complete(get_model())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+    closed_models: list[object] = []
+
+    async def fake_close(self):
+        closed_models.append(self)
+
+    monkeypatch.setattr(OpenAIResponsesWSModel, "close", fake_close)
+
+    asyncio.run(provider.aclose())
+
+    assert closed_models == [model]
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_aclose_closes_cached_models(monkeypatch):
+    provider = OpenAIProvider(use_responses=True, use_responses_websocket=True)
+    model1 = provider.get_model("gpt-4")
+
+    closed_models: list[object] = []
+
+    async def fake_close(self):
+        closed_models.append(self)
+
+    monkeypatch.setattr(OpenAIResponsesWSModel, "close", fake_close)
+
+    await provider.aclose()
+    assert closed_models == [model1]
+    assert provider.get_model("gpt-4") is not model1

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -1,14 +1,87 @@
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+import json
+from typing import Any, cast
 
+import httpx
 import pytest
-from openai import omit
+from openai import NOT_GIVEN, omit
 from openai.types.responses import ResponseCompletedEvent
+from openai.types.shared.reasoning import Reasoning
 
 from agents import ModelSettings, ModelTracing, __version__
-from agents.models.openai_responses import _HEADERS_OVERRIDE as RESP_HEADERS, OpenAIResponsesModel
+from agents.exceptions import UserError
+from agents.models.openai_responses import (
+    _HEADERS_OVERRIDE as RESP_HEADERS,
+    OpenAIResponsesModel,
+    OpenAIResponsesWSModel,
+    ResponsesWebSocketError,
+)
 from tests.fake_model import get_response_obj
+
+
+class DummyWSConnection:
+    def __init__(self, frames: list[str]):
+        self._frames = frames
+        self.sent_messages: list[dict[str, Any]] = []
+        self.close_calls = 0
+        self.close_code: int | None = None
+
+    async def send(self, payload: str) -> None:
+        self.sent_messages.append(json.loads(payload))
+
+    async def recv(self) -> str:
+        if not self._frames:
+            raise RuntimeError("No more websocket frames configured")
+        return self._frames.pop(0)
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        if self.close_code is None:
+            self.close_code = 1000
+
+
+class DummyWSClient:
+    def __init__(self):
+        self.base_url = httpx.URL("https://api.openai.com/v1/")
+        self.websocket_base_url = None
+        self.default_query: dict[str, Any] = {}
+        self.default_headers = {
+            "Authorization": "Bearer test-key",
+            "User-Agent": "AsyncOpenAI/Python test",
+        }
+        self.timeout: Any = None
+        self.refresh_calls = 0
+
+    async def _refresh_api_key(self) -> None:
+        self.refresh_calls += 1
+
+
+def _response_event_frame(event_type: str, response_id: str, sequence_number: int) -> str:
+    response = get_response_obj([]).model_dump()
+    response["id"] = response_id
+    return json.dumps(
+        {
+            "type": event_type,
+            "response": response,
+            "sequence_number": sequence_number,
+        }
+    )
+
+
+def _response_completed_frame(response_id: str, sequence_number: int) -> str:
+    return _response_event_frame("response.completed", response_id, sequence_number)
+
+
+def _response_error_frame(code: str, message: str, sequence_number: int) -> str:
+    return json.dumps(
+        {
+            "type": "response.error",
+            "error": {"code": code, "message": message, "param": None},
+            "sequence_number": sequence_number,
+        }
+    )
 
 
 @pytest.mark.allow_call_model_methods
@@ -64,6 +137,189 @@ async def test_user_agent_header_responses(override_ua: str | None):
 
     assert "extra_headers" in called_kwargs
     assert called_kwargs["extra_headers"]["User-Agent"] == expected_ua
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_close_closes_inner_http_stream_with_async_close(monkeypatch):
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    class DummyHTTPStream:
+        def __init__(self):
+            self._yielded = False
+            self.close_calls = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return ResponseCompletedEvent(
+                type="response.completed",
+                response=get_response_obj([]),
+                sequence_number=0,
+            )
+
+        async def close(self) -> None:
+            self.close_calls += 1
+
+    inner_stream = DummyHTTPStream()
+
+    async def fake_fetch_response(*args: Any, **kwargs: Any) -> DummyHTTPStream:
+        return inner_stream
+
+    monkeypatch.setattr(model, "_fetch_response", fake_fetch_response)
+
+    stream = model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+    stream_agen = cast(Any, stream)
+
+    event = await stream_agen.__anext__()
+    assert event.type == "response.completed"
+
+    await stream_agen.aclose()
+
+    assert inner_stream.close_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_ignores_inner_close_failure_after_terminal_event(monkeypatch):
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    class DummyHTTPStream:
+        def __init__(self):
+            self._yielded = False
+            self.close_calls = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return ResponseCompletedEvent(
+                type="response.completed",
+                response=get_response_obj([]),
+                sequence_number=0,
+            )
+
+        async def close(self) -> None:
+            self.close_calls += 1
+            raise RuntimeError("stream close failed")
+
+    inner_stream = DummyHTTPStream()
+
+    async def fake_fetch_response(*args: Any, **kwargs: Any) -> DummyHTTPStream:
+        return inner_stream
+
+    monkeypatch.setattr(model, "_fetch_response", fake_fetch_response)
+
+    events: list[ResponseCompletedEvent] = []
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    ):
+        assert isinstance(event, ResponseCompletedEvent)
+        events.append(event)
+
+    assert len(events) == 1
+    assert inner_stream.close_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_cancellation_does_not_block_on_inner_stream_close(monkeypatch):
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    class BlockingHTTPStream:
+        def __init__(self):
+            self.next_started = asyncio.Event()
+            self.close_started = asyncio.Event()
+            self.close_release = asyncio.Event()
+            self.close_calls = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            self.next_started.set()
+            await asyncio.Event().wait()
+            raise StopAsyncIteration
+
+        async def aclose(self) -> None:
+            self.close_calls += 1
+            self.close_started.set()
+            await self.close_release.wait()
+
+    inner_stream = BlockingHTTPStream()
+
+    async def fake_fetch_response(*args: Any, **kwargs: Any) -> BlockingHTTPStream:
+        return inner_stream
+
+    monkeypatch.setattr(model, "_fetch_response", fake_fetch_response)
+
+    stream = model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+    stream_agen = cast(Any, stream)
+    next_task = asyncio.create_task(stream_agen.__anext__())
+
+    await asyncio.wait_for(inner_stream.next_started.wait(), timeout=1.0)
+    next_task.cancel()
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(next_task, timeout=0.5)
+        await asyncio.wait_for(inner_stream.close_started.wait(), timeout=1.0)
+        assert inner_stream.close_calls == 1
+    finally:
+        inner_stream.close_release.set()
+        await asyncio.sleep(0)
+
+
+@pytest.mark.allow_call_model_methods
+def test_build_response_create_kwargs_rejects_duplicate_extra_args_keys():
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="multiple values.*stream"):
+        model._build_response_create_kwargs(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(extra_args={"stream": False}),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            previous_response_id=None,
+            conversation_id=None,
+            stream=True,
+            prompt=None,
+        )
 
 
 @pytest.mark.allow_call_model_methods
@@ -208,3 +464,1638 @@ async def test_prompt_id_keeps_literal_tool_choice_without_local_tools(tool_choi
 
     assert called_kwargs["tools"] is omit
     assert called_kwargs["tool_choice"] == tool_choice
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_reuses_connection_and_sends_response_create_frames(monkeypatch):
+    client = DummyWSClient()
+    ws = DummyWSConnection(
+        [
+            _response_completed_frame("resp-1", 1),
+            _response_completed_frame("resp-2", 2),
+        ]
+    )
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    opened: list[tuple[str, dict[str, str]]] = []
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        opened.append((ws_url, headers))
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    first = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(reasoning=Reasoning(effort="medium", summary="detailed")),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+    second = await model.get_response(
+        system_instructions=None,
+        input="next",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id="resp-1",
+    )
+
+    assert first.response_id == "resp-1"
+    assert second.response_id == "resp-2"
+    assert client.refresh_calls == 2
+    assert len(opened) == 1
+    assert ws.sent_messages[0]["type"] == "response.create"
+    assert ws.sent_messages[0]["stream"] is True
+    assert ws.sent_messages[0]["reasoning"] == {"effort": "medium", "summary": "detailed"}
+    assert ws.sent_messages[1]["type"] == "response.create"
+    assert ws.sent_messages[1]["stream"] is True
+    assert ws.sent_messages[1]["previous_response_id"] == "resp-1"
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_model_reconnects_when_reused_from_different_event_loop(monkeypatch):
+    client = DummyWSClient()
+    ws1 = DummyWSConnection([_response_completed_frame("resp-1", 1)])
+    ws2 = DummyWSConnection([_response_completed_frame("resp-2", 2)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    opened: list[tuple[str, dict[str, str]]] = []
+    ws_connections = [ws1, ws2]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        opened.append((ws_url, headers))
+        return ws_connections.pop(0)
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    async def get_response(input_text: str, previous_response_id: str | None = None):
+        return await model.get_response(
+            system_instructions=None,
+            input=input_text,
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=previous_response_id,
+        )
+
+    loop1 = asyncio.new_event_loop()
+    loop2 = asyncio.new_event_loop()
+    try:
+        first = loop1.run_until_complete(get_response("hi"))
+        second = loop2.run_until_complete(get_response("next", previous_response_id="resp-1"))
+    finally:
+        loop1.close()
+        loop2.close()
+        asyncio.set_event_loop(None)
+
+    assert first.response_id == "resp-1"
+    assert second.response_id == "resp-2"
+    assert len(opened) == 2
+    assert ws1.close_calls == 1
+    assert ws2.close_calls == 0
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_model_init_lazily_creates_request_lock(monkeypatch):
+    client = DummyWSClient()
+
+    def fail_lock(*args, **kwargs):
+        raise RuntimeError("asyncio.Lock() should not be called in __init__")
+
+    monkeypatch.setattr("agents.models.openai_responses.asyncio.Lock", fail_lock)
+
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    assert model._ws_request_lock is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_stream_response_yields_typed_events(monkeypatch):
+    client = DummyWSClient()
+    ws = DummyWSConnection([_response_completed_frame("resp-stream", 1)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    events = []
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    ):
+        events.append(event)
+
+    assert len(events) == 1
+    assert isinstance(events[0], ResponseCompletedEvent)
+    assert events[0].response.id == "resp-stream"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_event_type", ["response.incomplete", "response.failed"])
+async def test_websocket_model_get_response_accepts_terminal_response_payload_events(
+    monkeypatch, terminal_event_type: str
+):
+    client = DummyWSClient()
+    ws = DummyWSConnection([_response_event_frame(terminal_event_type, "resp-terminal", 1)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    response = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert response.response_id == "resp-terminal"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_event_type", ["response.incomplete", "response.failed"])
+async def test_websocket_model_stream_response_accepts_terminal_response_payload_events(
+    monkeypatch, terminal_event_type: str
+):
+    client = DummyWSClient()
+    ws = DummyWSConnection([_response_event_frame(terminal_event_type, "resp-terminal", 1)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    events = []
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    ):
+        events.append(event)
+
+    assert len(events) == 1
+    assert events[0].type == terminal_event_type
+    assert cast(Any, events[0]).response.id == "resp-terminal"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_get_response_surfaces_response_error_event(monkeypatch):
+    client = DummyWSClient()
+    ws = DummyWSConnection([_response_error_frame("invalid_request_error", "bad request", 1)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(ResponsesWebSocketError, match="response\\.error") as exc_info:
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    assert "invalid_request_error" in str(exc_info.value)
+    assert "bad request" in str(exc_info.value)
+    assert exc_info.value.event_type == "response.error"
+    assert exc_info.value.code == "invalid_request_error"
+    assert exc_info.value.error_message == "bad request"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_stream_response_raises_on_response_error_event(monkeypatch):
+    client = DummyWSClient()
+    ws = DummyWSConnection([_response_error_frame("invalid_request_error", "bad request", 1)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(ResponsesWebSocketError, match="response\\.error") as exc_info:
+        async for _event in model.stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        ):
+            pass
+
+    assert "invalid_request_error" in str(exc_info.value)
+    assert "bad request" in str(exc_info.value)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_stream_break_drops_persistent_connection(monkeypatch):
+    client = DummyWSClient()
+    ws = DummyWSConnection(
+        [
+            _response_event_frame("response.created", "resp-created", 1),
+            _response_completed_frame("resp-complete", 2),
+        ]
+    )
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    stream = await model._fetch_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        previous_response_id=None,
+        conversation_id=None,
+        stream=True,
+    )
+
+    stream_agen = cast(Any, stream)
+    event = await stream_agen.__anext__()
+    assert event.type == "response.created"
+    await stream_agen.aclose()
+
+    assert ws.close_calls == 0
+    assert model._ws_connection is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_stream_close_after_terminal_event_preserves_persistent_connection(
+    monkeypatch,
+):
+    client = DummyWSClient()
+    ws = DummyWSConnection(
+        [
+            _response_completed_frame("resp-complete-1", 1),
+            _response_completed_frame("resp-complete-2", 2),
+        ]
+    )
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    opened: list[DummyWSConnection] = []
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        opened.append(ws)
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    stream = await model._fetch_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        previous_response_id=None,
+        conversation_id=None,
+        stream=True,
+    )
+
+    stream_agen = cast(Any, stream)
+    event = await stream_agen.__anext__()
+    assert event.type == "response.completed"
+    await stream_agen.aclose()
+
+    assert ws.close_calls == 0
+    assert model._ws_connection is ws
+    assert model._ws_request_lock is not None
+    assert model._ws_request_lock.locked() is False
+
+    second = await model.get_response(
+        system_instructions=None,
+        input="next",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert second.response_id == "resp-complete-2"
+    assert len(opened) == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_stream_response_terminal_close_keeps_connection(
+    monkeypatch,
+):
+    client = DummyWSClient()
+    ws = DummyWSConnection(
+        [
+            _response_completed_frame("resp-complete-1", 1),
+            _response_completed_frame("resp-complete-2", 2),
+        ]
+    )
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    opened: list[DummyWSConnection] = []
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        opened.append(ws)
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    stream = model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    stream_agen = cast(Any, stream)
+    event = await stream_agen.__anext__()
+    assert event.type == "response.completed"
+    await stream_agen.aclose()
+
+    assert ws.close_calls == 0
+    assert model._ws_connection is ws
+
+    second = await model.get_response(
+        system_instructions=None,
+        input="next",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert second.response_id == "resp-complete-2"
+    assert len(opened) == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_stream_response_close_releases_inner_iterator(monkeypatch):
+    client = DummyWSClient()
+    ws = DummyWSConnection(
+        [
+            _response_event_frame("response.created", "resp-created", 1),
+            _response_completed_frame("resp-complete", 2),
+        ]
+    )
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    stream = model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    stream_agen = cast(Any, stream)
+    event = await stream_agen.__anext__()
+    assert event.type == "response.created"
+    await stream_agen.aclose()
+
+    assert ws.close_calls == 0
+    assert model._ws_connection is None
+    assert model._ws_request_lock is not None
+    assert model._ws_request_lock.locked() is False
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_stream_response_non_terminal_close_does_not_await_close_handshake(
+    monkeypatch,
+):
+    class BlockingCloseWSConnection(DummyWSConnection):
+        def __init__(self):
+            super().__init__(
+                [
+                    _response_event_frame("response.created", "resp-created", 1),
+                    _response_completed_frame("resp-complete", 2),
+                ]
+            )
+            self.close_started = asyncio.Event()
+            self.close_release = asyncio.Event()
+
+            class DummyTransport:
+                def __init__(inner_self, outer: BlockingCloseWSConnection):
+                    inner_self.outer = outer
+                    inner_self.abort_calls = 0
+
+                def abort(inner_self) -> None:
+                    inner_self.abort_calls += 1
+
+            self.transport = DummyTransport(self)
+
+        async def close(self) -> None:
+            self.close_calls += 1
+            self.close_started.set()
+            await self.close_release.wait()
+
+    client = DummyWSClient()
+    ws = BlockingCloseWSConnection()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    stream = model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    stream_agen = cast(Any, stream)
+    event = await stream_agen.__anext__()
+    assert event.type == "response.created"
+
+    try:
+        await asyncio.wait_for(stream_agen.aclose(), timeout=0.5)
+        assert ws.transport.abort_calls == 1
+        assert ws.close_calls == 0
+        assert model._ws_connection is None
+        assert model._ws_request_lock is not None
+        assert model._ws_request_lock.locked() is False
+    finally:
+        ws.close_release.set()
+        await asyncio.sleep(0)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_cancellation_drops_persistent_connection(monkeypatch):
+    class CancelOnRecvWSConnection(DummyWSConnection):
+        async def recv(self) -> str:
+            raise asyncio.CancelledError()
+
+    client = DummyWSClient()
+    ws = CancelOnRecvWSConnection([])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(asyncio.CancelledError):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    assert ws.close_calls == 0
+    assert model._ws_connection is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_cancellation_does_not_await_close_handshake(monkeypatch):
+    class BlockingCloseCancelOnRecvWSConnection(DummyWSConnection):
+        def __init__(self):
+            super().__init__([])
+            self.recv_started = asyncio.Event()
+            self.close_started = asyncio.Event()
+            self.close_release = asyncio.Event()
+
+            class DummyTransport:
+                def __init__(inner_self, outer: BlockingCloseCancelOnRecvWSConnection):
+                    inner_self.outer = outer
+                    inner_self.abort_calls = 0
+
+                def abort(inner_self) -> None:
+                    inner_self.abort_calls += 1
+
+            self.transport = DummyTransport(self)
+
+        async def recv(self) -> str:
+            self.recv_started.set()
+            await asyncio.Event().wait()
+            raise RuntimeError("unreachable")
+
+        async def close(self) -> None:
+            self.close_calls += 1
+            self.close_started.set()
+            await self.close_release.wait()
+
+    client = DummyWSClient()
+    ws = BlockingCloseCancelOnRecvWSConnection()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    request_task = asyncio.create_task(
+        model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+    )
+
+    await asyncio.wait_for(ws.recv_started.wait(), timeout=1.0)
+    request_task.cancel()
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(request_task, timeout=0.5)
+        assert ws.transport.abort_calls == 1
+        assert ws.close_calls == 0
+        assert model._ws_connection is None
+    finally:
+        ws.close_release.set()
+        await asyncio.sleep(0)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_preserves_pre_event_usererror(monkeypatch):
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        raise UserError("websockets dependency missing")
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(UserError, match="websockets dependency missing"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_preserves_pre_event_server_error_frame_message(monkeypatch):
+    client = DummyWSClient()
+    ws = DummyWSConnection(
+        [
+            json.dumps(
+                {
+                    "type": "error",
+                    "error": {"message": "bad auth", "type": "invalid_request_error"},
+                }
+            )
+        ]
+    )
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(ResponsesWebSocketError, match="Responses websocket error:") as exc_info:
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    assert "feature may not be enabled" not in str(exc_info.value)
+    assert "invalid_request_error" in str(exc_info.value)
+    assert exc_info.value.event_type == "error"
+    assert exc_info.value.error_type == "invalid_request_error"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_reconnects_if_cached_connection_is_closed(monkeypatch):
+    client = DummyWSClient()
+    ws1 = DummyWSConnection([_response_completed_frame("resp-1", 1)])
+    ws2 = DummyWSConnection([_response_completed_frame("resp-2", 2)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    opened: list[DummyWSConnection] = []
+    queue = [ws1, ws2]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        next_ws = queue.pop(0)
+        opened.append(next_ws)
+        return next_ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    first = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+    assert first.response_id == "resp-1"
+    assert len(opened) == 1
+
+    # Simulate an idle timeout/server-side close on the cached websocket connection.
+    ws1.close_code = 1001
+
+    second = await model.get_response(
+        system_instructions=None,
+        input="next",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert second.response_id == "resp-2"
+    assert len(opened) == 2
+    assert ws1.close_calls == 1
+    assert model._ws_connection is ws2
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_does_not_retry_if_send_raises_after_writing_on_reused_connection(
+    monkeypatch,
+):
+    client = DummyWSClient()
+
+    class ConnectionClosedError(Exception):
+        pass
+
+    ConnectionClosedError.__module__ = "websockets.client"
+
+    class DropAfterSendWriteOnReuseWSConnection(DummyWSConnection):
+        def __init__(self, frames: list[str]):
+            super().__init__(frames)
+            self.send_calls = 0
+
+        async def send(self, payload: str) -> None:
+            self.send_calls += 1
+            if self.send_calls > 1:
+                await super().send(payload)
+                raise ConnectionClosedError("peer closed during send after request write")
+            await super().send(payload)
+
+    ws1 = DropAfterSendWriteOnReuseWSConnection([_response_completed_frame("resp-1", 1)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    open_calls = 0
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        nonlocal open_calls
+        open_calls += 1
+        if open_calls > 1:
+            raise AssertionError("Unexpected websocket retry after send started")
+        return ws1
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    first = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+    with pytest.raises(RuntimeError, match="before any response events were received"):
+        await model.get_response(
+            system_instructions=None,
+            input="next",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    assert first.response_id == "resp-1"
+    assert open_calls == 1
+    assert ws1.send_calls == 2
+    assert len(ws1.sent_messages) == 2
+    assert ws1.close_calls == 1
+    assert model._ws_connection is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_does_not_retry_after_pre_event_disconnect_once_request_sent(
+    monkeypatch,
+):
+    client = DummyWSClient()
+
+    class ConnectionClosedError(Exception):
+        pass
+
+    ConnectionClosedError.__module__ = "websockets.client"
+
+    class DisconnectAfterSendWSConnection(DummyWSConnection):
+        def __init__(self):
+            super().__init__([])
+            self.send_calls = 0
+            self.recv_calls = 0
+
+        async def send(self, payload: str) -> None:
+            self.send_calls += 1
+            await super().send(payload)
+
+        async def recv(self) -> str:
+            self.recv_calls += 1
+            raise ConnectionClosedError("peer closed after request send")
+
+    ws = DisconnectAfterSendWSConnection()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    open_calls = 0
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DisconnectAfterSendWSConnection:
+        nonlocal open_calls
+        open_calls += 1
+        if open_calls > 1:
+            raise AssertionError("Unexpected websocket retry after request frame was sent")
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(RuntimeError, match="before any response events were received"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    assert open_calls == 1
+    assert ws.send_calls == 1
+    assert ws.recv_calls == 1
+    assert ws.close_calls == 1
+    assert model._ws_connection is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_does_not_retry_after_client_initiated_close(monkeypatch):
+    client = DummyWSClient()
+
+    class ConnectionClosedError(Exception):
+        pass
+
+    ConnectionClosedError.__module__ = "websockets.client"
+
+    class AbortableRecvWSConnection(DummyWSConnection):
+        def __init__(self):
+            super().__init__([])
+            self.send_calls = 0
+            self.recv_started = asyncio.Event()
+            self.abort_event = asyncio.Event()
+
+            class DummyTransport:
+                def __init__(inner_self, outer: AbortableRecvWSConnection):
+                    inner_self.outer = outer
+                    inner_self.abort_calls = 0
+
+                def abort(inner_self) -> None:
+                    inner_self.abort_calls += 1
+                    inner_self.outer.abort_event.set()
+
+            self.transport = DummyTransport(self)
+
+        async def send(self, payload: str) -> None:
+            self.send_calls += 1
+            await super().send(payload)
+
+        async def recv(self) -> str:
+            self.recv_started.set()
+            await self.abort_event.wait()
+            raise ConnectionClosedError("client closed websocket")
+
+    ws = AbortableRecvWSConnection()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    open_calls = 0
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> AbortableRecvWSConnection:
+        nonlocal open_calls
+        open_calls += 1
+        if open_calls > 1:
+            raise AssertionError("Unexpected websocket reconnect after client close")
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    request_task = asyncio.create_task(
+        model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+    )
+
+    await asyncio.wait_for(ws.recv_started.wait(), timeout=1.0)
+    await asyncio.wait_for(model.close(), timeout=1.0)
+
+    with pytest.raises(ConnectionClosedError, match="client closed websocket"):
+        await asyncio.wait_for(request_task, timeout=1.0)
+
+    assert open_calls == 1
+    assert ws.send_calls == 1
+    assert ws.transport.abort_calls == 1
+    assert model._ws_connection is None
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_model_prepare_websocket_url_preserves_non_tls_scheme_mapping():
+    client = DummyWSClient()
+    client.base_url = httpx.URL("http://127.0.0.1:8080/v1/")
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    ws_url = model._prepare_websocket_url(extra_query=None)
+
+    assert ws_url == "ws://127.0.0.1:8080/v1/responses"
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_model_prepare_websocket_url_appends_path_with_existing_query():
+    client = DummyWSClient()
+    client.websocket_base_url = "wss://proxy.example.test/v1?token=abc"
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    ws_url = model._prepare_websocket_url(extra_query={"route": "team-a"})
+    parsed = httpx.URL(ws_url)
+
+    assert parsed.path == "/v1/responses"
+    assert dict(parsed.params) == {"token": "abc", "route": "team-a"}
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.parametrize(
+    ("configured_ws_base_url", "expected_scheme"),
+    [
+        ("http://proxy.example.test/v1?token=abc", "ws"),
+        ("https://proxy.example.test/v1?token=abc", "wss"),
+    ],
+)
+def test_websocket_model_prepare_websocket_url_normalizes_explicit_http_schemes(
+    configured_ws_base_url: str, expected_scheme: str
+):
+    client = DummyWSClient()
+    client.websocket_base_url = configured_ws_base_url
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    ws_url = model._prepare_websocket_url(extra_query={"route": "team-a"})
+    parsed = httpx.URL(ws_url)
+
+    assert parsed.scheme == expected_scheme
+    assert parsed.path == "/v1/responses"
+    assert dict(parsed.params) == {"token": "abc", "route": "team-a"}
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.parametrize("extra_query", [omit, NOT_GIVEN])
+def test_websocket_model_prepare_websocket_url_treats_top_level_omit_sentinels_as_absent(
+    extra_query,
+):
+    client = DummyWSClient()
+    client.websocket_base_url = "wss://proxy.example.test/v1?token=abc"
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    ws_url = model._prepare_websocket_url(extra_query=extra_query)
+    parsed = httpx.URL(ws_url)
+
+    assert parsed.path == "/v1/responses"
+    assert dict(parsed.params) == {"token": "abc"}
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_model_prepare_websocket_url_skips_not_given_query_values():
+    client = DummyWSClient()
+    client.websocket_base_url = "wss://proxy.example.test/v1?token=abc"
+    client.default_query = {"api-version": NOT_GIVEN, "route": "team-a"}
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    ws_url = model._prepare_websocket_url(extra_query={"tenant": NOT_GIVEN, "region": "us"})
+    parsed = httpx.URL(ws_url)
+
+    assert parsed.path == "/v1/responses"
+    assert dict(parsed.params) == {"token": "abc", "route": "team-a", "region": "us"}
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_filters_omit_from_extra_body():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    frame, _ws_url, _headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+            "extra_body": {"keep": "value", "drop": omit},
+        }
+    )
+
+    assert frame["type"] == "response.create"
+    assert frame["keep"] == "value"
+    assert "drop" not in frame
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("extra_body", [omit, NOT_GIVEN])
+async def test_websocket_model_prepare_websocket_request_ignores_top_level_extra_body_sentinels(
+    extra_body,
+):
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    frame, _ws_url, _headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+            "extra_body": extra_body,
+        }
+    )
+
+    assert frame["type"] == "response.create"
+    assert frame["stream"] is True
+    assert frame["model"] == "gpt-4"
+    assert frame["input"] == "hi"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_preserves_envelope_fields():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    frame, _ws_url, _headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+            "extra_body": {
+                "type": "not-response-create",
+                "stream": False,
+                "custom": "value",
+            },
+        }
+    )
+
+    assert frame["type"] == "response.create"
+    assert frame["stream"] is True
+    assert frame["custom"] == "value"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_strips_client_timeout_kwarg():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    frame, _ws_url, _headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+            "timeout": 30.0,
+            "metadata": {"request_id": "123"},
+        }
+    )
+
+    assert frame["type"] == "response.create"
+    assert frame["metadata"] == {"request_id": "123"}
+    assert "timeout" not in frame
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_skips_not_given_values():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    frame, _ws_url, _headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+            "user": NOT_GIVEN,
+            "stream_options": NOT_GIVEN,
+            "extra_body": {
+                "metadata": {"request_id": "123"},
+                "optional_field": NOT_GIVEN,
+            },
+        }
+    )
+
+    assert frame["type"] == "response.create"
+    assert frame["stream"] is True
+    assert frame["metadata"] == {"request_id": "123"}
+    assert "user" not in frame
+    assert "stream_options" not in frame
+    assert "optional_field" not in frame
+    json.dumps(frame)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_get_response_applies_timeout_to_recv(monkeypatch):
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    class SlowRecvWSConnection(DummyWSConnection):
+        async def recv(self) -> str:
+            await asyncio.sleep(0.2)
+            return await super().recv()
+
+    ws = SlowRecvWSConnection([_response_completed_frame("resp-timeout", 1)])
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(TimeoutError, match="Responses websocket receive timed out"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(extra_args={"timeout": 0.01}),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    assert ws.close_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_get_response_applies_timeout_while_waiting_for_request_lock(
+    monkeypatch,
+):
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    recv_started = asyncio.Event()
+    release_first_request = asyncio.Event()
+
+    class BlockingRecvWSConnection(DummyWSConnection):
+        async def recv(self) -> str:
+            recv_started.set()
+            await release_first_request.wait()
+            return await super().recv()
+
+    ws = BlockingRecvWSConnection(
+        [
+            _response_completed_frame("resp-lock-1", 1),
+            _response_completed_frame("resp-lock-2", 2),
+        ]
+    )
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    first_task = asyncio.create_task(
+        model.get_response(
+            system_instructions=None,
+            input="first",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+    )
+
+    await asyncio.wait_for(recv_started.wait(), timeout=1.0)
+
+    with pytest.raises(TimeoutError, match="request lock wait timed out"):
+        await model.get_response(
+            system_instructions=None,
+            input="second",
+            model_settings=ModelSettings(extra_args={"timeout": 0.01}),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    release_first_request.set()
+    first_response = await first_task
+
+    assert first_response.response_id == "resp-lock-1"
+    assert len(ws.sent_messages) == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_get_response_allows_zero_pool_timeout_when_lock_uncontended(
+    monkeypatch,
+):
+    client = DummyWSClient()
+    client.timeout = httpx.Timeout(connect=1.0, read=1.0, write=1.0, pool=0.0)
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    ws = DummyWSConnection([_response_completed_frame("resp-zero-pool", 1)])
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    response = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert response.response_id == "resp-zero-pool"
+    assert len(ws.sent_messages) == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_get_response_allows_zero_timeout_when_ws_ops_are_immediate(
+    monkeypatch,
+):
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    ws = DummyWSConnection([_response_completed_frame("resp-zero-timeout", 1)])
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    response = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(extra_args={"timeout": 0}),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert response.response_id == "resp-zero-timeout"
+    assert len(ws.sent_messages) == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_get_response_uses_client_default_timeout_when_no_override(
+    monkeypatch,
+):
+    client = DummyWSClient()
+    client.timeout = httpx.Timeout(connect=1.0, read=0.01, write=1.0, pool=1.0)
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    class SlowRecvWSConnection(DummyWSConnection):
+        async def recv(self) -> str:
+            await asyncio.sleep(0.2)
+            return await super().recv()
+
+    ws = SlowRecvWSConnection([_response_completed_frame("resp-timeout-default", 1)])
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(TimeoutError, match="Responses websocket receive timed out"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    assert ws.close_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_get_response_uses_client_default_timeout_when_override_is_not_given(
+    monkeypatch,
+):
+    client = DummyWSClient()
+    client.timeout = httpx.Timeout(connect=1.0, read=0.01, write=1.0, pool=1.0)
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    class SlowRecvWSConnection(DummyWSConnection):
+        async def recv(self) -> str:
+            await asyncio.sleep(0.2)
+            return await super().recv()
+
+    ws = SlowRecvWSConnection([_response_completed_frame("resp-timeout-not-given", 1)])
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    with pytest.raises(TimeoutError, match="Responses websocket receive timed out"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(extra_args={"timeout": NOT_GIVEN}),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+    assert ws.close_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_omit_removes_inherited_header():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    _frame, _ws_url, headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+            "extra_headers": {"User-Agent": omit},
+        }
+    )
+
+    assert "Authorization" in headers
+    assert "User-Agent" not in headers
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_replaces_header_case_insensitively():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    _frame, _ws_url, headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+            "extra_headers": {
+                "authorization": "Bearer override-key",
+                "user-agent": "Custom UA",
+            },
+        }
+    )
+
+    assert headers["authorization"] == "Bearer override-key"
+    assert headers["user-agent"] == "Custom UA"
+    assert "Authorization" not in headers
+    assert "User-Agent" not in headers
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_skips_not_given_header_values():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    _frame, _ws_url, headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+            "extra_headers": {
+                "Authorization": NOT_GIVEN,
+                "X-Optional": NOT_GIVEN,
+            },
+        }
+    )
+
+    assert headers["Authorization"] == "Bearer test-key"
+    assert "X-Optional" not in headers
+    assert "NOT_GIVEN" not in headers.values()
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_model_prepare_websocket_url_includes_client_default_query():
+    client = DummyWSClient()
+    client.websocket_base_url = "wss://proxy.example.test/v1?token=abc"
+    client.default_query = {"api-version": "2025-01-01-preview", "omit_me": omit}
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    ws_url = model._prepare_websocket_url(
+        extra_query={"route": "team-a", "api-version": "2026-01-01-preview"}
+    )
+    parsed = httpx.URL(ws_url)
+
+    assert parsed.path == "/v1/responses"
+    assert dict(parsed.params) == {
+        "token": "abc",
+        "api-version": "2026-01-01-preview",
+        "route": "team-a",
+    }
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_model_prepare_websocket_url_omit_removes_inherited_query_params():
+    client = DummyWSClient()
+    client.websocket_base_url = "wss://proxy.example.test/v1?token=abc"
+    client.default_query = {"route": "team-a", "region": "us"}
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    ws_url = model._prepare_websocket_url(extra_query={"token": omit, "route": omit, "keep": "1"})
+    parsed = httpx.URL(ws_url)
+
+    assert parsed.path == "/v1/responses"
+    assert dict(parsed.params) == {"region": "us", "keep": "1"}
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_close_closes_persistent_connection(monkeypatch):
+    client = DummyWSClient()
+    ws = DummyWSConnection([_response_completed_frame("resp-close", 1)])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert ws.close_calls == 0
+    await model.close()
+    assert ws.close_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_close_falls_back_to_transport_abort_on_close_error():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    class DummyTransport:
+        def __init__(self):
+            self.abort_calls = 0
+
+        def abort(self):
+            self.abort_calls += 1
+
+    class FailingWSConnection:
+        def __init__(self):
+            self.transport = DummyTransport()
+
+        async def close(self):
+            raise RuntimeError("attached to a different loop")
+
+    ws = FailingWSConnection()
+    model._ws_connection = ws
+    model._ws_connection_identity = ("wss://example.test", (("authorization", "x"),))
+
+    await model.close()
+
+    assert ws.transport.abort_calls == 1
+    assert model._ws_connection is None
+    assert model._ws_connection_identity is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_close_does_not_wait_for_held_request_lock():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    request_lock = model._get_ws_request_lock()
+    await request_lock.acquire()
+
+    class DummyTransport:
+        def __init__(self):
+            self.abort_calls = 0
+
+        def abort(self):
+            self.abort_calls += 1
+
+    class HangingCloseWSConnection:
+        def __init__(self):
+            self.transport = DummyTransport()
+            self.close_calls = 0
+
+        async def close(self) -> None:
+            self.close_calls += 1
+            await asyncio.sleep(3600)
+
+    ws = HangingCloseWSConnection()
+    model._ws_connection = ws
+    model._ws_connection_identity = ("wss://example.test", (("authorization", "x"),))
+
+    try:
+        await asyncio.wait_for(model.close(), timeout=0.1)
+    finally:
+        if request_lock.locked():
+            request_lock.release()
+
+    assert ws.transport.abort_calls == 1
+    assert ws.close_calls == 0
+    assert model._ws_connection is None
+    assert model._ws_connection_identity is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_open_websocket_connection_disables_message_size_limit(monkeypatch):
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    async def fake_connect(*args: Any, **kwargs: Any) -> object:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr("websockets.asyncio.client.connect", fake_connect)
+
+    result = await model._open_websocket_connection(
+        "wss://proxy.example.test/v1/responses",
+        {"Authorization": "Bearer test-key"},
+        connect_timeout=None,
+    )
+
+    assert result is sentinel
+    assert captured["args"] == ("wss://proxy.example.test/v1/responses",)
+    assert captured["kwargs"]["user_agent_header"] is None
+    assert captured["kwargs"]["additional_headers"] == {"Authorization": "Bearer test-key"}
+    assert captured["kwargs"]["max_size"] is None
+    assert captured["kwargs"]["open_timeout"] is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_open_websocket_connection_honors_connect_timeout(monkeypatch):
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    async def fake_connect(*args: Any, **kwargs: Any) -> object:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr("websockets.asyncio.client.connect", fake_connect)
+
+    result = await model._open_websocket_connection(
+        "wss://proxy.example.test/v1/responses",
+        {"Authorization": "Bearer test-key"},
+        connect_timeout=42.0,
+    )
+
+    assert result is sentinel
+    assert captured["kwargs"]["open_timeout"] == 42.0

--- a/tests/test_responses_websocket_session.py
+++ b/tests/test_responses_websocket_session.py
@@ -1,0 +1,113 @@
+import importlib
+
+import pytest
+
+from agents import Agent, responses_websocket_session
+from agents.models.multi_provider import MultiProvider
+from agents.models.openai_provider import OpenAIProvider
+
+
+@pytest.mark.asyncio
+async def test_responses_websocket_session_builds_shared_run_config():
+    async with responses_websocket_session() as ws:
+        assert isinstance(ws.provider, OpenAIProvider)
+        assert ws.provider._use_responses is True
+        assert ws.provider._use_responses_websocket is True
+        assert isinstance(ws.run_config.model_provider, MultiProvider)
+        assert ws.run_config.model_provider.openai_provider is ws.provider
+
+
+@pytest.mark.asyncio
+async def test_responses_websocket_session_preserves_openai_prefix_routing(monkeypatch):
+    captured: dict[str, object] = {}
+    sentinel = object()
+
+    def fake_get_model(model_name):
+        captured["model_name"] = model_name
+        return sentinel
+
+    async with responses_websocket_session() as ws:
+        monkeypatch.setattr(ws.provider, "get_model", fake_get_model)
+
+        result = ws.run_config.model_provider.get_model("openai/gpt-4.1")
+
+        assert result is sentinel
+        assert captured["model_name"] == "gpt-4.1"
+
+
+@pytest.mark.asyncio
+async def test_responses_websocket_session_run_streamed_injects_run_config(monkeypatch):
+    agent = Agent(name="test", instructions="Be concise.", model="gpt-4")
+    captured = {}
+    sentinel = object()
+
+    def fake_run_streamed(starting_agent, input, **kwargs):
+        captured["starting_agent"] = starting_agent
+        captured["input"] = input
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    ws_module = importlib.import_module("agents.responses_websocket_session")
+    monkeypatch.setattr(ws_module.Runner, "run_streamed", fake_run_streamed)
+
+    async with responses_websocket_session() as ws:
+        result = ws.run_streamed(agent, "hello")
+
+        assert result is sentinel
+        assert captured["starting_agent"] is agent
+        assert captured["input"] == "hello"
+        assert captured["kwargs"]["run_config"] is ws.run_config
+
+
+@pytest.mark.asyncio
+async def test_responses_websocket_session_run_injects_run_config(monkeypatch):
+    agent = Agent(name="test", instructions="Be concise.", model="gpt-4")
+    captured = {}
+    sentinel = object()
+
+    async def fake_run(starting_agent, input, **kwargs):
+        captured["starting_agent"] = starting_agent
+        captured["input"] = input
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    ws_module = importlib.import_module("agents.responses_websocket_session")
+    monkeypatch.setattr(ws_module.Runner, "run", fake_run)
+
+    async with responses_websocket_session() as ws:
+        result = await ws.run(agent, "hello")
+
+        assert result is sentinel
+        assert captured["starting_agent"] is agent
+        assert captured["input"] == "hello"
+        assert captured["kwargs"]["run_config"] is ws.run_config
+
+
+@pytest.mark.asyncio
+async def test_responses_websocket_session_rejects_run_config_override():
+    agent = Agent(name="test", instructions="Be concise.", model="gpt-4")
+
+    async with responses_websocket_session() as ws:
+        with pytest.raises(ValueError, match="run_config"):
+            ws.run_streamed(agent, "hello", run_config=object())
+
+
+@pytest.mark.asyncio
+async def test_responses_websocket_session_context_manager_closes_provider(monkeypatch):
+    close_calls: list[OpenAIProvider] = []
+
+    async def fake_aclose(self):
+        close_calls.append(self)
+
+    monkeypatch.setattr(OpenAIProvider, "aclose", fake_aclose)
+
+    async with responses_websocket_session() as ws:
+        provider = ws.provider
+
+    assert close_calls == [provider]
+
+
+@pytest.mark.asyncio
+async def test_responses_websocket_session_does_not_expose_run_sync():
+    async with responses_websocket_session() as ws:
+        assert not hasattr(ws, "run_sync")


### PR DESCRIPTION
This pull request adds Responses WebSocket model support and a new `examples/basic/stream_ws.py` example to the Python Agents SDK.

The change introduces a `responses_websocket_session` implementation, extends model/provider/config plumbing to support a websocket-backed Responses path, and updates streamed runner behavior so the new model can run through existing agent interfaces. It also adds test coverage for config/model mapping, streamed execution, tracing, and websocket session behavior.

This is a user-facing runtime feature addition with public configuration/model-selection impact, so reviewers should pay attention to backward compatibility and streamed/non-streamed behavior alignment. Related docs reference: [WebSocket mode guide](https://developers.openai.com/api/docs/guides/websocket-mode).

```python
import asyncio
from agents import Agent, responses_websocket_session

async def main() -> None:
    agent = Agent(
        name="Assistant",
        instructions="You are a helpful assistant.",
        model="gpt-5.2-codex",
    )
    async with responses_websocket_session() as session:
        result = session.run_streamed(agent, "Say hello in one sentence.")
        async for event in result.stream_events():
            if event.type == "raw_response_event" and event.data.type == "response.output_text.delta":
                print(event.data.delta, end="", flush=True)

        print()  # newline after streamed text

asyncio.run(main())
```