### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ docker = ["docker>=6.1"]
 blaxel = ["blaxel>=0.2.50", "aiohttp>=3.12,<4"]
 daytona = ["daytona>=0.155.0"]
 cloudflare = ["aiohttp>=3.12,<4"]
+exa = ["exa-py>=2.0.0"]
 e2b = ["e2b==2.20.0", "e2b-code-interpreter==2.4.1"]
 modal = ["modal==1.3.5"]
 runloop = ["runloop_api_client>=1.16.0,<2.0.0"]
@@ -140,6 +141,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["modal", "modal.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["exa_py", "exa_py.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/agents/extensions/__init__.py
+++ b/src/agents/extensions/__init__.py
@@ -1,3 +1,12 @@
 from .tool_output_trimmer import ToolOutputTrimmer
 
 __all__ = ["ToolOutputTrimmer"]
+
+
+def __getattr__(name: str) -> object:
+    """Lazy-load optional extension symbols to avoid import errors for missing extras."""
+    if name == "exa_search_tool":
+        from .exa_search import exa_search_tool
+
+        return exa_search_tool
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/agents/extensions/exa_search.py
+++ b/src/agents/extensions/exa_search.py
@@ -205,9 +205,8 @@ def exa_search_tool(
             end_published_date: Filter results published before this date (ISO 8601).
         """
         kwargs: dict[str, Any] = {
-            "query": query,
             "num_results": num_results or default_num_results,
-            **contents_kwargs,
+            "contents": contents_kwargs if contents_kwargs else False,
         }
 
         if search_type:
@@ -227,7 +226,7 @@ def exa_search_tool(
         if end_published_date:
             kwargs["end_published_date"] = end_published_date
 
-        response = client.search_and_contents(**kwargs)
+        response = client.search(query, **kwargs)
         parsed = _parse_results(response)
         return _format_results(parsed)
 

--- a/src/agents/extensions/exa_search.py
+++ b/src/agents/extensions/exa_search.py
@@ -1,0 +1,234 @@
+"""Exa AI-powered search tool for OpenAI Agents.
+
+Wraps the `Exa <https://exa.ai>`_ search API as a :class:`~agents.tool.FunctionTool`
+so agents can perform neural web searches with content retrieval.
+
+Usage::
+
+    from agents import Agent
+    from agents.extensions.exa_search import exa_search_tool
+
+    agent = Agent(
+        name="Research Agent",
+        instructions="Use the Exa search tool to find information.",
+        tools=[exa_search_tool()],
+    )
+
+Requires the ``exa`` optional dependency group::
+
+    pip install "openai-agents[exa]"
+
+The tool reads ``EXA_API_KEY`` from the environment by default.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    from exa_py import Exa
+except ImportError:
+    Exa = None  # type: ignore[assignment,misc]
+
+
+@dataclass
+class ExaSearchResult:
+    """A single search result returned by the Exa API."""
+
+    title: str
+    url: str
+    published_date: str | None = None
+    author: str | None = None
+    score: float | None = None
+    text: str | None = None
+    highlights: list[str] | None = None
+    summary: str | None = None
+
+
+@dataclass
+class ExaSearchResponse:
+    """Parsed response from the Exa search API."""
+
+    results: list[ExaSearchResult] = field(default_factory=list)
+    search_type: str | None = None
+
+
+def _parse_results(response: Any) -> ExaSearchResponse:
+    """Parse an Exa SDK response into typed dataclasses."""
+    results: list[ExaSearchResult] = []
+    for item in getattr(response, "results", []):
+        results.append(
+            ExaSearchResult(
+                title=getattr(item, "title", "") or "",
+                url=getattr(item, "url", "") or "",
+                published_date=getattr(item, "published_date", None),
+                author=getattr(item, "author", None),
+                score=getattr(item, "score", None),
+                text=getattr(item, "text", None),
+                highlights=getattr(item, "highlights", None),
+                summary=getattr(item, "summary", None),
+            )
+        )
+    return ExaSearchResponse(
+        results=results,
+        search_type=getattr(response, "search_type", None),
+    )
+
+
+def _format_results(parsed: ExaSearchResponse) -> str:
+    """Format parsed results into a readable string for the LLM."""
+    if not parsed.results:
+        return "No results found."
+
+    parts: list[str] = []
+    for i, result in enumerate(parsed.results, 1):
+        lines = [f"{i}. {result.title}", f"   URL: {result.url}"]
+        if result.published_date:
+            lines.append(f"   Published: {result.published_date}")
+        if result.author:
+            lines.append(f"   Author: {result.author}")
+
+        snippet = _extract_snippet(result)
+        if snippet:
+            lines.append(f"   {snippet}")
+
+        parts.append("\n".join(lines))
+
+    return "\n\n".join(parts)
+
+
+def _extract_snippet(result: ExaSearchResult) -> str:
+    """Build a content snippet, cascading through available content fields."""
+    if result.highlights:
+        return " ... ".join(result.highlights)
+    if result.summary:
+        return result.summary
+    if result.text:
+        text = result.text.strip()
+        if len(text) > 500:
+            return text[:500] + "..."
+        return text
+    return ""
+
+
+def exa_search_tool(
+    *,
+    api_key: str | None = None,
+    num_results: int = 5,
+    text_max_characters: int = 1000,
+    highlights: bool = True,
+    summary: bool = False,
+) -> Any:
+    """Create an Exa search :class:`~agents.tool.FunctionTool`.
+
+    Args:
+        api_key: Exa API key. Falls back to the ``EXA_API_KEY`` environment variable.
+        num_results: Default number of results to return per search.
+        text_max_characters: Maximum characters of page text to retrieve per result.
+        highlights: Whether to request highlight excerpts from results.
+        summary: Whether to request a page summary for each result.
+
+    Returns:
+        A :class:`~agents.tool.FunctionTool` ready to be added to an agent's tool list.
+
+    Raises:
+        ImportError: If ``exa-py`` is not installed.
+        ValueError: If no API key is provided and ``EXA_API_KEY`` is not set.
+    """
+    if Exa is None:
+        raise ImportError(
+            "exa-py is required for the Exa search tool. "
+            "Install it with: pip install 'openai-agents[exa]'"
+        )
+
+    resolved_key = api_key or os.environ.get("EXA_API_KEY", "")
+    if not resolved_key:
+        raise ValueError(
+            "An Exa API key is required. Pass api_key= or set the EXA_API_KEY environment variable."
+        )
+
+    client = Exa(resolved_key)
+    client.headers["x-exa-integration"] = "openai-agents-python"
+
+    # Build the default contents configuration.
+    contents_kwargs: dict[str, Any] = {}
+    if text_max_characters:
+        contents_kwargs["text"] = {"max_characters": text_max_characters}
+    if highlights:
+        contents_kwargs["highlights"] = True
+    if summary:
+        contents_kwargs["summary"] = True
+
+    default_num_results = num_results
+
+    # Import here to avoid circular imports at module level.
+    from ..tool import function_tool as _function_tool
+
+    @_function_tool(
+        name_override="exa_search",
+        description_override=(
+            "Search the web using Exa, an AI-powered search engine. "
+            "Returns relevant web pages with titles, URLs, and content snippets. "
+            "Supports neural search, domain filtering, date filtering, and category filtering."
+        ),
+    )
+    def exa_search(
+        query: str,
+        num_results: int | None = None,
+        search_type: str | None = None,
+        category: str | None = None,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        include_text: list[str] | None = None,
+        exclude_text: list[str] | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+    ) -> str:
+        """Search the web using Exa.
+
+        Args:
+            query: The search query.
+            num_results: Number of results to return (1-100).
+            search_type: Search method: 'auto', 'neural', or 'fast'.
+            category: Focus area: 'company', 'research paper', 'news', 'personal site',
+                'financial report', or 'people'.
+            include_domains: Only include results from these domains.
+            exclude_domains: Exclude results from these domains.
+            include_text: Only include results containing these strings.
+            exclude_text: Exclude results containing these strings.
+            start_published_date: Filter results published after this date (ISO 8601).
+            end_published_date: Filter results published before this date (ISO 8601).
+        """
+        kwargs: dict[str, Any] = {
+            "query": query,
+            "num_results": num_results or default_num_results,
+            **contents_kwargs,
+        }
+
+        if search_type:
+            kwargs["type"] = search_type
+        if category:
+            kwargs["category"] = category
+        if include_domains:
+            kwargs["include_domains"] = include_domains
+        if exclude_domains:
+            kwargs["exclude_domains"] = exclude_domains
+        if include_text:
+            kwargs["include_text"] = include_text
+        if exclude_text:
+            kwargs["exclude_text"] = exclude_text
+        if start_published_date:
+            kwargs["start_published_date"] = start_published_date
+        if end_published_date:
+            kwargs["end_published_date"] = end_published_date
+
+        response = client.search_and_contents(**kwargs)
+        parsed = _parse_results(response)
+        return _format_results(parsed)
+
+    return exa_search

--- a/tests/extensions/test_exa_search.py
+++ b/tests/extensions/test_exa_search.py
@@ -1,0 +1,264 @@
+"""Tests for the Exa search tool extension."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.extensions.exa_search import (
+    ExaSearchResponse,
+    ExaSearchResult,
+    _extract_snippet,
+    _format_results,
+    _parse_results,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: mock Exa SDK response objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MockResult:
+    title: str = "Example Page"
+    url: str = "https://example.com"
+    published_date: str | None = "2024-01-15"
+    author: str | None = "Author Name"
+    score: float | None = 0.95
+    text: str | None = "Full page text content here."
+    highlights: list[str] | None = None
+    summary: str | None = None
+
+
+@dataclass
+class _MockResponse:
+    results: list[_MockResult]
+    search_type: str | None = "neural"
+
+
+def _mock_exa_client() -> tuple[MagicMock, MagicMock]:
+    """Return (mock_exa_class, mock_client_instance) with headers dict."""
+    mock_cls = MagicMock()
+    mock_client = MagicMock()
+    mock_client.headers = {}
+    mock_cls.return_value = mock_client
+    return mock_cls, mock_client
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseResults:
+    def test_parses_full_response(self) -> None:
+        mock_resp = _MockResponse(
+            results=[
+                _MockResult(
+                    title="Result 1",
+                    url="https://example.com/1",
+                    highlights=["key point"],
+                    summary="A summary",
+                ),
+                _MockResult(title="Result 2", url="https://example.com/2"),
+            ],
+            search_type="neural",
+        )
+        parsed = _parse_results(mock_resp)
+        assert len(parsed.results) == 2
+        assert parsed.search_type == "neural"
+        assert parsed.results[0].title == "Result 1"
+        assert parsed.results[0].highlights == ["key point"]
+        assert parsed.results[0].summary == "A summary"
+        assert parsed.results[1].title == "Result 2"
+
+    def test_parses_empty_response(self) -> None:
+        mock_resp = _MockResponse(results=[])
+        parsed = _parse_results(mock_resp)
+        assert len(parsed.results) == 0
+        assert parsed.search_type == "neural"
+
+    def test_handles_missing_optional_fields(self) -> None:
+        mock_resp = _MockResponse(
+            results=[
+                _MockResult(
+                    title="Minimal",
+                    url="https://example.com",
+                    published_date=None,
+                    author=None,
+                    score=None,
+                    text=None,
+                    highlights=None,
+                    summary=None,
+                ),
+            ],
+        )
+        parsed = _parse_results(mock_resp)
+        result = parsed.results[0]
+        assert result.title == "Minimal"
+        assert result.published_date is None
+        assert result.author is None
+        assert result.text is None
+        assert result.highlights is None
+        assert result.summary is None
+
+
+# ---------------------------------------------------------------------------
+# Snippet extraction / content fallback
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSnippet:
+    def test_prefers_highlights(self) -> None:
+        result = ExaSearchResult(
+            title="T",
+            url="https://example.com",
+            highlights=["Point A", "Point B"],
+            summary="A summary",
+            text="Full text",
+        )
+        snippet = _extract_snippet(result)
+        assert "Point A" in snippet
+        assert "Point B" in snippet
+
+    def test_falls_back_to_summary(self) -> None:
+        result = ExaSearchResult(
+            title="T",
+            url="https://example.com",
+            highlights=None,
+            summary="A summary of the page",
+            text="Full text",
+        )
+        assert _extract_snippet(result) == "A summary of the page"
+
+    def test_falls_back_to_text(self) -> None:
+        result = ExaSearchResult(
+            title="T",
+            url="https://example.com",
+            highlights=None,
+            summary=None,
+            text="Some page text content",
+        )
+        assert _extract_snippet(result) == "Some page text content"
+
+    def test_truncates_long_text(self) -> None:
+        long_text = "x" * 1000
+        result = ExaSearchResult(
+            title="T",
+            url="https://example.com",
+            text=long_text,
+        )
+        snippet = _extract_snippet(result)
+        assert len(snippet) == 503  # 500 chars + "..."
+        assert snippet.endswith("...")
+
+    def test_returns_empty_when_no_content(self) -> None:
+        result = ExaSearchResult(title="T", url="https://example.com")
+        assert _extract_snippet(result) == ""
+
+    def test_empty_highlights_list_falls_through(self) -> None:
+        result = ExaSearchResult(
+            title="T",
+            url="https://example.com",
+            highlights=[],
+            summary="Fallback summary",
+        )
+        assert _extract_snippet(result) == "Fallback summary"
+
+
+# ---------------------------------------------------------------------------
+# Result formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatResults:
+    def test_formats_multiple_results(self) -> None:
+        parsed = ExaSearchResponse(
+            results=[
+                ExaSearchResult(
+                    title="First Result",
+                    url="https://example.com/1",
+                    published_date="2024-01-01",
+                    author="Alice",
+                    highlights=["Important finding"],
+                ),
+                ExaSearchResult(
+                    title="Second Result",
+                    url="https://example.com/2",
+                    text="Some text content",
+                ),
+            ],
+        )
+        formatted = _format_results(parsed)
+        assert "1. First Result" in formatted
+        assert "https://example.com/1" in formatted
+        assert "Published: 2024-01-01" in formatted
+        assert "Author: Alice" in formatted
+        assert "Important finding" in formatted
+        assert "2. Second Result" in formatted
+        assert "https://example.com/2" in formatted
+
+    def test_formats_empty_results(self) -> None:
+        parsed = ExaSearchResponse(results=[])
+        assert _format_results(parsed) == "No results found."
+
+
+# ---------------------------------------------------------------------------
+# Tool creation and configuration
+# ---------------------------------------------------------------------------
+
+
+class TestExaSearchToolCreation:
+    def test_raises_import_error_when_exa_missing(self) -> None:
+        with patch("agents.extensions.exa_search.Exa", None):
+            from agents.extensions.exa_search import exa_search_tool
+
+            with pytest.raises(ImportError, match="exa-py is required"):
+                exa_search_tool(api_key="test-key")
+
+    def test_raises_value_error_without_api_key(self) -> None:
+        mock_cls, _mock_client = _mock_exa_client()
+        env = {k: v for k, v in os.environ.items() if k != "EXA_API_KEY"}
+        with (
+            patch("agents.extensions.exa_search.Exa", mock_cls),
+            patch.dict("os.environ", env, clear=True),
+        ):
+            from agents.extensions.exa_search import exa_search_tool
+
+            with pytest.raises(ValueError, match="Exa API key is required"):
+                exa_search_tool()
+
+    def test_creates_function_tool_with_api_key(self) -> None:
+        mock_cls, _mock_client = _mock_exa_client()
+        with patch("agents.extensions.exa_search.Exa", mock_cls):
+            from agents.extensions.exa_search import exa_search_tool
+
+            tool = exa_search_tool(api_key="test-key-123")
+
+            from agents.tool import FunctionTool
+
+            assert isinstance(tool, FunctionTool)
+            assert tool.name == "exa_search"
+            assert "Exa" in tool.description
+
+    def test_sets_integration_header(self) -> None:
+        mock_cls, mock_client = _mock_exa_client()
+        with patch("agents.extensions.exa_search.Exa", mock_cls):
+            from agents.extensions.exa_search import exa_search_tool
+
+            exa_search_tool(api_key="test-key-123")
+            assert mock_client.headers["x-exa-integration"] == "openai-agents-python"
+
+    def test_reads_api_key_from_env(self) -> None:
+        mock_cls, _mock_client = _mock_exa_client()
+        with (
+            patch("agents.extensions.exa_search.Exa", mock_cls),
+            patch.dict("os.environ", {"EXA_API_KEY": "env-key-456"}),
+        ):
+            from agents.extensions.exa_search import exa_search_tool
+
+            exa_search_tool()
+            mock_cls.assert_called_once_with("env-key-456")

--- a/uv.lock
+++ b/uv.lock
@@ -939,6 +939,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/fe/a17c106a1f4061ce83f04d14bcedcfb2c38c7793ea56bfb906a6fadae8cb/evdev-1.9.2.tar.gz", hash = "sha256:5d3278892ce1f92a74d6bf888cc8525d9f68af85dbe336c95d1c87fb8f423069", size = 33301, upload-time = "2025-05-01T19:53:47.69Z" }
 
 [[package]]
+name = "exa-py"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/d2/22f8e5b83fb7ff1a5b19528b21bb908504c8b6a716309b169801881e64ff/exa_py-2.12.0.tar.gz", hash = "sha256:2cd5fe2d47d8e0221f87dcb2be0f007cc0a1f0a643b16dfc586ab1421998f4fc", size = 58731, upload-time = "2026-04-15T12:55:17.616Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/87/e5c458741a34c945d6b612ec54f00088a6869ffc4f3f8a7b06ae080ec6af/exa_py-2.12.0-py3-none-any.whl", hash = "sha256:78b954ca99151228e4b853bd25e58829048a9a601d6187001befa512e0143f8f", size = 73896, upload-time = "2026-04-15T12:55:16.03Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2460,6 +2478,9 @@ e2b = [
 encrypt = [
     { name = "cryptography" },
 ]
+exa = [
+    { name = "exa-py" },
+]
 litellm = [
     { name = "litellm" },
 ]
@@ -2545,6 +2566,7 @@ requires-dist = [
     { name = "docker", marker = "extra == 'docker'", specifier = ">=6.1" },
     { name = "e2b", marker = "extra == 'e2b'", specifier = "==2.20.0" },
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = "==2.4.1" },
+    { name = "exa-py", marker = "extra == 'exa'", specifier = ">=2.0.0" },
     { name = "graphviz", marker = "extra == 'viz'", specifier = ">=0.17" },
     { name = "griffelib", specifier = ">=2,<3" },
     { name = "grpcio", marker = "extra == 'dapr'", specifier = ">=1.60.0" },
@@ -2567,7 +2589,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'realtime'", specifier = ">=15.0,<16" },
     { name = "websockets", marker = "extra == 'voice'", specifier = ">=15.0,<16" },
 ]
-provides-extras = ["voice", "viz", "litellm", "any-llm", "realtime", "sqlalchemy", "encrypt", "redis", "dapr", "docker", "blaxel", "daytona", "cloudflare", "e2b", "modal", "runloop", "vercel", "s3", "temporal"]
+provides-extras = ["voice", "viz", "litellm", "any-llm", "realtime", "sqlalchemy", "encrypt", "redis", "dapr", "docker", "blaxel", "daytona", "cloudflare", "exa", "e2b", "modal", "runloop", "vercel", "s3", "temporal"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Adds an Exa search extension (`agents.extensions.exa_search`) that wraps the [Exa](https://exa.ai) search API as a `FunctionTool`
- Supports neural/fast/auto search types, domain filtering, date filtering, category filtering, and content retrieval (highlights, text, summary)
- Typed response models (`ExaSearchResult`, `ExaSearchResponse`) with graceful content fallback (highlights -> summary -> text)
- Lazy-loaded via `extensions.__init__` to avoid import errors when `exa-py` is not installed

## Usage

```python
from agents import Agent, Runner
from agents.extensions.exa_search import exa_search_tool

agent = Agent(
    name="Research Agent",
    instructions="Use the Exa search tool to find information.",
    tools=[exa_search_tool()],  # reads EXA_API_KEY from env
)

result = await Runner.run(agent, "Find recent AI research papers on reasoning")
```

Install with: `pip install "openai-agents[exa]"`

## Files changed

- `src/agents/extensions/exa_search.py` — new Exa search tool extension
- `src/agents/extensions/__init__.py` — lazy-load export for `exa_search_tool`
- `pyproject.toml` — `[exa]` optional dependency group + mypy override for `exa_py`
- `tests/extensions/test_exa_search.py` — 16 unit tests
- `uv.lock` — lockfile update

## Test plan

- [x] API response parsing (full, empty, missing optional fields)
- [x] Content/snippet fallback logic (highlights -> summary -> text -> empty)
- [x] Long text truncation
- [x] Empty highlights list falls through to summary
- [x] Result formatting (multiple results, empty results)
- [x] Import error when `exa-py` is not installed
- [x] ValueError when no API key is provided
- [x] FunctionTool creation with explicit API key
- [x] Integration tracking header (`x-exa-integration: openai-agents-python`)
- [x] API key read from `EXA_API_KEY` environment variable
- [x] Ruff lint + format pass
- [x] Mypy type check pass
- [x] Full test suite (896 passed, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)