### PR TITLE
Pin openai/codex-action to commit SHA in release workflows

### DIFF
--- a/.github/workflows/release-pr-update.yml
+++ b/.github/workflows/release-pr-update.yml
@@ -65,7 +65,7 @@ jobs:
           git rebase origin/main
       - name: Run Codex release review
         if: steps.find.outputs.found == 'true'
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@5c16f9b5b3d5c4f0a7b8fa2e686c1ed4dbb7c7e2
         with:
           openai-api-key: ${{ secrets.PROD_OPENAI_API_KEY }}
           prompt-file: .github/codex/prompts/release-review.md

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -93,7 +93,7 @@ jobs:
           git commit -m "Bump version to ${RELEASE_VERSION}"
           git push --set-upstream origin "$branch"
       - name: Run Codex release review
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@5c16f9b5b3d5c4f0a7b8fa2e686c1ed4dbb7c7e2
         with:
           openai-api-key: ${{ secrets.PROD_OPENAI_API_KEY }}
           prompt-file: .github/codex/prompts/release-review.md


### PR DESCRIPTION
### Motivation
- Mitigate supply-chain risk by pinning the third-party GitHub Action `openai/codex-action` used in release workflows because the previous unpinned tag `@v1` receives `PROD_OPENAI_API_KEY` and runs in jobs with `GITHUB_TOKEN` write permissions.

### Description
- Replace `uses: openai/codex-action@v1` with `uses: openai/codex-action@5c16f9b5b3d5c4f0a7b8fa2e686c1ed4dbb7c7e2` in `.github/workflows/release-pr.yml` and `.github/workflows/release-pr-update.yml`.

### Testing
- No automated tests were executed because this is a workflow-only change and does not modify runtime code or unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6968694ed0c8832d91c2cdde0957dd42)