### PR TITLE
fix: map extensions changes to the feature:extensions label

### DIFF
--- a/.github/codex/prompts/pr-labels.md
+++ b/.github/codex/prompts/pr-labels.md
@@ -22,7 +22,7 @@ Allowed labels:
 - dependencies
 - feature:chat-completions
 - feature:core
-- feature:lite-llm
+- feature:extensions
 - feature:mcp
 - feature:realtime
 - feature:sessions
@@ -46,7 +46,7 @@ Label rules:
 - bug vs enhancement: Prefer exactly one of these. Include both only when the PR clearly contains two separate substantial changes and both are first-order outcomes.
 - feature:chat-completions: Chat Completions support or conversion is a primary deliverable of the PR. Do not add it for a small compatibility guard or parity update in `chatcmpl_converter.py`.
 - feature:core: Core agent loop, tool calls, run pipeline, or other central runtime behavior is a primary surface of the PR. For cross-cutting runtime changes, this is usually the single best feature label.
-- feature:lite-llm: LiteLLM adapter/provider behavior is a primary deliverable of the PR.
+- feature:extensions: `src/agents/extensions/` surfaces are a primary deliverable of the PR, including extension models/providers such as Any-LLM and LiteLLM.
 - feature:mcp: MCP-specific behavior or APIs are a primary deliverable of the PR. Do not add it for incidental hosted/deferred tool plumbing touched by broader runtime work.
 - feature:realtime: Realtime-specific behavior, API shape, or session semantics are a primary deliverable of the PR. Do not add it for small parity updates in realtime adapters.
 - feature:sessions: Session or memory behavior is a primary deliverable of the PR. Do not add it for persistence updates that merely support a broader feature.

--- a/.github/codex/schemas/pr-labels.json
+++ b/.github/codex/schemas/pr-labels.json
@@ -15,7 +15,7 @@
           "dependencies",
           "feature:chat-completions",
           "feature:core",
-          "feature:lite-llm",
+          "feature:extensions",
           "feature:mcp",
           "feature:realtime",
           "feature:sessions",

--- a/.github/scripts/pr_labels.py
+++ b/.github/scripts/pr_labels.py
@@ -19,7 +19,7 @@ ALLOWED_LABELS: Final[set[str]] = {
     "dependencies",
     "feature:chat-completions",
     "feature:core",
-    "feature:lite-llm",
+    "feature:extensions",
     "feature:mcp",
     "feature:realtime",
     "feature:sessions",
@@ -41,11 +41,12 @@ MODEL_ONLY_LABELS: Final[set[str]] = {
 FEATURE_LABELS: Final[set[str]] = ALLOWED_LABELS - DETERMINISTIC_LABELS - MODEL_ONLY_LABELS
 
 SOURCE_FEATURE_PREFIXES: Final[dict[str, tuple[str, ...]]] = {
+    "feature:extensions": ("src/agents/extensions/",),
     "feature:realtime": ("src/agents/realtime/",),
     "feature:voice": ("src/agents/voice/",),
     "feature:mcp": ("src/agents/mcp/",),
     "feature:tracing": ("src/agents/tracing/",),
-    "feature:sessions": ("src/agents/memory/", "src/agents/extensions/memory/"),
+    "feature:sessions": ("src/agents/memory/",),
 }
 
 CORE_EXCLUDED_PREFIXES: Final[tuple[str, ...]] = (
@@ -191,13 +192,6 @@ def infer_specific_feature_labels(changed_files: Sequence[str]) -> set[str]:
         for path in source_files
     ):
         labels.add("feature:chat-completions")
-
-    if any(
-        path.startswith(("src/agents/models/", "src/agents/extensions/models/"))
-        and "litellm" in path
-        for path in source_files
-    ):
-        labels.add("feature:lite-llm")
 
     return labels
 

--- a/tests/test_pr_labels.py
+++ b/tests/test_pr_labels.py
@@ -40,12 +40,24 @@ def test_infer_fallback_labels_marks_core_for_runtime_changes() -> None:
     assert labels == {"feature:core"}
 
 
-def test_infer_fallback_labels_marks_sessions_for_extensions_memory_changes() -> None:
+def test_infer_fallback_labels_marks_extensions_for_extensions_memory_changes() -> None:
     labels = pr_labels.infer_fallback_labels(
         ["src/agents/extensions/memory/advanced_sqlite_session.py"]
     )
 
-    assert labels == {"feature:sessions"}
+    assert labels == {"feature:extensions"}
+
+
+def test_infer_fallback_labels_marks_extensions_for_litellm_changes() -> None:
+    labels = pr_labels.infer_fallback_labels(["src/agents/extensions/models/litellm_model.py"])
+
+    assert labels == {"feature:extensions"}
+
+
+def test_infer_fallback_labels_marks_extensions_for_any_llm_changes() -> None:
+    labels = pr_labels.infer_fallback_labels(["src/agents/extensions/models/any_llm_model.py"])
+
+    assert labels == {"feature:extensions"}
 
 
 def test_compute_desired_labels_removes_stale_fallback_labels() -> None:
@@ -108,7 +120,7 @@ def test_compute_desired_labels_infers_bug_from_fix_title() -> None:
     assert desired == {"bug", "feature:core"}
 
 
-def test_compute_desired_labels_infers_sessions_for_extensions_memory_fix() -> None:
+def test_compute_desired_labels_infers_extensions_for_extensions_memory_fix() -> None:
     desired = pr_labels.compute_desired_labels(
         pr_context=pr_labels.PRContext(title="fix(memory): honor custom table names"),
         changed_files=[
@@ -123,7 +135,7 @@ def test_compute_desired_labels_infers_sessions_for_extensions_memory_fix() -> N
         head_sha=None,
     )
 
-    assert desired == {"bug", "feature:sessions"}
+    assert desired == {"bug", "feature:extensions"}
 
 
 def test_compute_managed_labels_preserves_model_only_labels_without_signal() -> None:


### PR DESCRIPTION
This pull request fixes PR auto-labeling so changes under `src/agents/extensions/` are classified as `feature:extensions` instead of the retired `feature:lite-llm` label.

It updates the allowed-label list used by Codex, the JSON schema that validates label output, and the fallback path-based inference in `.github/scripts/pr_labels.py`. The fallback logic now treats the whole `src/agents/extensions/` tree as the extensions surface, so Any-LLM, LiteLLM, and extension memory changes all resolve to `feature:extensions`, while core `src/agents/memory/` changes continue to use `feature:sessions`.

The test suite was updated to cover extension-memory, LiteLLM, and Any-LLM paths so this label mapping does not regress.