### PR TITLE
Serialize structured realtime tool outputs as JSON

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -82,7 +82,10 @@ def _serialize_tool_output(output: Any) -> str:
             except Exception:
                 return str(output)
     elif dataclasses.is_dataclass(output) and not isinstance(output, type):
-        output = dataclasses.asdict(output)
+        try:
+            output = dataclasses.asdict(output)
+        except Exception:
+            return str(output)
     try:
         return json.dumps(output, ensure_ascii=False)
     except (TypeError, ValueError):

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1,5 +1,7 @@
 import asyncio
+import dataclasses
 import json
+import threading
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
@@ -1450,6 +1452,16 @@ class TestToolCallExecution:
                 return "broken-model"
 
         assert _serialize_tool_output(BrokenModel(value=1)) == "broken-model"
+
+    def test_serialize_tool_output_returns_string_when_dataclass_asdict_fails(self) -> None:
+        @dataclasses.dataclass
+        class BrokenDataclass:
+            lock: Any
+
+            def __str__(self) -> str:
+                return "broken-dataclass"
+
+        assert _serialize_tool_output(BrokenDataclass(lock=threading.Lock())) == "broken-dataclass"
 
     @pytest.mark.asyncio
     async def test_mixed_tool_types_filtering(self, mock_model, mock_agent):


### PR DESCRIPTION
### Summary

- serialize structured realtime tool results to JSON instead of stringifying Python objects
- keep plain string outputs unchanged while handling Pydantic models and dataclasses predictably
- add regression coverage for dict and model-based tool return values

### Test plan

- `make sync`
- `make format`
- `make lint`
- `make mypy`
- `make tests`

### Issue number

Closes #1847

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass