### PR TITLE
fix: Trust filesystem permissions for Vercel roots

### DIFF
--- a/src/agents/extensions/sandbox/vercel/sandbox.py
+++ b/src/agents/extensions/sandbox/vercel/sandbox.py
@@ -43,6 +43,7 @@ from ....sandbox.errors import (
     WorkspaceArchiveReadError,
     WorkspaceArchiveWriteError,
     WorkspaceReadNotFoundError,
+    WorkspaceStartError,
     WorkspaceWriteTypeError,
 )
 from ....sandbox.manifest import Manifest
@@ -308,6 +309,24 @@ class VercelSandboxSession(BaseSandboxSession):
             raise ValueError(str(exc)) from exc
         except (tarfile.TarError, OSError) as exc:
             raise ValueError("invalid tar stream") from exc
+
+    async def _prepare_backend_workspace(self) -> None:
+        root = PurePosixPath(os.path.normpath(self.state.manifest.root))
+        try:
+            sandbox = await self._ensure_sandbox()
+            finished = await sandbox.run_command("mkdir", ["-p", "--", root.as_posix()])
+        except Exception as exc:
+            raise WorkspaceStartError(path=Path(str(root)), cause=exc) from exc
+
+        if finished.exit_code != 0:
+            raise WorkspaceStartError(
+                path=Path(str(root)),
+                context={
+                    "exit_code": finished.exit_code,
+                    "stdout": await finished.stdout(),
+                    "stderr": await finished.stderr(),
+                },
+            )
 
     async def _ensure_sandbox(self, *, source: Any | None = None) -> Any:
         sandbox = self._sandbox

--- a/src/agents/extensions/sandbox/vercel/sandbox.py
+++ b/src/agents/extensions/sandbox/vercel/sandbox.py
@@ -43,7 +43,6 @@ from ....sandbox.errors import (
     WorkspaceArchiveReadError,
     WorkspaceArchiveWriteError,
     WorkspaceReadNotFoundError,
-    WorkspaceStartError,
     WorkspaceWriteTypeError,
 )
 from ....sandbox.manifest import Manifest
@@ -125,21 +124,7 @@ def _resolve_manifest_root(manifest: Manifest | None) -> Manifest:
 
     if manifest.root == _DEFAULT_MANIFEST_ROOT:
         return manifest.model_copy(update={"root": DEFAULT_VERCEL_WORKSPACE_ROOT})
-
-    root = Path(manifest.root)
-    default_root = Path(DEFAULT_VERCEL_WORKSPACE_ROOT)
-    if not root.is_absolute() or root == default_root or default_root in root.parents:
-        return manifest
-
-    raise ConfigurationError(
-        message=(
-            "Vercel sandboxes require manifest.root to stay within "
-            f"{DEFAULT_VERCEL_WORKSPACE_ROOT!r}"
-        ),
-        error_code=ErrorCode.SANDBOX_CONFIG_INVALID,
-        op="start",
-        context={"backend": "vercel", "manifest_root": manifest.root},
-    )
+    return manifest
 
 
 def _validate_network_policy(value: object) -> NetworkPolicy | None:
@@ -323,45 +308,6 @@ class VercelSandboxSession(BaseSandboxSession):
             raise ValueError(str(exc)) from exc
         except (tarfile.TarError, OSError) as exc:
             raise ValueError("invalid tar stream") from exc
-
-    async def _ensure_workspace_root(self) -> None:
-        root = Path(self.state.manifest.root)
-        sandbox = await self._ensure_sandbox()
-        try:
-            finished = await sandbox.run_command("mkdir", ["-p", "--", root.as_posix()])
-        except Exception as exc:
-            raise WorkspaceStartError(path=root, cause=exc) from exc
-        if finished.exit_code != 0:
-            raise WorkspaceStartError(
-                path=root,
-                context={
-                    "exit_code": finished.exit_code,
-                    "stdout": await finished.stdout(),
-                    "stderr": await finished.stderr(),
-                },
-            )
-        try:
-            finished = await sandbox.run_command("test", ["-d", root.as_posix()])
-        except Exception as exc:
-            raise WorkspaceStartError(path=root, cause=exc) from exc
-        if finished.exit_code != 0:
-            raise WorkspaceStartError(
-                path=root,
-                context={
-                    "exit_code": finished.exit_code,
-                    "stdout": await finished.stdout(),
-                    "stderr": await finished.stderr(),
-                },
-            )
-
-    async def start(self) -> None:
-        try:
-            await self._ensure_workspace_root()
-        except WorkspaceStartError:
-            raise
-        except Exception as exc:
-            raise WorkspaceStartError(path=Path(self.state.manifest.root), cause=exc) from exc
-        await super().start()
 
     async def _ensure_sandbox(self, *, source: Any | None = None) -> Any:
         sandbox = self._sandbox

--- a/tests/extensions/test_sandbox_vercel.py
+++ b/tests/extensions/test_sandbox_vercel.py
@@ -524,7 +524,7 @@ async def test_vercel_exec_read_write_and_port_resolution(monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
-async def test_vercel_start_creates_workspace_root_before_manifest_apply(
+async def test_vercel_start_uses_base_session_contract_and_materializes_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vercel_module = _load_vercel_module(monkeypatch)
@@ -541,15 +541,15 @@ async def test_vercel_start_creates_workspace_root_before_manifest_apply(
     await session.start()
     payload = await session.read(Path("notes.txt"))
 
-    assert sandbox.run_command_calls[:2] == [
-        ("mkdir", ["-p", "--", "/workspace"], None),
-        ("test", ["-d", "/workspace"], None),
-    ]
+    assert ("mkdir", ["-p", "--", "/workspace"], None) not in sandbox.run_command_calls
+    assert ("test", ["-d", "/workspace"], None) not in sandbox.run_command_calls
+    assert ("mkdir", ["-p", "/workspace"], "/workspace") in sandbox.run_command_calls
+    assert session.state.workspace_root_ready is True
     assert payload.read() == b"payload"
 
 
 @pytest.mark.asyncio
-async def test_vercel_start_treats_manifest_root_as_literal_path(
+async def test_vercel_start_materializes_entries_under_literal_manifest_root(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vercel_module = _load_vercel_module(monkeypatch)
@@ -568,28 +568,28 @@ async def test_vercel_start_treats_manifest_root_as_literal_path(
     await session.start()
     payload = await session.read(Path("notes.txt"))
 
-    assert sandbox.run_command_calls[:2] == [
-        ("mkdir", ["-p", "--", "/workspace/my app"], None),
-        ("test", ["-d", "/workspace/my app"], None),
+    assert ("mkdir", ["-p", "--", "/workspace/my app"], None) not in sandbox.run_command_calls
+    assert ("test", ["-d", "/workspace/my app"], None) not in sandbox.run_command_calls
+    assert ("mkdir", ["-p", "/workspace/my app"], "/workspace/my app") in sandbox.run_command_calls
+    assert sandbox.write_files_calls == [
+        [{"path": "/workspace/my app/notes.txt", "content": b"payload"}]
     ]
     assert payload.read() == b"payload"
 
 
 @pytest.mark.asyncio
-async def test_vercel_create_rejects_manifest_root_outside_provider_workspace(
+async def test_vercel_create_allows_manifest_root_outside_provider_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vercel_module = _load_vercel_module(monkeypatch)
     client = vercel_module.VercelSandboxClient()
 
-    with pytest.raises(ConfigurationError) as exc_info:
-        await client.create(
-            manifest=Manifest(root="/tmp/outside"),
-            options=vercel_module.VercelSandboxClientOptions(),
-        )
+    session = await client.create(
+        manifest=Manifest(root="/tmp/outside"),
+        options=vercel_module.VercelSandboxClientOptions(),
+    )
 
-    assert exc_info.value.context["backend"] == "vercel"
-    assert exc_info.value.context["manifest_root"] == "/tmp/outside"
+    assert session._inner.state.manifest.root == "/tmp/outside"
 
 
 @pytest.mark.asyncio

--- a/tests/extensions/test_sandbox_vercel.py
+++ b/tests/extensions/test_sandbox_vercel.py
@@ -541,8 +541,7 @@ async def test_vercel_start_uses_base_session_contract_and_materializes_workspac
     await session.start()
     payload = await session.read(Path("notes.txt"))
 
-    assert ("mkdir", ["-p", "--", "/workspace"], None) not in sandbox.run_command_calls
-    assert ("test", ["-d", "/workspace"], None) not in sandbox.run_command_calls
+    assert sandbox.run_command_calls[0] == ("mkdir", ["-p", "--", "/workspace"], None)
     assert ("mkdir", ["-p", "/workspace"], "/workspace") in sandbox.run_command_calls
     assert session.state.workspace_root_ready is True
     assert payload.read() == b"payload"
@@ -568,12 +567,34 @@ async def test_vercel_start_materializes_entries_under_literal_manifest_root(
     await session.start()
     payload = await session.read(Path("notes.txt"))
 
-    assert ("mkdir", ["-p", "--", "/workspace/my app"], None) not in sandbox.run_command_calls
-    assert ("test", ["-d", "/workspace/my app"], None) not in sandbox.run_command_calls
+    assert sandbox.run_command_calls[0] == ("mkdir", ["-p", "--", "/workspace/my app"], None)
     assert ("mkdir", ["-p", "/workspace/my app"], "/workspace/my app") in sandbox.run_command_calls
     assert sandbox.write_files_calls == [
         [{"path": "/workspace/my app/notes.txt", "content": b"payload"}]
     ]
+    assert payload.read() == b"payload"
+
+
+@pytest.mark.asyncio
+async def test_vercel_start_bootstraps_arbitrary_absolute_root_before_using_it_as_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vercel_module = _load_vercel_module(monkeypatch)
+
+    state = vercel_module.VercelSandboxSessionState(
+        session_id="00000000-0000-0000-0000-000000000014",
+        manifest=Manifest(root="/tmp/outside", entries={"notes.txt": File(content=b"payload")}),
+        snapshot=NoopSnapshot(id="snapshot"),
+        sandbox_id="sandbox-start-outside",
+    )
+    sandbox = _FakeAsyncSandbox(sandbox_id="sandbox-start-outside")
+    session = vercel_module.VercelSandboxSession.from_state(state, sandbox=sandbox)
+
+    await session.start()
+    payload = await session.read(Path("notes.txt"))
+
+    assert sandbox.run_command_calls[0] == ("mkdir", ["-p", "--", "/tmp/outside"], None)
+    assert ("mkdir", ["-p", "/tmp/outside"], "/tmp/outside") in sandbox.run_command_calls
     assert payload.read() == b"payload"
 
 


### PR DESCRIPTION
Instead of trying to constraint the agent to only work in the workspace, allow it to fail freely without sudo.