### PR TITLE
feat(mcp): #2228 expose server name on function tools

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -313,6 +313,7 @@ class MCPUtil:
             strict_json_schema=is_strict,
             needs_approval=needs_approval,
             mcp_title=resolve_mcp_tool_title(tool),
+            mcp_server_name=server.name,
         )
         return function_tool
 

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -294,6 +294,9 @@ class FunctionTool:
     defer_loading: bool = False
     """Whether the Responses API should hide this tool definition until tool search loads it."""
 
+    mcp_server_name: str | None = field(default=None, kw_only=True)
+    """The MCP server name this tool originated from, if it was converted from an MCP tool."""
+
     _failure_error_function: ToolErrorFunction | None = field(
         default=None,
         kw_only=True,
@@ -428,6 +431,7 @@ def _build_wrapped_function_tool(
     defer_loading: bool = False,
     sync_invoker: bool = False,
     mcp_title: str | None = None,
+    mcp_server_name: str | None = None,
 ) -> FunctionTool:
     """Create a FunctionTool with copied-tool-aware failure handling bound in one place."""
     on_invoke_tool = with_function_tool_failure_error_handler(
@@ -452,6 +456,7 @@ def _build_wrapped_function_tool(
             timeout_behavior=timeout_behavior,
             timeout_error_function=timeout_error_function,
             defer_loading=defer_loading,
+            mcp_server_name=mcp_server_name,
             _mcp_title=mcp_title,
         ),
         failure_error_function,

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -81,6 +81,17 @@ async def test_get_all_function_tools():
     assert len(tools) == 5
     assert all(tool.name in names for tool in tools)
 
+    expected_server_names = [
+        server1.name,
+        server1.name,
+        server2.name,
+        server2.name,
+        server3.name,
+    ]
+    for tool, expected_server_name in zip(tools, expected_server_names):
+        assert isinstance(tool, FunctionTool)
+        assert tool.mcp_server_name == expected_server_name
+
 
 @pytest.mark.asyncio
 async def test_invoke_mcp_tool():
@@ -159,6 +170,7 @@ async def test_to_function_tool_passes_static_mcp_meta():
     )
 
     function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=False)
+    assert function_tool.mcp_server_name == server.name
     tool_context = ToolContext(
         context=None,
         tool_name="test_tool_1",

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -350,6 +350,7 @@ async def test_manual_function_tool_creation_works():
 
     assert tool.name == "test"
     assert tool.description == "Processes extracted user data"
+    assert tool.mcp_server_name is None
     for key, value in FunctionArgs.model_json_schema().items():
         assert tool.params_json_schema[key] == value
     assert tool.strict_json_schema
@@ -700,6 +701,25 @@ async def test_shallow_copied_function_tool_normal_failure_uses_copied_policy() 
         )
 
     assert cast(Any, copied_tool).custom_state is custom_state
+
+
+def test_function_tool_copy_preserves_mcp_server_name() -> None:
+    async def invoke(_ctx: ToolContext[Any], _args: str) -> str:
+        return "ok"
+
+    original_tool = FunctionTool(
+        name="tool_name",
+        description="tool_description",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=invoke,
+        mcp_server_name="filesystem",
+    )
+
+    shallow_copied_tool = copy.copy(original_tool)
+    replaced_tool = dataclasses.replace(original_tool, name="copied_tool")
+
+    assert shallow_copied_tool.mcp_server_name == "filesystem"
+    assert replaced_tool.mcp_server_name == "filesystem"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a public `mcp_server_name` field to `FunctionTool`
- populate that field when MCP tools are converted via `MCPUtil.to_function_tool()`
- keep the change narrow and typed instead of introducing a general metadata bag
- add focused tests for MCP population, non-MCP default behavior, and copy/replace preservation

Fixes #2228.

## Why
Issue #2228 asks for a reliable way to recover which MCP server a converted function tool came from. The maintainer feedback there suggested a specific field such as `mcp_server_name: str | None` on `FunctionTool` rather than a generic metadata dict. This patch follows that direction and preserves backward compatibility by making the new field keyword-only with a default of `None`.

## Validation
- `uv run ruff check src/agents/tool.py src/agents/mcp/util.py tests/mcp/test_mcp_util.py tests/test_function_tool.py`
- `PYTHONPATH=src uv run pytest tests/mcp/test_mcp_util.py tests/test_function_tool.py -q`
- `uv run mypy src/agents/tool.py src/agents/mcp/util.py --disable-error-code import-not-found --disable-error-code unused-ignore`

## Notes
The local pytest invocation uses `PYTHONPATH=src` because this workspace clone is not resolving the local `agents` package via `uv run` by default, but the test slice itself passes cleanly.