### PR TITLE
fix(realtime): preserve transport audio formats during agent handoff

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -693,9 +693,11 @@ class RealtimeSession(RealtimeModelListener):
             # Update current agent
             self._current_agent = result
 
-            # Get updated model settings from new agent
+            # Get updated model settings from new agent, preserving transport-configured
+            # settings (e.g. audio format) from initial_model_settings so they are not
+            # reset to defaults during the handoff session update.
             updated_settings = await self._get_updated_model_settings_from_agent(
-                starting_settings=None,
+                starting_settings=self._model_config.get("initial_model_settings", None),
                 agent=self._current_agent,
             )
 


### PR DESCRIPTION
## Summary

Fixes #1632 — Realtime agent handoff to Twilio closes the session and sends noise over the phone.

## Root Cause

During a Realtime agent handoff, `_handle_tool_call` called `_get_updated_model_settings_from_agent` with `starting_settings=None`. This caused `session.update` to reset `input_audio_format` and `output_audio_format` back to their `pcm16` defaults, overwriting the transport-configured `g711_ulaw` format that Twilio requires.

The asymmetry was:
- `__aenter__` (initial connect): correctly passes `starting_settings=self._model_config.get("initial_model_settings", None)`  
- `_handle_tool_call` (handoff): was passing `starting_settings=None` ← **bug**

## Fix

In `_handle_tool_call`, pass `initial_model_settings` as `starting_settings` to `_get_updated_model_settings_from_agent`, matching the behavior of `__aenter__`:

```python
# Before
updated_settings = await self._get_updated_model_settings_from_agent(
    starting_settings=None,
    agent=self._current_agent,
)

# After
updated_settings = await self._get_updated_model_settings_from_agent(
    starting_settings=self._model_config.get("initial_model_settings", None),
    agent=self._current_agent,
)
```

This ensures transport-configured audio formats (e.g. `g711_ulaw` set via `model_config["initial_model_settings"]`) are preserved when updating session settings during handoff, instead of being reset to `pcm16` defaults.

## Testing

All 215 realtime tests pass.