### PR TITLE
test(mcp): add runner-level coverage for upstream tool errors

### DIFF
--- a/tests/mcp/test_runner_calls_mcp.py
+++ b/tests/mcp/test_runner_calls_mcp.py
@@ -220,13 +220,13 @@ async def test_runner_handles_mcp_upstream_errors_as_tool_output(streaming: bool
     )
 
     if streaming:
-        result = Runner.run_streamed(agent, input="trigger mcp failure")
-        async for _ in result.stream_events():
+        streamed_result = Runner.run_streamed(agent, input="trigger mcp failure")
+        async for _ in streamed_result.stream_events():
             pass
-        final = result.final_output
+        final = streamed_result.final_output
     else:
-        result = await Runner.run(agent, input="trigger mcp failure")
-        final = result.final_output
+        non_streamed_result = await Runner.run(agent, input="trigger mcp failure")
+        final = non_streamed_result.final_output
 
     assert final == "done"
     assert server.tool_calls == ["failing_tool"]


### PR DESCRIPTION
## Summary
This PR adds runner-level regression coverage for MCP upstream tool errors (issue #879).

## Problem
Issue #879 reports that when an MCP upstream service returns an error (e.g., HTTP 422), the run can abort with an `AgentsException` instead of returning model-visible tool output.

Current code already implements graceful handling via `failure_error_function` in MCP tool wrappers, but there was no runner-level test that locks in this behavior end-to-end.

## Changes
- Added `test_runner_handles_mcp_upstream_errors_as_tool_output`:
  - Simulates an MCP server whose `call_tool` raises an upstream error.
  - Verifies `Runner.run` and `Runner.run_streamed` both continue and complete with the next model turn.
- Added `test_runner_raises_when_mcp_failure_error_function_disabled`:
  - Verifies explicit `mcp_config={"failure_error_function": None}` preserves raising behavior.

## Why this is useful
- Prevents regressions on a real production concern: MCP upstream errors should not unexpectedly terminate runs under default configuration.
- Clarifies behavior boundaries between default error handling and explicit opt-out.

## Local validation
- `uv run --with pytest pytest -q tests/mcp/test_runner_calls_mcp.py`
- `uv run --with ruff ruff check tests/mcp/test_runner_calls_mcp.py`
- `uv run --with pytest pytest -q tests/mcp/test_mcp_util.py -k 'graceful_error_handling or failure_error_function'`

Closes #879
