### PR TITLE
fix: serialize streamable-http MCP requests per session

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -681,8 +681,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         """List the prompts available on the server."""
         if not self.session:
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
-
-        return await self.session.list_prompts()
+        session = self.session
+        assert session is not None
+        return await self._maybe_serialize_request(lambda: session.list_prompts())
 
     async def get_prompt(
         self, name: str, arguments: dict[str, Any] | None = None
@@ -690,8 +691,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         """Get a specific prompt from the server."""
         if not self.session:
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
-
-        return await self.session.get_prompt(name, arguments)
+        session = self.session
+        assert session is not None
+        return await self._maybe_serialize_request(lambda: session.get_prompt(name, arguments))
 
     async def cleanup(self):
         """Cleanup the server."""

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -172,6 +172,18 @@ class ConcurrentCancellationSession:
     async def list_tools(self):
         return ListToolsResult(tools=[MCPTool(name="tool", inputSchema={})])
 
+    async def list_prompts(self):
+        await self._slow_started.wait()
+        assert self._slow_task is not None
+        self._slow_task.cancel()
+        raise RuntimeError("synthetic request failure")
+
+    async def get_prompt(self, name, arguments=None):
+        await self._slow_started.wait()
+        assert self._slow_task is not None
+        self._slow_task.cancel()
+        raise RuntimeError("synthetic request failure")
+
 
 @pytest.mark.asyncio
 async def test_serialized_session_requests_prevent_sibling_cancellation():
@@ -181,6 +193,25 @@ async def test_serialized_session_requests_prevent_sibling_cancellation():
     results = await asyncio.gather(
         server.call_tool("slow", None),
         server.call_tool("fail", None),
+        return_exceptions=True,
+    )
+
+    assert isinstance(results[0], CallToolResult)
+    assert isinstance(results[1], RuntimeError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prompt_method", ["list_prompts", "get_prompt"])
+async def test_serialized_prompt_requests_prevent_tool_cancellation(prompt_method: str):
+    session = ConcurrentCancellationSession()
+    server = DummyServer(session=cast(DummySession, session), retries=0, serialize_requests=True)
+
+    prompt_request = (
+        server.list_prompts() if prompt_method == "list_prompts" else server.get_prompt("prompt")
+    )
+    results = await asyncio.gather(
+        server.call_tool("slow", None),
+        prompt_request,
         return_exceptions=True,
     )
 


### PR DESCRIPTION
### Summary

Serialize request RPCs per `MCPServerStreamableHttp` session so one failed request cannot cancel sibling in-flight requests that share the same underlying streamable-HTTP transport task group.

This is a narrow SDK-side workaround for the shared transport behavior in the `mcp` client dependency. It keeps the public API unchanged and only affects how `MCPServerStreamableHttp` schedules requests on a single connected session.

### Test plan

- `make sync`
- `make format`
- `make lint`
- `make typecheck`
- `make tests`
- `uv run python -m pytest tests/mcp/test_client_session_retries.py -k 'serialized_session_requests_prevent_sibling_cancellation or test_call_tool_retries_until_success' -q`

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
