### PR TITLE
fix: optionize initialized notification tolerance

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -133,9 +133,9 @@ async def _streamablehttp_client_with_transport(
         auth=auth,
     )
     transport = transport_factory(url)
-    read_stream_writer, read_stream = anyio.create_memory_object_stream[
-        SessionMessage | Exception
-    ](0)
+    read_stream_writer, read_stream = anyio.create_memory_object_stream[SessionMessage | Exception](
+        0
+    )
     write_stream, write_stream_reader = anyio.create_memory_object_stream[SessionMessage](0)
 
     async with client:

--- a/tests/mcp/test_streamable_http_client_factory.py
+++ b/tests/mcp/test_streamable_http_client_factory.py
@@ -263,9 +263,7 @@ async def test_initialized_notification_failure_returns_synthetic_success():
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, request=request)
 
-    transport = _InitializedNotificationTolerantStreamableHTTPTransport(
-        "https://example.test/mcp"
-    )
+    transport = _InitializedNotificationTolerantStreamableHTTPTransport("https://example.test/mcp")
     read_stream_writer, _ = create_memory_object_stream[SessionMessage | Exception](0)
     client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     try:
@@ -293,9 +291,7 @@ async def test_initialized_notification_transport_exception_returns_synthetic_su
     async def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("boom", request=request)
 
-    transport = _InitializedNotificationTolerantStreamableHTTPTransport(
-        "https://example.test/mcp"
-    )
+    transport = _InitializedNotificationTolerantStreamableHTTPTransport("https://example.test/mcp")
     read_stream_writer, _ = create_memory_object_stream[SessionMessage | Exception](0)
     client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     try:
@@ -339,8 +335,7 @@ async def test_streamable_http_server_passes_ignore_initialized_notification_fai
         assert kwargs["sse_read_timeout"] == 300
         assert kwargs["terminate_on_close"] is True
         assert (
-            kwargs["transport_factory"]
-            is _InitializedNotificationTolerantStreamableHTTPTransport
+            kwargs["transport_factory"] is _InitializedNotificationTolerantStreamableHTTPTransport
         )
 
 
@@ -349,9 +344,7 @@ async def test_transport_preserves_non_initialized_failures():
     async def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("boom", request=request)
 
-    transport = _InitializedNotificationTolerantStreamableHTTPTransport(
-        "https://example.test/mcp"
-    )
+    transport = _InitializedNotificationTolerantStreamableHTTPTransport("https://example.test/mcp")
     read_stream_writer, _ = create_memory_object_stream[SessionMessage | Exception](0)
     client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     try:
@@ -382,9 +375,7 @@ async def test_stream_client_preserves_custom_factory_headers_timeout_and_auth()
 
     class RecordingAuth(httpx.Auth):
         def auth_flow(self, request: httpx.Request):
-            request.headers["Authorization"] = (
-                f"Basic {base64.b64encode(b'user:pass').decode()}"
-            )
+            request.headers["Authorization"] = f"Basic {base64.b64encode(b'user:pass').decode()}"
             yield request
 
     async def handler(request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
## Summary
- add an explicit MCP streamable-HTTP option for tolerating failed initialized notifications
- keep the default strict and only ignore the failure when callers opt in
- implement the option by wrapping the configured `httpx_client_factory`, rather than forking MCP's stream client orchestration
- add focused transport and wiring coverage for the new option

## Why
Best-effort `notifications/initialized` POST could fail and poison the transport, even though subsequent real requests could still succeed. This change keeps the behavior opt-in at the SDK layer so apps can choose the more tolerant transport policy explicitly.

## Validation
- `ruff check src/agents/mcp/server.py tests/mcp/test_streamable_http_client_factory.py`
- `PYTHONPATH=src pytest -q tests/mcp/test_streamable_http_client_factory.py`
