### PR TITLE
fix(tracing): serialize big integers as strings to prevent Traces dashboard precision loss

### DIFF
--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -1,11 +1,34 @@
 from __future__ import annotations
 
 import abc
+import json
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from openai.types.responses import Response, ResponseInputItemParam
+
+# JavaScript's Number.MAX_SAFE_INTEGER (2^53 - 1). Integers beyond this threshold
+# lose precision when parsed by JS, causing the Traces dashboard to display wrong values.
+_JS_MAX_SAFE_INTEGER = 9007199254740991
+
+
+def _sanitize_bigint(value: Any) -> Any:
+    """Recursively convert integers that exceed JS Number.MAX_SAFE_INTEGER to strings.
+
+    This prevents precision loss when the OpenAI Traces dashboard (JavaScript) parses
+    large integer values that cannot be represented exactly as IEEE-754 doubles.
+    """
+    if isinstance(value, bool):
+        # bool is a subclass of int; must be checked first to avoid converting True/False
+        return value
+    if isinstance(value, int) and abs(value) > _JS_MAX_SAFE_INTEGER:
+        return str(value)
+    if isinstance(value, dict):
+        return {k: _sanitize_bigint(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_bigint(item) for item in value]
+    return value
 
 
 class SpanData(abc.ABC):
@@ -157,10 +180,16 @@ class FunctionSpanData(SpanData):
         return "function"
 
     def export(self) -> dict[str, Any]:
+        sanitized_input: str | None = None
+        if self.input is not None:
+            try:
+                sanitized_input = json.dumps(_sanitize_bigint(json.loads(self.input)))
+            except (json.JSONDecodeError, TypeError):
+                sanitized_input = self.input
         return {
             "type": self.type,
             "name": self.name,
-            "input": self.input,
+            "input": sanitized_input,
             "output": str(self.output) if self.output else None,
             "mcp_data": self.mcp_data,
         }


### PR DESCRIPTION
## Summary

Fixes #2094

When a tool is called with integer arguments that exceed JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 − 1 = 9007199254740991), the OpenAI Traces dashboard loses precision because it parses the JSON number as an IEEE-754 double. For example, `9007199254740993` would display as `9007199254740992`.

## Root Cause

`FunctionSpanData.export()` serializes tool call arguments as a JSON string (`self.input`). Python integers can be arbitrarily large, but when the resulting JSON is consumed by JavaScript, any integer > 2^53 − 1 is silently truncated.

## Fix

In `FunctionSpanData.export()` (`src/agents/tracing/span_data.py`), before re-emitting the input JSON:

1. Parse the stored JSON string back to a Python object.
2. Walk the object recursively with `_sanitize_bigint()`, converting any `int` whose absolute value exceeds `_JS_MAX_SAFE_INTEGER` to its decimal string representation.
3. Re-serialize to JSON.

`bool` is checked before `int` (since `bool` is a subclass of `int` in Python) so `True`/`False` are never converted.

Malformed JSON in `self.input` is caught and passed through unchanged, preserving existing behavior.

## Testing

- 31 existing tracing tests pass without modification.
- No changes to the public API or any other span type.

## Example

```python
# Before fix — JS dashboard receives 9007199254740992 (wrong)
span_data = FunctionSpanData(name="tool", input='{"id": 9007199254740993}')
span_data.export()["input"]  # '{"id": 9007199254740993}'  ← JS truncates this

# After fix — JS dashboard receives the string "9007199254740993" (correct)
span_data.export()["input"]  # '{"id": "9007199254740993"}'
```