### PR TITLE
feat: #2658 preserve explicit approval rejection messages across resume flows

### DIFF
--- a/examples/agent_patterns/human_in_the_loop_custom_rejection.py
+++ b/examples/agent_patterns/human_in_the_loop_custom_rejection.py
@@ -3,8 +3,9 @@
 This example is intentionally minimal:
 1. A single sensitive tool requires human approval.
 2. The first turn always issues that tool call.
-3. Rejection uses a custom message via ``tool_error_formatter``.
-4. The example prints both the formatter output and the assistant's final reply.
+3. ``tool_error_formatter`` defines the universal fallback message shape.
+4. A per-call ``rejection_message`` passed to ``state.reject(...)`` overrides that fallback.
+5. The example prints both the tool output and the assistant's final reply.
 """
 
 import asyncio
@@ -21,7 +22,7 @@ from examples.auto_mode import confirm_with_fallback
 
 
 async def tool_error_formatter(args: ToolErrorFormatterArgs[None]) -> str | None:
-    """Build a simple output message for rejected tool calls."""
+    """Build the universal fallback output message for rejected tool calls."""
     if args.kind != "approval_rejected":
         return None
     # The default message is "Tool execution was not approved."
@@ -60,6 +61,8 @@ async def main() -> None:
         tools=[publish_announcement],
     )
     run_config = RunConfig(tool_error_formatter=tool_error_formatter)
+    # ``tool_error_formatter`` is the universal fallback for approval rejects.
+    # A specific ``rejection_message`` passed to ``state.reject(...)`` below overrides it.
 
     result = await Runner.run(
         agent,
@@ -81,7 +84,13 @@ async def main() -> None:
             if approved:
                 state.approve(interruption)
             else:
-                state.reject(interruption)
+                # This per-call rejection message takes precedence over ``tool_error_formatter``.
+                state.reject(
+                    interruption,
+                    rejection_message=(
+                        "Publish action was canceled because the reviewer denied approval."
+                    ),
+                )
 
         result = await Runner.run(agent, state, run_config=run_config)
 

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from pydantic import BaseModel
 from typing_extensions import assert_never
 
+from .._tool_identity import get_function_tool_lookup_key_for_tool
 from ..agent import Agent
 from ..exceptions import UserError
 from ..handoffs import Handoff
@@ -527,6 +528,14 @@ class RealtimeSession(RealtimeModelListener):
 
     async def _resolve_approval_rejection_message(self, *, tool: FunctionTool, call_id: str) -> str:
         """Resolve model-visible output text for approval rejections."""
+        explicit_message = self._context_wrapper.get_rejection_message(
+            tool.name,
+            call_id,
+            tool_lookup_key=get_function_tool_lookup_key_for_tool(tool),
+        )
+        if explicit_message is not None:
+            return explicit_message
+
         formatter = self._run_config.get("tool_error_formatter")
         if formatter is None:
             return REJECTION_MESSAGE
@@ -574,14 +583,24 @@ class RealtimeSession(RealtimeModelListener):
         else:
             await self._handle_tool_call(tool_call, agent_snapshot=agent_snapshot)
 
-    async def reject_tool_call(self, call_id: str, *, always: bool = False) -> None:
+    async def reject_tool_call(
+        self,
+        call_id: str,
+        *,
+        always: bool = False,
+        rejection_message: str | None = None,
+    ) -> None:
         """Reject a pending tool call and notify the model."""
         pending = self._pending_tool_calls.pop(call_id, None)
         if pending is None:
             return
 
         tool_call, agent_snapshot, function_tool, approval_item = pending
-        self._context_wrapper.reject_tool(approval_item, always_reject=always)
+        self._context_wrapper.reject_tool(
+            approval_item,
+            always_reject=always,
+            rejection_message=rejection_message,
+        )
         await self._send_tool_rejection(tool_call, tool=function_tool, agent=agent_snapshot)
 
     async def _handle_tool_call(

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -35,6 +35,8 @@ class _ApprovalRecord:
 
     approved: bool | list[str] = field(default_factory=list)
     rejected: bool | list[str] = field(default_factory=list)
+    rejection_messages: dict[str, str] = field(default_factory=dict)
+    sticky_rejection_message: str | None = None
 
 
 @dataclass(eq=False)
@@ -207,8 +209,101 @@ class RunContextWrapper(Generic[TContext]):
         # Per-call approvals are scoped to the exact call ID, so other calls require a new decision.
         return None
 
+    @staticmethod
+    def _clear_rejection_message(record: _ApprovalRecord, call_id: str | None) -> None:
+        if call_id is None:
+            return
+        record.rejection_messages.pop(call_id, None)
+
+    @staticmethod
+    def _get_rejection_message_for_key(record: _ApprovalRecord, call_id: str) -> str | None:
+        if record.rejected is True:
+            if call_id in record.rejection_messages:
+                return record.rejection_messages[call_id]
+            return record.sticky_rejection_message
+        if isinstance(record.rejected, list) and call_id in record.rejected:
+            return record.rejection_messages.get(call_id)
+        return None
+
+    def get_rejection_message(
+        self,
+        tool_name: str,
+        call_id: str,
+        *,
+        tool_namespace: str | None = None,
+        existing_pending: ToolApprovalItem | None = None,
+        tool_lookup_key: FunctionToolLookupKey | None = None,
+    ) -> str | None:
+        """Return a stored rejection message for a tool call if one exists."""
+        candidates: list[str] = []
+        explicit_namespace = (
+            tool_namespace if isinstance(tool_namespace, str) and tool_namespace else None
+        )
+        pending_namespace = (
+            self._resolve_tool_namespace(existing_pending) if existing_pending is not None else None
+        )
+        pending_key = self._resolve_approval_key(existing_pending) if existing_pending else None
+        pending_tool_name = self._resolve_tool_name(existing_pending) if existing_pending else None
+        pending_keys = (
+            list(self._resolve_approval_keys(existing_pending))
+            if existing_pending is not None
+            else []
+        )
+
+        if existing_pending and pending_key is not None:
+            candidates.append(pending_key)
+        explicit_keys = (
+            list(
+                get_function_tool_approval_keys(
+                    tool_name=tool_name,
+                    tool_namespace=explicit_namespace,
+                    tool_lookup_key=tool_lookup_key,
+                    include_legacy_deferred_key=True,
+                )
+            )
+            if explicit_namespace is not None or tool_lookup_key is not None
+            else []
+        )
+        for explicit_key in explicit_keys:
+            if explicit_key not in candidates:
+                candidates.append(explicit_key)
+        if not explicit_keys and pending_namespace and pending_key is not None:
+            if pending_key not in candidates:
+                candidates.append(pending_key)
+        if (
+            explicit_namespace is None
+            and tool_lookup_key is None
+            and existing_pending is None
+            and tool_name not in candidates
+        ):
+            candidates.append(tool_name)
+        if existing_pending:
+            for pending_candidate in pending_keys:
+                if pending_candidate not in candidates:
+                    candidates.append(pending_candidate)
+            if (
+                pending_namespace is None
+                and pending_tool_name is not None
+                and pending_tool_name not in candidates
+            ):
+                candidates.append(pending_tool_name)
+
+        for candidate in candidates:
+            approval_entry = self._approvals.get(candidate)
+            if not approval_entry:
+                continue
+            message = self._get_rejection_message_for_key(approval_entry, call_id)
+            if message is not None:
+                return message
+        return None
+
     def _apply_approval_decision(
-        self, approval_item: ToolApprovalItem, *, always: bool, approve: bool
+        self,
+        approval_item: ToolApprovalItem,
+        *,
+        always: bool,
+        approve: bool,
+        rejection_message: str | None = None,
     ) -> None:
         """Record an approval or rejection decision."""
         approval_keys = self._resolve_approval_keys(approval_item) or ("unknown_tool",)
@@ -223,6 +318,14 @@ class RunContextWrapper(Generic[TContext]):
                 approval_entry.rejected = [] if approve else True
                 if not approve:
                     approval_entry.approved = False
+                    if rejection_message is not None and call_id is not None:
+                        approval_entry.rejection_messages[call_id] = rejection_message
+                    elif call_id is not None:
+                        self._clear_rejection_message(approval_entry, call_id)
+                    approval_entry.sticky_rejection_message = rejection_message
+                else:
+                    approval_entry.rejection_messages.clear()
+                    approval_entry.sticky_rejection_message = None
                 continue
 
             opposite = approval_entry.rejected if approve else approval_entry.approved
@@ -232,6 +335,13 @@ class RunContextWrapper(Generic[TContext]):
             target = approval_entry.approved if approve else approval_entry.rejected
             if isinstance(target, list) and call_id not in target:
                 target.append(call_id)
+            if approve:
+                self._clear_rejection_message(approval_entry, call_id)
+            elif call_id is not None:
+                if rejection_message is not None:
+                    approval_entry.rejection_messages[call_id] = rejection_message
+                else:
+                    self._clear_rejection_message(approval_entry, call_id)
 
     def approve_tool(self, approval_item: ToolApprovalItem, always_approve: bool = False) -> None:
         """Approve a tool call, optionally for all future calls."""
@@ -241,12 +351,18 @@ class RunContextWrapper(Generic[TContext]):
             approve=True,
         )
 
-    def reject_tool(self, approval_item: ToolApprovalItem, always_reject: bool = False) -> None:
+    def reject_tool(
+        self,
+        approval_item: ToolApprovalItem,
+        always_reject: bool = False,
+        rejection_message: str | None = None,
+    ) -> None:
         """Reject a tool call, optionally for all future calls."""
         self._apply_approval_decision(
             approval_item,
             always=always_reject,
             approve=False,
+            rejection_message=rejection_message,
         )
 
     def get_approval_status(
@@ -326,6 +442,16 @@ class RunContextWrapper(Generic[TContext]):
             record = _ApprovalRecord()
             record.approved = record_dict.get("approved", [])
             record.rejected = record_dict.get("rejected", [])
+            rejection_messages = record_dict.get("rejection_messages", {})
+            if isinstance(rejection_messages, dict):
+                record.rejection_messages = {
+                    str(call_id): message
+                    for call_id, message in rejection_messages.items()
+                    if isinstance(message, str)
+                }
+            sticky_rejection_message = record_dict.get("sticky_rejection_message")
+            if isinstance(sticky_rejection_message, str):
+                record.sticky_rejection_message = sticky_rejection_message
             self._approvals[tool_name] = record
 
     def _fork_with_tool_input(self, tool_input: Any) -> RunContextWrapper[TContext]:

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1049,8 +1049,21 @@ async def resolve_approval_rejection_message(
     tool_type: Literal["function", "computer", "shell", "apply_patch"],
     tool_name: str,
     call_id: str,
+    tool_namespace: str | None = None,
+    tool_lookup_key: FunctionToolLookupKey | None = None,
+    existing_pending: ToolApprovalItem | None = None,
 ) -> str:
     """Resolve model-visible output text for approval rejections."""
+    explicit_message = context_wrapper.get_rejection_message(
+        tool_name,
+        call_id,
+        tool_namespace=tool_namespace,
+        tool_lookup_key=tool_lookup_key,
+        existing_pending=existing_pending,
+    )
+    if explicit_message is not None:
+        return explicit_message
+
     formatter = run_config.tool_error_formatter
     if formatter is None:
         return REJECTION_MESSAGE
@@ -1150,6 +1163,13 @@ def process_hosted_mcp_approvals(
                 "approval_request_id": request_id,
                 "approve": approved,
             }
+            rejection_message = context_wrapper.get_rejection_message(
+                tool_name=tool_name,
+                call_id=request_id,
+                existing_pending=approval_item,
+            )
+            if approved is False and rejection_message is not None:
+                raw_item["reason"] = rejection_message
             response_item = MCPApprovalResponseItem(raw_item=raw_item, agent=agent)
             append_item(response_item)
             continue
@@ -1199,6 +1219,13 @@ def collect_manual_mcp_approvals(
                 "approval_request_id": request_id,
                 "approve": approval_status,
             }
+            rejection_message = context_wrapper.get_rejection_message(
+                tool_name,
+                request_id,
+                existing_pending=existing_pending,
+            )
+            if approval_status is False and rejection_message is not None:
+                approval_response_raw["reason"] = rejection_message
             approved.append(MCPApprovalResponseItem(raw_item=approval_response_raw, agent=agent))
             continue
 
@@ -1520,6 +1547,8 @@ class _FunctionToolBatchExecutor:
             tool_type="function",
             tool_name=tool_trace_name(func_tool.name, tool_namespace) or func_tool.name,
             call_id=tool_call.call_id,
+            tool_namespace=tool_namespace,
+            tool_lookup_key=tool_lookup_key,
         )
         span_fn.set_error(
             SpanError(
@@ -1988,6 +2017,9 @@ async def execute_approved_tools(
                     tool_type="function",
                     tool_name=display_tool_name,
                     call_id=call_id,
+                    tool_namespace=tool_namespace,
+                    tool_lookup_key=tool_lookup_key,
+                    existing_pending=interruption,
                 )
             _append_error(
                 message=message,

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -32,6 +32,7 @@ from .._tool_identity import (
     build_function_tool_lookup_map,
     get_function_tool_lookup_key,
     get_function_tool_lookup_key_for_call,
+    get_function_tool_lookup_key_for_tool,
     get_tool_call_namespace,
     get_tool_call_qualified_name,
     get_tool_call_trace_name,
@@ -705,12 +706,16 @@ async def resolve_interrupted_turn(
             return
         rejection_message = REJECTION_MESSAGE
         if call_id:
+            tool_namespace = get_tool_call_namespace(tool_call)
             rejection_message = await resolve_approval_rejection_message(
                 context_wrapper=context_wrapper,
                 run_config=run_config,
                 tool_type="function",
                 tool_name=get_tool_call_trace_name(tool_call) or function_tool.name,
                 call_id=call_id,
+                tool_namespace=tool_namespace,
+                tool_lookup_key=get_function_tool_lookup_key_for_tool(function_tool),
+                existing_pending=approval_items_by_call_id.get(call_id),
             )
         rejected_function_outputs.append(
             function_rejection_item(

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -118,8 +118,10 @@ ContextDeserializer = Callable[[Mapping[str, Any]], Any]
 # 3. to_json() always emits CURRENT_SCHEMA_VERSION.
 # 4. Forward compatibility is intentionally fail-fast (older SDKs reject newer or unsupported
 #    versions).
-CURRENT_SCHEMA_VERSION = "1.5"
-SUPPORTED_SCHEMA_VERSIONS = frozenset({"1.0", "1.1", "1.2", "1.3", "1.4", CURRENT_SCHEMA_VERSION})
+CURRENT_SCHEMA_VERSION = "1.6"
+SUPPORTED_SCHEMA_VERSIONS = frozenset(
+    {"1.0", "1.1", "1.2", "1.3", "1.4", "1.5", CURRENT_SCHEMA_VERSION}
+)
 
 _FUNCTION_OUTPUT_ADAPTER: TypeAdapter[FunctionCallOutput] = TypeAdapter(FunctionCallOutput)
 _COMPUTER_OUTPUT_ADAPTER: TypeAdapter[ComputerCallOutput] = TypeAdapter(ComputerCallOutput)
@@ -271,11 +273,26 @@ class RunState(Generic[TContext, TAgent]):
             raise UserError("Cannot approve tool: RunState has no context")
         self._context.approve_tool(approval_item, always_approve=always_approve)
 
-    def reject(self, approval_item: ToolApprovalItem, always_reject: bool = False) -> None:
-        """Reject a tool call and rerun with this state to continue."""
+    def reject(
+        self,
+        approval_item: ToolApprovalItem,
+        always_reject: bool = False,
+        *,
+        rejection_message: str | None = None,
+    ) -> None:
+        """Reject a tool call and rerun with this state to continue.
+
+        When ``rejection_message`` is provided, that exact text is sent back to the model when the
+        run resumes. Otherwise the run-level tool error formatter or the SDK default message is
+        used.
+        """
         if self._context is None:
             raise UserError("Cannot reject tool: RunState has no context")
-        self._context.reject_tool(approval_item, always_reject=always_reject)
+        self._context.reject_tool(
+            approval_item,
+            always_reject=always_reject,
+            rejection_message=rejection_message,
+        )
 
     def _serialize_approvals(self) -> dict[str, dict[str, Any]]:
         """Serialize approval records into a JSON-friendly mapping."""
@@ -291,6 +308,12 @@ class RunState(Generic[TContext, TAgent]):
                 if isinstance(record.rejected, bool)
                 else list(record.rejected),
             }
+            if record.rejection_messages:
+                approvals_dict[tool_name]["rejection_messages"] = dict(record.rejection_messages)
+            if record.sticky_rejection_message is not None:
+                approvals_dict[tool_name]["sticky_rejection_message"] = (
+                    record.sticky_rejection_message
+                )
         return approvals_dict
 
     def _serialize_model_responses(self) -> list[dict[str, Any]]:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1285,6 +1285,48 @@ class TestToolCallExecution:
         )
 
     @pytest.mark.asyncio
+    async def test_reject_pending_tool_call_prefers_explicit_message(
+        self, mock_model, mock_agent, mock_function_tool
+    ):
+        """Rejecting a pending tool call should prefer the explicit rejection message."""
+        mock_function_tool.needs_approval = True
+        mock_agent.get_all_tools.return_value = [mock_function_tool]
+
+        session = RealtimeSession(
+            mock_model,
+            mock_agent,
+            None,
+            run_config={
+                "tool_error_formatter": (
+                    lambda args: f"run-level {args.tool_name} denied ({args.call_id})"
+                )
+            },
+        )
+
+        tool_call_event = RealtimeModelToolCallEvent(
+            name="test_function", call_id="call_reject_explicit", arguments="{}"
+        )
+
+        await session._handle_tool_call(tool_call_event)
+        await session.reject_tool_call(
+            tool_call_event.call_id,
+            rejection_message="explicit rejection message",
+        )
+
+        _sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
+        assert sent_output == "explicit rejection message"
+        assert start_response is True
+
+        events = []
+        while not session._event_queue.empty():
+            events.append(await session._event_queue.get())
+
+        assert any(
+            isinstance(ev, RealtimeToolEnd) and ev.output == "explicit rejection message"
+            for ev in events
+        )
+
+    @pytest.mark.asyncio
     async def test_function_tool_exception_handling(
         self, mock_model, mock_agent, mock_function_tool
     ):

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -5,7 +5,7 @@ import json
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, cast
 from unittest.mock import patch
 
 import httpx
@@ -107,6 +107,7 @@ async def run_execute_approved_tools(
     *,
     approve: bool | None,
     run_config: RunConfig | None = None,
+    mutate_state: Callable[[RunState[Any, Agent[Any]], ToolApprovalItem], None] | None = None,
 ) -> list[RunItem]:
     """Execute approved tools with a consistent setup."""
 
@@ -122,6 +123,8 @@ async def run_execute_approved_tools(
         state.approve(approval_item)
     elif approve is False:
         state.reject(approval_item)
+    if mutate_state is not None:
+        mutate_state(state, approval_item)
 
     generated_items: list[RunItem] = []
 
@@ -3575,6 +3578,36 @@ async def test_execute_approved_tools_with_rejected_tool_uses_run_level_formatte
 
 
 @pytest.mark.asyncio
+async def test_execute_approved_tools_with_rejected_tool_prefers_explicit_message():
+    """Rejected tools should prefer explicit rejection messages over the formatter."""
+
+    async def test_tool() -> str:
+        return "tool_result"
+
+    tool = function_tool(test_tool, name_override="test_tool")
+    _, agent = make_model_and_agent(tools=[tool])
+
+    tool_call = get_function_tool_call("test_tool", "{}")
+    assert isinstance(tool_call, ResponseFunctionToolCall)
+    approval_item = ToolApprovalItem(agent=agent, raw_item=tool_call)
+
+    generated_items = await run_execute_approved_tools(
+        agent=agent,
+        approval_item=approval_item,
+        approve=False,
+        run_config=RunConfig(
+            tool_error_formatter=lambda args: f"run-level {args.tool_name} denied ({args.call_id})"
+        ),
+        mutate_state=lambda state, item: state.reject(
+            item, rejection_message="explicit rejection message"
+        ),
+    )
+
+    assert len(generated_items) == 1
+    assert generated_items[0].output == "explicit rejection message"
+
+
+@pytest.mark.asyncio
 async def test_execute_approved_tools_with_rejected_deferred_tool_uses_display_name():
     """Rejected deferred tools should collapse synthetic namespaces in formatter output."""
 
@@ -3844,6 +3877,57 @@ async def test_execute_approved_tools_uses_internal_lookup_key_for_deferred_top_
     assert generated_items[0].output == "deferred"
     assert visible_calls == []
     assert deferred_calls == ["deferred"]
+
+
+@pytest.mark.asyncio
+async def test_deferred_collision_rejection_prefers_explicit_message() -> None:
+    async def visible_lookup() -> str:
+        return "visible"
+
+    async def deferred_lookup() -> str:
+        return "deferred"
+
+    visible_tool = function_tool(
+        visible_lookup,
+        name_override="lookup_account.lookup_account",
+    )
+    deferred_tool = function_tool(
+        deferred_lookup,
+        name_override="lookup_account",
+        defer_loading=True,
+    )
+    agent = Agent(name="TestAgent", model=FakeModel(), tools=[visible_tool, deferred_tool])
+
+    tool_call = get_function_tool_call(
+        "lookup_account",
+        "{}",
+        call_id="call-deferred",
+        namespace="lookup_account",
+    )
+    assert isinstance(tool_call, ResponseFunctionToolCall)
+    approval_item = ToolApprovalItem(
+        agent=agent,
+        raw_item=tool_call,
+        tool_name="lookup_account",
+        tool_namespace="lookup_account",
+        tool_lookup_key=("deferred_top_level", "lookup_account"),
+    )
+
+    generated_items = await run_execute_approved_tools(
+        agent=agent,
+        approval_item=approval_item,
+        approve=False,
+        run_config=RunConfig(
+            tool_error_formatter=lambda args: f"run-level {args.tool_name} denied ({args.call_id})"
+        ),
+        mutate_state=lambda state, item: state.reject(
+            item, rejection_message="explicit rejection message"
+        ),
+    )
+
+    assert len(generated_items) == 1
+    assert isinstance(generated_items[0], ToolCallOutputItem)
+    assert generated_items[0].output == "explicit rejection message"
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_context_approvals.py
+++ b/tests/test_run_context_approvals.py
@@ -52,6 +52,31 @@ def test_namespaced_approval_status_does_not_fall_back_to_bare_tool_decisions() 
     )
 
 
+def test_namespaced_rejection_message_does_not_fall_back_to_bare_tool_decisions() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    bare_item = make_tool_approval_item(agent, call_id="call-bare", name="lookup_account")
+    billing_item = make_tool_approval_item(
+        agent,
+        call_id="call-billing",
+        name="lookup_account",
+        namespace="billing",
+    )
+
+    context_wrapper.reject_tool(bare_item, always_reject=True, rejection_message="bare denial")
+
+    assert (
+        context_wrapper.get_rejection_message(
+            "lookup_account",
+            "call-billing-2",
+            tool_namespace="billing",
+            existing_pending=billing_item,
+        )
+        is None
+    )
+    assert context_wrapper.get_rejection_message("lookup_account", "call-bare-2") == "bare denial"
+
+
 def test_deferred_top_level_per_call_approval_keeps_bare_name_lookup() -> None:
     agent = Agent(name="test-agent")
     context_wrapper = RunContextWrapper(context=None)
@@ -66,6 +91,22 @@ def test_deferred_top_level_per_call_approval_keeps_bare_name_lookup() -> None:
     context_wrapper.approve_tool(deferred_item)
 
     assert context_wrapper.is_tool_approved("get_weather", "call-weather") is True
+
+
+def test_deferred_top_level_rejection_message_keeps_bare_name_lookup() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    deferred_item = make_tool_approval_item(
+        agent,
+        call_id="call-weather",
+        name="get_weather",
+        namespace="get_weather",
+        allow_bare_name_alias=True,
+    )
+
+    context_wrapper.reject_tool(deferred_item, rejection_message="weather denied")
+
+    assert context_wrapper.get_rejection_message("get_weather", "call-weather") == "weather denied"
 
 
 def test_deferred_top_level_permanent_approval_does_not_alias_to_bare_name() -> None:

--- a/tests/test_run_context_wrapper.py
+++ b/tests/test_run_context_wrapper.py
@@ -61,6 +61,39 @@ def test_run_context_honors_global_approval_and_rejection() -> None:
     assert wrapper.is_tool_approved("tool_call", "call-3") is False
 
 
+def test_run_context_stores_per_call_rejection_messages() -> None:
+    wrapper: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    agent = make_agent()
+    approval = ToolApprovalItem(agent=agent, raw_item={"type": "tool_call", "call_id": "call-1"})
+
+    wrapper.reject_tool(approval, rejection_message="Denied by policy")
+
+    assert wrapper.get_rejection_message("tool_call", "call-1") == "Denied by policy"
+    assert wrapper.get_rejection_message("tool_call", "call-2") is None
+
+
+def test_run_context_stores_sticky_rejection_messages_for_always_reject() -> None:
+    wrapper: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    agent = make_agent()
+    approval = ToolApprovalItem(agent=agent, raw_item={"type": "tool_call", "call_id": "call-1"})
+
+    wrapper.reject_tool(approval, always_reject=True, rejection_message="")
+
+    assert wrapper.get_rejection_message("tool_call", "call-1") == ""
+    assert wrapper.get_rejection_message("tool_call", "call-2") == ""
+
+
+def test_run_context_clears_rejection_message_after_approval() -> None:
+    wrapper: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    agent = make_agent()
+    approval = ToolApprovalItem(agent=agent, raw_item={"type": "tool_call", "call_id": "call-1"})
+
+    wrapper.reject_tool(approval, rejection_message="Denied by policy")
+    wrapper.approve_tool(approval)
+
+    assert wrapper.get_rejection_message("tool_call", "call-1") is None
+
+
 def test_run_context_unknown_tool_name_fallback() -> None:
     agent = make_agent()
     raw: dict[str, Any] = {}

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -384,6 +384,21 @@ class TestRunState:
         assert state._context is not None
         assert state._context.is_tool_approved(tool_name="toolY", call_id="cid456") is False
 
+    def test_reject_stores_rejection_message(self):
+        """Test that reject() stores the explicit rejection message."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="AgentRejectMessage")
+        state = make_state(agent, context=context, original_input="", max_turns=1)
+
+        approval_item = make_tool_approval_item(
+            agent, call_id="cid456", name="toolY", arguments="arguments"
+        )
+
+        state.reject(approval_item, rejection_message="Denied by reviewer")
+
+        assert state._context is not None
+        assert state._context.get_rejection_message("toolY", "cid456") == "Denied by reviewer"
+
     def test_to_json_non_mapping_context_warns_and_omits(self, caplog):
         """Ensure non-mapping contexts are omitted with a warning during serialization."""
 
@@ -699,6 +714,23 @@ class TestRunState:
         assert state._context is not None
         assert state._context.is_tool_approved(tool_name="toolZ", call_id="cid789") is False
         assert state._context.is_tool_approved(tool_name="toolZ", call_id="cid999") is None
+        assert state._context.get_rejection_message("toolZ", "cid999") is None
+
+    def test_always_reject_reuses_rejection_message_for_future_calls(self):
+        """Test that always_reject stores a sticky rejection message."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="AgentStickyReject")
+        state = make_state(agent, context=context, original_input="", max_turns=1)
+
+        approval_item = make_tool_approval_item(
+            agent, call_id="cid789", name="toolZ", arguments="arguments"
+        )
+
+        state.reject(approval_item, always_reject=True, rejection_message="")
+
+        assert state._context is not None
+        assert state._context.get_rejection_message("toolZ", "cid789") == ""
+        assert state._context.get_rejection_message("toolZ", "cid999") == ""
 
     def test_approve_raises_when_context_is_none(self):
         """Test that approve raises UserError when context is None."""
@@ -1014,6 +1046,94 @@ class TestRunState:
         assert new_state._context is not None
         assert new_state._context.is_tool_approved(tool_name="tool1", call_id="cid1") is True
         assert new_state._context.is_tool_approved(tool_name="tool2", call_id="cid2") is False
+        assert new_state._context.get_rejection_message("tool2", "cid2") is None
+
+    async def test_serializes_and_restores_rejection_messages(self):
+        """Test that rejection messages are preserved through serialization."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="ApprovalMessageAgent")
+        state = make_state(agent, context=context, original_input="test")
+
+        raw_item = ResponseFunctionToolCall(
+            type="function_call",
+            name="tool2",
+            call_id="cid2",
+            status="completed",
+            arguments="",
+        )
+        approval_item = ToolApprovalItem(agent=agent, raw_item=raw_item)
+        state.reject(approval_item, always_reject=True, rejection_message="Denied by reviewer")
+
+        new_state = await RunState.from_string(agent, state.to_string())
+
+        assert new_state._context is not None
+        assert new_state._context.get_rejection_message("tool2", "cid2") == "Denied by reviewer"
+        assert new_state._context.get_rejection_message("tool2", "cid3") == "Denied by reviewer"
+
+    async def test_from_json_accepts_previous_schema_version_without_rejection_messages(self):
+        """Test that 1.5 snapshots restore even without rejection message fields."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="ApprovalLegacyAgent")
+        state = make_state(agent, context=context, original_input="test")
+
+        raw_item = ResponseFunctionToolCall(
+            type="function_call",
+            name="tool2",
+            call_id="cid2",
+            status="completed",
+            arguments="",
+        )
+        approval_item = ToolApprovalItem(agent=agent, raw_item=raw_item)
+        state.reject(approval_item, rejection_message="Denied by reviewer")
+
+        json_data = state.to_json()
+        json_data["$schemaVersion"] = "1.5"
+        del json_data["context"]["approvals"]["tool2"]["rejection_messages"]
+
+        restored = await RunState.from_json(agent, json_data)
+
+        assert restored._context is not None
+        assert restored._context.is_tool_approved("tool2", "cid2") is False
+        assert restored._context.get_rejection_message("tool2", "cid2") is None
+
+    async def test_from_json_with_context_override_uses_serialized_rejection_messages(self):
+        """Test that serialized approvals rebuild onto the override context."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={"source": "saved"})
+        agent = Agent(name="ApprovalOverrideAgent")
+        state = make_state(agent, context=context, original_input="test")
+
+        approval_item = ToolApprovalItem(
+            agent=agent,
+            raw_item=ResponseFunctionToolCall(
+                type="function_call",
+                name="tool2",
+                call_id="cid2",
+                status="completed",
+                arguments="",
+            ),
+        )
+        state.reject(approval_item, always_reject=True, rejection_message="Denied by reviewer")
+
+        override_context: RunContextWrapper[dict[str, str]] = RunContextWrapper(
+            context={"source": "override"}
+        )
+        override_context.reject_tool(
+            approval_item,
+            always_reject=True,
+            rejection_message="override denial",
+        )
+
+        restored = await RunState.from_json(
+            agent,
+            state.to_json(),
+            context_override=override_context,
+        )
+
+        assert restored._context is override_context
+        assert restored._context is not None
+        assert restored._context.context == {"source": "override"}
+        assert restored._context.get_rejection_message("tool2", "cid2") == "Denied by reviewer"
+        assert restored._context.get_rejection_message("tool2", "cid3") == "Denied by reviewer"
 
 
 class TestBuildAgentMap:
@@ -3849,7 +3969,7 @@ class TestRunStateSerializationEdgeCases:
             await RunState.from_json(agent, state_json)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("schema_version", ["1.6", "1.7", "2.0"])
+    @pytest.mark.parametrize("schema_version", ["1.7", "2.0"])
     async def test_from_json_unsupported_schema_version(self, schema_version: str):
         """Test that from_json raises error when schema version is unsupported."""
         agent = Agent(name="TestAgent")
@@ -3901,7 +4021,7 @@ class TestRunStateSerializationEdgeCases:
     def test_supported_schema_versions_match_released_boundary(self):
         """The support set should include released versions plus the current unreleased writer."""
         assert SUPPORTED_SCHEMA_VERSIONS == frozenset(
-            {"1.0", "1.1", "1.2", "1.3", "1.4", CURRENT_SCHEMA_VERSION}
+            {"1.0", "1.1", "1.2", "1.3", "1.4", "1.5", CURRENT_SCHEMA_VERSION}
         )
 
     @pytest.mark.asyncio

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -2853,4 +2853,65 @@ async def test_execute_tools_emits_hosted_mcp_rejection_response():
     assert responses, "Rejection should emit an MCP approval response."
     assert responses[0].raw_item["approve"] is False
     assert responses[0].raw_item["approval_request_id"] == "mcp-approval-reject"
