### PR TITLE
docs: add Rewind to ecosystem tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -222,3 +222,4 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
 -   [HoneyHive](https://docs.honeyhive.ai/v2/integrations/openai-agents)
 -   [Asqav](https://www.asqav.com/docs/integrations#openai-agents)
+-   [Rewind](https://github.com/agentoptics/rewind/blob/master/docs/openai-agents-sdk.md)


### PR DESCRIPTION
Adds [Rewind](https://github.com/agentoptics/rewind) to the external tracing processors list.

Rewind provides [`RewindTracingProcessor`](https://github.com/agentoptics/rewind/blob/master/python/rewind_agent/openai_agents.py#L57), a subclass of `agents.tracing.TracingProcessor` that captures agent spans into a local time-travel debugger.

**TracingProcessor implementation:**

```python
from agents.tracing import TracingProcessor

class RewindTracingProcessor(TracingProcessor):
    """Subclasses TracingProcessor to capture all agent spans."""

    def on_trace_start(self, trace): ...
    def on_trace_end(self, trace): ...
    def on_span_start(self, span): ...
    def on_span_end(self, span): ...  # maps GenerationSpanData, FunctionSpanData, HandoffSpanData → Rewind steps
    def shutdown(self): ...
    def force_flush(self): ...
```

**Registration via `add_trace_processor()`:**

```python
from agents.tracing import add_trace_processor
from rewind_agent.openai_agents import RewindTracingProcessor
from rewind_agent.store import Store

store = Store()
session_id, timeline_id = store.create_session("my-agent")
processor = RewindTracingProcessor(store, session_id, timeline_id)
add_trace_processor(processor)
```

- **Source**: https://github.com/agentoptics/rewind/blob/master/python/rewind_agent/openai_agents.py
- **Docs**: https://github.com/agentoptics/rewind/blob/master/docs/openai-agents-sdk.md
- **PyPI**: `pip install rewind-agent[agents]`