### PR TITLE
examples/mcp: add HashLock OTC remote MCP example

### DIFF
--- a/examples/mcp/hashlock_example/README.md
+++ b/examples/mcp/hashlock_example/README.md
@@ -1,0 +1,41 @@
+# MCP HashLock OTC Example
+
+Connects to the HashLock OTC remote MCP server
+(`https://mcp.hashlock.markets/mcp`) over Streamable HTTP and lets the
+agent request OTC crypto quotes via HTLC atomic settlement.
+
+Run it with:
+
+```bash
+uv run python examples/mcp/hashlock_example/main.py
+```
+
+## Prerequisites
+
+Get a HashLock access token (SIWE wallet signature, 30-day expiry,
+no email/password):
+
+1. Visit https://hashlock.markets/mcp/auth
+2. Sign the login message with your wallet
+3. Copy the bearer token
+4. Export it:
+
+```bash
+export HASHLOCK_ACCESS_TOKEN="<your-token>"
+```
+
+## What it demonstrates
+
+- Passing a bearer token to a remote MCP server via the `headers` param
+- Requesting a quote with `create_rfq`
+- The agent's instructions keep on-chain HTLC writes off-limits — settlement
+  happens out-of-band in the user's browser wallet, not from the agent loop
+
+## Tools exposed
+
+- `create_rfq` / `respond_rfq` — post / answer quote requests
+- `get_htlc` / `get_rfq` — query trade state
+- `create_htlc` / `withdraw_htlc` / `refund_htlc` — HTLC lifecycle
+  (read by the agent; writes require user signature)
+
+More: https://github.com/Hashlock-Tech/hashlock-mcp

--- a/examples/mcp/hashlock_example/main.py
+++ b/examples/mcp/hashlock_example/main.py
@@ -1,0 +1,57 @@
+import asyncio
+import os
+
+from agents import Agent, Runner, gen_trace_id, trace
+from agents.mcp import MCPServerStreamableHttp
+
+
+HASHLOCK_MCP_URL = "https://mcp.hashlock.markets/mcp"
+
+
+async def main():
+    token = os.environ.get("HASHLOCK_ACCESS_TOKEN")
+    if not token:
+        raise SystemExit(
+            "Missing HASHLOCK_ACCESS_TOKEN. "
+            "Get one at https://hashlock.markets/mcp/auth (SIWE wallet signature)."
+        )
+
+    async with MCPServerStreamableHttp(
+        name="HashLock OTC Streamable HTTP Server",
+        params={
+            "url": HASHLOCK_MCP_URL,
+            "headers": {"Authorization": f"Bearer {token}"},
+            "timeout": 15,
+            "sse_read_timeout": 300,
+        },
+        # Remote quote polling can be slow when market makers are busy.
+        max_retry_attempts=2,
+        retry_backoff_seconds_base=2.0,
+        client_session_timeout_seconds=15,
+    ) as server:
+        agent = Agent(
+            name="OTC Quote Assistant",
+            instructions=(
+                "You help users request OTC crypto quotes via HashLock. "
+                "Use create_rfq to post a quote request, then poll with "
+                "get_rfq until quotes arrive or the RFQ expires. "
+                "NEVER trigger on-chain HTLC writes — those require the user "
+                "to sign in their own wallet at hashlock.markets."
+            ),
+            mcp_servers=[server],
+        )
+
+        trace_id = gen_trace_id()
+        with trace(workflow_name="HashLock OTC Streamable HTTP Example", trace_id=trace_id):
+            print(
+                f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n"
+            )
+            result = await Runner.run(
+                agent,
+                "I want to sell 0.5 ETH for USDC. What's the best quote?",
+            )
+            print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### What

Adds a minimal, self-contained example that connects the Agents SDK to HashLock OTC's remote MCP server (`https://mcp.hashlock.markets/mcp`) over Streamable HTTP. The agent requests an OTC crypto quote and streams quotes back from institutional market makers.

### Why

HashLock exposes atomic HTLC settlement via MCP. Including it alongside the existing HTTP examples gives developers a realistic non-toy integration to copy from.

### Scope

- `examples/mcp/hashlock_example/main.py` — ~55 LOC, mirrors the style of `streamable_http_remote_example`
- `examples/mcp/hashlock_example/README.md` — setup + token instructions
- No library code changes

### Safety note

The example is explicit that on-chain HTLC writes should not be triggered from the agent loop. That matches HashLock's own design: settlement signatures happen out-of-band in the user's browser wallet.

### How I tested

Locally with `HASHLOCK_ACCESS_TOKEN` set:

```bash
python examples/mcp/hashlock_example/main.py
# -> streams quotes from the RFQ
```

### Checklist

- [x] Added to `examples/mcp/` directory
- [x] README included
- [x] No new dependencies beyond `openai-agents` and stdlib
- [x] Works out of the box once `HASHLOCK_ACCESS_TOKEN` is set