### PR TITLE
fix: remove_all_tools missing hosted tool types

### DIFF
--- a/src/agents/extensions/handoff_filters.py
+++ b/src/agents/extensions/handoff_filters.py
@@ -13,6 +13,7 @@ from ..items import (
     MCPListToolsItem,
     ReasoningItem,
     RunItem,
+    ToolApprovalItem,
     ToolCallItem,
     ToolCallOutputItem,
     ToolSearchCallItem,
@@ -63,6 +64,7 @@ def _remove_tools_from_items(items: tuple[RunItem, ...]) -> tuple[RunItem, ...]:
             or isinstance(item, MCPListToolsItem)
             or isinstance(item, MCPApprovalRequestItem)
             or isinstance(item, MCPApprovalResponseItem)
+            or isinstance(item, ToolApprovalItem)
         ):
             continue
         filtered_items.append(item)
@@ -86,6 +88,14 @@ def _remove_tool_types_from_input(
         "mcp_approval_request",
         "mcp_approval_response",
         "reasoning",
+        "code_interpreter_call",
+        "image_generation_call",
+        "local_shell_call",
+        "local_shell_call_output",
+        "shell_call",
+        "shell_call_output",
+        "apply_patch_call",
+        "apply_patch_call_output",
     ]
 
     filtered_items: list[TResponseInputItem] = []

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -24,6 +24,7 @@ from agents.items import (
     MCPListToolsItem,
     MessageOutputItem,
     ReasoningItem,
+    ToolApprovalItem,
     ToolCallItem,
     ToolCallOutputItem,
     ToolSearchCallItem,
@@ -1013,5 +1014,59 @@ def test_removes_mixed_mcp_and_function_items() -> None:
     )
     filtered_data = remove_all_tools(handoff_input_data)
     assert len(filtered_data.input_history) == 2
+    assert len(filtered_data.pre_handoff_items) == 1
+    assert len(filtered_data.new_items) == 1
+
+
+def _get_hosted_tool_input_item(type_name: str) -> TResponseInputItem:
+    return cast(TResponseInputItem, {"id": "ht1", "type": type_name})
+
+
+def _get_tool_approval_run_item() -> ToolApprovalItem:
+    return ToolApprovalItem(
+        agent=fake_agent(),
+        raw_item={"type": "function_call", "call_id": "c1", "name": "fn", "arguments": "{}"},
+        tool_name="fn",
+    )
+
+
+def test_removes_hosted_tool_types_from_input_history() -> None:
+    """Hosted tool types in raw input history should be removed by remove_all_tools."""
+    hosted_types = [
+        "code_interpreter_call",
+        "image_generation_call",
+        "local_shell_call",
+        "local_shell_call_output",
+        "shell_call",
+        "shell_call_output",
+        "apply_patch_call",
+        "apply_patch_call_output",
+    ]
+    input_items: list[TResponseInputItem] = [_get_message_input_item("Hello")]
+    for t in hosted_types:
+        input_items.append(_get_hosted_tool_input_item(t))
+    input_items.append(_get_message_input_item("World"))
+
+    handoff_input_data = handoff_data(input_history=tuple(input_items))
+    filtered_data = remove_all_tools(handoff_input_data)
+    assert len(filtered_data.input_history) == 2
+    for item in filtered_data.input_history:
+        assert not isinstance(item, str)
+        assert item.get("type") not in set(hosted_types)
+
+
+def test_removes_tool_approval_from_new_items() -> None:
+    """ToolApprovalItem should be removed from new_items and pre_handoff_items."""
+    handoff_input_data = handoff_data(
+        pre_handoff_items=(
+            _get_tool_approval_run_item(),
+            _get_message_output_run_item("kept"),
+        ),
+        new_items=(
+            _get_tool_approval_run_item(),
+            _get_message_output_run_item("also kept"),
+        ),
+    )
+    filtered_data = remove_all_tools(handoff_input_data)
     assert len(filtered_data.pre_handoff_items) == 1
     assert len(filtered_data.new_items) == 1


### PR DESCRIPTION
### Summary

`remove_all_tools` already strips function calls, computer calls, web/file/tool search calls, MCP items, and reasoning items, but it still leaves hosted tool calls and `ToolApprovalItem` in the handoff input. After a handoff that uses this filter, the next agent receives `code_interpreter_call`, `image_generation_call`, `local_shell_call(_output)`, `shell_call(_output)`, and `apply_patch_call(_output)` items in its raw input history, plus any unresolved `ToolApprovalItem` entries in `pre_handoff_items` and `new_items`.

This is the same gap #2700 closed for MCP and reasoning items, applied to the remaining hosted tool types.

Changes:
- Add `ToolApprovalItem` to `_remove_tools_from_items`.
- Add the eight hosted tool call type literals to `_remove_tool_types_from_input`.

### Test plan

- New `test_removes_hosted_tool_types_from_input_history` covering all eight new types in raw input history.
- New `test_removes_tool_approval_from_new_items` covering `ToolApprovalItem` removal from `pre_handoff_items` and `new_items`.
- `uv run pytest tests/test_extension_filters.py` — 36 passed.
- `make lint`, `make format`, `make typecheck` on the touched files — all clean.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass