### PR TITLE
fix: synthesize assistant message for session when tool_use_behavior produces final output

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1119,30 +1119,36 @@ class AgentRunner:
                                 item for item in items_to_save_turn if item.type != "tool_call_item"
                             ]
                         if session_persistence_enabled:
-                            output_call_ids = {
-                                item.raw_item.get("call_id")
-                                if isinstance(item.raw_item, dict)
-                                else getattr(item.raw_item, "call_id", None)
-                                for item in turn_result.new_step_items
-                                if item.type == "tool_call_output_item"
-                            }
-                            for item in generated_items:
-                                if item.type != "tool_call_item":
-                                    continue
-                                call_id = (
+                            # When session_step_items is explicitly set, the turn
+                            # resolution has already decided what should be persisted
+                            # (e.g. a synthesized assistant message instead of raw
+                            # tool call items).  Skip the tool-call back-fill so we
+                            # don't re-add the items that were intentionally excluded.
+                            if turn_result.session_step_items is None:
+                                output_call_ids = {
                                     item.raw_item.get("call_id")
                                     if isinstance(item.raw_item, dict)
                                     else getattr(item.raw_item, "call_id", None)
-                                )
-                                if (
-                                    call_id in output_call_ids
-                                    and item not in items_to_save_turn
-                                    and not (
-                                        run_state
-                                        and run_state._current_turn_persisted_item_count > 0
+                                    for item in turn_result.new_step_items
+                                    if item.type == "tool_call_output_item"
+                                }
+                                for item in generated_items:
+                                    if item.type != "tool_call_item":
+                                        continue
+                                    call_id = (
+                                        item.raw_item.get("call_id")
+                                        if isinstance(item.raw_item, dict)
+                                        else getattr(item.raw_item, "call_id", None)
                                     )
-                                ):
-                                    items_to_save_turn.append(item)
+                                    if (
+                                        call_id in output_call_ids
+                                        and item not in items_to_save_turn
+                                        and not (
+                                            run_state
+                                            and run_state._current_turn_persisted_item_count > 0
+                                        )
+                                    ):
+                                        items_to_save_turn.append(item)
                             if items_to_save_turn:
                                 logger.debug(
                                     "Persisting turn items (types=%s)",

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -14,6 +14,7 @@ from openai.types.responses import (
     ResponseFunctionToolCall,
     ResponseFunctionWebSearch,
     ResponseOutputMessage,
+    ResponseOutputText,
 )
 from openai.types.responses.response_code_interpreter_tool_call import (
     ResponseCodeInterpreterToolCall,
@@ -90,6 +91,7 @@ from .items import (
     function_rejection_item,
     shell_rejection_item,
 )
+from ..models.fake_id import FAKE_RESPONSES_ID
 from .run_steps import (
     NOT_FINAL_OUTPUT,
     NextStepFinalOutput,
@@ -181,7 +183,7 @@ async def _maybe_finalize_from_tool_results(
             "you know what you're doing."
         )
 
-    return await execute_final_output(
+    result = await execute_final_output(
         agent=agent,
         original_input=original_input,
         new_response=new_response,
@@ -193,6 +195,34 @@ async def _maybe_finalize_from_tool_results(
         tool_input_guardrail_results=tool_input_guardrail_results,
         tool_output_guardrail_results=tool_output_guardrail_results,
     )
+
+    # When a tool output becomes the final answer (via tool_use_behavior like
+    # stop_on_first_tool), save an assistant message to the session instead of the
+    # raw function_call + function_call_output items.  This prevents subsequent
+    # calls from seeing the previous tool invocation in history, which can cause
+    # the model to skip calling the tool again.
+    if check_tool_use.final_output is not None:
+        output_text = str(check_tool_use.final_output)
+        synthesized_message = MessageOutputItem(
+            agent=agent,
+            raw_item=ResponseOutputMessage(
+                id=FAKE_RESPONSES_ID,
+                type="message",
+                role="assistant",
+                content=[
+                    ResponseOutputText(
+                        text=output_text,
+                        type="output_text",
+                        annotations=[],
+                        logprobs=[],
+                    )
+                ],
+                status="completed",
+            ),
+        )
+        result.session_step_items = [synthesized_message]
+
+    return result
 
 
 async def run_final_output_hooks(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -741,3 +741,79 @@ async def test_runner_with_session_settings_override():
         assert len(history_items) == 2
 
         session.close()
+
+
+@pytest.mark.asyncio
+async def test_session_stop_on_first_tool_saves_assistant_message():
+    """When tool_use_behavior='stop_on_first_tool', the session should store an assistant
+    message instead of raw function_call + function_call_output items.  This prevents the
+    model from seeing previous tool calls in history and skipping the tool on subsequent
+    calls.
+
+    Regression test for https://github.com/openai/openai-agents-python/issues/1465
+    """
+    from .test_responses import get_function_tool, get_function_tool_call
+
+    model = FakeModel()
+    tool = get_function_tool("get_pm", return_value="PM is Justin Trudeau")
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[tool],
+        tool_use_behavior="stop_on_first_tool",
+    )
+
+    session = SQLiteSession("stop_on_first_tool_test")
+
+    # First call: model returns a function call
+    model.set_next_output([get_function_tool_call("get_pm", '{"name": "Canada"}')])
+    result1 = await Runner.run(
+        agent,
+        "Who is the PM of Canada?",
+        session=session,
+    )
+    assert result1.final_output == "PM is Justin Trudeau"
+
+    # Inspect session history: should contain user message + assistant text message,
+    # NOT raw function_call / function_call_output items.
+    history = await session.get_items()
+    types_in_history = [item.get("type") for item in history if isinstance(item, dict)]
+    roles_in_history = [item.get("role") for item in history if isinstance(item, dict)]
+
+    # There should be no function_call or function_call_output items in the session
+    assert "function_call" not in types_in_history, (
+        "Session should not contain raw function_call items when tool_use_behavior "
+        "produces a final output"
+    )
+    assert "function_call_output" not in types_in_history, (
+        "Session should not contain raw function_call_output items when tool_use_behavior "
+        "produces a final output"
+    )
+    # Should have an assistant message with the tool output
+    assert "assistant" in roles_in_history, (
+        "Session should contain a synthesized assistant message with the tool output"
+    )
+
+    # Second call: the model should NOT see the previous tool call in history.
+    # It should receive the user message history and assistant text, not function_call items.
+    model.set_next_output([get_function_tool_call("get_pm", '{"name": "Canada"}')])
+    result2 = await Runner.run(
+        agent,
+        "Who is the PM of Canada?",
+        session=session,
+    )
+    assert result2.final_output == "PM is Justin Trudeau"
+
+    # Verify the model input on the second call does not contain function_call items
+    second_call_input = model.last_turn_args["input"]
+    input_types = [
+        item.get("type") for item in second_call_input if isinstance(item, dict)
+    ]
+    assert "function_call" not in input_types, (
+        "Model input should not contain function_call items from session history"
+    )
+    assert "function_call_output" not in input_types, (
+        "Model input should not contain function_call_output items from session history"
+    )
+
+    session.close()


### PR DESCRIPTION
## Problem

When using `tool_use_behavior="stop_on_first_tool"` with a `SQLiteSession`, the agent exhibits an alternating pattern where a tool fires on one call, gets **skipped** on the next, fires again, and so on. This makes persistent-session agents with tool-stopping behavior unreliable for production use.

### Root Cause

When `tool_use_behavior` turns a tool's output into the final answer, the session was saving raw `function_call` + `function_call_output` items to history. On the next run, `prepare_input_with_session` loads them back into the model's context — the model sees the previous tool invocation already completed and short-circuits, skipping the tool call entirely.

## Solution

Two targeted changes that keep the session history clean:

### 1. Synthesize an assistant message for session storage (`turn_resolution.py`)

When a tool output becomes the final answer via `tool_use_behavior`, we now store a clean `MessageOutputItem` (assistant text message containing the tool's output) instead of the raw `function_call` + `function_call_output` items. This means subsequent runs see a normal assistant reply in history, not a completed tool invocation.

```python
# Before: session stores raw tool call artifacts
# [function_call, function_call_output]  ← model skips tool on next run

# After: session stores a clean assistant message
# [message(role=assistant, text="PM is Justin Trudeau")]  ← model behaves normally
```

### 2. Guard tool-call back-fill logic (`run.py`)

The existing back-fill logic (which finds `function_call` items matching `function_call_output` items and adds them to session storage) needed a guard to skip when `session_step_items` is explicitly set. Without this, the back-fill would re-add raw `function_call` items even though we'd already overridden them with the synthesized message.

## Testing

Added a regression test (`test_session_stop_on_first_tool_saves_assistant_message`) that:

1. Creates an agent with `stop_on_first_tool` + `SQLiteSession`
2. Runs the agent — verifies session contains an **assistant message** (not `function_call` items)
3. Runs again — verifies the model input on the second call **does not** contain stale tool call history
4. Confirms the tool fires correctly on both consecutive calls

## Files Changed

| File | Change |
|------|--------|
| `src/agents/run_internal/turn_resolution.py` | Synthesize `MessageOutputItem` for session when tool output is final answer |
| `src/agents/run.py` | Guard tool-call back-fill to respect explicit `session_step_items` |
| `tests/test_session.py` | Regression test for consecutive tool invocations with persistent session |

Fixes #1465
