### PR TITLE
fix: Retry MCP 408s on isolated session

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -20,6 +20,7 @@ from mcp import ClientSession, StdioServerParameters, Tool as MCPTool, stdio_cli
 from mcp.client.session import MessageHandlerFnT
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import GetSessionIdCallback, streamablehttp_client
+from mcp.shared.exceptions import McpError
 from mcp.shared.message import SessionMessage
 from mcp.types import CallToolResult, GetPromptResult, InitializeResult, ListPromptsResult
 from typing_extensions import NotRequired, TypedDict
@@ -1195,6 +1196,8 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
             return True
         if isinstance(exc, httpx.HTTPStatusError):
             return exc.response.status_code >= 500
+        if isinstance(exc, McpError):
+            return exc.error.code == httpx.codes.REQUEST_TIMEOUT
         if isinstance(exc, BaseExceptionGroup):
             return bool(exc.exceptions) and all(
                 self._should_retry_in_isolated_session(inner) for inner in exc.exceptions

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -7,7 +7,8 @@ import httpx
 import pytest
 from anyio import ClosedResourceError
 from mcp import ClientSession, Tool as MCPTool
-from mcp.types import CallToolResult, GetPromptResult, ListPromptsResult, ListToolsResult
+from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult, ErrorData, GetPromptResult, ListPromptsResult, ListToolsResult
 
 from agents.exceptions import UserError
 from agents.mcp.server import MCPServerStreamableHttp, _MCPServerWithClientSession
@@ -228,6 +229,18 @@ class ClosedResourceSession:
         raise ClosedResourceError()
 
 
+class McpRequestTimeoutSession:
+    def __init__(self, message: str = "timed out"):
+        self.call_tool_attempts = 0
+        self.message = message
+
+    async def call_tool(self, tool_name, arguments, meta=None):
+        self.call_tool_attempts += 1
+        raise McpError(
+            ErrorData(code=httpx.codes.REQUEST_TIMEOUT, message=self.message),
+        )
+
+
 class IsolatedRetrySession:
     def __init__(self):
         self.call_tool_attempts = 0
@@ -318,6 +331,21 @@ async def test_streamable_http_retries_5xx_on_isolated_session():
 async def test_streamable_http_retries_closed_resource_on_isolated_session():
     isolated_session = IsolatedRetrySession()
     server = DummyStreamableHttpServer(ClosedResourceSession(), isolated_session)
+    server.max_retry_attempts = 1
+
+    result = await server.call_tool("tool", None)
+
+    assert isinstance(result, CallToolResult)
+    assert isolated_session.call_tool_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_retries_mcp_408_on_isolated_session():
+    isolated_session = IsolatedRetrySession()
+    server = DummyStreamableHttpServer(
+        McpRequestTimeoutSession("Timed out while waiting for response to ClientRequest."),
+        isolated_session,
+    )
     server.max_retry_attempts = 1
 
     result = await server.call_tool("tool", None)


### PR DESCRIPTION
## Summary
- treat MCP-wrapped request timeouts (`McpError` with code 408) as eligible for isolated-session retry
- add a regression test covering the MCP 408 retry path

## Validation
- `ruff check src/agents/mcp/server.py tests/mcp/test_client_session_retries.py`
- `PYTHONPATH=/Users/elainegan/code/openai-agents-python/src pytest -q tests/mcp/test_client_session_retries.py -k "mcp_408_on_isolated_session or retries_5xx_on_isolated_session or retries_cancelled_request_on_isolated_session or does_not_retry_4xx_on_isolated_session"