### PR TITLE
feat: expose MCP server name on converted FunctionTool and ToolCallItem

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -358,6 +358,9 @@ class ToolCallItem(RunItemBase[Any]):
     title: str | None = None
     """Optional short display label if known at item creation time."""
 
+    mcp_server_name: str | None = None
+    """Name of the MCP server that provided this tool, if applicable."""
+
 
 ToolCallOutputTypes: TypeAlias = Union[
     FunctionCallOutput,

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -313,6 +313,7 @@ class MCPUtil:
             strict_json_schema=is_strict,
             needs_approval=needs_approval,
             mcp_title=resolve_mcp_tool_title(tool),
+            mcp_server_name=server.name,
         )
         return function_tool
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1385,6 +1385,7 @@ async def run_single_turn_streamed(
                     )
                     tool_description: str | None = None
                     tool_title: str | None = None
+                    tool_mcp_server_name: str | None = None
                     if isinstance(output_item, McpCall):
                         metadata = hosted_mcp_tool_metadata.get(
                             (output_item.server_label, output_item.name)
@@ -1392,15 +1393,18 @@ async def run_single_turn_streamed(
                         if metadata is not None:
                             tool_description = metadata.description
                             tool_title = metadata.title
+                        tool_mcp_server_name = output_item.server_label
                     elif matched_tool is not None:
                         tool_description = getattr(matched_tool, "description", None)
                         tool_title = getattr(matched_tool, "_mcp_title", None)
+                        tool_mcp_server_name = getattr(matched_tool, "_mcp_server_name", None)
 
                     tool_item = ToolCallItem(
                         raw_item=cast(ToolCallItemTypes, output_item),
                         agent=agent,
                         description=tool_description,
                         title=tool_title,
+                        mcp_server_name=tool_mcp_server_name,
                     )
                     streamed_result._event_queue.put_nowait(
                         RunItemStreamEvent(item=tool_item, name="tool_called")

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -1523,6 +1523,7 @@ def process_model_response(
                     agent=agent,
                     description=metadata.description if metadata is not None else None,
                     title=metadata.title if metadata is not None else None,
+                    mcp_server_name=output.server_label,
                 )
             )
             tools_used.append("mcp")
@@ -1659,6 +1660,7 @@ def process_model_response(
                     agent=agent,
                     description=func_tool.description,
                     title=func_tool._mcp_title,
+                    mcp_server_name=func_tool._mcp_server_name,
                 )
             )
             functions.append(

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -326,6 +326,9 @@ class FunctionTool:
     _mcp_title: str | None = field(default=None, kw_only=True, repr=False)
     """Internal MCP display title used for ToolCallItem metadata."""
 
+    _mcp_server_name: str | None = field(default=None, kw_only=True, repr=False)
+    """Internal MCP server name identifying which server provided this tool."""
+
     @property
     def qualified_name(self) -> str:
         """Return the public qualified name used to identify this function tool."""
@@ -428,6 +431,7 @@ def _build_wrapped_function_tool(
     defer_loading: bool = False,
     sync_invoker: bool = False,
     mcp_title: str | None = None,
+    mcp_server_name: str | None = None,
 ) -> FunctionTool:
     """Create a FunctionTool with copied-tool-aware failure handling bound in one place."""
     on_invoke_tool = with_function_tool_failure_error_handler(
@@ -453,6 +457,7 @@ def _build_wrapped_function_tool(
             timeout_error_function=timeout_error_function,
             defer_loading=defer_loading,
             _mcp_title=mcp_title,
+            _mcp_server_name=mcp_server_name,
         ),
         failure_error_function,
     )

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1455,3 +1455,55 @@ def test_to_function_tool_description_falls_back_to_mcp_title():
 
     assert function_tool.description == "Search Docs"
     assert function_tool._mcp_title == "Search Docs"
+
+
+def test_to_function_tool_stores_mcp_server_name():
+    """Test that to_function_tool stores the MCP server name on the converted FunctionTool."""
+    server = FakeMCPServer(server_name="my_git_server")
+    tool = MCPTool(
+        name="list_commits",
+        inputSchema={},
+        description="List recent commits",
+    )
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=False)
+
+    assert function_tool._mcp_server_name == "my_git_server"
+
+
+def test_to_function_tool_default_mcp_server_name():
+    """Test that FunctionTool defaults _mcp_server_name to None for non-MCP tools."""
+    tool = FunctionTool(
+        name="plain_tool",
+        description="A plain tool",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=lambda ctx, args: None,  # type: ignore[arg-type, return-value]
+        strict_json_schema=False,
+    )
+
+    assert tool._mcp_server_name is None
+
+
+@pytest.mark.asyncio
+async def test_get_all_function_tools_preserve_server_name():
+    """Test that get_all_function_tools preserves server name across multiple servers."""
+    server_a = FakeMCPServer(server_name="server_a")
+    server_a.add_tool("tool_x", {"type": "object", "properties": {}})
+
+    server_b = FakeMCPServer(server_name="server_b")
+    server_b.add_tool("tool_y", {"type": "object", "properties": {}})
+
+    agent = Agent(name="test", instructions="test")
+    run_context = RunContextWrapper(context=None)
+
+    tools = await MCPUtil.get_all_function_tools(
+        [server_a, server_b],
+        convert_schemas_to_strict=False,
+        run_context=run_context,
+        agent=agent,
+    )
+
+    func_tools = [t for t in tools if isinstance(t, FunctionTool)]
+    tool_names_to_server = {t.name: t._mcp_server_name for t in func_tools}
+    assert tool_names_to_server["tool_x"] == "server_a"
+    assert tool_names_to_server["tool_y"] == "server_b"


### PR DESCRIPTION
### Summary

When MCP tools are converted to `FunctionTool` via `MCPUtil.to_function_tool()`, the originating server name is captured in the `on_invoke_tool` closure but not exposed on the tool object itself. With multiple MCP servers, callers inspecting `ToolCallItem` or `FunctionTool` instances cannot determine which server provided a given tool.

This PR adds a `_mcp_server_name` field to `FunctionTool` and a public `mcp_server_name` field to `ToolCallItem`, following the existing pattern established by `_mcp_title` / `title`. The server name is populated during `MCPUtil.to_function_tool()` and propagated to `ToolCallItem` in both the non-streaming (`turn_resolution.py`) and streaming (`run_loop.py`) paths, including hosted MCP tools where `server_label` is used directly.

This follows the approach suggested by @seratch in the issue discussion — using specific named fields rather than a generic metadata dict.

### Test plan

- Added `test_to_function_tool_stores_mcp_server_name`: verifies `_mcp_server_name` is set on `FunctionTool` after conversion.
- Added `test_to_function_tool_default_mcp_server_name`: verifies non-MCP `FunctionTool` defaults to `None`.
- Added `test_get_all_function_tools_preserve_server_name`: verifies server name is preserved across multiple MCP servers.
- Full test suite passes (2670 tests, 0 failures).
- `make format`, `make lint`, `make typecheck` all pass clean.

### Issue number

Closes #2228

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass