### PR TITLE
fix: retry transient streamable-http MCP failures on isolated session

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -5,7 +5,7 @@ import asyncio
 import inspect
 import sys
 from collections.abc import Awaitable
-from contextlib import AbstractAsyncContextManager, AsyncExitStack
+from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, Union, cast
@@ -66,6 +66,12 @@ class _UnsetType:
 
 
 _UNSET = _UnsetType()
+
+
+class _SharedSessionRequestNeedsIsolation(Exception):
+    """Raised when a shared-session streamable HTTP request should be retried in isolation."""
+
+    pass
 
 if TYPE_CHECKING:
     from ..agent import AgentBase
@@ -1107,6 +1113,114 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 sse_read_timeout=self.params.get("sse_read_timeout", 60 * 5),
                 terminate_on_close=self.params.get("terminate_on_close", True),
             )
+
+    @asynccontextmanager
+    async def _isolated_client_session(self):
+        async with AsyncExitStack() as exit_stack:
+            transport = await exit_stack.enter_async_context(self.create_streams())
+            read, write, *_ = transport
+            session = await exit_stack.enter_async_context(
+                ClientSession(
+                    read,
+                    write,
+                    timedelta(seconds=self.client_session_timeout_seconds)
+                    if self.client_session_timeout_seconds
+                    else None,
+                    message_handler=self.message_handler,
+                )
+            )
+            await session.initialize()
+            yield session
+
+    async def _call_tool_with_session(
+        self,
+        session: ClientSession,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
+        if meta is None:
+            return await session.call_tool(tool_name, arguments)
+        return await session.call_tool(tool_name, arguments, meta=meta)
+
+    def _should_retry_in_isolated_session(self, exc: BaseException) -> bool:
+        if isinstance(exc, (asyncio.CancelledError, httpx.ConnectError, httpx.TimeoutException)):
+            return True
+        if isinstance(exc, httpx.HTTPStatusError):
+            return exc.response.status_code >= 500
+        if isinstance(exc, BaseExceptionGroup):
+            return any(self._should_retry_in_isolated_session(inner) for inner in exc.exceptions)
+        return False
+
+    async def _call_tool_with_shared_session(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
+        session = self.session
+        assert session is not None
+        try:
+            return await self._call_tool_with_session(session, tool_name, arguments, meta)
+        except BaseException as exc:
+            if self._should_retry_in_isolated_session(exc):
+                raise _SharedSessionRequestNeedsIsolation from exc
+            raise
+
+    async def _call_tool_with_isolated_retry(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
+        request_task = asyncio.create_task(
+            self._call_tool_with_shared_session(tool_name, arguments, meta)
+        )
+        try:
+            return await asyncio.shield(request_task)
+        except _SharedSessionRequestNeedsIsolation:
+            logger.warning(
+                "Retrying streamable-http MCP tool '%s' on isolated session after shared "
+                "transport failure.",
+                tool_name,
+            )
+            async with self._isolated_client_session() as session:
+                return await self._call_tool_with_session(session, tool_name, arguments, meta)
+        except asyncio.CancelledError:
+            if not request_task.done():
+                request_task.cancel()
+            try:
+                await request_task
+            except BaseException:
+                pass
+            raise
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
+        """Invoke a tool on the server."""
+        if not self.session:
+            raise UserError("Server not initialized. Make sure you call `connect()` first.")
+
+        try:
+            self._validate_required_parameters(tool_name=tool_name, arguments=arguments)
+            return await self._run_with_retries(
+                lambda: self._call_tool_with_isolated_retry(tool_name, arguments, meta)
+            )
+        except httpx.HTTPStatusError as e:
+            status_code = e.response.status_code
+            raise UserError(
+                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"HTTP error {status_code}"
+            ) from e
+        except httpx.ConnectError as e:
+            raise UserError(
+                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': Connection lost. "
+                f"The server may have disconnected."
+            ) from e
 
     @property
     def name(self) -> str:

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -1,11 +1,14 @@
+import asyncio
+from contextlib import asynccontextmanager
 from typing import cast
 
+import httpx
 import pytest
 from mcp import ClientSession, Tool as MCPTool
 from mcp.types import CallToolResult, ListToolsResult
 
 from agents.exceptions import UserError
-from agents.mcp.server import _MCPServerWithClientSession
+from agents.mcp.server import MCPServerStreamableHttp, _MCPServerWithClientSession
 
 
 class DummySession:
@@ -148,3 +151,122 @@ async def test_call_tool_rejects_non_object_arguments_before_remote_call():
         await server.call_tool("tool", cast(dict[str, object] | None, ["bad"]))
 
     assert session.call_tool_attempts == 0
+
+
+class ConcurrentCancellationSession:
+    def __init__(self):
+        self._slow_task: asyncio.Task[CallToolResult] | None = None
+        self._slow_started = asyncio.Event()
+
+    async def call_tool(self, tool_name, arguments, meta=None):
+        if tool_name == "slow":
+            self._slow_task = cast(asyncio.Task[CallToolResult], asyncio.current_task())
+            self._slow_started.set()
+            await asyncio.sleep(0.1)
+            return CallToolResult(content=[])
+
+        await self._slow_started.wait()
+        assert self._slow_task is not None
+        self._slow_task.cancel()
+        raise RuntimeError("synthetic request failure")
+
+
+class SharedHttpStatusSession:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    async def call_tool(self, tool_name, arguments, meta=None):
+        req = httpx.Request("POST", "https://example.test/mcp")
+        resp = httpx.Response(self.status_code, request=req)
+        raise httpx.HTTPStatusError(
+            f"HTTP error {self.status_code}",
+            request=req,
+            response=resp,
+        )
+
+
+class IsolatedRetrySession:
+    def __init__(self):
+        self.call_tool_attempts = 0
+
+    async def call_tool(self, tool_name, arguments, meta=None):
+        self.call_tool_attempts += 1
+        return CallToolResult(content=[])
+
+
+class HangingSession:
+    async def call_tool(self, tool_name, arguments, meta=None):
+        await asyncio.sleep(10)
+
+
+class DummyStreamableHttpServer(MCPServerStreamableHttp):
+    def __init__(self, shared_session: object, isolated_session: IsolatedRetrySession):
+        super().__init__(
+            params={"url": "https://example.test/mcp"},
+            client_session_timeout_seconds=None,
+            max_retry_attempts=0,
+        )
+        self.session = cast(ClientSession, shared_session)
+        self._isolated_session = cast(ClientSession, isolated_session)
+
+    def create_streams(self):
+        raise NotImplementedError
+
+    @asynccontextmanager
+    async def _isolated_client_session(self):
+        yield self._isolated_session
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_retries_cancelled_request_on_isolated_session():
+    shared_session = ConcurrentCancellationSession()
+    isolated_session = IsolatedRetrySession()
+    server = DummyStreamableHttpServer(shared_session, isolated_session)
+
+    results = await asyncio.gather(
+        server.call_tool("slow", None),
+        server.call_tool("fail", None),
+        return_exceptions=True,
+    )
+
+    assert isinstance(results[0], CallToolResult)
+    assert isinstance(results[1], RuntimeError)
+    assert shared_session._slow_task is not None
+    assert isolated_session.call_tool_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_retries_5xx_on_isolated_session():
+    isolated_session = IsolatedRetrySession()
+    server = DummyStreamableHttpServer(SharedHttpStatusSession(504), isolated_session)
+
+    result = await server.call_tool("tool", None)
+
+    assert isinstance(result, CallToolResult)
+    assert isolated_session.call_tool_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_does_not_retry_4xx_on_isolated_session():
+    isolated_session = IsolatedRetrySession()
+    server = DummyStreamableHttpServer(SharedHttpStatusSession(401), isolated_session)
+
+    with pytest.raises(UserError, match="HTTP error 401"):
+        await server.call_tool("tool", None)
+
+    assert isolated_session.call_tool_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_preserves_outer_cancellation():
+    isolated_session = IsolatedRetrySession()
+    server = DummyStreamableHttpServer(HangingSession(), isolated_session)
+
+    task = asyncio.create_task(server.call_tool("slow", None))
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert isolated_session.call_tool_attempts == 0


### PR DESCRIPTION
## Summary
- retry a streamable-HTTP MCP tool call on a fresh isolated session when the shared session hits a transient transport failure
- keep shared-session healthy-path parallelism; only isolate on the failure path
- add focused regression tests for cancelled sibling calls, 5xx retry, 4xx no-retry, and preserved outer cancellation

## Why
The likely remaining bug is earlier in the chain than `MCPUtil.invoke_mcp_tool()`: one shared-session streamable-HTTP request failure can still fan out into sibling request cancellations. This patch keeps the normal shared session on the healthy path, but retries just the affected call on an isolated session when the shared session sees a transient transport failure.

Concretely, the isolated retry triggers for:
- `asyncio.CancelledError`
- `httpx.ConnectError`
- `httpx.TimeoutException`
- `httpx.HTTPStatusError` with status >= 500
- `BaseExceptionGroup` containing one of the above

It does not retry 4xx errors.

## Validation
- `uv run pytest -q tests/mcp/test_client_session_retries.py`
- `uv run mypy src/agents/mcp/server.py tests/mcp/test_client_session_retries.py`
- `ruff check src/agents/mcp/server.py tests/mcp/test_client_session_retries.py`
