### PR TITLE
Require approval for callable MCP policies when agent is omitted

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -236,7 +236,7 @@ class MCPServer(abc.ABC):
 
         if callable(policy):
             if agent is None:
-                return False
+                return True
 
             async def _needs_approval(
                 run_context: RunContextWrapper[Any], _args: dict[str, Any], _call_id: str

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -240,8 +240,9 @@ class MCPUtil:
 
         The ``agent`` parameter is optional for backward compatibility with older
         call sites that used ``MCPUtil.to_function_tool(tool, server, strict)``.
-        When omitted, this helper preserves the historical behavior and leaves
-        ``needs_approval`` disabled.
+        When omitted, this helper preserves the historical behavior for static
+        policies. If the server uses a callable approval policy, approvals default
+        to required to avoid bypassing dynamic checks.
         """
         invoke_func_impl = functools.partial(cls.invoke_mcp_tool, server, tool)
         effective_failure_error_function = server._get_failure_error_function(

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -323,6 +323,31 @@ async def test_to_function_tool_legacy_call_without_agent_uses_server_policy():
 
 
 @pytest.mark.asyncio
+async def test_to_function_tool_legacy_call_callable_policy_requires_approval():
+    """Legacy to_function_tool calls should default to approval for callable policies."""
+
+    server = FakeMCPServer()
+    server.add_tool("legacy_callable_tool", {})
+
+    def require_approval(
+        _run_context: RunContextWrapper[Any],
+        _agent: Agent,
+        _tool: MCPTool,
+    ) -> bool:
+        return False
+
+    server._needs_approval_policy = require_approval  # type: ignore[assignment]
+
+    function_tool = MCPUtil.to_function_tool(
+        MCPTool(name="legacy_callable_tool", inputSchema={}),
+        server,
+        convert_schemas_to_strict=False,
+    )
+
+    assert function_tool.needs_approval is True
+
+
+@pytest.mark.asyncio
 async def test_mcp_tool_failure_error_function_agent_default():
     """Agent-level failure_error_function should handle MCP tool failures."""
 


### PR DESCRIPTION
### Motivation

- A legacy-compatible change made `MCPUtil.to_function_tool` accept an optional `agent`, and the server path returned `False` for callable (dynamic) approval policies when `agent` was `None`, which disabled approvals and created an approval bypass for callable policies.

### Description

- Change `_get_needs_approval_for_tool` to return `True` when the server `needs_approval` policy is callable and `agent` is `None`, so legacy conversions default to requiring approval rather than disabling it. 
- Update the `to_function_tool` docstring to clarify that omitting `agent` preserves historical behavior for static policies but defaults to required approval for callable policies. 
- Add a regression test `test_to_function_tool_legacy_call_callable_policy_requires_approval` in `tests/mcp/test_mcp_util.py` to ensure legacy three-argument calls respect callable approval policies. 

### Testing

- Ran formatting with `make format` and linting with `make lint`, both of which passed. 
- Ran static typing checks with `make mypy`, which reported no issues. 
- Ran the full test suite with `make tests`, which completed successfully and reported `1767 passed, 5 skipped`, and the new regression test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698295843c5c832d9efd82441fe0b8cc)