### PR TITLE
fix: handle inner MCP tool cancellations as tool errors

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -365,43 +365,22 @@ class MCPUtil:
                 if merged_meta is None
                 else server.call_tool(tool.name, json_data, meta=merged_meta)
             )
-            current_task = asyncio.current_task()
-            cancelling = getattr(current_task, "cancelling", None)
-            cancel_count_before = 0
-            if callable(cancelling):
-                cancel_count_before_raw = cancelling()
-                if isinstance(cancel_count_before_raw, int):
-                    cancel_count_before = cancel_count_before_raw
             try:
-                result = await asyncio.shield(call_task)
-            except asyncio.CancelledError as e:
-                current_task = asyncio.current_task()
-                cancelling = getattr(current_task, "cancelling", None)
-                cancel_count_after = cancel_count_before
-                if callable(cancelling):
-                    cancel_count_after_raw = cancelling()
-                    if isinstance(cancel_count_after_raw, int):
-                        cancel_count_after = cancel_count_after_raw
-                if current_task is not None and cancel_count_after > cancel_count_before:
-                    if not call_task.done():
-                        call_task.cancel()
-                        try:
-                            await call_task
-                        except (asyncio.CancelledError, Exception):
-                            pass
-                    raise
-                if not call_task.done():
-                    call_task.cancel()
-                    try:
-                        await call_task
-                    except (asyncio.CancelledError, Exception):
-                        pass
-                    raise
-                if call_task.cancelled():
+                done, _ = await asyncio.wait({call_task}, return_when=asyncio.FIRST_COMPLETED)
+                finished_task = done.pop()
+                if finished_task.cancelled():
                     raise UserError(
                         f"Failed to call tool '{tool.name}' on MCP server '{server.name}': "
                         "tool execution was cancelled."
-                    ) from e
+                    )
+                result = finished_task.result()
+            except asyncio.CancelledError:
+                if not call_task.done():
+                    call_task.cancel()
+                try:
+                    await call_task
+                except (asyncio.CancelledError, Exception):
+                    pass
                 raise
         except UserError:
             # Re-raise UserError as-is (it already has a good message)

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -280,22 +280,6 @@ async def test_mcp_tool_inner_cancellation_still_becomes_tool_error_with_prior_c
 
 
 @pytest.mark.asyncio
-async def test_mcp_tool_cancellation_paths_work_without_task_cancelling_api(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    server = CancelledFakeMCPServer()
-    server.add_tool("cancel_tool", {})
-
-    ctx = RunContextWrapper(context=None)
-    tool = MCPTool(name="cancel_tool", inputSchema={})
-
-    monkeypatch.setattr(asyncio, "current_task", lambda: object())
-
-    with pytest.raises(UserError, match="tool execution was cancelled"):
-        await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
-
-
-@pytest.mark.asyncio
 async def test_mcp_tool_outer_cancellation_still_propagates():
     server = SlowFakeMCPServer()
     server.add_tool("slow_tool", {})
@@ -321,11 +305,13 @@ async def test_mcp_tool_outer_cancellation_after_inner_completion_still_propagat
     ctx = RunContextWrapper(context=None)
     tool = MCPTool(name="fast_tool", inputSchema={})
 
-    async def fake_shield(task: asyncio.Task[CallToolResult]) -> CallToolResult:
+    async def fake_wait(tasks, *, return_when):
+        del return_when
+        (task,) = tuple(tasks)
         await task
         raise asyncio.CancelledError("synthetic outer cancellation")
 
-    monkeypatch.setattr(asyncio, "shield", fake_shield)
+    monkeypatch.setattr(asyncio, "wait", fake_wait)
 
     with pytest.raises(asyncio.CancelledError):
         await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
@@ -341,14 +327,16 @@ async def test_mcp_tool_outer_cancellation_after_inner_exception_still_propagate
     ctx = RunContextWrapper(context=None)
     tool = MCPTool(name="boom_tool", inputSchema={})
 
-    async def fake_shield(task: asyncio.Task[CallToolResult]) -> CallToolResult:
+    async def fake_wait(tasks, *, return_when):
+        del return_when
+        (task,) = tuple(tasks)
         try:
             await task
         except Exception:
             pass
         raise asyncio.CancelledError("synthetic outer cancellation")
 
-    monkeypatch.setattr(asyncio, "shield", fake_shield)
+    monkeypatch.setattr(asyncio, "wait", fake_wait)
 
     with pytest.raises(asyncio.CancelledError):
         await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
@@ -364,25 +352,16 @@ async def test_mcp_tool_outer_cancellation_after_inner_cancellation_still_propag
     ctx = RunContextWrapper(context=None)
     tool = MCPTool(name="slow_tool", inputSchema={})
 
-    class CancellingTaskStub:
-        def __init__(self):
-            self.cancel_count = 0
-
-        def cancelling(self) -> int:
-            return self.cancel_count
-
-    task_stub = CancellingTaskStub()
-
-    async def fake_shield(task: asyncio.Task[CallToolResult]) -> CallToolResult:
+    async def fake_wait(tasks, *, return_when):
+        del return_when
+        (task,) = tuple(tasks)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
 
-        task_stub.cancel_count = 1
         raise asyncio.CancelledError("synthetic combined cancellation")
 
-    monkeypatch.setattr(asyncio, "shield", fake_shield)
-    monkeypatch.setattr(asyncio, "current_task", lambda: task_stub)
+    monkeypatch.setattr(asyncio, "wait", fake_wait)
 
     with pytest.raises(asyncio.CancelledError):
         await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")


### PR DESCRIPTION
### Summary

Normalize MCP-internal `asyncio.CancelledError` into a normal tool failure instead of letting it cancel the surrounding agent stream.

This change shields the inner `server.call_tool(...)` task in `MCPUtil.invoke_mcp_tool()`. If that inner task itself is cancelled, the SDK now raises `UserError` so the existing function-tool failure pipeline can surface a normal tool error. True outer task cancellation still propagates as `CancelledError`.

### Test plan

- `make format`
- `make lint`
- `make typecheck`
- `make tests`
- `uv run python -m pytest tests/mcp/test_mcp_util.py -k 'inner_cancellation or outer_cancellation or test_mcp_invocation_crash_causes_error' -q`
- Direct synthetic sanity check in the fresh clone:
  - inner MCP cancellation becomes `UserError` / normal tool error string
  - true outer cancellation remains `CancelledError`

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
