### PR TITLE
docs: align translated sandbox nav and refresh generated refs

### DIFF
--- a/docs/ref/extensions/sandbox/blaxel/mounts.md
+++ b/docs/ref/extensions/sandbox/blaxel/mounts.md
@@ -1,0 +1,3 @@
+# `Mounts`
+
+::: agents.extensions.sandbox.blaxel.mounts

--- a/docs/ref/extensions/sandbox/blaxel/sandbox.md
+++ b/docs/ref/extensions/sandbox/blaxel/sandbox.md
@@ -1,0 +1,3 @@
+# `Sandbox`
+
+::: agents.extensions.sandbox.blaxel.sandbox

--- a/docs/ref/extensions/sandbox/cloudflare/mounts.md
+++ b/docs/ref/extensions/sandbox/cloudflare/mounts.md
@@ -1,0 +1,3 @@
+# `Mounts`
+
+::: agents.extensions.sandbox.cloudflare.mounts

--- a/docs/ref/extensions/sandbox/cloudflare/sandbox.md
+++ b/docs/ref/extensions/sandbox/cloudflare/sandbox.md
@@ -1,0 +1,3 @@
+# `Sandbox`
+
+::: agents.extensions.sandbox.cloudflare.sandbox

--- a/docs/ref/extensions/sandbox/daytona/mounts.md
+++ b/docs/ref/extensions/sandbox/daytona/mounts.md
@@ -1,0 +1,3 @@
+# `Mounts`
+
+::: agents.extensions.sandbox.daytona.mounts

--- a/docs/ref/extensions/sandbox/daytona/sandbox.md
+++ b/docs/ref/extensions/sandbox/daytona/sandbox.md
@@ -1,0 +1,3 @@
+# `Sandbox`
+
+::: agents.extensions.sandbox.daytona.sandbox

--- a/docs/ref/extensions/sandbox/e2b/mounts.md
+++ b/docs/ref/extensions/sandbox/e2b/mounts.md
@@ -1,0 +1,3 @@
+# `Mounts`
+
+::: agents.extensions.sandbox.e2b.mounts

--- a/docs/ref/extensions/sandbox/e2b/sandbox.md
+++ b/docs/ref/extensions/sandbox/e2b/sandbox.md
@@ -1,0 +1,3 @@
+# `Sandbox`
+
+::: agents.extensions.sandbox.e2b.sandbox

--- a/docs/ref/extensions/sandbox/modal/mounts.md
+++ b/docs/ref/extensions/sandbox/modal/mounts.md
@@ -1,0 +1,3 @@
+# `Mounts`
+
+::: agents.extensions.sandbox.modal.mounts

--- a/docs/ref/extensions/sandbox/modal/sandbox.md
+++ b/docs/ref/extensions/sandbox/modal/sandbox.md
@@ -1,0 +1,3 @@
+# `Sandbox`
+
+::: agents.extensions.sandbox.modal.sandbox

--- a/docs/ref/extensions/sandbox/runloop/mounts.md
+++ b/docs/ref/extensions/sandbox/runloop/mounts.md
@@ -1,0 +1,3 @@
+# `Mounts`
+
+::: agents.extensions.sandbox.runloop.mounts

--- a/docs/ref/extensions/sandbox/runloop/sandbox.md
+++ b/docs/ref/extensions/sandbox/runloop/sandbox.md
@@ -1,0 +1,3 @@
+# `Sandbox`
+
+::: agents.extensions.sandbox.runloop.sandbox

--- a/docs/ref/extensions/sandbox/vercel/sandbox.md
+++ b/docs/ref/extensions/sandbox/vercel/sandbox.md
@@ -1,0 +1,3 @@
+# `Sandbox`
+
+::: agents.extensions.sandbox.vercel.sandbox

--- a/docs/ref/models/openai_agent_registration.md
+++ b/docs/ref/models/openai_agent_registration.md
@@ -1,0 +1,3 @@
+# `Openai Agent Registration`
+
+::: agents.models.openai_agent_registration

