### PR TITLE
fix: default trace_include_sensitive_data to False (secure-by-default)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -73,7 +73,7 @@ from agents import set_tracing_disabled
 set_tracing_disabled(True)
 ```
 
-If you want to keep tracing enabled but exclude potentially sensitive inputs/outputs from trace payloads, set [`RunConfig.trace_include_sensitive_data`][agents.run.RunConfig.trace_include_sensitive_data] to `False`:
+Tracing is enabled by default, but potentially sensitive inputs/outputs are excluded from trace payloads by default. To include them, set [`RunConfig.trace_include_sensitive_data`][agents.run.RunConfig.trace_include_sensitive_data] to `True`:
 
 ```python
 from agents import Runner, RunConfig
@@ -81,14 +81,14 @@ from agents import Runner, RunConfig
 await Runner.run(
     agent,
     input="Hello",
-    run_config=RunConfig(trace_include_sensitive_data=False),
+    run_config=RunConfig(trace_include_sensitive_data=True),
 )
 ```
 
 You can also change the default without code by setting this environment variable before your app starts:
 
 ```bash
-export OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA=0
+export OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA=1
 ```
 
 For full tracing controls, see the [tracing guide](tracing.md).

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -86,7 +86,7 @@ The `generation_span()` stores the inputs/outputs of the LLM generation, and `fu
 
 Similarly, Audio spans include base64-encoded PCM data for input and output audio by default. You can disable capturing this audio data by configuring [`VoicePipelineConfig.trace_include_sensitive_audio_data`][agents.voice.pipeline_config.VoicePipelineConfig.trace_include_sensitive_audio_data].
 
-By default, `trace_include_sensitive_data` is `True`. You can set the default without code by exporting the `OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA` environment variable to `true/1` or `false/0` before running your app.
+By default, `trace_include_sensitive_data` is `False`, following the principle of secure-by-default. To include sensitive data in traces, set it to `True` in your `RunConfig` or export the `OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA` environment variable to `true/1` before running your app.
 
 ## Custom tracing processors
 

--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -29,7 +29,7 @@ DEFAULT_MAX_TURNS = 10
 
 def _default_trace_include_sensitive_data() -> bool:
     """Return the default for trace_include_sensitive_data based on environment."""
-    val = os.getenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", "true")
+    val = os.getenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", "false")
     return val.strip().lower() in ("1", "true", "yes", "on")
 
 

--- a/src/agents/voice/pipeline_config.py
+++ b/src/agents/voice/pipeline_config.py
@@ -22,9 +22,9 @@ class VoicePipelineConfig:
     tracing: TracingConfig | None = None
     """Tracing configuration for this pipeline."""
 
-    trace_include_sensitive_data: bool = True
-    """Whether to include sensitive data in traces. Defaults to `True`. This is specifically for the
-      voice pipeline, and not for anything that goes on inside your Workflow."""
+    trace_include_sensitive_data: bool = False
+    """Whether to include sensitive data in traces. Defaults to `False`. This is specifically
+      for the voice pipeline, and not for anything that goes on inside your Workflow."""
 
     trace_include_sensitive_audio_data: bool = True
     """Whether to include audio data in traces. Defaults to `True`."""

--- a/tests/test_apply_patch_tool.py
+++ b/tests/test_apply_patch_tool.py
@@ -162,7 +162,7 @@ async def test_apply_patch_tool_emits_function_span() -> None:
             call=tool_run,
             hooks=RunHooks[Any](),
             context_wrapper=context_wrapper,
-            config=RunConfig(),
+            config=RunConfig(trace_include_sensitive_data=True),
         )
 
     assert isinstance(result, ToolCallOutputItem)

--- a/tests/test_computer_action.py
+++ b/tests/test_computer_action.py
@@ -415,7 +415,7 @@ async def test_execute_emits_function_span() -> None:
             action=tool_run,
             hooks=RunHooks[Any](),
             context_wrapper=RunContextWrapper(context=None),
-            config=RunConfig(),
+            config=RunConfig(trace_include_sensitive_data=True),
         )
 
     assert isinstance(result, ToolCallOutputItem)
@@ -487,7 +487,7 @@ async def test_execute_emits_batched_actions_in_function_span() -> None:
             action=tool_run,
             hooks=RunHooks[Any](),
             context_wrapper=RunContextWrapper(context=None),
-            config=RunConfig(),
+            config=RunConfig(trace_include_sensitive_data=True),
         )
 
     assert isinstance(result, ToolCallOutputItem)

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -88,11 +88,11 @@ async def test_agent_model_object_is_used_when_present() -> None:
     assert result.final_output == "from-agent-object"
 
 
-def test_trace_include_sensitive_data_defaults_to_true_when_env_not_set(monkeypatch):
-    """By default, trace_include_sensitive_data should be True when the env is not set."""
+def test_trace_include_sensitive_data_defaults_to_false_when_env_not_set(monkeypatch):
+    """By default, trace_include_sensitive_data should be False when the env is not set."""
     monkeypatch.delenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", raising=False)
     config = RunConfig()
-    assert config.trace_include_sensitive_data is True
+    assert config.trace_include_sensitive_data is False
 
 
 @pytest.mark.parametrize(
@@ -137,4 +137,14 @@ def test_trace_include_sensitive_data_explicit_override_takes_precedence(monkeyp
 
     monkeypatch.setenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", "true")
     config = RunConfig(trace_include_sensitive_data=False)
+    assert config.trace_include_sensitive_data is False
+
+
+def test_voice_pipeline_config_trace_defaults_to_false():
+    """VoicePipelineConfig should default trace_include_sensitive_data to False."""
+    pytest.importorskip("numpy", reason="voice extras not installed")
+    pytest.importorskip("websockets", reason="voice extras not installed")
+    from agents.voice.pipeline_config import VoicePipelineConfig
+
+    config = VoicePipelineConfig()
     assert config.trace_include_sensitive_data is False

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -299,7 +299,7 @@ async def test_shell_tool_emits_function_span() -> None:
             call=tool_run,
             hooks=RunHooks[Any](),
             context_wrapper=context_wrapper,
-            config=RunConfig(),
+            config=RunConfig(trace_include_sensitive_data=True),
         )
 
     assert isinstance(result, ToolCallOutputItem)


### PR DESCRIPTION
### Summary

Changes the default value of `trace_include_sensitive_data` from `True` to `False` across both `RunConfig` and `VoicePipelineConfig`, following the principle of secure-by-default.

This prevents accidental exposure of PII, secrets, and confidential business data in traces. Users who need sensitive data in traces can explicitly opt in via `RunConfig(trace_include_sensitive_data=True)` or by setting `OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA=true`.

**Migration for existing users:**
```python
# Option 1: In code
run_config = RunConfig(trace_include_sensitive_data=True)

# Option 2: Environment variable
# export OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA=true
```

**Note:** Translated docs under `docs/ja/`, `docs/ko/`, and `docs/zh/` will be updated by the translation pipeline (`make build-full-docs`) and are not modified in this PR per contribution guidelines.

### Test plan

- Updated existing default test to verify `False` default when env var is not set
- Added test for `VoicePipelineConfig` default (skips gracefully when voice extras are not installed)
- Updated span-content tests (`test_apply_patch_tool`, `test_computer_action`, `test_shell_tool`) to explicitly set `trace_include_sensitive_data=True` where they check for sensitive data in spans
- Verified env var override still works in both directions
- Verified explicit parameter override still takes precedence
- Full test suite passes with no new failures

### Issue number

Closes #2393

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass