### PR TITLE
fix: #2856 stop recursive trace preview truncation

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -296,7 +296,11 @@ class BackendSpanExporter(TracingExporter):
         if isinstance(value, list):
             return self._truncate_list_for_json_limit(value, max_bytes)
 
-        return self._truncated_preview(value)
+        preview = self._truncated_preview(value)
+        if self._value_json_size_bytes(preview) <= max_bytes:
+            return preview
+
+        return value
 
     def _truncate_mapping_for_json_limit(
         self, value: dict[str, Any], max_bytes: int

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -920,6 +920,48 @@ def test_sanitize_for_openai_tracing_api_replaces_unserializable_output():
     exporter.close()
 
 
+def test_truncate_json_value_for_limit_terminates_preview_dict_under_zero_budget():
+    exporter = BackendSpanExporter(api_key="test_key")
+    preview = exporter._truncated_preview(None)
+
+    truncated = exporter._truncate_json_value_for_limit(preview, 0)
+
+    assert truncated == {}
+    exporter.close()
+
+
+def test_sanitize_for_openai_tracing_api_handles_none_content_under_tight_budget():
+    exporter = BackendSpanExporter(api_key="test_key")
+    payload: dict[str, Any] = {
+        "object": "trace.span",
+        "span_data": {
+            "type": "generation",
+            "output": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "name": "a" * 25_000,
+                    "tool_calls": [],
+                }
+                for _ in range(8)
+            ],
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        },
+    }
+
+    sanitized = exporter._sanitize_for_openai_tracing_api(payload)
+    sanitized_output = cast(list[Any], sanitized["span_data"]["output"])
+
+    assert isinstance(sanitized_output, list)
+    assert sanitized_output != payload["span_data"]["output"]
+    assert (
+        exporter._value_json_size_bytes(sanitized_output)
+        <= exporter._OPENAI_TRACING_MAX_FIELD_BYTES
+    )
+    assert any(item == {} for item in sanitized_output)
+    exporter.close()
+
+
 def test_truncate_string_for_json_limit_returns_original_when_within_limit():
     exporter = BackendSpanExporter(api_key="test_key")
     value = "hello"


### PR DESCRIPTION
This pull request resolves #2856. It fixes a tracing sanitization bug where JSON-compatible scalar values such as `None` could be replaced with preview dicts that were then recursively re-truncated under tiny byte budgets, eventually raising `RecursionError` inside OpenAI trace payload sanitization.

The change keeps the existing preview dict shape when a preview fits within the remaining budget, but treats the scalar as terminal when that preview would still be too large so the parent container can drop the child cleanly. This preserves the current behavior for normal oversized values while preventing preview-of-a-preview recursion in deeply truncated payloads.

It also adds regression coverage for the zero-budget preview path and for an oversized generation payload containing assistant messages whose `content` is `None`, ensuring tracing sanitization terminates and stays within the field-size limit.