+    assert "reason" not in responses[0].raw_item
     assert not isinstance(result.next_step, NextStepInterruption)
+
+
+@pytest.mark.asyncio
+async def test_execute_tools_emits_hosted_mcp_rejection_reason_from_explicit_message():
+    """Hosted MCP rejections should forward explicit rejection messages as reasons."""
+
+    mcp_tool = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "test_mcp_server",
+            "server_url": "https://example.com",
+            "require_approval": "always",
+        },
+        on_approval_request=None,
+    )
+    agent = make_agent(tools=[mcp_tool])
+    request_item = McpApprovalRequest(
+        id="mcp-approval-reject-reason",
+        type="mcp_approval_request",
+        server_label="test_mcp_server",
+        arguments="{}",
+        name="list_repo_languages",
+    )
+    processed_response = make_processed_response(
+        new_items=[MCPApprovalRequestItem(raw_item=request_item, agent=agent)],
+        mcp_approval_requests=[
+            ToolRunMCPApprovalRequest(
+                request_item=request_item,
+                mcp_tool=mcp_tool,
+            )
+        ],
+    )
+    context_wrapper = make_context_wrapper()
+    reject_tool_call(
+        context_wrapper,
+        agent,
+        request_item,
+        tool_name="list_repo_languages",
+        rejection_message="Denied by policy",
+    )
+
+    result = await run_loop.execute_tools_and_side_effects(
+        agent=agent,
+        original_input="test",
+        pre_step_items=[],
+        new_response=ModelResponse(output=[], usage=Usage(), response_id="resp"),
+        processed_response=processed_response,
+        output_schema=None,
+        hooks=RunHooks(),
+        context_wrapper=context_wrapper,
+        run_config=RunConfig(),
+    )
+
+    responses = [
+        item for item in result.new_step_items if isinstance(item, MCPApprovalResponseItem)
+    ]
+    assert responses, "Rejection should emit an MCP approval response."
+    assert responses[0].raw_item["approve"] is False
+    assert responses[0].raw_item["approval_request_id"] == "mcp-approval-reject-reason"
+    assert responses[0].raw_item["reason"] == "Denied by policy"

