### PR TITLE
fix: preserve output type in FunctionSpanData.export()

### DIFF
--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -88,7 +88,7 @@ class FunctionSpanData(SpanData):
             "type": self.type,
             "name": self.name,
             "input": self.input,
-            "output": str(self.output) if self.output else None,
+            "output": self.output,
             "mcp_data": self.mcp_data,
         }
 

--- a/tests/mcp/test_mcp_tracing.py
+++ b/tests/mcp/test_mcp_tracing.py
@@ -62,7 +62,7 @@ async def test_mcp_tracing():
                                 "data": {
                                     "name": "test_tool_1",
                                     "input": "",
-                                    "output": "{'type': 'text', 'text': 'result_test_tool_1_{}'}",  # noqa: E501
+                                    "output": {"type": "text", "text": "result_test_tool_1_{}"},  # noqa: E501
                                     "mcp_data": {"server": "fake_mcp_server"},
                                 },
                             },
@@ -133,7 +133,7 @@ async def test_mcp_tracing():
                                 "data": {
                                     "name": "test_tool_2",
                                     "input": "",
-                                    "output": "{'type': 'text', 'text': 'result_test_tool_2_{}'}",  # noqa: E501
+                                    "output": {"type": "text", "text": "result_test_tool_2_{}"},  # noqa: E501
                                     "mcp_data": {"server": "fake_mcp_server"},
                                 },
                             },
@@ -197,7 +197,7 @@ async def test_mcp_tracing():
                                 "data": {
                                     "name": "test_tool_3",
                                     "input": "",
-                                    "output": "{'type': 'text', 'text': 'result_test_tool_3_{}'}",  # noqa: E501
+                                    "output": {"type": "text", "text": "result_test_tool_3_{}"},  # noqa: E501
                                     "mcp_data": {"server": "fake_mcp_server"},
                                 },
                             },

--- a/tests/tracing/test_span_data.py
+++ b/tests/tracing/test_span_data.py
@@ -1,0 +1,67 @@
+"""Tests for span data export methods."""
+
+from __future__ import annotations
+
+import pytest
+
+from agents.tracing.span_data import FunctionSpanData
+
+
+class TestFunctionSpanDataExport:
+    """FunctionSpanData.export() must preserve output values faithfully."""
+
+    def test_dict_output_preserved_as_dict(self) -> None:
+        """Dict outputs should stay as dicts, not be converted to Python repr strings."""
+        span = FunctionSpanData(name="my_tool", input="query", output={"key": "value", "n": 42})
+        exported = span.export()
+        assert exported["output"] == {"key": "value", "n": 42}
+        assert isinstance(exported["output"], dict)
+
+    def test_string_output_preserved(self) -> None:
+        span = FunctionSpanData(name="my_tool", input="query", output="hello world")
+        exported = span.export()
+        assert exported["output"] == "hello world"
+
+    def test_none_output_preserved(self) -> None:
+        span = FunctionSpanData(name="my_tool", input="query", output=None)
+        exported = span.export()
+        assert exported["output"] is None
+
+    @pytest.mark.parametrize(
+        "output",
+        [0, False, "", []],
+        ids=["zero", "false", "empty_str", "empty_list"],
+    )
+    def test_falsy_output_not_converted_to_none(self, output: object) -> None:
+        """Falsy but valid outputs (0, False, '', []) must not become None."""
+        span = FunctionSpanData(name="my_tool", input="query", output=output)
+        exported = span.export()
+        assert exported["output"] is not None
+        assert exported["output"] == output
+
+    def test_list_output_preserved(self) -> None:
+        span = FunctionSpanData(name="my_tool", input="query", output=[1, 2, 3])
+        exported = span.export()
+        assert exported["output"] == [1, 2, 3]
+        assert isinstance(exported["output"], list)
+
+    def test_numeric_output_preserved(self) -> None:
+        span = FunctionSpanData(name="my_tool", input="query", output=42)
+        exported = span.export()
+        assert exported["output"] == 42
+
+    def test_export_includes_all_fields(self) -> None:
+        span = FunctionSpanData(
+            name="my_tool",
+            input="query",
+            output="result",
+            mcp_data={"server": "test"},
+        )
+        exported = span.export()
+        assert exported == {
+            "type": "function",
+            "name": "my_tool",
+            "input": "query",
+            "output": "result",
+            "mcp_data": {"server": "test"},
+        }


### PR DESCRIPTION
### Summary

`FunctionSpanData.export()` applies `str(self.output) if self.output else None`, which corrupts traced tool outputs in two ways:

1. **Dict/list outputs become Python repr strings.** A tool returning `{"status": "ok"}` gets exported as the string `"{'status': 'ok'}"` — single quotes, Python-style booleans — instead of staying as a dict that `json.dumps` can serialize correctly. This means the tracing ingest API receives malformed data.

2. **Falsy but valid outputs are dropped.** A tool returning `0`, `False`, `""`, or `[]` gets exported as `None`, losing the actual result.

The sibling class `GenerationSpanData.export()` passes `self.output` through directly without conversion. This fix aligns `FunctionSpanData` with that pattern.

### Test plan

- Added `tests/tracing/test_span_data.py` with 10 unit tests covering dict, string, None, falsy (0, False, empty string, empty list), list, and numeric outputs.
- Updated MCP tracing snapshot assertions to expect dict outputs instead of Python repr strings.
- Full suite: 2446 passed, 0 failures.
- `make format`, `make lint`, `make typecheck` all clean.

### Issue number

N/A — found via code inspection; no existing issue.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass