### PR TITLE
fix: re-raise cancelled tool execution

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -847,10 +847,6 @@ async def execute_function_tool_calls(
     tool_state_scope_id = get_agent_tool_state_scope(context_wrapper)
 
     async def run_single_tool(func_tool: FunctionTool, tool_call: ResponseFunctionToolCall) -> Any:
-        @dataclasses.dataclass
-        class _ToolCancelledResult:
-            error_output: str
-
         with function_span(func_tool.name) as span_fn:
             tool_context = ToolContext.from_agent_context(
                 context_wrapper,
@@ -934,38 +930,20 @@ async def execute_function_tool_calls(
                             else _coro.noop_coroutine()
                         ),
                     )
-
-                    async def _invoke_tool() -> Any:
-                        try:
-                            return await invoke_function_tool(
-                                function_tool=func_tool,
-                                context=tool_context,
-                                arguments=tool_call.arguments,
-                            )
-                        except asyncio.CancelledError as e:
-                            _error_tracing.attach_error_to_current_span(
-                                SpanError(
-                                    message="Tool execution cancelled",
-                                    data={"tool_name": func_tool.name, "error": str(e)},
-                                )
-                            )
-                            error_output = (
-                                f"Tool execution failed: {type(e).__name__}: {e}"
-                                if str(e)
-                                else f"Tool execution failed: {type(e).__name__}"
-                            )
-                            return _ToolCancelledResult(error_output)
-
-                    invoke_task = asyncio.create_task(_invoke_tool())
+                    invoke_task = asyncio.create_task(
+                        invoke_function_tool(
+                            function_tool=func_tool,
+                            context=tool_context,
+                            arguments=tool_call.arguments,
+                        )
+                    )
                     try:
                         real_result = await asyncio.shield(invoke_task)
                     except asyncio.CancelledError:
-                        invoke_task.cancel()
+                        if not invoke_task.done():
+                            invoke_task.cancel()
                         await asyncio.gather(invoke_task, return_exceptions=True)
                         raise
-
-                    if isinstance(real_result, _ToolCancelledResult):
-                        real_result = real_result.error_output
 
                     final_result = await _execute_tool_output_guardrails(
                         func_tool=func_tool,

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -373,7 +373,7 @@ async def test_multiple_tool_calls_with_tool_context():
 
 
 @pytest.mark.asyncio
-async def test_multiple_tool_calls_preserve_successful_outputs_when_sibling_cancelled():
+async def test_multiple_tool_calls_re_raise_tool_cancelled_error():
     async def _ok_tool() -> str:
         return "ok"
 
@@ -397,16 +397,8 @@ async def test_multiple_tool_calls_preserve_successful_outputs_when_sibling_canc
         response_id=None,
     )
 
-    result = await get_execute_result(agent, response)
-
-    assert len(result.generated_items) == 4
-    assert isinstance(result.next_step, NextStepRunAgain)
-    assert_item_is_function_tool_call(result.generated_items[0], "ok_tool", "{}")
-    assert_item_is_function_tool_call(result.generated_items[1], "cancel_tool", "{}")
-    assert_item_is_function_tool_call_output(result.generated_items[2], "ok")
-    cancelled_output = cast(dict[str, Any], result.generated_items[3].raw_item)["output"]
-    assert cancelled_output.startswith("Tool execution failed:")
-    assert "CancelledError" in cancelled_output
+    with pytest.raises(asyncio.CancelledError):
+        await get_execute_result(agent, response)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

- restore the pre-PR behavior for tool-raised `asyncio.CancelledError` so it propagates instead of being converted into a normal tool output item
- keep the shielded invoke-task cleanup so parent cancellation still drains the child task deterministically
- update the parallel tool regression test to assert that tool-raised cancellation is re-raised

### Test plan

- `make sync`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

- N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass