### PR TITLE
fix: pin liteLLM upper bound to 1.82.6 to mitigate supply chain attack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Repository = "https://github.com/openai/openai-agents-python"
 [project.optional-dependencies]
 voice = ["numpy>=2.2.0, <3; python_version>='3.10'", "websockets>=15.0, <16"]
 viz = ["graphviz>=0.17"]
-litellm = ["litellm>=1.81.0, <2"]
+litellm = ["litellm>=1.81.0, <=1.82.6"]
 any-llm = ["any-llm-sdk>=1.11.0, <2; python_version >= '3.11'"]
 realtime = ["websockets>=15.0, <16"]
 sqlalchemy = ["SQLAlchemy>=2.0", "asyncpg>=0.29.0"]


### PR DESCRIPTION
## Summary

liteLLM versions **1.82.7** and **1.82.8** have been compromised by the **TeamPCP** hacking group via a supply chain attack through **Trivy**. The current dependency constraint `>=1.81.0, <2` allows these malicious versions to be pulled in.

## Impact

The compromised versions steal sensitive credentials and secrets, including:

- **SSH keys** (`~/.ssh/`)
- **AWS credentials** (`~/.aws/`)
- **GCP credentials** (`~/.config/gcloud/`)
- **Kubernetes secrets** (`~/.kube/`)
- **Cryptocurrency wallets**
- **CI/CD tokens** (GitHub, GitLab, Jenkins, etc.)
- **Environment variables** containing secrets

Version **1.82.8** additionally installs a **`.pth` persistence mechanism** in `site-packages`, ensuring the malicious payload survives package upgrades and executes automatically on every Python interpreter startup — even after liteLLM itself is uninstalled.

## Fix

This PR pins the upper bound of the liteLLM optional dependency from `<2` to `<=1.82.6`, which is the **last known safe version** before the compromise.

```diff
- litellm = ["litellm>=1.81.0, <2"]
+ litellm = ["litellm>=1.81.0, <=1.82.6"]
```

Once BerriAI publishes a verified clean release, this upper bound can be raised again.

## References

- [BerriAI/litellm#24512](https://github.com/BerriAI/litellm/issues/24512) — Incident report
- [Endor Labs Advisory](https://www.endorlabs.com/learn/litellm-compromised-in-supply-chain-attack-via-pypi) — Supply chain attack analysis
- [PyPI yanked versions](https://pypi.org/project/litellm/#history) — 1.82.7 and 1.82.8 yanked