### PR TITLE
feat: #2886 add convenience properties to ToolCallItem and ToolCallOutputItem

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -358,6 +358,20 @@ class ToolCallItem(RunItemBase[Any]):
     title: str | None = None
     """Optional short display label if known at item creation time."""
 
+    @property
+    def tool_name(self) -> str | None:
+        """Return the tool name from the raw item, if available."""
+        if isinstance(self.raw_item, dict):
+            return self.raw_item.get("name")
+        return getattr(self.raw_item, "name", None)
+
+    @property
+    def call_id(self) -> str | None:
+        """Return the call identifier from the raw item, if available."""
+        if isinstance(self.raw_item, dict):
+            return self.raw_item.get("call_id") or self.raw_item.get("id")
+        return getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
+
 
 ToolCallOutputTypes: TypeAlias = Union[
     FunctionCallOutput,
@@ -381,6 +395,14 @@ class ToolCallOutputItem(RunItemBase[Any]):
     """
 
     type: Literal["tool_call_output_item"] = "tool_call_output_item"
+
+    @property
+    def call_id(self) -> str | None:
+        """Return the call identifier from the raw item, if available."""
+        if isinstance(self.raw_item, dict):
+            cid = self.raw_item.get("call_id") or self.raw_item.get("id")
+            return str(cid) if cid is not None else None
+        return getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
 
     def to_input_item(self) -> TResponseInputItem:
         """Converts the tool output into an input item for the next model turn.


### PR DESCRIPTION
### Summary

`ToolApprovalItem` exposes `tool_name` and `call_id` as properties for easy inspection of tool calls. `ToolCallItem` and `ToolCallOutputItem` lack equivalent accessors, requiring users to reach into `raw_item` internals with `getattr` chains and `isinstance` checks.

This adds the same convenience properties to both classes, following the existing `ToolApprovalItem` patterns:

- `ToolCallItem`: `tool_name`, `call_id`
- `ToolCallOutputItem`: `call_id`

### Test plan

- `make format` — pass
- `make lint` — pass
- `mypy src/agents/items.py` — pass
- Existing `tests/test_items_helpers.py` passes (31 tests, no regressions)

### Issue number

Closes #2886

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass