### PR TITLE
fix: preserve original name for warning in transform_string_function_style

### DIFF
--- a/src/agents/util/_transforms.py
+++ b/src/agents/util/_transforms.py
@@ -4,18 +4,21 @@ from ..logger import logger
 
 
 def transform_string_function_style(name: str) -> str:
+    # Preserve the original name for comparison and warning message
+    original_name = name
+
     # Replace spaces with underscores
     name = name.replace(" ", "_")
 
     # Replace non-alphanumeric characters with underscores
     transformed_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+    final_name = transformed_name.lower()
 
-    if transformed_name != name:
-        final_name = transformed_name.lower()
+    if final_name != original_name:
         logger.warning(
-            f"Tool name {name!r} contains invalid characters for function calling and has been "
+            f"Tool name {original_name!r} contains invalid characters for function calling and has been "
             f"transformed to {final_name!r}. Please use only letters, digits, and underscores "
             "to avoid potential naming conflicts."
         )
 
-    return transformed_name.lower()
+    return final_name


### PR DESCRIPTION
Closes #2951

## Problem
`transform_string_function_style` modified `name` (replacing spaces with `_`) before comparing it to `transformed_name`. This meant tool names containing **only spaces** (as invalid chars) never triggered the warning, even though the returned value silently differed from the original input.

## Fix
Capture `original_name = name` before any mutation, and compare the final lowercased result against the original to decide whether to warn.

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>