### PR TITLE
feat(sessions): add offset parameter to get_items() for pagination

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -160,12 +160,15 @@ class AdvancedSQLiteSession(SQLiteSession):
         self,
         limit: int | None = None,
         branch_id: str | None = None,
+        offset: int = 0,
     ) -> list[TResponseInputItem]:
         """Get items from current or specified branch.
 
         Args:
             limit: Maximum number of items to return. If None, uses session_settings.limit.
             branch_id: Branch to get items from. If None, uses current branch.
+            offset: Number of most-recent items to skip before applying the limit.
+                    Defaults to 0. Use with limit to paginate backwards through history.
 
         Returns:
             List of conversation items from the specified branch.
@@ -180,7 +183,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                 """Synchronous helper to get all items for a branch."""
                 with self._locked_connection() as conn:
                     with closing(conn.cursor()) as cursor:
-                        if session_limit is None:
+                        if session_limit is None and offset == 0:
                             cursor.execute(
                                 f"""
                                 SELECT m.message_data
@@ -192,6 +195,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                                 (self.session_id, branch_id),
                             )
                         else:
+                            sql_limit = session_limit if session_limit is not None else -1
                             cursor.execute(
                                 f"""
                                 SELECT m.message_data
@@ -199,13 +203,13 @@ class AdvancedSQLiteSession(SQLiteSession):
                                 JOIN message_structure s ON m.id = s.message_id
                                 WHERE m.session_id = ? AND s.branch_id = ?
                                 ORDER BY s.sequence_number DESC
-                                LIMIT ?
+                                LIMIT ? OFFSET ?
                             """,
-                                (self.session_id, branch_id, session_limit),
+                                (self.session_id, branch_id, sql_limit, offset),
                             )
 
                         rows = cursor.fetchall()
-                        if session_limit is not None:
+                        if session_limit is not None or offset > 0:
                             rows = list(reversed(rows))
 
                     items = []
@@ -224,7 +228,7 @@ class AdvancedSQLiteSession(SQLiteSession):
             with self._locked_connection() as conn:
                 with closing(conn.cursor()) as cursor:
                     # Get message IDs in correct order for this branch
