### PR TITLE
fix: move module docstring to top of `handoff_filters.py` so it is assigned to `__doc__`

### DIFF
--- a/src/agents/extensions/handoff_filters.py
+++ b/src/agents/extensions/handoff_filters.py
@@ -1,3 +1,5 @@
+"""Contains common handoff input filters, for convenience."""
+
 from __future__ import annotations
 
 from ..handoffs import (
@@ -20,8 +22,6 @@ from ..items import (
     ToolSearchOutputItem,
     TResponseInputItem,
 )
-
-"""Contains common handoff input filters, for convenience. """
 
 __all__ = [
     "remove_all_tools",


### PR DESCRIPTION
Fixes #2949

## Problem

The module-level docstring in `src/agents/extensions/handoff_filters.py`:

```python
"""Contains common handoff input filters, for convenience. """
```

was placed **after** all the `import` statements. In Python, only a string literal that is the **very first statement** of a module is treated as the module docstring and assigned to `__doc__`. Any string literal appearing after other statements is discarded as an expression and never bound to `__doc__`.

```python
# Before fix
import agents.extensions.handoff_filters as m
print(m.__doc__)  # None
```

This causes confusion for IDEs, `help()`, and documentation generators.

## Fix

Move the docstring to the very top of the file (before all imports), where Python expects it.

```python
# After fix
import agents.extensions.handoff_filters as m
print(m.__doc__)  # "Contains common handoff input filters, for convenience."
```

## Changes

- `src/agents/extensions/handoff_filters.py`: Move module docstring to before imports; remove trailing space from docstring.