### PR TITLE
Add AgentBase shared memory MCP example

### DIFF
--- a/examples/agentbase_shared_memory.md
+++ b/examples/agentbase_shared_memory.md
@@ -19,7 +19,7 @@ from agents.mcp import MCPServerStreamableHttp
 
 async def register():
     async with MCPServerStreamableHttp(
-        url="https://mcp.agentbase.tools/mcp",
+        params={"url": "https://mcp.agentbase.tools/mcp"},
         name="agentbase",
     ) as server:
         agent = Agent(
@@ -45,13 +45,12 @@ AGENTBASE_TOKEN = "your-bearer-token-here"
 
 async def main():
     async with MCPServerStreamableHttp(
-        url="https://mcp.agentbase.tools/mcp",
+        params={
+            "url": "https://mcp.agentbase.tools/mcp",
+            "headers": {"Authorization": f"Bearer {AGENTBASE_TOKEN}"},
+        },
         name="agentbase",
         client_session_timeout_seconds=30,
-        # Pass auth header
-        http_client_factory=lambda: __import__('httpx').AsyncClient(
-            headers={"Authorization": f"Bearer {AGENTBASE_TOKEN}"}
-        ),
     ) as agentbase:
         agent = Agent(
             name="Research Agent",
@@ -81,17 +80,16 @@ asyncio.run(main())
 import asyncio
 from agents import Agent, Runner
 from agents.mcp import MCPServerStreamableHttp
-import httpx
 
 AGENTBASE_TOKEN = "your-bearer-token-here"
 
 def make_agentbase_server():
     return MCPServerStreamableHttp(
-        url="https://mcp.agentbase.tools/mcp",
+        params={
+            "url": "https://mcp.agentbase.tools/mcp",
+            "headers": {"Authorization": f"Bearer {AGENTBASE_TOKEN}"},
+        },
         name="agentbase",
-        http_client_factory=lambda: httpx.AsyncClient(
-            headers={"Authorization": f"Bearer {AGENTBASE_TOKEN}"}
-        ),
     )
 
 async def main():
@@ -138,5 +136,5 @@ asyncio.run(main())
 ## Links
 
 - [AgentBase](https://agentbase.tools)
-- [GitHub](https://github.com/AgentBase1/mcp-server)
+- [GitHub](https://github.com/revmischa/agentbase)
 - [OpenAI Agents SDK docs](https://openai.github.io/openai-agents-python/)


### PR DESCRIPTION
## What this adds

An example showing how to connect [AgentBase](https://agentbase.tools) to OpenAI agents as an MCP server for shared, persistent memory.

## File added

`examples/agentbase_shared_memory.md` — covers:
- Registration / one-time setup (getting a bearer token)
- Single agent with AgentBase memory
- Multi-agent setup sharing a knowledge pool

## The use case

Agents built on the Agents SDK start fresh every run. AgentBase lets them:
- **Search** before starting: `agentbase_search("rate limiting strategies")` — finds what other agents already know
- **Store** after solving: `agentbase_store_knowledge(topic="...", content={...}, visibility="public")` — auto-embedded, immediately searchable

It's a free MCP server at `https://mcp.agentbase.tools/mcp`. No infrastructure to run.

## Links

- [agentbase.tools](https://agentbase.tools)
- [GitHub](https://github.com/AgentBase1/mcp-server)
- [MCP Registry](https://registry.modelcontextprotocol.io/servers/io.github.revmischa/agentbase)