### PR TITLE
feat(tools): support @function_tool on class instance methods (fixes #94)

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -36,6 +36,10 @@ class FuncSchema:
     """The signature of the function."""
     takes_context: bool = False
     """Whether the function takes a RunContextWrapper argument (must be the first argument)."""
+    skips_receiver: bool = False
+    """Whether the function's leading ``self`` or ``cls`` parameter was stripped from the schema.
+    When True, the tool is a *method tool* and must be called with a receiver prepended to the
+    argument list (see :meth:`FunctionTool.__get__`)."""
     strict_json_schema: bool = True
     """Whether the JSON schema is in strict mode. We **strongly** recommend setting this to True,
     as it increases the likelihood of correct JSON input."""
@@ -286,23 +290,46 @@ def function_schema(
     sig = inspect.signature(func)
     params = list(sig.parameters.items())
     takes_context = False
+    skips_receiver = False
     filtered_params = []
+    # Index into `params` where non-receiver, non-context processing begins.
+    _params_start = 0
 
     if params:
         first_name, first_param = params[0]
         # Prefer the evaluated type hint if available
         ann = type_hints.get(first_name, first_param.annotation)
-        if ann != inspect._empty:
+        if ann == inspect._empty and first_name in ("self", "cls"):
+            # Unannotated self/cls → this is an instance or class method receiver.
+            # Exclude it from the schema so the LLM never sees it; the tool's __get__
+            # descriptor will supply the receiver at call time.
+            skips_receiver = True
+            _params_start = 1
+        elif ann != inspect._empty:
             origin = get_origin(ann) or ann
             if origin is RunContextWrapper or origin is ToolContext:
                 takes_context = True  # Mark that the function takes context
+                _params_start = 1
             else:
                 filtered_params.append((first_name, first_param))
+                _params_start = 1
         else:
             filtered_params.append((first_name, first_param))
+            _params_start = 1
 
-    # For parameters other than the first, raise error if any use RunContextWrapper or ToolContext.
-    for name, param in params[1:]:
+    # When the first param is a method receiver, the *next* param may be a context arg.
+    if skips_receiver and len(params) > 1:
+        second_name, second_param = params[1]
+        second_ann = type_hints.get(second_name, second_param.annotation)
+        if second_ann != inspect._empty:
+            origin = get_origin(second_ann) or second_ann
+            if origin is RunContextWrapper or origin is ToolContext:
+                takes_context = True
+                _params_start = 2
+
+    # For parameters beyond the first (and optional context), raise an error if any use
+    # RunContextWrapper or ToolContext in an unsupported position.
+    for name, param in params[_params_start:]:
         ann = type_hints.get(name, param.annotation)
         if ann != inspect._empty:
             origin = get_origin(ann) or ann
@@ -312,6 +339,12 @@ def function_schema(
                     f" {func.__name__}"
                 )
         filtered_params.append((name, param))
+
+    # If this is a method, strip the receiver from the stored signature so that
+    # to_call_args() never attempts to populate self/cls from LLM-supplied JSON.
+    if skips_receiver:
+        receiver_name = params[0][0]
+        sig = sig.replace(parameters=[p for n, p in sig.parameters.items() if n != receiver_name])
 
     # We will collect field definitions for create_model as a dict:
     #   field_name -> (type_annotation, default_value_or_Field(...))
@@ -419,5 +452,6 @@ def function_schema(
         params_json_schema=json_schema,
         signature=sig,
         takes_context=takes_context,
+        skips_receiver=skips_receiver,
         strict_json_schema=strict_json_schema,
     )

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -353,6 +353,31 @@ class FunctionTool:
                 setattr(copied_tool, attr_name, attr_value)
         return copied_tool
 
+    def __get__(self, obj: Any, objtype: Any = None) -> FunctionTool:
+        """Descriptor protocol: bind this method tool to a class instance.
+
+        When a :func:`function_tool`-decorated method is accessed on an instance
+        (e.g. ``my_instance.my_tool``), this returns a new :class:`FunctionTool`
+        whose invocation automatically prepends ``my_instance`` as the receiver,
+        so the underlying method receives the correct ``self``/``cls`` argument.
+
+        Accessing the tool on the *class* (``MyClass.my_tool``) returns the
+        unbound :class:`FunctionTool` unchanged.
+        """
+        if obj is None:
+            # Class-level access — return the unbound tool descriptor.
+            return self
+        make_impl = getattr(self, "_make_impl", None)
+        if make_impl is None:
+            # Not a method tool; behave as a plain attribute (no binding needed).
+            return self
+        # Build a copy and rewire its invoker to use the bound receiver.
+        bound_tool = copy.copy(self)
+        handler = bound_tool.on_invoke_tool
+        if isinstance(handler, _FailureHandlingFunctionToolInvoker):
+            handler._invoke_tool_impl = make_impl(obj)
+        return bound_tool
+
 
 class _FailureHandlingFunctionToolInvoker:
     """Internal callable that rebinds wrapper error handling for copied FunctionTools."""
@@ -1669,6 +1694,97 @@ def function_tool(
             strict_json_schema=strict_mode,
         )
 
+        _on_handled_error = _build_handled_function_tool_error_handler(
+            span_message="Error running tool (non-fatal)",
+            span_message_for_json_decode_error="Error running tool",
+            log_label="Tool",
+        )
+
+        if schema.skips_receiver:
+            # The decorated function is an unbound instance/class method.  We
+            # store a factory (_make_impl) on the returned FunctionTool so that
+            # the __get__ descriptor can produce a correctly-bound invoker when
+            # the tool is accessed via a class instance.
+            def _make_impl(
+                receiver: Any,
+            ) -> Callable[[ToolContext[Any], str], Awaitable[Any]]:
+                async def _method_invoke_impl(ctx: ToolContext[Any], input: str) -> Any:
+                    tool_name = ctx.tool_name
+                    json_data = _parse_function_tool_json_input(
+                        tool_name=tool_name, input_json=input
+                    )
+                    _log_function_tool_invocation(tool_name=tool_name, input_json=input)
+
+                    try:
+                        parsed = (
+                            schema.params_pydantic_model(**json_data)
+                            if json_data
+                            else schema.params_pydantic_model()
+                        )
+                    except ValidationError as e:
+                        raise ModelBehaviorError(
+                            f"Invalid JSON input for tool {tool_name}: {e}"
+                        ) from e
+
+                    args, kwargs_dict = schema.to_call_args(parsed)
+
+                    if not _debug.DONT_LOG_TOOL_DATA:
+                        logger.debug(f"Tool call args: {args}, kwargs: {kwargs_dict}")
+
+                    if receiver is None:
+                        raise UserError(
+                            f"Tool '{schema.name}' was decorated on a class method and must be "
+                            f"accessed via a class instance before being invoked. "
+                            f"Use 'instance.{schema.name}' or bind the tool with "
+                            f"'tool.__get__(instance)' before adding it to an agent."
+                        )
+
+                    if not is_sync_function_tool:
+                        if schema.takes_context:
+                            result = await the_func(receiver, ctx, *args, **kwargs_dict)
+                        else:
+                            result = await the_func(receiver, *args, **kwargs_dict)
+                    else:
+                        if schema.takes_context:
+                            result = await asyncio.to_thread(
+                                the_func, receiver, ctx, *args, **kwargs_dict
+                            )
+                        else:
+                            result = await asyncio.to_thread(
+                                the_func, receiver, *args, **kwargs_dict
+                            )
+
+                    if _debug.DONT_LOG_TOOL_DATA:
+                        logger.debug(f"Tool {tool_name} completed.")
+                    else:
+                        logger.debug(f"Tool {tool_name} returned {result}")
+
+                    return result
+
+                return _method_invoke_impl
+
+            function_tool = _build_wrapped_function_tool(
+                name=schema.name,
+                description=schema.description or "",
+                params_json_schema=schema.params_json_schema,
+                invoke_tool_impl=_make_impl(None),  # unbound placeholder
+                on_handled_error=_on_handled_error,
+                failure_error_function=failure_error_function,
+                strict_json_schema=strict_mode,
+                is_enabled=is_enabled,
+                needs_approval=needs_approval,
+                tool_input_guardrails=tool_input_guardrails,
+                tool_output_guardrails=tool_output_guardrails,
+                timeout_seconds=timeout,
+                timeout_behavior=timeout_behavior,
+                timeout_error_function=timeout_error_function,
+                defer_loading=defer_loading,
+                sync_invoker=is_sync_function_tool,
+            )
+            # Store the factory so __get__ can bind a receiver on instance access.
+            function_tool._make_impl = _make_impl  # type: ignore[attr-defined]
+            return function_tool
+
         async def _on_invoke_tool_impl(ctx: ToolContext[Any], input: str) -> Any:
             tool_name = ctx.tool_name
             json_data = _parse_function_tool_json_input(tool_name=tool_name, input_json=input)
@@ -1711,11 +1827,7 @@ def function_tool(
             description=schema.description or "",
             params_json_schema=schema.params_json_schema,
             invoke_tool_impl=_on_invoke_tool_impl,
-            on_handled_error=_build_handled_function_tool_error_handler(
-                span_message="Error running tool (non-fatal)",
-                span_message_for_json_decode_error="Error running tool",
-                log_label="Tool",
-            ),
+            on_handled_error=_on_handled_error,
             failure_error_function=failure_error_function,
             strict_json_schema=strict_mode,
             is_enabled=is_enabled,

--- a/tests/test_method_tool.py
+++ b/tests/test_method_tool.py
@@ -1,0 +1,327 @@
+"""Tests for @function_tool applied to class instance methods (issue #94).
+
+Covers the descriptor protocol (__get__), schema generation (self/cls stripped),
+receiver binding at call time, and edge cases flagged in previous review rounds.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agents import RunContextWrapper
+from agents.exceptions import UserError
+from agents.function_schema import function_schema
+from agents.tool import FunctionTool, function_tool
+from agents.tool_context import ToolContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_context(tool_name: str = "test_tool") -> ToolContext:
+    return ToolContext(context=None, tool_name=tool_name, tool_call_id="1", tool_arguments="")
+
+
+# ---------------------------------------------------------------------------
+# function_schema unit tests
+# ---------------------------------------------------------------------------
+
+
+class _BasicMethodClass:
+    multiplier: int
+
+    def __init__(self, multiplier: int) -> None:
+        self.multiplier = multiplier
+
+    def multiply(self, x: int) -> int:
+        """Multiply x by the instance multiplier.
+
+        Args:
+            x: The value to multiply.
+        """
+        return x * self.multiplier
+
+
+def test_function_schema_strips_self() -> None:
+    """function_schema must not include self in the JSON schema."""
+    schema = function_schema(_BasicMethodClass.multiply)
+    assert schema.skips_receiver is True
+    assert schema.takes_context is False
+    assert "self" not in schema.params_json_schema.get("properties", {})
+    assert "x" in schema.params_json_schema.get("properties", {})
+
+
+def test_function_schema_strips_self_from_stored_signature() -> None:
+    """The stored signature must not include self so to_call_args never fetches it."""
+    schema = function_schema(_BasicMethodClass.multiply)
+    assert "self" not in schema.signature.parameters
+
+
+def test_function_schema_to_call_args_without_receiver() -> None:
+    """to_call_args must return only the non-receiver arguments."""
+    schema = function_schema(_BasicMethodClass.multiply)
+    parsed = schema.params_pydantic_model(x=7)
+    args, kwargs = schema.to_call_args(parsed)
+    # args should be [7]; no None placeholder for self
+    assert args == [7]
+    assert kwargs == {}
+
+
+def test_function_schema_cls_is_stripped() -> None:
+    """Leading cls parameter (unannotated) must also be treated as a receiver.
+
+    We test the undecorated classmethod function directly (before @classmethod
+    binds cls) because @classmethod already hides cls from the signature.
+    """
+
+    # Define an unbound function that uses cls as its first unannotated param,
+    # as if it were the raw underlying function of a classmethod.
+    def greet(cls, name: str) -> str:
+        """Say hi.
+
+        Args:
+            name: Who to greet.
+        """
+        return f"hi {name}"
+
+    schema = function_schema(greet)
+    assert schema.skips_receiver is True
+    assert "cls" not in schema.params_json_schema.get("properties", {})
+    assert "name" in schema.params_json_schema.get("properties", {})
+
+
+def test_function_schema_annotated_self_not_stripped() -> None:
+    """A first parameter named self *with* a type annotation must not be stripped."""
+
+    def weird(self: int, y: int) -> int:
+        return self + y
+
+    schema = function_schema(weird)
+    assert schema.skips_receiver is False
+    assert "self" in schema.params_json_schema.get("properties", {})
+
+
+def test_function_schema_self_with_context_param() -> None:
+    """self followed immediately by RunContextWrapper must set both flags correctly."""
+
+    class _WithCtx:
+        def act(self, ctx: RunContextWrapper[None], value: int) -> int:
+            """Do something.
+
+            Args:
+                value: The input value.
+            """
+            return value
+
+    schema = function_schema(_WithCtx.act)
+    assert schema.skips_receiver is True
+    assert schema.takes_context is True
+    assert "self" not in schema.params_json_schema.get("properties", {})
+    assert "ctx" not in schema.params_json_schema.get("properties", {})
+    assert "value" in schema.params_json_schema.get("properties", {})
+
+
+def test_function_schema_context_in_wrong_position_raises() -> None:
+    """RunContextWrapper after self but not in position 1 must raise UserError."""
+
+    class _Bad:
+        def bad(self, x: int, ctx: RunContextWrapper[None]) -> int:
+            return x
+
+    with pytest.raises(UserError, match="non-first position"):
+        function_schema(_Bad.bad)
+
+
+def test_function_schema_regular_function_unchanged() -> None:
+    """function_schema on a plain function must behave exactly as before."""
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers.
+
+        Args:
+            a: First.
+            b: Second.
+        """
+        return a + b
+
+    schema = function_schema(add)
+    assert schema.skips_receiver is False
+    assert schema.takes_context is False
+    assert "a" in schema.params_json_schema.get("properties", {})
+    assert "b" in schema.params_json_schema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# FunctionTool descriptor / __get__ tests
+# ---------------------------------------------------------------------------
+
+
+class _Calculator:
+    def __init__(self, base: int) -> None:
+        self.base = base
+
+    @function_tool
+    def add(self, x: int) -> int:
+        """Add x to the base.
+
+        Args:
+            x: Value to add.
+        """
+        return self.base + x
+
+    @function_tool
+    async def async_add(self, x: int) -> int:
+        """Async-add x to the base.
+
+        Args:
+            x: Value to add.
+        """
+        return self.base + x
+
+
+def test_class_level_access_returns_function_tool() -> None:
+    """Accessing the tool on the class should return a FunctionTool (unbound)."""
+    assert isinstance(_Calculator.add, FunctionTool)
+
+
+def test_instance_access_returns_function_tool() -> None:
+    """Accessing the tool on an instance should also return a FunctionTool."""
+    calc = _Calculator(base=10)
+    assert isinstance(calc.add, FunctionTool)
+
+
+def test_instance_access_returns_different_object() -> None:
+    """Each instance access should produce a new (bound) FunctionTool."""
+    calc = _Calculator(base=10)
+    bound1 = calc.add
+    bound2 = calc.add
+    assert bound1 is not bound2
+    assert bound1 is not _Calculator.add
+
+
+def test_bound_tool_schema_unchanged() -> None:
+    """The schema of the bound tool must be identical to the class-level tool."""
+    calc = _Calculator(base=10)
+    assert calc.add.params_json_schema == _Calculator.add.params_json_schema
+    assert calc.add.name == _Calculator.add.name
+
+
+@pytest.mark.asyncio
+async def test_bound_tool_invokes_correct_instance() -> None:
+    """The bound tool must call the method on the correct instance."""
+    calc5 = _Calculator(base=5)
+    calc20 = _Calculator(base=20)
+
+    ctx = _make_tool_context("add")
+    result5 = await calc5.add.on_invoke_tool(ctx, '{"x": 3}')
+    result20 = await calc20.add.on_invoke_tool(ctx, '{"x": 3}')
+
+    assert result5 == 8  # 5 + 3
+    assert result20 == 23  # 20 + 3
+
+
+@pytest.mark.asyncio
+async def test_async_bound_tool_invokes_correct_instance() -> None:
+    """The async variant also dispatches to the right instance."""
+    calc = _Calculator(base=100)
+    ctx = _make_tool_context("async_add")
+    result = await calc.async_add.on_invoke_tool(ctx, '{"x": 1}')
+    assert result == 101
+
+
+@pytest.mark.asyncio
+async def test_unbound_tool_returns_error_message() -> None:
+    """Calling the class-level (unbound) tool must produce an error message.
+
+    The UserError raised internally is caught by the failure error handler and
+    returned as a string so the LLM receives a meaningful error rather than
+    crashing the run.
+    """
+    ctx = _make_tool_context("add")
+    result = await _Calculator.add.on_invoke_tool(ctx, '{"x": 1}')
+    assert isinstance(result, str)
+    assert "class instance" in result
+
+
+# ---------------------------------------------------------------------------
+# Method tool with RunContextWrapper
+# ---------------------------------------------------------------------------
+
+
+class _ContextAwareService:
+    def __init__(self, prefix: str) -> None:
+        self.prefix = prefix
+
+    @function_tool
+    def greet(self, ctx: RunContextWrapper[None], name: str) -> str:
+        """Greet someone.
+
+        Args:
+            name: The person's name.
+        """
+        return f"{self.prefix}: hello {name}"
+
+
+@pytest.mark.asyncio
+async def test_method_tool_with_context() -> None:
+    """Method tool that also takes RunContextWrapper must pass ctx correctly."""
+    svc = _ContextAwareService(prefix="BOT")
+    tool_ctx = _make_tool_context("greet")
+
+    result = await svc.greet.on_invoke_tool(tool_ctx, '{"name": "Alice"}')
+    assert result == "BOT: hello Alice"
+
+
+# ---------------------------------------------------------------------------
+# Only the leading self/cls is stripped (not all params named self)
+# ---------------------------------------------------------------------------
+
+
+def test_only_leading_self_is_stripped() -> None:
+    """A parameter named 'self' that is NOT the first parameter must appear in the schema."""
+
+    class _Tricky:
+        def method(self, value: int, self_count: int = 0) -> int:
+            """Do something.
+
+            Args:
+                value: Main value.
+                self_count: Extra count (not a receiver).
+            """
+            return value + self_count
+
+    schema = function_schema(_Tricky.method)
+    props = schema.params_json_schema.get("properties", {})
+    assert "self" not in props
+    assert "value" in props
+    assert "self_count" in props
+
+
+# ---------------------------------------------------------------------------
+# Decorator with arguments still works for methods
+# ---------------------------------------------------------------------------
+
+
+class _Described:
+    @function_tool(name_override="my_described_tool", description_override="A described tool.")
+    def compute(self, n: int) -> int:
+        """Fallback docstring.
+
+        Args:
+            n: Input.
+        """
+        return n * 2
+
+
+def test_function_tool_with_args_on_method() -> None:
+    assert _Described.compute.name == "my_described_tool"
+    assert _Described.compute.description == "A described tool."
+
+
+@pytest.mark.asyncio
+async def test_function_tool_with_args_on_method_binding() -> None:
+    obj = _Described()
+    ctx = _make_tool_context("my_described_tool")
+    result = await obj.compute.on_invoke_tool(ctx, '{"n": 4}')
+    assert result == 8


### PR DESCRIPTION
This implements the method tool support requested in #94 — the previous attempt (#2734) was closed after Codex flagged implementation issues; this PR addresses all of them.

## What changed

**`function_schema.py`**
- `FuncSchema` gains a `skips_receiver: bool` field
- `function_schema()` detects an unannotated leading `self` or `cls` and strips it from the JSON schema and stored signature — the LLM never sees it, and `to_call_args()` never tries to populate it from model output
- A `RunContextWrapper`/`ToolContext` immediately after `self`/`cls` is handled correctly (`takes_context=True`); wrong position still raises `UserError`

**`tool.py`**
- `FunctionTool` gains a `__get__` descriptor method
- Accessing a method tool on an instance (e.g. `instance.my_tool`) returns a bound copy whose invoker prepends the instance as the receiver
- Accessing via the class returns the unbound tool unchanged
- Calling an unbound method tool returns a descriptive error string via the standard failure handler

## Issues from #2734 — all fixed

| Issue | Fix |
|---|---|
| Context not immediately after self/cls should raise UserError | Only position 1 after receiver accepted; wrong position raises `UserError` |
| `to_call_args()` includes `self` in stored signature | Receiver stripped from stored `sig` before building `FuncSchema` |
| Signature stripping gated on `takes_context` instead of `skips_receiver` | New `skips_receiver` flag controls receiver stripping independently |
| Unbound methods can't be called without receiver | `__get__` descriptor binds the receiver at instance access time |
| Stripping ALL params named `self`/`cls` | Only the single leading parameter is checked |
| Raising UserError at decoration time | No errors at decoration time; unbound call returns graceful error string |

## Usage

```python
from agents import Agent, Runner, function_tool

class WeatherService:
    def __init__(self, api_key: str):
        self.api_key = api_key

    @function_tool
    def get_weather(self, city: str) -> str:
        """Get current weather for a city.

        Args:
            city: The city name.
        """
        return f"Weather in {city}: sunny"

svc = WeatherService(api_key="secret")
agent = Agent(name="Weather Bot", tools=[svc.get_weather])
result = await Runner.run(agent, "What's the weather in London?")
```

## Test plan

- 19 new tests in `tests/test_method_tool.py` covering schema stripping, descriptor binding, sync/async methods, context params, wrong-position context error, and `@function_tool(...)` with arguments
- All 2702 existing tests pass
- `make format` and `make lint` clean
- No new typecheck errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)