### PR TITLE
Add AgentMD support for AGENTS.md validation in CI

### DIFF
--- a/.github/workflows/agentmd.yml
+++ b/.github/workflows/agentmd.yml
@@ -1,0 +1,25 @@
+# Validate AGENTS.md with AgentMD (https://agentmd.vercel.app/).
+# Ensures the contributor guide is parseable and agent-ready.
+# If the action fails to load, install the AgentMD GitHub App (free for 3 repos).
+name: AgentMD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Validate AGENTS.md
+        uses: agentmd/agentmd/.github/actions/agentmd@main
+        with:
+          command: validate
+          path: .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,10 @@ make tests
 - Run `make format`, `make lint`, `make mypy`, and `make tests` before marking work ready.
 - Commit messages should be concise and written in the imperative mood. Small, focused commits are preferred.
 
+### AgentMD
+
+This repository uses [AgentMD](https://agentmd.vercel.app/) to validate `AGENTS.md` in CI. The workflow runs on push and pull requests. To get a readiness score or run locally, use `npx @agentmd/cli init` (optional) or connect the AgentMD GitHub App.
+
 ### Review Process & What Reviewers Look For
 
 - ✅ Checks pass (`make format`, `make lint`, `make mypy`, `make tests`).


### PR DESCRIPTION
### Summary

Adds [AgentMD](https://agentmd.vercel.app/) to validate `AGENTS.md` in CI so the contributor guide stays parseable and agent-ready, and drift (e.g. renamed Makefile targets or broken code blocks) is caught before merge.

**Changes:**

- **`.github/workflows/agentmd.yml`** — New workflow that runs on push to `main` and on all pull requests. Uses the official AgentMD action with `command: validate` and `path: .` per their docs. Includes a note that the AgentMD GitHub App may need to be installed if the action fails to load (free for 3 repos).
- **`AGENTS.md`** — New "AgentMD" subsection under Pull Request & Commit Guidelines describing use of AgentMD in CI and how to use the CLI or GitHub App for readiness score / local use.

### Test plan

- Confirmed workflow YAML is valid and follows existing patterns (same checkout pin as other workflows).
- No runtime code or test changes; only CI and docs. `AGENTS.md` and `.github/` are repo-meta, so full `$code-change-verification` was not run per AGENTS.md.

### Checks

- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [ ] I've made sure tests pass