### PR TITLE
fix: exclude null acknowledged_safety_checks from GA ComputerCallOutput

### DIFF
--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -169,7 +169,11 @@ class ComputerAction:
                         "image_url": image_url,
                     },
                     type="computer_call_output",
-                    acknowledged_safety_checks=acknowledged_safety_checks,
+                    **(
+                        {"acknowledged_safety_checks": acknowledged_safety_checks}
+                        if acknowledged_safety_checks is not None
+                        else {}
+                    ),
                 ),
             )
 


### PR DESCRIPTION
## Problem

When using the GA `computer` tool with `gpt-5.4`, the SDK serializes `acknowledged_safety_checks: null` in `ComputerCallOutput` when there are no pending safety checks. The GA computer endpoint rejects this:

```
Error code: 400 - acknowledged_safety_checks is not supported for the "computer" tool.
```

## Root Cause

In `ComputerAction.execute()`, `acknowledged_safety_checks` defaults to `None`. For GA requests without pending safety checks, it stays `None` and is passed directly to `ComputerCallOutput`. Pydantic serializes `None` as `"acknowledged_safety_checks": null`, which the GA endpoint rejects.

## Fix

Only include `acknowledged_safety_checks` in the `ComputerCallOutput` when it is not `None`, using a conditional spread:

```python
**(
    {"acknowledged_safety_checks": acknowledged_safety_checks}
    if acknowledged_safety_checks is not None
    else {}
),
```

This omits the field entirely when there are no safety checks to acknowledge, avoiding the 400 error.

## Testing

- Verified that when `acknowledged_safety_checks` is `None`, the field is excluded from the dict
- Verified that when `acknowledged_safety_checks` has values, it is included as before

Fixes #2741