### PR TITLE
docs: clarify realtime transport boundaries and SIP attach flows

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -69,10 +69,10 @@ Check out a variety of sample implementations of the SDK in the examples section
 -   **[realtime](https://github.com/openai/openai-agents-python/tree/main/examples/realtime):**
     Examples showing how to build real-time experiences using the SDK, including:
 
-    -   Web applications
-    -   Command-line interfaces
-    -   Twilio integration
-    -   Twilio SIP integration
+    -   Web application patterns with structured text and image messages
+    -   Command-line audio loops and playback handling
+    -   Twilio Media Streams integration over WebSocket
+    -   Twilio SIP integration using Realtime Calls API attach flows
 
 -   **[reasoning_content](https://github.com/openai/openai-agents-python/tree/main/examples/reasoning_content):**
     Examples demonstrating how to work with reasoning content and structured outputs.

--- a/docs/human_in_the_loop.md
+++ b/docs/human_in_the_loop.md
@@ -119,7 +119,7 @@ To stream output while waiting for approvals, call `Runner.run_streamed`, consum
 - **Local MCP servers**: Use `require_approval` on `MCPServerStdio` / `MCPServerSse` / `MCPServerStreamableHttp` to gate MCP tool calls (see `examples/mcp/get_all_mcp_tools_example/main.py` and `examples/mcp/tool_filter_example/main.py`).
 - **Hosted MCP servers**: Set `require_approval` to `"always"` on `HostedMCPTool` to force HITL, optionally providing `on_approval_request` to auto-approve or reject (see `examples/hosted_mcp/human_in_the_loop.py` and `examples/hosted_mcp/on_approval.py`). Use `"never"` for trusted servers (`examples/hosted_mcp/simple.py`).
 - **Sessions and memory**: Pass a session to `Runner.run` so approvals and conversation history survive multiple turns. SQLite and OpenAI Conversations session variants are in `examples/memory/memory_session_hitl_example.py` and `examples/memory/openai_session_hitl_example.py`.
-- **Realtime agents**: The realtime demo exposes WebSocket messages that approve or reject tool calls via `approve_tool_call` / `reject_tool_call` on the `RealtimeSession` (see `examples/realtime/app/server.py` for the server-side handlers).
+- **Realtime agents**: The realtime demo exposes WebSocket messages that approve or reject tool calls via `approve_tool_call` / `reject_tool_call` on the `RealtimeSession` (see `examples/realtime/app/server.py` for the server-side handlers and [Realtime guide](realtime/guide.md#tool-approvals) for the API surface).
 
 ## Long-running approvals
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,5 +73,5 @@ Use this table when you know the job you want to do, but not which page explains
 | Keep memory across turns | [Running agents](running_agents.md#choose-a-memory-strategy) and [Sessions](sessions/index.md) |
 | Use OpenAI models, websocket transport, or non-OpenAI providers | [Models](models/index.md) |
 | Review outputs, run items, interruptions, and resume state | [Results](results.md) |
-| Build a low-latency voice agent | [Realtime agents quickstart](realtime/quickstart.md) |
+| Build a low-latency voice agent | [Realtime agents quickstart](realtime/quickstart.md) and [Realtime transport](realtime/transport.md) |
 | Build a speech-to-text / agent / text-to-speech pipeline | [Voice pipeline quickstart](voice/quickstart.md) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -34,7 +34,8 @@ The Agents SDK delivers a focused set of Python primitives—agents, tools, guar
 - [Voice pipeline](https://openai.github.io/openai-agents-python/voice/pipeline/): Customize audio capture, buffering, model invocation, and playback in voice-first experiences.
 - [Voice tracing](https://openai.github.io/openai-agents-python/voice/tracing/): Inspect voice session traces, latency breakdowns, and audio event timelines.
 - [Realtime quickstart](https://openai.github.io/openai-agents-python/realtime/quickstart/): Launch realtime agents over websockets (WebRTC is not available in the Python SDK), subscribe to events, and manage low-latency execution.
-- [Realtime guide](https://openai.github.io/openai-agents-python/realtime/guide/): Deep dive into realtime session lifecycle, event schemas, concurrency, and backpressure handling.
+- [Realtime transport](https://openai.github.io/openai-agents-python/realtime/transport/): Choose between the default server-side WebSocket path and SIP attach flows, with the browser WebRTC boundary called out explicitly.
+- [Realtime guide](https://openai.github.io/openai-agents-python/realtime/guide/): Deep dive into realtime session lifecycle, structured input, approvals, interruptions, and low-level transport control.
 
 ## Models and Provider Integrations
 - [Model catalog](https://openai.github.io/openai-agents-python/models/): Lists supported OpenAI and partner models with guidance on selecting capabilities for different workloads.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -37,7 +37,8 @@ The SDK focuses on a concise set of primitives so you can orchestrate multi-agen
 - [Voice quickstart](https://openai.github.io/openai-agents-python/voice/quickstart/): Build speech-enabled agents with streaming transcription and TTS.
 - [Voice pipeline](https://openai.github.io/openai-agents-python/voice/pipeline/): Customize audio ingestion, tool execution, and response rendering.
 - [Realtime quickstart](https://openai.github.io/openai-agents-python/realtime/quickstart/): Stand up low-latency realtime agents with websocket transport (WebRTC is not available in the Python SDK).
-- [Realtime guide](https://openai.github.io/openai-agents-python/realtime/guide/): Deep dive into session lifecycle, event formats, and concurrency patterns.
+- [Realtime transport](https://openai.github.io/openai-agents-python/realtime/transport/): Decide between the default server-side WebSocket path and SIP attach flows, with the browser WebRTC boundary called out explicitly.
+- [Realtime guide](https://openai.github.io/openai-agents-python/realtime/guide/): Deep dive into session lifecycle, structured input, approvals, interruptions, and low-level transport control.
 
 ## API Reference Highlights
 - [Agents API index](https://openai.github.io/openai-agents-python/ref/index/): Entry point for class and function documentation throughout the SDK.

--- a/docs/realtime/guide.md
+++ b/docs/realtime/guide.md
@@ -1,157 +1,258 @@
 # Realtime agents guide
 
-This guide provides an in-depth look at building voice-enabled AI agents using the OpenAI Agents SDK's realtime capabilities.
+This guide explains how the OpenAI Agents SDK's realtime layer maps onto the OpenAI Realtime API, and what extra behavior the Python SDK adds on top.
 
 !!! warning "Beta feature"
-Realtime agents are in beta. Expect some breaking changes as we improve the implementation.
+
+    Realtime agents are in beta. Expect some breaking changes as we improve the implementation.
+
+!!! note "Start here"
+
+    If you want the default Python path, read the [quickstart](quickstart.md) first. If you are deciding whether your app should use server-side WebSocket or SIP, read [Realtime transport](transport.md). Browser WebRTC transport is not part of the Python SDK.
 
 ## Overview
 
-Realtime agents allow for conversational flows, processing audio and text inputs in real time and responding with realtime audio. They maintain persistent connections with OpenAI's Realtime API, enabling natural voice conversations with low latency and the ability to handle interruptions gracefully.
+Realtime agents keep a long-lived connection open to the Realtime API so the model can process text and audio incrementally, stream audio output, call tools, and handle interruptions without restarting a fresh request on every turn.
 
-## Architecture
+The main SDK components are:
 
-### Core components
+-   **RealtimeAgent**: Instructions, tools, output guardrails, and handoffs for one realtime specialist
+-   **RealtimeRunner**: Session factory that wires a starting agent to a realtime transport
+-   **RealtimeSession**: A live session that sends input, receives events, tracks history, and executes tools
+-   **RealtimeModel**: The transport abstraction. The default is OpenAI's server-side WebSocket implementation.
 
-The realtime system consists of several key components:
+## Session lifecycle
 
--   **RealtimeAgent**: An agent, configured with instructions, tools and handoffs.
--   **RealtimeRunner**: Manages configuration. You can call `runner.run()` to get a session.
--   **RealtimeSession**: A single interaction session. You typically create one each time a user starts a conversation, and keep it alive until the conversation is done.
--   **RealtimeModel**: The underlying model interface (typically OpenAI's WebSocket implementation)
+A typical realtime session looks like this:
 
-### Session flow
+1. Create one or more `RealtimeAgent`s.
+2. Create a `RealtimeRunner` with the starting agent.
+3. Call `await runner.run()` to get a `RealtimeSession`.
+4. Enter the session with `async with session:` or `await session.enter()`.
+5. Send user input with `send_message()` or `send_audio()`.
+6. Iterate over session events until the conversation ends.
 
-A typical realtime session follows this flow:
+Unlike text-only runs, `runner.run()` does not produce a final result immediately. It returns a live session object that keeps local history, background tool execution, guardrail state, and the active agent configuration in sync with the transport layer.
 
-1. **Create your RealtimeAgent(s)** with instructions, tools and handoffs.
-2. **Set up a RealtimeRunner** with the agent and configuration options
-3. **Start the session** using `await runner.run()` which returns a RealtimeSession.
-4. **Send audio or text messages** to the session using `send_audio()` or `send_message()`
-5. **Listen for events** by iterating over the session - events include audio output, transcripts, tool calls, handoffs, and errors
-6. **Handle interruptions** when users speak over the agent, which automatically stops current audio generation
+By default, `RealtimeRunner` uses `OpenAIRealtimeWebSocketModel`, so the default Python path is a server-side WebSocket connection to the Realtime API. If you pass a different `RealtimeModel`, the same session lifecycle and agent features still apply, while the connection mechanics can change.
 
-The session maintains the conversation history and manages the persistent connection with the realtime model.
+## Agent and session configuration
 
-## Agent configuration
+`RealtimeAgent` is intentionally narrower than the regular `Agent` type:
 
-RealtimeAgent works similarly to the regular Agent class with some key differences. For full API details, see the [`RealtimeAgent`][agents.realtime.agent.RealtimeAgent] API reference.
+-   Model choice is configured at the session level, not per agent.
+-   Structured outputs are not supported.
+-   Voice can be configured, but it cannot change after the session has already produced spoken audio.
+-   Instructions, function tools, handoffs, hooks, and output guardrails all still work.
 
-Key differences from regular agents:
+`RealtimeSessionModelSettings` supports both a newer nested `audio` config and older flat aliases. Prefer the nested shape for new code:
 
--   Model choice is configured at the session level, not the agent level.
--   No structured output support (`outputType` is not supported).
--   Voice can be configured per agent but cannot be changed after the first agent speaks.
--   All other features like tools, handoffs, and instructions work the same way.
+```python
+runner = RealtimeRunner(
+    starting_agent=agent,
+    config={
+        "model_settings": {
+            "model_name": "gpt-realtime",
+            "audio": {
+                "input": {
+                    "format": "pcm16",
+                    "transcription": {"model": "gpt-4o-mini-transcribe"},
+                    "turn_detection": {"type": "semantic_vad", "interrupt_response": True},
+                },
+                "output": {"format": "pcm16", "voice": "ash"},
+            },
+            "tool_choice": "auto",
+        }
+    },
+)
+```
 
-## Session configuration
+Useful session-level settings include:
 
-### Model settings
+-   `audio.input.format`, `audio.output.format`
+-   `audio.input.transcription`
+-   `audio.input.noise_reduction`
+-   `audio.input.turn_detection`
+-   `audio.output.voice`, `audio.output.speed`
+-   `output_modalities`
+-   `tool_choice`
+-   `prompt`
+-   `tracing`
 
-The session configuration allows you to control the underlying realtime model behavior. You can configure the model name (such as `gpt-realtime`), voice selection (alloy, echo, fable, onyx, nova, shimmer), and supported modalities (text and/or audio). Audio formats can be set for both input and output, with PCM16 being the default.
+Useful run-level settings on `RealtimeRunner(config=...)` include:
 
-### Audio configuration
+-   `async_tool_calls`
+-   `output_guardrails`
+-   `guardrails_settings.debounce_text_length`
+-   `tool_error_formatter`
+-   `tracing_disabled`
 
-Audio settings control how the session handles voice input and output. You can configure input audio transcription using models like Whisper, set language preferences, and provide transcription prompts to improve accuracy for domain-specific terms. Turn detection settings control when the agent should start and stop responding, with options for voice activity detection thresholds, silence duration, and padding around detected speech.
+See [`RealtimeRunConfig`][agents.realtime.config.RealtimeRunConfig] and [`RealtimeSessionModelSettings`][agents.realtime.config.RealtimeSessionModelSettings] for the full typed surface.
 
-Additional configuration options you can set on `RealtimeRunner(config=...)` include:
+## Inputs and outputs
 
--   `model_settings.output_modalities` to constrain output to text and/or audio.
--   `model_settings.input_audio_noise_reduction` to tune noise reduction for near-field or far-field audio.
--   `guardrails_settings.debounce_text_length` to control how frequently output guardrails run.
--   `async_tool_calls` to run function tools concurrently.
--   `tool_error_formatter` to customize model-visible tool error messages.
+### Text and structured user messages
 
-See [`RealtimeRunConfig`][agents.realtime.config.RealtimeRunConfig] and [`RealtimeSessionModelSettings`][agents.realtime.config.RealtimeSessionModelSettings] for the complete typed configuration.
+Use [`session.send_message()`][agents.realtime.session.RealtimeSession.send_message] for plain text or structured realtime messages.
 
-## Tools and functions
+```python
+from agents.realtime import RealtimeUserInputMessage
 
-### Adding tools
+await session.send_message("Summarize what we discussed so far.")
 
-Just like regular agents, realtime agents support function tools that execute during conversations:
+message: RealtimeUserInputMessage = {
+    "type": "message",
+    "role": "user",
+    "content": [
+        {"type": "input_text", "text": "Describe this image."},
+        {"type": "input_image", "image_url": image_data_url, "detail": "high"},
+    ],
+}
+await session.send_message(message)
+```
+
+Structured messages are the main way to include image input in a realtime conversation. The example web demo in [`examples/realtime/app/server.py`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/app/server.py) forwards `input_image` messages this way.
+
+### Audio input
+
+Use [`session.send_audio()`][agents.realtime.session.RealtimeSession.send_audio] to stream raw audio bytes:
+
+```python
+await session.send_audio(audio_bytes)
+```
+
+If server-side turn detection is disabled, you are responsible for marking turn boundaries. The high-level convenience is:
+
+```python
+await session.send_audio(audio_bytes, commit=True)
+```
+
+If you need lower-level control, you can also send raw client events such as `input_audio_buffer.commit` through the underlying model transport.
+
+### Manual response control
+
+`session.send_message()` sends user input using the high-level path and starts a response for you. Raw audio buffering does **not** automatically do the same in every configuration.
+
+At the Realtime API level, manual turn control means clearing `turn_detection` with a raw `session.update`, then sending `input_audio_buffer.commit` and `response.create` yourself.
+
+If you are managing turns manually, you can send raw client events through the model transport:
+
+```python
+from agents.realtime.model_inputs import RealtimeModelSendRawMessage
+
+await session.model.send_event(
+    RealtimeModelSendRawMessage(
+        message={
+            "type": "response.create",
+        }
+    )
+)
+```
+
+This pattern is useful when:
+
+-   `turn_detection` is disabled and you want to decide when the model should respond
+-   you want to inspect or gate user input before triggering a response
+-   you need a custom prompt for an out-of-band response
+
+The SIP example in [`examples/realtime/twilio_sip/server.py`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/twilio_sip/server.py) uses a raw `response.create` to force an opening greeting.
+
+## Events, history, and interruptions
+
+`RealtimeSession` emits higher-level SDK events while still forwarding raw model events when you need them.
+
+High-value session events include:
+
+-   `audio`, `audio_end`, `audio_interrupted`
+-   `agent_start`, `agent_end`
+-   `tool_start`, `tool_end`, `tool_approval_required`
+-   `handoff`
+-   `history_added`, `history_updated`
+-   `guardrail_tripped`
+-   `input_audio_timeout_triggered`
+-   `error`
+-   `raw_model_event`
+
+The most useful events for UI state are usually `history_added` and `history_updated`. They expose the session's local history as `RealtimeItem` objects, including user messages, assistant messages, and tool calls.
+
+### Interruptions and playback tracking
+
+When the user interrupts the assistant, the session emits `audio_interrupted` and updates history so the server-side conversation stays aligned with what the user actually heard.
+
+In low-latency local playback, the default playback tracker is often enough. In remote or delayed playback scenarios, especially telephony, use [`RealtimePlaybackTracker`][agents.realtime.model.RealtimePlaybackTracker] so interruption truncation is based on actual playback progress rather than assuming all generated audio has already been heard.
+
+The Twilio example in [`examples/realtime/twilio/twilio_handler.py`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/twilio/twilio_handler.py) shows this pattern.
+
+## Tools, approvals, handoffs, and guardrails
+
+### Function tools
+
+Realtime agents support function tools during live conversations:
 
 ```python
 from agents import function_tool
 
+
 @function_tool
 def get_weather(city: str) -> str:
     """Get current weather for a city."""
-    # Your weather API logic here
-    return f"The weather in {city} is sunny, 72°F"
+    return f"The weather in {city} is sunny, 72F."
 
-@function_tool
-def book_appointment(date: str, time: str, service: str) -> str:
-    """Book an appointment."""
-    # Your booking logic here
-    return f"Appointment booked for {service} on {date} at {time}"
 
 agent = RealtimeAgent(
     name="Assistant",
-    instructions="You can help with weather and appointments.",
-    tools=[get_weather, book_appointment],
+    instructions="You can answer weather questions.",
+    tools=[get_weather],
 )
 ```
 
-## Handoffs
+### Tool approvals
 
-### Creating handoffs
-
-Handoffs allow transferring conversations between specialized agents.
+Function tools can require human approval before execution. When that happens, the session emits `tool_approval_required` and pauses the tool run until you call `approve_tool_call()` or `reject_tool_call()`.
 
 ```python
-from agents.realtime import realtime_handoff
+async for event in session:
+    if event.type == "tool_approval_required":
+        await session.approve_tool_call(event.call_id)
+```
 
-# Specialized agents
+For a concrete server-side approval loop, see [`examples/realtime/app/server.py`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/app/server.py). The human-in-the-loop docs also point back to this flow in [Human in the loop](../human_in_the_loop.md).
+
+### Handoffs
+
+Realtime handoffs let one agent transfer the live conversation to another specialist:
+
+```python
+from agents.realtime import RealtimeAgent, realtime_handoff
+
 billing_agent = RealtimeAgent(
     name="Billing Support",
-    instructions="You specialize in billing and payment issues.",
+    instructions="You specialize in billing issues.",
 )
 
-technical_agent = RealtimeAgent(
-    name="Technical Support",
-    instructions="You handle technical troubleshooting.",
-)
-
-# Main agent with handoffs
 main_agent = RealtimeAgent(
     name="Customer Service",
-    instructions="You are the main customer service agent. Hand off to specialists when needed.",
-    handoffs=[
-        realtime_handoff(billing_agent, tool_description="Transfer to billing support"),
-        realtime_handoff(technical_agent, tool_description="Transfer to technical support"),
-    ]
+    instructions="Triage the request and hand off when needed.",
+    handoffs=[realtime_handoff(billing_agent, tool_description="Transfer to billing support")],
 )
 ```
 
-## Runtime behavior and session handling
-
-### Event handling
-
-The session streams events that you can listen to by iterating over the session object. Events include audio output chunks, transcription results, tool execution start and end, agent handoffs, and errors. Key events to handle include:
-
--   **audio**: Raw audio data from the agent's response
--   **audio_end**: Agent finished speaking
--   **audio_interrupted**: User interrupted the agent
--   **tool_start/tool_end**: Tool execution lifecycle
--   **handoff**: Agent handoff occurred
--   **error**: Error occurred during processing
-
-For complete event details, see [`RealtimeSessionEvent`][agents.realtime.events.RealtimeSessionEvent].
+Bare `RealtimeAgent` handoffs are auto-wrapped, and `realtime_handoff(...)` lets you customize names, descriptions, validation, callbacks, and availability. Realtime handoffs do **not** support the regular handoff `input_filter`.
 
 ### Guardrails
 
-Only output guardrails are supported for realtime agents. These guardrails are debounced and run periodically (not on every word) to avoid performance issues during real-time generation. The default debounce length is 100 characters, but this is configurable.
-
-Guardrails can be attached directly to a `RealtimeAgent` or provided via the session's `run_config`. Guardrails from both sources run together.
+Only output guardrails are supported for realtime agents. They run on debounced transcript accumulation rather than on every partial token, and they emit `guardrail_tripped` instead of raising an exception.
 
 ```python
 from agents.guardrail import GuardrailFunctionOutput, OutputGuardrail
+
 
 def sensitive_data_check(context, agent, output):
     return GuardrailFunctionOutput(
         tripwire_triggered="password" in output,
         output_info=None,
     )
+
 
 agent = RealtimeAgent(
     name="Assistant",
@@ -160,70 +261,79 @@ agent = RealtimeAgent(
 )
 ```
 
-When a guardrail is triggered, it generates a `guardrail_tripped` event and can interrupt the agent's current response. The debounce behavior helps balance safety with real-time performance requirements. Unlike text agents, realtime agents do **not** raise an Exception when guardrails are tripped.
+## SIP and telephony
 
-### Audio processing
+The Python SDK includes a first-class SIP attach flow via [`OpenAIRealtimeSIPModel`][agents.realtime.openai_realtime.OpenAIRealtimeSIPModel].
 
-Send audio to the session using [`session.send_audio(audio_bytes)`][agents.realtime.session.RealtimeSession.send_audio] or send text using [`session.send_message()`][agents.realtime.session.RealtimeSession.send_message].
-
-For audio output, listen for `audio` events and play the audio data through your preferred audio library. Make sure to listen for `audio_interrupted` events to stop playback immediately and clear any queued audio when the user interrupts the agent.
-
-## Advanced integrations and low-level access
-
-### SIP integration
-
-You can attach realtime agents to phone calls that arrive via the [Realtime Calls API](https://platform.openai.com/docs/guides/realtime-sip). The SDK provides [`OpenAIRealtimeSIPModel`][agents.realtime.openai_realtime.OpenAIRealtimeSIPModel], which reuses the same agent flow while negotiating media over SIP.
-
-To use it, pass the model instance to the runner and supply the SIP `call_id` when starting the session. The call ID is delivered by the webhook that signals an incoming call.
+Use it when a call arrives through the Realtime Calls API and you want to attach an agent session to the resulting `call_id`:
 
 ```python
-from agents.realtime import RealtimeAgent, RealtimeRunner
+from agents.realtime import RealtimeRunner
 from agents.realtime.openai_realtime import OpenAIRealtimeSIPModel
 
-runner = RealtimeRunner(
-    starting_agent=agent,
-    model=OpenAIRealtimeSIPModel(),
-)
+runner = RealtimeRunner(starting_agent=agent, model=OpenAIRealtimeSIPModel())
 
 async with await runner.run(
     model_config={
         "call_id": call_id_from_webhook,
-        "initial_model_settings": {
-            "turn_detection": {"type": "semantic_vad", "interrupt_response": True},
-        },
-    },
+    }
 ) as session:
     async for event in session:
         ...
 ```
 
-When the caller hangs up, the SIP session ends and the realtime connection closes automatically. For a complete telephony example, see [`examples/realtime/twilio_sip`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/twilio_sip).
+If you need to accept the call first and want the accept payload to match the agent-derived session configuration, use `OpenAIRealtimeSIPModel.build_initial_session_payload(...)`. The complete flow is shown in [`examples/realtime/twilio_sip/server.py`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/twilio_sip/server.py).
 
-### Direct model access
+## Low-level access and custom endpoints
 
-You can access the underlying model to add custom listeners or perform advanced operations:
+You can access the underlying transport object through `session.model`.
+
+Use this when you need:
+
+-   custom listeners via `session.model.add_listener(...)`
+-   raw client events such as `response.create` or `session.update`
+-   custom `url`, `headers`, or `api_key` handling through `model_config`
+-   `call_id` attach to an existing realtime call
+
+`RealtimeModelConfig` supports:
+
+-   `api_key`
+-   `url`
+-   `headers`
+-   `initial_model_settings`
+-   `playback_tracker`
+-   `call_id`
+
+This repository's shipped `call_id` example is SIP. The broader Realtime API also uses `call_id` for some server-side control flows, but those are not packaged as Python examples here.
+
+When connecting to Azure OpenAI, pass a GA Realtime endpoint URL and explicit headers. For example:
 
 ```python
-# Add a custom listener to the model
-session.model.add_listener(my_custom_listener)
+session = await runner.run(
+    model_config={
+        "url": "wss://<your-resource>.openai.azure.com/openai/v1/realtime?model=<deployment-name>",
+        "headers": {"api-key": "<your-azure-api-key>"},
+    }
+)
 ```
 
-This gives you direct access to the [`RealtimeModel`][agents.realtime.model.RealtimeModel] interface for advanced use cases where you need lower-level control over the connection.
-
-### Examples and further reading
-
-For complete working examples, check out the [examples/realtime directory](https://github.com/openai/openai-agents-python/tree/main/examples/realtime) which includes demos with and without UI components.
-
-### Azure OpenAI endpoint format
-
-When connecting to Azure OpenAI, use the GA Realtime endpoint format and pass credentials via
-headers in `model_config`:
+For token-based authentication, use a bearer token in `headers`:
 
 ```python
-model_config = {
-    "url": "wss://<your-resource>.openai.azure.com/openai/v1/realtime?model=<deployment-name>",
-    "headers": {"api-key": "<your-azure-api-key>"},
-}
+session = await runner.run(
+    model_config={
+        "url": "wss://<your-resource>.openai.azure.com/openai/v1/realtime?model=<deployment-name>",
+        "headers": {"authorization": f"Bearer {token}"},
+    }
+)
 ```
 
-For token-based auth, use `{"authorization": f"Bearer {token}"}` in `headers`.
+If you pass `headers`, the SDK does not add `Authorization` automatically. Avoid the legacy beta path (`/openai/realtime?api-version=...`) with realtime agents.
+
+## Further reading
+
+-   [Realtime transport](transport.md)
+-   [Quickstart](quickstart.md)
+-   [OpenAI Realtime conversations](https://developers.openai.com/api/docs/guides/realtime-conversations/)
+-   [OpenAI Realtime server-side controls](https://developers.openai.com/api/docs/guides/realtime-server-controls/)
+-   [`examples/realtime`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime)

--- a/docs/realtime/quickstart.md
+++ b/docs/realtime/quickstart.md
@@ -1,9 +1,14 @@
 # Quickstart
 
-Realtime agents enable voice conversations with your AI agents using OpenAI's Realtime API. This guide walks you through creating your first realtime voice agent.
+Realtime agents in the Python SDK are server-side, low-latency agents built on the OpenAI Realtime API over WebSocket transport.
 
 !!! warning "Beta feature"
-Realtime agents are in beta. Expect some breaking changes as we improve the implementation.
+
+    Realtime agents are in beta. Expect some breaking changes as we improve the implementation.
+
+!!! note "Python SDK boundary"
+
+    The Python SDK does **not** provide a browser WebRTC transport. This page only covers Python-managed realtime sessions over server-side WebSockets. Use this SDK for server-side orchestration, tools, approvals, and telephony integrations. See also [Realtime transport](transport.md).
 
 ## Prerequisites
 
@@ -19,25 +24,28 @@ If you haven't already, install the OpenAI Agents SDK:
 pip install openai-agents
 ```
 
-## Creating your first realtime agent
+## Create a server-side realtime session
 
-### 1. Import required components
+### 1. Import the realtime components
 
 ```python
 import asyncio
+
 from agents.realtime import RealtimeAgent, RealtimeRunner
 ```
 
-### 2. Create a realtime agent
+### 2. Define the starting agent
 
 ```python
 agent = RealtimeAgent(
     name="Assistant",
-    instructions="You are a helpful voice assistant. Keep your responses conversational and friendly.",
+    instructions="You are a helpful voice assistant. Keep responses short and conversational.",
 )
 ```
 
-### 3. Set up the runner
+### 3. Configure the runner
+
+Prefer the nested `audio.input` / `audio.output` session settings shape for new code.
 
 ```python
 runner = RealtimeRunner(
@@ -45,224 +53,106 @@ runner = RealtimeRunner(
     config={
         "model_settings": {
             "model_name": "gpt-realtime",
-            "voice": "ash",
-            "modalities": ["audio"],
-            "input_audio_format": "pcm16",
-            "output_audio_format": "pcm16",
-            "input_audio_transcription": {"model": "gpt-4o-mini-transcribe"},
-            "turn_detection": {"type": "semantic_vad", "interrupt_response": True},
+            "audio": {
+                "input": {
+                    "format": "pcm16",
+                    "transcription": {"model": "gpt-4o-mini-transcribe"},
+                    "turn_detection": {
+                        "type": "semantic_vad",
+                        "interrupt_response": True,
+                    },
+                },
+                "output": {
+                    "format": "pcm16",
+                    "voice": "ash",
+                },
+            },
         }
-    }
+    },
 )
 ```
 
-### 4. Start a session
+### 4. Start the session and send input
+
+`runner.run()` returns a `RealtimeSession`. The connection is opened when you enter the session context.
 
 ```python
-# Start the session
-session = await runner.run()
-
-async with session:
-    print("Session started! The agent will stream audio responses in real-time.")
-    # Process events
-    async for event in session:
-        try:
-            if event.type == "agent_start":
-                print(f"Agent started: {event.agent.name}")
-            elif event.type == "agent_end":
-                print(f"Agent ended: {event.agent.name}")
-            elif event.type == "handoff":
-                print(f"Handoff from {event.from_agent.name} to {event.to_agent.name}")
-            elif event.type == "tool_start":
-                print(f"Tool started: {event.tool.name}")
-            elif event.type == "tool_end":
-                print(f"Tool ended: {event.tool.name}; output: {event.output}")
-            elif event.type == "audio_end":
-                print("Audio ended")
-            elif event.type == "audio":
-                # Enqueue audio for callback-based playback with metadata
-                # Non-blocking put; queue is unbounded, so drops won’t occur.
-                pass
-            elif event.type == "audio_interrupted":
-                print("Audio interrupted")
-                # Begin graceful fade + flush in the audio callback and rebuild jitter buffer.
-            elif event.type == "error":
-                print(f"Error: {event.error}")
-            elif event.type == "history_updated":
-                pass  # Skip these frequent events
-            elif event.type == "history_added":
-                pass  # Skip these frequent events
-            elif event.type == "raw_model_event":
-                print(f"Raw model event: {_truncate_str(str(event.data), 200)}")
-            else:
-                print(f"Unknown event type: {event.type}")
-        except Exception as e:
-            print(f"Error processing event: {_truncate_str(str(e), 200)}")
-
-def _truncate_str(s: str, max_length: int) -> str:
-    if len(s) > max_length:
-        return s[:max_length] + "..."
-    return s
-```
-
-## Full example (same flow in one file)
-
-This is the same quickstart flow rewritten as a single script.
-
-```python
-import asyncio
-from agents.realtime import RealtimeAgent, RealtimeRunner
-
-async def main():
-    # Create the agent
-    agent = RealtimeAgent(
-        name="Assistant",
-        instructions="You are a helpful voice assistant. Keep responses brief and conversational.",
-    )
-    # Set up the runner with configuration
-    runner = RealtimeRunner(
-        starting_agent=agent,
-        config={
-            "model_settings": {
-                "model_name": "gpt-realtime",
-                "voice": "ash",
-                "modalities": ["audio"],
-                "input_audio_format": "pcm16",
-                "output_audio_format": "pcm16",
-                "input_audio_transcription": {"model": "gpt-4o-mini-transcribe"},
-                "turn_detection": {"type": "semantic_vad", "interrupt_response": True},
-            }
-        },
-    )
-    # Start the session
+async def main() -> None:
     session = await runner.run()
 
     async with session:
-        print("Session started! The agent will stream audio responses in real-time.")
-        # Process events
-        async for event in session:
-            try:
-                if event.type == "agent_start":
-                    print(f"Agent started: {event.agent.name}")
-                elif event.type == "agent_end":
-                    print(f"Agent ended: {event.agent.name}")
-                elif event.type == "handoff":
-                    print(f"Handoff from {event.from_agent.name} to {event.to_agent.name}")
-                elif event.type == "tool_start":
-                    print(f"Tool started: {event.tool.name}")
-                elif event.type == "tool_end":
-                    print(f"Tool ended: {event.tool.name}; output: {event.output}")
-                elif event.type == "audio_end":
-                    print("Audio ended")
-                elif event.type == "audio":
-                    # Enqueue audio for callback-based playback with metadata
-                    # Non-blocking put; queue is unbounded, so drops won’t occur.
-                    pass
-                elif event.type == "audio_interrupted":
-                    print("Audio interrupted")
-                    # Begin graceful fade + flush in the audio callback and rebuild jitter buffer.
-                elif event.type == "error":
-                    print(f"Error: {event.error}")
-                elif event.type == "history_updated":
-                    pass  # Skip these frequent events
-                elif event.type == "history_added":
-                    pass  # Skip these frequent events
-                elif event.type == "raw_model_event":
-                    print(f"Raw model event: {_truncate_str(str(event.data), 200)}")
-                else:
-                    print(f"Unknown event type: {event.type}")
-            except Exception as e:
-                print(f"Error processing event: {_truncate_str(str(e), 200)}")
+        await session.send_message("Say hello in one short sentence.")
 
-def _truncate_str(s: str, max_length: int) -> str:
-    if len(s) > max_length:
-        return s[:max_length] + "..."
-    return s
+        async for event in session:
+            if event.type == "audio":
+                # Forward or play event.audio.data.
+                pass
+            elif event.type == "history_added":
+                print(event.item)
+            elif event.type == "agent_end":
+                # One assistant turn finished.
+                break
+            elif event.type == "error":
+                print(f"Error: {event.error}")
+
 
 if __name__ == "__main__":
-    # Run the session
     asyncio.run(main())
 ```
 
-## Configuration and deployment notes
+`session.send_message()` accepts either a plain string or a structured realtime message. For raw audio chunks, use [`session.send_audio()`][agents.realtime.session.RealtimeSession.send_audio].
 
-Use these options after you have a basic session running.
+## What this quickstart does not include
 
-### Model settings
+-   Microphone capture and speaker playback code. See the realtime examples in [`examples/realtime`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime).
+-   SIP / telephony attach flows. See [Realtime transport](transport.md) and the [SIP section](guide.md#sip-and-telephony).
 
--   `model_name`: Choose from available realtime models (e.g., `gpt-realtime`)
--   `voice`: Select voice (`alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`)
--   `modalities`: Enable text or audio (`["text"]` or `["audio"]`)
--   `output_modalities`: Optionally constrain output to text and/or audio (`["text"]`, `["audio"]`, or both)
+## Key settings
 
-### Audio settings
+Once the basic session works, the settings most people reach for next are:
 
--   `input_audio_format`: Format for input audio (`pcm16`, `g711_ulaw`, `g711_alaw`)
--   `output_audio_format`: Format for output audio
--   `input_audio_transcription`: Transcription configuration
--   `input_audio_noise_reduction`: Input noise-reduction config (`near_field` or `far_field`)
+-   `model_name`
+-   `audio.input.format`, `audio.output.format`
+-   `audio.input.transcription`
+-   `audio.input.noise_reduction`
+-   `audio.input.turn_detection` for automatic turn detection
+-   `audio.output.voice`
+-   `tool_choice`, `prompt`, `tracing`
+-   `async_tool_calls`, `guardrails_settings.debounce_text_length`, `tool_error_formatter`
 
-### Turn detection
+The older flat aliases such as `input_audio_format`, `output_audio_format`, `input_audio_transcription`, and `turn_detection` still work, but nested `audio` settings are preferred for new code.
 
--   `type`: Detection method (`server_vad`, `semantic_vad`)
--   `threshold`: Voice activity threshold (0.0-1.0)
--   `silence_duration_ms`: Silence duration to detect turn end
--   `prefix_padding_ms`: Audio padding before speech
+For manual turn control, use a raw `session.update` / `input_audio_buffer.commit` / `response.create` flow as described in the [Realtime agents guide](guide.md#manual-response-control).
 
-### Run settings
+For the full schema, see [`RealtimeRunConfig`][agents.realtime.config.RealtimeRunConfig] and [`RealtimeSessionModelSettings`][agents.realtime.config.RealtimeSessionModelSettings].
 
--   `async_tool_calls`: Whether function tools run asynchronously (defaults to `True`)
--   `guardrails_settings.debounce_text_length`: Minimum accumulated transcript size before output guardrails run (defaults to `100`)
--   `tool_error_formatter`: Callback to customize model-visible tool error messages
+## Connection options
 
-For the full schema, see the API reference for [`RealtimeRunConfig`][agents.realtime.config.RealtimeRunConfig] and [`RealtimeSessionModelSettings`][agents.realtime.config.RealtimeSessionModelSettings].
-
-### Authentication
-
-Make sure your OpenAI API key is set in your environment:
+Set your API key in the environment:
 
 ```bash
 export OPENAI_API_KEY="your-api-key-here"
 ```
 
-Or pass it directly when creating the session:
+Or pass it directly when starting the session:
 
 ```python
 session = await runner.run(model_config={"api_key": "your-api-key"})
 ```
 
-### Azure OpenAI endpoint format
+`model_config` also supports:
 
-If you connect to Azure OpenAI instead of OpenAI's default endpoint, pass a GA Realtime URL in
-`model_config["url"]` and set auth headers explicitly.
+-   `url`: Custom WebSocket endpoint
+-   `headers`: Custom request headers
+-   `call_id`: Attach to an existing realtime call. In this repo, the documented attach flow is SIP.
+-   `playback_tracker`: Report how much audio the user has actually heard
 
-```python
-session = await runner.run(
-    model_config={
-        "url": "wss://<your-resource>.openai.azure.com/openai/v1/realtime?model=<deployment-name>",
-        "headers": {"api-key": "<your-azure-api-key>"},
-    }
-)
-```
+If you pass `headers` explicitly, the SDK will **not** inject an `Authorization` header for you.
 
-You can also use a bearer token:
-
-```python
-session = await runner.run(
-    model_config={
-        "url": "wss://<your-resource>.openai.azure.com/openai/v1/realtime?model=<deployment-name>",
-        "headers": {"authorization": f"Bearer {token}"},
-    }
-)
-```
-
-Avoid using the legacy beta path (`/openai/realtime?api-version=...`) with realtime agents. The
-SDK expects the GA Realtime interface.
+When connecting to Azure OpenAI, pass a GA Realtime endpoint URL in `model_config["url"]` and explicit headers. Avoid the legacy beta path (`/openai/realtime?api-version=...`) with realtime agents. See the [Realtime agents guide](guide.md#low-level-access-and-custom-endpoints) for details.
 
 ## Next steps
 
--   [Learn more about realtime agents](guide.md)
--   Check out working examples in the [examples/realtime](https://github.com/openai/openai-agents-python/tree/main/examples/realtime) folder
--   Add tools to your agent
--   Implement handoffs between agents
--   Set up guardrails for safety
+-   Read [Realtime transport](transport.md) to choose between server-side WebSocket and SIP.
+-   Read the [Realtime agents guide](guide.md) for lifecycle, structured input, approvals, handoffs, guardrails, and low-level control.
+-   Browse the examples in [`examples/realtime`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime).

--- a/docs/realtime/transport.md
+++ b/docs/realtime/transport.md
@@ -1,0 +1,72 @@
+# Realtime transport
+
+Use this page to decide how realtime agents fit into your Python application.
+
+!!! note "Python SDK boundary"
+
+    The Python SDK does **not** include a browser WebRTC transport. This page is only about Python SDK transport choices: server-side WebSockets and SIP attach flows. Browser WebRTC is a separate platform topic, documented in the official [Realtime API with WebRTC](https://developers.openai.com/api/docs/guides/realtime-webrtc/) guide.
+
+## Decision guide
+
+| Goal | Start with | Why |
+| --- | --- | --- |
+| Build a server-managed realtime app | [Quickstart](quickstart.md) | The default Python path is a server-side WebSocket session managed by `RealtimeRunner`. |
+| Understand which transport and deployment shape to choose | This page | Use this before you commit to a transport or deployment shape. |
+| Attach agents to phone or SIP calls | [Realtime guide](guide.md) and [`examples/realtime/twilio_sip`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/twilio_sip) | The repo ships a SIP attach flow driven by `call_id`. |
+
+## Server-side WebSocket is the default Python path
+
+`RealtimeRunner` uses `OpenAIRealtimeWebSocketModel` unless you pass a custom `RealtimeModel`.
+
+That means the standard Python topology looks like this:
+
+1. Your Python service creates a `RealtimeRunner`.
+2. `await runner.run()` returns a `RealtimeSession`.
+3. Enter the session and send text, structured messages, or audio.
+4. Consume `RealtimeSessionEvent` items and forward audio or transcripts to your application.
+
+This is the topology used by the core demo app, the CLI example, and the Twilio Media Streams example:
+
+-   [`examples/realtime/app`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/app)
+-   [`examples/realtime/cli`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/cli)
+-   [`examples/realtime/twilio`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/twilio)
+
+Use this path when your server owns the audio pipeline, tool execution, approval flow, and history handling.
+
+## SIP attach is the telephony path
+
+For the telephony flow documented in this repository, the Python SDK attaches to an existing realtime call via `call_id`.
+
+This topology looks like:
+
+1. OpenAI sends your service a webhook such as `realtime.call.incoming`.
+2. Your service accepts the call through the Realtime Calls API.
+3. Your Python service starts a `RealtimeRunner(..., model=OpenAIRealtimeSIPModel())`.
+4. The session connects with `model_config={"call_id": ...}` and then processes events like any other realtime session.
+
+This is the topology shown in [`examples/realtime/twilio_sip`](https://github.com/openai/openai-agents-python/tree/main/examples/realtime/twilio_sip).
+
+The broader Realtime API also uses `call_id` for some server-side control patterns, but this repository's shipped attach example is SIP.
+
+## Browser WebRTC is outside this SDK
+
+If your app's primary client is a browser using Realtime WebRTC:
+
+-   Treat it as outside the scope of the Python SDK docs in this repository.
+-   Use the official [Realtime API with WebRTC](https://developers.openai.com/api/docs/guides/realtime-webrtc/) and [Realtime conversations](https://developers.openai.com/api/docs/guides/realtime-conversations/) docs for the client-side flow and event model.
+-   Use the official [Realtime server-side controls](https://developers.openai.com/api/docs/guides/realtime-server-controls/) guide if you need a sideband server connection on top of a browser WebRTC client.
+-   Do not expect this repository to provide a browser-side `RTCPeerConnection` abstraction or a ready-made browser WebRTC sample.
+
+This repository also does not currently ship a browser WebRTC plus Python sideband example.
+
+## Custom endpoints and attach points
+
+The transport configuration surface in [`RealtimeModelConfig`][agents.realtime.model.RealtimeModelConfig] lets you adapt the default paths:
+
+-   `url`: Override the WebSocket endpoint
+-   `headers`: Provide explicit headers such as Azure auth headers
+-   `api_key`: Pass an API key directly or via callback
+-   `call_id`: Attach to an existing realtime call. In this repository, the documented example is SIP.
+-   `playback_tracker`: Report actual playback progress for interruption handling
+
+See the [Realtime agents guide](guide.md) for the detailed lifecycle and capability surface once you've chosen a topology.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ plugins:
                 - tracing.md
                 - Realtime agents:
                     - realtime/quickstart.md
+                    - realtime/transport.md
                     - realtime/guide.md
                 - Voice agents:
                     - voice/quickstart.md

--- a/src/agents/realtime/model.py
+++ b/src/agents/realtime/model.py
@@ -143,7 +143,8 @@ class RealtimeModelConfig(TypedDict):
     """Attach to an existing realtime call instead of creating a new session.
 
     When provided, the transport connects using the `call_id` query string parameter rather than a
-    model name. This is used for SIP-originated calls that are accepted via the Realtime Calls API.
+    model name. In this repository, the shipped example for this flow is SIP via the Realtime
+    Calls API.
     """
 
 


### PR DESCRIPTION
This pull request updates the realtime docs to separate transport selection from the deeper guide, clarify that the Python SDK covers server-side WebSocket and SIP attach flows rather than browser WebRTC, and tighten the call_id guidance to match the shipped SIP example. The main edits are in docs/realtime/transport.md, docs/realtime/quickstart.md, docs/realtime/guide.md, mkdocs.yml, and src/agents/realtime/model.py, with supporting link updates in docs/index.md, docs/examples.md, docs/human_in_the_loop.md, docs/llms.txt, and docs/llms-full.txt