### PR TITLE
docs: add Rewind to external tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -207,6 +207,7 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [AgentOps](https://docs.agentops.ai/v1/integrations/agentssdk)
 -   [Scorecard](https://docs.scorecard.io/docs/documentation/features/tracing#openai-agents-sdk-integration)
 -   [Respan](https://respan.ai/docs/integrations/tracing/openai-agents-sdk)
+-   [Rewind](https://github.com/agentoptics/rewind)
 -   [LangSmith](https://docs.smith.langchain.com/observability/how_to_guides/trace_with_openai_agents_sdk)
 -   [Maxim AI](https://www.getmaxim.ai/docs/observe/integrations/openai-agents-sdk)
 -   [Comet Opik](https://www.comet.com/docs/opik/tracing/integrations/openai_agents)


### PR DESCRIPTION
## What

Adds [Rewind](https://github.com/agentoptics/rewind) to the external tracing processors list in `docs/tracing.md`.

## Why

Rewind provides a `RewindTracingProcessor` that captures agent spans into a local time-travel debugger, useful for debugging agent behavior locally.

## Testing

This is a documentation-only change adding an entry to an existing list.

Closes #2872