### PR TITLE
Highlight gpt-realtime-1.5 in public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The OpenAI Agents SDK is a lightweight yet powerful framework for building multi
 1. [**Human in the loop**](https://openai.github.io/openai-agents-python/human_in_the_loop/): Built-in mechanisms for involving humans across agent runs
 1. [**Sessions**](https://openai.github.io/openai-agents-python/sessions/): Automatic conversation history management across agent runs
 1. [**Tracing**](https://openai.github.io/openai-agents-python/tracing/): Built-in tracking of agent runs, allowing you to view, debug and optimize your workflows
-1. [**Realtime Agents**](https://openai.github.io/openai-agents-python/realtime/quickstart/): Build powerful voice agents with full features
+1. [**Realtime Agents**](https://openai.github.io/openai-agents-python/realtime/quickstart/): Build powerful voice agents with `gpt-realtime-1.5` and full agent features
 
 Explore the [examples](https://github.com/openai/openai-agents-python/tree/main/examples) directory to see the SDK in action, and read our [documentation](https://openai.github.io/openai-agents-python/) for more details.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Here are the main features of the SDK:
 -   **Sessions**: A persistent memory layer for maintaining working context within an agent loop.
 -   **Human in the loop**: Built-in mechanisms for involving humans across agent runs.
 -   **Tracing**: Built-in tracing for visualizing, debugging, and monitoring workflows, with support for the OpenAI suite of evaluation, fine-tuning, and distillation tools.
--   **Realtime Agents**: Build powerful voice agents with features such as automatic interruption detection, context management, guardrails, and more.
+-   **Realtime Agents**: Build powerful voice agents with `gpt-realtime-1.5`, automatic interruption detection, context management, guardrails, and more.
 
 ## Installation
 
@@ -73,5 +73,5 @@ Use this table when you know the job you want to do, but not which page explains
 | Keep memory across turns | [Running agents](running_agents.md#choose-a-memory-strategy) and [Sessions](sessions/index.md) |
 | Use OpenAI models, websocket transport, or non-OpenAI providers | [Models](models/index.md) |
 | Review outputs, run items, interruptions, and resume state | [Results](results.md) |
-| Build a low-latency voice agent | [Realtime agents quickstart](realtime/quickstart.md) and [Realtime transport](realtime/transport.md) |
+| Build a low-latency voice agent with `gpt-realtime-1.5` | [Realtime agents quickstart](realtime/quickstart.md) and [Realtime transport](realtime/transport.md) |
 | Build a speech-to-text / agent / text-to-speech pipeline | [Voice pipeline quickstart](voice/quickstart.md) |

--- a/docs/realtime/guide.md
+++ b/docs/realtime/guide.md
@@ -45,14 +45,14 @@ By default, `RealtimeRunner` uses `OpenAIRealtimeWebSocketModel`, so the default
 -   Voice can be configured, but it cannot change after the session has already produced spoken audio.
 -   Instructions, function tools, handoffs, hooks, and output guardrails all still work.
 
-`RealtimeSessionModelSettings` supports both a newer nested `audio` config and older flat aliases. Prefer the nested shape for new code:
+`RealtimeSessionModelSettings` supports both a newer nested `audio` config and older flat aliases. Prefer the nested shape for new code, and start with `gpt-realtime-1.5` for new realtime agents:
 
 ```python
 runner = RealtimeRunner(
     starting_agent=agent,
     config={
         "model_settings": {
-            "model_name": "gpt-realtime",
+            "model_name": "gpt-realtime-1.5",
             "audio": {
                 "input": {
                     "format": "pcm16",

--- a/docs/realtime/quickstart.md
+++ b/docs/realtime/quickstart.md
@@ -45,14 +45,14 @@ agent = RealtimeAgent(
 
 ### 3. Configure the runner
 
-Prefer the nested `audio.input` / `audio.output` session settings shape for new code.
+Prefer the nested `audio.input` / `audio.output` session settings shape for new code. For new realtime agents, start with `gpt-realtime-1.5`.
 
 ```python
 runner = RealtimeRunner(
     starting_agent=agent,
     config={
         "model_settings": {
-            "model_name": "gpt-realtime",
+            "model_name": "gpt-realtime-1.5",
             "audio": {
                 "input": {
                     "format": "pcm16",

--- a/examples/realtime/app/server.py
+++ b/examples/realtime/app/server.py
@@ -52,6 +52,7 @@ class RealtimeWebSocketManager:
         # runner = RealtimeRunner(agent, config=runner_config)
         model_config: RealtimeModelConfig = {
             "initial_model_settings": {
+                "model_name": "gpt-realtime-1.5",
                 "turn_detection": {
                     "type": "server_vad",
                     "prefix_padding_ms": 300,

--- a/examples/realtime/cli/demo.py
+++ b/examples/realtime/cli/demo.py
@@ -225,6 +225,7 @@ class NoUIDemo:
             model_config: RealtimeModelConfig = {
                 "playback_tracker": self.playback_tracker,
                 "initial_model_settings": {
+                    "model_name": "gpt-realtime-1.5",
                     "turn_detection": {
                         "type": "semantic_vad",
                         "interrupt_response": True,

--- a/examples/realtime/twilio/twilio_handler.py
+++ b/examples/realtime/twilio/twilio_handler.py
@@ -93,6 +93,7 @@ class TwilioHandler:
             model_config={
                 "api_key": api_key,
                 "initial_model_settings": {
+                    "model_name": "gpt-realtime-1.5",
                     "input_audio_format": "g711_ulaw",
                     "output_audio_format": "g711_ulaw",
                     "turn_detection": {


### PR DESCRIPTION
**Default guidance in public documentation**
https://openai.github.io/openai-agents-python/

**Before**
The public Agents SDK docs still mostly pointed realtime users at gpt-realtime, so new users were landing on stale guidance instead of the recommended gpt-realtime-1.5 path. This showed up in the top-level docs entry points and the English realtime quickstart/guide.

**After**
The public documentation now points new realtime users to gpt-realtime-1.5 in the top-level discovery pages and the English realtime quickstart/guide. The SDK’s implicit runtime default was intentionally left unchanged, so this updates guidance without changing behavior for existing integrations that omit model_name.