### PR TITLE
feat: add rejection_message parameter to RunState.reject()

### DIFF
--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -76,6 +76,9 @@ class ToolErrorFormatterArgs(Generic[TContext]):
     run_context: RunContextWrapper[TContext]
     """The active run context for the current execution."""
 
+    rejection_message: str | None = None
+    """The user-provided reason for rejecting the tool call (via RunState.reject())."""
+
 
 ToolErrorFormatter = Callable[[ToolErrorFormatterArgs[Any]], MaybeAwaitable[Optional[str]]]
 

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -169,13 +169,28 @@ class RunContextWrapper(Generic[TContext]):
             approve=True,
         )
 
-    def reject_tool(self, approval_item: ToolApprovalItem, always_reject: bool = False) -> None:
-        """Reject a tool call, optionally for all future calls."""
+    def reject_tool(
+        self, approval_item: ToolApprovalItem, always_reject: bool = False, rejection_message: str | None = None
+    ) -> None:
+        """Reject a tool call, optionally for all future calls.
+        
+        Args:
+            approval_item: The tool approval item to reject.
+            always_reject: If True, reject all future calls to this tool without prompting.
+            rejection_message: Optional message explaining why the tool call was rejected.
+        """
         self._apply_approval_decision(
             approval_item,
             always=always_reject,
             approve=False,
         )
+        # Store rejection message for use in tool error formatter
+        if rejection_message:
+            call_id = approval_item.raw_item.get("call_id") if isinstance(approval_item.raw_item, dict) else getattr(approval_item.raw_item, "call_id", None)
+            if call_id:
+                if not hasattr(self, "_rejection_messages"):
+                    self._rejection_messages = {}
+                self._rejection_messages[call_id] = rejection_message
 
     def get_approval_status(
         self, tool_name: str, call_id: str, *, existing_pending: ToolApprovalItem | None = None

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -995,7 +995,16 @@ async def resolve_approval_rejection_message(
 ) -> str:
     """Resolve model-visible output text for approval rejections."""
     formatter = run_config.tool_error_formatter
+    
+    # Get rejection message from context if available
+    rejection_message = None
+    if hasattr(context_wrapper, "_rejection_messages"):
+        rejection_message = context_wrapper._rejection_messages.get(call_id)
+    
     if formatter is None:
+        # If no formatter but we have a rejection message, use it
+        if rejection_message:
+            return rejection_message
         return REJECTION_MESSAGE
 
     try:
@@ -1007,6 +1016,7 @@ async def resolve_approval_rejection_message(
                 call_id=call_id,
                 default_message=REJECTION_MESSAGE,
                 run_context=context_wrapper,
+                rejection_message=rejection_message,
             )
         )
         message = await maybe_message if inspect.isawaitable(maybe_message) else maybe_message

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -249,11 +249,20 @@ class RunState(Generic[TContext, TAgent]):
             raise UserError("Cannot approve tool: RunState has no context")
         self._context.approve_tool(approval_item, always_approve=always_approve)
 
-    def reject(self, approval_item: ToolApprovalItem, always_reject: bool = False) -> None:
-        """Reject a tool call and rerun with this state to continue."""
+    def reject(
+        self, approval_item: ToolApprovalItem, always_reject: bool = False, rejection_message: str | None = None
+    ) -> None:
+        """Reject a tool call and rerun with this state to continue.
+        
+        Args:
+            approval_item: The tool approval item to reject.
+            always_reject: If True, reject all future calls to this tool without prompting.
+            rejection_message: Optional message explaining why the tool call was rejected.
+                This will be passed to the model instead of the default rejection message.
+        """
         if self._context is None:
             raise UserError("Cannot reject tool: RunState has no context")
-        self._context.reject_tool(approval_item, always_reject=always_reject)
+        self._context.reject_tool(approval_item, always_reject=always_reject, rejection_message=rejection_message)
 
     def _serialize_approvals(self) -> dict[str, dict[str, Any]]:
         """Serialize approval records into a JSON-friendly mapping."""


### PR DESCRIPTION
## Summary

Add optional `rejection_message` parameter to `RunState.reject()` method to allow passing a specific reason for tool call rejection to the model.

## Problem

When using the Human-in-the-loop (HITL) feature, rejecting a tool call via `RunState.reject()` currently only tells the model that execution was "not approved" — there is no way to communicate WHY the call was rejected.

This makes it difficult for the model to understand context and adjust its response accordingly.

## Solution

Add a new optional `rejection_message` parameter to `RunState.reject()`:

```python
state = result.to_state()
for interruption in result.interruptions:
    reason = ask_user_why_they_rejected(interruption)
    state.reject(
        interruption,
        rejection_message=reason,  # ← new parameter
    )
result = await Runner.run(agent, state)
```

## Changes

1. **run_config.py**: Add `rejection_message` field to `ToolErrorFormatterArgs`
2. **run_state.py**: Add `rejection_message` parameter to `RunState.reject()` method
3. **run_context.py**: Store rejection message in context and pass to formatter
4. **tool_execution.py**: Pass rejection message to tool error formatter

## Testing

- [ ] Test with custom tool error formatter
- [ ] Test without custom formatter (should use rejection_message if provided)
- [ ] Test serialization/deserialization of RunState

## Related

Fixes #2658

---

Good day! I hope this contribution helps. Please let me know if there are any issues or if the implementation needs adjustment. I am happy to make changes.

Warmly,
Jah-yee