### PR TITLE
fix(tracing): prevent RecursionError in truncation of truncated previews

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -299,7 +299,7 @@ class BackendSpanExporter(TracingExporter):
             # Use a sentinel key to reliably identify SDK-generated previews
             # without matching arbitrary user data that happens to use the
             # same key names.
-            if self._TRUNCATED_PREVIEW_KEY in value:
+            if value.get(self._TRUNCATED_PREVIEW_KEY) is True and "original_type" in value and "preview" in value:
                 return value
             return self._truncate_mapping_for_json_limit(value, max_bytes)
 


### PR DESCRIPTION
## Problem

When LLM responses contain `None` values and need truncation, `_truncate_json_value_for_limit` crashes with `RecursionError`. The truncation logic re-processes its own preview dicts, creating an infinite loop.

## Root Cause

1. `_truncated_preview()` returns `{"truncated": True, "original_type": "NoneType", "preview": "..."}`
2. `_truncate_json_value_for_limit()` treats this as a regular dict → calls `_truncate_mapping_for_json_limit()`
3. The `True` bool value gets wrapped by `_truncated_preview(True)` into yet another dict
4. This new dict is again treated as a regular mapping → infinite recursion

## Solution

Detect truncated preview dicts (have `"truncated": True`, `"original_type"`, `"preview"` keys) and return them immediately without re-processing.

```python
if value.get("truncated") is True and "original_type" in value and "preview" in value:
    return value
```

Fixes #2856