### PR TITLE
fix: sync realtime model literals in realtime config

### DIFF
--- a/src/agents/realtime/config.py
+++ b/src/agents/realtime/config.py
@@ -19,15 +19,17 @@ from ..tool import Tool
 RealtimeModelName: TypeAlias = Union[
     Literal[
         "gpt-realtime",
+        "gpt-realtime-1.5",
         "gpt-realtime-2025-08-28",
         "gpt-4o-realtime-preview",
-        "gpt-4o-mini-realtime-preview",
-        "gpt-4o-realtime-preview-2025-06-03",
-        "gpt-4o-realtime-preview-2024-12-17",
         "gpt-4o-realtime-preview-2024-10-01",
+        "gpt-4o-realtime-preview-2024-12-17",
+        "gpt-4o-realtime-preview-2025-06-03",
+        "gpt-4o-mini-realtime-preview",
         "gpt-4o-mini-realtime-preview-2024-12-17",
         "gpt-realtime-mini",
         "gpt-realtime-mini-2025-10-06",
+        "gpt-realtime-mini-2025-12-15",
     ],
     str,
 ]


### PR DESCRIPTION
This pull request updates the realtime model literal list in `/src/agents/realtime/config.py` to match the current supported model names.
