### PR TITLE
docs: clarify agent runtime, handoff, HITL, and results flows

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,18 +1,43 @@
 # Agents
 
-Agents are the core building block in your apps. An agent is a large language model (LLM), configured with instructions and tools.
+Agents are the core building block in your apps. An agent is a large language model (LLM) configured with instructions, tools, and optional runtime behavior such as handoffs, guardrails, and structured outputs.
+
+Use this page when you want to define or customize a single agent. If you are deciding how multiple agents should collaborate, read [Agent orchestration](multi_agent.md).
+
+## Choose the next guide
+
+Use this page as the hub for agent definition. Jump to the adjacent guide that matches the next decision you need to make.
+
+| If you want to... | Read next |
+| --- | --- |
+| Choose a model or provider setup | [Models](models/index.md) |
+| Add capabilities to the agent | [Tools](tools.md) |
+| Decide between manager-style orchestration and handoffs | [Agent orchestration](multi_agent.md) |
+| Configure handoff behavior | [Handoffs](handoffs.md) |
+| Run turns, stream events, or manage conversation state | [Running agents](running_agents.md) |
+| Inspect final output, run items, or resumable state | [Results](results.md) |
+| Share local dependencies and runtime state | [Context management](context.md) |
 
 ## Basic configuration
 
-The most common properties of an agent you'll configure are:
+The most common properties of an agent are:
 
--   `name`: A required string that identifies your agent.
--   `instructions`: also known as a developer message or system prompt.
--   `model`: which LLM to use, and optional `model_settings` to configure model tuning parameters like temperature, top_p, etc.
--   `prompt`: Reference a prompt template by id (and variables) when using OpenAI's Responses API.
--   `tools`: Tools that the agent can use to achieve its tasks.
--   `mcp_servers`: MCP servers that provide tools to the agent. See the [MCP guide](mcp.md).
--   `reset_tool_choice`: Whether to reset `tool_choice` after a tool call (default: `True`) to avoid tool-use loops. See [Forcing tool use](#forcing-tool-use).
+| Property | Required | Description |
+| --- | --- | --- |
+| `name` | yes | Human-readable agent name. |
+| `instructions` | yes | System prompt or dynamic instructions callback. See [Dynamic instructions](#dynamic-instructions). |
+| `prompt` | no | OpenAI Responses API prompt configuration. Accepts a static prompt object or a function. See [Prompt templates](#prompt-templates). |
+| `handoff_description` | no | Short description exposed when this agent is offered as a handoff target. |
+| `handoffs` | no | Delegate the conversation to specialist agents. See [handoffs](handoffs.md). |
+| `model` | no | Which LLM to use. See [Models](models/index.md). |
+| `model_settings` | no | Model tuning parameters such as `temperature`, `top_p`, and `tool_choice`. |
+| `tools` | no | Tools the agent can call. See [Tools](tools.md). |
+| `mcp_servers` | no | MCP-backed tools for the agent. See the [MCP guide](mcp.md). |
+| `input_guardrails` | no | Guardrails that run on the first user input for this agent chain. See [Guardrails](guardrails.md). |
+| `output_guardrails` | no | Guardrails that run on the final output for this agent. See [Guardrails](guardrails.md). |
+| `output_type` | no | Structured output type instead of plain text. See [Output types](#output-types). |
+| `tool_use_behavior` | no | Control whether tool results loop back to the model or end the run. See [Tool use behavior](#tool-use-behavior). |
+| `reset_tool_choice` | no | Reset `tool_choice` after a tool call (default: `True`) to avoid tool-use loops. See [Forcing tool use](#forcing-tool-use). |
 
 ```python
 from agents import Agent, ModelSettings, function_tool
@@ -92,6 +117,8 @@ result = await Runner.run(
 ## Context
 
 Agents are generic on their `context` type. Context is a dependency-injection tool: it's an object you create and pass to `Runner.run()`, that is passed to every agent, tool, handoff etc, and it serves as a grab bag of dependencies and state for the agent run. You can provide any Python object as the context.
+
+Read the [context guide](context.md) for the full `RunContextWrapper` surface, shared usage tracking, nested `tool_input`, and serialization caveats.
 
 ```python
 @dataclass

--- a/docs/context.md
+++ b/docs/context.md
@@ -25,6 +25,23 @@ You can use the context for things like:
 
     The context object is **not** sent to the LLM. It is purely a local object that you can read from, write to and call methods on it.
 
+Within a single run, derived wrappers share the same underlying app context, approval state, and usage tracking. Nested [`Agent.as_tool()`][agents.agent.Agent.as_tool] runs may attach a different `tool_input`, but they do not get an isolated copy of your app state by default.
+
+### What `RunContextWrapper` exposes
+
+[`RunContextWrapper`][agents.run_context.RunContextWrapper] is a wrapper around your app-defined context object. In practice you will most often use:
+
+-   [`wrapper.context`][agents.run_context.RunContextWrapper.context] for your own mutable app state and dependencies.
+-   [`wrapper.usage`][agents.run_context.RunContextWrapper.usage] for aggregated request and token usage across the current run.
+-   [`wrapper.tool_input`][agents.run_context.RunContextWrapper.tool_input] for structured input when the current run is executing inside [`Agent.as_tool()`][agents.agent.Agent.as_tool].
+-   [`wrapper.approve_tool(...)`][agents.run_context.RunContextWrapper.approve_tool] / [`wrapper.reject_tool(...)`][agents.run_context.RunContextWrapper.reject_tool] when you need to update approval state programmatically.
+
+Only `wrapper.context` is your app-defined object. The other fields are runtime metadata managed by the SDK.
+
+If you later serialize a [`RunState`][agents.run_state.RunState] for human-in-the-loop or durable job workflows, that runtime metadata is saved with the state. Avoid putting secrets in [`RunContextWrapper.context`][agents.run_context.RunContextWrapper.context] if you intend to persist or transmit serialized state.
+
+Conversation state is a separate concern. Use `result.to_input_list()`, `session`, `conversation_id`, or `previous_response_id` depending on how you want to carry turns forward. See [results](results.md), [running agents](running_agents.md), and [sessions](sessions/index.md) for that decision.
+
 ```python
 import asyncio
 from dataclasses import dataclass
@@ -109,7 +126,7 @@ plus additional fields specific to the current tool call:
 - `tool_arguments` – the raw argument string passed to the tool  
 
 Use `ToolContext` when you need tool-level metadata during execution.  
-For general context sharing between agents and tools, `RunContextWrapper` remains sufficient.
+For general context sharing between agents and tools, `RunContextWrapper` remains sufficient. Because `ToolContext` extends `RunContextWrapper`, it can also expose `.tool_input` when a nested `Agent.as_tool()` run supplied structured input.
 
 ---
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -7,6 +7,16 @@ There are two kinds of guardrails:
 1. Input guardrails run on the initial user input
 2. Output guardrails run on the final agent output
 
+## Workflow boundaries
+
+Guardrails are attached to agents and tools, but they do not all run at the same points in a workflow:
+
+-   **Input guardrails** run only for the first agent in the chain.
+-   **Output guardrails** run only for the agent that produces the final output.
+-   **Tool guardrails** run on every custom function-tool invocation, with input guardrails before execution and output guardrails after execution.
+
+If you need checks around each custom function-tool call in a workflow that includes managers, handoffs, or delegated specialists, use tool guardrails instead of relying only on agent-level input/output guardrails.
+
 ## Input guardrails
 
 Input guardrails run in 3 steps:
@@ -47,7 +57,7 @@ Tool guardrails wrap **function tools** and let you validate or block tool calls
 
 - Input tool guardrails run before the tool executes and can skip the call, replace the output with a message, or raise a tripwire.
 - Output tool guardrails run after the tool executes and can replace the output or raise a tripwire.
-- Tool guardrails apply only to function tools created with [`function_tool`][agents.function_tool]; hosted tools (`WebSearchTool`, `FileSearchTool`, `HostedMCPTool`, `CodeInterpreterTool`, `ImageGenerationTool`) and built-in execution tools (`ComputerTool`, `ShellTool`, `ApplyPatchTool`, `LocalShellTool`) do not use this guardrail pipeline.
+- Tool guardrails apply only to function tools created with [`function_tool`][agents.tool.function_tool]. Handoffs run through the SDK's handoff pipeline rather than the normal function-tool pipeline, so tool guardrails do not apply to the handoff call itself. Hosted tools (`WebSearchTool`, `FileSearchTool`, `HostedMCPTool`, `CodeInterpreterTool`, `ImageGenerationTool`) and built-in execution tools (`ComputerTool`, `ShellTool`, `ApplyPatchTool`, `LocalShellTool`) also do not use this guardrail pipeline, and [`Agent.as_tool()`][agents.agent.Agent.as_tool] does not currently expose tool-guardrail options directly.
 
 See the code snippet below for details.
 

--- a/docs/handoffs.md
+++ b/docs/handoffs.md
@@ -36,10 +36,12 @@ The [`handoff()`][agents.handoffs.handoff] function lets you customize things.
 -   `tool_name_override`: By default, the `Handoff.default_tool_name()` function is used, which resolves to `transfer_to_<agent_name>`. You can override this.
 -   `tool_description_override`: Override the default tool description from `Handoff.default_tool_description()`
 -   `on_handoff`: A callback function executed when the handoff is invoked. This is useful for things like kicking off some data fetching as soon as you know a handoff is being invoked. This function receives the agent context, and can optionally also receive LLM generated input. The input data is controlled by the `input_type` param.
--   `input_type`: The type of input expected by the handoff (optional).
+-   `input_type`: The schema for the handoff tool-call arguments. When set, the parsed payload is passed to `on_handoff`.
 -   `input_filter`: This lets you filter the input received by the next agent. See below for more.
 -   `is_enabled`: Whether the handoff is enabled. This can be a boolean or a function that returns a boolean, allowing you to dynamically enable or disable the handoff at runtime.
 -   `nest_handoff_history`: Optional per-call override for the RunConfig-level `nest_handoff_history` setting. If `None`, the value defined in the active run configuration is used instead.
+
+The [`handoff()`][agents.handoffs.handoff] helper always transfers control to the specific `agent` you passed in. If you have multiple possible destinations, register one handoff per destination and let the model choose among them. Use a custom [`Handoff`][agents.handoffs.Handoff] only when your own handoff code must decide which agent to return at invocation time.
 
 ```python
 from agents import Agent, handoff, RunContextWrapper
@@ -81,11 +83,42 @@ handoff_obj = handoff(
 )
 ```
 
+`input_type` describes the arguments for the handoff tool call itself. The SDK exposes that schema to the model as the handoff tool's `parameters`, validates the returned JSON locally, and passes the parsed value to `on_handoff`.
+
+It does not replace the next agent's main input, and it does not choose a different destination. The [`handoff()`][agents.handoffs.handoff] helper still transfers to the specific agent you wrapped, and the receiving agent still sees the conversation history unless you change it with an [`input_filter`][agents.handoffs.Handoff.input_filter] or nested handoff history settings.
+
+`input_type` is also separate from [`RunContextWrapper.context`][agents.run_context.RunContextWrapper.context]. Use `input_type` for metadata the model decides at handoff time, not for application state or dependencies you already have locally.
+
+### When to use `input_type`
+
+Use `input_type` when the handoff needs a small piece of model-generated metadata such as `reason`, `language`, `priority`, or `summary`. For example, a triage agent can hand off to a refund agent with `{ "reason": "duplicate_charge", "priority": "high" }`, and `on_handoff` can log or persist that metadata before the refund agent takes over.
+
+Choose a different mechanism when the goal is different:
+
+-   Put existing application state and dependencies in [`RunContextWrapper.context`][agents.run_context.RunContextWrapper.context]. See the [context guide](context.md).
+-   Use [`input_filter`][agents.handoffs.Handoff.input_filter], [`RunConfig.nest_handoff_history`][agents.run.RunConfig.nest_handoff_history], or [`RunConfig.handoff_history_mapper`][agents.run.RunConfig.handoff_history_mapper] if you want to change what history the receiving agent sees.
+-   Register one handoff per destination if there are multiple possible specialists. `input_type` can add metadata to the chosen handoff, but it does not dispatch between destinations.
+-   If you want structured input for a nested specialist without transferring the conversation, prefer [`Agent.as_tool(parameters=...)`][agents.agent.Agent.as_tool]. See [tools](tools.md#structured-input-for-tool-agents).
+
 ## Input filters
 
 When a handoff occurs, it's as though the new agent takes over the conversation, and gets to see the entire previous conversation history. If you want to change this, you can set an [`input_filter`][agents.handoffs.Handoff.input_filter]. An input filter is a function that receives the existing input via a [`HandoffInputData`][agents.handoffs.HandoffInputData], and must return a new `HandoffInputData`.
 
+[`HandoffInputData`][agents.handoffs.HandoffInputData] includes:
+
+-   `input_history`: the input history before `Runner.run(...)` started.
+-   `pre_handoff_items`: items generated before the agent turn where the handoff was invoked.
+-   `new_items`: items generated during the current turn, including the handoff call and handoff output items.
+-   `input_items`: optional items to forward to the next agent instead of `new_items`, allowing you to filter model input while keeping `new_items` intact for session history.
+-   `run_context`: the active [`RunContextWrapper`][agents.run_context.RunContextWrapper] at the time the handoff was invoked.
+
 Nested handoffs are available as an opt-in beta and are disabled by default while we stabilize them. When you enable [`RunConfig.nest_handoff_history`][agents.run.RunConfig.nest_handoff_history], the runner collapses the prior transcript into a single assistant summary message and wraps it in a `<CONVERSATION HISTORY>` block that keeps appending new turns when multiple handoffs happen during the same run. You can provide your own mapping function via [`RunConfig.handoff_history_mapper`][agents.run.RunConfig.handoff_history_mapper] to replace the generated message without writing a full `input_filter`. The opt-in only applies when neither the handoff nor the run supplies an explicit `input_filter`, so existing code that already customizes the payload (including the examples in this repository) keeps its current behavior without changes. You can override the nesting behaviour for a single handoff by passing `nest_handoff_history=True` or `False` to [`handoff(...)`][agents.handoffs.handoff], which sets [`Handoff.nest_handoff_history`][agents.handoffs.Handoff.nest_handoff_history]. If you just need to change the wrapper text for the generated summary, call [`set_conversation_history_wrappers`][agents.handoffs.set_conversation_history_wrappers] (and optionally [`reset_conversation_history_wrappers`][agents.handoffs.reset_conversation_history_wrappers]) before running your agents.
+
+If both the handoff and the active [`RunConfig.handoff_input_filter`][agents.run.RunConfig.handoff_input_filter] define a filter, the per-handoff [`input_filter`][agents.handoffs.Handoff.input_filter] takes precedence for that specific handoff.
+
+!!! note
+
+    Handoffs stay within a single run. Input guardrails still apply only to the first agent in the chain, and output guardrails only to the agent that produces the final output. Use tool guardrails when you need checks around each custom function-tool call inside the workflow.
 
 There are some common patterns (for example removing all tool calls from the history), which are implemented for you in [`agents.extensions.handoff_filters`][]
 

--- a/docs/human_in_the_loop.md
+++ b/docs/human_in_the_loop.md
@@ -2,6 +2,12 @@
 
 Use the human-in-the-loop (HITL) flow to pause agent execution until a person approves or rejects sensitive tool calls. Tools declare when they need approval, run results surface pending approvals as interruptions, and `RunState` lets you serialize and resume runs after decisions are made.
 
+That approval surface is run-wide, not limited to the current top-level agent. The same pattern applies when the tool belongs to the current agent, to an agent reached through a handoff, or to a nested [`Agent.as_tool()`][agents.agent.Agent.as_tool] execution. In the nested `Agent.as_tool()` case, the interruption still surfaces on the outer run, so you approve or reject it on the outer `RunState` and resume the original top-level run.
+
+With `Agent.as_tool()`, approvals can happen at two different layers: the agent tool itself can require approval via `Agent.as_tool(..., needs_approval=...)`, and tools inside the nested agent can later raise their own approvals after the nested run starts. Both are handled through the same outer-run interruption flow.
+
+This page focuses on the manual approval flow via `interruptions`. If your app can decide in code, some tool types also support programmatic approval callbacks so the run can continue without pausing.
+
 ## Marking tools that need approval
 
 Set `needs_approval` to `True` to always require approval or provide an async function that decides per call. The callable receives the run context, parsed tool parameters, and the tool call ID.
@@ -35,11 +41,31 @@ agent = Agent(
 
 ## How the approval flow works
 
-1. When the model emits a tool call, the runner evaluates `needs_approval`.
-2. If an approval decision for that tool call is already stored in the [`RunContextWrapper`][agents.run_context.RunContextWrapper] (for example, from `always_approve=True`), the runner proceeds without prompting. Per-call approvals are scoped to the specific call ID; use `always_approve=True` to allow future calls automatically.
-3. Otherwise, execution pauses and `RunResult.interruptions` (or `RunResultStreaming.interruptions`) contains `ToolApprovalItem` entries with details such as `agent.name`, `name`, and `arguments`.
-4. Convert the result to a `RunState` with `result.to_state()`, call `state.approve(...)` or `state.reject(...)` (optionally passing `always_approve` or `always_reject`), and then resume with `Runner.run(agent, state)` or `Runner.run_streamed(agent, state)`.
+1. When the model emits a tool call, the runner evaluates its approval rule (`needs_approval`, `require_approval`, or the hosted MCP equivalent).
+2. If an approval decision for that tool call is already stored in the [`RunContextWrapper`][agents.run_context.RunContextWrapper], the runner proceeds without prompting. Per-call approvals are scoped to the specific call ID; pass `always_approve=True` or `always_reject=True` to persist the same decision for future calls to that tool during the rest of the run.
+3. Otherwise, execution pauses and `RunResult.interruptions` (or `RunResultStreaming.interruptions`) contains [`ToolApprovalItem`][agents.items.ToolApprovalItem] entries with details such as `agent.name`, `tool_name`, and `arguments`. This includes approvals raised after a handoff or inside nested `Agent.as_tool()` executions.
+4. Convert the result to a `RunState` with `result.to_state()`, call `state.approve(...)` or `state.reject(...)`, and then resume with `Runner.run(agent, state)` or `Runner.run_streamed(agent, state)`, where `agent` is the original top-level agent for the run.
 5. The resumed run continues where it left off and will re-enter this flow if new approvals are needed.
+
+Sticky decisions created with `always_approve=True` or `always_reject=True` are stored in the run state, so they survive `state.to_string()` / `RunState.from_string(...)` and `state.to_json()` / `RunState.from_json(...)` when you resume the same paused run later.
+
+You do not need to resolve every pending approval in the same pass. `interruptions` can contain a mix of regular function tools, hosted MCP approvals, and nested `Agent.as_tool()` approvals. If you rerun after approving or rejecting only some items, those resolved calls can continue while unresolved ones remain in `interruptions` and pause the run again.
+
+## Automatic approval decisions
+
+Manual `interruptions` are the most general pattern, but they are not the only one:
+
+-   Local [`ShellTool`][agents.tool.ShellTool] and [`ApplyPatchTool`][agents.tool.ApplyPatchTool] can use `on_approval` to approve or reject immediately in code.
+-   [`HostedMCPTool`][agents.tool.HostedMCPTool] can use `tool_config={"require_approval": "always"}` together with `on_approval_request` for the same kind of programmatic decision.
+-   Plain [`function_tool`][agents.tool.function_tool] tools and [`Agent.as_tool()`][agents.agent.Agent.as_tool] use the manual interruption flow on this page.
+
+When these callbacks return a decision, the run continues without pausing for a human response. For Realtime and voice session APIs, see the approval flow in the [Realtime guide](realtime/guide.md).
+
+## Streaming and sessions
+
+The same interruption flow works in streaming runs. After a streamed run pauses, keep consuming [`RunResultStreaming.stream_events()`][agents.result.RunResultStreaming.stream_events] until the iterator finishes, inspect [`RunResultStreaming.interruptions`][agents.result.RunResultStreaming.interruptions], resolve them, and resume with [`Runner.run_streamed(...)`][agents.run.Runner.run_streamed] if you want the resumed output to keep streaming. See [Streaming](streaming.md) for the streamed version of this pattern.
+
+If you are also using a session, keep passing the same session instance when you resume from `RunState`, or pass another session object that points at the same backing store. The resumed turn is then appended to the same stored conversation history. See [Sessions](sessions/index.md) for the session lifecycle details.
 
 ## Example: pause, approve, resume
 
@@ -114,8 +140,8 @@ To stream output while waiting for approvals, call `Runner.run_streamed`, consum
 ## Repository patterns and examples
 
 - **Streaming approvals**: `examples/agent_patterns/human_in_the_loop_stream.py` shows how to drain `stream_events()` and then approve pending tool calls before resuming with `Runner.run_streamed(agent, state)`.
-- **Agent as tool approvals**: `Agent.as_tool(..., needs_approval=...)` applies the same interruption flow when delegated agent tasks need review.
-- **Shell and apply_patch tools**: `ShellTool` and `ApplyPatchTool` also support `needs_approval`. Use `state.approve(interruption, always_approve=True)` or `state.reject(..., always_reject=True)` to cache the decision for future calls. For automatic decisions, provide `on_approval` (see `examples/tools/shell.py`); for manual decisions, handle interruptions (see `examples/tools/shell_human_in_the_loop.py`).
+- **Agent as tool approvals**: `Agent.as_tool(..., needs_approval=...)` applies the same interruption flow when delegated agent tasks need review. Nested interruptions still surface on the outer run, so resume the original top-level agent rather than the nested one.
+- **Local shell and apply_patch tools**: `ShellTool` and `ApplyPatchTool` also support `needs_approval`. Use `state.approve(interruption, always_approve=True)` or `state.reject(..., always_reject=True)` to cache the decision for future calls. For automatic decisions, provide `on_approval` (see `examples/tools/shell.py`); for manual decisions, handle interruptions (see `examples/tools/shell_human_in_the_loop.py`). Hosted shell environments do not support `needs_approval` or `on_approval`; see the [tools guide](tools.md).
 - **Local MCP servers**: Use `require_approval` on `MCPServerStdio` / `MCPServerSse` / `MCPServerStreamableHttp` to gate MCP tool calls (see `examples/mcp/get_all_mcp_tools_example/main.py` and `examples/mcp/tool_filter_example/main.py`).
 - **Hosted MCP servers**: Set `require_approval` to `"always"` on `HostedMCPTool` to force HITL, optionally providing `on_approval_request` to auto-approve or reject (see `examples/hosted_mcp/human_in_the_loop.py` and `examples/hosted_mcp/on_approval.py`). Use `"never"` for trusted servers (`examples/hosted_mcp/simple.py`).
 - **Sessions and memory**: Pass a session to `Runner.run` so approvals and conversation history survive multiple turns. SQLite and OpenAI Conversations session variants are in `examples/memory/memory_session_hitl_example.py` and `examples/memory/openai_session_hitl_example.py`.
@@ -128,6 +154,7 @@ To stream output while waiting for approvals, call `Runner.run_streamed`, consum
 Useful serialization options:
 
 -   `context_serializer`: Customize how non-mapping context objects are serialized.
+-   `context_deserializer`: Rebuild non-mapping context objects when loading state with `RunState.from_json(...)` or `RunState.from_string(...)`.
 -   `strict_context=True`: Fail serialization or deserialization unless the context is already a
     mapping or you provide the appropriate serializer/deserializer.
 -   `context_override`: Replace the serialized context when loading state. This is useful when you
@@ -136,8 +163,11 @@ Useful serialization options:
 -   `include_tracing_api_key=True`: Include the tracing API key in the serialized trace payload
     when you need resumed work to keep exporting traces with the same credentials.
 
-`RunState` also preserves trace metadata and server-managed conversation settings, so a resumed run
-can continue the same trace and the same `conversation_id` / `previous_response_id` chain.
+Serialized run state includes your app context plus SDK-managed runtime metadata such as approvals,
+usage, serialized `tool_input`, nested agent-as-tool resumptions, trace metadata, and server-managed
+conversation settings. If you plan to store or transmit serialized state, treat
+`RunContextWrapper.context` as persisted data and avoid placing secrets there unless you
+intentionally want them to travel with the state.
 
 ## Versioning pending tasks
 

--- a/docs/results.md
+++ b/docs/results.md
@@ -1,102 +1,87 @@
 # Results
 
-When you call the `Runner.run` methods, you either get a:
+When you call the `Runner.run` methods, you receive one of two result types:
 
--   [`RunResult`][agents.result.RunResult] if you call `run` or `run_sync`
--   [`RunResultStreaming`][agents.result.RunResultStreaming] if you call `run_streamed`
+-   [`RunResult`][agents.result.RunResult] from `Runner.run(...)` or `Runner.run_sync(...)`
+-   [`RunResultStreaming`][agents.result.RunResultStreaming] from `Runner.run_streamed(...)`
 
-Both of these inherit from [`RunResultBase`][agents.result.RunResultBase], which is where most useful information is present.
+Both inherit from [`RunResultBase`][agents.result.RunResultBase], which exposes the shared result surfaces such as `final_output`, `new_items`, `last_agent`, `raw_responses`, and `to_state()`.
 
-## Which result property should I use?
+`RunResultStreaming` adds streaming-specific controls such as [`stream_events()`][agents.result.RunResultStreaming.stream_events], [`current_agent`][agents.result.RunResultStreaming.current_agent], [`is_complete`][agents.result.RunResultStreaming.is_complete], and [`cancel(...)`][agents.result.RunResultStreaming.cancel].
+
+## Choose the right result surface
 
 Most applications only need a few result properties or helpers:
 
-| Property or helper | Use it when you need... |
+| If you need... | Use |
 | --- | --- |
-| `final_output` | The final answer to show the user. |
-| `to_input_list()` | A full next-turn input list when you are manually carrying conversation history yourself. |
-| `new_items` | Rich run items with agent, tool, and handoff metadata for logs, UIs, or audits. |
-| `last_agent` | The agent that should usually handle the next turn. |
-| `last_response_id` | Continuation with `previous_response_id` on the next OpenAI Responses turn. |
-| `agent_tool_invocation` | Metadata about the outer tool call when this result came from `Agent.as_tool()`. |
-| `interruptions` | Pending tool approvals you must resolve before resuming. |
-| `to_state()` | A serializable snapshot for pause/resume or durable job workflows. |
+| The final answer to show the user | `final_output` |
+| A replay-ready next-turn input list with the full local transcript | `to_input_list()` |
+| Rich run items with agent, tool, handoff, and approval metadata | `new_items` |
+| The agent that should usually handle the next user turn | `last_agent` |
+| OpenAI Responses API chaining with `previous_response_id` | `last_response_id` |
+| Pending approvals and a resumable snapshot | `interruptions` and `to_state()` |
+| Metadata about the current nested `Agent.as_tool()` invocation | `agent_tool_invocation` |
+| Raw model calls or guardrail diagnostics | `raw_responses` and the guardrail result arrays |
 
 ## Final output
 
 The [`final_output`][agents.result.RunResultBase.final_output] property contains the final output of the last agent that ran. This is either:
 
--   a `str`, if the last agent didn't have an `output_type` defined
--   an object of type `last_agent.output_type`, if the agent had an output type defined.
+-   a `str`, if the last agent did not have an `output_type` defined
+-   an object of type `last_agent.output_type`, if the last agent had an output type defined
+-   `None`, if the run stopped before a final output was produced, for example because it paused on an approval interruption
 
 !!! note
 
-    `final_output` is of type `Any`. We can't statically type this, because of handoffs. If handoffs occur, that means any Agent might be the last agent, so we don't statically know the set of possible output types.
+    `final_output` is typed as `Any`. Handoffs can change which agent finishes the run, so the SDK cannot statically know the full set of possible output types.
 
-## Inputs for the next turn
+In streaming mode, `final_output` stays `None` until the stream has finished processing. See [Streaming](streaming.md) for the event-by-event flow.
 
-You can use [`result.to_input_list()`][agents.result.RunResultBase.to_input_list] to turn the result into an input list that concatenates the original input you provided, to the items generated during the agent run. This makes it convenient to take the outputs of one agent run and pass them into another run, or to run it in a loop and append new user inputs each time.
+## Input, next-turn history, and new items
+
+These surfaces answer different questions:
+
+| Property or helper | What it contains | Best for |
+| --- | --- | --- |
+| [`input`][agents.result.RunResultBase.input] | The base input for this run segment. If a handoff input filter rewrote the history, this reflects the filtered input the run continued with. | Auditing what this run actually used as input |
+| [`to_input_list()`][agents.result.RunResultBase.to_input_list] | A replay-ready next-turn input list built from `input` plus the converted `new_items` from this run. | Manual chat loops and client-managed conversation state |
+| [`new_items`][agents.result.RunResultBase.new_items] | Rich [`RunItem`][agents.items.RunItem] wrappers with agent, tool, handoff, and approval metadata. | Logs, UIs, audits, and debugging |
+| [`raw_responses`][agents.result.RunResultBase.raw_responses] | Raw [`ModelResponse`][agents.items.ModelResponse] objects from each model call in the run. | Provider-level diagnostics or raw response inspection |
 
 In practice:
 
--   Use `result.to_input_list()` when your application manually carries the entire conversation transcript.
+-   Use `to_input_list()` when your application manually carries the entire conversation transcript.
 -   Use [`session=...`](sessions/index.md) when you want the SDK to load and save history for you.
--   If you are using OpenAI server-managed state with `conversation_id` or `previous_response_id`, usually pass only the new user input and reuse the stored ID instead of resending `result.to_input_list()`.
+-   If you are using OpenAI server-managed state with `conversation_id` or `previous_response_id`, usually pass only the new user input and reuse the stored ID instead of resending `to_input_list()`.
 
-## Last agent
+Unlike the JavaScript SDK, Python does not expose a separate `output` property for the model-shaped delta only. Use `new_items` when you need SDK metadata, or inspect `raw_responses` when you need the raw model payloads.
 
-The [`last_agent`][agents.result.RunResultBase.last_agent] property contains the last agent that ran. Depending on your application, this is often useful for the next time the user inputs something. For example, if you have a frontline triage agent that hands off to a language-specific agent, you can store the last agent, and re-use it the next time the user messages the agent.
+### New items
 
-In streaming mode, [`RunResultStreaming.current_agent`][agents.result.RunResultStreaming.current_agent] updates as the run progresses, so you can observe handoffs as they happen.
+[`new_items`][agents.result.RunResultBase.new_items] gives you the richest view of what happened during the run. Common item types are:
 
-## New items
+-   [`MessageOutputItem`][agents.items.MessageOutputItem] for assistant messages
+-   [`ReasoningItem`][agents.items.ReasoningItem] for reasoning items
+-   [`ToolCallItem`][agents.items.ToolCallItem] and [`ToolCallOutputItem`][agents.items.ToolCallOutputItem] for tool calls and their results
+-   [`ToolApprovalItem`][agents.items.ToolApprovalItem] for tool calls that paused for approval
+-   [`HandoffCallItem`][agents.items.HandoffCallItem] and [`HandoffOutputItem`][agents.items.HandoffOutputItem] for handoff requests and completed transfers
 
-The [`new_items`][agents.result.RunResultBase.new_items] property contains the new items generated during the run. The items are [`RunItem`][agents.items.RunItem]s. A run item wraps the raw item generated by the LLM.
+Choose `new_items` over `to_input_list()` whenever you need agent associations, tool outputs, handoff boundaries, or approval boundaries.
 
--   [`MessageOutputItem`][agents.items.MessageOutputItem] indicates a message from the LLM. The raw item is the message generated.
--   [`HandoffCallItem`][agents.items.HandoffCallItem] indicates that the LLM called the handoff tool. The raw item is the tool call item from the LLM.
--   [`HandoffOutputItem`][agents.items.HandoffOutputItem] indicates that a handoff occurred. The raw item is the tool response to the handoff tool call. You can also access the source/target agents from the item.
--   [`ToolCallItem`][agents.items.ToolCallItem] indicates that the LLM invoked a tool.
--   [`ToolCallOutputItem`][agents.items.ToolCallOutputItem] indicates that a tool was called. The raw item is the tool response. You can also access the tool output from the item.
--   [`ReasoningItem`][agents.items.ReasoningItem] indicates a reasoning item from the LLM. The raw item is the reasoning generated.
+## Continue or resume the conversation
 
-## Run state
+### Next-turn agent
 
-Call [`result.to_state()`][agents.result.RunResult.to_state] when you need a serializable snapshot of the run. This is the bridge between a finished or paused run and a later resume, especially for approval flows or durable worker systems.
+[`last_agent`][agents.result.RunResultBase.last_agent] contains the last agent that ran. This is often the best agent to reuse for the next user turn after handoffs.
 
-## Agent-as-tool metadata
+In streaming mode, [`RunResultStreaming.current_agent`][agents.result.RunResultStreaming.current_agent] updates as the run progresses, so you can observe handoffs before the stream finishes.
 
-When a result comes from a nested [`Agent.as_tool()`][agents.agent.Agent.as_tool] run, [`agent_tool_invocation`][agents.result.RunResultBase.agent_tool_invocation] exposes immutable metadata about the outer tool call:
+### Interruptions and run state
 
--   `tool_name`
--   `tool_call_id`
--   `tool_arguments`
+If a tool needs approval, pending approvals are exposed in [`RunResult.interruptions`][agents.result.RunResult.interruptions] or [`RunResultStreaming.interruptions`][agents.result.RunResultStreaming.interruptions]. This can include approvals raised by direct tools, by tools reached after a handoff, or by nested [`Agent.as_tool()`][agents.agent.Agent.as_tool] runs.
 
-For ordinary top-level runs, `agent_tool_invocation` is `None`.
-
-## Other information
-
-### Guardrail results
-
-The [`input_guardrail_results`][agents.result.RunResultBase.input_guardrail_results] and [`output_guardrail_results`][agents.result.RunResultBase.output_guardrail_results] properties contain the results of the guardrails, if any. Guardrail results can sometimes contain useful information you want to log or store, so we make these available to you.
-
-Tool guardrail results are available separately as [`tool_input_guardrail_results`][agents.result.RunResultBase.tool_input_guardrail_results] and [`tool_output_guardrail_results`][agents.result.RunResultBase.tool_output_guardrail_results]. These guardrails can be attached to tools, and those tool calls execute the guardrails during the agent workflow.
-
-### Raw responses
-
-The [`raw_responses`][agents.result.RunResultBase.raw_responses] property contains the [`ModelResponse`][agents.items.ModelResponse]s generated by the LLM.
-
-### Original input
-
-The [`input`][agents.result.RunResultBase.input] property contains the original input you provided to the `run` method. In most cases you won't need this, but it's available in case you do.
-
-### Interruptions and resuming runs
-
-If a run pauses for tool approval, pending approvals are exposed in
-[`RunResult.interruptions`][agents.result.RunResult.interruptions] or
-[`RunResultStreaming.interruptions`][agents.result.RunResultStreaming.interruptions]. Convert the
-result into a [`RunState`][agents.run_state.RunState] with `to_state()`, approve or reject the
-interruption(s), and resume with `Runner.run(...)` or `Runner.run_streamed(...)`.
+Call [`to_state()`][agents.result.RunResult.to_state] to capture a resumable [`RunState`][agents.run_state.RunState], approve or reject the pending items, and then resume with `Runner.run(...)` or `Runner.run_streamed(...)`.
 
 ```python
 from agents import Agent, Runner
@@ -111,15 +96,59 @@ if result.interruptions:
     result = await Runner.run(agent, state)
 ```
 
-Both [`RunResult`][agents.result.RunResult] and
-[`RunResultStreaming`][agents.result.RunResultStreaming] support `to_state()`. For durable
-approval workflows, see the [human-in-the-loop guide](human_in_the_loop.md).
+For streaming runs, finish consuming [`stream_events()`][agents.result.RunResultStreaming.stream_events] first, then inspect `result.interruptions` and resume from `result.to_state()`. For the full approval flow, see [Human-in-the-loop](human_in_the_loop.md).
 
-### Convenience helpers
+### Server-managed continuation
 
-`RunResultBase` includes a few helper methods/properties that are useful in production flows:
+[`last_response_id`][agents.result.RunResultBase.last_response_id] is the latest model response ID from the run. Pass it back as `previous_response_id` on the next turn when you want to continue an OpenAI Responses API chain.
 
-- [`final_output_as(...)`][agents.result.RunResultBase.final_output_as] casts final output to a specific type (optionally with runtime type checking).
-- [`last_response_id`][agents.result.RunResultBase.last_response_id] returns the latest model response ID. Pass this back as `previous_response_id` when you want to continue an OpenAI Responses API chain on the next turn.
-- [`agent_tool_invocation`][agents.result.RunResultBase.agent_tool_invocation] returns metadata about the outer tool call when the result comes from `Agent.as_tool()`.
-- [`release_agents(...)`][agents.result.RunResultBase.release_agents] drops strong references to agents when you want to reduce memory pressure after inspecting results.
+If you already continue the conversation with `to_input_list()`, `session`, or `conversation_id`, you usually do not need `last_response_id`. If you need every model response from a multi-step run, inspect `raw_responses` instead.
+
+## Agent-as-tool metadata
+
+When a result comes from a nested [`Agent.as_tool()`][agents.agent.Agent.as_tool] run, [`agent_tool_invocation`][agents.result.RunResultBase.agent_tool_invocation] exposes immutable metadata about the outer tool call:
+
+-   `tool_name`
+-   `tool_call_id`
+-   `tool_arguments`
+
+For ordinary top-level runs, `agent_tool_invocation` is `None`.
+
+This is especially useful inside `custom_output_extractor`, where you may need the outer tool name, call ID, or raw arguments while post-processing the nested result. See [Tools](tools.md) for the surrounding `Agent.as_tool()` patterns.
+
+If you also need the parsed structured input for that nested run, read `context_wrapper.tool_input`. That is the field [`RunState`][agents.run_state.RunState] serializes generically for nested tool input, while `agent_tool_invocation` is the live result accessor for the current nested invocation.
+
+## Streaming lifecycle and diagnostics
+
+[`RunResultStreaming`][agents.result.RunResultStreaming] inherits the same result surfaces above, but adds streaming-specific controls:
+
+-   [`stream_events()`][agents.result.RunResultStreaming.stream_events] to consume semantic stream events
+-   [`current_agent`][agents.result.RunResultStreaming.current_agent] to track the active agent mid-run
+-   [`is_complete`][agents.result.RunResultStreaming.is_complete] to see whether the streamed run has fully finished
+-   [`cancel(...)`][agents.result.RunResultStreaming.cancel] to stop the run immediately or after the current turn
+
+Keep consuming `stream_events()` until the async iterator finishes. A streaming run is not complete until that iterator ends, and summary properties such as `final_output`, `interruptions`, `raw_responses`, and session-persistence side effects may still be settling after the last visible token arrives.
+
+If you call `cancel()`, continue consuming `stream_events()` so cancellation and cleanup can finish correctly.
+
+Python does not expose a separate streamed `completed` promise or `error` property. Terminal streaming failures are surfaced by raising from `stream_events()`, and `is_complete` reflects whether the run has reached its terminal state.
+
+### Raw responses
+
+[`raw_responses`][agents.result.RunResultBase.raw_responses] contains the raw model responses collected during the run. Multi-step runs can produce more than one response, for example across handoffs or repeated model/tool/model cycles.
+
+[`last_response_id`][agents.result.RunResultBase.last_response_id] is just the ID from the last entry in `raw_responses`.
+
+### Guardrail results
+
+Agent-level guardrails are exposed as [`input_guardrail_results`][agents.result.RunResultBase.input_guardrail_results] and [`output_guardrail_results`][agents.result.RunResultBase.output_guardrail_results].
+
+Tool guardrails are exposed separately as [`tool_input_guardrail_results`][agents.result.RunResultBase.tool_input_guardrail_results] and [`tool_output_guardrail_results`][agents.result.RunResultBase.tool_output_guardrail_results].
+
+These arrays accumulate across the run, so they are useful for logging decisions, storing extra guardrail metadata, or debugging why a run was blocked.
+
+### Context and usage
+
+[`context_wrapper`][agents.result.RunResultBase.context_wrapper] exposes your app context together with SDK-managed runtime metadata such as approvals, usage, and nested `tool_input`.
+
+Usage is tracked on `context_wrapper.usage`. For streamed runs, the usage totals can lag until the stream's final chunks have been processed. See [Context management](context.md) for the full wrapper shape and persistence caveats.

--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -376,6 +376,8 @@ settings so the resumed turn continues in the same server-managed conversation.
 
 Use `call_model_input_filter` to edit the model input right before the model call. The hook receives the current agent, context, and the combined input items (including session history when present) and returns a new `ModelInputData`.
 
+The return value must be a [`ModelInputData`][agents.run.ModelInputData] object. Its `input` field is required and must be a list of input items. Returning any other shape raises a `UserError`.
+
 ```python
 from agents import Agent, Runner, RunConfig
 from agents.run import CallModelData, ModelInputData
@@ -392,6 +394,12 @@ result = Runner.run_sync(
     run_config=RunConfig(call_model_input_filter=drop_old_messages),
 )
 ```
+
+The runner passes a copy of the prepared input list to the hook, so you can trim, replace, or reorder it without mutating the caller's original list in place.
+
+If you are using a session, `call_model_input_filter` runs after session history has already been loaded and merged with the current turn. Use [`session_input_callback`][agents.run.RunConfig.session_input_callback] when you want to customize that earlier merge step itself.
+
+If you are using OpenAI server-managed conversation state with `conversation_id`, `previous_response_id`, or `auto_previous_response_id`, the hook runs on the prepared payload for the next Responses API call. That payload may already represent only the new-turn delta rather than a full replay of earlier history. Only the items you return are marked as sent for that server-managed continuation.
 
 Set the hook per run via `run_config` to redact sensitive data, trim long histories, or inject additional system guidance.
 

--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -4,7 +4,7 @@ The Agents SDK provides built-in session memory to automatically maintain conver
 
 Sessions stores conversation history for a specific session, allowing agents to maintain context without requiring explicit manual memory management. This is particularly useful for building chat applications or multi-turn conversations where you want the agent to remember previous interactions.
 
-Use sessions when you want the SDK to manage client-side memory for you. If you are already using OpenAI server-managed state with `conversation_id` or `previous_response_id`, you usually do not also need a session for the same conversation.
+Use sessions when you want the SDK to manage client-side memory for you. Sessions cannot be combined with `conversation_id`, `previous_response_id`, or `auto_previous_response_id` in the same run. If you want OpenAI server-managed continuation instead, choose one of those mechanisms rather than layering a session on top.
 
 ## Quick start
 
@@ -83,6 +83,8 @@ Use [`RunConfig.session_input_callback`][agents.run.RunConfig.session_input_call
 
 Return the final list of input items that should be sent to the model.
 
+The callback receives copies of both lists, so you can safely mutate them. The returned list controls the model input for that turn, but the SDK still persists only items that belong to the new turn. Reordering or filtering old history therefore does not cause old session items to be saved again as fresh input.
+
 ```python
 from agents import Agent, RunConfig, Runner, SQLiteSession
 
@@ -103,7 +105,7 @@ result = await Runner.run(
 )
 ```
 
-Use this when you need custom pruning, reordering, or selective inclusion of history without changing how the session stores items.
+Use this when you need custom pruning, reordering, or selective inclusion of history without changing how the session stores items. If you need a later final pass immediately before the model call, use [`call_model_input_filter`][agents.run.RunConfig.call_model_input_filter] from the [running agents guide](../running_agents.md).
 
 ## Limiting retrieved history
 

--- a/src/agents/handoffs/__init__.py
+++ b/src/agents/handoffs/__init__.py
@@ -106,7 +106,12 @@ class Handoff(Generic[TContext, TAgent]):
     """The description of the tool that represents the handoff."""
 
     input_json_schema: dict[str, Any]
-    """The JSON schema for the handoff input. Can be empty if the handoff does not take an input."""
+    """The JSON schema for the handoff tool-call arguments.
+
+    This schema is exposed to the model as the handoff tool's ``parameters``. It only describes the
+    structured payload passed to ``on_invoke_handoff`` and does not replace the next agent's main
+    input.
+    """
 
     on_invoke_handoff: Callable[[RunContextWrapper[Any], str], Awaitable[TAgent]]
     """The function that invokes the handoff.
@@ -226,9 +231,13 @@ def handoff(
         tool_name_override: Optional override for the name of the tool that represents the handoff.
         tool_description_override: Optional override for the description of the tool that
             represents the handoff.
-        on_handoff: A function that runs when the handoff is invoked.
-        input_type: The type of the input to the handoff. If provided, the input will be validated
-            against this type. Only relevant if you pass a function that takes an input.
+        on_handoff: A function that runs when the handoff is invoked. The ``handoff()`` helper
+            always returns the specific ``agent`` captured here, so use ``on_handoff`` for side
+            effects or bookkeeping rather than dynamic destination selection.
+        input_type: The type of the handoff tool-call arguments. If provided, the model-generated
+            JSON arguments are validated against this type and the parsed value is passed to
+            ``on_handoff``. This only affects the handoff tool payload, not the next agent's main
+            input.
         input_filter: A function that filters the inputs that are passed to the next agent.
         nest_handoff_history: Optional override for the RunConfig-level ``nest_handoff_history``
             flag. If ``None`` we fall back to the run's configuration.


### PR DESCRIPTION
This pull request updates the Python documentation to make the SDK's runtime surfaces easier to navigate and reason about across multi-agent workflows. It rewrites the result guide around surface selection instead of a flat property inventory, clarifies handoff input typing and guardrail boundaries, expands the HITL guide around run-wide approvals and resumable flows, and tightens the docs for context, sessions, and model-input shaping so the guides agree on how state moves through a run.

The main changes are in `docs/results.md`, `docs/human_in_the_loop.md`, `docs/handoffs.md`, `docs/context.md`, and `docs/agents.md`, with supporting clarifications in `docs/guardrails.md`, `docs/running_agents.md`, `docs/sessions/index.md`, and the generated handoff reference docstrings in `src/agents/handoffs/__init__.py`.

Behavioral/documentation clarifications included in this PR:
- `handoff(input_type=...)` is documented as the handoff tool-call payload schema rather than the next agent's main input.
- HITL approvals are documented as run-wide across direct tools, handoffs, and nested `Agent.as_tool()` runs, including partial resolution and resume behavior.
- Result surfaces now explain the relationship between `input`, `to_input_list()`, `new_items`, `raw_responses`, `last_response_id`, `agent_tool_invocation`, and streaming lifecycle caveats.
- Context and session docs now distinguish local app context from conversation state, explain what `RunContextWrapper` exposes, and clarify when to use `session_input_callback` versus `call_model_input_filter`.
- The agents guide now acts as a navigation hub for related runtime guides and calls out key agent configuration fields more explicitly.