### PR TITLE
docs: add Asqav to external tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -221,4 +221,4 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [Traccia](https://traccia.ai/docs/integrations/openai-agents)
 -   [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
 -   [HoneyHive](https://docs.honeyhive.ai/v2/integrations/openai-agents)
--   [Asqav](https://asqav.com/docs/integrations)
+-   [Asqav](https://www.asqav.com/docs/integrations#openai-agents)


### PR DESCRIPTION
### Summary

Add [Asqav](https://asqav.com/docs/integrations) to the external tracing processors list. Asqav now implements the `TracingProcessor` interface via `AsqavTracingProcessor` (added in [commit 807e695](https://github.com/jagmarques/asqav-sdk/commit/807e695)), which signs trace and span lifecycle events as governance records.

This follows up on the feedback from #2858, where @seratch noted the page lists only integrations supporting the tracing interface. Asqav previously only had a guardrail integration - it now supports tracing as well.

- PyPI: https://pypi.org/project/asqav/
- Integration module: `asqav.extras.openai_agents`

### Test plan

- Docs-only change (single line addition to `docs/tracing.md`)
- Link format matches existing entries

### Issue number

Follow-up to #2858

### Checks

- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass