### PR TITLE
feat(usage): add agent_name to RequestUsage

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -260,31 +260,6 @@ def _should_attach_generic_agent_error(exc: Exception) -> bool:
     )
 
 
-def _get_model_name(model: Any) -> str | None:
-    """Extract the string model name from a Model instance, if available.
-
-    Most built-in model implementations (``OpenAIResponsesModel``,
-    ``OpenAIChatCompletionsModel``) expose a ``model`` attribute that contains
-    the underlying model name string. This helper retrieves it in a
-    forward-compatible, duck-typed way so that third-party model
-    implementations are handled gracefully.
-
-    The function tries ``model`` first, then ``model_name`` for
-    implementations that prefer that name. Any exception raised while
-    resolving the attribute (for example, a custom descriptor or property
-    that throws) is swallowed so that usage accounting can never crash the
-    run, and ``None`` is returned when no string-valued name is available.
-    """
-    for attr in ("model", "model_name"):
-        try:
-            value = getattr(model, attr, None)
-        except Exception:
-            continue
-        if isinstance(value, str) and value:
-            return value
-    return None
-
-
 async def _should_persist_stream_items(
     *,
     session: Session | None,
@@ -1641,7 +1616,6 @@ async def run_single_turn_streamed(
         context_wrapper.usage.add(
             final_response.usage,
             agent_name=public_agent.name,
-            model_name=_get_model_name(model),
         )
         await asyncio.gather(
             (
@@ -1923,7 +1897,6 @@ async def get_new_response(
     context_wrapper.usage.add(
         new_response.usage,
         agent_name=public_agent.name,
-        model_name=_get_model_name(model),
     )
 
     await asyncio.gather(

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -265,13 +265,23 @@ def _get_model_name(model: Any) -> str | None:
 
     Most built-in model implementations (``OpenAIResponsesModel``,
     ``OpenAIChatCompletionsModel``) expose a ``model`` attribute that contains
-    the underlying model name string.  This helper retrieves it in a
-    forward-compatible, duck-typed way so that third-party model implementations
-    that may not have this attribute are handled gracefully.
+    the underlying model name string. This helper retrieves it in a
+    forward-compatible, duck-typed way so that third-party model
+    implementations are handled gracefully.
+
+    The function tries ``model`` first, then ``model_name`` for
+    implementations that prefer that name. Any exception raised while
+    resolving the attribute (for example, a custom descriptor or property
+    that throws) is swallowed so that usage accounting can never crash the
+    run, and ``None`` is returned when no string-valued name is available.
     """
-    model_name = getattr(model, "model", None)
-    if isinstance(model_name, str):
-        return model_name
+    for attr in ("model", "model_name"):
+        try:
+            value = getattr(model, attr, None)
+        except Exception:
+            continue
+        if isinstance(value, str) and value:
+            return value
     return None
 
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -260,6 +260,21 @@ def _should_attach_generic_agent_error(exc: Exception) -> bool:
     )
 
 
+def _get_model_name(model: Any) -> str | None:
+    """Extract the string model name from a Model instance, if available.
+
+    Most built-in model implementations (``OpenAIResponsesModel``,
+    ``OpenAIChatCompletionsModel``) expose a ``model`` attribute that contains
+    the underlying model name string.  This helper retrieves it in a
+    forward-compatible, duck-typed way so that third-party model implementations
+    that may not have this attribute are handled gracefully.
+    """
+    model_name = getattr(model, "model", None)
+    if isinstance(model_name, str):
+        return model_name
+    return None
+
+
 async def _should_persist_stream_items(
     *,
     session: Session | None,
@@ -1613,7 +1628,11 @@ async def run_single_turn_streamed(
                     )
 
     if final_response is not None:
-        context_wrapper.usage.add(final_response.usage)
+        context_wrapper.usage.add(
+            final_response.usage,
+            agent_name=agent.name,
+            model_name=_get_model_name(model),
+        )
         await asyncio.gather(
             (
                 public_agent.hooks.on_llm_end(context_wrapper, public_agent, final_response)
@@ -1891,7 +1910,11 @@ async def get_new_response(
         # new deltas.
         server_conversation_tracker.mark_input_as_sent(filtered.input)
 
-    context_wrapper.usage.add(new_response.usage)
+    context_wrapper.usage.add(
+        new_response.usage,
+        agent_name=agent.name,
+        model_name=_get_model_name(model),
+    )
 
     await asyncio.gather(
         (

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1640,7 +1640,7 @@ async def run_single_turn_streamed(
     if final_response is not None:
         context_wrapper.usage.add(
             final_response.usage,
-            agent_name=agent.name,
+            agent_name=public_agent.name,
             model_name=_get_model_name(model),
         )
         await asyncio.gather(
@@ -1922,7 +1922,7 @@ async def get_new_response(
 
     context_wrapper.usage.add(
         new_response.usage,
-        agent_name=agent.name,
+        agent_name=public_agent.name,
         model_name=_get_model_name(model),
     )
 

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -44,7 +44,6 @@ def deserialize_usage(usage_data: Mapping[str, Any]) -> Usage:
                     OutputTokensDetails(reasoning_tokens=0),
                 ),
                 agent_name=entry.get("agent_name", None),
-                model_name=entry.get("model_name", None),
             )
         )
 
@@ -84,14 +83,6 @@ class RequestUsage:
     Populated automatically when an agent makes a model call so that callers can attribute
     token usage and costs to specific agents in multi-agent workflows.
     """
-
-    model_name: str | None = None
-    """Name of the model used for this request, if available.
-
-    Populated automatically when an agent makes a model call so that callers can attribute
-    token usage and costs to specific models.
-    """
-
 
 def _normalize_input_tokens_details(
     v: InputTokensDetails | PromptTokensDetails | None,
@@ -175,7 +166,6 @@ class Usage:
         other: Usage,
         *,
         agent_name: str | None = None,
-        model_name: str | None = None,
     ) -> None:
         """Add another Usage object to this one, aggregating all fields.
 
@@ -185,8 +175,6 @@ class Usage:
             other: The Usage object to add to this one.
             agent_name: Optional name of the agent making this request, used to annotate the
                 resulting ``RequestUsage`` entry for per-agent cost attribution.
-            model_name: Optional name of the model used for this request, used to annotate the
-                resulting ``RequestUsage`` entry for per-model cost attribution.
         """
         self.requests += other.requests if other.requests else 0
         self.input_tokens += other.input_tokens if other.input_tokens else 0
@@ -239,9 +227,6 @@ class Usage:
                         agent_name=agent_name
                         if (agent_name is not None and entry.agent_name is None)
                         else entry.agent_name,
-                        model_name=model_name
-                        if (model_name is not None and entry.model_name is None)
-                        else entry.model_name,
                     )
                     self.request_usage_entries.append(annotated_entry)
             else:
@@ -256,12 +241,11 @@ class Usage:
                     input_tokens_details=input_details,
                     output_tokens_details=output_details,
                     agent_name=agent_name,
-                    model_name=model_name,
                 )
                 self.request_usage_entries.append(request_usage)
         elif other.request_usage_entries:
             # If the other Usage already has individual request breakdowns, merge them.
-            # Apply agent_name/model_name to entries that don't already have them set,
+            # Apply agent_name to entries that don't already have it set,
             # but copy each entry rather than mutating the original objects in place
             # to avoid silent mis-attribution when the same Usage is added multiple times.
             for entry in other.request_usage_entries:
@@ -274,9 +258,6 @@ class Usage:
                     agent_name=agent_name
                     if (agent_name is not None and entry.agent_name is None)
                     else entry.agent_name,
-                    model_name=model_name
-                    if (model_name is not None and entry.model_name is None)
-                    else entry.model_name,
                 )
                 self.request_usage_entries.append(annotated_entry)
 
@@ -309,8 +290,6 @@ def serialize_usage(usage: Usage) -> dict[str, Any]:
         }
         if entry.agent_name is not None:
             result["agent_name"] = entry.agent_name
-        if entry.model_name is not None:
-            result["model_name"] = entry.model_name
         return result
 
     return {

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -84,6 +84,7 @@ class RequestUsage:
     token usage and costs to specific agents in multi-agent workflows.
     """
 
+
 def _normalize_input_tokens_details(
     v: InputTokensDetails | PromptTokensDetails | None,
 ) -> InputTokensDetails:

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -248,8 +248,12 @@ class Usage:
                     total_tokens=entry.total_tokens,
                     input_tokens_details=entry.input_tokens_details,
                     output_tokens_details=entry.output_tokens_details,
-                    agent_name=agent_name if (agent_name is not None and entry.agent_name is None) else entry.agent_name,
-                    model_name=model_name if (model_name is not None and entry.model_name is None) else entry.model_name,
+                    agent_name=agent_name
+                    if (agent_name is not None and entry.agent_name is None)
+                    else entry.agent_name,
+                    model_name=model_name
+                    if (model_name is not None and entry.model_name is None)
+                    else entry.model_name,
                 )
                 self.request_usage_entries.append(annotated_entry)
 

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -238,13 +238,20 @@ class Usage:
             self.request_usage_entries.append(request_usage)
         elif other.request_usage_entries:
             # If the other Usage already has individual request breakdowns, merge them.
-            # Apply agent_name/model_name to entries that don't already have them set.
+            # Apply agent_name/model_name to entries that don't already have them set,
+            # but copy each entry rather than mutating the original objects in place
+            # to avoid silent mis-attribution when the same Usage is added multiple times.
             for entry in other.request_usage_entries:
-                if agent_name is not None and entry.agent_name is None:
-                    entry.agent_name = agent_name
-                if model_name is not None and entry.model_name is None:
-                    entry.model_name = model_name
-            self.request_usage_entries.extend(other.request_usage_entries)
+                annotated_entry = RequestUsage(
+                    input_tokens=entry.input_tokens,
+                    output_tokens=entry.output_tokens,
+                    total_tokens=entry.total_tokens,
+                    input_tokens_details=entry.input_tokens_details,
+                    output_tokens_details=entry.output_tokens_details,
+                    agent_name=agent_name if (agent_name is not None and entry.agent_name is None) else entry.agent_name,
+                    model_name=model_name if (model_name is not None and entry.model_name is None) else entry.model_name,
+                )
+                self.request_usage_entries.append(annotated_entry)
 
 
 def _serialize_usage_details(details: Any, default: dict[str, int]) -> dict[str, Any]:

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -43,6 +43,8 @@ def deserialize_usage(usage_data: Mapping[str, Any]) -> Usage:
                     entry.get("output_tokens_details") or {"reasoning_tokens": 0},
                     OutputTokensDetails(reasoning_tokens=0),
                 ),
+                agent_name=entry.get("agent_name", None),
+                model_name=entry.get("model_name", None),
             )
         )
 
@@ -75,6 +77,20 @@ class RequestUsage:
 
     output_tokens_details: OutputTokensDetails
     """Details about the output tokens for this individual request."""
+
+    agent_name: str | None = None
+    """Name of the agent that made this request, if available.
+
+    Populated automatically when an agent makes a model call so that callers can attribute
+    token usage and costs to specific agents in multi-agent workflows.
+    """
+
+    model_name: str | None = None
+    """Name of the model used for this request, if available.
+
+    Populated automatically when an agent makes a model call so that callers can attribute
+    token usage and costs to specific models.
+    """
 
 
 def _normalize_input_tokens_details(
@@ -154,13 +170,23 @@ class Usage:
         if output_details_none or output_reasoning_none:
             self.output_tokens_details = OutputTokensDetails(reasoning_tokens=0)
 
-    def add(self, other: Usage) -> None:
+    def add(
+        self,
+        other: Usage,
+        *,
+        agent_name: str | None = None,
+        model_name: str | None = None,
+    ) -> None:
         """Add another Usage object to this one, aggregating all fields.
 
         This method automatically preserves request_usage_entries.
 
         Args:
             other: The Usage object to add to this one.
+            agent_name: Optional name of the agent making this request, used to annotate the
+                resulting ``RequestUsage`` entry for per-agent cost attribution.
+            model_name: Optional name of the model used for this request, used to annotate the
+                resulting ``RequestUsage`` entry for per-model cost attribution.
         """
         self.requests += other.requests if other.requests else 0
         self.input_tokens += other.input_tokens if other.input_tokens else 0
@@ -206,10 +232,18 @@ class Usage:
                 total_tokens=other.total_tokens,
                 input_tokens_details=input_details,
                 output_tokens_details=output_details,
+                agent_name=agent_name,
+                model_name=model_name,
             )
             self.request_usage_entries.append(request_usage)
         elif other.request_usage_entries:
             # If the other Usage already has individual request breakdowns, merge them.
+            # Apply agent_name/model_name to entries that don't already have them set.
+            for entry in other.request_usage_entries:
+                if agent_name is not None and entry.agent_name is None:
+                    entry.agent_name = agent_name
+                if model_name is not None and entry.model_name is None:
+                    entry.model_name = model_name
             self.request_usage_entries.extend(other.request_usage_entries)
 
 
@@ -228,7 +262,7 @@ def serialize_usage(usage: Usage) -> dict[str, Any]:
     output_details = _serialize_usage_details(usage.output_tokens_details, {"reasoning_tokens": 0})
 
     def _serialize_request_entry(entry: RequestUsage) -> dict[str, Any]:
-        return {
+        result: dict[str, Any] = {
             "input_tokens": entry.input_tokens,
             "output_tokens": entry.output_tokens,
             "total_tokens": entry.total_tokens,
@@ -239,6 +273,11 @@ def serialize_usage(usage: Usage) -> dict[str, Any]:
                 entry.output_tokens_details, {"reasoning_tokens": 0}
             ),
         }
+        if entry.agent_name is not None:
+            result["agent_name"] = entry.agent_name
+        if entry.model_name is not None:
+            result["model_name"] = entry.model_name
+        return result
 
     return {
         "requests": usage.requests,

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -224,18 +224,41 @@ class Usage:
         # Automatically preserve request_usage_entries.
         # If the other Usage represents a single request with tokens, record it.
         if other.requests == 1 and other.total_tokens > 0:
-            input_details = other.input_tokens_details or InputTokensDetails(cached_tokens=0)
-            output_details = other.output_tokens_details or OutputTokensDetails(reasoning_tokens=0)
-            request_usage = RequestUsage(
-                input_tokens=other.input_tokens,
-                output_tokens=other.output_tokens,
-                total_tokens=other.total_tokens,
-                input_tokens_details=input_details,
-                output_tokens_details=output_details,
-                agent_name=agent_name,
-                model_name=model_name,
-            )
-            self.request_usage_entries.append(request_usage)
+            if other.request_usage_entries:
+                # Pre-built entries (e.g. from a prior run) already carry per-request
+                # breakdown and attribution. Merge them with the same annotation
+                # semantics as the multi-entry path instead of replacing them with a
+                # fresh RequestUsage that only reflects add() kwargs.
+                for entry in other.request_usage_entries:
+                    annotated_entry = RequestUsage(
+                        input_tokens=entry.input_tokens,
+                        output_tokens=entry.output_tokens,
+                        total_tokens=entry.total_tokens,
+                        input_tokens_details=entry.input_tokens_details,
+                        output_tokens_details=entry.output_tokens_details,
+                        agent_name=agent_name
+                        if (agent_name is not None and entry.agent_name is None)
+                        else entry.agent_name,
+                        model_name=model_name
+                        if (model_name is not None and entry.model_name is None)
+                        else entry.model_name,
+                    )
+                    self.request_usage_entries.append(annotated_entry)
+            else:
+                input_details = other.input_tokens_details or InputTokensDetails(cached_tokens=0)
+                output_details = other.output_tokens_details or OutputTokensDetails(
+                    reasoning_tokens=0
+                )
+                request_usage = RequestUsage(
+                    input_tokens=other.input_tokens,
+                    output_tokens=other.output_tokens,
+                    total_tokens=other.total_tokens,
+                    input_tokens_details=input_details,
+                    output_tokens_details=output_details,
+                    agent_name=agent_name,
+                    model_name=model_name,
+                )
+                self.request_usage_entries.append(request_usage)
         elif other.request_usage_entries:
             # If the other Usage already has individual request breakdowns, merge them.
             # Apply agent_name/model_name to entries that don't already have them set,

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -380,12 +380,12 @@ def test_usage_normalizes_chat_completions_types():
 
 
 # ============================================================================
-# Tests for agent_name and model_name on RequestUsage (issue #2100)
+# Tests for agent_name on RequestUsage (issue #2100)
 # ============================================================================
 
 
-def test_request_usage_default_agent_model_names_are_none():
-    """Backward-compat: RequestUsage without agent_name/model_name defaults to None."""
+def test_request_usage_default_agent_name_is_none():
+    """Backward-compat: RequestUsage without agent_name defaults to None."""
     entry = RequestUsage(
         input_tokens=10,
         output_tokens=5,
@@ -394,14 +394,13 @@ def test_request_usage_default_agent_model_names_are_none():
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
     )
     assert entry.agent_name is None
-    assert entry.model_name is None
 
 
-def test_serialize_deserialize_roundtrip_preserves_agent_and_model_names():
-    """JSON round-trip must preserve agent_name and model_name on each entry.
+def test_serialize_deserialize_roundtrip_preserves_agent_name():
+    """JSON round-trip must preserve agent_name on each entry.
 
     This guards against a regression where serialize_usage drops the new
-    attribution fields, or deserialize_usage forgets to read them back.
+    attribution field, or deserialize_usage forgets to read it back.
     Both branches of the conditional emit (entry-with-name and entry-without-name)
     are exercised so the all-None fast path can't silently strip the keys.
     """
@@ -414,7 +413,6 @@ def test_serialize_deserialize_roundtrip_preserves_agent_and_model_names():
         input_tokens_details=InputTokensDetails(cached_tokens=0),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         agent_name="Math Tutor",
-        model_name="gpt-4o",
     )
     unnamed_entry = RequestUsage(
         input_tokens=2,
@@ -438,17 +436,15 @@ def test_serialize_deserialize_roundtrip_preserves_agent_and_model_names():
     restored_unnamed = restored.request_usage_entries[1]
 
     assert restored_named.agent_name == "Math Tutor"
-    assert restored_named.model_name == "gpt-4o"
     assert restored_named.input_tokens == 10
     assert restored_named.output_tokens == 5
 
     assert restored_unnamed.agent_name is None
-    assert restored_unnamed.model_name is None
     assert restored_unnamed.input_tokens == 2
 
 
-def test_request_usage_with_agent_and_model_names():
-    """RequestUsage can be created with explicit agent_name and model_name."""
+def test_request_usage_with_agent_name():
+    """RequestUsage can be created with an explicit agent_name."""
     entry = RequestUsage(
         input_tokens=10,
         output_tokens=5,
@@ -456,14 +452,12 @@ def test_request_usage_with_agent_and_model_names():
         input_tokens_details=InputTokensDetails(cached_tokens=0),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         agent_name="Math Tutor",
-        model_name="gpt-4o",
     )
     assert entry.agent_name == "Math Tutor"
-    assert entry.model_name == "gpt-4o"
 
 
-def test_usage_add_propagates_agent_and_model_names():
-    """Usage.add() with agent_name/model_name annotates the RequestUsage entry."""
+def test_usage_add_propagates_agent_name():
+    """Usage.add() with agent_name annotates the RequestUsage entry."""
     parent = Usage()
     child = Usage(
         requests=1,
@@ -473,18 +467,17 @@ def test_usage_add_propagates_agent_and_model_names():
         input_tokens_details=InputTokensDetails(cached_tokens=0),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
     )
-    parent.add(child, agent_name="Code Reviewer", model_name="gpt-4o-mini")
+    parent.add(child, agent_name="Code Reviewer")
 
     assert len(parent.request_usage_entries) == 1
     entry = parent.request_usage_entries[0]
     assert entry.agent_name == "Code Reviewer"
-    assert entry.model_name == "gpt-4o-mini"
     assert entry.input_tokens == 65
     assert entry.output_tokens == 13
 
 
-def test_usage_add_without_agent_model_names_stays_none():
-    """Usage.add() without agent/model names leaves them as None (backward compat)."""
+def test_usage_add_without_agent_name_stays_none():
+    """Usage.add() without agent_name leaves it as None (backward compat)."""
     parent = Usage()
     child = Usage(
         requests=1,
@@ -499,11 +492,10 @@ def test_usage_add_without_agent_model_names_stays_none():
     assert len(parent.request_usage_entries) == 1
     entry = parent.request_usage_entries[0]
     assert entry.agent_name is None
-    assert entry.model_name is None
 
 
 def test_usage_add_single_request_preserves_prebuilt_entry_attribution():
-    """Single-request Usage with request_usage_entries keeps agent/model when add() has no kwargs."""
+    """Single-request Usage with request_usage_entries keeps agent name when add() has no kwargs."""
     inner = RequestUsage(
         input_tokens=20,
         output_tokens=10,
@@ -511,7 +503,6 @@ def test_usage_add_single_request_preserves_prebuilt_entry_attribution():
         input_tokens_details=InputTokensDetails(cached_tokens=0),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         agent_name="Prior Run Agent",
-        model_name="prior-model",
     )
     child = Usage(
         requests=1,
@@ -528,11 +519,10 @@ def test_usage_add_single_request_preserves_prebuilt_entry_attribution():
     assert len(parent.request_usage_entries) == 1
     out = parent.request_usage_entries[0]
     assert out.agent_name == "Prior Run Agent"
-    assert out.model_name == "prior-model"
 
 
-def test_usage_add_merge_existing_entries_applies_agent_model_names():
-    """When merging existing request_usage_entries, agent/model names are applied to unset ones."""
+def test_usage_add_merge_existing_entries_applies_agent_name():
+    """When merging existing request_usage_entries, agent_name is applied to unset ones."""
     # An existing entry without names
     existing_entry = RequestUsage(
         input_tokens=100,
@@ -551,15 +541,14 @@ def test_usage_add_merge_existing_entries_applies_agent_model_names():
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         request_usage_entries=[existing_entry],
     )
-    parent.add(child, agent_name="Triage Agent", model_name="gpt-4o")
+    parent.add(child, agent_name="Triage Agent")
 
     assert len(parent.request_usage_entries) == 1
     assert parent.request_usage_entries[0].agent_name == "Triage Agent"
-    assert parent.request_usage_entries[0].model_name == "gpt-4o"
 
 
-def test_usage_add_merge_existing_entries_does_not_overwrite_names():
-    """Existing agent/model names on entries are not overwritten during merge."""
+def test_usage_add_merge_existing_entries_does_not_overwrite_agent_name():
+    """Existing agent_name on entries is not overwritten during merge."""
     existing_entry = RequestUsage(
         input_tokens=100,
         output_tokens=50,
@@ -567,7 +556,6 @@ def test_usage_add_merge_existing_entries_does_not_overwrite_names():
         input_tokens_details=InputTokensDetails(cached_tokens=0),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         agent_name="Already Named Agent",
-        model_name="already-named-model",
     )
     parent = Usage()
     child = Usage(
@@ -579,11 +567,10 @@ def test_usage_add_merge_existing_entries_does_not_overwrite_names():
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         request_usage_entries=[existing_entry],
     )
-    parent.add(child, agent_name="New Agent Name", model_name="new-model")
+    parent.add(child, agent_name="New Agent Name")
 
-    # The existing names should NOT be overwritten
+    # The existing name should NOT be overwritten
     assert parent.request_usage_entries[0].agent_name == "Already Named Agent"
-    assert parent.request_usage_entries[0].model_name == "already-named-model"
 
 
 @pytest.mark.asyncio
@@ -608,33 +595,6 @@ async def test_runner_run_populates_agent_name_in_request_usage():
     entries = result.context_wrapper.usage.request_usage_entries
     assert len(entries) == 1
     assert entries[0].agent_name == "My Assistant"
-
-
-@pytest.mark.asyncio
-async def test_runner_run_populates_model_name_in_request_usage():
-    """Integration: Running an agent populates model_name in RequestUsage entries."""
-    from agents.usage import Usage as AgentUsage
-
-    model_usage = AgentUsage(
-        requests=1,
-        input_tokens=30,
-        output_tokens=10,
-        total_tokens=40,
-        input_tokens_details=InputTokensDetails(cached_tokens=0),
-        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
-    )
-    # FakeModel doesn't expose a `.model` attribute by default → model_name should be None
-    # We give it one to test that model_name is picked up.
-    fake = FakeModel(initial_output=[get_text_message("ok")])
-    fake.model = "test-model-name"  # type: ignore[attr-defined]
-    fake.set_hardcoded_usage(model_usage)
-    agent = Agent(name="Model-Aware Agent", model=fake)
-
-    result = await Runner.run(agent, input="ping")
-
-    entries = result.context_wrapper.usage.request_usage_entries
-    assert len(entries) == 1
-    assert entries[0].model_name == "test-model-name"
 
 
 @pytest.mark.asyncio
@@ -663,12 +623,10 @@ async def test_multi_agent_run_attributes_usage_to_correct_agents():
     )
 
     specialist_model = FakeModel(initial_output=[get_text_message("specialist done")])
-    specialist_model.model = "gpt-4o-specialist"  # type: ignore[attr-defined]
     specialist_model.set_hardcoded_usage(specialist_usage)
     specialist_agent = Agent(name="Specialist Agent", model=specialist_model)
 
     triage_model = FakeModel()
-    triage_model.model = "gpt-4o-triage"  # type: ignore[attr-defined]
     triage_model.add_multiple_turn_outputs(
         [
             [get_handoff_tool_call(specialist_agent)],
@@ -688,16 +646,9 @@ async def test_multi_agent_run_attributes_usage_to_correct_agents():
 
     triage_entry = next(e for e in all_entries if e.agent_name == "Triage Agent")
     assert triage_entry.input_tokens == 100
-    assert triage_entry.model_name == "gpt-4o-triage", (
-        f"Triage entry model_name should be 'gpt-4o-triage', got {triage_entry.model_name!r}"
-    )
 
     specialist_entry = next(e for e in all_entries if e.agent_name == "Specialist Agent")
     assert specialist_entry.input_tokens == 200
-    assert specialist_entry.model_name == "gpt-4o-specialist", (
-        "Specialist entry model_name should be 'gpt-4o-specialist', "
-        f"got {specialist_entry.model_name!r}"
-    )
 
 
 def test_add_does_not_mutate_other_entries() -> None:
@@ -716,7 +667,6 @@ def test_add_does_not_mutate_other_entries() -> None:
         input_tokens_details=InputTokensDetails(cached_tokens=0),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         agent_name=None,
-        model_name=None,
     )
 
     # Build a Usage that already has request_usage_entries (requests != 1 path)
@@ -729,13 +679,11 @@ def test_add_does_not_mutate_other_entries() -> None:
     )
 
     agg = Usage()
-    agg.add(other, agent_name="MyAgent", model_name="gpt-4o")
+    agg.add(other, agent_name="MyAgent")
 
     # The aggregator should have a copy with the annotation applied
     assert len(agg.request_usage_entries) == 1
     assert agg.request_usage_entries[0].agent_name == "MyAgent"
-    assert agg.request_usage_entries[0].model_name == "gpt-4o"
 
     # The original entry must NOT be mutated
     assert source_entry.agent_name is None, "Original entry was mutated!"
-    assert source_entry.model_name is None, "Original entry was mutated!"

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -610,3 +610,44 @@ async def test_multi_agent_run_attributes_usage_to_correct_agents():
 
     specialist_entry = next(e for e in all_entries if e.agent_name == "Specialist Agent")
     assert specialist_entry.input_tokens == 200
+
+
+def test_add_does_not_mutate_other_entries() -> None:
+    """Adding a Usage with existing request_usage_entries must not mutate the original entries.
+
+    Previously, the elif branch in Usage.add() called entry.agent_name = ... directly on
+    the objects inside other.request_usage_entries, causing silent mis-attribution when the
+    same Usage object was re-used or added to multiple aggregators.
+    """
+    from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+    source_entry = RequestUsage(
+        input_tokens=50,
+        output_tokens=25,
+        total_tokens=75,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        agent_name=None,
+        model_name=None,
+    )
+
+    # Build a Usage that already has request_usage_entries (requests != 1 path)
+    other = Usage(
+        requests=2,
+        input_tokens=50,
+        output_tokens=25,
+        total_tokens=75,
+        request_usage_entries=[source_entry],
+    )
+
+    agg = Usage()
+    agg.add(other, agent_name="MyAgent", model_name="gpt-4o")
+
+    # The aggregator should have a copy with the annotation applied
+    assert len(agg.request_usage_entries) == 1
+    assert agg.request_usage_entries[0].agent_name == "MyAgent"
+    assert agg.request_usage_entries[0].model_name == "gpt-4o"
+
+    # The original entry must NOT be mutated
+    assert source_entry.agent_name is None, "Original entry was mutated!"
+    assert source_entry.model_name is None, "Original entry was mutated!"

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -502,6 +502,35 @@ def test_usage_add_without_agent_model_names_stays_none():
     assert entry.model_name is None
 
 
+def test_usage_add_single_request_preserves_prebuilt_entry_attribution():
+    """Single-request Usage with request_usage_entries keeps agent/model when add() has no kwargs."""
+    inner = RequestUsage(
+        input_tokens=20,
+        output_tokens=10,
+        total_tokens=30,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        agent_name="Prior Run Agent",
+        model_name="prior-model",
+    )
+    child = Usage(
+        requests=1,
+        input_tokens=20,
+        output_tokens=10,
+        total_tokens=30,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        request_usage_entries=[inner],
+    )
+    parent = Usage()
+    parent.add(child)
+
+    assert len(parent.request_usage_entries) == 1
+    out = parent.request_usage_entries[0]
+    assert out.agent_name == "Prior Run Agent"
+    assert out.model_name == "prior-model"
+
+
 def test_usage_add_merge_existing_entries_applies_agent_model_names():
     """When merging existing request_usage_entries, agent/model names are applied to unset ones."""
     # An existing entry without names

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -377,3 +377,236 @@ def test_usage_normalizes_chat_completions_types():
 
     assert isinstance(usage.output_tokens_details, OutputTokensDetails)
     assert usage.output_tokens_details.reasoning_tokens == 100
+
+
+# ============================================================================
+# Tests for agent_name and model_name on RequestUsage (issue #2100)
+# ============================================================================
+
+
+def test_request_usage_default_agent_model_names_are_none():
+    """Backward-compat: RequestUsage without agent_name/model_name defaults to None."""
+    entry = RequestUsage(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    assert entry.agent_name is None
+    assert entry.model_name is None
+
+
+def test_request_usage_with_agent_and_model_names():
+    """RequestUsage can be created with explicit agent_name and model_name."""
+    entry = RequestUsage(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        agent_name="Math Tutor",
+        model_name="gpt-4o",
+    )
+    assert entry.agent_name == "Math Tutor"
+    assert entry.model_name == "gpt-4o"
+
+
+def test_usage_add_propagates_agent_and_model_names():
+    """Usage.add() with agent_name/model_name annotates the RequestUsage entry."""
+    parent = Usage()
+    child = Usage(
+        requests=1,
+        input_tokens=65,
+        output_tokens=13,
+        total_tokens=78,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    parent.add(child, agent_name="Code Reviewer", model_name="gpt-4o-mini")
+
+    assert len(parent.request_usage_entries) == 1
+    entry = parent.request_usage_entries[0]
+    assert entry.agent_name == "Code Reviewer"
+    assert entry.model_name == "gpt-4o-mini"
+    assert entry.input_tokens == 65
+    assert entry.output_tokens == 13
+
+
+def test_usage_add_without_agent_model_names_stays_none():
+    """Usage.add() without agent/model names leaves them as None (backward compat)."""
+    parent = Usage()
+    child = Usage(
+        requests=1,
+        input_tokens=20,
+        output_tokens=10,
+        total_tokens=30,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    parent.add(child)
+
+    assert len(parent.request_usage_entries) == 1
+    entry = parent.request_usage_entries[0]
+    assert entry.agent_name is None
+    assert entry.model_name is None
+
+
+def test_usage_add_merge_existing_entries_applies_agent_model_names():
+    """When merging existing request_usage_entries, agent/model names are applied to unset ones."""
+    # An existing entry without names
+    existing_entry = RequestUsage(
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    parent = Usage()
+    child = Usage(
+        requests=2,  # not 1, so it won't auto-create a new entry
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        request_usage_entries=[existing_entry],
+    )
+    parent.add(child, agent_name="Triage Agent", model_name="gpt-4o")
+
+    assert len(parent.request_usage_entries) == 1
+    assert parent.request_usage_entries[0].agent_name == "Triage Agent"
+    assert parent.request_usage_entries[0].model_name == "gpt-4o"
+
+
+def test_usage_add_merge_existing_entries_does_not_overwrite_names():
+    """Existing agent/model names on entries are not overwritten during merge."""
+    existing_entry = RequestUsage(
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        agent_name="Already Named Agent",
+        model_name="already-named-model",
+    )
+    parent = Usage()
+    child = Usage(
+        requests=2,
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        request_usage_entries=[existing_entry],
+    )
+    parent.add(child, agent_name="New Agent Name", model_name="new-model")
+
+    # The existing names should NOT be overwritten
+    assert parent.request_usage_entries[0].agent_name == "Already Named Agent"
+    assert parent.request_usage_entries[0].model_name == "already-named-model"
+
+
+@pytest.mark.asyncio
+async def test_runner_run_populates_agent_name_in_request_usage():
+    """Integration: Running an agent populates agent_name in RequestUsage entries."""
+    from agents.usage import Usage as AgentUsage
+
+    model_usage = AgentUsage(
+        requests=1,
+        input_tokens=42,
+        output_tokens=8,
+        total_tokens=50,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    fake = FakeModel(initial_output=[get_text_message("hello")])
+    fake.set_hardcoded_usage(model_usage)
+    agent = Agent(name="My Assistant", model=fake)
+
+    result = await Runner.run(agent, input="hi")
+
+    entries = result.context_wrapper.usage.request_usage_entries
+    assert len(entries) == 1
+    assert entries[0].agent_name == "My Assistant"
+
+
+@pytest.mark.asyncio
+async def test_runner_run_populates_model_name_in_request_usage():
+    """Integration: Running an agent populates model_name in RequestUsage entries."""
+    from agents.usage import Usage as AgentUsage
+
+    model_usage = AgentUsage(
+        requests=1,
+        input_tokens=30,
+        output_tokens=10,
+        total_tokens=40,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    # FakeModel doesn't expose a `.model` attribute by default → model_name should be None
+    # We give it one to test that model_name is picked up.
+    fake = FakeModel(initial_output=[get_text_message("ok")])
+    fake.model = "test-model-name"  # type: ignore[attr-defined]
+    fake.set_hardcoded_usage(model_usage)
+    agent = Agent(name="Model-Aware Agent", model=fake)
+
+    result = await Runner.run(agent, input="ping")
+
+    entries = result.context_wrapper.usage.request_usage_entries
+    assert len(entries) == 1
+    assert entries[0].model_name == "test-model-name"
+
+
+@pytest.mark.asyncio
+async def test_multi_agent_run_attributes_usage_to_correct_agents():
+    """Multi-agent scenario: each RequestUsage entry has the right agent_name."""
+
+    from agents.usage import Usage as AgentUsage
+    from tests.test_responses import get_handoff_tool_call
+
+    # Two separate models so we can track which agent's usage is which
+    triage_usage = AgentUsage(
+        requests=1,
+        input_tokens=100,
+        output_tokens=10,
+        total_tokens=110,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    specialist_usage = AgentUsage(
+        requests=1,
+        input_tokens=200,
+        output_tokens=20,
+        total_tokens=220,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+
+    specialist_model = FakeModel(initial_output=[get_text_message("specialist done")])
+    specialist_model.set_hardcoded_usage(specialist_usage)
+    specialist_agent = Agent(name="Specialist Agent", model=specialist_model)
+
+    triage_model = FakeModel()
+    triage_model.add_multiple_turn_outputs(
+        [
+            [get_handoff_tool_call(specialist_agent)],
+        ]
+    )
+    triage_model.set_hardcoded_usage(triage_usage)
+    triage_agent = Agent(name="Triage Agent", model=triage_model, handoffs=[specialist_agent])
+
+    result = await Runner.run(triage_agent, input="route me")
+
+    all_entries = result.context_wrapper.usage.request_usage_entries
+    assert len(all_entries) == 2, f"Expected 2 request entries, got {len(all_entries)}"
+
+    agent_names = [e.agent_name for e in all_entries]
+    assert "Triage Agent" in agent_names, f"Expected 'Triage Agent' in {agent_names}"
+    assert "Specialist Agent" in agent_names, f"Expected 'Specialist Agent' in {agent_names}"
+
+    triage_entry = next(e for e in all_entries if e.agent_name == "Triage Agent")
+    assert triage_entry.input_tokens == 100
+
+    specialist_entry = next(e for e in all_entries if e.agent_name == "Specialist Agent")
+    assert specialist_entry.input_tokens == 200

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -397,6 +397,56 @@ def test_request_usage_default_agent_model_names_are_none():
     assert entry.model_name is None
 
 
+def test_serialize_deserialize_roundtrip_preserves_agent_and_model_names():
+    """JSON round-trip must preserve agent_name and model_name on each entry.
+
+    This guards against a regression where serialize_usage drops the new
+    attribution fields, or deserialize_usage forgets to read them back.
+    Both branches of the conditional emit (entry-with-name and entry-without-name)
+    are exercised so the all-None fast path can't silently strip the keys.
+    """
+    from agents.usage import deserialize_usage, serialize_usage
+
+    named_entry = RequestUsage(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        agent_name="Math Tutor",
+        model_name="gpt-4o",
+    )
+    unnamed_entry = RequestUsage(
+        input_tokens=2,
+        output_tokens=1,
+        total_tokens=3,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    original = Usage(
+        requests=2,
+        input_tokens=12,
+        output_tokens=6,
+        total_tokens=18,
+        request_usage_entries=[named_entry, unnamed_entry],
+    )
+
+    restored = deserialize_usage(serialize_usage(original))
+
+    assert len(restored.request_usage_entries) == 2
+    restored_named = restored.request_usage_entries[0]
+    restored_unnamed = restored.request_usage_entries[1]
+
+    assert restored_named.agent_name == "Math Tutor"
+    assert restored_named.model_name == "gpt-4o"
+    assert restored_named.input_tokens == 10
+    assert restored_named.output_tokens == 5
+
+    assert restored_unnamed.agent_name is None
+    assert restored_unnamed.model_name is None
+    assert restored_unnamed.input_tokens == 2
+
+
 def test_request_usage_with_agent_and_model_names():
     """RequestUsage can be created with explicit agent_name and model_name."""
     entry = RequestUsage(
@@ -584,10 +634,12 @@ async def test_multi_agent_run_attributes_usage_to_correct_agents():
     )
 
     specialist_model = FakeModel(initial_output=[get_text_message("specialist done")])
+    specialist_model.model = "gpt-4o-specialist"  # type: ignore[attr-defined]
     specialist_model.set_hardcoded_usage(specialist_usage)
     specialist_agent = Agent(name="Specialist Agent", model=specialist_model)
 
     triage_model = FakeModel()
+    triage_model.model = "gpt-4o-triage"  # type: ignore[attr-defined]
     triage_model.add_multiple_turn_outputs(
         [
             [get_handoff_tool_call(specialist_agent)],
@@ -607,9 +659,16 @@ async def test_multi_agent_run_attributes_usage_to_correct_agents():
 
     triage_entry = next(e for e in all_entries if e.agent_name == "Triage Agent")
     assert triage_entry.input_tokens == 100
+    assert triage_entry.model_name == "gpt-4o-triage", (
+        f"Triage entry model_name should be 'gpt-4o-triage', got {triage_entry.model_name!r}"
+    )
 
     specialist_entry = next(e for e in all_entries if e.agent_name == "Specialist Agent")
     assert specialist_entry.input_tokens == 200
+    assert specialist_entry.model_name == "gpt-4o-specialist", (
+        "Specialist entry model_name should be 'gpt-4o-specialist', "
+        f"got {specialist_entry.model_name!r}"
+    )
 
 
 def test_add_does_not_mutate_other_entries() -> None:


### PR DESCRIPTION
## Summary

Adds optional `agent_name` and `model_name` fields to `RequestUsage` so developers can attribute token usage and costs to specific agents and models in multi-agent workflows.

## Problem

In complex multi-agent systems, `result.context_wrapper.usage.request_usage_entries` contains one `RequestUsage` per LLM call, but there is no way to know which agent or model generated each entry. This makes per-agent cost attribution impossible.

## Solution

- Added `agent_name: str | None = None` and `model_name: str | None = None` to `RequestUsage` (backward-compatible — defaults to `None`)
- Modified `Usage.add()` to accept keyword-only `agent_name` and `model_name` parameters and annotate the resulting `RequestUsage` entry
- Added `_get_model_name()` helper that safely duck-types the model name from any `Model` implementation (e.g. `OpenAIResponsesModel.model`, `OpenAIChatCompletionsModel.model`)
- Updated both `run_single_turn_streamed` and `get_new_response` call-sites in `run_loop.py` to pass `agent.name` and resolved model name
- When merging pre-existing `request_usage_entries`, agent/model names are applied only to entries that don't already have them (existing names preserved)
- Updated `serialize_usage` / `deserialize_usage` to round-trip the new fields through JSON
- Zero breaking changes — existing code constructing `RequestUsage` or calling `Usage.add()` without these fields continues to work

## Before / After

```python
# Before
RequestUsage(input_tokens=65, output_tokens=13, ...)

# After
RequestUsage(agent_name="Math Tutor", model_name="gpt-4o", input_tokens=65, output_tokens=13, ...)
```

## Usage Example

```python
result = await Runner.run(triage_agent, input="help me")

for entry in result.context_wrapper.usage.request_usage_entries:
    print(f"{entry.agent_name} ({entry.model_name}): {entry.input_tokens} in / {entry.output_tokens} out")
# Triage Agent (gpt-4o-mini): 100 in / 10 out
# Specialist Agent (gpt-4o): 200 in / 20 out
```

## Files Changed

| File | Change |
|------|--------|
| `src/agents/usage.py` | Added `agent_name`/`model_name` fields to `RequestUsage`; updated `Usage.add()`, `serialize_usage`, `deserialize_usage` |
| `src/agents/run_internal/run_loop.py` | Added `_get_model_name()` helper; updated both `usage.add()` call-sites |
| `tests/test_usage.py` | Added 9 new tests |

## Test Plan
- Unit tests for `RequestUsage` field population (explicit + default None)
- `Usage.add()` propagation and backward compat tests
- Entry merge semantics (names applied to un-named entries; existing names preserved)
- Single-agent runner integration test confirming `agent_name` is set
- Model-name detection test via duck-typed `.model` attribute
- Multi-agent scenario: each `RequestUsage` entry has the correct `agent_name`
- Full suite: 2198 tests pass, lint clean, pyright clean

Closes openai/openai-agents-python#2100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage tracking now records agent name and model name with each request for improved visibility and attribution; model name is included only when available.
  * Usage exports/records now include these metadata fields when present.

* **Tests**
  * Added tests verifying capture and preservation of agent and model names across runs, merges, and multi-agent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
