### PR TITLE
fix(run): fail fast for server conversation + handoff history mutations

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -56,6 +56,7 @@ from .run_internal.agent_runner_helpers import (
     save_turn_items_if_needed,
     should_cancel_parallel_model_task_on_input_guardrail_trip,
     update_run_state_for_interruption,
+    validate_server_conversation_handoff_settings,
     validate_session_conversation_settings,
 )
 from .run_internal.approvals import approvals_from_step
@@ -441,6 +442,13 @@ class AgentRunner:
                 previous_response_id=previous_response_id,
                 auto_previous_response_id=auto_previous_response_id,
             )
+            validate_server_conversation_handoff_settings(
+                starting_agent,
+                run_config,
+                conversation_id=conversation_id,
+                previous_response_id=previous_response_id,
+                auto_previous_response_id=auto_previous_response_id,
+            )
             starting_input = run_state._original_input
             original_user_input = copy_input_items(run_state._original_input)
             prepared_input = normalize_resumed_input(original_user_input)
@@ -458,6 +466,13 @@ class AgentRunner:
 
             validate_session_conversation_settings(
                 session,
+                conversation_id=conversation_id,
+                previous_response_id=previous_response_id,
+                auto_previous_response_id=auto_previous_response_id,
+            )
+            validate_server_conversation_handoff_settings(
+                starting_agent,
+                run_config,
                 conversation_id=conversation_id,
                 previous_response_id=previous_response_id,
                 auto_previous_response_id=auto_previous_response_id,

--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -39,6 +39,7 @@ __all__ = [
     "ensure_context_wrapper",
     "finalize_conversation_tracking",
     "input_guardrails_triggered",
+    "validate_server_conversation_handoff_settings",
     "validate_session_conversation_settings",
     "resolve_trace_settings",
     "resolve_processed_response",
@@ -101,6 +102,74 @@ def validate_session_conversation_settings(
     raise UserError(
         "Session persistence cannot be combined with conversation_id, "
         "previous_response_id, or auto_previous_response_id."
+    )
+
+
+def validate_server_conversation_handoff_settings(
+    starting_agent: Agent[Any],
+    run_config: RunConfig,
+    *,
+    conversation_id: str | None,
+    previous_response_id: str | None,
+    auto_previous_response_id: bool,
+) -> None:
+    """Fail fast when server conversation is combined with handoff history mutations."""
+    if conversation_id is None and previous_response_id is None and not auto_previous_response_id:
+        return
+
+    conflicts: list[str] = []
+    visited_agents: set[int] = set()
+    queue: list[Agent[Any]] = [starting_agent]
+
+    while queue:
+        agent = queue.pop(0)
+        agent_id = id(agent)
+        if agent_id in visited_agents:
+            continue
+        visited_agents.add(agent_id)
+
+        for handoff_item in agent.handoffs:
+            if isinstance(handoff_item, Agent):
+                target_name = handoff_item.name
+                effective_input_filter = run_config.handoff_input_filter
+                effective_nest_handoff_history = run_config.nest_handoff_history
+                target_agent: Agent[Any] | None = handoff_item
+            else:
+                target_name = handoff_item.agent_name
+                effective_input_filter = (
+                    handoff_item.input_filter or run_config.handoff_input_filter
+                )
+                effective_nest_handoff_history = (
+                    handoff_item.nest_handoff_history
+                    if handoff_item.nest_handoff_history is not None
+                    else run_config.nest_handoff_history
+                )
+                target_agent_ref = handoff_item._agent_ref() if handoff_item._agent_ref else None
+                target_agent = target_agent_ref if isinstance(target_agent_ref, Agent) else None
+
+            if effective_input_filter or effective_nest_handoff_history:
+                conflict_kinds: list[str] = []
+                if effective_input_filter:
+                    conflict_kinds.append("input_filter")
+                if effective_nest_handoff_history:
+                    conflict_kinds.append("nest_handoff_history")
+                conflicts.append(f"{agent.name} -> {target_name} ({', '.join(conflict_kinds)})")
+
+            if target_agent is not None:
+                queue.append(target_agent)
+
+    if not conflicts:
+        return
+
+    preview = "; ".join(conflicts[:3])
+    if len(conflicts) > 3:
+        preview = f"{preview}; ..."
+
+    raise UserError(
+        "Server-managed conversation "
+        "(conversation_id/previous_response_id/auto_previous_response_id) "
+        "cannot be combined with handoff input filtering or nested handoff history. "
+        f"Conflicts: {preview}."
     )
 
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -67,7 +67,10 @@ from ..tracing.model_tracing import get_model_tracing_impl
 from ..tracing.span_data import AgentSpanData
 from ..usage import Usage
 from ..util import _coro, _error_tracing
-from .agent_runner_helpers import apply_resumed_conversation_settings
+from .agent_runner_helpers import (
+    apply_resumed_conversation_settings,
+    validate_server_conversation_handoff_settings,
+)
 from .approvals import (
     append_input_items_excluding_approvals,
     approvals_from_step,
@@ -418,6 +421,14 @@ async def start_streaming(
             previous_response_id=previous_response_id,
             auto_previous_response_id=auto_previous_response_id,
         )
+
+    validate_server_conversation_handoff_settings(
+        starting_agent,
+        run_config,
+        conversation_id=conversation_id,
+        previous_response_id=previous_response_id,
+        auto_previous_response_id=auto_previous_response_id,
+    )
 
     resolved_reasoning_item_id_policy: ReasoningItemIdPolicy | None = (
         run_config.reasoning_item_id_policy

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2611,6 +2611,41 @@ async def test_run_streamed_rejects_session_with_resumed_conversation_state():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "run_config",
+    [
+        RunConfig(),
+        RunConfig(nest_handoff_history=True),
+    ],
+)
+async def test_run_rejects_server_conversation_with_history_mutating_handoffs(
+    run_config: RunConfig,
+):
+    model = FakeModel()
+    refund_agent = Agent(name="refund", model=model)
+    triage_agent = Agent(
+        name="triage",
+        model=model,
+        handoffs=[
+            handoff(
+                refund_agent,
+                input_filter=(lambda data: data)
+                if run_config.nest_handoff_history is False
+                else None,
+            )
+        ],
+    )
+
+    with pytest.raises(UserError, match="cannot be combined with handoff"):
+        await Runner.run(
+            triage_agent,
+            input="test",
+            conversation_id="conv-test",
+            run_config=run_config,
+        )
+
+
+@pytest.mark.asyncio
 async def test_multi_turn_previous_response_id_passed_between_runs():
     """Test that previous_response_id is passed to the model on subsequent runs."""
 


### PR DESCRIPTION
### Summary
- add fail-fast validation for server-managed conversation mode when any reachable handoff applies `input_filter` or effective `nest_handoff_history`
- apply the same validation in both non-streamed and streamed run entry paths
- add regression tests for incompatible combinations in `Runner.run`

### Test plan
- `make format`
- `make lint`
- `make mypy` *(fails in this environment due missing optional stubs/deps like numpy/litellm/sqlalchemy; no new project-local mypy errors from this change)*
- `uv run pytest tests/test_agent_runner.py -k "history_mutating_handoffs or run_rejects_session_with_server_managed_conversation or run_streamed_rejects_session_with_server_managed_conversation"`

### Issue number
Closes #2151

### Checks
- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
