### PR TITLE
fix: make computer environment and dimensions optional

### DIFF
--- a/src/agents/computer.py
+++ b/src/agents/computer.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 Environment = Literal["mac", "windows", "ubuntu", "browser"]
 Button = Literal["left", "right", "wheel", "back", "forward"]
+Dimensions = tuple[int, int]
 
 
 class Computer(abc.ABC):
@@ -10,14 +11,12 @@ class Computer(abc.ABC):
     operations needed to control a computer or browser."""
 
     @property
-    @abc.abstractmethod
-    def environment(self) -> Environment:
-        pass
+    def environment(self) -> Environment | None:
+        return None
 
     @property
-    @abc.abstractmethod
-    def dimensions(self) -> tuple[int, int]:
-        pass
+    def dimensions(self) -> Dimensions | None:
+        return None
 
     @abc.abstractmethod
     def screenshot(self) -> str:
@@ -61,14 +60,12 @@ class AsyncComputer(abc.ABC):
     operations needed to control a computer or browser."""
 
     @property
-    @abc.abstractmethod
-    def environment(self) -> Environment:
-        pass
+    def environment(self) -> Environment | None:
+        return None
 
     @property
-    @abc.abstractmethod
-    def dimensions(self) -> tuple[int, int]:
-        pass
+    def dimensions(self) -> Dimensions | None:
+        return None
 
     @abc.abstractmethod
     async def screenshot(self) -> str:

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1446,12 +1446,15 @@ class Converter:
                     "resolve_computer({ tool, run_context }) with a run context first "
                     "when building payloads manually."
                 )
-            converted_tool = {
+            computer_payload: dict[str, Any] = {
                 "type": "computer_use_preview",
-                "environment": computer.environment,
-                "display_width": computer.dimensions[0],
-                "display_height": computer.dimensions[1],
             }
+            if computer.environment is not None:
+                computer_payload["environment"] = computer.environment
+            if computer.dimensions is not None:
+                computer_payload["display_width"] = computer.dimensions[0]
+                computer_payload["display_height"] = computer.dimensions[1]
+            converted_tool = cast(ToolParam, computer_payload)
             includes = None
         elif isinstance(tool, HostedMCPTool):
             converted_tool = tool.tool_config

--- a/tests/test_openai_responses_converter.py
+++ b/tests/test_openai_responses_converter.py
@@ -83,6 +83,35 @@ class DummyComputer(Computer):
         raise NotImplementedError
 
 
+class MinimalComputer(Computer):
+    def screenshot(self) -> str:
+        raise NotImplementedError
+
+    def click(self, x: int, y: int, button: str) -> None:
+        raise NotImplementedError
+
+    def double_click(self, x: int, y: int) -> None:
+        raise NotImplementedError
+
+    def scroll(self, x: int, y: int, scroll_x: int, scroll_y: int) -> None:
+        raise NotImplementedError
+
+    def type(self, text: str) -> None:
+        raise NotImplementedError
+
+    def wait(self) -> None:
+        raise NotImplementedError
+
+    def move(self, x: int, y: int) -> None:
+        raise NotImplementedError
+
+    def keypress(self, keys: list[str]) -> None:
+        raise NotImplementedError
+
+    def drag(self, path: list[tuple[int, int]]) -> None:
+        raise NotImplementedError
+
+
 def test_convert_tool_choice_standard_values():
     """
     Make sure that the standard tool_choice values map to themselves or
@@ -188,6 +217,15 @@ def test_convert_tools_basic_types_and_includes():
     # Only one computer tool should be allowed.
     with pytest.raises(UserError):
         Converter.convert_tools(tools=[comp_tool, comp_tool], handoffs=[])
+
+
+def test_convert_tools_computer_omits_environment_and_dimensions_when_not_provided() -> None:
+    converted = Converter.convert_tools(
+        tools=[ComputerTool(computer=MinimalComputer())], handoffs=[]
+    )
+
+    assert converted.tools == [{"type": "computer_use_preview"}]
+    assert converted.includes == []
 
 
 def test_convert_tools_shell_local_environment() -> None:


### PR DESCRIPTION
### Summary
- make `Computer.environment` and `Computer.dimensions` optional by default so subclasses are not forced to implement them
- make `AsyncComputer.environment` and `AsyncComputer.dimensions` optional by default for parity
- update Responses tool conversion to omit `environment` and display dimensions when they are not provided
- add regression coverage that verifies `computer_use_preview` is still serialized correctly when those fields are omitted

### Test plan
- make format
- make lint
- uv run mypy src/agents/computer.py src/agents/models/openai_responses.py tests/test_openai_responses_converter.py
- uv run pytest tests/test_openai_responses_converter.py -k "computer"

### Issue number
Closes #2636

### Checks
- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