-                    if session_limit is None:
+                    if session_limit is None and offset == 0:
                         cursor.execute(
                             f"""
                             SELECT m.message_data
@@ -236,6 +240,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                             (self.session_id, branch_id),
                         )
                     else:
+                        sql_limit = session_limit if session_limit is not None else -1
                         cursor.execute(
                             f"""
                             SELECT m.message_data
@@ -243,13 +248,13 @@ class AdvancedSQLiteSession(SQLiteSession):
                             JOIN message_structure s ON m.id = s.message_id
                             WHERE m.session_id = ? AND s.branch_id = ?
                             ORDER BY s.sequence_number DESC
-                            LIMIT ?
+                            LIMIT ? OFFSET ?
                         """,
-                            (self.session_id, branch_id, session_limit),
+                            (self.session_id, branch_id, sql_limit, offset),
                         )
 
                     rows = cursor.fetchall()
-                    if session_limit is not None:
+                    if session_limit is not None or offset > 0:
                         rows = list(reversed(rows))
 
                 items = []

--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -102,19 +102,23 @@ class AsyncSQLiteSession(SessionABC):
             conn = await self._get_connection()
             yield conn
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, retrieves all items.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of most-recent items to skip before applying the limit.
+                    Defaults to 0. Use with limit to paginate backwards through history.
 
         Returns:
             List of input items representing the conversation history
         """
 
         async with self._locked_connection() as conn:
-            if limit is None:
+            if limit is None and offset == 0:
                 cursor = await conn.execute(
                     f"""
                     SELECT message_data FROM {self.messages_table}
@@ -124,20 +128,22 @@ class AsyncSQLiteSession(SessionABC):
                     (self.session_id,),
                 )
             else:
+                # LIMIT -1 means no limit in SQLite.
+                sql_limit = limit if limit is not None else -1
                 cursor = await conn.execute(
                     f"""
                     SELECT message_data FROM {self.messages_table}
                     WHERE session_id = ?
                     ORDER BY id DESC
-                    LIMIT ?
+                    LIMIT ? OFFSET ?
                     """,
-                    (self.session_id, limit),
+                    (self.session_id, sql_limit, offset),
                 )
 
             rows = list(await cursor.fetchall())
             await cursor.close()
 
-        if limit is not None:
+        if limit is not None or offset > 0:
             rows = rows[::-1]
 
         items: list[TResponseInputItem] = []

--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -232,12 +232,16 @@ class DaprSession(SessionABC):
     # Session protocol implementation
     # ------------------------------------------------------------------
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of most-recent items to skip before applying the limit.
+                    Defaults to 0. Use with limit to paginate backwards through history.
 
         Returns:
             List of input items representing the conversation history
@@ -255,6 +259,11 @@ class DaprSession(SessionABC):
             messages = self._decode_messages(response.data)
             if not messages:
                 return []
+            # Apply offset from the newest end, then limit.
+            end = len(messages) - offset if offset > 0 else len(messages)
+            if end <= 0:
+                return []
+            messages = messages[:end]
             if session_limit is not None:
                 if session_limit <= 0:
                     return []

--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -170,8 +170,10 @@ class EncryptedSession(SessionABC):
         except (InvalidToken, KeyError):
             return None
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
-        encrypted_items = await self.underlying_session.get_items(limit)
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
+        encrypted_items = await self.underlying_session.get_items(limit, offset)
         valid_items: list[TResponseInputItem] = []
         for enc in encrypted_items:
             item = self._unwrap(enc)

--- a/src/agents/extensions/memory/redis_session.py
+++ b/src/agents/extensions/memory/redis_session.py
@@ -140,12 +140,16 @@ class RedisSession(SessionABC):
     # Session protocol implementation
     # ------------------------------------------------------------------
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of most-recent items to skip before applying the limit.
+                    Defaults to 0. Use with limit to paginate backwards through history.
 
         Returns:
             List of input items representing the conversation history
@@ -153,15 +157,21 @@ class RedisSession(SessionABC):
         session_limit = resolve_session_limit(limit, self.session_settings)
 
         async with self._lock:
-            if session_limit is None:
+            if session_limit is None and offset == 0:
                 # Get all messages in chronological order
                 raw_messages = await self._redis.lrange(self._messages_key, 0, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
             else:
-                if session_limit <= 0:
+                if session_limit is not None and session_limit <= 0:
                     return []
-                # Get the latest N messages (Redis list is ordered chronologically)
-                # Use negative indices to get from the end - Redis uses -N to -1 for last N items
-                raw_messages = await self._redis.lrange(self._messages_key, -session_limit, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
+                # Redis list is ordered chronologically (index 0 = oldest).
+                # Use negative indices to address from the newest end.
+                # -1 = newest, -(offset+1) = newest after skipping offset items.
+                end = -(offset + 1) if offset > 0 else -1
+                if session_limit is None:
+                    start = 0
+                else:
+                    start = -(session_limit + offset)
+                raw_messages = await self._redis.lrange(self._messages_key, start, end)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
 
             items: list[TResponseInputItem] = []
             for raw_msg in raw_messages:

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -274,12 +274,16 @@ class SQLAlchemySession(SessionABC):
         finally:
             self._init_lock.release()
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of most-recent items to skip before applying the limit.
+                    Defaults to 0. Use with limit to paginate backwards through history.
 
         Returns:
             List of input items representing the conversation history
@@ -289,7 +293,7 @@ class SQLAlchemySession(SessionABC):
         session_limit = resolve_session_limit(limit, self.session_settings)
 
         async with self._session_factory() as sess:
-            if session_limit is None:
+            if session_limit is None and offset == 0:
                 stmt = (
                     select(self._messages.c.message_data)
                     .where(self._messages.c.session_id == self.session_id)
@@ -302,19 +306,21 @@ class SQLAlchemySession(SessionABC):
                 stmt = (
                     select(self._messages.c.message_data)
                     .where(self._messages.c.session_id == self.session_id)
-                    # Use DESC + LIMIT to get the latest N
+                    # Use DESC + LIMIT/OFFSET to get the latest N after skipping offset items,
                     # then reverse later for chronological order.
                     .order_by(
                         self._messages.c.created_at.desc(),
                         self._messages.c.id.desc(),
                     )
-                    .limit(session_limit)
+                    .offset(offset)
                 )
+                if session_limit is not None:
+                    stmt = stmt.limit(session_limit)
 
             result = await sess.execute(stmt)
             rows: list[str] = [row[0] for row in result.all()]
 
-            if session_limit is not None:
+            if session_limit is not None or offset > 0:
                 rows.reverse()
 
             items: list[TResponseInputItem] = []

--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -70,13 +70,15 @@ class OpenAIConversationsSession(SessionABC):
     async def _clear_session_id(self) -> None:
         self._session_id = None
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         session_id = await self._get_session_id()
 
         session_limit = resolve_session_limit(limit, self.session_settings)
 
         all_items = []
-        if session_limit is None:
+        if session_limit is None and offset == 0:
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
                 order="asc",
@@ -84,15 +86,20 @@ class OpenAIConversationsSession(SessionABC):
                 # calling model_dump() to make this serializable
                 all_items.append(item.model_dump(exclude_unset=True))
         else:
+            # Fetch limit+offset items in DESC order (newest first), skip the first
+            # `offset` (most-recent) items, then reverse for chronological order.
+            fetch_limit = (session_limit + offset) if session_limit is not None else None
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
-                limit=session_limit,
+                **({"limit": fetch_limit} if fetch_limit is not None else {}),
                 order="desc",
             ):
                 # calling model_dump() to make this serializable
                 all_items.append(item.model_dump(exclude_unset=True))
-                if session_limit is not None and len(all_items) >= session_limit:
+                if fetch_limit is not None and len(all_items) >= fetch_limit:
                     break
+            # Drop the `offset` newest items (head of the DESC list) then restore order.
+            all_items = all_items[offset:]
             all_items.reverse()
 
         return all_items  # type: ignore

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -239,8 +239,10 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             f"candidates={len(self._compaction_candidate_items)})"
         )
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
-        return await self.underlying_session.get_items(limit)
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
+        return await self.underlying_session.get_items(limit, offset)
 
     async def _defer_compaction(self, response_id: str, store: bool | None = None) -> None:
         if self._deferred_response_id is not None:

--- a/src/agents/memory/session.py
+++ b/src/agents/memory/session.py
@@ -21,12 +21,16 @@ class Session(Protocol):
     session_id: str
     session_settings: SessionSettings | None = None
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, retrieves all items.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of most-recent items to skip before applying the limit.
+                    Defaults to 0. Use with limit to paginate backwards through history.
 
         Returns:
             List of input items representing the conversation history
@@ -68,12 +72,16 @@ class SessionABC(ABC):
     session_settings: SessionSettings | None = None
 
     @abstractmethod
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, retrieves all items.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of most-recent items to skip before applying the limit.
+                    Defaults to 0. Use with limit to paginate backwards through history.
 
         Returns:
             List of input items representing the conversation history

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -190,12 +190,16 @@ class SQLiteSession(SessionABC):
             (self.session_id,),
         )
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
         Args:
             limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
                    When specified, returns the latest N items in chronological order.
+            offset: Number of most-recent items to skip before applying the limit.
+                    Defaults to 0. Use with limit to paginate backwards through history.
 
         Returns:
             List of input items representing the conversation history
@@ -204,7 +208,7 @@ class SQLiteSession(SessionABC):
 
         def _get_items_sync():
             with self._locked_connection() as conn:
-                if session_limit is None:
+                if session_limit is None and offset == 0:
                     # Fetch all items in chronological order
                     cursor = conn.execute(
                         f"""
@@ -215,21 +219,23 @@ class SQLiteSession(SessionABC):
                         (self.session_id,),
                     )
                 else:
-                    # Fetch the latest N items in chronological order
+                    # Fetch latest N items with optional offset, in chronological order.
+                    # LIMIT -1 means no limit in SQLite.
+                    sql_limit = session_limit if session_limit is not None else -1
                     cursor = conn.execute(
                         f"""
                         SELECT message_data FROM {self.messages_table}
                         WHERE session_id = ?
                         ORDER BY id DESC
-                        LIMIT ?
+                        LIMIT ? OFFSET ?
                         """,
-                        (self.session_id, session_limit),
+                        (self.session_id, sql_limit, offset),
                     )
 
                 rows = cursor.fetchall()
 
                 # Reverse to get chronological order when using DESC
-                if session_limit is not None:
+                if session_limit is not None or offset > 0:
                     rows = list(reversed(rows))
 
                 items = []

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -702,6 +702,49 @@ async def test_session_settings_resolve():
 
 
 @pytest.mark.asyncio
+async def test_sqlite_session_get_items_with_offset():
+    """Test SQLiteSession get_items with offset parameter for pagination."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_offset.db"
+        session = SQLiteSession("offset_test", db_path)
+
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": f"Message {i}"} for i in range(6)
+        ]
+        await session.add_items(items)
+
+        # offset=0 is the default — same as no offset
+        page0 = await session.get_items(limit=2, offset=0)
+        assert len(page0) == 2
+        assert page0[0].get("content") == "Message 4"
+        assert page0[1].get("content") == "Message 5"
+
+        # offset=2 skips the 2 most-recent items then returns the next 2
+        page1 = await session.get_items(limit=2, offset=2)
+        assert len(page1) == 2
+        assert page1[0].get("content") == "Message 2"
+        assert page1[1].get("content") == "Message 3"
+
+        # offset=4 skips 4 most-recent, returns the 2 oldest
+        page2 = await session.get_items(limit=2, offset=4)
+        assert len(page2) == 2
+        assert page2[0].get("content") == "Message 0"
+        assert page2[1].get("content") == "Message 1"
+
+        # offset without limit returns everything except the N most-recent
+        without_limit = await session.get_items(offset=2)
+        assert len(without_limit) == 4
+        assert without_limit[0].get("content") == "Message 0"
+        assert without_limit[-1].get("content") == "Message 3"
+
+        # offset >= total items returns empty list
+        empty = await session.get_items(limit=2, offset=10)
+        assert len(empty) == 0
+
+        session.close()
+
+
+@pytest.mark.asyncio
 async def test_runner_with_session_settings_override():
     """Test that RunConfig can override session's default settings."""
     from agents.memory import SessionSettings

--- a/tests/utils/simple_session.py
+++ b/tests/utils/simple_session.py
@@ -24,12 +24,21 @@ class SimpleListSession(Session):
         # Mirror saved_items used by some tests for inspection.
         self.saved_items: list[TResponseInputItem] = self._items
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+    async def get_items(
+        self, limit: int | None = None, offset: int = 0
+    ) -> list[TResponseInputItem]:
+        items = self._items
+        total = len(items)
+        # Work from the newest end: exclude the `offset` most-recent items first.
+        end = total - offset
+        if end <= 0:
+            return []
         if limit is None:
-            return list(self._items)
+            return list(items[:end])
         if limit <= 0:
             return []
-        return self._items[-limit:]
+        start = max(0, end - limit)
+        return list(items[start:end])
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
         self._items.extend(items)

--- a/tests/utils/test_simple_session.py
+++ b/tests/utils/test_simple_session.py
@@ -38,6 +38,35 @@ async def test_counting_session_tracks_pop_calls() -> None:
 
 
 @pytest.mark.asyncio
+async def test_simple_list_session_get_items_offset() -> None:
+    """Test that SimpleListSession.get_items respects the offset parameter."""
+    items: list[TResponseInputItem] = [
+        cast(TResponseInputItem, {"content": f"msg{i}", "role": "user"}) for i in range(6)
+    ]
+    session = SimpleListSession(history=items)
+
+    # offset=0 is default — same as no offset
+    page0 = await session.get_items(limit=2, offset=0)
+    assert [i["content"] for i in page0] == ["msg4", "msg5"]
+
+    # offset=2 skips the 2 most-recent, returns the next 2
+    page1 = await session.get_items(limit=2, offset=2)
+    assert [i["content"] for i in page1] == ["msg2", "msg3"]
+
+    # offset=4 skips 4 most-recent, returns the 2 oldest
+    page2 = await session.get_items(limit=2, offset=4)
+    assert [i["content"] for i in page2] == ["msg0", "msg1"]
+
+    # offset without limit returns all except the N most-recent
+    without_limit = await session.get_items(offset=2)
+    assert [i["content"] for i in without_limit] == ["msg0", "msg1", "msg2", "msg3"]
+
+    # offset >= total returns empty
+    empty = await session.get_items(limit=2, offset=10)
+    assert empty == []
+
+
+@pytest.mark.asyncio
 async def test_id_stripping_session_removes_ids_on_add() -> None:
     session = IdStrippingSession()
     items: list[TResponseInputItem] = [


### PR DESCRIPTION
## Summary

Closes #2810

Adds an optional `offset: int = 0` parameter to `get_items()` across all session backends, enabling proper pagination through conversation history.

```python
# Page 1: 10 most recent items (existing behavior, unchanged)
page1 = await session.get_items(limit=10)

# Page 2: next 10 older items
page2 = await session.get_items(limit=10, offset=10)

# Everything except the 5 most recent
older = await session.get_items(offset=5)
```

Backends updated:
- `SQLiteSession` — `LIMIT ? OFFSET ?` in SQL query
- `AsyncSQLiteSession` — same SQL pattern
- `SQLAlchemySession` — `.offset()` clause
- `RedisSession` — adjusted `lrange` negative index range
- `DaprSession` — list slicing from newest end
- `EncryptSession` — passes `offset` through to underlying session
- `OpenAIResponsesCompactionSession` — passes `offset` through to underlying session
- `OpenAIConversationsSession` — fetches `limit+offset` in DESC, skips first `offset`, reverses
- `AdvancedSQLiteSession` — same SQL pattern, `offset` appended after `branch_id`

## Test plan

- [x] Added `test_sqlite_session_get_items_with_offset` covering offset+limit pagination, offset-only, and out-of-range offset
- [x] Added `test_simple_list_session_get_items_offset` for the in-memory test utility
- [x] Full test suite passes: `2678 passed, 5 skipped`
- [x] `make format`, `make lint`, `make typecheck` all clean
- [x] Fully backwards compatible — `offset` defaults to `0`, existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)