### PR TITLE
fix: #2664 drop orphan hosted shell calls before multi-turn replay

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -33,6 +33,7 @@ __all__ = [
     "copy_input_items",
     "drop_orphan_function_calls",
     "ensure_input_item_format",
+    "prepare_model_input_items",
     "run_item_to_input_item",
     "run_items_to_input_items",
     "normalize_input_items_for_api",
@@ -86,7 +87,11 @@ def run_items_to_input_items(
     return converted
 
 
-def drop_orphan_function_calls(items: list[TResponseInputItem]) -> list[TResponseInputItem]:
+def drop_orphan_function_calls(
+    items: list[TResponseInputItem],
+    *,
+    pruning_indexes: set[int] | None = None,
+) -> list[TResponseInputItem]:
     """
     Remove tool call items that do not have corresponding outputs so resumptions or retries do not
     replay stale tool calls.
@@ -106,6 +111,9 @@ def drop_orphan_function_calls(items: list[TResponseInputItem]) -> list[TRespons
             continue
         output_type = _TOOL_CALL_TO_OUTPUT_TYPE.get(entry_type)
         if output_type is None:
+            filtered.append(entry)
+            continue
+        if pruning_indexes is not None and index not in pruning_indexes:
             filtered.append(entry)
             continue
         call_id = entry.get("call_id")
@@ -143,6 +151,20 @@ def normalize_input_items_for_api(items: list[TResponseInputItem]) -> list[TResp
         normalized_item = dict(coerced)
         normalized.append(cast(TResponseInputItem, normalized_item))
     return normalized
+
+
+def prepare_model_input_items(
+    caller_items: Sequence[TResponseInputItem],
+    generated_items: Sequence[TResponseInputItem] = (),
+) -> list[TResponseInputItem]:
+    """Normalize model input while pruning orphans only from runner-generated history."""
+    normalized_caller_items = normalize_input_items_for_api(list(caller_items))
+    if not generated_items:
+        return normalized_caller_items
+
+    normalized_generated_items = normalize_input_items_for_api(list(generated_items))
+    filtered_generated_items = drop_orphan_function_calls(normalized_generated_items)
+    return normalized_caller_items + filtered_generated_items
 
 
 def normalize_resumed_input(

--- a/src/agents/run_internal/oai_conversation.py
+++ b/src/agents/run_internal/oai_conversation.py
@@ -23,6 +23,7 @@ from .items import (
     drop_orphan_function_calls,
     fingerprint_input_item,
     normalize_input_items_for_api,
+    prepare_model_input_items,
     run_item_to_input_item,
 )
 
@@ -153,8 +154,7 @@ class OpenAIServerConversationTracker:
 
         normalized_input = original_input
         if isinstance(original_input, list):
-            normalized = normalize_input_items_for_api(original_input)
-            normalized_input = drop_orphan_function_calls(normalized)
+            normalized_input = prepare_model_input_items(original_input)
 
         for item in ItemHelpers.input_to_new_input_list(normalized_input):
             if item is None:
@@ -404,13 +404,17 @@ class OpenAIServerConversationTracker:
         generated_items: list[RunItem],
     ) -> list[TResponseInputItem]:
         """Assemble the next model input while skipping duplicates and approvals."""
-        input_items: list[TResponseInputItem] = []
+        prepared_initial_items: list[TResponseInputItem] = []
+        prepared_generated_items: list[TResponseInputItem] = []
+        generated_item_sources: dict[int, TResponseInputItem] = {}
 
         if not self.sent_initial_input:
             initial_items = ItemHelpers.input_to_new_input_list(original_input)
-            input_items.extend(initial_items)
-            for item in initial_items:
-                self._register_prepared_item_source(item)
+            prepared_initial_items = normalize_input_items_for_api(initial_items)
+            for prepared_item, source_item in zip(
+                prepared_initial_items, initial_items, strict=False
+            ):
+                self._register_prepared_item_source(prepared_item, source_item)
             filtered_initials = []
             for item in initial_items:
                 if item is None or isinstance(item, (str, bytes)):
@@ -419,9 +423,11 @@ class OpenAIServerConversationTracker:
             self.remaining_initial_input = filtered_initials or None
             self.sent_initial_input = True
         elif self.remaining_initial_input:
-            input_items.extend(self.remaining_initial_input)
-            for item in self.remaining_initial_input:
-                self._register_prepared_item_source(item)
+            prepared_initial_items = normalize_input_items_for_api(self.remaining_initial_input)
+            for prepared_item, source_item in zip(
+                prepared_initial_items, self.remaining_initial_input, strict=False
+            ):
+                self._register_prepared_item_source(prepared_item, source_item)
 
         for item in generated_items:  # type: ignore[assignment]
             run_item: RunItem = cast(RunItem, item)
@@ -474,13 +480,23 @@ class OpenAIServerConversationTracker:
             ):
                 continue
 
-            input_items.append(converted_input_item)
-            self._register_prepared_item_source(
-                converted_input_item,
-                cast(TResponseInputItem, raw_item),
-            )
+            prepared_generated_items.append(converted_input_item)
+            generated_item_sources[id(converted_input_item)] = cast(TResponseInputItem, raw_item)
 
-        return input_items
+        normalized_generated_items = normalize_input_items_for_api(prepared_generated_items)
+        normalized_generated_sources = {
+            id(normalized_item): generated_item_sources[id(source_item)]
+            for normalized_item, source_item in zip(
+                normalized_generated_items, prepared_generated_items, strict=False
+            )
+        }
+        filtered_generated_items = drop_orphan_function_calls(normalized_generated_items)
+        for item in filtered_generated_items:
+            prepared_source_item = normalized_generated_sources.get(id(item))
+            if prepared_source_item is not None:
+                self._register_prepared_item_source(item, prepared_source_item)
+
+        return prepared_initial_items + filtered_generated_items
 
     def _register_prepared_item_source(
         self, prepared_item: TResponseInputItem, source_item: TResponseInputItem | None = None

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -69,10 +69,7 @@ from ..tracing.span_data import AgentSpanData
 from ..usage import Usage
 from ..util import _coro, _error_tracing
 from .agent_runner_helpers import apply_resumed_conversation_settings
-from .approvals import (
-    append_input_items_excluding_approvals,
-    approvals_from_step,
-)
+from .approvals import approvals_from_step
 from .error_handlers import (
     build_run_error_data,
     create_message_output_item,
@@ -93,8 +90,9 @@ from .items import (
     copy_input_items,
     deduplicate_input_items_preferring_latest,
     ensure_input_item_format,
-    normalize_input_items_for_api,
     normalize_resumed_input,
+    prepare_model_input_items,
+    run_items_to_input_items,
 )
 from .model_retry import (
     apply_retry_attempt_usage,
@@ -242,6 +240,16 @@ async def _should_persist_stream_items(
         return False
     should_skip_session_save = await input_guardrail_tripwire_triggered_for_stream(streamed_result)
     return should_skip_session_save is False
+
+
+def _prepare_turn_input_items(
+    caller_input: str | list[TResponseInputItem],
+    generated_items: list[RunItem],
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None,
+) -> list[TResponseInputItem]:
+    caller_items = ItemHelpers.input_to_new_input_list(caller_input)
+    continuation_items = run_items_to_input_items(generated_items, reasoning_item_id_policy)
+    return prepare_model_input_items(caller_items, continuation_items)
 
 
 def _complete_stream_interruption(
@@ -1164,15 +1172,11 @@ async def run_single_turn_streamed(
             else 0,
         )
     else:
-        input = ItemHelpers.input_to_new_input_list(streamed_result.input)
-        append_input_items_excluding_approvals(
-            input,
+        input = _prepare_turn_input_items(
+            streamed_result.input,
             streamed_result._model_input_items,
             reasoning_item_id_policy,
         )
-
-    if isinstance(input, list):
-        input = normalize_input_items_for_api(input)
 
     filtered = await maybe_filter_model_input(
         agent=agent,
@@ -1512,23 +1516,7 @@ async def run_single_turn(
     if server_conversation_tracker is not None:
         input = server_conversation_tracker.prepare_input(original_input, generated_items)
     else:
-        input = ItemHelpers.input_to_new_input_list(original_input)
-        if isinstance(input, list):
-            append_input_items_excluding_approvals(
-                input,
-                generated_items,
-                reasoning_item_id_policy,
-            )
-        else:
-            input = ItemHelpers.input_to_new_input_list(input)
-            append_input_items_excluding_approvals(
-                input,
-                generated_items,
-                reasoning_item_id_policy,
-            )
-
-    if isinstance(input, list):
-        input = normalize_input_items_for_api(input)
+        input = _prepare_turn_input_items(original_input, generated_items, reasoning_item_id_policy)
 
     new_response = await get_new_response(
         agent,

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -91,6 +91,8 @@ async def prepare_input_with_session(
         ensure_input_item_format(item) for item in ItemHelpers.input_to_new_input_list(input)
     ]
 
+    prune_history_indexes: set[int] = set()
+
     if session_input_callback is None or not include_history_in_prepared_input:
         prepared_items_raw: list[TResponseInputItem] = (
             converted_history + new_input_list
@@ -98,6 +100,8 @@ async def prepare_input_with_session(
             else list(new_input_list)
         )
         appended_items = list(new_input_list)
+        if include_history_in_prepared_input:
+            prune_history_indexes = set(range(len(converted_history)))
     else:
         if not callable(session_input_callback):
             raise UserError(
@@ -121,7 +125,7 @@ async def prepare_input_with_session(
         new_counts = _build_frequency_map(new_items_for_callback)
 
         appended: list[Any] = []
-        for item in combined:
+        for combined_index, item in enumerate(combined):
             key = _session_item_key(item)
             if _consume_reference(new_refs, key, item):
                 new_counts[key] = max(new_counts.get(key, 0) - 1, 0)
@@ -129,9 +133,11 @@ async def prepare_input_with_session(
                 continue
             if _consume_reference(history_refs, key, item):
                 history_counts[key] = max(history_counts.get(key, 0) - 1, 0)
+                prune_history_indexes.add(combined_index)
                 continue
             if history_counts.get(key, 0) > 0:
                 history_counts[key] = history_counts.get(key, 0) - 1
+                prune_history_indexes.add(combined_index)
                 continue
             if new_counts.get(key, 0) > 0:
                 new_counts[key] = max(new_counts.get(key, 0) - 1, 0)
@@ -151,7 +157,10 @@ async def prepare_input_with_session(
     # Normalize exactly as the runtime does elsewhere so the prepared model input and the
     # persisted session items are derived from the same item shape and dedupe rules.
     prepared_as_inputs = [ensure_input_item_format(item) for item in prepared_items_raw]
-    filtered = drop_orphan_function_calls(prepared_as_inputs)
+    filtered = drop_orphan_function_calls(
+        prepared_as_inputs,
+        pruning_indexes=prune_history_indexes,
+    )
     normalized = normalize_input_items_for_api(filtered)
     deduplicated = deduplicate_input_items_preferring_latest(normalized)
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -74,7 +74,7 @@ from agents.run_internal.session_persistence import (
 from agents.run_internal.tool_execution import execute_approved_tools
 from agents.run_internal.tool_use_tracker import AgentToolUseTracker
 from agents.run_state import RunState
-from agents.tool import ComputerTool, FunctionToolResult, function_tool
+from agents.tool import ComputerTool, FunctionToolResult, ShellTool, function_tool
 from agents.tool_context import ToolContext
 from agents.usage import Usage
 
@@ -88,7 +88,7 @@ from .test_responses import (
     get_text_message,
 )
 from .utils.factories import make_run_state
-from .utils.hitl import make_context_wrapper, make_model_and_agent
+from .utils.hitl import make_context_wrapper, make_model_and_agent, make_shell_call
 from .utils.simple_session import CountingSession, IdStrippingSession, SimpleListSession
 
 
@@ -1694,6 +1694,45 @@ async def test_prepare_input_with_session_drops_orphan_function_calls():
     )
 
 
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_preserves_pending_new_shell_calls() -> None:
+    orphan_call = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call",
+            "call_id": "orphan_call",
+            "name": "tool_orphan",
+            "arguments": "{}",
+        },
+    )
+    pending_shell_call = cast(
+        TResponseInputItem,
+        make_shell_call("manual_shell", id_value="shell_1", commands=["echo hi"]),
+    )
+    session = SimpleListSession(history=[orphan_call])
+
+    prepared_input, session_items = await prepare_input_with_session(
+        [pending_shell_call],
+        session,
+        None,
+    )
+
+    assert isinstance(prepared_input, list)
+    assert session_items == [pending_shell_call]
+    assert not any(
+        isinstance(item, dict)
+        and item.get("type") == "function_call"
+        and item.get("call_id") == "orphan_call"
+        for item in prepared_input
+    )
+    assert any(
+        isinstance(item, dict)
+        and item.get("type") == "shell_call"
+        and item.get("call_id") == "manual_shell"
+        for item in prepared_input
+    )
+
+
 def test_ensure_api_input_item_handles_model_dump_objects():
     class _ModelDumpItem:
         def model_dump(self, exclude_unset: bool = True) -> dict[str, Any]:
@@ -3155,6 +3194,198 @@ async def test_default_send_all_items_streamed():
     # Check function result
     assert function_result.get("type") == "function_call_output"
     assert function_result.get("call_id") is not None
+
+
+@pytest.mark.asyncio
+async def test_default_multi_turn_drops_orphan_hosted_shell_calls() -> None:
+    model = FakeModel()
+    agent = Agent(
+        name="hosted-shell",
+        model=model,
+        tools=[ShellTool(environment={"type": "container_auto"})],
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [make_shell_call("call_shell_1", id_value="shell_1", commands=["echo hi"])],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = await Runner.run(agent, input="user_message")
+
+    assert result.final_output == "done"
+
+    last_input = model.last_turn_args["input"]
+    assert isinstance(last_input, list)
+    assert len(last_input) == 1
+    assert not any(
+        isinstance(item, dict) and item.get("type") == "shell_call" for item in last_input
+    )
+    assert last_input[0].get("role") == "user"
+    assert last_input[0].get("content") == "user_message"
+
+
+@pytest.mark.asyncio
+async def test_manual_pending_shell_call_input_is_preserved_non_streamed() -> None:
+    model = FakeModel()
+    agent = Agent(
+        name="manual-shell",
+        model=model,
+        tools=[get_function_tool("test_func", "tool_result")],
+    )
+    pending_shell_call = cast(
+        TResponseInputItem,
+        make_shell_call("manual_shell", id_value="shell_1", commands=["echo hi"]),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("test_func", '{"arg": "foo"}')],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = await Runner.run(agent, input=[pending_shell_call])
+
+    assert result.final_output == "done"
+    assert isinstance(model.first_turn_args, dict)
+    assert any(
+        isinstance(item, dict)
+        and item.get("type") == "shell_call"
+        and item.get("call_id") == "manual_shell"
+        for item in model.first_turn_args["input"]
+    )
+
+    last_input = model.last_turn_args["input"]
+    assert isinstance(last_input, list)
+    assert any(
+        isinstance(item, dict)
+        and item.get("type") == "shell_call"
+        and item.get("call_id") == "manual_shell"
+        for item in last_input
+    )
+
+
+@pytest.mark.asyncio
+async def test_manual_pending_shell_call_input_is_preserved_non_streamed_with_session() -> None:
+    model = FakeModel()
+    agent = Agent(
+        name="manual-shell",
+        model=model,
+        tools=[get_function_tool("test_func", "tool_result")],
+    )
+    session = SimpleListSession()
+    pending_shell_call = cast(
+        TResponseInputItem,
+        make_shell_call("manual_shell", id_value="shell_1", commands=["echo hi"]),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("test_func", '{"arg": "foo"}')],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = await Runner.run(agent, input=[pending_shell_call], session=session)
+
+    assert result.final_output == "done"
+    assert isinstance(model.first_turn_args, dict)
+    assert any(
+        isinstance(item, dict)
+        and item.get("type") == "shell_call"
+        and item.get("call_id") == "manual_shell"
+        for item in model.first_turn_args["input"]
+    )
+
+    last_input = model.last_turn_args["input"]
+    assert isinstance(last_input, list)
+    assert any(
+        isinstance(item, dict)
+        and item.get("type") == "shell_call"
+        and item.get("call_id") == "manual_shell"
+        for item in last_input
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_multi_turn_streamed_drops_orphan_hosted_shell_calls() -> None:
+    model = FakeModel()
+    agent = Agent(
+        name="hosted-shell",
+        model=model,
+        tools=[ShellTool(environment={"type": "container_auto"})],
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [make_shell_call("call_shell_1", id_value="shell_1", commands=["echo hi"])],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="user_message")
+    async for _ in result.stream_events():
+        pass
+
+    assert result.final_output == "done"
+
+    last_input = model.last_turn_args["input"]
+    assert isinstance(last_input, list)
+    assert len(last_input) == 1
+    assert not any(
+        isinstance(item, dict) and item.get("type") == "shell_call" for item in last_input
+    )
+    assert last_input[0].get("role") == "user"
+    assert last_input[0].get("content") == "user_message"
+
+
+@pytest.mark.asyncio
+async def test_manual_pending_shell_call_input_is_preserved_streamed() -> None:
+    model = FakeModel()
+    agent = Agent(name="manual-shell", model=model)
+    pending_shell_call = cast(
+        TResponseInputItem,
+        make_shell_call("manual_shell", id_value="shell_1", commands=["echo hi"]),
+    )
+    model.set_next_output([get_text_message("done")])
+
+    result = Runner.run_streamed(agent, input=[pending_shell_call])
+    async for _ in result.stream_events():
+        pass
+
+    assert result.final_output == "done"
+    last_input = model.last_turn_args["input"]
+    assert isinstance(last_input, list)
+    assert any(
+        isinstance(item, dict)
+        and item.get("type") == "shell_call"
+        and item.get("call_id") == "manual_shell"
+        for item in last_input
+    )
+
+
+@pytest.mark.asyncio
+async def test_manual_pending_shell_call_input_is_preserved_streamed_with_session() -> None:
+    model = FakeModel()
+    agent = Agent(name="manual-shell", model=model)
+    session = SimpleListSession()
+    pending_shell_call = cast(
+        TResponseInputItem,
+        make_shell_call("manual_shell", id_value="shell_1", commands=["echo hi"]),
+    )
+    model.set_next_output([get_text_message("done")])
+
+    result = Runner.run_streamed(agent, input=[pending_shell_call], session=session)
+    async for _ in result.stream_events():
+        pass
+
+    assert result.final_output == "done"
+    last_input = model.last_turn_args["input"]
+    assert isinstance(last_input, list)
+    assert any(
+        isinstance(item, dict)
+        and item.get("type") == "shell_call"
+        and item.get("call_id") == "manual_shell"
+        for item in last_input
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes orphan hosted shell calls being replayed into subsequent model turns when the Responses API returns a `shell_call` without a matching `shell_call_output`. It updates the default multi-turn run loop to drop orphan tool calls after normalizing input items in both streamed and non-streamed execution, which keeps the normal path consistent with the existing resumed-session and server-managed conversation defenses. This pull request resolves #2664.

The change is intentionally narrow: hosted shell calls are still preserved in run results for inspection, but they are no longer forwarded back to the model unless a corresponding output item exists. Regression coverage now exercises both `Runner.run(...)` and `Runner.run_streamed(...)` with hosted `ShellTool(environment={"type": "container_auto"})` so the default path cannot reintroduce the replay bug.