### PR TITLE
fix: Retry ClosedResourceError on isolated session

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -14,6 +14,7 @@ import httpx
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup  # pyright: ignore[reportMissingImports]
+from anyio import ClosedResourceError
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp import ClientSession, StdioServerParameters, Tool as MCPTool, stdio_client
 from mcp.client.session import MessageHandlerFnT
@@ -1165,7 +1166,15 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
         return await session.call_tool(tool_name, arguments, meta=meta)
 
     def _should_retry_in_isolated_session(self, exc: BaseException) -> bool:
-        if isinstance(exc, (asyncio.CancelledError, httpx.ConnectError, httpx.TimeoutException)):
+        if isinstance(
+            exc,
+            (
+                asyncio.CancelledError,
+                ClosedResourceError,
+                httpx.ConnectError,
+                httpx.TimeoutException,
+            ),
+        ):
             return True
         if isinstance(exc, httpx.HTTPStatusError):
             return exc.response.status_code >= 500

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -5,6 +5,7 @@ from typing import cast
 
 import httpx
 import pytest
+from anyio import ClosedResourceError
 from mcp import ClientSession, Tool as MCPTool
 from mcp.types import CallToolResult, GetPromptResult, ListPromptsResult, ListToolsResult
 
@@ -218,6 +219,15 @@ class TimeoutSession:
         raise httpx.TimeoutException(self.message)
 
 
+class ClosedResourceSession:
+    def __init__(self):
+        self.call_tool_attempts = 0
+
+    async def call_tool(self, tool_name, arguments, meta=None):
+        self.call_tool_attempts += 1
+        raise ClosedResourceError()
+
+
 class IsolatedRetrySession:
     def __init__(self):
         self.call_tool_attempts = 0
@@ -296,6 +306,18 @@ async def test_streamable_http_retries_cancelled_request_on_isolated_session():
 async def test_streamable_http_retries_5xx_on_isolated_session():
     isolated_session = IsolatedRetrySession()
     server = DummyStreamableHttpServer(SharedHttpStatusSession(504), isolated_session)
+    server.max_retry_attempts = 1
+
+    result = await server.call_tool("tool", None)
+
+    assert isinstance(result, CallToolResult)
+    assert isolated_session.call_tool_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_retries_closed_resource_on_isolated_session():
+    isolated_session = IsolatedRetrySession()
+    server = DummyStreamableHttpServer(ClosedResourceSession(), isolated_session)
     server.max_retry_attempts = 1
 
     result = await server.call_tool("tool", None)


### PR DESCRIPTION
## Summary
- make `ClosedResourceError` trigger isolated-session retry for shared-session MCP tool calls
- add focused regression coverage for the retry classifier

## Testing
- ruff check src/agents/mcp/server.py tests/mcp/test_client_session_retries.py
- PYTHONPATH=/Users/elainegan/code/openai-agents-python/src pytest -q tests/mcp/test_client_session_retries.py -k "closed_resource_on_isolated_session or retries_5xx_on_isolated_session or retries_cancelled_request_on_isolated_session or does_not_retry_4xx_on_isolated_session"