### PR TITLE
feat: add subscription bridge example harness

### DIFF
--- a/examples/subscription_bridge/README.md
+++ b/examples/subscription_bridge/README.md
@@ -1,0 +1,86 @@
+# Subscription bridge
+
+This example shows how to drive `openai-agents-python` through a local OpenAI-compatible bridge that routes requests into the authenticated vendor CLIs instead of raw provider APIs:
+
+- `codex/...` -> `codex exec`
+- `claude/...` or `anthropic/...` -> `claude -p`
+
+This is useful when you want local agent loops to land on ChatGPT/Codex or Claude Max CLI-backed usage where supported.
+
+Important limitation: this does not make arbitrary raw OpenAI or Anthropic API calls bill to those app plans. The working path is:
+
+`openai-agents-python` -> local bridge -> `codex` / `claude` CLI
+
+## What is included
+
+- `server.py`
+  - exposes `/health`, `/v1/chat/completions`, and `/v1/responses`
+  - supports non-streaming text responses and structured tool-call loops
+- `demo_agent.py`
+  - starts an embedded local bridge or connects to an existing one
+  - runs a simple tool-using `Agent` through `OpenAIChatCompletionsModel`
+
+## Quick start
+
+Run the embedded demo with Codex:
+
+```bash
+uv run --python 3.11 python examples/subscription_bridge/demo_agent.py --backend codex
+```
+
+Run the embedded demo with Claude:
+
+```bash
+uv run --python 3.11 python examples/subscription_bridge/demo_agent.py --backend claude
+```
+
+Use an already-running bridge instead of starting an embedded one:
+
+```bash
+uv run --python 3.11 python examples/subscription_bridge/server.py --backend codex --port 8787
+uv run --python 3.11 python examples/subscription_bridge/demo_agent.py --backend codex --base-url http://127.0.0.1:8787
+```
+
+Override the model or prompt:
+
+```bash
+uv run --python 3.11 python examples/subscription_bridge/demo_agent.py \
+  --backend codex \
+  --model codex/gpt-5.4 \
+  --prompt "What is the weather in Tokyo?"
+```
+
+## Expected behavior
+
+The demo agent includes a simple `get_weather(city)` function tool. A working run should:
+
+1. ask the bridge for the next assistant turn
+2. emit a tool call
+3. execute the local tool
+4. call the bridge again
+5. return plain final assistant text
+
+Example final outputs seen on ATHAME:
+
+- Codex: `The weather in Tokyo is sunny and 72 F.`
+- Claude: `The weather in Tokyo is currently sunny with a temperature of 72°F.`
+
+## Verification
+
+Run the targeted tests:
+
+```bash
+uv run --python 3.11 pytest tests/examples/test_subscription_bridge.py tests/examples/test_subscription_bridge_demo_agent.py -q
+```
+
+## Current limits
+
+Validated:
+- chat-completions-compatible tool loop through the bridge
+- Codex-backed local tool loop
+- Claude-backed local tool loop
+
+Not yet validated:
+- streaming responses
+- full Responses API parity beyond the current minimal implementation
+- multi-agent handoffs and handoff semantics

--- a/examples/subscription_bridge/__init__.py
+++ b/examples/subscription_bridge/__init__.py
@@ -1,0 +1,4 @@
+from . import demo_agent
+from .server import main, make_server
+
+__all__ = ["demo_agent", "main", "make_server"]

--- a/examples/subscription_bridge/demo_agent.py
+++ b/examples/subscription_bridge/demo_agent.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import threading
+import time
+from pathlib import Path
+from typing import Literal
+
+from openai import AsyncOpenAI
+
+from agents import Agent, OpenAIChatCompletionsModel, Runner, function_tool, set_tracing_disabled
+
+try:
+    from .server import make_server
+except ImportError:  # pragma: no cover - script execution path
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from examples.subscription_bridge.server import make_server
+
+Backend = Literal["codex", "claude"]
+
+
+def default_model_for_backend(backend: Backend) -> str:
+    if backend == "claude":
+        return "claude/claude-sonnet-4-6"
+    return "codex/gpt-5.4"
+
+
+def resolve_model(backend: Backend, model: str | None) -> str:
+    return model or default_model_for_backend(backend)
+
+
+def normalize_api_base_url(base_url: str) -> str:
+    stripped = base_url.rstrip("/")
+    if stripped.endswith("/v1"):
+        return stripped
+    return f"{stripped}/v1"
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    return f"The weather in {city} is sunny and 72 F."
+
+
+async def run_demo(*, prompt: str, backend: Backend, model: str | None, api_base_url: str) -> str:
+    set_tracing_disabled(disabled=True)
+    client = AsyncOpenAI(base_url=normalize_api_base_url(api_base_url), api_key="dummy")
+    agent = Agent(
+        name="Subscription Bridge Demo",
+        instructions="Use tools when useful, then answer clearly.",
+        model=OpenAIChatCompletionsModel(
+            model=resolve_model(backend, model),
+            openai_client=client,
+        ),
+        tools=[get_weather],
+    )
+    result = await Runner.run(agent, prompt)
+    return str(result.final_output)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a local openai-agents-python demo through the subscription bridge."
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["codex", "claude"],
+        default="codex",
+        help="Which CLI-backed bridge backend to use.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Optional full model name override, e.g. codex/gpt-5.4 or claude/claude-sonnet-4-6.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="What is the weather in Tokyo?",
+        help="Prompt to send to the demo agent.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Bridge host for local embedded mode.")
+    parser.add_argument(
+        "--port", type=int, default=8787, help="Bridge port for local embedded mode."
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Use an already-running bridge instead of starting a local embedded bridge.",
+    )
+    parser.add_argument(
+        "--workdir",
+        default=str(Path.cwd()),
+        help="Working directory to pass to the local embedded bridge.",
+    )
+    return parser
+
+
+async def _main_async(args: argparse.Namespace) -> str:
+    if args.base_url:
+        return await run_demo(
+            prompt=args.prompt,
+            backend=args.backend,
+            model=args.model,
+            api_base_url=args.base_url,
+        )
+
+    httpd = make_server(
+        args.host,
+        args.port,
+        default_backend=args.backend,
+        workdir=Path(args.workdir).resolve(),
+    )
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(0.2)
+    try:
+        return await run_demo(
+            prompt=args.prompt,
+            backend=args.backend,
+            model=args.model,
+            api_base_url=f"http://{args.host}:{args.port}",
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    print(asyncio.run(_main_async(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/subscription_bridge/server.py
+++ b/examples/subscription_bridge/server.py
@@ -136,6 +136,58 @@ def _describe_tool_choice(tool_choice: Any) -> str:
     return "auto"
 
 
+def _required_tool_choice_name(tool_choice: Any) -> str | None:
+    if not isinstance(tool_choice, dict):
+        return None
+    if tool_choice.get("type") == "function":
+        function = tool_choice.get("function")
+        if isinstance(function, dict):
+            name = function.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+    name = tool_choice.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None
+
+
+def _tool_choice_requires_tool_calls(tool_choice: Any) -> bool:
+    return tool_choice == "required" or _required_tool_choice_name(tool_choice) is not None
+
+
+def _tool_choice_allows_structured_tool_calls(tool_choice: Any) -> bool:
+    return tool_choice != "none"
+
+
+def _validate_tool_choice_decision(decision: dict[str, Any], payload: dict[str, Any]) -> None:
+    tool_choice = payload.get("tool_choice")
+    required_tool_name = _required_tool_choice_name(tool_choice)
+
+    if tool_choice == "none":
+        if decision.get("type") == "tool_calls":
+            raise RuntimeError("tool_choice='none' forbids tool calls")
+        return
+
+    if required_tool_name is not None:
+        if decision.get("type") != "tool_calls":
+            raise RuntimeError(
+                f"required tool choice {required_tool_name!r} requires a tool call"
+            )
+        invalid_names = [
+            tool_call.get("name")
+            for tool_call in decision.get("tool_calls", [])
+            if tool_call.get("name") != required_tool_name
+        ]
+        if invalid_names:
+            raise RuntimeError(
+                f"backend violated required tool choice {required_tool_name!r}"
+            )
+        return
+
+    if _tool_choice_requires_tool_calls(tool_choice) and decision.get("type") != "tool_calls":
+        raise RuntimeError("tool_choice='required' requires a tool call")
+
+
 def _chat_message_blocks(messages: Any) -> list[str]:
     if not isinstance(messages, list) or not messages:
         raise ValueError("chat.completions payload must include non-empty messages")
@@ -239,7 +291,9 @@ def build_responses_prompt(payload: dict[str, Any]) -> str:
 
 
 def _build_structured_decision_prompt(base_prompt: str, payload: dict[str, Any]) -> str:
-    tool_choice = _describe_tool_choice(payload.get("tool_choice"))
+    raw_tool_choice = payload.get("tool_choice")
+    tool_choice = _describe_tool_choice(raw_tool_choice)
+    required_tool_name = _required_tool_choice_name(raw_tool_choice)
     parallel_tool_calls = bool(payload.get("parallel_tool_calls"))
     instructions = [
         "Return JSON only.",
@@ -256,6 +310,11 @@ def _build_structured_decision_prompt(base_prompt: str, payload: dict[str, Any])
         "When you emit tool_calls, arguments_json must be a valid JSON string encoding an object that matches the tool schema.",
         "Do not invent tools.",
     ]
+    if raw_tool_choice == "required":
+        instructions.append("You must return at least one tool call.")
+    if required_tool_name is not None:
+        instructions.append("You must return at least one tool call.")
+        instructions.append(f"Every tool call name must be exactly {required_tool_name}.")
     return f"{base_prompt}\n\nDecision rules:\n- " + "\n- ".join(instructions)
 
 
@@ -285,8 +344,10 @@ def _coerce_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]
                 arguments = json.loads(arguments)
             except json.JSONDecodeError:
                 arguments = {"value": arguments}
-        if not isinstance(arguments, dict):
+        if arguments is None:
             arguments = {}
+        elif not isinstance(arguments, dict):
+            raise ValueError("tool call arguments must decode to a JSON object")
         normalized.append(
             {
                 "call_id": tool_call.get("call_id") or f"call_{uuid.uuid4().hex}",
@@ -625,7 +686,9 @@ def _respond_for_chat_request(
     payload: dict[str, Any], *, backend: str, model: str, workdir: Path, request_id: str
 ) -> dict[str, Any]:
     prompt = build_chat_prompt(payload)
-    if _normalize_tools(payload.get("tools")):
+    if _normalize_tools(payload.get("tools")) and _tool_choice_allows_structured_tool_calls(
+        payload.get("tool_choice")
+    ):
         try:
             decision = run_backend_structured(
                 backend=backend,
@@ -634,6 +697,7 @@ def _respond_for_chat_request(
                 workdir=workdir,
                 schema=DecisionSchema,
             )
+            _validate_tool_choice_decision(decision, payload)
             if decision.get("type") == "tool_calls":
                 return build_chat_completion_response(
                     model=model,
@@ -656,7 +720,9 @@ def _respond_for_responses_request(
     payload: dict[str, Any], *, backend: str, model: str, workdir: Path, request_id: str
 ) -> dict[str, Any]:
     prompt = build_responses_prompt(payload)
-    if _normalize_tools(payload.get("tools")):
+    if _normalize_tools(payload.get("tools")) and _tool_choice_allows_structured_tool_calls(
+        payload.get("tool_choice")
+    ):
         try:
             decision = run_backend_structured(
                 backend=backend,
@@ -665,6 +731,7 @@ def _respond_for_responses_request(
                 workdir=workdir,
                 schema=DecisionSchema,
             )
+            _validate_tool_choice_decision(decision, payload)
             if decision.get("type") == "tool_calls":
                 return build_responses_api_response(
                     model=model,

--- a/examples/subscription_bridge/server.py
+++ b/examples/subscription_bridge/server.py
@@ -1,0 +1,764 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+import time
+import uuid
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+DecisionSchema = {
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "enum": ["final", "tool_calls"]},
+        "content": {"type": "string"},
+        "tool_calls": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "arguments_json": {"type": "string"},
+                },
+                "required": ["name", "arguments_json"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["type", "content", "tool_calls"],
+    "additionalProperties": False,
+}
+
+
+def resolve_backend(model: str | None, default_backend: str = "codex") -> str:
+    normalized = (model or "").strip().lower()
+    if normalized.startswith("codex/"):
+        return "codex"
+    if normalized.startswith("claude/") or normalized.startswith("anthropic/"):
+        return "claude"
+    return default_backend
+
+
+def _model_flag_value(model: str | None) -> str | None:
+    if not model:
+        return None
+    return model.split("/", 1)[1] if "/" in model else model
+
+
+def _flatten_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                for key in ("text", "output_text", "input_text"):
+                    value = item.get(key)
+                    if isinstance(value, str) and value.strip():
+                        parts.append(value.strip())
+                        break
+                else:
+                    if item.get("type") == "input_text":
+                        text = item.get("text")
+                        if isinstance(text, str) and text.strip():
+                            parts.append(text.strip())
+            elif isinstance(item, str) and item.strip():
+                parts.append(item.strip())
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        for key in ("text", "output_text", "input_text"):
+            value = content.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _normalize_tools(tools: Any) -> list[dict[str, Any]]:
+    if not isinstance(tools, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            continue
+        raw_function = tool.get("function")
+        function: dict[str, Any] = raw_function if isinstance(raw_function, dict) else tool
+        name = function.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        normalized.append(
+            {
+                "name": name,
+                "description": function.get("description") or "",
+                "parameters": function.get("parameters") or {"type": "object", "properties": {}},
+            }
+        )
+    return normalized
+
+
+def _format_tool_block(payload: dict[str, Any]) -> str:
+    tools = _normalize_tools(payload.get("tools"))
+    if not tools:
+        return ""
+    rendered = json.dumps(tools, indent=2, ensure_ascii=False, sort_keys=True)
+    return f"Available function tools:\n{rendered}"
+
+
+def _describe_tool_choice(tool_choice: Any) -> str:
+    if tool_choice is None:
+        return "auto"
+    if isinstance(tool_choice, str):
+        return tool_choice
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") == "function":
+            function = tool_choice.get("function")
+            if isinstance(function, dict) and isinstance(function.get("name"), str):
+                return f"required:{function['name']}"
+        if isinstance(tool_choice.get("name"), str):
+            return f"required:{tool_choice['name']}"
+    return "auto"
+
+
+def _chat_message_blocks(messages: Any) -> list[str]:
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("chat.completions payload must include non-empty messages")
+
+    blocks: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "user")
+        content = _flatten_content(message.get("content"))
+        if content and role != "tool":
+            blocks.append(f"[{role}]\n{content}")
+        if role == "assistant":
+            tool_calls = message.get("tool_calls")
+            if isinstance(tool_calls, list):
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    raw_function = tool_call.get("function")
+                    function: dict[str, Any] = (
+                        raw_function if isinstance(raw_function, dict) else {}
+                    )
+                    name = function.get("name")
+                    arguments = function.get("arguments")
+                    call_id = tool_call.get("id") or f"call_{uuid.uuid4().hex}"
+                    if isinstance(name, str):
+                        arg_text = (
+                            arguments if isinstance(arguments, str) else json.dumps(arguments or {})
+                        )
+                        blocks.append(f"[assistant_tool_call {call_id}]\n{name} {arg_text}")
+        if role == "tool":
+            tool_call_id = message.get("tool_call_id") or f"call_{uuid.uuid4().hex}"
+            tool_text = _flatten_content(message.get("content"))
+            if tool_text:
+                blocks.append(f"[tool {tool_call_id}]\n{tool_text}")
+    return blocks
+
+
+def _responses_input_blocks(items: Any) -> list[str]:
+    if isinstance(items, str) and items.strip():
+        return [f"[user]\n{items.strip()}"]
+    if not isinstance(items, list) or not items:
+        raise ValueError("responses payload must include non-empty input")
+
+    blocks: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if item_type == "function_call":
+            call_id = item.get("call_id") or f"call_{uuid.uuid4().hex}"
+            name = item.get("name")
+            arguments = item.get("arguments")
+            if isinstance(name, str):
+                arg_text = arguments if isinstance(arguments, str) else json.dumps(arguments or {})
+                blocks.append(f"[assistant_tool_call {call_id}]\n{name} {arg_text}")
+            continue
+        if item_type == "function_call_output":
+            call_id = item.get("call_id") or f"call_{uuid.uuid4().hex}"
+            output = _flatten_content(item.get("output"))
+            if output:
+                blocks.append(f"[tool {call_id}]\n{output}")
+            continue
+        role = str(item.get("role") or "user")
+        content = _flatten_content(item.get("content"))
+        if content:
+            blocks.append(f"[{role}]\n{content}")
+    return blocks
+
+
+def build_chat_prompt(payload: dict[str, Any]) -> str:
+    blocks = _chat_message_blocks(payload.get("messages"))
+    if not blocks:
+        raise ValueError("chat.completions payload must include at least one text or tool message")
+
+    parts = [
+        "You are servicing an OpenAI-compatible chat.completions request via a CLI model.",
+        _format_tool_block(payload),
+        f"Tool choice constraint: {_describe_tool_choice(payload.get('tool_choice'))}",
+        "Conversation transcript:",
+        "\n\n".join(blocks),
+        "If no structured schema is requested, return only the assistant's next natural-language message.",
+    ]
+    return "\n\n".join(part for part in parts if part)
+
+
+def build_responses_prompt(payload: dict[str, Any]) -> str:
+    blocks = _responses_input_blocks(payload.get("input"))
+    if not blocks:
+        raise ValueError("responses payload must include at least one text or tool item")
+
+    parts = [
+        "You are servicing an OpenAI-compatible responses.create request via a CLI model.",
+        _format_tool_block(payload),
+        f"Tool choice constraint: {_describe_tool_choice(payload.get('tool_choice'))}",
+        "Conversation transcript:",
+        "\n\n".join(blocks),
+        "If no structured schema is requested, return only the assistant's next natural-language message.",
+    ]
+    return "\n\n".join(part for part in parts if part)
+
+
+def _build_structured_decision_prompt(base_prompt: str, payload: dict[str, Any]) -> str:
+    tool_choice = _describe_tool_choice(payload.get("tool_choice"))
+    parallel_tool_calls = bool(payload.get("parallel_tool_calls"))
+    instructions = [
+        "Return JSON only.",
+        "Choose exactly one action for the next assistant turn.",
+        "If enough information is already available, return a final answer.",
+        "If tool use is required, return tool_calls using only the listed function tools.",
+        f"Tool choice constraint: {tool_choice}.",
+        f"Parallel tool calls allowed: {'yes' if parallel_tool_calls else 'no'}.",
+        "Always include both content and tool_calls in the JSON.",
+        "For a final answer, set tool_calls to [] and put the answer in content.",
+        "For a final answer, content must be plain natural-language text only.",
+        "Do not wrap the final answer in JSON, quoted JSON, markdown fences, or any other envelope.",
+        "For tool use, set content to an empty string and put one or more tool call objects in tool_calls.",
+        "When you emit tool_calls, arguments_json must be a valid JSON string encoding an object that matches the tool schema.",
+        "Do not invent tools.",
+    ]
+    return f"{base_prompt}\n\nDecision rules:\n- " + "\n- ".join(instructions)
+
+
+def _build_usage() -> dict[str, int]:
+    return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+
+def _coerce_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            continue
+        name = tool_call.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        arguments = tool_call.get("arguments")
+        arguments_json = tool_call.get("arguments_json")
+        if isinstance(arguments_json, str):
+            try:
+                arguments = json.loads(arguments_json)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"tool call arguments_json was not valid JSON: {arguments_json}"
+                ) from exc
+        elif isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                arguments = {"value": arguments}
+        if not isinstance(arguments, dict):
+            arguments = {}
+        normalized.append(
+            {
+                "call_id": tool_call.get("call_id") or f"call_{uuid.uuid4().hex}",
+                "name": name,
+                "arguments": arguments,
+            }
+        )
+    if not normalized:
+        raise ValueError("tool_calls payload must include at least one valid tool call")
+    return normalized
+
+
+def build_chat_completion_response(
+    model: str,
+    request_id: str,
+    *,
+    content: str | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    created = int(time.time())
+    if tool_calls:
+        normalized_tool_calls = _coerce_tool_calls(tool_calls)
+        return {
+            "id": request_id,
+            "object": "chat.completion",
+            "created": created,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": tool_call["call_id"],
+                                "type": "function",
+                                "function": {
+                                    "name": tool_call["name"],
+                                    "arguments": json.dumps(
+                                        tool_call["arguments"], separators=(",", ":")
+                                    ),
+                                },
+                            }
+                            for tool_call in normalized_tool_calls
+                        ],
+                    },
+                }
+            ],
+            "usage": _build_usage(),
+        }
+
+    return {
+        "id": request_id,
+        "object": "chat.completion",
+        "created": created,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": content or ""},
+            }
+        ],
+        "usage": _build_usage(),
+    }
+
+
+def build_responses_api_response(
+    model: str,
+    request_id: str,
+    *,
+    content: str | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    created = int(time.time())
+    if tool_calls:
+        normalized_tool_calls = _coerce_tool_calls(tool_calls)
+        return {
+            "id": request_id,
+            "object": "response",
+            "created_at": created,
+            "status": "completed",
+            "model": model,
+            "output": [
+                {
+                    "id": f"fc_{uuid.uuid4().hex}",
+                    "type": "function_call",
+                    "call_id": tool_call["call_id"],
+                    "name": tool_call["name"],
+                    "arguments": json.dumps(tool_call["arguments"], separators=(",", ":")),
+                    "status": "completed",
+                }
+                for tool_call in normalized_tool_calls
+            ],
+            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            "output_text": "",
+        }
+
+    text = content or ""
+    return {
+        "id": request_id,
+        "object": "response",
+        "created_at": created,
+        "status": "completed",
+        "model": model,
+        "output": [
+            {
+                "id": f"msg_{uuid.uuid4().hex}",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ],
+        "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        "output_text": text,
+    }
+
+
+def _run_command(cmd: list[str], *, workdir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(workdir),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _strip_code_fence(raw: str) -> str:
+    text = raw.strip()
+    if text.startswith("```") and text.endswith("```"):
+        lines = text.splitlines()
+        if len(lines) >= 3:
+            return "\n".join(lines[1:-1]).strip()
+    return text
+
+
+def _load_json_output(raw: str) -> dict[str, Any]:
+    candidate = _strip_code_fence(raw)
+    payload = json.loads(candidate)
+    if isinstance(payload, dict):
+        structured_output = payload.get("structured_output")
+        if isinstance(structured_output, dict) and isinstance(structured_output.get("type"), str):
+            return structured_output
+        for key in ("result", "output", "response"):
+            nested = payload.get(key)
+            if isinstance(nested, dict) and isinstance(nested.get("type"), str):
+                return nested
+            if isinstance(nested, str):
+                nested_candidate = _strip_code_fence(nested)
+                try:
+                    nested_payload = json.loads(nested_candidate)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(nested_payload, dict):
+                    return nested_payload
+        return payload
+    raise RuntimeError("backend returned non-object JSON payload")
+
+
+def _extract_nested_decision_payload(content: str) -> dict[str, Any] | None:
+    current = content
+    for _ in range(3):
+        candidate = _strip_code_fence(current).strip()
+        if not candidate:
+            return {"type": "final", "content": ""}
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+
+        decision_type = parsed.get("type")
+        content_value = parsed.get("content")
+        tool_calls = parsed.get("tool_calls")
+        if decision_type == "tool_calls" or (isinstance(tool_calls, list) and tool_calls):
+            return {"type": "tool_calls", "tool_calls": tool_calls}
+
+        if decision_type == "final" or (
+            set(parsed).issubset({"type", "content", "tool_calls"})
+            and isinstance(content_value, str)
+        ):
+            if not isinstance(content_value, str):
+                return None
+            nested_candidate = _strip_code_fence(content_value).strip()
+            if not nested_candidate:
+                return {"type": "final", "content": ""}
+            try:
+                nested = json.loads(nested_candidate)
+            except json.JSONDecodeError:
+                return {"type": "final", "content": content_value}
+            if isinstance(nested, dict) and set(nested).intersection(
+                {"type", "content", "tool_calls"}
+            ):
+                current = content_value
+                continue
+            return {"type": "final", "content": content_value}
+
+        return None
+    return None
+
+
+def _normalize_decision_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    decision_type = payload.get("type")
+    if decision_type == "final":
+        content = payload.get("content")
+        if not isinstance(content, str):
+            raise RuntimeError("structured backend response missing final content")
+        nested_payload = _extract_nested_decision_payload(content)
+        if nested_payload:
+            return _normalize_decision_payload(nested_payload)
+        return {"type": "final", "content": content}
+    if decision_type == "tool_calls":
+        tool_calls = payload.get("tool_calls")
+        if not isinstance(tool_calls, list) or not tool_calls:
+            raise RuntimeError("structured backend response missing tool_calls")
+        return {"type": "tool_calls", "tool_calls": _coerce_tool_calls(tool_calls)}
+    raise RuntimeError(f"structured backend response has unsupported type: {decision_type!r}")
+
+
+def run_backend(backend: str, prompt: str, model: str | None, workdir: Path) -> str:
+    model_name = _model_flag_value(model)
+    if backend == "codex":
+        with tempfile.TemporaryDirectory(prefix="subscription-bridge-") as tmp_dir:
+            output_path = Path(tmp_dir) / "codex-last-message.txt"
+            cmd = [
+                "codex",
+                "exec",
+                "--skip-git-repo-check",
+                "--ephemeral",
+                "-C",
+                str(workdir),
+                "-o",
+                str(output_path),
+                prompt,
+            ]
+            if model_name:
+                cmd[2:2] = ["-m", model_name]
+            result = _run_command(cmd, workdir=workdir)
+            if result.returncode != 0:
+                stderr = (result.stderr or result.stdout or "backend execution failed").strip()
+                raise RuntimeError(stderr)
+            text = (
+                output_path.read_text().strip() if output_path.exists() else result.stdout.strip()
+            )
+            if not text:
+                raise RuntimeError("backend returned empty output")
+            return text
+
+    if backend == "claude":
+        cmd = ["claude", "-p", prompt, "--max-turns", "1", "--no-session-persistence"]
+        if model_name:
+            cmd.extend(["--model", model_name])
+        result = _run_command(cmd, workdir=workdir)
+        if result.returncode != 0:
+            stderr = (result.stderr or result.stdout or "backend execution failed").strip()
+            raise RuntimeError(stderr)
+        text = result.stdout.strip()
+        if not text:
+            raise RuntimeError("backend returned empty output")
+        return text
+
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def run_backend_structured(
+    backend: str,
+    prompt: str,
+    model: str | None,
+    workdir: Path,
+    schema: dict[str, Any],
+) -> dict[str, Any]:
+    model_name = _model_flag_value(model)
+    if backend == "codex":
+        with tempfile.TemporaryDirectory(prefix="subscription-bridge-") as tmp_dir:
+            temp_dir = Path(tmp_dir)
+            schema_path = temp_dir / "schema.json"
+            output_path = temp_dir / "codex-structured.json"
+            schema_path.write_text(json.dumps(schema, indent=2, ensure_ascii=False))
+            cmd = [
+                "codex",
+                "exec",
+                "--skip-git-repo-check",
+                "--ephemeral",
+                "-C",
+                str(workdir),
+                "--output-schema",
+                str(schema_path),
+                "-o",
+                str(output_path),
+                prompt,
+            ]
+            if model_name:
+                cmd[2:2] = ["-m", model_name]
+            result = _run_command(cmd, workdir=workdir)
+            if result.returncode != 0:
+                stderr = (result.stderr or result.stdout or "backend execution failed").strip()
+                raise RuntimeError(stderr)
+            raw = output_path.read_text() if output_path.exists() else result.stdout
+            return _normalize_decision_payload(_load_json_output(raw))
+
+    if backend == "claude":
+        cmd = [
+            "claude",
+            "-p",
+            prompt,
+            "--max-turns",
+            "2",
+            "--no-session-persistence",
+            "--output-format",
+            "json",
+            "--json-schema",
+            json.dumps(schema, separators=(",", ":")),
+        ]
+        if model_name:
+            cmd.extend(["--model", model_name])
+        result = _run_command(cmd, workdir=workdir)
+        if result.returncode != 0:
+            stderr = (result.stderr or result.stdout or "backend execution failed").strip()
+            raise RuntimeError(stderr)
+        return _normalize_decision_payload(_load_json_output(result.stdout))
+
+    raise ValueError(f"Unsupported backend: {backend}")
+
+
+def _respond_for_chat_request(
+    payload: dict[str, Any], *, backend: str, model: str, workdir: Path, request_id: str
+) -> dict[str, Any]:
+    prompt = build_chat_prompt(payload)
+    if _normalize_tools(payload.get("tools")):
+        decision = run_backend_structured(
+            backend=backend,
+            prompt=_build_structured_decision_prompt(prompt, payload),
+            model=model,
+            workdir=workdir,
+            schema=DecisionSchema,
+        )
+        if decision.get("type") == "tool_calls":
+            return build_chat_completion_response(
+                model=model,
+                request_id=request_id,
+                tool_calls=decision.get("tool_calls"),
+            )
+        return build_chat_completion_response(
+            model=model,
+            request_id=request_id,
+            content=str(decision.get("content") or ""),
+        )
+
+    text = run_backend(backend=backend, prompt=prompt, model=model, workdir=workdir)
+    return build_chat_completion_response(model=model, request_id=request_id, content=text)
+
+
+def _respond_for_responses_request(
+    payload: dict[str, Any], *, backend: str, model: str, workdir: Path, request_id: str
+) -> dict[str, Any]:
+    prompt = build_responses_prompt(payload)
+    if _normalize_tools(payload.get("tools")):
+        decision = run_backend_structured(
+            backend=backend,
+            prompt=_build_structured_decision_prompt(prompt, payload),
+            model=model,
+            workdir=workdir,
+            schema=DecisionSchema,
+        )
+        if decision.get("type") == "tool_calls":
+            return build_responses_api_response(
+                model=model,
+                request_id=request_id,
+                tool_calls=decision.get("tool_calls"),
+            )
+        return build_responses_api_response(
+            model=model,
+            request_id=request_id,
+            content=str(decision.get("content") or ""),
+        )
+
+    text = run_backend(backend=backend, prompt=prompt, model=model, workdir=workdir)
+    return build_responses_api_response(model=model, request_id=request_id, content=text)
+
+
+class SubscriptionBridgeHandler(BaseHTTPRequestHandler):
+    server_version = "SubscriptionBridge/0.2"
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length") or "0")
+        raw = self.rfile.read(length) if length else b"{}"
+        data = json.loads(raw.decode("utf-8") or "{}")
+        if not isinstance(data, dict):
+            raise ValueError("request body must be a JSON object")
+        return data
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health":
+            self._send_json(HTTPStatus.OK, {"ok": True, "backend": self.server.default_backend})  # type: ignore[attr-defined]
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": {"message": "Not found"}})
+
+    def do_POST(self) -> None:  # noqa: N802
+        try:
+            payload = self._read_json()
+            model = str(payload.get("model") or "codex/gpt-5.4")
+            backend = resolve_backend(model, default_backend=self.server.default_backend)  # type: ignore[attr-defined]
+            workdir = Path(self.server.workdir)  # type: ignore[attr-defined]
+            request_id = f"bridge_{uuid.uuid4().hex}"
+
+            if self.path == "/v1/chat/completions":
+                self._send_json(
+                    HTTPStatus.OK,
+                    _respond_for_chat_request(
+                        payload,
+                        backend=backend,
+                        model=model,
+                        workdir=workdir,
+                        request_id=request_id,
+                    ),
+                )
+                return
+
+            if self.path == "/v1/responses":
+                self._send_json(
+                    HTTPStatus.OK,
+                    _respond_for_responses_request(
+                        payload,
+                        backend=backend,
+                        model=model,
+                        workdir=workdir,
+                        request_id=request_id,
+                    ),
+                )
+                return
+
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": {"message": "Not found"}})
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": {"message": str(exc)}})
+        except RuntimeError as exc:
+            self._send_json(HTTPStatus.BAD_GATEWAY, {"error": {"message": str(exc)}})
+        except Exception as exc:  # pragma: no cover - defensive
+            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": {"message": str(exc)}})
+
+
+def make_server(
+    host: str, port: int, *, default_backend: str, workdir: Path
+) -> ThreadingHTTPServer:
+    httpd = ThreadingHTTPServer((host, port), SubscriptionBridgeHandler)
+    httpd.default_backend = default_backend  # type: ignore[attr-defined]
+    httpd.workdir = str(workdir)  # type: ignore[attr-defined]
+    return httpd
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="OpenAI-compatible bridge backed by Codex or Claude CLI plans"
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--backend", choices=["codex", "claude"], default="codex")
+    parser.add_argument("--workdir", default=str(Path.cwd()))
+    args = parser.parse_args()
+
+    httpd = make_server(
+        args.host,
+        args.port,
+        default_backend=args.backend,
+        workdir=Path(args.workdir).resolve(),
+    )
+    print(f"subscription bridge listening on http://{args.host}:{args.port} via {args.backend}")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/subscription_bridge/server.py
+++ b/examples/subscription_bridge/server.py
@@ -43,6 +43,19 @@ def resolve_backend(model: str | None, default_backend: str = "codex") -> str:
     return default_backend
 
 
+def default_model_for_backend(backend: str) -> str:
+    if backend == "claude":
+        return "claude/claude-sonnet-4-6"
+    return "codex/gpt-5.4"
+
+
+def resolve_request_model(payload: dict[str, Any], *, default_backend: str) -> str:
+    raw_model = payload.get("model")
+    if isinstance(raw_model, str) and raw_model.strip():
+        return raw_model.strip()
+    return default_model_for_backend(default_backend)
+
+
 def _model_flag_value(model: str | None) -> str | None:
     if not model:
         return None
@@ -686,8 +699,9 @@ class SubscriptionBridgeHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         try:
             payload = self._read_json()
-            model = str(payload.get("model") or "codex/gpt-5.4")
-            backend = resolve_backend(model, default_backend=self.server.default_backend)  # type: ignore[attr-defined]
+            default_backend = self.server.default_backend  # type: ignore[attr-defined]
+            model = resolve_request_model(payload, default_backend=default_backend)
+            backend = resolve_backend(model, default_backend=default_backend)
             workdir = Path(self.server.workdir)  # type: ignore[attr-defined]
             request_id = f"bridge_{uuid.uuid4().hex}"
 

--- a/examples/subscription_bridge/server.py
+++ b/examples/subscription_bridge/server.py
@@ -589,7 +589,10 @@ def run_backend_structured(
                 stderr = (result.stderr or result.stdout or "backend execution failed").strip()
                 raise RuntimeError(stderr)
             raw = output_path.read_text() if output_path.exists() else result.stdout
-            return _normalize_decision_payload(_load_json_output(raw))
+            try:
+                return _normalize_decision_payload(_load_json_output(raw))
+            except ValueError as exc:
+                raise RuntimeError(str(exc)) from exc
 
     if backend == "claude":
         cmd = [
@@ -610,7 +613,10 @@ def run_backend_structured(
         if result.returncode != 0:
             stderr = (result.stderr or result.stdout or "backend execution failed").strip()
             raise RuntimeError(stderr)
-        return _normalize_decision_payload(_load_json_output(result.stdout))
+        try:
+            return _normalize_decision_payload(_load_json_output(result.stdout))
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
 
     raise ValueError(f"Unsupported backend: {backend}")
 
@@ -620,24 +626,27 @@ def _respond_for_chat_request(
 ) -> dict[str, Any]:
     prompt = build_chat_prompt(payload)
     if _normalize_tools(payload.get("tools")):
-        decision = run_backend_structured(
-            backend=backend,
-            prompt=_build_structured_decision_prompt(prompt, payload),
-            model=model,
-            workdir=workdir,
-            schema=DecisionSchema,
-        )
-        if decision.get("type") == "tool_calls":
+        try:
+            decision = run_backend_structured(
+                backend=backend,
+                prompt=_build_structured_decision_prompt(prompt, payload),
+                model=model,
+                workdir=workdir,
+                schema=DecisionSchema,
+            )
+            if decision.get("type") == "tool_calls":
+                return build_chat_completion_response(
+                    model=model,
+                    request_id=request_id,
+                    tool_calls=decision.get("tool_calls"),
+                )
             return build_chat_completion_response(
                 model=model,
                 request_id=request_id,
-                tool_calls=decision.get("tool_calls"),
+                content=str(decision.get("content") or ""),
             )
-        return build_chat_completion_response(
-            model=model,
-            request_id=request_id,
-            content=str(decision.get("content") or ""),
-        )
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
 
     text = run_backend(backend=backend, prompt=prompt, model=model, workdir=workdir)
     return build_chat_completion_response(model=model, request_id=request_id, content=text)
@@ -648,24 +657,27 @@ def _respond_for_responses_request(
 ) -> dict[str, Any]:
     prompt = build_responses_prompt(payload)
     if _normalize_tools(payload.get("tools")):
-        decision = run_backend_structured(
-            backend=backend,
-            prompt=_build_structured_decision_prompt(prompt, payload),
-            model=model,
-            workdir=workdir,
-            schema=DecisionSchema,
-        )
-        if decision.get("type") == "tool_calls":
+        try:
+            decision = run_backend_structured(
+                backend=backend,
+                prompt=_build_structured_decision_prompt(prompt, payload),
+                model=model,
+                workdir=workdir,
+                schema=DecisionSchema,
+            )
+            if decision.get("type") == "tool_calls":
+                return build_responses_api_response(
+                    model=model,
+                    request_id=request_id,
+                    tool_calls=decision.get("tool_calls"),
+                )
             return build_responses_api_response(
                 model=model,
                 request_id=request_id,
-                tool_calls=decision.get("tool_calls"),
+                content=str(decision.get("content") or ""),
             )
-        return build_responses_api_response(
-            model=model,
-            request_id=request_id,
-            content=str(decision.get("content") or ""),
-        )
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
 
     text = run_backend(backend=backend, prompt=prompt, model=model, workdir=workdir)
     return build_responses_api_response(model=model, request_id=request_id, content=text)

--- a/tests/examples/test_subscription_bridge.py
+++ b/tests/examples/test_subscription_bridge.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from examples.subscription_bridge import server
+
+
+def test_resolve_backend_prefers_model_prefix() -> None:
+    assert server.resolve_backend("codex/gpt-5.4", default_backend="claude") == "codex"
+    assert server.resolve_backend("claude/sonnet", default_backend="codex") == "claude"
+    assert server.resolve_backend("gpt-5.4", default_backend="codex") == "codex"
+
+
+def test_build_chat_prompt_from_messages_preserves_roles() -> None:
+    payload = {
+        "messages": [
+            {"role": "system", "content": "Be terse."},
+            {"role": "user", "content": "Say hi."},
+            {"role": "assistant", "content": "Previous reply."},
+        ]
+    }
+
+    prompt = server.build_chat_prompt(payload)
+
+    assert "[system]\nBe terse." in prompt
+    assert "[user]\nSay hi." in prompt
+    assert "[assistant]\nPrevious reply." in prompt
+
+
+def test_build_chat_prompt_includes_tools_and_tool_results() -> None:
+    payload = {
+        "messages": [
+            {"role": "system", "content": "Use tools when needed."},
+            {"role": "user", "content": "What is the weather in Tokyo?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_weather",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_weather", "content": "Sunny and 72 F"},
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+    }
+
+    prompt = server.build_chat_prompt(payload)
+
+    assert "Available function tools" in prompt
+    assert '"name": "get_weather"' in prompt
+    assert '[assistant_tool_call call_weather]\nget_weather {"city":"Tokyo"}' in prompt
+    assert "[tool call_weather]\nSunny and 72 F" in prompt
+    assert "[tool]\nSunny and 72 F" not in prompt
+
+
+def test_build_responses_prompt_handles_list_items_and_tool_outputs() -> None:
+    payload = {
+        "input": [
+            {"role": "system", "content": [{"type": "input_text", "text": "Be terse."}]},
+            {"role": "user", "content": [{"type": "input_text", "text": "Say hi."}]},
+            {
+                "type": "function_call",
+                "call_id": "call_weather",
+                "name": "get_weather",
+                "arguments": '{"city":"Tokyo"}',
+            },
+            {"type": "function_call_output", "call_id": "call_weather", "output": "Sunny and 72 F"},
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get the weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        ],
+    }
+
+    prompt = server.build_responses_prompt(payload)
+
+    assert "[system]\nBe terse." in prompt
+    assert "[user]\nSay hi." in prompt
+    assert '[assistant_tool_call call_weather]\nget_weather {"city":"Tokyo"}' in prompt
+    assert "[tool call_weather]\nSunny and 72 F" in prompt
+
+
+def test_build_chat_completion_response_matches_openai_shape() -> None:
+    response = server.build_chat_completion_response(
+        model="codex/gpt-5.4",
+        request_id="req_123",
+        content="hello",
+    )
+
+    assert response["object"] == "chat.completion"
+    assert response["model"] == "codex/gpt-5.4"
+    assert response["choices"][0]["finish_reason"] == "stop"
+    assert response["choices"][0]["message"]["content"] == "hello"
+    assert response["usage"]["total_tokens"] == 0
+
+
+def test_build_chat_completion_response_can_emit_tool_calls() -> None:
+    response = server.build_chat_completion_response(
+        model="codex/gpt-5.4",
+        request_id="req_456",
+        tool_calls=[{"name": "get_weather", "arguments": {"city": "Tokyo"}}],
+    )
+
+    choice = response["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    tool_call = choice["message"]["tool_calls"][0]
+    assert tool_call["function"]["name"] == "get_weather"
+    assert json.loads(tool_call["function"]["arguments"]) == {"city": "Tokyo"}
+
+
+def test_build_responses_api_response_can_emit_function_calls() -> None:
+    response = server.build_responses_api_response(
+        model="codex/gpt-5.4",
+        request_id="req_789",
+        tool_calls=[{"name": "get_weather", "arguments": {"city": "Tokyo"}}],
+    )
+
+    function_call = response["output"][0]
+    assert function_call["type"] == "function_call"
+    assert function_call["name"] == "get_weather"
+    assert json.loads(function_call["arguments"]) == {"city": "Tokyo"}
+    assert response["output_text"] == ""
+
+
+def test_run_backend_invokes_codex_with_repo_check_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *, workdir: Path) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        output_file = Path(cmd[cmd.index("-o") + 1])
+        output_file.write_text("CODEX_OK\n")
+        return subprocess.CompletedProcess(cmd, 0, stdout="ignored", stderr="")
+
+    monkeypatch.setattr(server, "_run_command", fake_run)
+
+    output = server.run_backend(
+        backend="codex",
+        prompt="Reply with exactly CODEX_OK.",
+        model="codex/gpt-5.4",
+        workdir=tmp_path,
+    )
+
+    assert output == "CODEX_OK"
+    assert calls[0][:9] == [
+        "codex",
+        "exec",
+        "-m",
+        "gpt-5.4",
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "-C",
+        str(tmp_path),
+        "-o",
+    ]
+    assert calls[0][-1] == "Reply with exactly CODEX_OK."
+
+
+def test_run_backend_invokes_claude_print_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], *, workdir: Path) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="CLAUDE_OK\n", stderr="")
+
+    monkeypatch.setattr(server, "_run_command", fake_run)
+
+    output = server.run_backend(
+        backend="claude",
+        prompt="Reply with exactly CLAUDE_OK.",
+        model="claude/claude-sonnet-4-6",
+        workdir=tmp_path,
+    )
+
+    assert output == "CLAUDE_OK"
+    assert calls[0] == [
+        "claude",
+        "-p",
+        "Reply with exactly CLAUDE_OK.",
+        "--max-turns",
+        "1",
+        "--no-session-persistence",
+        "--model",
+        "claude-sonnet-4-6",
+    ]
+
+
+def test_decision_schema_avoids_top_level_one_of_for_codex_compatibility() -> None:
+    assert server.DecisionSchema["type"] == "object"
+    assert "oneOf" not in server.DecisionSchema
+    properties = cast(dict[str, Any], server.DecisionSchema["properties"])
+    tool_calls_schema = cast(dict[str, Any], properties["tool_calls"])
+    tool_call_item = cast(dict[str, Any], tool_calls_schema["items"])
+    assert tool_call_item["properties"]["arguments_json"]["type"] == "string"
+    assert server.DecisionSchema["required"] == ["type", "content", "tool_calls"]
+
+
+def test_structured_decision_prompt_requires_plain_text_final_content() -> None:
+    prompt = server._build_structured_decision_prompt(
+        "Conversation transcript:\n\n[user]\nSay hi.",
+        {"tool_choice": "auto", "parallel_tool_calls": False},
+    )
+
+    assert "content must be plain natural-language text only" in prompt
+    assert "Do not wrap the final answer in JSON" in prompt
+
+
+def test_normalize_decision_payload_unwraps_nested_final_json_content() -> None:
+    payload = {
+        "type": "final",
+        "content": '{"content":"The weather in Tokyo is sunny and 72 F.","tool_calls":[]}',
+        "tool_calls": [],
+    }
+
+    assert server._normalize_decision_payload(payload) == {
+        "type": "final",
+        "content": "The weather in Tokyo is sunny and 72 F.",
+    }
+
+
+def test_normalize_decision_payload_preserves_nested_tool_calls() -> None:
+    payload = {
+        "type": "final",
+        "content": (
+            '{"content":"","tool_calls":[{"name":"get_weather",'
+            '"arguments_json":"{\\"city\\":\\"Tokyo\\"}"}]}'
+        ),
+        "tool_calls": [],
+    }
+
+    result = server._normalize_decision_payload(payload)
+
+    assert result["type"] == "tool_calls"
+    tool_call = result["tool_calls"][0]
+    assert tool_call["name"] == "get_weather"
+    assert tool_call["arguments"] == {"city": "Tokyo"}
+    assert tool_call["call_id"].startswith("call_")
+
+
+def test_run_backend_structured_uses_cli_schema_support(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+        stdout = (
+            '{"type":"tool_calls","tool_calls":[{"name":"get_weather",'
+            '"arguments":{"city":"Tokyo"}}]}'
+        )
+        stderr = ""
+
+    def fake_run(cmd: list[str], *, workdir: Path) -> Result:
+        calls.append(cmd)
+        if cmd[0] == "codex":
+            schema_path = Path(cmd[cmd.index("--output-schema") + 1])
+            output_path = Path(cmd[cmd.index("-o") + 1])
+            assert json.loads(schema_path.read_text())["type"] == "object"
+            output_path.write_text(Result.stdout)
+        return Result()
+
+    monkeypatch.setattr(server, "_run_command", fake_run)
+
+    schema = {
+        "type": "object",
+        "properties": {"type": {"type": "string"}},
+        "required": ["type"],
+        "additionalProperties": True,
+    }
+    payload = server.run_backend_structured(
+        backend="codex",
+        prompt="Return a tool call.",
+        model="codex/gpt-5.4",
+        workdir=tmp_path,
+        schema=schema,
+    )
+
+    assert payload["type"] == "tool_calls"
+    assert calls[0][0:2] == ["codex", "exec"]
+
+
+def test_load_json_output_prefers_claude_structured_output_wrapper() -> None:
+    raw = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": '```json\n{"content":"ignored","tool_calls":[]}\n```',
+            "structured_output": {
+                "type": "final",
+                "content": "The weather in Tokyo is sunny and 72 F.",
+                "tool_calls": [],
+            },
+        }
+    )
+
+    assert server._load_json_output(raw) == {
+        "type": "final",
+        "content": "The weather in Tokyo is sunny and 72 F.",
+        "tool_calls": [],
+    }
+
+
+def test_run_backend_structured_uses_claude_json_wrapper_and_two_turn_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "structured_output": {
+                    "type": "final",
+                    "content": "The weather in Tokyo is sunny and 72 F.",
+                    "tool_calls": [],
+                },
+            }
+        )
+        stderr = ""
+
+    def fake_run(cmd: list[str], *, workdir: Path) -> Result:
+        calls.append(cmd)
+        return Result()
+
+    monkeypatch.setattr(server, "_run_command", fake_run)
+
+    schema = {
+        "type": "object",
+        "properties": {"type": {"type": "string"}},
+        "required": ["type"],
+        "additionalProperties": True,
+    }
+    payload = server.run_backend_structured(
+        backend="claude",
+        prompt="Return a final answer.",
+        model="claude/claude-sonnet-4-6",
+        workdir=tmp_path,
+        schema=schema,
+    )
+
+    assert payload == {"type": "final", "content": "The weather in Tokyo is sunny and 72 F."}
+    assert calls[0] == [
+        "claude",
+        "-p",
+        "Return a final answer.",
+        "--max-turns",
+        "2",
+        "--no-session-persistence",
+        "--output-format",
+        "json",
+        "--json-schema",
+        json.dumps(schema, separators=(",", ":")),
+        "--model",
+        "claude-sonnet-4-6",
+    ]

--- a/tests/examples/test_subscription_bridge.py
+++ b/tests/examples/test_subscription_bridge.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 import subprocess
+import threading
+import time
+import urllib.request
 from pathlib import Path
 from typing import Any, cast
 
@@ -14,6 +17,46 @@ def test_resolve_backend_prefers_model_prefix() -> None:
     assert server.resolve_backend("codex/gpt-5.4", default_backend="claude") == "codex"
     assert server.resolve_backend("claude/sonnet", default_backend="codex") == "claude"
     assert server.resolve_backend("gpt-5.4", default_backend="codex") == "codex"
+
+
+def test_resolve_request_model_uses_backend_default_when_model_is_omitted() -> None:
+    assert server.resolve_request_model({}, default_backend="codex") == "codex/gpt-5.4"
+    assert server.resolve_request_model({}, default_backend="claude") == "claude/claude-sonnet-4-6"
+    assert (
+        server.resolve_request_model({"model": "claude/claude-sonnet-4-6"}, default_backend="codex")
+        == "claude/claude-sonnet-4-6"
+    )
+
+
+def test_http_server_uses_backend_default_model_when_request_omits_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run_backend(*, backend: str, prompt: str, model: str | None, workdir: Path) -> str:
+        return f"backend={backend};model={model};workdir={workdir.name}"
+
+    monkeypatch.setattr(server, "run_backend", fake_run_backend)
+
+    httpd = server.make_server("127.0.0.1", 0, default_backend="claude", workdir=tmp_path)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(0.05)
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{httpd.server_address[1]}/v1/chat/completions",
+            data=json.dumps({"messages": [{"role": "user", "content": "Say hi."}]}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+    assert payload["model"] == "claude/claude-sonnet-4-6"
+    assert payload["choices"][0]["message"]["content"].startswith(
+        "backend=claude;model=claude/claude-sonnet-4-6"
+    )
 
 
 def test_build_chat_prompt_from_messages_preserves_roles() -> None:

--- a/tests/examples/test_subscription_bridge.py
+++ b/tests/examples/test_subscription_bridge.py
@@ -59,6 +59,55 @@ def test_http_server_uses_backend_default_model_when_request_omits_model(
     )
 
 
+def test_http_server_returns_502_for_backend_value_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run_backend_structured(
+        *, backend: str, prompt: str, model: str | None, workdir: Path, schema: dict[str, Any]
+    ) -> dict[str, Any]:
+        raise ValueError("backend emitted malformed JSON")
+
+    monkeypatch.setattr(server, "run_backend_structured", fake_run_backend_structured)
+
+    httpd = server.make_server("127.0.0.1", 0, default_backend="codex", workdir=tmp_path)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(0.05)
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{httpd.server_address[1]}/v1/chat/completions",
+            data=json.dumps(
+                {
+                    "messages": [{"role": "user", "content": "Use the weather tool."}],
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "description": "Get the weather for a city.",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {"city": {"type": "string"}},
+                                },
+                            },
+                        }
+                    ],
+                }
+            ).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+    assert exc_info.value.code == 502
+    payload = json.loads(exc_info.value.read().decode("utf-8"))
+    assert payload == {"error": {"message": "backend emitted malformed JSON"}}
+
+
 def test_build_chat_prompt_from_messages_preserves_roles() -> None:
     payload = {
         "messages": [

--- a/tests/examples/test_subscription_bridge.py
+++ b/tests/examples/test_subscription_bridge.py
@@ -230,6 +230,119 @@ def test_build_chat_completion_response_can_emit_tool_calls() -> None:
     assert json.loads(tool_call["function"]["arguments"]) == {"city": "Tokyo"}
 
 
+def test_build_chat_completion_response_rejects_non_object_tool_arguments() -> None:
+    with pytest.raises(ValueError, match="must decode to a JSON object"):
+        server.build_chat_completion_response(
+            model="codex/gpt-5.4",
+            request_id="req_bad",
+            tool_calls=[{"name": "get_weather", "arguments_json": '[]'}],
+        )
+
+
+def test_respond_for_chat_request_skips_structured_tool_mode_when_tool_choice_is_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    called: dict[str, bool] = {"structured": False, "plain": False}
+
+    def fake_run_backend_structured(**_: Any) -> dict[str, Any]:
+        called["structured"] = True
+        raise AssertionError("structured backend should not run when tool_choice is none")
+
+    def fake_run_backend(*, backend: str, prompt: str, model: str | None, workdir: Path) -> str:
+        called["plain"] = True
+        return "No tool call emitted."
+
+    monkeypatch.setattr(server, "run_backend_structured", fake_run_backend_structured)
+    monkeypatch.setattr(server, "run_backend", fake_run_backend)
+
+    response = server._respond_for_chat_request(
+        {
+            "messages": [{"role": "user", "content": "Just answer directly."}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get the weather for a city.",
+                        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                    },
+                }
+            ],
+            "tool_choice": "none",
+        },
+        backend="codex",
+        model="codex/gpt-5.4",
+        workdir=tmp_path,
+        request_id="req_none",
+    )
+
+    assert called == {"structured": False, "plain": True}
+    assert response["choices"][0]["finish_reason"] == "stop"
+    assert response["choices"][0]["message"]["content"] == "No tool call emitted."
+
+
+def test_respond_for_chat_request_rejects_tool_calls_outside_required_tool_choice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run_backend_structured(**_: Any) -> dict[str, Any]:
+        return {"type": "tool_calls", "tool_calls": [{"name": "other_tool", "arguments": {}}]}
+
+    monkeypatch.setattr(server, "run_backend_structured", fake_run_backend_structured)
+
+    with pytest.raises(RuntimeError, match="required tool choice"):
+        server._respond_for_chat_request(
+            {
+                "messages": [{"role": "user", "content": "Use the weather tool."}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get the weather for a city.",
+                            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                        },
+                    }
+                ],
+                "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            },
+            backend="codex",
+            model="codex/gpt-5.4",
+            workdir=tmp_path,
+            request_id="req_specific",
+        )
+
+
+def test_respond_for_chat_request_requires_tool_calls_when_tool_choice_is_required(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run_backend_structured(**_: Any) -> dict[str, Any]:
+        return {"type": "final", "content": "Here is a direct answer."}
+
+    monkeypatch.setattr(server, "run_backend_structured", fake_run_backend_structured)
+
+    with pytest.raises(RuntimeError, match="requires a tool call"):
+        server._respond_for_chat_request(
+            {
+                "messages": [{"role": "user", "content": "Use a tool."}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get the weather for a city.",
+                            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                        },
+                    }
+                ],
+                "tool_choice": "required",
+            },
+            backend="codex",
+            model="codex/gpt-5.4",
+            workdir=tmp_path,
+            request_id="req_required",
+        )
+
+
 def test_build_responses_api_response_can_emit_function_calls() -> None:
     response = server.build_responses_api_response(
         model="codex/gpt-5.4",
@@ -328,6 +441,27 @@ def test_structured_decision_prompt_requires_plain_text_final_content() -> None:
 
     assert "content must be plain natural-language text only" in prompt
     assert "Do not wrap the final answer in JSON" in prompt
+
+
+def test_structured_decision_prompt_requires_tool_calls_when_tool_choice_is_required() -> None:
+    prompt = server._build_structured_decision_prompt(
+        "Conversation transcript:\n\n[user]\nUse a tool.",
+        {"tool_choice": "required", "parallel_tool_calls": False},
+    )
+
+    assert "You must return at least one tool call." in prompt
+
+
+def test_structured_decision_prompt_limits_specific_tool_choice() -> None:
+    prompt = server._build_structured_decision_prompt(
+        "Conversation transcript:\n\n[user]\nUse the weather tool.",
+        {
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+            "parallel_tool_calls": False,
+        },
+    )
+
+    assert "Every tool call name must be exactly get_weather." in prompt
 
 
 def test_normalize_decision_payload_unwraps_nested_final_json_content() -> None:

--- a/tests/examples/test_subscription_bridge_demo_agent.py
+++ b/tests/examples/test_subscription_bridge_demo_agent.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from examples.subscription_bridge import demo_agent
+
+
+def test_default_model_for_backend() -> None:
+    assert demo_agent.default_model_for_backend("codex") == "codex/gpt-5.4"
+    assert demo_agent.default_model_for_backend("claude") == "claude/claude-sonnet-4-6"
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        ("http://127.0.0.1:8787", "http://127.0.0.1:8787/v1"),
+        ("http://127.0.0.1:8787/", "http://127.0.0.1:8787/v1"),
+        ("http://127.0.0.1:8787/v1", "http://127.0.0.1:8787/v1"),
+        ("http://127.0.0.1:8787/v1/", "http://127.0.0.1:8787/v1"),
+    ],
+)
+def test_normalize_api_base_url(base_url: str, expected: str) -> None:
+    assert demo_agent.normalize_api_base_url(base_url) == expected
+
+
+def test_resolve_model_prefers_explicit_override() -> None:
+    assert demo_agent.resolve_model("codex", "codex/gpt-5.4-mini") == "codex/gpt-5.4-mini"
+    assert demo_agent.resolve_model("claude", None) == "claude/claude-sonnet-4-6"
+
+
+def test_demo_agent_module_can_be_loaded_from_file_path() -> None:
+    path = Path("examples/subscription_bridge/demo_agent.py").resolve()
+    spec = importlib.util.spec_from_file_location("subscription_bridge_demo_agent_file", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.default_model_for_backend("codex") == "codex/gpt-5.4"


### PR DESCRIPTION
## Summary
- add a local OpenAI-compatible subscription bridge example backed by `codex exec` and `claude -p`
- add a runnable `demo_agent.py` example for real `openai-agents-python` tool loops through the bridge
- document setup, usage, expected behavior, verification commands, and current limits
- cover prompt shaping, tool-call emission, structured-output parsing, and demo helper utilities with targeted tests

## What this validates
- `OpenAIChatCompletionsModel` can run against a local `AsyncOpenAI(base_url=...)` client pointed at the bridge
- Codex-backed tool loops work end-to-end through the bridge
- Claude-backed tool loops work end-to-end through the bridge
- final assistant text is returned as plain natural language after tool execution

## Test plan
- `uv run --python 3.11 pytest tests/examples/test_subscription_bridge.py tests/examples/test_subscription_bridge_demo_agent.py -q`
- `uv run --python 3.11 python examples/subscription_bridge/demo_agent.py --backend codex`
- `uv run --python 3.11 python examples/subscription_bridge/demo_agent.py --backend claude`

## Current limits
- non-streaming only
- partial `/v1/responses` parity
- no handoff or multi-agent validation yet

## Notes
This bridge intentionally routes local SDK traffic into authenticated CLI products. It does not make arbitrary raw OpenAI or Anthropic API calls bill to ChatGPT/Codex or Claude Max plans.
