### PR TITLE
sanitize OpenAI tracing export payloads

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -39,6 +39,7 @@ class BackendSpanExporter(TracingExporter):
             "output_tokens",
         }
     )
+    _OPENAI_TRACING_USAGE_SPAN_TYPES = frozenset({"generation"})
     _UNSERIALIZABLE = object()
 
     def __init__(
@@ -203,7 +204,12 @@ class BackendSpanExporter(TracingExporter):
                 did_mutate = True
             sanitized_span_data[field_name] = sanitized_field
 
-        if span_data.get("type") != "generation":
+        if span_data.get("type") not in self._OPENAI_TRACING_USAGE_SPAN_TYPES:
+            if "usage" in span_data:
+                if not did_mutate:
+                    sanitized_span_data = dict(span_data)
+                    did_mutate = True
+                sanitized_span_data.pop("usage", None)
             if not did_mutate:
                 return payload_item
             sanitized_payload_item = dict(payload_item)

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -572,7 +572,7 @@ def test_backend_span_exporter_keeps_generation_usage_for_custom_endpoint(mock_c
 
 
 @patch("httpx.Client")
-def test_backend_span_exporter_does_not_modify_non_generation_usage(mock_client):
+def test_backend_span_exporter_drops_non_generation_usage_for_openai_endpoint(mock_client):
     class DummyItem:
         tracing_api_key = None
 
@@ -590,6 +590,35 @@ def test_backend_span_exporter_does_not_modify_non_generation_usage(mock_client)
     mock_client.return_value.post.return_value = mock_response
 
     exporter = BackendSpanExporter(api_key="test_key")
+    exporter.export([cast(Any, DummyItem())])
+
+    sent_payload = mock_client.return_value.post.call_args.kwargs["json"]["data"][0]
+    assert "usage" not in sent_payload["span_data"]
+    exporter.close()
+
+
+@patch("httpx.Client")
+def test_backend_span_exporter_keeps_non_generation_usage_for_custom_endpoint(mock_client):
+    class DummyItem:
+        tracing_api_key = None
+
+        def export(self):
+            return {
+                "object": "trace.span",
+                "span_data": {
+                    "type": "function",
+                    "usage": {"requests": 1},
+                },
+            }
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_client.return_value.post.return_value = mock_response
+
+    exporter = BackendSpanExporter(
+        api_key="test_key",
+        endpoint="https://example.com/v1/traces/ingest",
+    )
     exporter.export([cast(Any, DummyItem())])
 
     sent_payload = mock_client.return_value.post.call_args.kwargs["json"]["data"][0]


### PR DESCRIPTION
### Summary

Updates the OpenAI tracing exporter to align usage metadata with the trace ingest payload shape.

For the default OpenAI tracing endpoint, usage metadata is now only included on generation spans, where it is normalized to the supported token-count shape. Other tracing endpoints continue to receive the raw SDK payload.

Adds regression coverage for OpenAI endpoint sanitization and custom endpoint behavior.

### Test plan

- `make format`
- `make lint`
- `make sync && make typecheck`
- `uv run pytest tests/test_openai_responses.py::test_get_response_span_exports_usage tests/test_trace_processor.py` (46 passed)
- Manual tracing repro: `Runner.run(...)` completed, `flush_traces()` completed, and no tracing client errors were emitted.
- `make tests` reached 3858 passed, 10 failed locally in sandbox tests because `sandbox-exec` returned `sandbox_apply: Operation not permitted`.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [ ] I've made sure tests pass
