### PR TITLE
docs: add non-OpenAI provider code example

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -204,16 +204,8 @@ from agents import Agent, AsyncOpenAI, OpenAIChatCompletionsModel, set_tracing_d
 
 set_tracing_disabled(disabled=True)
 
-provider = AsyncOpenAI(
-    api_key="Api_Key",
-    base_url="Base URL of Provider",
-)
-
-model = OpenAIChatCompletionsModel(
-    model="Model_Name",
-    openai_client=provider
-)
-
+provider = AsyncOpenAI(api_key="Api_Key", base_url="Base URL of Provider")
+model = OpenAIChatCompletionsModel(model="Model_Name", openai_client=provider)
 
 agent= Agent(name="Helping Agent", instructions="You are a Helping Agent", model=model)
 ```


### PR DESCRIPTION
Add a minimal code example demonstrating how to configure a non-OpenAI provider using OpenAIChatCompletionsModel with a custom base_url, api_key, and set_tracing_disabled in the Non-OpenAI models section.