### PR TITLE
ci: add sandbox auto-label mapping

### DIFF
--- a/.github/codex/prompts/pr-labels.md
+++ b/.github/codex/prompts/pr-labels.md
@@ -25,6 +25,7 @@ Allowed labels:
 - feature:extensions
 - feature:mcp
 - feature:realtime
+- feature:sandboxes
 - feature:sessions
 - feature:tracing
 - feature:voice
@@ -46,9 +47,10 @@ Label rules:
 - bug vs enhancement: Prefer exactly one of these. Include both only when the PR clearly contains two separate substantial changes and both are first-order outcomes.
 - feature:chat-completions: Chat Completions support or conversion is a primary deliverable of the PR. Do not add it for a small compatibility guard or parity update in `chatcmpl_converter.py`.
 - feature:core: Core agent loop, tool calls, run pipeline, or other central runtime behavior is a primary surface of the PR. For cross-cutting runtime changes, this is usually the single best feature label.
-- feature:extensions: `src/agents/extensions/` surfaces are a primary deliverable of the PR, including extension models/providers such as Any-LLM and LiteLLM.
+- feature:extensions: `src/agents/extensions/` surfaces are a primary deliverable of the PR, including extension models/providers such as Any-LLM and LiteLLM. Changes under `src/agents/extensions/sandbox/` can warrant this label alongside `feature:sandboxes`.
 - feature:mcp: MCP-specific behavior or APIs are a primary deliverable of the PR. Do not add it for incidental hosted/deferred tool plumbing touched by broader runtime work.
 - feature:realtime: Realtime-specific behavior, API shape, or session semantics are a primary deliverable of the PR. Do not add it for small parity updates in realtime adapters.
+- feature:sandboxes: Sandbox runtime or sandbox extension behavior is a primary deliverable of the PR, including changes under `src/agents/sandbox/` and `src/agents/extensions/sandbox/`. Prefer this over `feature:core` for sandbox-focused work; for `src/agents/extensions/sandbox/`, `feature:extensions` may also be appropriate.
 - feature:sessions: Session or memory behavior is a primary deliverable of the PR. Do not add it for persistence updates that merely support a broader feature.
 - feature:tracing: Tracing is a primary deliverable of the PR. Do not add it for trace naming or metadata changes that accompany another feature.
 - feature:voice: Voice pipeline behavior is a primary deliverable of the PR.

--- a/.github/codex/schemas/pr-labels.json
+++ b/.github/codex/schemas/pr-labels.json
@@ -18,6 +18,7 @@
           "feature:extensions",
           "feature:mcp",
           "feature:realtime",
+          "feature:sandboxes",
           "feature:sessions",
           "feature:tracing",
           "feature:voice"

--- a/.github/scripts/pr_labels.py
+++ b/.github/scripts/pr_labels.py
@@ -22,6 +22,7 @@ ALLOWED_LABELS: Final[set[str]] = {
     "feature:extensions",
     "feature:mcp",
     "feature:realtime",
+    "feature:sandboxes",
     "feature:sessions",
     "feature:tracing",
     "feature:voice",
@@ -41,8 +42,8 @@ MODEL_ONLY_LABELS: Final[set[str]] = {
 FEATURE_LABELS: Final[set[str]] = ALLOWED_LABELS - DETERMINISTIC_LABELS - MODEL_ONLY_LABELS
 
 SOURCE_FEATURE_PREFIXES: Final[dict[str, tuple[str, ...]]] = {
-    "feature:extensions": ("src/agents/extensions/",),
     "feature:realtime": ("src/agents/realtime/",),
+    "feature:sandboxes": ("src/agents/sandbox/", "src/agents/extensions/sandbox/"),
     "feature:voice": ("src/agents/voice/",),
     "feature:mcp": ("src/agents/mcp/",),
     "feature:tracing": ("src/agents/tracing/",),
@@ -186,6 +187,9 @@ def infer_specific_feature_labels(changed_files: Sequence[str]) -> set[str]:
         if any(path.startswith(prefix) for path in source_files for prefix in prefixes):
             labels.add(label)
 
+    if any(path.startswith("src/agents/extensions/") for path in source_files):
+        labels.add("feature:extensions")
+
     if any(
         path.startswith(("src/agents/models/", "src/agents/extensions/models/"))
         and ("chatcmpl" in path or "chatcompletions" in path)
@@ -327,6 +331,9 @@ def compute_desired_labels(
         desired.update(title_intent_labels)
     elif codex_ran and codex_output_valid:
         desired.update(codex_model_only_labels)
+
+    if any(path.startswith("src/agents/extensions/sandbox/") for path in changed_files):
+        desired.update({"feature:extensions", "feature:sandboxes"})
 
     return desired
 

--- a/tests/test_pr_labels.py
+++ b/tests/test_pr_labels.py
@@ -60,6 +60,18 @@ def test_infer_fallback_labels_marks_extensions_for_any_llm_changes() -> None:
     assert labels == {"feature:extensions"}
 
 
+def test_infer_fallback_labels_marks_sandboxes_for_core_sandbox_changes() -> None:
+    labels = pr_labels.infer_fallback_labels(["src/agents/sandbox/runtime.py"])
+
+    assert labels == {"feature:sandboxes"}
+
+
+def test_infer_fallback_labels_marks_sandboxes_for_extension_sandbox_changes() -> None:
+    labels = pr_labels.infer_fallback_labels(["src/agents/extensions/sandbox/e2b/sandbox.py"])
+
+    assert labels == {"feature:extensions", "feature:sandboxes"}
+
+
 def test_compute_desired_labels_removes_stale_fallback_labels() -> None:
     desired = pr_labels.compute_desired_labels(
         pr_context=pr_labels.PRContext(),
@@ -136,6 +148,41 @@ def test_compute_desired_labels_infers_extensions_for_extensions_memory_fix() ->
     )
 
     assert desired == {"bug", "feature:extensions"}
+
+
+def test_compute_desired_labels_infers_sandboxes_for_sandbox_fix() -> None:
+    desired = pr_labels.compute_desired_labels(
+        pr_context=pr_labels.PRContext(title="fix: restore sandbox cleanup behavior"),
+        changed_files=[
+            "src/agents/extensions/sandbox/e2b/sandbox.py",
+            "tests/extensions/sandbox/test_e2b_sandbox.py",
+        ],
+        diff_text="",
+        codex_ran=True,
+        codex_output_valid=True,
+        codex_labels=[],
+        base_sha=None,
+        head_sha=None,
+    )
+
+    assert desired == {"bug", "feature:extensions", "feature:sandboxes"}
+
+
+def test_compute_desired_labels_adds_extensions_for_extension_sandbox_when_codex_is_partial() -> (
+    None
+):
+    desired = pr_labels.compute_desired_labels(
+        pr_context=pr_labels.PRContext(),
+        changed_files=["src/agents/extensions/sandbox/e2b/sandbox.py"],
+        diff_text="",
+        codex_ran=True,
+        codex_output_valid=True,
+        codex_labels=["feature:sandboxes"],
+        base_sha=None,
+        head_sha=None,
+    )
+
+    assert desired == {"feature:extensions", "feature:sandboxes"}
 
 
 def test_compute_managed_labels_preserves_model_only_labels_without_signal() -> None:


### PR DESCRIPTION
This pull request adds a dedicated feature:sandboxes label to the PR auto-labeling flow so sandbox-focused changes are classified explicitly instead of falling back to broader feature labels.

It updates .github/scripts/pr_labels.py to recognize changes under src/agents/sandbox/ and src/agents/extensions/sandbox/, keeps non-sandbox extension changes on feature:extensions, and adds targeted coverage in tests/test_pr_labels.py for both fallback inference and desired-label computation. It also updates the Codex labeling prompt and schema under .github/codex/ so CI can emit the new label consistently.

There is no backward-compatibility risk for the SDK runtime here; the behavior change is limited to repository PR labeling automation.