--- a/docs/ref/models/openai_client_utils.md
+++ b/docs/ref/models/openai_client_utils.md
@@ -1,0 +1,3 @@
+# `Openai Client Utils`
+
+::: agents.models.openai_client_utils

--- a/docs/ref/run_internal/agent_bindings.md
+++ b/docs/ref/run_internal/agent_bindings.md
@@ -1,0 +1,3 @@
+# `Agent Bindings`
+
+::: agents.run_internal.agent_bindings

--- a/docs/ref/run_internal/prompt_cache_key.md
+++ b/docs/ref/run_internal/prompt_cache_key.md
@@ -1,0 +1,3 @@
+# `Prompt Cache Key`
+
+::: agents.run_internal.prompt_cache_key

--- a/docs/ref/run_internal/run_grouping.md
+++ b/docs/ref/run_internal/run_grouping.md
@@ -1,0 +1,3 @@
+# `Run Grouping`
+
+::: agents.run_internal.run_grouping

--- a/docs/ref/sandbox/apply_patch.md
+++ b/docs/ref/sandbox/apply_patch.md
@@ -1,0 +1,3 @@
+# `Apply Patch`
+
+::: agents.sandbox.apply_patch

--- a/docs/ref/sandbox/capabilities/tools/apply_patch_tool.md
+++ b/docs/ref/sandbox/capabilities/tools/apply_patch_tool.md
@@ -1,0 +1,3 @@
+# `Apply Patch Tool`
+
+::: agents.sandbox.capabilities.tools.apply_patch_tool

--- a/docs/ref/sandbox/capabilities/tools/shell_tool.md
+++ b/docs/ref/sandbox/capabilities/tools/shell_tool.md
@@ -1,0 +1,3 @@
+# `Shell Tool`
+
+::: agents.sandbox.capabilities.tools.shell_tool

--- a/docs/ref/sandbox/capabilities/tools/view_image.md
+++ b/docs/ref/sandbox/capabilities/tools/view_image.md
@@ -1,0 +1,3 @@
+# `View Image`
+
+::: agents.sandbox.capabilities.tools.view_image

--- a/docs/ref/sandbox/config.md
+++ b/docs/ref/sandbox/config.md
@@ -1,0 +1,3 @@
+# `Config`
+
+::: agents.sandbox.config

--- a/docs/ref/sandbox/entries/artifacts.md
+++ b/docs/ref/sandbox/entries/artifacts.md
@@ -1,0 +1,3 @@
+# `Artifacts`
+
+::: agents.sandbox.entries.artifacts

--- a/docs/ref/sandbox/entries/base.md
+++ b/docs/ref/sandbox/entries/base.md
@@ -1,0 +1,3 @@
+# `Base`
+
+::: agents.sandbox.entries.base

--- a/docs/ref/sandbox/entries/mounts/base.md
+++ b/docs/ref/sandbox/entries/mounts/base.md
@@ -1,0 +1,3 @@
+# `Base`
+
+::: agents.sandbox.entries.mounts.base

--- a/docs/ref/sandbox/entries/mounts/patterns.md
+++ b/docs/ref/sandbox/entries/mounts/patterns.md
@@ -1,0 +1,3 @@
+# `Patterns`
+
+::: agents.sandbox.entries.mounts.patterns

--- a/docs/ref/sandbox/entries/mounts/providers/azure_blob.md
+++ b/docs/ref/sandbox/entries/mounts/providers/azure_blob.md
@@ -1,0 +1,3 @@
+# `Azure Blob`
+
+::: agents.sandbox.entries.mounts.providers.azure_blob

--- a/docs/ref/sandbox/entries/mounts/providers/base.md
+++ b/docs/ref/sandbox/entries/mounts/providers/base.md
@@ -1,0 +1,3 @@
+# `Base`
+
+::: agents.sandbox.entries.mounts.providers.base

--- a/docs/ref/sandbox/entries/mounts/providers/gcs.md
+++ b/docs/ref/sandbox/entries/mounts/providers/gcs.md
@@ -1,0 +1,3 @@
+# `Gcs`
+
+::: agents.sandbox.entries.mounts.providers.gcs

--- a/docs/ref/sandbox/entries/mounts/providers/r2.md
+++ b/docs/ref/sandbox/entries/mounts/providers/r2.md
@@ -1,0 +1,3 @@
+# `R2`
+
+::: agents.sandbox.entries.mounts.providers.r2

--- a/docs/ref/sandbox/entries/mounts/providers/s3.md
+++ b/docs/ref/sandbox/entries/mounts/providers/s3.md
@@ -1,0 +1,3 @@
+# `S3`
+
+::: agents.sandbox.entries.mounts.providers.s3

--- a/docs/ref/sandbox/entries/mounts/providers/s3_files.md
+++ b/docs/ref/sandbox/entries/mounts/providers/s3_files.md
@@ -1,0 +1,3 @@
+# `S3 Files`
+
+::: agents.sandbox.entries.mounts.providers.s3_files

--- a/docs/ref/sandbox/errors.md
+++ b/docs/ref/sandbox/errors.md
@@ -1,0 +1,3 @@
+# `Errors`
+
+::: agents.sandbox.errors

--- a/docs/ref/sandbox/files.md
+++ b/docs/ref/sandbox/files.md
@@ -1,0 +1,3 @@
+# `Files`
+
+::: agents.sandbox.files

--- a/docs/ref/sandbox/manifest_render.md
+++ b/docs/ref/sandbox/manifest_render.md
@@ -1,0 +1,3 @@
+# `Manifest Render`
+
+::: agents.sandbox.manifest_render

--- a/docs/ref/sandbox/materialization.md
+++ b/docs/ref/sandbox/materialization.md
@@ -1,0 +1,3 @@
+# `Materialization`
+
+::: agents.sandbox.materialization

--- a/docs/ref/sandbox/memory/interface.md
+++ b/docs/ref/sandbox/memory/interface.md
@@ -1,0 +1,3 @@
+# `Interface`
+
+::: agents.sandbox.memory.interface

--- a/docs/ref/sandbox/memory/manager.md
+++ b/docs/ref/sandbox/memory/manager.md
@@ -1,0 +1,3 @@
+# `Manager`
+
+::: agents.sandbox.memory.manager

--- a/docs/ref/sandbox/memory/phase_one.md
+++ b/docs/ref/sandbox/memory/phase_one.md
@@ -1,0 +1,3 @@
+# `Phase One`
+
+::: agents.sandbox.memory.phase_one

--- a/docs/ref/sandbox/memory/phase_two.md
+++ b/docs/ref/sandbox/memory/phase_two.md
@@ -1,0 +1,3 @@
+# `Phase Two`
+
+::: agents.sandbox.memory.phase_two

--- a/docs/ref/sandbox/memory/prompts.md
+++ b/docs/ref/sandbox/memory/prompts.md
@@ -1,0 +1,3 @@
+# `Prompts`
+
+::: agents.sandbox.memory.prompts

--- a/docs/ref/sandbox/memory/rollouts.md
+++ b/docs/ref/sandbox/memory/rollouts.md
@@ -1,0 +1,3 @@
+# `Rollouts`
+
+::: agents.sandbox.memory.rollouts

--- a/docs/ref/sandbox/memory/storage.md
+++ b/docs/ref/sandbox/memory/storage.md
@@ -1,0 +1,3 @@
+# `Storage`
+
+::: agents.sandbox.memory.storage

--- a/docs/ref/sandbox/remote_mount_policy.md
+++ b/docs/ref/sandbox/remote_mount_policy.md
@@ -1,0 +1,3 @@
+# `Remote Mount Policy`
+
+::: agents.sandbox.remote_mount_policy

--- a/docs/ref/sandbox/runtime.md
+++ b/docs/ref/sandbox/runtime.md
@@ -1,0 +1,3 @@
+# `Runtime`
+
+::: agents.sandbox.runtime

