### PR TITLE
Remove duplicate CompactionItem from RunItem union

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -609,7 +609,6 @@ RunItem: TypeAlias = Union[
     HandoffOutputItem,
     ToolCallItem,
     ToolCallOutputItem,
-    CompactionItem,
     ReasoningItem,
     MCPListToolsItem,
     MCPApprovalRequestItem,


### PR DESCRIPTION
### Summary
- remove duplicated `CompactionItem` entry from `RunItem` union in `src/agents/items.py`
- keep a single `CompactionItem` entry while preserving intended member set
- no runtime behavior change; this is a type alias cleanup

### Test plan
- `make format`
- `make lint`
- `make typecheck`

### Issue number
- N/A

### Checks
- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [ ] I've made sure tests pass
