### PR TITLE
Add offset parameter to get_items() for pagination

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -138,12 +138,15 @@ class AdvancedSQLiteSession(SQLiteSession):
     async def get_items(
         self,
         limit: int | None = None,
+        offset: int = 0,
         branch_id: str | None = None,
     ) -> list[TResponseInputItem]:
         """Get items from current or specified branch.
 
         Args:
             limit: Maximum number of items to return. If None, uses session_settings.limit.
+            offset: Number of items to skip (from the most recent) before applying the limit.
+                    Defaults to 0. Combined with limit, enables pagination over history.
             branch_id: Branch to get items from. If None, uses current branch.
 
         Returns:
@@ -161,7 +164,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                 # TODO: Refactor SQLiteSession to use asyncio.Lock instead of threading.Lock and update this code  # noqa: E501
                 with self._lock if self._is_memory_db else threading.Lock():
                     with closing(conn.cursor()) as cursor:
-                        if session_limit is None:
+                        if session_limit is None and offset == 0:
                             cursor.execute(
                                 f"""
                                 SELECT m.message_data
@@ -173,6 +176,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                                 (self.session_id, branch_id),
                             )
                         else:
+                            sql_limit = session_limit if session_limit is not None else -1
                             cursor.execute(
                                 f"""
                                 SELECT m.message_data
@@ -180,13 +184,13 @@ class AdvancedSQLiteSession(SQLiteSession):
                                 JOIN message_structure s ON m.id = s.message_id
                                 WHERE m.session_id = ? AND s.branch_id = ?
                                 ORDER BY s.sequence_number DESC
-                                LIMIT ?
+                                LIMIT ? OFFSET ?
                             """,
-                                (self.session_id, branch_id, session_limit),
+                                (self.session_id, branch_id, sql_limit, offset),
                             )
 
                         rows = cursor.fetchall()
-                        if session_limit is not None:
+                        if session_limit is not None or offset > 0:
                             rows = list(reversed(rows))
 
                     items = []
@@ -207,7 +211,7 @@ class AdvancedSQLiteSession(SQLiteSession):
             with self._lock if self._is_memory_db else threading.Lock():
                 with closing(conn.cursor()) as cursor:
                     # Get message IDs in correct order for this branch
