### PR TITLE
fix: show the GA computer alias in tracing

### DIFF
--- a/examples/tools/computer_use.py
+++ b/examples/tools/computer_use.py
@@ -15,7 +15,6 @@ from agents import (
     Button,
     ComputerProvider,
     ComputerTool,
-    Environment,
     RunContextWrapper,
     Runner,
     trace,
@@ -109,10 +108,6 @@ class LocalPlaywrightComputer(AsyncComputer):
     def page(self) -> Page:
         assert self._page is not None
         return self._page
-
-    @property
-    def environment(self) -> Environment:
-        return "browser"
 
     @property
     def dimensions(self) -> tuple[int, int]:

--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -161,6 +161,16 @@ def get_tool_call_trace_name(tool_call: Any) -> str | None:
     )
 
 
+def get_tool_trace_name_for_tool(tool: Any) -> str | None:
+    """Return the trace display name for a tool definition."""
+    trace_name = getattr(tool, "trace_name", None)
+    if isinstance(trace_name, str) and trace_name:
+        return trace_name
+
+    tool_name = getattr(tool, "name", None)
+    return tool_name if isinstance(tool_name, str) and tool_name else None
+
+
 def _remove_tool_call_namespace(tool_call: Any) -> Any:
     """Return a shallow copy of the tool call without its namespace field."""
     if isinstance(tool_call, dict):

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -8,6 +8,7 @@ from typing import Union, cast
 from typing_extensions import Unpack
 
 from . import _debug
+from ._tool_identity import get_tool_trace_name_for_tool
 from .agent import Agent
 from .agent_tool_state import set_agent_tool_state_scope
 from .exceptions import (
@@ -858,7 +859,11 @@ class AgentRunner:
                             output_type=output_type_name,
                         )
                         current_span.start(mark_as_current=True)
-                        current_span.span_data.tools = [t.name for t in all_tools]
+                        current_span.span_data.tools = [
+                            tool_name
+                            for tool in all_tools
+                            if (tool_name := get_tool_trace_name_for_tool(tool)) is not None
+                        ]
 
                     current_turn += 1
                     if current_turn > max_turns:

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -21,6 +21,7 @@ from .._tool_identity import (
     NamedToolLookupKey,
     build_function_tool_lookup_map,
     get_function_tool_lookup_key_for_call,
+    get_tool_trace_name_for_tool,
 )
 from ..agent import Agent
 from ..agent_output import AgentOutputSchemaBase
@@ -708,7 +709,11 @@ async def start_streaming(
                     output_type=output_type_name,
                 )
                 current_span.start(mark_as_current=True)
-                tool_names = [t.name for t in all_tools]
+                tool_names = [
+                    tool_name
+                    for tool in all_tools
+                    if (tool_name := get_tool_trace_name_for_tool(tool)) is not None
+                ]
                 current_span.span_data.tools = tool_names
 
             current_turn += 1

--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -17,7 +17,7 @@ from openai.types.responses.response_input_item_param import (
 )
 from openai.types.responses.response_input_param import ComputerCallOutput
 
-from .._tool_identity import get_mapping_or_attr
+from .._tool_identity import get_mapping_or_attr, get_tool_trace_name_for_tool
 from ..agent import Agent
 from ..exceptions import ModelBehaviorError
 from ..items import RunItem, ToolCallOutputItem
@@ -89,8 +89,8 @@ def _serialize_trace_payload(payload: Any) -> str:
 class ComputerAction:
     """Execute computer tool actions and emit screenshot outputs with hooks fired."""
 
-    TRACE_TOOL_NAME = "computer_use_preview"
-    """Keep tracing aligned with the released computer tool name used by hooks and RunState."""
+    TRACE_TOOL_NAME = "computer"
+    """Tracing should expose the GA computer tool alias."""
 
     @classmethod
     async def execute(
@@ -104,6 +104,7 @@ class ComputerAction:
         acknowledged_safety_checks: list[ComputerCallOutputAcknowledgedSafetyCheck] | None = None,
     ) -> RunItem:
         """Run a computer action, capturing a screenshot and notifying hooks."""
+        trace_tool_name = get_tool_trace_name_for_tool(action.computer_tool) or cls.TRACE_TOOL_NAME
 
         async def _run_action(span: Any | None) -> RunItem:
             if span and config.trace_include_sensitive_data:
@@ -137,7 +138,7 @@ class ComputerAction:
                         SpanError(
                             message="Error running tool",
                             data={
-                                "tool_name": cls.TRACE_TOOL_NAME,
+                                "tool_name": trace_tool_name,
                                 "error": trace_error,
                             },
                         )
