### PR TITLE
fix: #2938 avoid importing unix local sandboxes on Windows

### DIFF
--- a/src/agents/sandbox/sandboxes/__init__.py
+++ b/src/agents/sandbox/sandboxes/__init__.py
@@ -5,12 +5,20 @@ This subpackage contains concrete session/client implementations for different
 execution environments (e.g. Docker, local Unix).
 """
 
-from .unix_local import (
-    UnixLocalSandboxClient,
-    UnixLocalSandboxClientOptions,
-    UnixLocalSandboxSession,
-    UnixLocalSandboxSessionState,
-)
+import sys
+
+_HAS_UNIX_LOCAL = False
+
+if sys.platform != "win32":
+    # The Unix local backend depends on Unix-only stdlib modules like fcntl and termios.
+    from .unix_local import (
+        UnixLocalSandboxClient,
+        UnixLocalSandboxClientOptions,
+        UnixLocalSandboxSession,
+        UnixLocalSandboxSessionState,
+    )
+
+    _HAS_UNIX_LOCAL = True
 
 try:
     from .docker import (  # noqa: F401
@@ -25,12 +33,17 @@ except Exception:  # pragma: no cover
     # Docker is an optional extra; keep base imports working without it.
     _HAS_DOCKER = False
 
-__all__ = [
-    "UnixLocalSandboxClient",
-    "UnixLocalSandboxClientOptions",
-    "UnixLocalSandboxSession",
-    "UnixLocalSandboxSessionState",
-]
+__all__: list[str] = []
+
+if _HAS_UNIX_LOCAL:
+    __all__.extend(
+        [
+            "UnixLocalSandboxClient",
+            "UnixLocalSandboxClientOptions",
+            "UnixLocalSandboxSession",
+            "UnixLocalSandboxSessionState",
+        ]
+    )
 
 if _HAS_DOCKER:
     __all__.extend(

--- a/tests/sandbox/test_sandboxes_import.py
+++ b/tests/sandbox/test_sandboxes_import.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_sandboxes_package_import_skips_unix_local_on_windows(monkeypatch) -> None:
+    original_module = sys.modules.get("agents.sandbox.sandboxes")
+    sandbox_package = importlib.import_module("agents.sandbox")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    sys.modules.pop("agents.sandbox.sandboxes", None)
+
+    try:
+        sandboxes = importlib.import_module("agents.sandbox.sandboxes")
+        assert sandboxes.__name__ == "agents.sandbox.sandboxes"
+        assert "UnixLocalSandboxClient" not in sandboxes.__all__
+        assert not hasattr(sandboxes, "UnixLocalSandboxClient")
+    finally:
+        sys.modules.pop("agents.sandbox.sandboxes", None)
+        if original_module is not None:
+            sys.modules["agents.sandbox.sandboxes"] = original_module
+            setattr(sandbox_package, "sandboxes", original_module)
+        else:
+            try:
+                delattr(sandbox_package, "sandboxes")
+            except AttributeError:
+                pass


### PR DESCRIPTION
## Summary
- avoid importing the Unix local sandbox backend on Windows when `agents.sandbox.sandboxes` is imported
- keep Unix local exports available on non-Windows platforms and leave Docker imports optional
- add a regression test that reloads the sandboxes package under a simulated `win32` platform

## Testing
- `py -3.14 -m py_compile src/agents/sandbox/sandboxes/__init__.py tests/sandbox/test_sandboxes_import.py`
- Unable to run `pytest` locally in this environment because the available Python does not have the repo's dev dependencies installed (`pytest` was missing, and `uv` was not available on PATH)

Closes #2938.
