### PR TITLE
fix: #2938 make `agents.sandbox.sandboxes` importable on Windows

### DIFF
--- a/src/agents/sandbox/sandboxes/__init__.py
+++ b/src/agents/sandbox/sandboxes/__init__.py
@@ -25,7 +25,7 @@ if sys.platform != "win32":
 
     _HAS_UNIX_LOCAL = True
 elif TYPE_CHECKING:  # pragma: no cover
-    from .unix_local import (
+    from .unix_local import (  # noqa: F401
         UnixLocalSandboxClient,
         UnixLocalSandboxClientOptions,
         UnixLocalSandboxSession,

--- a/src/agents/sandbox/sandboxes/__init__.py
+++ b/src/agents/sandbox/sandboxes/__init__.py
@@ -45,8 +45,7 @@ except Exception:  # pragma: no cover
     # Docker is an optional extra; keep base imports working without it.
     _HAS_DOCKER = False
 
-__all__ = [
-]
+__all__ = []
 
 if _HAS_UNIX_LOCAL:
     __all__.extend(

--- a/src/agents/sandbox/sandboxes/__init__.py
+++ b/src/agents/sandbox/sandboxes/__init__.py
@@ -5,12 +5,32 @@ This subpackage contains concrete session/client implementations for different
 execution environments (e.g. Docker, local Unix).
 """
 
-from .unix_local import (
-    UnixLocalSandboxClient,
-    UnixLocalSandboxClientOptions,
-    UnixLocalSandboxSession,
-    UnixLocalSandboxSessionState,
-)
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+_HAS_UNIX_LOCAL = False
+
+# The unix_local backend depends on Unix-only stdlib modules (e.g. fcntl/termios). Importing it
+# unconditionally makes `import agents.sandbox.sandboxes` fail on Windows, even if callers only
+# want other backends.
+if sys.platform != "win32":
+    from .unix_local import (
+        UnixLocalSandboxClient,
+        UnixLocalSandboxClientOptions,
+        UnixLocalSandboxSession,
+        UnixLocalSandboxSessionState,
+    )
+
+    _HAS_UNIX_LOCAL = True
+elif TYPE_CHECKING:  # pragma: no cover
+    from .unix_local import (
+        UnixLocalSandboxClient,
+        UnixLocalSandboxClientOptions,
+        UnixLocalSandboxSession,
+        UnixLocalSandboxSessionState,
+    )
 
 try:
     from .docker import (  # noqa: F401
@@ -26,11 +46,17 @@ except Exception:  # pragma: no cover
     _HAS_DOCKER = False
 
 __all__ = [
-    "UnixLocalSandboxClient",
-    "UnixLocalSandboxClientOptions",
-    "UnixLocalSandboxSession",
-    "UnixLocalSandboxSessionState",
 ]
+
+if _HAS_UNIX_LOCAL:
+    __all__.extend(
+        [
+            "UnixLocalSandboxClient",
+            "UnixLocalSandboxClientOptions",
+            "UnixLocalSandboxSession",
+            "UnixLocalSandboxSessionState",
+        ]
+    )
 
 if _HAS_DOCKER:
     __all__.extend(

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -1,3 +1,13 @@
+import sys
+
+# This backend uses Unix-only APIs (pty, termios, fcntl). Raise a clear error when imported on
+# Windows rather than failing later with confusing ModuleNotFoundError exceptions.
+if sys.platform == "win32":  # pragma: no cover
+    raise ImportError(
+        "UnixLocalSandbox is not supported on Windows. "
+        "Use DockerSandboxClient (requires the optional 'docker' extra) or another sandbox backend."
+    )
+
 import asyncio
 import errno
 import fcntl

--- a/tests/sandbox/test_sandboxes_imports.py
+++ b/tests/sandbox/test_sandboxes_imports.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_import_agents_sandbox_sandboxes_does_not_raise() -> None:
+    # Historically this import failed on Windows because the module imported the Unix-only backend
+    # unconditionally (which depends on fcntl/termios).
+    import agents.sandbox.sandboxes as sandboxes  # noqa: F401
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only behavior")
+def test_importing_unix_local_backend_raises_clear_error_on_windows() -> None:
+    with pytest.raises(ImportError, match=r"not supported on Windows"):
+        import agents.sandbox.sandboxes.unix_local  # noqa: F401


### PR DESCRIPTION
**PR Description**
- **Problem**: On Windows, `import agents.sandbox.sandboxes` fails with `ModuleNotFoundError: fcntl` because the package eagerly imports the Unix-only `unix_local` backend (which depends on Unix-only stdlib like `fcntl`/`termios`).
- **Change**:
  - Guard `unix_local` imports in src/agents/sandbox/sandboxes/__init__.py so the `sandboxes` package can be imported on Windows even when the Unix backend is unavailable.
  - Add an explicit, user-facing `ImportError` in src/agents/sandbox/sandboxes/unix_local.py when imported on Windows (clearer than the current `ModuleNotFoundError`).
  - Add regression tests in tests/sandbox/test_sandboxes_imports.py.
- **Why this approach**: `unix_local` is inherently Unix-only; the SDK should stay importable cross-platform and only fail when a platform-incompatible backend is explicitly imported/used.
- **Tests**: `python -m pytest -q tests/sandbox/test_sandboxes_imports.py`

Fixes #2938