### PR TITLE
fix: #2823 AnyLLM reasoning extraction for iterable vLLM/any-llm Reasoning objects

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -163,14 +163,15 @@ def _flatten_any_llm_reasoning_value(value: Any) -> str:
             if flattened:
                 return flattened
         return ""
-    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
-        parts = [_flatten_any_llm_reasoning_value(item) for item in value]
-        return "".join(part for part in parts if part)
 
     for attr in ("content", "text", "thinking"):
         flattened = _flatten_any_llm_reasoning_value(getattr(value, attr, None))
         if flattened:
             return flattened
+
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        parts = [_flatten_any_llm_reasoning_value(item) for item in value]
+        return "".join(part for part in parts if part)
     return ""
 
 
@@ -829,6 +830,7 @@ class AnyLLMModel(Model):
             handoffs=handoffs,
             model=self._provider_model,
         )
+
         converted_tools = OpenAIResponsesConverter.convert_tools(
             tools,
             handoffs,

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -739,3 +739,17 @@ def test_any_llm_provider_passes_api_override() -> None:
 
     assert isinstance(model, AnyLLMModel)
     assert model.api == "chat_completions"
+
+
+def test_any_llm_reasoning_objects_prefer_content_attributes_over_iterable_pairs() -> None:
+    pytest.importorskip(
+        "any_llm",
+        reason="`any-llm-sdk` is only available when the optional dependency is installed.",
+    )
+    from any_llm.types.completion import Reasoning
+
+    from agents.extensions.models.any_llm_model import _extract_any_llm_reasoning_text
+
+    delta = pytypes.SimpleNamespace(reasoning=Reasoning(content="用户"))
+
+    assert _extract_any_llm_reasoning_text(delta) == "用户"


### PR DESCRIPTION
### Summary

Fix `AnyLLMModel` reasoning extraction on the chat-completions path for `any-llm` `Reasoning` objects.

This was observed with a vLLM OpenAI-compatible endpoint, where reasoning deltas reached `AnyLLMModel` as values like `Reasoning(content="用户")`. The previous implementation flattened generic iterables before checking `.content`, `.text`, and `.thinking`, so iterable Pydantic objects could be normalized incorrectly as `content用户` instead of `用户`.

This change makes the helper prefer reasoning attributes first, then fall back to iterable flattening.

### Test plan

- Added a regression test covering `Reasoning(content="用户")`
- Ran `uv run pytest tests/models/test_any_llm_model.py -q`
- Ran `make format`
- Ran `make lint`

### Issue number

Closes #2823

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
