### PR TITLE
test(mcp): assert runner emits tool_call_output_item on MCP failures

### DIFF
--- a/tests/mcp/test_runner_calls_mcp.py
+++ b/tests/mcp/test_runner_calls_mcp.py
@@ -3,7 +3,15 @@ import json
 import pytest
 from pydantic import BaseModel
 
-from agents import Agent, ModelBehaviorError, Runner, UserError
+from agents import (
+    Agent,
+    ModelBehaviorError,
+    RunContextWrapper,
+    Runner,
+    UserError,
+    default_tool_error_function,
+)
+from agents.exceptions import AgentsException
 
 from ..fake_model import FakeModel
 from ..test_responses import get_function_tool_call, get_text_message
@@ -195,3 +203,60 @@ async def test_runner_calls_mcp_tool_with_args(streaming: bool):
     assert server.tool_results == [f"result_test_tool_2_{json_args}"]
 
     await server.cleanup()
+
+
+class CrashingFakeMCPServer(FakeMCPServer):
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, object] | None,
+        meta: dict[str, object] | None = None,
+    ):
+        raise Exception("Crash!")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_runner_emits_mcp_error_tool_call_output_item(streaming: bool):
+    """Runner should emit tool_call_output_item with failure output when MCP tool raises."""
+    server = CrashingFakeMCPServer()
+    server.add_tool("crashing_tool", {})
+
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        mcp_servers=[server],
+    )
+
+    model.add_multiple_turn_outputs(
+        [
+            [get_text_message("a_message"), get_function_tool_call("crashing_tool", "{}")],
+            [get_text_message("done")],
+        ]
+    )
+
+    if streaming:
+        streamed_result = Runner.run_streamed(agent, input="user_message")
+        async for _ in streamed_result.stream_events():
+            pass
+        tool_output_items = [
+            item for item in streamed_result.new_items if item.type == "tool_call_output_item"
+        ]
+        assert streamed_result.final_output == "done"
+    else:
+        non_streamed_result = await Runner.run(agent, input="user_message")
+        tool_output_items = [
+            item for item in non_streamed_result.new_items if item.type == "tool_call_output_item"
+        ]
+        assert non_streamed_result.final_output == "done"
+
+    assert tool_output_items, "Expected tool_call_output_item for MCP failure"
+    wrapped_error = AgentsException(
+        "Error invoking MCP tool crashing_tool on server 'fake_mcp_server': Crash!"
+    )
+    expected_error_message = default_tool_error_function(
+        RunContextWrapper(context=None),
+        wrapped_error,
+    )
+    assert tool_output_items[0].output == expected_error_message


### PR DESCRIPTION
## Summary
This is a follow-up to #2554, adjusted based on maintainer feedback.

Instead of only asserting that the run continues, this test now explicitly verifies that runner-level MCP tool failures are surfaced as a generated `tool_call_output_item`.

## What changed
- Added `test_runner_emits_mcp_error_tool_call_output_item` in `tests/mcp/test_runner_calls_mcp.py`.
- Introduced a crashing fake MCP server for deterministic failure behavior.
- Asserted both sync and streaming paths:
  - a `tool_call_output_item` is produced
  - the item output matches the expected error text from `default_tool_error_function`
  - the run still continues to the next turn (`final_output == "done"`)

## Validation
Locally run:
- `env -u all_proxy -u ALL_PROXY -u http_proxy -u HTTP_PROXY -u https_proxy -u HTTPS_PROXY -u no_proxy -u NO_PROXY uv run --with pytest pytest -q tests/mcp/test_runner_calls_mcp.py`
- `uv run --with ruff ruff check tests/mcp/test_runner_calls_mcp.py`
- `uv run --with mypy mypy tests/mcp/test_runner_calls_mcp.py`

All passed locally.
