### PR TITLE
Add Asqav to external tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -221,3 +221,4 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [Traccia](https://traccia.ai/docs/integrations/openai-agents)
 -   [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
 -   [HoneyHive](https://docs.honeyhive.ai/v2/integrations/openai-agents)
+-   [Asqav](https://asqav.com/docs/integrations)


### PR DESCRIPTION
### Summary

Add [Asqav](https://github.com/jagmarques/asqav-sdk) to the external tracing processors list in the tracing docs. Asqav provides AI agent governance with tamper-evident audit trails and quantum-safe signatures.

- PyPI: https://pypi.org/project/asqav/
- Integration module: `asqav.extras.openai_agents`
- Docs: https://asqav.com/docs/integrations

### Test plan

- Docs-only change (single line addition to `docs/tracing.md`)
- Verified link format matches existing entries

### Issue number

N/A

### Checks

- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass