### PR TITLE
fix: #2798 avoid stale hydrated input ids in server conversation tracker

### DIFF
--- a/src/agents/run_internal/oai_conversation.py
+++ b/src/agents/run_internal/oai_conversation.py
@@ -156,10 +156,11 @@ class OpenAIServerConversationTracker:
         if isinstance(original_input, list):
             normalized_input = prepare_model_input_items(original_input)
 
+        # Hydrated initial input is reconstructed during resume, so object identity is not a
+        # stable dedupe key and can later collide with unrelated freshly allocated items.
         for item in ItemHelpers.input_to_new_input_list(normalized_input):
             if item is None:
                 continue
-            self.sent_items.add(id(item))
             item_id = _normalize_server_item_id(
                 item.get("id") if isinstance(item, dict) else getattr(item, "id", None)
             )

--- a/tests/test_server_conversation_tracker.py
+++ b/tests/test_server_conversation_tracker.py
@@ -84,6 +84,41 @@ def test_prepare_input_filters_items_seen_by_server_and_tool_calls() -> None:
     assert tracker.remaining_initial_input is None
 
 
+def test_hydrate_from_state_does_not_track_string_initial_input_by_object_identity() -> None:
+    tracker = OpenAIServerConversationTracker(
+        conversation_id="conv-init-string", previous_response_id=None
+    )
+
+    tracker.hydrate_from_state(
+        original_input="hello",
+        generated_items=[],
+        model_responses=[],
+    )
+
+    assert tracker.sent_items == set()
+    assert tracker.sent_initial_input is True
+    assert tracker.remaining_initial_input is None
+    assert len(tracker.sent_item_fingerprints) == 1
+
+
+def test_hydrate_from_state_does_not_track_list_initial_input_by_object_identity() -> None:
+    tracker = OpenAIServerConversationTracker(
+        conversation_id="conv-init-list", previous_response_id=None
+    )
+    original_input = [cast(TResponseInputItem, {"role": "user", "content": "hello"})]
+
+    tracker.hydrate_from_state(
+        original_input=original_input,
+        generated_items=[],
+        model_responses=[],
+    )
+
+    assert tracker.sent_items == set()
+    assert tracker.sent_initial_input is True
+    assert tracker.remaining_initial_input is None
+    assert len(tracker.sent_item_fingerprints) == 1
+
+
 def test_mark_input_as_sent_and_rewind_input_respects_remaining_initial_input() -> None:
     tracker = OpenAIServerConversationTracker(conversation_id="conv2", previous_response_id=None)
     pending_1: TResponseInputItem = cast(TResponseInputItem, {"id": "p-1", "type": "message"})


### PR DESCRIPTION
This pull request fixes #2798 a resumed server-managed conversation bug where `OpenAIServerConversationTracker.hydrate_from_state()` could record `id()` values for reconstructed initial input items and later misclassify unrelated freshly allocated items as already sent. In the failure case, a new `function_call_output` could be dropped from the next payload, leading to `"No tool output found for function call <call_id>."`

The change updates `src/agents/run_internal/oai_conversation.py` so hydrated initial input is deduplicated only through stable identifiers and content fingerprints, not Python object identity. It also adds regression coverage in `tests/test_server_conversation_tracker.py` for both string and list initial inputs to lock in the resume behavior and prevent stale identity tracking from returning.