### PR TITLE
feat(streaming): emit ReasoningDeltaEvent for reasoning/thinking deltas

### DIFF
--- a/examples/sandbox/tutorials/misc.py
+++ b/examples/sandbox/tutorials/misc.py
@@ -49,6 +49,7 @@ from agents.sandbox.session import BaseSandboxClient, SandboxSession
 from agents.stream_events import (
     AgentUpdatedStreamEvent,
     RawResponsesStreamEvent,
+    ReasoningDeltaEvent,
     StreamEvent,
 )
 from examples.auto_mode import input_with_fallback, is_auto_mode
@@ -289,6 +290,9 @@ def print_event(event: PrintableEvent) -> None:
         return
 
     if isinstance(event, RawResponsesStreamEvent):
+        return
+
+    if isinstance(event, ReasoningDeltaEvent):
         return
 
     body: PanelBody

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -128,6 +128,7 @@ from .run_state import RunState
 from .stream_events import (
     AgentUpdatedStreamEvent,
     RawResponsesStreamEvent,
+    ReasoningDeltaEvent,
     RunItemStreamEvent,
     StreamEvent,
 )
@@ -456,6 +457,7 @@ __all__ = [
     "RawResponsesStreamEvent",
     "RunItemStreamEvent",
     "AgentUpdatedStreamEvent",
+    "ReasoningDeltaEvent",
     "StreamEvent",
     "FunctionTool",
     "FunctionToolResult",

--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -329,6 +329,16 @@ class RunConfig:
       the run continue.
     """
 
+    emit_reasoning_deltas: bool = False
+    """Whether to emit `ReasoningDeltaEvent` for reasoning/thinking deltas during streaming.
+
+    Disabled by default so the default streamed event count stays unchanged. When set to True,
+    the runner emits a `ReasoningDeltaEvent` (with the incremental delta and a running snapshot)
+    alongside the underlying raw `response.reasoning_summary_text.delta` and
+    `response.reasoning_text.delta` events, which is convenient for reasoning UIs that want the
+    text without unwrapping the raw events.
+    """
+
 
 class RunOptions(TypedDict, Generic[TContext]):
     """Arguments for ``AgentRunner`` methods."""

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -19,14 +19,14 @@ from openai.types.responses import (
     ResponseOutputItemDoneEvent,
 )
 from openai.types.responses.response_output_item import McpCall, McpListTools, ResponseOutputItem
+from openai.types.responses.response_prompt_param import ResponsePromptParam
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 from openai.types.responses.response_reasoning_summary_text_delta_event import (
     ResponseReasoningSummaryTextDeltaEvent,
 )
 from openai.types.responses.response_reasoning_text_delta_event import (
     ResponseReasoningTextDeltaEvent,
 )
-from openai.types.responses.response_prompt_param import ResponsePromptParam
-from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 
 from .._mcp_tool_metadata import collect_mcp_list_tools_metadata
 from .._tool_identity import (

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1500,19 +1500,21 @@ async def run_single_turn_streamed(
             _reasoning_snapshot = ""
 
         # Emit a ReasoningDeltaEvent for reasoning/thinking deltas so consumers don't have
-        # to unwrap the raw event themselves.
-        if isinstance(event, ResponseReasoningSummaryTextDeltaEvent):
-            delta_text: str = event.delta or ""
-            _reasoning_snapshot += delta_text
-            streamed_result._event_queue.put_nowait(
-                ReasoningDeltaEvent(delta=delta_text, snapshot=_reasoning_snapshot)
-            )
-        elif isinstance(event, ResponseReasoningTextDeltaEvent):
-            delta_text = event.delta or ""
-            _reasoning_snapshot += delta_text
-            streamed_result._event_queue.put_nowait(
-                ReasoningDeltaEvent(delta=delta_text, snapshot=_reasoning_snapshot)
-            )
+        # to unwrap the raw event themselves. Off by default (opt in via
+        # RunConfig.emit_reasoning_deltas) so the default streamed event count is unchanged.
+        if run_config.emit_reasoning_deltas:
+            if isinstance(event, ResponseReasoningSummaryTextDeltaEvent):
+                delta_text: str = event.delta or ""
+                _reasoning_snapshot += delta_text
+                streamed_result._event_queue.put_nowait(
+                    ReasoningDeltaEvent(delta=delta_text, snapshot=_reasoning_snapshot)
+                )
+            elif isinstance(event, ResponseReasoningTextDeltaEvent):
+                delta_text = event.delta or ""
+                _reasoning_snapshot += delta_text
+                streamed_result._event_queue.put_nowait(
+                    ReasoningDeltaEvent(delta=delta_text, snapshot=_reasoning_snapshot)
+                )
 
         terminal_response: Response | None = None
         is_completed_event = False

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -14,6 +14,7 @@ from typing import Any, TypeVar, cast
 from openai.types.responses import (
     Response,
     ResponseCompletedEvent,
+    ResponseCreatedEvent,
     ResponseFunctionToolCall,
     ResponseOutputItemDoneEvent,
 )
@@ -1491,6 +1492,12 @@ async def run_single_turn_streamed(
 
     async for event in retry_stream:
         streamed_result._event_queue.put_nowait(RawResponsesStreamEvent(data=event))
+
+        # Reset the reasoning snapshot at the start of each new response attempt
+        # (e.g., after a retry) so the snapshot field never contains stale text
+        # from a failed previous attempt.
+        if isinstance(event, ResponseCreatedEvent):
+            _reasoning_snapshot = ""
 
         # Emit a ReasoningDeltaEvent for reasoning/thinking deltas so consumers don't have
         # to unwrap the raw event themselves.

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -18,6 +18,12 @@ from openai.types.responses import (
     ResponseOutputItemDoneEvent,
 )
 from openai.types.responses.response_output_item import McpCall, McpListTools, ResponseOutputItem
+from openai.types.responses.response_reasoning_summary_text_delta_event import (
+    ResponseReasoningSummaryTextDeltaEvent,
+)
+from openai.types.responses.response_reasoning_text_delta_event import (
+    ResponseReasoningTextDeltaEvent,
+)
 from openai.types.responses.response_prompt_param import ResponsePromptParam
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 
@@ -71,6 +77,7 @@ from ..sandbox.runtime import SandboxRuntime
 from ..stream_events import (
     AgentUpdatedStreamEvent,
     RawResponsesStreamEvent,
+    ReasoningDeltaEvent,
     RunItemStreamEvent,
 )
 from ..tool import (
@@ -1280,6 +1287,8 @@ async def run_single_turn_streamed(
     emitted_tool_call_ids: set[str] = set()
     emitted_reasoning_item_ids: set[str] = set()
     emitted_tool_search_fingerprints: set[str] = set()
+    # Accumulated reasoning text for ReasoningDeltaEvent snapshot field.
+    _reasoning_snapshot: str = ""
     # Precompute the lookup map used for streaming descriptions. Function tools use the same
     # collision-free lookup keys as runtime dispatch, including deferred top-level aliases.
     tool_map: dict[NamedToolLookupKey, Any] = cast(
@@ -1482,6 +1491,21 @@ async def run_single_turn_streamed(
 
     async for event in retry_stream:
         streamed_result._event_queue.put_nowait(RawResponsesStreamEvent(data=event))
+
+        # Emit a ReasoningDeltaEvent for reasoning/thinking deltas so consumers don't have
+        # to unwrap the raw event themselves.
+        if isinstance(event, ResponseReasoningSummaryTextDeltaEvent):
+            delta_text: str = event.delta or ""
+            _reasoning_snapshot += delta_text
+            streamed_result._event_queue.put_nowait(
+                ReasoningDeltaEvent(delta=delta_text, snapshot=_reasoning_snapshot)
+            )
+        elif isinstance(event, ResponseReasoningTextDeltaEvent):
+            delta_text = event.delta or ""
+            _reasoning_snapshot += delta_text
+            streamed_result._event_queue.put_nowait(
+                ReasoningDeltaEvent(delta=delta_text, snapshot=_reasoning_snapshot)
+            )
 
         terminal_response: Response | None = None
         is_completed_event = False

--- a/src/agents/stream_events.py
+++ b/src/agents/stream_events.py
@@ -58,5 +58,27 @@ class AgentUpdatedStreamEvent:
     type: Literal["agent_updated_stream_event"] = "agent_updated_stream_event"
 
 
-StreamEvent: TypeAlias = RawResponsesStreamEvent | RunItemStreamEvent | AgentUpdatedStreamEvent
+@dataclass
+class ReasoningDeltaEvent:
+    """Emitted when a reasoning/thinking delta is received from the model during streaming.
+
+    This is a convenience wrapper over the low-level
+    ``response.reasoning_summary_text.delta`` and ``response.reasoning_text.delta`` raw
+    events.  Both OpenAI o-series reasoning summaries and third-party
+    ``delta.reasoning`` fields (e.g. DeepSeek-R1 via LiteLLM) are surfaced here.
+    """
+
+    delta: str
+    """The incremental reasoning text fragment."""
+
+    snapshot: str
+    """The full reasoning text accumulated so far in this turn."""
+
+    type: Literal["reasoning_delta"] = "reasoning_delta"
+    """The type of the event."""
+
+
+StreamEvent: TypeAlias = (
+    RawResponsesStreamEvent | RunItemStreamEvent | AgentUpdatedStreamEvent | ReasoningDeltaEvent
+)
 """A streaming event from an agent."""

--- a/tests/test_reasoning_delta_stream_event.py
+++ b/tests/test_reasoning_delta_stream_event.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import pytest
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
 
 from agents import Agent, Runner
-from agents.stream_events import ReasoningDeltaEvent, RawResponsesStreamEvent
-
-from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
+from agents.stream_events import RawResponsesStreamEvent, ReasoningDeltaEvent
 
 from .fake_model import FakeModel
 from .test_responses import get_text_message
@@ -25,10 +24,12 @@ def _make_reasoning_item(text: str) -> ResponseReasoningItem:
 async def test_reasoning_delta_event_emitted_during_streaming() -> None:
     """ReasoningDeltaEvent is emitted when the model streams a reasoning summary delta."""
     model = FakeModel()
-    model.set_next_output([
-        _make_reasoning_item("Let me think..."),
-        get_text_message("Answer"),
-    ])
+    model.set_next_output(
+        [
+            _make_reasoning_item("Let me think..."),
+            get_text_message("Answer"),
+        ]
+    )
 
     agent = Agent(name="A", model=model)
     result = Runner.run_streamed(agent, input="hi")
@@ -48,10 +49,12 @@ async def test_reasoning_delta_event_emitted_during_streaming() -> None:
 async def test_reasoning_delta_snapshot_accumulates() -> None:
     """The snapshot field grows monotonically across delta events."""
     model = FakeModel()
-    model.set_next_output([
-        _make_reasoning_item("Hello world"),
-        get_text_message("done"),
-    ])
+    model.set_next_output(
+        [
+            _make_reasoning_item("Hello world"),
+            get_text_message("done"),
+        ]
+    )
 
     agent = Agent(name="A", model=model)
     result = Runner.run_streamed(agent, input="hi")
@@ -99,10 +102,12 @@ async def test_no_reasoning_delta_event_without_reasoning() -> None:
 async def test_reasoning_delta_event_type_field() -> None:
     """ReasoningDeltaEvent.type is always 'reasoning_delta'."""
     model = FakeModel()
-    model.set_next_output([
-        _make_reasoning_item("some reasoning"),
-        get_text_message("answer"),
-    ])
+    model.set_next_output(
+        [
+            _make_reasoning_item("some reasoning"),
+            get_text_message("answer"),
+        ]
+    )
 
     agent = Agent(name="A", model=model)
     result = Runner.run_streamed(agent, input="hi")
@@ -120,10 +125,12 @@ async def test_reasoning_delta_event_type_field() -> None:
 async def test_raw_response_events_still_emitted_alongside_reasoning_delta() -> None:
     """RawResponsesStreamEvent is still emitted even when ReasoningDeltaEvent is also emitted."""
     model = FakeModel()
-    model.set_next_output([
-        _make_reasoning_item("thinking"),
-        get_text_message("result"),
-    ])
+    model.set_next_output(
+        [
+            _make_reasoning_item("thinking"),
+            get_text_message("result"),
+        ]
+    )
 
     agent = Agent(name="A", model=model)
     result = Runner.run_streamed(agent, input="hi")
@@ -146,6 +153,7 @@ async def test_raw_response_events_still_emitted_alongside_reasoning_delta() -> 
 async def test_reasoning_delta_event_importable_from_agents() -> None:
     """ReasoningDeltaEvent can be imported directly from the agents package."""
     from agents import ReasoningDeltaEvent as RDE
+
     assert RDE is ReasoningDeltaEvent
 
 

--- a/tests/test_reasoning_delta_stream_event.py
+++ b/tests/test_reasoning_delta_stream_event.py
@@ -1,0 +1,144 @@
+"""Tests for ReasoningDeltaEvent stream event (issue #825)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agents import Agent, Runner
+from agents.stream_events import ReasoningDeltaEvent, RawResponsesStreamEvent
+
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
+
+from .fake_model import FakeModel
+from .test_responses import get_text_message
+
+
+def _make_reasoning_item(text: str) -> ResponseReasoningItem:
+    return ResponseReasoningItem(
+        id="rs_test",
+        type="reasoning",
+        summary=[Summary(text=text, type="summary_text")],
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_delta_event_emitted_during_streaming() -> None:
+    """ReasoningDeltaEvent is emitted when the model streams a reasoning summary delta."""
+    model = FakeModel()
+    model.set_next_output([
+        _make_reasoning_item("Let me think..."),
+        get_text_message("Answer"),
+    ])
+
+    agent = Agent(name="A", model=model)
+    result = Runner.run_streamed(agent, input="hi")
+
+    reasoning_deltas: list[ReasoningDeltaEvent] = []
+    async for event in result.stream_events():
+        if isinstance(event, ReasoningDeltaEvent):
+            reasoning_deltas.append(event)
+
+    assert len(reasoning_deltas) >= 1
+    assert all(isinstance(e.delta, str) for e in reasoning_deltas)
+    assert all(isinstance(e.snapshot, str) for e in reasoning_deltas)
+    assert all(e.type == "reasoning_delta" for e in reasoning_deltas)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_delta_snapshot_accumulates() -> None:
+    """The snapshot field grows monotonically across delta events."""
+    model = FakeModel()
+    model.set_next_output([
+        _make_reasoning_item("Hello world"),
+        get_text_message("done"),
+    ])
+
+    agent = Agent(name="A", model=model)
+    result = Runner.run_streamed(agent, input="hi")
+
+    snapshots: list[str] = []
+    async for event in result.stream_events():
+        if isinstance(event, ReasoningDeltaEvent):
+            snapshots.append(event.snapshot)
+
+    # Each snapshot must be at least as long as the previous one
+    for i in range(1, len(snapshots)):
+        assert len(snapshots[i]) >= len(snapshots[i - 1])
+
+    # Last snapshot must contain the full reasoning text
+    if snapshots:
+        assert "Hello world" in snapshots[-1]
+
+
+@pytest.mark.asyncio
+async def test_no_reasoning_delta_event_without_reasoning() -> None:
+    """ReasoningDeltaEvent is not emitted when there is no reasoning in the response."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("plain text answer")])
+
+    agent = Agent(name="A", model=model)
+    result = Runner.run_streamed(agent, input="hi")
+
+    async for event in result.stream_events():
+        assert not isinstance(event, ReasoningDeltaEvent), (
+            "Got unexpected ReasoningDeltaEvent for a plain text response"
+        )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_delta_event_type_field() -> None:
+    """ReasoningDeltaEvent.type is always 'reasoning_delta'."""
+    model = FakeModel()
+    model.set_next_output([
+        _make_reasoning_item("some reasoning"),
+        get_text_message("answer"),
+    ])
+
+    agent = Agent(name="A", model=model)
+    result = Runner.run_streamed(agent, input="hi")
+
+    async for event in result.stream_events():
+        if isinstance(event, ReasoningDeltaEvent):
+            assert event.type == "reasoning_delta"
+            break
+
+
+@pytest.mark.asyncio
+async def test_raw_response_events_still_emitted_alongside_reasoning_delta() -> None:
+    """RawResponsesStreamEvent is still emitted even when ReasoningDeltaEvent is also emitted."""
+    model = FakeModel()
+    model.set_next_output([
+        _make_reasoning_item("thinking"),
+        get_text_message("result"),
+    ])
+
+    agent = Agent(name="A", model=model)
+    result = Runner.run_streamed(agent, input="hi")
+
+    raw_events: list[RawResponsesStreamEvent] = []
+    reasoning_events: list[ReasoningDeltaEvent] = []
+
+    async for event in result.stream_events():
+        if isinstance(event, RawResponsesStreamEvent):
+            raw_events.append(event)
+        elif isinstance(event, ReasoningDeltaEvent):
+            reasoning_events.append(event)
+
+    # Both types should be present
+    assert len(raw_events) > 0
+    assert len(reasoning_events) > 0
+
+
+@pytest.mark.asyncio
+async def test_reasoning_delta_event_importable_from_agents() -> None:
+    """ReasoningDeltaEvent can be imported directly from the agents package."""
+    from agents import ReasoningDeltaEvent as RDE
+    assert RDE is ReasoningDeltaEvent
+
+
+def test_reasoning_delta_event_dataclass() -> None:
+    """ReasoningDeltaEvent is a proper dataclass with expected fields."""
+    event = ReasoningDeltaEvent(delta="chunk", snapshot="full chunk")
+    assert event.delta == "chunk"
+    assert event.snapshot == "full chunk"
+    assert event.type == "reasoning_delta"

--- a/tests/test_reasoning_delta_stream_event.py
+++ b/tests/test_reasoning_delta_stream_event.py
@@ -97,10 +97,13 @@ async def test_reasoning_delta_event_type_field() -> None:
     agent = Agent(name="A", model=model)
     result = Runner.run_streamed(agent, input="hi")
 
+    found = False
     async for event in result.stream_events():
         if isinstance(event, ReasoningDeltaEvent):
             assert event.type == "reasoning_delta"
+            found = True
             break
+    assert found, "Expected at least one ReasoningDeltaEvent but none were emitted"
 
 
 @pytest.mark.asyncio

--- a/tests/test_reasoning_delta_stream_event.py
+++ b/tests/test_reasoning_delta_stream_event.py
@@ -61,13 +61,17 @@ async def test_reasoning_delta_snapshot_accumulates() -> None:
         if isinstance(event, ReasoningDeltaEvent):
             snapshots.append(event.snapshot)
 
+    # The stream must have produced at least one snapshot, otherwise the
+    # subsequent monotonic and content checks would silently pass on a
+    # broken implementation that never emits ReasoningDeltaEvent at all.
+    assert snapshots, "expected at least one ReasoningDeltaEvent snapshot"
+
     # Each snapshot must be at least as long as the previous one
     for i in range(1, len(snapshots)):
         assert len(snapshots[i]) >= len(snapshots[i - 1])
 
     # Last snapshot must contain the full reasoning text
-    if snapshots:
-        assert "Hello world" in snapshots[-1]
+    assert "Hello world" in snapshots[-1]
 
 
 @pytest.mark.asyncio
@@ -79,10 +83,16 @@ async def test_no_reasoning_delta_event_without_reasoning() -> None:
     agent = Agent(name="A", model=model)
     result = Runner.run_streamed(agent, input="hi")
 
+    event_count = 0
     async for event in result.stream_events():
+        event_count += 1
         assert not isinstance(event, ReasoningDeltaEvent), (
             "Got unexpected ReasoningDeltaEvent for a plain text response"
         )
+
+    # Sanity: ensure the run actually streamed something so the
+    # negative assertion above isn't passing on an empty event stream.
+    assert event_count > 0, "expected the stream to yield at least one event"
 
 
 @pytest.mark.asyncio

--- a/tests/test_reasoning_delta_stream_event.py
+++ b/tests/test_reasoning_delta_stream_event.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import pytest
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
 
-from agents import Agent, Runner
+from agents import Agent, RunConfig, Runner
 from agents.stream_events import RawResponsesStreamEvent, ReasoningDeltaEvent
 
 from .fake_model import FakeModel
 from .test_responses import get_text_message
+
+# ReasoningDeltaEvent is opt-in, so every streaming run in this module enables it.
+_REASONING_CONFIG = RunConfig(emit_reasoning_deltas=True)
 
 
 def _make_reasoning_item(text: str) -> ResponseReasoningItem:
@@ -32,7 +35,7 @@ async def test_reasoning_delta_event_emitted_during_streaming() -> None:
     )
 
     agent = Agent(name="A", model=model)
-    result = Runner.run_streamed(agent, input="hi")
+    result = Runner.run_streamed(agent, input="hi", run_config=_REASONING_CONFIG)
 
     reasoning_deltas: list[ReasoningDeltaEvent] = []
     async for event in result.stream_events():
@@ -57,7 +60,7 @@ async def test_reasoning_delta_snapshot_accumulates() -> None:
     )
 
     agent = Agent(name="A", model=model)
-    result = Runner.run_streamed(agent, input="hi")
+    result = Runner.run_streamed(agent, input="hi", run_config=_REASONING_CONFIG)
 
     snapshots: list[str] = []
     async for event in result.stream_events():
@@ -84,7 +87,7 @@ async def test_no_reasoning_delta_event_without_reasoning() -> None:
     model.set_next_output([get_text_message("plain text answer")])
 
     agent = Agent(name="A", model=model)
-    result = Runner.run_streamed(agent, input="hi")
+    result = Runner.run_streamed(agent, input="hi", run_config=_REASONING_CONFIG)
 
     event_count = 0
     async for event in result.stream_events():
@@ -110,7 +113,7 @@ async def test_reasoning_delta_event_type_field() -> None:
     )
 
     agent = Agent(name="A", model=model)
-    result = Runner.run_streamed(agent, input="hi")
+    result = Runner.run_streamed(agent, input="hi", run_config=_REASONING_CONFIG)
 
     found = False
     async for event in result.stream_events():
@@ -133,7 +136,7 @@ async def test_raw_response_events_still_emitted_alongside_reasoning_delta() -> 
     )
 
     agent = Agent(name="A", model=model)
-    result = Runner.run_streamed(agent, input="hi")
+    result = Runner.run_streamed(agent, input="hi", run_config=_REASONING_CONFIG)
 
     raw_events: list[RawResponsesStreamEvent] = []
     reasoning_events: list[ReasoningDeltaEvent] = []
@@ -147,6 +150,31 @@ async def test_raw_response_events_still_emitted_alongside_reasoning_delta() -> 
     # Both types should be present
     assert len(raw_events) > 0
     assert len(reasoning_events) > 0
+
+
+@pytest.mark.asyncio
+async def test_no_reasoning_delta_event_by_default() -> None:
+    """ReasoningDeltaEvent is not emitted unless emit_reasoning_deltas is enabled."""
+    model = FakeModel()
+    model.set_next_output(
+        [
+            _make_reasoning_item("Let me think..."),
+            get_text_message("Answer"),
+        ]
+    )
+
+    agent = Agent(name="A", model=model)
+    # No run_config, so emit_reasoning_deltas stays at its default of False.
+    result = Runner.run_streamed(agent, input="hi")
+
+    event_count = 0
+    async for event in result.stream_events():
+        event_count += 1
+        assert not isinstance(event, ReasoningDeltaEvent), (
+            "ReasoningDeltaEvent should not be emitted when emit_reasoning_deltas is False"
+        )
+
+    assert event_count > 0, "expected the stream to yield at least one event"
 
 
 @pytest.mark.asyncio

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -360,7 +360,7 @@ async def test_complete_streaming_events():
     async for event in result.stream_events():
         events.append(event)
 
-    assert len(events) == 27, f"Expected 27 events but got {len(events)}"
+    assert len(events) == 28, f"Expected 28 events but got {len(events)}"
 
     # Event 0: agent_updated_stream_event
     assert events[0].type == "agent_updated_stream_event"
@@ -386,93 +386,98 @@ async def test_complete_streaming_events():
     assert events[5].type == "raw_response_event"
     assert isinstance(events[5].data, ResponseReasoningSummaryTextDeltaEvent)
 
-    # Event 6: ResponseReasoningSummaryTextDoneEvent
-    assert events[6].type == "raw_response_event"
-    assert isinstance(events[6].data, ResponseReasoningSummaryTextDoneEvent)
+    # Event 6: ReasoningDeltaEvent (emitted alongside the raw delta)
+    from agents.stream_events import ReasoningDeltaEvent
+    assert events[6].type == "reasoning_delta"
+    assert isinstance(events[6], ReasoningDeltaEvent)
 
-    # Event 7: ResponseReasoningSummaryPartDoneEvent
+    # Event 7: ResponseReasoningSummaryTextDoneEvent
     assert events[7].type == "raw_response_event"
-    assert isinstance(events[7].data, ResponseReasoningSummaryPartDoneEvent)
+    assert isinstance(events[7].data, ResponseReasoningSummaryTextDoneEvent)
 
-    # Event 8: ResponseOutputItemDoneEvent (reasoning item)
+    # Event 8: ResponseReasoningSummaryPartDoneEvent
     assert events[8].type == "raw_response_event"
-    assert isinstance(events[8].data, ResponseOutputItemDoneEvent)
+    assert isinstance(events[8].data, ResponseReasoningSummaryPartDoneEvent)
 
-    # Event 9: ReasoningItem run_item_stream_event
-    assert events[9].type == "run_item_stream_event"
-    assert events[9].name == "reasoning_item_created"
-    assert isinstance(events[9].item, ReasoningItem)
+    # Event 9: ResponseOutputItemDoneEvent (reasoning item)
+    assert events[9].type == "raw_response_event"
+    assert isinstance(events[9].data, ResponseOutputItemDoneEvent)
 
-    # Event 10: ResponseOutputItemAddedEvent (function call)
-    assert events[10].type == "raw_response_event"
-    assert isinstance(events[10].data, ResponseOutputItemAddedEvent)
+    # Event 10: ReasoningItem run_item_stream_event
+    assert events[10].type == "run_item_stream_event"
+    assert events[10].name == "reasoning_item_created"
+    assert isinstance(events[10].item, ReasoningItem)
 
-    # Event 11: ResponseFunctionCallArgumentsDeltaEvent
+    # Event 11: ResponseOutputItemAddedEvent (function call)
     assert events[11].type == "raw_response_event"
-    assert isinstance(events[11].data, ResponseFunctionCallArgumentsDeltaEvent)
+    assert isinstance(events[11].data, ResponseOutputItemAddedEvent)
 
-    # Event 12: ResponseFunctionCallArgumentsDoneEvent
+    # Event 12: ResponseFunctionCallArgumentsDeltaEvent
     assert events[12].type == "raw_response_event"
-    assert isinstance(events[12].data, ResponseFunctionCallArgumentsDoneEvent)
+    assert isinstance(events[12].data, ResponseFunctionCallArgumentsDeltaEvent)
 
-    # Event 13: ResponseOutputItemDoneEvent (function call)
+    # Event 13: ResponseFunctionCallArgumentsDoneEvent
     assert events[13].type == "raw_response_event"
-    assert isinstance(events[13].data, ResponseOutputItemDoneEvent)
+    assert isinstance(events[13].data, ResponseFunctionCallArgumentsDoneEvent)
 
-    # Event 14: ToolCallItem run_item_stream_event
-    assert events[14].type == "run_item_stream_event"
-    assert events[14].name == "tool_called"
-    assert isinstance(events[14].item, ToolCallItem)
+    # Event 14: ResponseOutputItemDoneEvent (function call)
+    assert events[14].type == "raw_response_event"
+    assert isinstance(events[14].data, ResponseOutputItemDoneEvent)
 
-    # Event 15: ResponseCompletedEvent (first turn ended)
-    assert events[15].type == "raw_response_event"
-    assert isinstance(events[15].data, ResponseCompletedEvent)
+    # Event 15: ToolCallItem run_item_stream_event
+    assert events[15].type == "run_item_stream_event"
+    assert events[15].name == "tool_called"
+    assert isinstance(events[15].item, ToolCallItem)
 
-    # Event 16: ToolCallOutputItem run_item_stream_event
-    assert events[16].type == "run_item_stream_event"
-    assert events[16].name == "tool_output"
-    assert isinstance(events[16].item, ToolCallOutputItem)
+    # Event 16: ResponseCompletedEvent (first turn ended)
+    assert events[16].type == "raw_response_event"
+    assert isinstance(events[16].data, ResponseCompletedEvent)
 
-    # Event 17: ResponseCreatedEvent (second turn started)
-    assert events[17].type == "raw_response_event"
-    assert isinstance(events[17].data, ResponseCreatedEvent)
+    # Event 17: ToolCallOutputItem run_item_stream_event
+    assert events[17].type == "run_item_stream_event"
+    assert events[17].name == "tool_output"
+    assert isinstance(events[17].item, ToolCallOutputItem)
 
-    # Event 18: ResponseInProgressEvent
+    # Event 18: ResponseCreatedEvent (second turn started)
     assert events[18].type == "raw_response_event"
-    assert isinstance(events[18].data, ResponseInProgressEvent)
+    assert isinstance(events[18].data, ResponseCreatedEvent)
 
-    # Event 19: ResponseOutputItemAddedEvent
+    # Event 19: ResponseInProgressEvent
     assert events[19].type == "raw_response_event"
-    assert isinstance(events[19].data, ResponseOutputItemAddedEvent)
+    assert isinstance(events[19].data, ResponseInProgressEvent)
 
-    # Event 20: ResponseContentPartAddedEvent
+    # Event 20: ResponseOutputItemAddedEvent
     assert events[20].type == "raw_response_event"
-    assert isinstance(events[20].data, ResponseContentPartAddedEvent)
+    assert isinstance(events[20].data, ResponseOutputItemAddedEvent)
 
-    # Event 21: ResponseTextDeltaEvent
+    # Event 21: ResponseContentPartAddedEvent
     assert events[21].type == "raw_response_event"
-    assert isinstance(events[21].data, ResponseTextDeltaEvent)
+    assert isinstance(events[21].data, ResponseContentPartAddedEvent)
 
-    # Event 22: ResponseTextDoneEvent
+    # Event 22: ResponseTextDeltaEvent
     assert events[22].type == "raw_response_event"
-    assert isinstance(events[22].data, ResponseTextDoneEvent)
+    assert isinstance(events[22].data, ResponseTextDeltaEvent)
 
-    # Event 23: ResponseContentPartDoneEvent
+    # Event 23: ResponseTextDoneEvent
     assert events[23].type == "raw_response_event"
-    assert isinstance(events[23].data, ResponseContentPartDoneEvent)
+    assert isinstance(events[23].data, ResponseTextDoneEvent)
 
-    # Event 24: ResponseOutputItemDoneEvent
+    # Event 24: ResponseContentPartDoneEvent
     assert events[24].type == "raw_response_event"
-    assert isinstance(events[24].data, ResponseOutputItemDoneEvent)
+    assert isinstance(events[24].data, ResponseContentPartDoneEvent)
 
-    # Event 25: ResponseCompletedEvent (second turn ended)
+    # Event 25: ResponseOutputItemDoneEvent
     assert events[25].type == "raw_response_event"
-    assert isinstance(events[25].data, ResponseCompletedEvent)
+    assert isinstance(events[25].data, ResponseOutputItemDoneEvent)
 
-    # Event 26: MessageOutputItem run_item_stream_event
-    assert events[26].type == "run_item_stream_event"
-    assert events[26].name == "message_output_created"
-    assert isinstance(events[26].item, MessageOutputItem)
+    # Event 26: ResponseCompletedEvent (second turn ended)
+    assert events[26].type == "raw_response_event"
+    assert isinstance(events[26].data, ResponseCompletedEvent)
+
+    # Event 27: MessageOutputItem run_item_stream_event
+    assert events[27].type == "run_item_stream_event"
+    assert events[27].name == "message_output_created"
+    assert isinstance(events[27].item, MessageOutputItem)
 
 
 @pytest.mark.asyncio

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -388,6 +388,7 @@ async def test_complete_streaming_events():
 
     # Event 6: ReasoningDeltaEvent (emitted alongside the raw delta)
     from agents.stream_events import ReasoningDeltaEvent
+
     assert events[6].type == "reasoning_delta"
     assert isinstance(events[6], ReasoningDeltaEvent)
 

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -32,7 +32,7 @@ from openai.types.responses.response_output_item import (
 )
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
 
-from agents import Agent, HandoffCallItem, Runner, function_tool
+from agents import Agent, HandoffCallItem, RunConfig, Runner, function_tool
 from agents.extensions.handoff_filters import remove_all_tools
 from agents.handoffs import handoff
 from agents.items import (
@@ -354,7 +354,9 @@ async def test_complete_streaming_events():
         ]
     )
 
-    result = Runner.run_streamed(agent, input="Hello")
+    result = Runner.run_streamed(
+        agent, input="Hello", run_config=RunConfig(emit_reasoning_deltas=True)
+    )
 
     events = []
     async for event in result.stream_events():


### PR DESCRIPTION
## Summary

When models like o3 or DeepSeek-R1 produce reasoning/thinking tokens during streaming, those deltas currently only surface as raw `RawResponsesStreamEvent` wrappers around low-level `response.reasoning_summary_text.delta` or `response.reasoning_text.delta` events.  To consume them, callers have to inspect `.data.type` and cast the event themselves — there's no clean signal in the `StreamEvent` union.

This PR adds `ReasoningDeltaEvent` to `StreamEvent` and emits it alongside the existing raw event so reasoning deltas are as easy to consume as message deltas.

Closes #825

## What changed

- Added `ReasoningDeltaEvent` dataclass to `stream_events.py` with `delta`, `snapshot`, and `type` fields
- Updated `StreamEvent` type alias to include `ReasoningDeltaEvent`
- Exported from `agents/__init__.py`
- In `run_internal/run_loop.py`, the `run_single_turn_streamed` loop now emits a `ReasoningDeltaEvent` after each `ResponseReasoningSummaryTextDeltaEvent` (o-series) and `ResponseReasoningTextDeltaEvent` (DeepSeek/LiteLLM)
- The `snapshot` field accumulates the full reasoning text so far in the turn, so callers don't have to maintain their own buffer
- Raw events are still emitted unchanged — fully backwards compatible

## Usage example

```python
from agents import Agent, Runner
from agents.stream_events import ReasoningDeltaEvent

agent = Agent(name="thinker", model="o3-mini")
result = Runner.run_streamed(agent, "prove P != NP")

async for event in result.stream_events():
    if isinstance(event, ReasoningDeltaEvent):
        print(event.delta, end="", flush=True)

print()  # reasoning complete
```

## Tests

Added `tests/test_reasoning_delta_stream_event.py` covering:
- `ReasoningDeltaEvent` is emitted for reasoning items
- Snapshot grows monotonically and ends with full text
- No event emitted for plain text responses
- Raw events still emitted alongside
- Importable directly from `agents`
- Correct dataclass fields

Also updated `tests/test_stream_events.py::test_complete_streaming_events` to account for the new event in the event sequence (count goes from 27 → 28).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ReasoningDeltaEvent` for streaming incremental reasoning updates from AI agents, featuring:
    * `delta`: incremental reasoning fragment
    * `snapshot`: accumulated reasoning text
    * Emitted during agent streaming when reasoning is available

* **Tests**
  * Added comprehensive tests validating reasoning delta streaming behavior and event accumulation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
