### PR TITLE
fix(mcp): suppress resource_tracker semaphore warnings in MCPServerStdio

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -901,7 +901,23 @@ class MCPServerStdio(_MCPServerWithClientSession):
         self,
     ) -> AbstractAsyncContextManager[MCPStreamTransport]:
         """Create the streams for the server."""
-        return stdio_client(self.params)
+        return stdio_client(self._params_with_warning_suppression())
+
+    def _params_with_warning_suppression(self) -> StdioServerParameters:
+        """Return a copy of params with resource_tracker warnings suppressed.
+
+        When the MCP server subprocess uses multiprocessing internally, its
+        resource_tracker may warn about leaked semaphore objects on termination.
+        These warnings are spurious because the OS reclaims the resources when
+        the subprocess exits. Suppress them via PYTHONWARNINGS in the subprocess
+        environment.
+        """
+        warning_filter = "ignore:resource_tracker:UserWarning:multiprocessing.resource_tracker"
+        env = dict(self.params.env) if self.params.env is not None else {}
+        existing = env.get("PYTHONWARNINGS", "")
+        if warning_filter not in existing:
+            env["PYTHONWARNINGS"] = f"{existing},{warning_filter}" if existing else warning_filter
+        return self.params.model_copy(update={"env": env})
 
     @property
     def name(self) -> str:

--- a/tests/mcp/test_connect_disconnect.py
+++ b/tests/mcp/test_connect_disconnect.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from mcp import StdioServerParameters
 from mcp.types import ListToolsResult, Tool as MCPTool
 
 from agents.mcp import MCPServerStdio
@@ -67,3 +68,51 @@ async def test_manual_connect_disconnect_works(
 
     await server.cleanup()
     assert server.session is None, "Server should be disconnected"
+
+
+@pytest.mark.asyncio
+@patch("agents.mcp.server.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+async def test_stdio_suppresses_resource_tracker_warnings(
+    mock_initialize: AsyncMock, mock_stdio_client: AsyncMock
+):
+    """Test that MCPServerStdio suppresses resource_tracker semaphore warnings."""
+    server = MCPServerStdio(
+        params={"command": tee},
+        cache_tools_list=True,
+    )
+
+    async with server:
+        pass
+
+    # Verify stdio_client was called with params containing PYTHONWARNINGS.
+    mock_stdio_client.assert_called_once()
+    params = mock_stdio_client.call_args[0][0]
+    assert isinstance(params, StdioServerParameters)
+    assert params.env is not None
+    assert "PYTHONWARNINGS" in params.env
+    assert "resource_tracker" in params.env["PYTHONWARNINGS"]
+
+
+@pytest.mark.asyncio
+@patch("agents.mcp.server.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+async def test_stdio_preserves_existing_pythonwarnings(
+    mock_initialize: AsyncMock, mock_stdio_client: AsyncMock
+):
+    """Test that existing PYTHONWARNINGS values are preserved."""
+    server = MCPServerStdio(
+        params={
+            "command": tee,
+            "env": {"PYTHONWARNINGS": "error::DeprecationWarning"},
+        },
+        cache_tools_list=True,
+    )
+
+    async with server:
+        pass
+
+    params = mock_stdio_client.call_args[0][0]
+    assert params.env is not None
+    assert "error::DeprecationWarning" in params.env["PYTHONWARNINGS"]
+    assert "resource_tracker" in params.env["PYTHONWARNINGS"]


### PR DESCRIPTION
## Summary

- suppress spurious `resource_tracker` semaphore leak warnings when using `MCPServerStdio` with Python-based MCP servers
- set `PYTHONWARNINGS` in the subprocess environment to filter out `UserWarning` from `multiprocessing.resource_tracker`
- preserve any existing `PYTHONWARNINGS` value the user may have set

## Why

When `MCPServerStdio` spawns a Python-based MCP server that uses `multiprocessing` internally, the subprocess's `resource_tracker` warns about leaked semaphore objects at shutdown:

```
resource_tracker: There appear to be 24 leaked semaphore objects to clean up at shutdown
```

These are spurious — the OS reclaims the resources when the process exits, but the `resource_tracker` daemon doesn't know that. This follows the same pattern as the existing cancel-scope error suppression in `cleanup()`.

Non-Python MCP servers ignore the env var, so this is a no-op for them.

## Testing

- `uv run pytest tests/mcp/test_connect_disconnect.py -v`
- `uv run ruff check src/agents/mcp/server.py tests/mcp/test_connect_disconnect.py`

Closes #618