### PR TITLE
docs: refresh docs and examples to gpt-5.4

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -293,7 +293,7 @@ By using the `clone()` method on an agent, you can duplicate an Agent, and optio
 pirate_agent = Agent(
     name="Pirate",
     instructions="Write like a pirate",
-    model="gpt-5.2",
+    model="gpt-5.4",
 )
 
 robot_agent = pirate_agent.clone(

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -19,16 +19,16 @@ Use this page in the following order depending on your setup:
 
 ## OpenAI models
 
-When you don't specify a model when initializing an `Agent`, the default model will be used. The default is currently [`gpt-4.1`](https://platform.openai.com/docs/models/gpt-4.1) for compatibility and low latency. If you have access, we recommend setting your agents to [`gpt-5.2`](https://platform.openai.com/docs/models/gpt-5.2) for higher quality while keeping explicit `model_settings`.
+When you don't specify a model when initializing an `Agent`, the default model will be used. The default is currently [`gpt-4.1`](https://developers.openai.com/api/docs/models/gpt-4.1) for compatibility and low latency. If you have access, we recommend setting your agents to [`gpt-5.4`](https://developers.openai.com/api/docs/models/gpt-5.4) for higher quality while keeping explicit `model_settings`.
 
-If you want to switch to other models like [`gpt-5.2`](https://platform.openai.com/docs/models/gpt-5.2), there are two ways to configure your agents.
+If you want to switch to other models like [`gpt-5.4`](https://developers.openai.com/api/docs/models/gpt-5.4), there are two ways to configure your agents.
 
 ### Default model
 
 First, if you want to consistently use a specific model for all agents that do not set a custom model, set the `OPENAI_DEFAULT_MODEL` environment variable before running your agents.
 
 ```bash
-export OPENAI_DEFAULT_MODEL=gpt-5.2
+export OPENAI_DEFAULT_MODEL=gpt-5.4
 python3 my_awesome_agent.py
 ```
 
@@ -45,13 +45,13 @@ agent = Agent(
 result = await Runner.run(
     agent,
     "Hello",
-    run_config=RunConfig(model="gpt-5.2"),
+    run_config=RunConfig(model="gpt-5.4"),
 )
 ```
 
-#### GPT-5.x models
+#### GPT-5 models
 
-When you use any GPT-5.x model such as [`gpt-5.2`](https://platform.openai.com/docs/models/gpt-5.2) in this way, the SDK applies default `ModelSettings`. It sets the ones that work the best for most use cases. To adjust the reasoning effort for the default model, pass your own `ModelSettings`:
+When you use any GPT-5 model such as [`gpt-5.4`](https://developers.openai.com/api/docs/models/gpt-5.4) in this way, the SDK applies default `ModelSettings`. It sets the ones that work the best for most use cases. To adjust the reasoning effort for the default model, pass your own `ModelSettings`:
 
 ```python
 from openai.types.shared import Reasoning
@@ -60,14 +60,14 @@ from agents import Agent, ModelSettings
 my_agent = Agent(
     name="My Agent",
     instructions="You're a helpful agent.",
-    # If OPENAI_DEFAULT_MODEL=gpt-5.2 is set, passing only model_settings works.
-    # It's also fine to pass a GPT-5.x model name explicitly:
-    model="gpt-5.2",
+    # If OPENAI_DEFAULT_MODEL=gpt-5.4 is set, passing only model_settings works.
+    # It's also fine to pass a GPT-5 model name explicitly:
+    model="gpt-5.4",
     model_settings=ModelSettings(reasoning=Reasoning(effort="high"), verbosity="low")
 )
 ```
 
-For lower latency, using `reasoning.effort="none"` with `gpt-5.2` is recommended. The gpt-4.1 family (including mini and nano variants) also remains a solid choice for building interactive agent apps.
+For lower latency, using `reasoning.effort="none"` with `gpt-5.4` is recommended. The gpt-4.1 family (including mini and nano variants) also remains a solid choice for building interactive agent apps.
 
 #### Non-GPT-5 models
 
@@ -83,7 +83,7 @@ from agents import set_default_openai_responses_transport
 set_default_openai_responses_transport("websocket")
 ```
 
-This affects OpenAI Responses models resolved by the default OpenAI provider (including string model names such as `"gpt-5.2"`).
+This affects OpenAI Responses models resolved by the default OpenAI provider (including string model names such as `"gpt-5.4"`).
 
 Transport selection happens when the SDK resolves a model name into a model instance. If you pass a concrete [`Model`][agents.models.interface.Model] object, its transport is already fixed: [`OpenAIResponsesWSModel`][agents.models.openai_responses.OpenAIResponsesWSModel] uses websocket, [`OpenAIResponsesModel`][agents.models.openai_responses.OpenAIResponsesModel] uses HTTP, and [`OpenAIChatCompletionsModel`][agents.models.openai_chatcompletions.OpenAIChatCompletionsModel] stays on Chat Completions. If you pass `RunConfig(model_provider=...)`, that provider controls transport selection instead of the global default.
 
@@ -213,7 +213,7 @@ triage_agent = Agent(
     name="Triage agent",
     instructions="Handoff to the appropriate agent based on the language of the request.",
     handoffs=[spanish_agent, english_agent],
-    model="gpt-5",
+    model="gpt-5.4",
 )
 
 async def main():
@@ -254,7 +254,7 @@ from agents import Agent, ModelSettings
 
 research_agent = Agent(
     name="Research agent",
-    model="gpt-5.2",
+    model="gpt-5.4",
     model_settings=ModelSettings(
         parallel_tool_calls=False,
         truncation="auto",

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -69,7 +69,7 @@ csv_skill: ShellToolSkillReference = {
 
 agent = Agent(
     name="Container shell agent",
-    model="gpt-5.2",
+    model="gpt-5.4",
     instructions="Use the mounted skill when helpful.",
     tools=[
         ShellTool(
@@ -698,7 +698,7 @@ agent = Agent(
             sandbox_mode="workspace-write",
             working_directory="/path/to/repo",
             default_thread_options=ThreadOptions(
-                model="gpt-5.2-codex",
+                model="gpt-5.4",
                 model_reasoning_effort="low",
                 network_access_enabled=True,
                 web_search_mode="disabled",

--- a/docs/voice/quickstart.md
+++ b/docs/voice/quickstart.md
@@ -72,7 +72,7 @@ spanish_agent = Agent(
     instructions=prompt_with_handoff_instructions(
         "You're speaking to a human, so be polite and concise. Speak in Spanish.",
     ),
-    model="gpt-5.2",
+    model="gpt-5.4",
 )
 
 agent = Agent(
@@ -80,7 +80,7 @@ agent = Agent(
     instructions=prompt_with_handoff_instructions(
         "You're speaking to a human, so be polite and concise. If the user speaks in Spanish, handoff to the spanish agent.",
     ),
-    model="gpt-5.2",
+    model="gpt-5.4",
     handoffs=[spanish_agent],
     tools=[get_weather],
 )
@@ -156,7 +156,7 @@ spanish_agent = Agent(
     instructions=prompt_with_handoff_instructions(
         "You're speaking to a human, so be polite and concise. Speak in Spanish.",
     ),
-    model="gpt-5.2",
+    model="gpt-5.4",
 )
 
 agent = Agent(
@@ -164,7 +164,7 @@ agent = Agent(
     instructions=prompt_with_handoff_instructions(
         "You're speaking to a human, so be polite and concise. If the user speaks in Spanish, handoff to the spanish agent.",
     ),
-    model="gpt-5.2",
+    model="gpt-5.4",
     handoffs=[spanish_agent],
     tools=[get_weather],
 )

--- a/examples/basic/hello_world_gpt_5.py
+++ b/examples/basic/hello_world_gpt_5.py
@@ -9,16 +9,16 @@ from agents import Agent, ModelSettings, Runner
 # from openai import AsyncOpenAI
 # client = AsyncOpenAI()
 # from agents import OpenAIChatCompletionsModel
-# chat_completions_model = OpenAIChatCompletionsModel(model="gpt-5", openai_client=client)
+# chat_completions_model = OpenAIChatCompletionsModel(model="gpt-5.4", openai_client=client)
 
 
 async def main():
     agent = Agent(
         name="Knowledgable GPT-5 Assistant",
         instructions="You're a knowledgable assistant. You always provide an interesting answer.",
-        model="gpt-5",
+        model="gpt-5.4",
         model_settings=ModelSettings(
-            reasoning=Reasoning(effort="minimal"),  # "minimal", "low", "medium", "high"
+            reasoning=Reasoning(effort="low"),  # "none", "low", "medium", "high", "xhigh"
             verbosity="low",  # "low", "medium", "high"
         ),
     )

--- a/examples/basic/stream_ws.py
+++ b/examples/basic/stream_ws.py
@@ -12,7 +12,7 @@ Required environment variable:
 - `OPENAI_API_KEY`
 
 Optional environment variables:
-- `OPENAI_MODEL` (defaults to `gpt-5.2`)
+- `OPENAI_MODEL` (defaults to `gpt-5.4`)
 - `OPENAI_BASE_URL`
 - `OPENAI_WEBSOCKET_BASE_URL`
 - `EXAMPLES_INTERACTIVE_MODE=auto` (auto-approve HITL prompts for scripted runs)
@@ -160,7 +160,7 @@ async def run_streamed_turn(
 
 
 async def main() -> None:
-    model_name = os.getenv("OPENAI_MODEL", "gpt-5.2-codex")
+    model_name = os.getenv("OPENAI_MODEL", "gpt-5.4")
     policy_agent = Agent(
         name="RefundPolicySpecialist",
         instructions=(

--- a/examples/financial_research_agent/agents/search_agent.py
+++ b/examples/financial_research_agent/agents/search_agent.py
@@ -11,7 +11,7 @@ INSTRUCTIONS = (
 
 search_agent = Agent(
     name="FinancialSearchAgent",
-    model="gpt-5.2",
+    model="gpt-5.4",
     instructions=INSTRUCTIONS,
     tools=[WebSearchTool()],
 )

--- a/examples/financial_research_agent/agents/verifier_agent.py
+++ b/examples/financial_research_agent/agents/verifier_agent.py
@@ -22,6 +22,6 @@ class VerificationResult(BaseModel):
 verifier_agent = Agent(
     name="VerificationAgent",
     instructions=VERIFIER_PROMPT,
-    model="gpt-5.2",
+    model="gpt-5.4",
     output_type=VerificationResult,
 )

--- a/examples/financial_research_agent/agents/writer_agent.py
+++ b/examples/financial_research_agent/agents/writer_agent.py
@@ -29,6 +29,6 @@ class FinancialReportData(BaseModel):
 writer_agent = Agent(
     name="FinancialWriterAgent",
     instructions=WRITER_PROMPT,
-    model="gpt-5.2",
+    model="gpt-5.4",
     output_type=FinancialReportData,
 )

--- a/examples/memory/hitl_session_scenario.py
+++ b/examples/memory/hitl_session_scenario.py
@@ -389,7 +389,7 @@ async def main() -> None:
         print("OPENAI_API_KEY must be set to run the HITL session scenario.")
         raise SystemExit(1)
 
-    model_override = os.environ.get("HITL_MODEL", "gpt-5.2")
+    model_override = os.environ.get("HITL_MODEL", "gpt-5.4")
     if model_override:
         print(f"Model: {model_override}")
 

--- a/examples/reasoning_content/main.py
+++ b/examples/reasoning_content/main.py
@@ -1,13 +1,13 @@
 """
 Example demonstrating how to access reasoning summaries when a model returns them.
 
-Some models, like gpt-5, provide a reasoning_content field in addition to the regular content.
+Some models, like gpt-5.4, provide a reasoning_content field in addition to the regular content.
 This example shows how to access that content from both streaming and non-streaming responses,
 and how to handle responses that do not include a reasoning summary.
 
 To run this example, you need to:
 1. Set your OPENAI_API_KEY environment variable
-2. Use a model that supports reasoning content (e.g., gpt-5)
+2. Use a model that supports reasoning content (e.g., gpt-5.4)
 """
 
 import asyncio
@@ -21,7 +21,7 @@ from agents import ModelSettings
 from agents.models.interface import ModelTracing
 from agents.models.openai_provider import OpenAIProvider
 
-MODEL_NAME = os.getenv("REASONING_MODEL_NAME") or "gpt-5.2"
+MODEL_NAME = os.getenv("REASONING_MODEL_NAME") or "gpt-5.4"
 
 
 async def stream_with_reasoning_content():
@@ -121,7 +121,7 @@ async def main():
     except Exception as e:
         print(f"Error: {e}")
         print("\nNote: This example requires a model that supports reasoning content.")
-        print("You may need to use a specific model like gpt-5 or similar.")
+        print("You may need to use a specific model like gpt-5.4 or similar.")
 
 
 if __name__ == "__main__":

--- a/examples/reasoning_content/runner_example.py
+++ b/examples/reasoning_content/runner_example.py
@@ -6,7 +6,7 @@ the Runner API, which is the most common way users interact with the Agents libr
 
 To run this example, you need to:
 1. Set your OPENAI_API_KEY environment variable
-2. Use a model that supports reasoning content (e.g., gpt-5)
+2. Use a model that supports reasoning content (e.g., gpt-5.4)
 """
 
 import asyncio
@@ -17,7 +17,7 @@ from openai.types.shared.reasoning import Reasoning
 from agents import Agent, ModelSettings, Runner, trace
 from agents.items import ReasoningItem
 
-MODEL_NAME = os.getenv("REASONING_MODEL_NAME") or "gpt-5.2"
+MODEL_NAME = os.getenv("REASONING_MODEL_NAME") or "gpt-5.4"
 
 
 async def main():

--- a/examples/research_bot/agents/planner_agent.py
+++ b/examples/research_bot/agents/planner_agent.py
@@ -25,7 +25,7 @@ class WebSearchPlan(BaseModel):
 planner_agent = Agent(
     name="PlannerAgent",
     instructions=PROMPT,
-    model="gpt-5",
+    model="gpt-5.4",
     model_settings=ModelSettings(reasoning=Reasoning(effort="medium")),
     output_type=WebSearchPlan,
 )

--- a/examples/research_bot/agents/search_agent.py
+++ b/examples/research_bot/agents/search_agent.py
@@ -11,7 +11,7 @@ INSTRUCTIONS = (
 
 search_agent = Agent(
     name="Search agent",
-    model="gpt-5.2",
+    model="gpt-5.4",
     instructions=INSTRUCTIONS,
     tools=[WebSearchTool()],
 )

--- a/examples/tools/apply_patch.py
+++ b/examples/tools/apply_patch.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--model",
-        default="gpt-5.2",
+        default="gpt-5.4",
         help="Model ID to use for the agent.",
     )
     args = parser.parse_args()

--- a/examples/tools/code_interpreter.py
+++ b/examples/tools/code_interpreter.py
@@ -16,7 +16,7 @@ async def main():
         name="Code interpreter",
         # Note: using gpt-5-class models with streaming for this tool may require org verification.
         # Code interpreter does not support gpt-5 minimal reasoning effort; use default effort.
-        model="gpt-5.2",
+        model="gpt-5.4",
         instructions=(
             "Always use the code interpreter tool to solve numeric problems, and show the code "
             "you ran when possible."

--- a/examples/tools/codex.py
+++ b/examples/tools/codex.py
@@ -118,7 +118,7 @@ async def main() -> None:
                 default_thread_options=ThreadOptions(
                     # You can pass a Codex instance to customize CLI details
                     # codex=Codex(executable_path="/path/to/codex", base_url="..."),
-                    model="gpt-5.2-codex",
+                    model="gpt-5.4",
                     model_reasoning_effort="low",
                     network_access_enabled=True,
                     web_search_enabled=False,

--- a/examples/tools/codex_same_thread.py
+++ b/examples/tools/codex_same_thread.py
@@ -73,7 +73,7 @@ async def main() -> None:
                 name="codex_engineer",
                 sandbox_mode="read-only",
                 default_thread_options=ThreadOptions(
-                    model="gpt-5.2-codex",
+                    model="gpt-5.4",
                     model_reasoning_effort="low",
                     network_access_enabled=True,
                     web_search_enabled=False,

--- a/examples/tools/container_shell_inline_skill.py
+++ b/examples/tools/container_shell_inline_skill.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--model",
-        default="gpt-5.2",
+        default="gpt-5.4",
         help="Model name to use.",
     )
     args = parser.parse_args()

--- a/examples/tools/container_shell_skill_reference.py
+++ b/examples/tools/container_shell_skill_reference.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--model",
-        default="gpt-5.2",
+        default="gpt-5.4",
         help="Model name to use.",
     )
     args = parser.parse_args()

--- a/examples/tools/local_shell_skill.py
+++ b/examples/tools/local_shell_skill.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--model",
-        default="gpt-5.2",
+        default="gpt-5.4",
         help="Model name to use.",
     )
     args = parser.parse_args()

--- a/examples/tools/shell.py
+++ b/examples/tools/shell.py
@@ -135,7 +135,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--model",
-        default="gpt-5.2",
+        default="gpt-5.4",
     )
     args = parser.parse_args()
     asyncio.run(main(args.prompt, args.model))

--- a/examples/tools/shell_human_in_the_loop.py
+++ b/examples/tools/shell_human_in_the_loop.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--model",
-        default="gpt-5.1",
+        default="gpt-5.4",
     )
     args = parser.parse_args()
     asyncio.run(main(args.prompt, args.model))

--- a/examples/voice/streamed/my_workflow.py
+++ b/examples/voice/streamed/my_workflow.py
@@ -21,7 +21,7 @@ spanish_agent = Agent(
     instructions=prompt_with_handoff_instructions(
         "You're speaking to a human, so be polite and concise. Speak in Spanish.",
     ),
-    model="gpt-5.2",
+    model="gpt-5.4",
 )
 
 agent = Agent(
@@ -29,7 +29,7 @@ agent = Agent(
     instructions=prompt_with_handoff_instructions(
         "You're speaking to a human, so be polite and concise. If the user speaks in Spanish, handoff to the spanish agent.",
     ),
-    model="gpt-5.2",
+    model="gpt-5.4",
     handoffs=[spanish_agent],
     tools=[get_weather],
 )


### PR DESCRIPTION
This pull request updates the main OpenAI-hosted docs and runnable examples to use `gpt-5.4` instead of older `gpt-5`, `gpt-5.1`, and `gpt-5.2` defaults where those examples are meant to show the current flagship GPT-5 path. It refreshes model guidance in the docs, updates websocket/Codex/tooling/research/voice examples, and keeps intentionally smaller-model examples on `gpt-5-mini` and `gpt-5-nano` unchanged.

It also fixes the `examples/basic/hello_world_gpt_5.py` sample so its explicit reasoning setting remains valid on `gpt-5.4`, replacing the old unsupported `minimal` effort with a supported value. The overall goal is to keep the repo’s user-facing examples aligned with current OpenAI model guidance while preserving example intent and minimizing churn.