### PR TITLE
fix: #2951 warn for tool name character replacement

### DIFF
--- a/src/agents/util/_transforms.py
+++ b/src/agents/util/_transforms.py
@@ -4,18 +4,16 @@ from ..logger import logger
 
 
 def transform_string_function_style(name: str) -> str:
-    # Replace spaces with underscores
-    name = name.replace(" ", "_")
+    transformed_name = name.replace(" ", "_")
 
-    # Replace non-alphanumeric characters with underscores
-    transformed_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+    transformed_name = re.sub(r"[^a-zA-Z0-9_]", "_", transformed_name)
+    final_name = transformed_name.lower()
 
     if transformed_name != name:
-        final_name = transformed_name.lower()
         logger.warning(
             f"Tool name {name!r} contains invalid characters for function calling and has been "
             f"transformed to {final_name!r}. Please use only letters, digits, and underscores "
             "to avoid potential naming conflicts."
         )
 
-    return transformed_name.lower()
+    return final_name

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,43 @@
+import logging
+
+import pytest
+
+from agents.util._transforms import transform_string_function_style
+
+
+@pytest.mark.parametrize(
+    ("name", "transformed"),
+    [
+        ("My Tool", "my_tool"),
+        ("My-Tool", "my_tool"),
+    ],
+)
+def test_transform_string_function_style_warns_for_replaced_characters(
+    caplog: pytest.LogCaptureFixture,
+    name: str,
+    transformed: str,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        assert transform_string_function_style(name) == transformed
+
+    assert f"Tool name {name!r} contains invalid characters" in caplog.text
+    assert f"transformed to {transformed!r}" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("name", "transformed"),
+    [
+        ("MyTool", "mytool"),
+        ("transfer_to_Agent", "transfer_to_agent"),
+        ("snake_case", "snake_case"),
+    ],
+)
+def test_transform_string_function_style_does_not_warn_for_case_only_changes(
+    caplog: pytest.LogCaptureFixture,
+    name: str,
+    transformed: str,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        assert transform_string_function_style(name) == transformed
+
+    assert caplog.records == []


### PR DESCRIPTION
This pull request fixes #2951 `transform_string_function_style` so tool names that require character replacement, such as spaces or punctuation, emit the existing warning while preserving the current lowercase normalization behavior.

The previous implementation replaced spaces before comparing the transformed name, so names like `"My Tool"` silently became `"my_tool"` without warning. This update compares the post-replacement name against the original input before lowercasing, which keeps case-only normalization such as `"MyTool"` -> `"mytool"` quiet and avoids warning noise for valid letters.