### PR TITLE
docs: clarify OpenAI provider configuration guidance

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,13 @@ custom_client = AsyncOpenAI(base_url="...", api_key="...")
 set_default_openai_client(custom_client)
 ```
 
+If you prefer environment-based endpoint configuration, the default OpenAI provider also reads `OPENAI_BASE_URL`. When you enable Responses websocket transport, it also reads `OPENAI_WEBSOCKET_BASE_URL` for the websocket `/responses` endpoint.
+
+```bash
+export OPENAI_BASE_URL="https://your-openai-compatible-endpoint.example/v1"
+export OPENAI_WEBSOCKET_BASE_URL="wss://your-openai-compatible-endpoint.example/v1"
+```
+
 Finally, you can also customize the OpenAI API that is used. By default, we use the OpenAI Responses API. You can override this to use the Chat Completions API by using the [set_default_openai_api()][agents.set_default_openai_api] function.
 
 ```python
@@ -48,6 +55,21 @@ Tracing is enabled by default. By default it uses the same OpenAI API key as you
 from agents import set_tracing_export_api_key
 
 set_tracing_export_api_key("sk-...")
+```
+
+If your model traffic uses one key or client but tracing should use a different OpenAI key, pass `use_for_tracing=False` when setting the default key or client, then configure tracing separately. The same pattern works with [`set_default_openai_key()`][agents.set_default_openai_key] if you are not using a custom client.
+
+```python
+from openai import AsyncOpenAI
+from agents import (
+    set_default_openai_client,
+    set_tracing_export_api_key,
+)
+
+custom_client = AsyncOpenAI(base_url="https://your-openai-compatible-endpoint.example/v1", api_key="provider-key")
+set_default_openai_client(custom_client, use_for_tracing=False)
+
+set_tracing_export_api_key("sk-tracing")
 ```
 
 If you need to attribute traces to a specific organization or project when using the default exporter, set these environment variables before your app starts:

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -133,6 +133,30 @@ result = await Runner.run(
 )
 ```
 
+OpenAI-backed providers also accept optional agent registration config. This is an advanced option for cases where your OpenAI setup expects provider-level registration metadata such as a harness ID.
+
+```python
+from agents import (
+    Agent,
+    OpenAIAgentRegistrationConfig,
+    OpenAIProvider,
+    RunConfig,
+    Runner,
+)
+
+provider = OpenAIProvider(
+    use_responses_websocket=True,
+    agent_registration=OpenAIAgentRegistrationConfig(harness_id="your-harness-id"),
+)
+
+agent = Agent(name="Assistant")
+result = await Runner.run(
+    agent,
+    "Hello",
+    run_config=RunConfig(model_provider=provider),
+)
+```
+
 #### Advanced routing with `MultiProvider`
 
 If you need prefix-based model routing (for example mixing `openai/...` and `any-llm/...` model names in one run), use [`MultiProvider`][agents.MultiProvider] and set `openai_use_responses_websocket=True` there instead.
@@ -169,6 +193,8 @@ result = await Runner.run(
 ```
 
 Use `openai_prefix_mode="model_id"` when a backend expects the literal `openai/...` string. Use `unknown_prefix_mode="model_id"` when the backend expects other namespaced model IDs such as `openrouter/openai/gpt-4.1-mini`. These options also work on `MultiProvider` outside websocket transport; this example keeps websocket enabled because it is part of the transport setup described in this section. The same options are also available on [`responses_websocket_session()`][agents.responses_websocket_session].
+
+If you need the same provider-level registration metadata while routing through `MultiProvider`, pass `openai_agent_registration=OpenAIAgentRegistrationConfig(...)` and it will be forwarded to the underlying OpenAI provider.
 
 If you use a custom OpenAI-compatible endpoint or proxy, websocket transport also requires a compatible websocket `/responses` endpoint. In those setups you may need to set `websocket_base_url` explicitly.
 

--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -163,7 +163,7 @@ Use `tool_error_formatter` to customize the message that is returned to the mode
 The formatter receives [`ToolErrorFormatterArgs`][agents.run_config.ToolErrorFormatterArgs] with:
 
 -   `kind`: The error category. Today this is `"approval_rejected"`.
--   `tool_type`: The tool runtime (`"function"`, `"computer"`, `"shell"`, or `"apply_patch"`).
+-   `tool_type`: The tool runtime (`"function"`, `"computer"`, `"shell"`, `"apply_patch"`, or `"custom"`).
 -   `tool_name`: The tool name.
 -   `call_id`: The tool call ID.
 -   `default_message`: The SDK's default model-visible message.


### PR DESCRIPTION
This pull request updates the OpenAI model and runtime documentation to better explain configuration paths that already exist in the SDK but were hard to discover from the English docs.

It clarifies:
- the default OpenAI provider's environment-based endpoint configuration in `docs/config.md`
- how to separate model credentials from tracing credentials with `use_for_tracing=False` in `docs/config.md`
- how to pass provider-level agent registration metadata through `OpenAIProvider(...)` and `MultiProvider(...)` in `docs/models/index.md`
- the current `tool_error_formatter` `tool_type` values, including `"custom"`, in `docs/running_agents.md`

These changes are documentation-only, but they improve guidance around public configuration surfaces and reduce confusion when wiring OpenAI-compatible endpoints, tracing, and provider constructor options.