### PR TITLE
fix: omit null computer safety checks

### DIFF
--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -169,7 +169,11 @@ class ComputerAction:
                         "image_url": image_url,
                     },
                     type="computer_call_output",
-                    acknowledged_safety_checks=acknowledged_safety_checks,
+                    **(
+                        {"acknowledged_safety_checks": acknowledged_safety_checks}
+                        if acknowledged_safety_checks is not None
+                        else {}
+                    ),
                 ),
             )
 

--- a/tests/test_computer_action.py
+++ b/tests/test_computer_action.py
@@ -391,6 +391,7 @@ async def test_execute_invokes_hooks_and_returns_tool_call_output() -> None:
     assert raw["output"]["type"] == "computer_screenshot"
     assert "image_url" in raw["output"]
     assert raw["output"]["image_url"].endswith("xyz")
+    assert "acknowledged_safety_checks" not in raw
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- omit `acknowledged_safety_checks` from `computer_call_output` when it is `None`
- keep acknowledged safety checks unchanged when they are present
- add a regression assertion for the no-safety-check path

## Testing
- `.venv/bin/pytest tests/test_computer_action.py`

Fixes #2741