### PR TITLE
Handle unknown model prefixes in MultiProvider

### DIFF
--- a/src/agents/models/multi_provider.py
+++ b/src/agents/models/multi_provider.py
@@ -144,12 +144,19 @@ class MultiProvider(ModelProvider):
         Returns:
             A Model.
         """
+        original_model_name = model_name
         prefix, model_name = self._get_prefix_and_model_name(model_name)
 
+        # Route known prefixes to dedicated providers.
         if prefix and self.provider_map and (provider := self.provider_map.get_provider(prefix)):
             return provider.get_model(model_name)
-        else:
+        if prefix in {"openai", "litellm", None}:
             return self._get_fallback_provider(prefix).get_model(model_name)
+
+        # Unknown prefixes are treated as part of the model name for OpenAI-compatible providers.
+        # This supports endpoints like OpenRouter that use namespaced model IDs such as
+        # "openrouter/openai/gpt-4o".
+        return self._get_fallback_provider(None).get_model(original_model_name)
 
     async def aclose(self) -> None:
         """Close cached resources held by child providers."""

--- a/tests/models/test_map.py
+++ b/tests/models/test_map.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from agents import Agent, MultiProvider, OpenAIResponsesModel, OpenAIResponsesWSModel, RunConfig
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.run_internal.run_loop import get_model
@@ -53,3 +55,25 @@ def test_multi_provider_passes_websocket_base_url_to_openai_provider(monkeypatch
 
     MultiProvider(openai_websocket_base_url="wss://proxy.example.test/v1")
     assert captured_kwargs["websocket_base_url"] == "wss://proxy.example.test/v1"
+
+
+def test_unknown_prefix_model_name_keeps_prefix_for_openai_fallback(monkeypatch):
+    captured_model: dict[str, Any] = {}
+    captured_result: dict[str, Any] = {}
+
+    class FakeOpenAIProvider:
+        def __init__(self, **kwargs):
+            pass
+
+        def get_model(self, model_name):
+            captured_model["value"] = model_name
+            fake_model = object()
+            captured_result["value"] = fake_model
+            return fake_model
+
+    monkeypatch.setattr("agents.models.multi_provider.OpenAIProvider", FakeOpenAIProvider)
+
+    provider = MultiProvider()
+    result = provider.get_model("openrouter/openai/gpt-4o")
+    assert result is captured_result["value"]
+    assert captured_model["value"] == "openrouter/openai/gpt-4o"


### PR DESCRIPTION
### Summary

Fix #2492 by changing `MultiProvider.get_model()` to treat unknown model prefixes as part of the model id and route through the OpenAI fallback. This avoids `Unknown prefix` errors for namespaced model names like `openrouter/openai/gpt-4o` used by OpenAI-compatible providers.

### Test plan

- `make format`
- `make lint`
- `make mypy`
- `make tests`

### Issue number

Closes #2492

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
