### PR TITLE
feat: Add DNS-AID tools for agent discovery via DNS

### DIFF
--- a/src/agents/extensions/dns_aid/__init__.py
+++ b/src/agents/extensions/dns_aid/__init__.py
@@ -1,0 +1,15 @@
+"""DNS-AID tools for OpenAI Agents SDK - agent discovery via DNS."""
+
+from agents.extensions.dns_aid.handoff_resolver import DnsAidHandoffResolver
+from agents.extensions.dns_aid.tools import (
+    discover_agents,
+    publish_agent,
+    unpublish_agent,
+)
+
+__all__ = [
+    "discover_agents",
+    "publish_agent",
+    "unpublish_agent",
+    "DnsAidHandoffResolver",
+]

--- a/src/agents/extensions/dns_aid/handoff_resolver.py
+++ b/src/agents/extensions/dns_aid/handoff_resolver.py
@@ -1,0 +1,67 @@
+"""DNS-AID Handoff Resolver for OpenAI Agents SDK.
+
+Discovers agents via DNS-AID and builds Handoff objects,
+replacing hardcoded agent URLs with dynamic DNS-based resolution.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class DnsAidHandoffResolver:
+    """Discovers agents via DNS-AID and builds Handoff objects for the OpenAI Agents SDK.
+
+    Replaces hardcoded agent URLs with dynamic DNS-based resolution.
+
+    Example::
+
+        resolver = DnsAidHandoffResolver()
+        handoffs = await resolver.resolve_handoffs("agents.example.com", protocol="mcp")
+
+        agent = Agent(
+            name="orchestrator",
+            instructions="Route to the best agent for the task.",
+            handoffs=handoffs,
+        )
+    """
+
+    def __init__(
+        self,
+        backend_name: Optional[str] = None,
+        backend: Any = None,
+    ) -> None:
+        self._backend_name = backend_name
+        self._backend = backend
+
+    async def resolve_handoffs(
+        self,
+        domain: str,
+        protocol: Optional[str] = None,
+    ) -> list[Any]:
+        """Discover agents at domain and return Handoff objects.
+
+        Each discovered agent becomes a Handoff target that the SDK
+        can use for dynamic multi-agent routing.
+        """
+        import dns_aid
+        from agents import Agent, Handoff
+
+        result = await dns_aid.discover(domain=domain, protocol=protocol)
+        handoffs = []
+        for agent_record in result.agents:
+            caps = ", ".join(agent_record.capabilities or [])
+            agent = Agent(
+                name=agent_record.name,
+                instructions=(
+                    f"Remote agent at {agent_record.endpoint_url}. "
+                    f"Capabilities: {caps}"
+                ),
+            )
+            handoff = Handoff(
+                agent=agent,
+                description=agent_record.description
+                or f"Hand off to {agent_record.name}",
+            )
+            handoffs.append(handoff)
+        return handoffs

--- a/src/agents/extensions/dns_aid/tools.py
+++ b/src/agents/extensions/dns_aid/tools.py
@@ -1,0 +1,86 @@
+"""DNS-AID tools for OpenAI Agents SDK.
+
+Uses @function_tool decorator to create async-native tools
+that agents can call for DNS-based agent discovery.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from agents import function_tool
+
+
+@function_tool
+async def discover_agents(
+    domain: str,
+    protocol: Optional[str] = None,
+    name: Optional[str] = None,
+    require_dnssec: bool = False,
+) -> str:
+    """Discover AI agents at a domain via DNS-AID SVCB records.
+
+    Queries DNS to find published agents, optionally filtering by protocol or name.
+    Returns JSON with agent names, endpoints, capabilities, and protocols.
+    """
+    import dns_aid
+
+    result = await dns_aid.discover(
+        domain=domain, protocol=protocol, name=name, require_dnssec=require_dnssec
+    )
+    return json.dumps(result.model_dump(), default=str)
+
+
+@function_tool
+async def publish_agent(
+    agent_name: str,
+    domain: str,
+    protocol: str = "mcp",
+    endpoint: str = "",
+    port: int = 443,
+    capabilities: Optional[list[str]] = None,
+    version: str = "1.0.0",
+    description: Optional[str] = None,
+    ttl: int = 3600,
+) -> str:
+    """Publish an AI agent to DNS using DNS-AID protocol.
+
+    Creates SVCB and TXT records so the agent becomes discoverable
+    by other agents querying DNS.
+    """
+    import dns_aid
+
+    result = await dns_aid.publish(
+        name=agent_name,
+        domain=domain,
+        protocol=protocol,
+        endpoint=endpoint,
+        port=port,
+        capabilities=capabilities,
+        version=version,
+        description=description,
+        ttl=ttl,
+    )
+    return json.dumps(result.model_dump(), default=str)
+
+
+@function_tool
+async def unpublish_agent(
+    agent_name: str,
+    domain: str,
+    protocol: str = "mcp",
+) -> str:
+    """Remove an AI agent's DNS-AID records, making it no longer discoverable."""
+    import dns_aid
+
+    deleted = await dns_aid.unpublish(
+        name=agent_name, domain=domain, protocol=protocol
+    )
+    if deleted:
+        return json.dumps(
+            {"success": True, "message": f"Agent '{agent_name}' unpublished from {domain}"}
+        )
+    return json.dumps(
+        {"success": False, "message": f"Agent '{agent_name}' not found at {domain}"}
+    )


### PR DESCRIPTION
## Summary
- Add DNS-AID tools for agent discovery and publishing via DNS SVCB records
- Implements @function_tool decorated functions following OpenAI Agents SDK conventions
- Includes DnsAidHandoffResolver for dynamic agent routing via DNS discovery
- Enables agents to discover and connect with other agents using the DNS-AID protocol (IETF draft-mozleywilliams-dnsop-dnsaid-01)

## What is DNS-AID?
DNS-AID (DNS-based Agent Identification and Discovery) is an IETF draft that uses DNS SVCB records to enable AI agents to discover and connect with each other. Agents publish their capabilities, endpoints, and protocols to DNS, and other agents query DNS to find available services.

## Test plan
- [ ] Unit tests with mocked DNS backend
- [ ] Test DnsAidHandoffResolver builds correct Handoff objects