-                    if session_limit is None:
+                    if session_limit is None and offset == 0:
                         cursor.execute(
                             f"""
                             SELECT m.message_data
@@ -219,6 +223,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                             (self.session_id, branch_id),
                         )
                     else:
+                        sql_limit = session_limit if session_limit is not None else -1
                         cursor.execute(
                             f"""
                             SELECT m.message_data
@@ -226,13 +231,13 @@ class AdvancedSQLiteSession(SQLiteSession):
                             JOIN message_structure s ON m.id = s.message_id
                             WHERE m.session_id = ? AND s.branch_id = ?
                             ORDER BY s.sequence_number DESC
-                            LIMIT ?
+                            LIMIT ? OFFSET ?
                         """,
-                            (self.session_id, branch_id, session_limit),
+                            (self.session_id, branch_id, sql_limit, offset),
                         )
 
                     rows = cursor.fetchall()
-                    if session_limit is not None:
+                    if session_limit is not None or offset > 0:
                         rows = list(reversed(rows))
 
                 items = []

--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -102,19 +102,23 @@ class AsyncSQLiteSession(SessionABC):
             conn = await self._get_connection()
             yield conn
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, retrieves all items.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of items to skip (from the most recent) before applying the limit.
+                    Defaults to 0. Combined with limit, enables pagination over history.
 
         Returns:
             List of input items representing the conversation history
         """
 
         async with self._locked_connection() as conn:
-            if limit is None:
+            if limit is None and offset == 0:
                 cursor = await conn.execute(
                     f"""
                     SELECT message_data FROM {self.messages_table}
@@ -124,20 +128,21 @@ class AsyncSQLiteSession(SessionABC):
                     (self.session_id,),
                 )
             else:
+                sql_limit = limit if limit is not None else -1
                 cursor = await conn.execute(
                     f"""
                     SELECT message_data FROM {self.messages_table}
                     WHERE session_id = ?
                     ORDER BY id DESC
-                    LIMIT ?
+                    LIMIT ? OFFSET ?
                     """,
-                    (self.session_id, limit),
+                    (self.session_id, sql_limit, offset),
                 )
 
             rows = list(await cursor.fetchall())
             await cursor.close()
 
-        if limit is not None:
+        if limit is not None or offset > 0:
             rows = rows[::-1]
 
         items: list[TResponseInputItem] = []

--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -232,12 +232,16 @@ class DaprSession(SessionABC):
     # Session protocol implementation
     # ------------------------------------------------------------------
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of items to skip (from the most recent) before applying the limit.
+                    Defaults to 0. Combined with limit, enables pagination over history.
 
         Returns:
             List of input items representing the conversation history
@@ -253,6 +257,11 @@ class DaprSession(SessionABC):
             )
 
             messages = self._decode_messages(response.data)
+            if not messages:
+                return []
+            # Apply offset: trim from the end
+            if offset > 0:
+                messages = messages[:-offset] if offset < len(messages) else []
             if not messages:
                 return []
             if session_limit is not None:

--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -170,8 +170,10 @@ class EncryptedSession(SessionABC):
         except (InvalidToken, KeyError):
             return None
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
-        encrypted_items = await self.underlying_session.get_items(limit)
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
+        encrypted_items = await self.underlying_session.get_items(limit, offset=offset)
         valid_items: list[TResponseInputItem] = []
         for enc in encrypted_items:
             item = self._unwrap(enc)

--- a/src/agents/extensions/memory/redis_session.py
+++ b/src/agents/extensions/memory/redis_session.py
@@ -140,12 +140,16 @@ class RedisSession(SessionABC):
     # Session protocol implementation
     # ------------------------------------------------------------------
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of items to skip (from the most recent) before applying the limit.
+                    Defaults to 0. Combined with limit, enables pagination over history.
 
         Returns:
             List of input items representing the conversation history
@@ -153,15 +157,21 @@ class RedisSession(SessionABC):
         session_limit = resolve_session_limit(limit, self.session_settings)
 
         async with self._lock:
-            if session_limit is None:
+            if session_limit is None and offset == 0:
                 # Get all messages in chronological order
                 raw_messages = await self._redis.lrange(self._messages_key, 0, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
-            else:
+            elif session_limit is not None:
                 if session_limit <= 0:
                     return []
-                # Get the latest N messages (Redis list is ordered chronologically)
-                # Use negative indices to get from the end - Redis uses -N to -1 for last N items
-                raw_messages = await self._redis.lrange(self._messages_key, -session_limit, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
+                # Calculate Redis range indices from the end, accounting for offset
+                # e.g., limit=3, offset=2 on a list of 10 → indices -5 to -3
+                end_idx = -(offset + 1)
+                start_idx = -(offset + session_limit)
+                raw_messages = await self._redis.lrange(self._messages_key, start_idx, end_idx)  # type: ignore[misc]
+            else:
+                # offset > 0 but no limit: skip the last `offset` items
+                end_idx = -(offset + 1)
+                raw_messages = await self._redis.lrange(self._messages_key, 0, end_idx)  # type: ignore[misc]
 
             items: list[TResponseInputItem] = []
             for raw_msg in raw_messages:

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -224,12 +224,16 @@ class SQLAlchemySession(SessionABC):
         finally:
             self._init_lock.release()
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of items to skip (from the most recent) before applying the limit.
+                    Defaults to 0. Combined with limit, enables pagination over history.
 
         Returns:
             List of input items representing the conversation history
@@ -239,7 +243,7 @@ class SQLAlchemySession(SessionABC):
         session_limit = resolve_session_limit(limit, self.session_settings)
 
         async with self._session_factory() as sess:
-            if session_limit is None:
+            if session_limit is None and offset == 0:
                 stmt = (
                     select(self._messages.c.message_data)
                     .where(self._messages.c.session_id == self.session_id)
@@ -252,19 +256,21 @@ class SQLAlchemySession(SessionABC):
                 stmt = (
                     select(self._messages.c.message_data)
                     .where(self._messages.c.session_id == self.session_id)
-                    # Use DESC + LIMIT to get the latest N
-                    # then reverse later for chronological order.
+                    # Use DESC + LIMIT/OFFSET to paginate from most recent,
+                    # then reverse for chronological order.
                     .order_by(
                         self._messages.c.created_at.desc(),
                         self._messages.c.id.desc(),
                     )
-                    .limit(session_limit)
+                    .offset(offset)
                 )
+                if session_limit is not None:
+                    stmt = stmt.limit(session_limit)
 
             result = await sess.execute(stmt)
             rows: list[str] = [row[0] for row in result.all()]
 
-            if session_limit is not None:
+            if session_limit is not None or offset > 0:
                 rows.reverse()
 
             items: list[TResponseInputItem] = []

--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -70,7 +70,9 @@ class OpenAIConversationsSession(SessionABC):
     async def _clear_session_id(self) -> None:
         self._session_id = None
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         session_id = await self._get_session_id()
 
         session_limit = resolve_session_limit(limit, self.session_settings)

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -239,8 +239,10 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             f"candidates={len(self._compaction_candidate_items)})"
         )
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
-        return await self.underlying_session.get_items(limit)
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
+        return await self.underlying_session.get_items(limit, offset=offset)
 
     async def _defer_compaction(self, response_id: str, store: bool | None = None) -> None:
         if self._deferred_response_id is not None:

--- a/src/agents/memory/session.py
+++ b/src/agents/memory/session.py
@@ -21,12 +21,16 @@ class Session(Protocol):
     session_id: str
     session_settings: SessionSettings | None = None
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, retrieves all items.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of items to skip (from the end) before applying the limit.
+                    Defaults to 0. Combined with limit, enables pagination over history.
 
         Returns:
             List of input items representing the conversation history
@@ -68,12 +72,16 @@ class SessionABC(ABC):
     session_settings: SessionSettings | None = None
 
     @abstractmethod
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, retrieves all items.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of items to skip (from the end) before applying the limit.
+                    Defaults to 0. Combined with limit, enables pagination over history.
 
         Returns:
             List of input items representing the conversation history

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -114,12 +114,16 @@ class SQLiteSession(SessionABC):
 
         conn.commit()
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of items to skip (from the most recent) before applying the limit.
+                    Defaults to 0. Combined with limit, enables pagination over history.
 
         Returns:
             List of input items representing the conversation history
@@ -129,8 +133,8 @@ class SQLiteSession(SessionABC):
         def _get_items_sync():
             conn = self._get_connection()
             with self._lock if self._is_memory_db else threading.Lock():
-                if session_limit is None:
-                    # Fetch all items in chronological order
+                if session_limit is None and offset == 0:
+                    # Fast path: fetch all items in chronological order
                     cursor = conn.execute(
                         f"""
                         SELECT message_data FROM {self.messages_table}
@@ -140,21 +144,23 @@ class SQLiteSession(SessionABC):
                         (self.session_id,),
                     )
                 else:
-                    # Fetch the latest N items in chronological order
+                    # Use DESC + LIMIT/OFFSET to paginate from most recent,
+                    # then reverse to return in chronological order.
+                    sql_limit = session_limit if session_limit is not None else -1
                     cursor = conn.execute(
                         f"""
                         SELECT message_data FROM {self.messages_table}
                         WHERE session_id = ?
                         ORDER BY id DESC
-                        LIMIT ?
+                        LIMIT ? OFFSET ?
                         """,
-                        (self.session_id, session_limit),
+                        (self.session_id, sql_limit, offset),
                     )
 
                 rows = cursor.fetchall()
 
                 # Reverse to get chronological order when using DESC
-                if session_limit is not None:
+                if session_limit is not None or offset > 0:
                     rows = list(reversed(rows))
 
                 items = []

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -368,6 +368,54 @@ async def test_sqlite_session_get_items_with_limit():
         session.close()
 
 
+@pytest.mark.asyncio
+async def test_sqlite_session_get_items_with_offset():
+    """Test SQLiteSession get_items with offset for pagination."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_offset.db"
+        session_id = "offset_test"
+        session = SQLiteSession(session_id, db_path)
+
+        # Add 6 items: Message 1, Response 1, ... Message 3, Response 3
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": f"Message {i}"}
+            if i % 2 == 0
+            else {"role": "assistant", "content": f"Response {i}"}
+            for i in range(6)
+        ]
+        await session.add_items(items)
+
+        # Page 1: 2 most recent items (offset=0)
+        page1 = await session.get_items(limit=2, offset=0)
+        assert len(page1) == 2
+        assert page1[0].get("content") == "Message 4"
+        assert page1[1].get("content") == "Response 5"
+
+        # Page 2: next 2 items (offset=2)
+        page2 = await session.get_items(limit=2, offset=2)
+        assert len(page2) == 2
+        assert page2[0].get("content") == "Message 2"
+        assert page2[1].get("content") == "Response 3"
+
+        # Page 3: last 2 items (offset=4)
+        page3 = await session.get_items(limit=2, offset=4)
+        assert len(page3) == 2
+        assert page3[0].get("content") == "Message 0"
+        assert page3[1].get("content") == "Response 1"
+
+        # Offset beyond available items
+        empty = await session.get_items(limit=2, offset=10)
+        assert len(empty) == 0
+
+        # Offset without limit: skip the 2 most recent, return the rest
+        skipped = await session.get_items(offset=2)
+        assert len(skipped) == 4
+        assert skipped[0].get("content") == "Message 0"
+        assert skipped[-1].get("content") == "Response 3"
+
+        session.close()
+
+
 @pytest.mark.parametrize("runner_method", ["run", "run_sync", "run_streamed"])
 @pytest.mark.asyncio
 async def test_session_memory_appends_list_input_by_default(runner_method):


### PR DESCRIPTION
## Summary

- Adds `offset` parameter to `get_items()` across **all** session backends, enabling real pagination over conversation history
- Currently `limit` only truncates (returns the latest N items) — with `offset`, users can now paginate through the full history
- Fully backward compatible: `offset` defaults to `0`

## Usage

```python
# Page 1: 10 most recent items
page1 = await session.get_items(limit=10, offset=0)

# Page 2: next 10 items  
page2 = await session.get_items(limit=10, offset=10)

# Skip the 5 most recent, get the rest
older = await session.get_items(offset=5)
```

## Backends updated

| Backend | File |
|---------|------|
| Session protocol | `src/agents/memory/session.py` |
| SessionABC | `src/agents/memory/session.py` |
| SQLiteSession | `src/agents/memory/sqlite_session.py` |
| AsyncSQLiteSession | `src/agents/extensions/memory/async_sqlite_session.py` |
| SQLAlchemySession | `src/agents/extensions/memory/sqlalchemy_session.py` |
| RedisSession | `src/agents/extensions/memory/redis_session.py` |
| DaprSession | `src/agents/extensions/memory/dapr_session.py` |
| AdvancedSQLiteSession | `src/agents/extensions/memory/advanced_sqlite_session.py` |
| EncryptedSession | `src/agents/extensions/memory/encrypt_session.py` |
| OpenAIResponsesCompactionSession | `src/agents/memory/openai_responses_compaction_session.py` |
| OpenAIConversationsSession | `src/agents/memory/openai_conversations_session.py` |

## Test plan

- [x] All 33 existing session tests pass (backward compatible)
- [x] New `test_sqlite_session_get_items_with_offset` — verifies limit+offset pagination, offset-only, and edge cases

Closes #2810