--- a/docs/ref/sandbox/runtime_agent_preparation.md
+++ b/docs/ref/sandbox/runtime_agent_preparation.md
@@ -1,0 +1,3 @@
+# `Runtime Agent Preparation`
+
+::: agents.sandbox.runtime_agent_preparation

--- a/docs/ref/sandbox/runtime_session_manager.md
+++ b/docs/ref/sandbox/runtime_session_manager.md
@@ -1,0 +1,3 @@
+# `Runtime Session Manager`
+
+::: agents.sandbox.runtime_session_manager

--- a/docs/ref/sandbox/session/archive_extraction.md
+++ b/docs/ref/sandbox/session/archive_extraction.md
@@ -1,0 +1,3 @@
+# `Archive Extraction`
+
+::: agents.sandbox.session.archive_extraction

--- a/docs/ref/sandbox/session/base_sandbox_session.md
+++ b/docs/ref/sandbox/session/base_sandbox_session.md
@@ -1,0 +1,3 @@
+# `Base Sandbox Session`
+
+::: agents.sandbox.session.base_sandbox_session

--- a/docs/ref/sandbox/session/dependencies.md
+++ b/docs/ref/sandbox/session/dependencies.md
@@ -1,0 +1,3 @@
+# `Dependencies`
+
+::: agents.sandbox.session.dependencies

--- a/docs/ref/sandbox/session/events.md
+++ b/docs/ref/sandbox/session/events.md
@@ -1,0 +1,3 @@
+# `Events`
+
+::: agents.sandbox.session.events

--- a/docs/ref/sandbox/session/manager.md
+++ b/docs/ref/sandbox/session/manager.md
@@ -1,0 +1,3 @@
+# `Manager`
+
+::: agents.sandbox.session.manager

--- a/docs/ref/sandbox/session/manifest_application.md
+++ b/docs/ref/sandbox/session/manifest_application.md
@@ -1,0 +1,3 @@
+# `Manifest Application`
+
+::: agents.sandbox.session.manifest_application

--- a/docs/ref/sandbox/session/pty_types.md
+++ b/docs/ref/sandbox/session/pty_types.md
@@ -1,0 +1,3 @@
+# `Pty Types`
+
+::: agents.sandbox.session.pty_types

--- a/docs/ref/sandbox/session/runtime_helpers.md
+++ b/docs/ref/sandbox/session/runtime_helpers.md
@@ -1,0 +1,3 @@
+# `Runtime Helpers`
+
+::: agents.sandbox.session.runtime_helpers

--- a/docs/ref/sandbox/session/sinks.md
+++ b/docs/ref/sandbox/session/sinks.md
@@ -1,0 +1,3 @@
+# `Sinks`
+
+::: agents.sandbox.session.sinks

--- a/docs/ref/sandbox/session/utils.md
+++ b/docs/ref/sandbox/session/utils.md
@@ -1,0 +1,3 @@
+# `Utils`
+
+::: agents.sandbox.session.utils

--- a/docs/ref/sandbox/session/workspace_payloads.md
+++ b/docs/ref/sandbox/session/workspace_payloads.md
@@ -1,0 +1,3 @@
+# `Workspace Payloads`
+
+::: agents.sandbox.session.workspace_payloads

--- a/docs/ref/sandbox/snapshot_defaults.md
+++ b/docs/ref/sandbox/snapshot_defaults.md
@@ -1,0 +1,3 @@
+# `Snapshot Defaults`
+
+::: agents.sandbox.snapshot_defaults

--- a/docs/ref/sandbox/types.md
+++ b/docs/ref/sandbox/types.md
@@ -1,0 +1,3 @@
+# `Types`
+
+::: agents.sandbox.types

--- a/docs/ref/sandbox/util/checksums.md
+++ b/docs/ref/sandbox/util/checksums.md
@@ -1,0 +1,3 @@
+# `Checksums`
+
+::: agents.sandbox.util.checksums

--- a/docs/ref/sandbox/util/deep_merge.md
+++ b/docs/ref/sandbox/util/deep_merge.md
@@ -1,0 +1,3 @@
+# `Deep Merge`
+
+::: agents.sandbox.util.deep_merge

--- a/docs/ref/sandbox/util/github.md
+++ b/docs/ref/sandbox/util/github.md
@@ -1,0 +1,3 @@
+# `Github`
+
+::: agents.sandbox.util.github

--- a/docs/ref/sandbox/util/iterator_io.md
+++ b/docs/ref/sandbox/util/iterator_io.md
@@ -1,0 +1,3 @@
+# `Iterator Io`
+
+::: agents.sandbox.util.iterator_io

--- a/docs/ref/sandbox/util/parse_utils.md
+++ b/docs/ref/sandbox/util/parse_utils.md
@@ -1,0 +1,3 @@
+# `Parse Utils`
+
+::: agents.sandbox.util.parse_utils

--- a/docs/ref/sandbox/util/retry.md
+++ b/docs/ref/sandbox/util/retry.md
@@ -1,0 +1,3 @@
+# `Retry`
+
+::: agents.sandbox.util.retry

--- a/docs/ref/sandbox/util/tar_utils.md
+++ b/docs/ref/sandbox/util/tar_utils.md
@@ -1,0 +1,3 @@
+# `Tar Utils`
+
+::: agents.sandbox.util.tar_utils

--- a/docs/ref/sandbox/util/token_truncation.md
+++ b/docs/ref/sandbox/util/token_truncation.md
@@ -1,0 +1,3 @@
+# `Token Truncation`
+
+::: agents.sandbox.util.token_truncation

--- a/docs/ref/sandbox/workspace_paths.md
+++ b/docs/ref/sandbox/workspace_paths.md
@@ -1,0 +1,3 @@
+# `Workspace Paths`
+
+::: agents.sandbox.workspace_paths

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -202,7 +202,11 @@ plugins:
             - config.md
             - ドキュメント:
                 - agents.md
-                - sandbox_agents.md
+                - Sandbox エージェント:
+                    - クイックスタート: sandbox_agents.md
+                    - 概念: sandbox/guide.md
+                    - Sandbox クライアント: sandbox/clients.md
+                    - エージェントメモリ: sandbox/memory.md
                 - モデル: models/index.md
                 - tools.md
                 - guardrails.md
@@ -241,7 +245,11 @@ plugins:
             - config.md
             - 문서:
                 - agents.md
-                - sandbox_agents.md
+                - Sandbox 에이전트:
+                    - 빠른 시작: sandbox_agents.md
+                    - 개념: sandbox/guide.md
+                    - 샌드박스 클라이언트: sandbox/clients.md
+                    - 에이전트 메모리: sandbox/memory.md
                 - 모델: models/index.md
                 - tools.md
                 - guardrails.md
@@ -280,7 +288,11 @@ plugins:
             - config.md
             - 文档:
                 - agents.md
-                - sandbox_agents.md
+                - 沙盒智能体:
+                    - 快速入门: sandbox_agents.md
+                    - 概念: sandbox/guide.md
+                    - 沙箱客户端: sandbox/clients.md
+                    - 智能体记忆: sandbox/memory.md
                 - 模型: models/index.md
                 - tools.md
                 - guardrails.md


### PR DESCRIPTION
This pull request updates the translated Sandbox agents documentation so the Japanese, Korean, and Simplified Chinese nav trees match the English structure for Quickstart, Concepts, Sandbox clients, and Agent memory. It also refreshes the generated reference stub pages that are currently staged from the docs build.

- updates `mkdocs.yml` to replace the single translated `sandbox_agents.md` entry with a nested four-page Sandbox section in `ja`, `ko`, and `zh`
- adds the currently generated reference stub pages under `docs/ref/sandbox/**`, `docs/ref/extensions/sandbox/**`, `docs/ref/run_internal/**`, and `docs/ref/models/**`
- keeps the change limited to documentation navigation and generated reference-site content; there is no runtime or public API behavior change