--- a/tests/utils/hitl.py
+++ b/tests/utils/hitl.py
@@ -478,10 +478,12 @@ def reject_tool_call(
     agent: Agent[Any],
     raw_item: Any,
     tool_name: str,
+    *,
+    rejection_message: str | None = None,
 ) -> ToolApprovalItem:
     """Reject a tool call in the context and return the approval item used."""
     approval_item = ToolApprovalItem(agent=agent, raw_item=raw_item, tool_name=tool_name)
-    context_wrapper.reject_tool(approval_item)
+    context_wrapper.reject_tool(approval_item, rejection_message=rejection_message)
     return approval_item
 
 


### PR DESCRIPTION
This pull request fixes #2658 how explicit tool approval rejection messages are handled.

Today, `state.reject(..., rejection_message=...)` can be used to provide a model-visible denial reason, but that message was not preserved consistently across interruption resume paths and related approval surfaces. As a result, resumed runs could fall back to the run-level `tool_error_formatter` or the default rejection text instead of returning the reviewer-provided message.

This change stores explicit rejection messages in the approval state, serializes them in `RunState`, and prefers them over formatter-generated fallback text when rejected tool calls are replayed. It also carries the same rejection reason through realtime session rejections and Hosted MCP approval responses, so approval-denied behavior is consistent across runtime paths.

see also: https://github.com/openai/openai-agents-js/pull/1058