### PR TITLE
docs: add docstrings to Computer and AsyncComputer abstract methods

### DIFF
--- a/src/agents/computer.py
+++ b/src/agents/computer.py
@@ -21,38 +21,47 @@ class Computer(abc.ABC):
 
     @abc.abstractmethod
     def screenshot(self) -> str:
+        """Take a screenshot and return the base64-encoded image data."""
         pass
 
     @abc.abstractmethod
     def click(self, x: int, y: int, button: Button) -> None:
+        """Click a mouse button at the given (x, y) screen coordinates."""
         pass
 
     @abc.abstractmethod
     def double_click(self, x: int, y: int) -> None:
+        """Double-click at the given (x, y) screen coordinates."""
         pass
 
     @abc.abstractmethod
     def scroll(self, x: int, y: int, scroll_x: int, scroll_y: int) -> None:
+        """Scroll at the given (x, y) coordinates by (scroll_x, scroll_y) units."""
         pass
 
     @abc.abstractmethod
     def type(self, text: str) -> None:
+        """Type the given text at the current cursor position."""
         pass
 
     @abc.abstractmethod
     def wait(self) -> None:
+        """Wait for the computer to be ready for the next action."""
         pass
 
     @abc.abstractmethod
     def move(self, x: int, y: int) -> None:
+        """Move the mouse cursor to the given (x, y) screen coordinates."""
         pass
 
     @abc.abstractmethod
     def keypress(self, keys: list[str]) -> None:
+        """Press one or more keys simultaneously (e.g. ``["ctrl", "c"]``)."""
         pass
 
     @abc.abstractmethod
     def drag(self, path: list[tuple[int, int]]) -> None:
+        """Click-and-drag the mouse along the sequence of (x, y) waypoints."""
         pass
 
 
@@ -72,36 +81,45 @@ class AsyncComputer(abc.ABC):
 
     @abc.abstractmethod
     async def screenshot(self) -> str:
+        """Take a screenshot and return the base64-encoded image data."""
         pass
 
     @abc.abstractmethod
     async def click(self, x: int, y: int, button: Button) -> None:
+        """Click a mouse button at the given (x, y) screen coordinates."""
         pass
 
     @abc.abstractmethod
     async def double_click(self, x: int, y: int) -> None:
+        """Double-click at the given (x, y) screen coordinates."""
         pass
 
     @abc.abstractmethod
     async def scroll(self, x: int, y: int, scroll_x: int, scroll_y: int) -> None:
+        """Scroll at the given (x, y) coordinates by (scroll_x, scroll_y) units."""
         pass
 
     @abc.abstractmethod
     async def type(self, text: str) -> None:
+        """Type the given text at the current cursor position."""
         pass
 
     @abc.abstractmethod
     async def wait(self) -> None:
+        """Wait for the computer to be ready for the next action."""
         pass
 
     @abc.abstractmethod
     async def move(self, x: int, y: int) -> None:
+        """Move the mouse cursor to the given (x, y) screen coordinates."""
         pass
 
     @abc.abstractmethod
     async def keypress(self, keys: list[str]) -> None:
+        """Press one or more keys simultaneously (e.g. ``["ctrl", "c"]``)."""
         pass
 
     @abc.abstractmethod
     async def drag(self, path: list[tuple[int, int]]) -> None:
+        """Click-and-drag the mouse along the sequence of (x, y) waypoints."""
         pass


### PR DESCRIPTION
## Summary

The abstract methods on `Computer` and `AsyncComputer` in `src/agents/computer.py` had no docstrings. Both classes are part of the public API (exported from `agents/__init__.py`) and are intended to be subclassed by users who want to integrate custom computer-control backends with the `ComputerTool`.

Without docstrings, IDE tooltips and `help()` show nothing for these methods, making the contract unclear for implementors.

This PR adds a single-line docstring to each of the 9 abstract methods on both classes (18 methods total):

- `screenshot` — describe return value (base64-encoded image data)
- `click` — describe coordinate and button parameters
- `double_click` — describe coordinate parameters
- `scroll` — describe coordinate and scroll-unit parameters
- `type` — describe what text is typed and where
- `wait` — describe purpose (signal readiness for next action)
- `move` — describe cursor movement
- `keypress` — describe key list format (e.g. `["ctrl", "c"]`)
- `drag` — describe waypoint path argument

## Test plan

- [x] `ruff format --check src/agents/computer.py` — already formatted
- [x] `ruff check src/agents/computer.py` — no lint errors
- [x] Docs-only change; no runtime behaviour is altered