@@ -174,7 +175,7 @@ class ComputerAction:
 
         return await with_tool_function_span(
             config=config,
-            tool_name=cls.TRACE_TOOL_NAME,
+            tool_name=trace_tool_name,
             fn=_run_action,
         )
 

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -519,10 +519,15 @@ class ComputerTool(Generic[ComputerT]):
 
     @property
     def name(self):
-        # Keep the released preview-era runtime name for hooks, tracing, and
-        # persisted RunState compatibility. The Responses serializer selects
-        # the actual wire tool type separately.
+        # Keep the released preview-era runtime name for hooks and persisted
+        # RunState compatibility. The Responses serializer selects the actual
+        # wire tool type separately.
         return "computer_use_preview"
+
+    @property
+    def trace_name(self):
+        # Tracing should display the GA tool alias even while runtime names preserve compatibility.
+        return "computer"
 
 
 @dataclass

--- a/tests/test_computer_action.py
+++ b/tests/test_computer_action.py
@@ -37,6 +37,7 @@ from agents import (
     RunConfig,
     RunContextWrapper,
     RunHooks,
+    Runner,
     set_tracing_disabled,
     trace,
 )
@@ -45,6 +46,8 @@ from agents.run_internal import run_loop
 from agents.run_internal.run_loop import ComputerAction, ToolRunComputerAction
 from agents.tool import ComputerToolSafetyCheckData
 
+from .fake_model import FakeModel
+from .test_responses import get_text_message
 from .testing_processor import SPAN_PROCESSOR_TESTING
 
 
@@ -59,6 +62,19 @@ def _get_function_span(tool_name: str) -> dict[str, Any]:
         if span_data.get("type") == "function" and span_data.get("name") == tool_name:
             return exported
     raise AssertionError(f"Function span for tool '{tool_name}' not found")
+
+
+def _get_agent_span(agent_name: str) -> dict[str, Any]:
+    for span in SPAN_PROCESSOR_TESTING.get_ordered_spans(including_empty=True):
+        exported = span.export()
+        if not exported:
+            continue
+        span_data = exported.get("span_data")
+        if not isinstance(span_data, dict):
+            continue
+        if span_data.get("type") == "agent" and span_data.get("name") == agent_name:
+            return exported
+    raise AssertionError(f"Agent span for '{agent_name}' not found")
 
 
 class LoggingComputer(Computer):
@@ -403,11 +419,47 @@ async def test_execute_emits_function_span() -> None:
         )
 
     assert isinstance(result, ToolCallOutputItem)
-    assert ComputerAction.TRACE_TOOL_NAME == "computer_use_preview"
+    assert ComputerAction.TRACE_TOOL_NAME == "computer"
     function_span = _get_function_span(ComputerAction.TRACE_TOOL_NAME)
     span_data = cast(dict[str, Any], function_span["span_data"])
     assert span_data.get("input") is not None
     assert cast(str, span_data.get("output", "")).startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_runner_trace_lists_ga_computer_tool_name() -> None:
+    SPAN_PROCESSOR_TESTING.clear()
+
+    computer = LoggingComputer(screenshot_return="trace_img")
+    tool_call = ResponseComputerToolCall(
+        id="tool_trace_agent_tools",
+        type="computer_call",
+        action=ActionScreenshot(type="screenshot"),
+        call_id="tool_trace_agent_tools",
+        pending_safety_checks=[],
+        status="completed",
+    )
+    model = FakeModel(tracing_enabled=True)
+    model.add_multiple_turn_outputs(
+        [
+            [tool_call],
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(
+        name="test_agent_trace_tools",
+        model=model,
+        tools=[ComputerTool(computer=computer)],
+    )
+
+    set_tracing_disabled(False)
+    with trace("computer-agent-span-test"):
+        result = await Runner.run(agent, input="take a screenshot")
+
+    assert result.final_output == "done"
+    agent_span = _get_agent_span(agent.name)
+    span_data = cast(dict[str, Any], agent_span["span_data"])
+    assert span_data["tools"] == ["computer"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -42,6 +42,7 @@ def test_tool_name_properties() -> None:
     assert FileSearchTool(vector_store_ids=[]).name == "file_search"
     assert WebSearchTool().name == "web_search"
     assert ComputerTool(computer=dummy_computer).name == "computer_use_preview"
+    assert ComputerTool(computer=dummy_computer).trace_name == "computer"
     assert HostedMCPTool(tool_config=dummy_mcp).name == "hosted_mcp"
     assert CodeInterpreterTool(tool_config=dummy_code).name == "code_interpreter"
     assert ImageGenerationTool(tool_config=dummy_image).name == "image_generation"


### PR DESCRIPTION
This pull request fixes computer-tool tracing output so traces render the GA alias `computer` instead of the preview-era label `computer_use_preview`, while preserving the released runtime compatibility name used by hooks and RunState. This trace label change aligns with TS SDK's current behavior.
