### PR TITLE
feat: Add create_session and get_session classmethods

### DIFF
--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -316,31 +316,33 @@ class AsyncSQLiteSession(SessionABC):
         return session
 
     @classmethod
-    async def get_session(
+    async def get_sessions(
         cls,
         user_id: str,
-        session_id: str,
         db_path: str | Path = ":memory:",
         sessions_table: str = "agent_sessions",
         messages_table: str = "agent_messages",
         users_table: str = "agent_users",
-    ) -> AsyncSQLiteSession | None:
-        """Retrieve an existing session for a user.
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[AsyncSQLiteSession]:
+        """Retrieve all sessions for a user.
 
         Args:
-            user_id: The user identifier who owns the session.
-            session_id: The session identifier to retrieve.
+            user_id: The user identifier to look up sessions for.
             db_path: Path to the SQLite database file. Defaults to ':memory:'.
             sessions_table: Name of the sessions table. Defaults to 'agent_sessions'.
             messages_table: Name of the messages table. Defaults to 'agent_messages'.
             users_table: Name of the users table. Defaults to 'agent_users'.
+            limit: Maximum number of sessions to return. If None, returns all sessions.
+            offset: Number of sessions to skip before returning results. Defaults to 0.
 
         Returns:
-            The AsyncSQLiteSession instance if it exists and belongs to the user,
-            None otherwise.
+            List of AsyncSQLiteSession instances belonging to the user, ordered by
+            most recently updated first.
         """
-        session = cls(
-            session_id=session_id,
+        probe = cls(
+            session_id="__probe__",
             db_path=db_path,
             sessions_table=sessions_table,
             messages_table=messages_table,
@@ -348,21 +350,43 @@ class AsyncSQLiteSession(SessionABC):
             user_id=user_id,
         )
 
-        async with session._locked_connection() as conn:
-            cursor = await conn.execute(
-                f"""
-                SELECT session_id FROM {sessions_table}
-                WHERE session_id = ? AND user_id = ?
-                """,
-                (session_id, user_id),
-            )
-            row = await cursor.fetchone()
+        async with probe._locked_connection() as conn:
+            if limit is None:
+                cursor = await conn.execute(
+                    f"""
+                    SELECT session_id FROM {sessions_table}
+                    WHERE user_id = ?
+                    ORDER BY updated_at DESC
+                    LIMIT -1 OFFSET ?
+                    """,
+                    (user_id, offset),
+                )
+            else:
+                cursor = await conn.execute(
+                    f"""
+                    SELECT session_id FROM {sessions_table}
+                    WHERE user_id = ?
+                    ORDER BY updated_at DESC
+                    LIMIT ? OFFSET ?
+                    """,
+                    (user_id, limit, offset),
+                )
+            rows = await cursor.fetchall()
             await cursor.close()
 
-        if row is None:
-            await session.close()
-            return None
-        return session
+        await probe.close()
+
+        return [
+            cls(
+                session_id=row[0],
+                db_path=db_path,
+                sessions_table=sessions_table,
+                messages_table=messages_table,
+                users_table=users_table,
+                user_id=user_id,
+            )
+            for row in rows
+        ]
 
     async def get_sessions_for_user(
         self,

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -487,10 +487,9 @@ class SQLAlchemySession(SessionABC):
         return session
 
     @classmethod
-    async def get_session(
+    async def get_sessions(
         cls,
         user_id: str,
-        session_id: str,
         *,
         engine: AsyncEngine,
         create_tables: bool = False,
@@ -498,25 +497,28 @@ class SQLAlchemySession(SessionABC):
         messages_table: str = "agent_messages",
         users_table: str = "agent_users",
         session_settings: SessionSettings | None = None,
-    ) -> SQLAlchemySession | None:
-        """Retrieve an existing session for a user.
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[SQLAlchemySession]:
+        """Retrieve all sessions for a user.
 
         Args:
-            user_id: The user identifier who owns the session.
-            session_id: The session identifier to retrieve.
+            user_id: The user identifier to look up sessions for.
             engine: A pre-configured SQLAlchemy async engine.
             create_tables: Whether to auto-create tables. Defaults to False.
             sessions_table: Override the default table name for sessions.
             messages_table: Override the default table name for messages.
             users_table: Override the default table name for users.
             session_settings: Session configuration settings.
+            limit: Maximum number of sessions to return. If None, returns all sessions.
+            offset: Number of sessions to skip before returning results. Defaults to 0.
 
         Returns:
-            The SQLAlchemySession instance if it exists and belongs to the user,
-            None otherwise.
+            List of SQLAlchemySession instances belonging to the user, ordered by
+            most recently updated first.
         """
-        session = cls(
-            session_id=session_id,
+        probe = cls(
+            session_id="__probe__",
             engine=engine,
             create_tables=create_tables,
             sessions_table=sessions_table,
@@ -526,18 +528,32 @@ class SQLAlchemySession(SessionABC):
             session_settings=session_settings,
         )
 
-        await session._ensure_tables()
-        async with session._session_factory() as sess:
-            result = await sess.execute(
-                select(session._sessions.c.session_id).where(
-                    (session._sessions.c.session_id == session_id)
-                    & (session._sessions.c.user_id == user_id)
-                )
+        await probe._ensure_tables()
+        async with probe._session_factory() as sess:
+            stmt = (
+                select(probe._sessions.c.session_id)
+                .where(probe._sessions.c.user_id == user_id)
+                .order_by(probe._sessions.c.updated_at.desc())
+                .offset(offset)
             )
-            if not result.scalar_one_or_none():
-                return None
+            if limit is not None:
+                stmt = stmt.limit(limit)
+            result = await sess.execute(stmt)
+            session_ids = [row[0] for row in result.all()]
 
-        return session
+        return [
+            cls(
+                session_id=sid,
+                engine=engine,
+                create_tables=False,
+                sessions_table=sessions_table,
+                messages_table=messages_table,
+                users_table=users_table,
+                user_id=user_id,
+                session_settings=session_settings,
+            )
+            for sid in session_ids
+        ]
 
     async def get_sessions_for_user(
         self,

--- a/src/agents/memory/session.py
+++ b/src/agents/memory/session.py
@@ -69,37 +69,6 @@ class SessionABC(ABC):
     user_id: str | None = None
     session_settings: SessionSettings | None = None
 
-    @classmethod
-    @abstractmethod
-    async def create_session(cls, user_id: str, **kwargs: object) -> SessionABC:
-        """Create a new session for a user with an auto-generated session ID.
-
-        Args:
-            user_id: The user identifier to associate with the new session.
-            **kwargs: Backend-specific configuration (e.g., db_path, engine).
-
-        Returns:
-            A new session instance with an auto-generated session_id.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    async def get_session(
-        cls, user_id: str, session_id: str, **kwargs: object
-    ) -> SessionABC | None:
-        """Retrieve an existing session for a user.
-
-        Args:
-            user_id: The user identifier who owns the session.
-            session_id: The session identifier to retrieve.
-            **kwargs: Backend-specific configuration (e.g., db_path, engine).
-
-        Returns:
-            The session instance if it exists and belongs to the user, None otherwise.
-        """
-        ...
-
     @abstractmethod
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -363,32 +363,36 @@ class SQLiteSession(SessionABC):
         return session
 
     @classmethod
-    async def get_session(
+    async def get_sessions(
         cls,
         user_id: str,
-        session_id: str,
         db_path: str | Path = ":memory:",
         sessions_table: str = "agent_sessions",
         messages_table: str = "agent_messages",
         users_table: str = "agent_users",
         session_settings: SessionSettings | None = None,
-    ) -> SQLiteSession | None:
-        """Retrieve an existing session for a user.
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[SQLiteSession]:
+        """Retrieve all sessions for a user.
 
         Args:
-            user_id: The user identifier who owns the session.
-            session_id: The session identifier to retrieve.
+            user_id: The user identifier to look up sessions for.
             db_path: Path to the SQLite database file. Defaults to ':memory:'.
             sessions_table: Name of the sessions table. Defaults to 'agent_sessions'.
             messages_table: Name of the messages table. Defaults to 'agent_messages'.
             users_table: Name of the users table. Defaults to 'agent_users'.
             session_settings: Session configuration settings.
+            limit: Maximum number of sessions to return. If None, returns all sessions.
+            offset: Number of sessions to skip before returning results. Defaults to 0.
 
         Returns:
-            The SQLiteSession instance if it exists and belongs to the user, None otherwise.
+            List of SQLiteSession instances belonging to the user, ordered by most
+            recently updated first.
         """
-        session = cls(
-            session_id=session_id,
+        # Use a temporary instance to access the DB and query session IDs
+        probe = cls(
+            session_id="__probe__",
             db_path=db_path,
             sessions_table=sessions_table,
             messages_table=messages_table,
@@ -397,23 +401,46 @@ class SQLiteSession(SessionABC):
             session_settings=session_settings,
         )
 
-        def _check_session():
-            conn = session._get_connection()
-            with session._lock if session._is_memory_db else threading.Lock():
-                cursor = conn.execute(
-                    f"""
-                    SELECT session_id FROM {sessions_table}
-                    WHERE session_id = ? AND user_id = ?
-                    """,
-                    (session_id, user_id),
-                )
-                return cursor.fetchone() is not None
+        def _fetch_ids():
+            conn = probe._get_connection()
+            with probe._lock if probe._is_memory_db else threading.Lock():
+                if limit is None:
+                    cursor = conn.execute(
+                        f"""
+                        SELECT session_id FROM {sessions_table}
+                        WHERE user_id = ?
+                        ORDER BY updated_at DESC
+                        LIMIT -1 OFFSET ?
+                        """,
+                        (user_id, offset),
+                    )
+                else:
+                    cursor = conn.execute(
+                        f"""
+                        SELECT session_id FROM {sessions_table}
+                        WHERE user_id = ?
+                        ORDER BY updated_at DESC
+                        LIMIT ? OFFSET ?
+                        """,
+                        (user_id, limit, offset),
+                    )
+                return [row[0] for row in cursor.fetchall()]
 
-        exists = await asyncio.to_thread(_check_session)
-        if not exists:
-            session.close()
-            return None
-        return session
+        session_ids = await asyncio.to_thread(_fetch_ids)
+        probe.close()
+
+        return [
+            cls(
+                session_id=sid,
+                db_path=db_path,
+                sessions_table=sessions_table,
+                messages_table=messages_table,
+                users_table=users_table,
+                user_id=user_id,
+                session_settings=session_settings,
+            )
+            for sid in session_ids
+        ]
 
     async def get_sessions_for_user(
         self,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -797,39 +797,70 @@ async def test_sqlite_create_session():
 
 
 @pytest.mark.asyncio
-async def test_sqlite_get_session():
-    """Test get_session retrieves an existing session or returns None."""
+async def test_sqlite_get_sessions():
+    """Test get_sessions retrieves all sessions for a user."""
     with tempfile.TemporaryDirectory() as temp_dir:
         db_path = Path(temp_dir) / "test_get.db"
 
-        # Create a session first
-        created = await SQLiteSession.create_session("bob", db_path=db_path)
-        session_id = created.session_id
+        # Create sessions for bob
+        s1 = await SQLiteSession.create_session("bob", db_path=db_path)
+        s2 = await SQLiteSession.create_session("bob", db_path=db_path)
+        # Create a session for eve
+        await SQLiteSession.create_session("eve", db_path=db_path)
 
-        # Add some items
+        # Add items to s1
         items: list[TResponseInputItem] = [{"role": "user", "content": "Hi Bob"}]
-        await created.add_items(items)
-        created.close()
+        await s1.add_items(items)
+        s1.close()
+        s2.close()
 
-        # Retrieve it
-        retrieved = await SQLiteSession.get_session("bob", session_id, db_path=db_path)
-        assert retrieved is not None
-        assert retrieved.session_id == session_id
-        assert retrieved.user_id == "bob"
+        # Retrieve bob's sessions
+        bob_sessions = await SQLiteSession.get_sessions("bob", db_path=db_path)
+        assert len(bob_sessions) == 2
+        session_ids = {s.session_id for s in bob_sessions}
+        assert s1.session_id in session_ids
+        assert s2.session_id in session_ids
 
-        # Verify items are preserved
-        history = await retrieved.get_items()
-        assert len(history) == 1
-        assert history[0]["content"] == "Hi Bob"
-        retrieved.close()
+        # Each returned session should be usable
+        for s in bob_sessions:
+            assert s.user_id == "bob"
+            if s.session_id == s1.session_id:
+                history = await s.get_items()
+                assert len(history) == 1
+                assert history[0]["content"] == "Hi Bob"
+            s.close()
 
-        # Wrong user_id should return None
-        wrong_user = await SQLiteSession.get_session("eve", session_id, db_path=db_path)
-        assert wrong_user is None
+        # Non-existent user returns empty list
+        empty = await SQLiteSession.get_sessions("nobody", db_path=db_path)
+        assert empty == []
 
-        # Non-existent session_id should return None
-        missing = await SQLiteSession.get_session("bob", "non-existent-id", db_path=db_path)
-        assert missing is None
+
+@pytest.mark.asyncio
+async def test_sqlite_get_sessions_pagination():
+    """Test get_sessions supports limit and offset."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_pagination_get.db"
+
+        created = []
+        for _ in range(5):
+            s = await SQLiteSession.create_session("paguser", db_path=db_path)
+            created.append(s)
+            s.close()
+
+        page1 = await SQLiteSession.get_sessions("paguser", db_path=db_path, limit=2)
+        assert len(page1) == 2
+
+        page2 = await SQLiteSession.get_sessions("paguser", db_path=db_path, limit=2, offset=2)
+        assert len(page2) == 2
+
+        page3 = await SQLiteSession.get_sessions("paguser", db_path=db_path, limit=2, offset=4)
+        assert len(page3) == 1
+
+        all_ids = {s.session_id for s in page1 + page2 + page3}
+        assert all_ids == {s.session_id for s in created}
+
+        for s in page1 + page2 + page3:
+            s.close()
 
 
 @pytest.mark.asyncio
@@ -844,11 +875,13 @@ async def test_sqlite_create_multiple_sessions_for_user():
         assert s1.session_id != s2.session_id
         assert s1.user_id == s2.user_id == "charlie"
 
-        sessions = await s1.get_sessions_for_user("charlie")
-        assert set(sessions) == {s1.session_id, s2.session_id}
+        sessions = await SQLiteSession.get_sessions("charlie", db_path=db_path)
+        assert {s.session_id for s in sessions} == {s1.session_id, s2.session_id}
 
         s1.close()
         s2.close()
+        for s in sessions:
+            s.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds `create_session(user_id, ...)` classmethod to all SQL-based session backends (SQLiteSession, AsyncSQLiteSession, SQLAlchemySession) that creates a new session with an **auto-generated UUID** `session_id`, persisting user and session rows immediately
- Adds `get_sessions(user_id, ...)` classmethod that retrieves **all sessions for a user** as a list of ready-to-use session instances, with `limit`/`offset` pagination support
- No changes to `SessionABC` or the `Session` protocol — these methods are backend-specific conveniences

### API

```python
# Create a new session (session_id auto-generated)
session = await SQLiteSession.create_session("alice", db_path="./data.db")
print(session.session_id)  # "550e8400-e29b-41d4-..."

# Retrieve all sessions for a user
sessions = await SQLiteSession.get_sessions("alice", db_path="./data.db")
for s in sessions:
    items = await s.get_items()  # each instance is fully functional
    print(s.session_id, len(items))

# With pagination
page = await SQLiteSession.get_sessions("alice", db_path="./data.db", limit=10, offset=0)
```

## Motivation

Builds on #2809 (agent_users table). Currently the caller must invent a `session_id` and the session row is only created lazily on `add_items()`. This PR provides a proper factory pattern where:
1. The `user_id` is the primary entry point (not the `session_id`)
2. The `session_id` is generated internally via `uuid4()`
3. `get_sessions` returns fully functional session instances (not just IDs like `get_sessions_for_user`)

## Test plan

- [x] All 35 existing session tests pass (backward compatible)
- [x] `test_sqlite_create_session` — verifies UUID generation, DB persistence, and normal usage
- [x] `test_sqlite_get_sessions` — verifies retrieval of all user sessions, item preservation, empty result for unknown user
- [x] `test_sqlite_get_sessions_pagination` — verifies limit/offset pagination
- [x] `test_sqlite_create_multiple_sessions_for_user` — verifies multiple sessions per user with unique IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)