### PR TITLE
docs(tracing): add Long-running workers section

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -136,6 +136,50 @@ await Runner.run(
 )
 ```
 
+## Long-running workers
+
+In long-lived processes such as Celery workers, FastAPI background tasks, RQ, or Dramatiq, traces
+are buffered by the default `BatchTraceProcessor` and only flushed automatically on process
+shutdown. Because these processes never exit between tasks, buffered traces may never be exported
+to the Traces dashboard.
+
+To ensure traces are exported after each unit of work, call `force_flush()` on the global trace
+provider:
+
+```python
+from agents.tracing import get_trace_provider
+
+# Celery example
+@celery_app.task
+def run_agent_task(prompt: str):
+    with trace("my_task"):
+        result = Runner.run_sync(agent, prompt)
+    get_trace_provider().force_flush()  # flush after each task
+    return result
+```
+
+```python
+# FastAPI background task example
+from fastapi import BackgroundTasks
+from agents.tracing import get_trace_provider
+
+def process_in_background(prompt: str):
+    with trace("background_job"):
+        result = Runner.run_sync(agent, prompt)
+    get_trace_provider().force_flush()
+
+@app.post("/run")
+async def run(background_tasks: BackgroundTasks, prompt: str):
+    background_tasks.add_task(process_in_background, prompt)
+    return {"status": "queued"}
+```
+
+!!!note
+
+    `force_flush()` is a blocking call. It waits until all currently buffered spans have been
+    exported before returning. Call it after the `trace()` context manager exits to avoid
+    flushing a partially-built trace.
+
 ## Additional notes
 - View free traces at Openai Traces dashboard.
 


### PR DESCRIPTION
## Summary

In long-lived processes (Celery workers, FastAPI background tasks, RQ, Dramatiq), traces created with `agents.trace()` are buffered by `BatchTraceProcessor` but never exported — the flush that normally happens on process shutdown never fires between tasks.

This is a well-known pain point (#2135, 5 comments, reported Nov 2025), but `docs/tracing.md` currently has no mention of it. The section under "Additional notes" is just "View free traces at OpenAI Traces dashboard."

This PR adds a **Long-running workers** section that:
- Explains why traces are dropped in worker processes
- Documents the `get_trace_provider().force_flush()` pattern using the existing public API
- Includes working Celery and FastAPI background task examples
- Notes that `force_flush()` is blocking (call it after the trace context exits)

## Relationship to PR #2735

PR #2735 proposes adding a dedicated `flush_traces()` top-level convenience function. This docs PR is complementary — it documents the underlying mechanism that `flush_traces()` would wrap, using the already-public `get_trace_provider().force_flush()` API. If #2735 ships, this section can be updated to use the simpler import.

## Code references

- `get_trace_provider()`: [`src/agents/tracing/__init__.py`](https://github.com/openai/openai-agents-python/blob/main/src/agents/tracing/__init__.py#L22)
- `TraceProvider.force_flush()`: [`src/agents/tracing/provider.py:119`](https://github.com/openai/openai-agents-python/blob/main/src/agents/tracing/provider.py#L119)
- `BatchTraceProcessor.force_flush()`: [`src/agents/tracing/processors.py:547`](https://github.com/openai/openai-agents-python/blob/main/src/agents/tracing/processors.py#L547)

Closes #2135