### PR TITLE
feat: add remove_all_reasoning handoff filter

### DIFF
--- a/src/agents/extensions/handoff_filters.py
+++ b/src/agents/extensions/handoff_filters.py
@@ -19,6 +19,7 @@ from ..items import (
 
 __all__ = [
     "remove_all_tools",
+    "remove_all_reasoning",
     "nest_handoff_history",
     "default_handoff_history_mapper",
 ]
@@ -35,6 +36,31 @@ def remove_all_tools(handoff_input_data: HandoffInputData) -> HandoffInputData:
     )
     filtered_pre_handoff_items = _remove_tools_from_items(handoff_input_data.pre_handoff_items)
     filtered_new_items = _remove_tools_from_items(new_items)
+
+    return HandoffInputData(
+        input_history=filtered_history,
+        pre_handoff_items=filtered_pre_handoff_items,
+        new_items=filtered_new_items,
+        run_context=handoff_input_data.run_context,
+    )
+
+
+def remove_all_reasoning(handoff_input_data: HandoffInputData) -> HandoffInputData:
+    """Filters out all reasoning items from handoff input.
+
+    Use this filter when handing off from a reasoning model (e.g. o4-mini) to a
+    non-reasoning model (e.g. gpt-4.1) to avoid 400 errors caused by reasoning
+    items being sent to a model that does not support them.
+    """
+
+    history = handoff_input_data.input_history
+    new_items = handoff_input_data.new_items
+
+    filtered_history = (
+        _remove_reasoning_types_from_input(history) if isinstance(history, tuple) else history
+    )
+    filtered_pre_handoff_items = _remove_reasoning_from_items(handoff_input_data.pre_handoff_items)
+    filtered_new_items = _remove_reasoning_from_items(new_items)
 
     return HandoffInputData(
         input_history=filtered_history,
@@ -75,6 +101,27 @@ def _remove_tool_types_from_input(
     for item in items:
         itype = item.get("type")
         if itype in tool_types:
+            continue
+        filtered_items.append(item)
+    return tuple(filtered_items)
+
+
+def _remove_reasoning_from_items(items: tuple[RunItem, ...]) -> tuple[RunItem, ...]:
+    filtered_items = []
+    for item in items:
+        if isinstance(item, ReasoningItem):
+            continue
+        filtered_items.append(item)
+    return tuple(filtered_items)
+
+
+def _remove_reasoning_types_from_input(
+    items: tuple[TResponseInputItem, ...],
+) -> tuple[TResponseInputItem, ...]:
+    filtered_items: list[TResponseInputItem] = []
+    for item in items:
+        itype = item.get("type")
+        if itype == "reasoning":
             continue
         filtered_items.append(item)
     return tuple(filtered_items)

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -16,7 +16,11 @@ from agents import (
     reset_conversation_history_wrappers,
     set_conversation_history_wrappers,
 )
-from agents.extensions.handoff_filters import nest_handoff_history, remove_all_tools
+from agents.extensions.handoff_filters import (
+    nest_handoff_history,
+    remove_all_reasoning,
+    remove_all_tools,
+)
 from agents.items import (
     HandoffOutputItem,
     MessageOutputItem,
@@ -261,6 +265,132 @@ def test_removes_handoffs_from_history():
     filtered_data = remove_all_tools(handoff_input_data)
     assert len(filtered_data.input_history) == 1
     assert len(filtered_data.pre_handoff_items) == 1
+    assert len(filtered_data.new_items) == 1
+
+
+# --- remove_all_reasoning tests ---
+
+
+def test_remove_reasoning_empty_data():
+    handoff_input_data = handoff_data()
+    filtered_data = remove_all_reasoning(handoff_input_data)
+    assert filtered_data.input_history == ()
+    assert filtered_data.pre_handoff_items == ()
+    assert filtered_data.new_items == ()
+
+
+def test_remove_reasoning_no_reasoning_items():
+    """Non-reasoning items should pass through unchanged."""
+    handoff_input_data = handoff_data(
+        input_history=(
+            _get_message_input_item("Hello"),
+            _get_function_result_input_item("result"),
+        ),
+        pre_handoff_items=(_get_message_output_run_item("pre"),),
+        new_items=(_get_message_output_run_item("new"),),
+    )
+    filtered_data = remove_all_reasoning(handoff_input_data)
+    assert len(filtered_data.input_history) == 2
+    assert len(filtered_data.pre_handoff_items) == 1
+    assert len(filtered_data.new_items) == 1
+
+
+def test_remove_reasoning_from_input_history():
+    """Reasoning items in input_history should be filtered out."""
+    handoff_input_data = handoff_data(
+        input_history=(
+            _get_message_input_item("Hello"),
+            _get_reasoning_input_item(),
+            _get_message_input_item("World"),
+        ),
+    )
+    filtered_data = remove_all_reasoning(handoff_input_data)
+    assert len(filtered_data.input_history) == 2
+
+
+def test_remove_reasoning_from_pre_handoff_items():
+    """Reasoning RunItems in pre_handoff_items should be filtered out."""
+    handoff_input_data = handoff_data(
+        pre_handoff_items=(
+            _get_reasoning_output_run_item(),
+            _get_message_output_run_item("Hello"),
+            _get_reasoning_output_run_item(),
+        ),
+    )
+    filtered_data = remove_all_reasoning(handoff_input_data)
+    assert len(filtered_data.pre_handoff_items) == 1
+
+
+def test_remove_reasoning_from_new_items():
+    """Reasoning RunItems in new_items should be filtered out."""
+    handoff_input_data = handoff_data(
+        new_items=(
+            _get_reasoning_output_run_item(),
+            _get_message_output_run_item("Hello"),
+            _get_tool_output_run_item("World"),
+        ),
+    )
+    filtered_data = remove_all_reasoning(handoff_input_data)
+    assert len(filtered_data.new_items) == 2
+
+
+def test_remove_reasoning_from_all_locations():
+    """Reasoning items should be filtered from all three locations at once."""
+    handoff_input_data = handoff_data(
+        input_history=(
+            _get_message_input_item("Hello"),
+            _get_reasoning_input_item(),
+            _get_function_result_input_item("result"),
+        ),
+        pre_handoff_items=(
+            _get_reasoning_output_run_item(),
+            _get_message_output_run_item("pre"),
+        ),
+        new_items=(
+            _get_reasoning_output_run_item(),
+            _get_message_output_run_item("new"),
+            _get_tool_output_run_item("tool"),
+        ),
+    )
+    filtered_data = remove_all_reasoning(handoff_input_data)
+    assert len(filtered_data.input_history) == 2
+    assert len(filtered_data.pre_handoff_items) == 1
+    assert len(filtered_data.new_items) == 2
+
+
+def test_remove_reasoning_preserves_tools():
+    """Tool items should not be affected by remove_all_reasoning."""
+    handoff_input_data = handoff_data(
+        input_history=(
+            _get_function_result_input_item("result"),
+            _get_reasoning_input_item(),
+        ),
+        pre_handoff_items=(
+            _get_tool_output_run_item("tool"),
+            _get_reasoning_output_run_item(),
+        ),
+        new_items=(
+            _get_handoff_output_run_item("handoff"),
+            _get_reasoning_output_run_item(),
+        ),
+    )
+    filtered_data = remove_all_reasoning(handoff_input_data)
+    assert len(filtered_data.input_history) == 1
+    assert len(filtered_data.pre_handoff_items) == 1
+    assert len(filtered_data.new_items) == 1
+
+
+def test_remove_reasoning_str_history():
+    """String input_history should pass through unchanged."""
+    handoff_input_data = handoff_data(
+        input_history="Hello",
+        new_items=(
+            _get_reasoning_output_run_item(),
+            _get_message_output_run_item("World"),
+        ),
+    )
+    filtered_data = remove_all_reasoning(handoff_input_data)
+    assert filtered_data.input_history == "Hello"
     assert len(filtered_data.new_items) == 1
 
 


### PR DESCRIPTION
### Summary

Add a `remove_all_reasoning` handoff input filter in `agents.extensions.handoff_filters` that strips reasoning items from input history, pre-handoff items, and new items during handoffs.

When handing off from a reasoning model (e.g. o4-mini) to a non-reasoning model (e.g. gpt-4.1), reasoning items in the input cause a 400 error:

> Reasoning input items can only be provided to a reasoning or computer use model.

This filter can be used as an `input_filter` on `handoff()` to prevent this error:

```python
from agents import handoff
from agents.extensions.handoff_filters import remove_all_reasoning

handoff(target_agent, input_filter=remove_all_reasoning)
```

The implementation follows the same pattern as the existing `remove_all_tools` filter, filtering reasoning items from all three components of `HandoffInputData`:
- `input_history` (raw `TResponseInputItem` dicts with `type: "reasoning"`)
- `pre_handoff_items` (typed `ReasoningItem` run items)
- `new_items` (typed `ReasoningItem` run items)

### Test plan

Added 8 unit tests in `tests/test_extension_filters.py` covering:
- Empty data passthrough
- No-op when no reasoning items present
- Filtering from `input_history` only
- Filtering from `pre_handoff_items` only
- Filtering from `new_items` only
- Filtering from all three locations simultaneously
- Preserving tool/handoff items (not affected by reasoning filter)
- String `input_history` passthrough

All existing tests continue to pass. Verified with `ruff check`, `ruff format`, and `mypy`.

### Issue number

Closes #569

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass