### PR TITLE
fix: #2617 lower minimum pydantic version to 2.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 authors = [{ name = "OpenAI", email = "support@openai.com" }]
 dependencies = [
     "openai>=2.25.0,<3",
-    "pydantic>=2.12.3, <3",
+    "pydantic>=2.12.2, <3",
     "griffe>=1.5.6, <2",
     "typing-extensions>=4.12.2, <5",
     "requests>=2.0, <3",

--- a/uv.lock
+++ b/uv.lock
@@ -1965,7 +1965,7 @@ requires-dist = [
     { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.19.0,<2" },
     { name = "numpy", marker = "python_full_version >= '3.10' and extra == 'voice'", specifier = ">=2.2.0,<3" },
     { name = "openai", specifier = ">=2.25.0,<3" },
-    { name = "pydantic", specifier = ">=2.12.3,<3" },
+    { name = "pydantic", specifier = ">=2.12.2,<3" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=7" },
     { name = "requests", specifier = ">=2.0,<3" },
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0" },


### PR DESCRIPTION
This pull request resolves #2617 by relaxing the SDK's minimum `pydantic` requirement from `>=2.12.3` to `>=2.12.2`.

The previous floor was stricter than necessary and blocked environments that pin `pydantic==2.12.2`, including Home Assistant integrations. This change updates the published dependency spec in `pyproject.toml` and the corresponding project metadata in `uv.lock` without changing the resolved development lock version, so repository installs still use the current patch release while downstream consumers can satisfy the package requirement with 2.12.2.