### PR TITLE
feat: expose immutable agent tool invocation metadata on run results (ref #2575)

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -86,7 +86,7 @@ from .models.openai_responses import OpenAIResponsesModel, OpenAIResponsesWSMode
 from .prompts import DynamicPromptFunction, GenerateDynamicPromptData, Prompt
 from .repl import run_demo_loop
 from .responses_websocket_session import ResponsesWebSocketSession, responses_websocket_session
-from .result import RunResult, RunResultStreaming
+from .result import AgentToolInvocation, RunResult, RunResultStreaming
 from .run import (
     ReasoningItemIdPolicy,
     RunConfig,
@@ -359,6 +359,7 @@ __all__ = [
     "RunErrorHandlerInput",
     "RunErrorHandlerResult",
     "RunErrorHandlers",
+    "AgentToolInvocation",
     "RunResult",
     "RunResultStreaming",
     "ResponsesWebSocketSession",

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -501,7 +501,8 @@ class Agent(AgentBase, Generic[TContext]):
             tool_description: The description of the tool, which should indicate what it does and
                 when to use it.
             custom_output_extractor: A function that extracts the output from the agent. If not
-                provided, the last message from the agent will be used.
+                provided, the last message from the agent will be used. Nested run results expose
+                `agent_tool_invocation` metadata when this agent is invoked via `as_tool()`.
             is_enabled: Whether the tool is enabled. Can be a bool or a callable that takes the run
                 context and agent and returns whether the tool is enabled. Disabled tools are hidden
                 from the LLM at runtime.


### PR DESCRIPTION
This pull request is a follow-up of #2575 and it adds a narrow public accessor for nested `Agent.as_tool()` runs so custom output extractors can read tool invocation metadata without receiving the live `ToolContext`. It introduces an immutable `AgentToolInvocation` value on `RunResult` and `RunResultStreaming`, returns `None` for ordinary top-level runs, and avoids adding any new `RunState` persistence or schema changes.

The change also updates the public exports and agent-as-tool docs to describe the new accessor, and adds regression coverage for plain runs plus nested non-streaming and streaming extractor paths.