### PR TITLE
feat: add BoxLite as a sandbox provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ e2b = ["e2b==2.20.0", "e2b-code-interpreter==2.4.1"]
 modal = ["modal==1.3.5"]
 runloop = ["runloop_api_client>=1.16.0,<2.0.0"]
 vercel = ["vercel>=0.5.6,<0.6"]
+boxlite = ["boxlite>=0.8.2"]
 s3 = ["boto3>=1.34"]
 temporal = [
     "temporalio==1.26.0",
@@ -162,6 +163,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["vercel", "vercel.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["boxlite", "boxlite.*"]
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/src/agents/extensions/sandbox/__init__.py
+++ b/src/agents/extensions/sandbox/__init__.py
@@ -109,6 +109,19 @@ try:
 except Exception:  # pragma: no cover
     _HAS_VERCEL = False
 
+try:
+    from .boxlite import (
+        DEFAULT_BOXLITE_WORKSPACE_ROOT as DEFAULT_BOXLITE_WORKSPACE_ROOT,
+        BoxliteSandboxClient as BoxliteSandboxClient,
+        BoxliteSandboxClientOptions as BoxliteSandboxClientOptions,
+        BoxliteSandboxSession as BoxliteSandboxSession,
+        BoxliteSandboxSessionState as BoxliteSandboxSessionState,
+    )
+
+    _HAS_BOXLITE = True
+except Exception:  # pragma: no cover
+    _HAS_BOXLITE = False
+
 __all__: list[str] = []
 
 if _HAS_E2B:
@@ -184,6 +197,17 @@ if _HAS_VERCEL:
             "VercelSandboxClientOptions",
             "VercelSandboxSession",
             "VercelSandboxSessionState",
+        ]
+    )
+
+if _HAS_BOXLITE:
+    __all__.extend(
+        [
+            "DEFAULT_BOXLITE_WORKSPACE_ROOT",
+            "BoxliteSandboxClient",
+            "BoxliteSandboxClientOptions",
+            "BoxliteSandboxSession",
+            "BoxliteSandboxSessionState",
         ]
     )
 

--- a/src/agents/extensions/sandbox/boxlite/__init__.py
+++ b/src/agents/extensions/sandbox/boxlite/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .sandbox import (
+    DEFAULT_BOXLITE_WORKSPACE_ROOT,
+    BoxliteSandboxClient,
+    BoxliteSandboxClientOptions,
+    BoxliteSandboxSession,
+    BoxliteSandboxSessionState,
+)
+
+__all__ = [
+    "BoxliteSandboxClient",
+    "BoxliteSandboxClientOptions",
+    "BoxliteSandboxSession",
+    "BoxliteSandboxSessionState",
+    "DEFAULT_BOXLITE_WORKSPACE_ROOT",
+]

--- a/src/agents/extensions/sandbox/boxlite/sandbox.py
+++ b/src/agents/extensions/sandbox/boxlite/sandbox.py
@@ -1,0 +1,531 @@
+"""BoxLite sandbox (https://github.com/boxlite-ai/boxlite) implementation.
+
+BoxLite is a local-first micro-VM sandbox for AI agents with hardware-level isolation
+(KVM on Linux, Hypervisor.framework on macOS) and no daemon. This module wires
+``boxlite.SimpleBox`` into the Agents SDK sandbox contract.
+
+The ``boxlite`` dependency is optional, so package-level exports guard the import of
+this module. Within this module, BoxLite imports are normal so users with the extra
+installed get full type navigation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import os
+import tarfile
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal, cast
+
+from boxlite import SimpleBox
+
+from ....sandbox.errors import (
+    ConfigurationError,
+    ErrorCode,
+    ExecNonZeroError,
+    ExecTimeoutError,
+    ExecTransportError,
+    WorkspaceArchiveReadError,
+    WorkspaceArchiveWriteError,
+    WorkspaceReadNotFoundError,
+    WorkspaceStartError,
+    WorkspaceWriteTypeError,
+)
+from ....sandbox.manifest import Manifest
+from ....sandbox.session import SandboxSession, SandboxSessionState
+from ....sandbox.session.base_sandbox_session import BaseSandboxSession
+from ....sandbox.session.dependencies import Dependencies
+from ....sandbox.session.manager import Instrumentation
+from ....sandbox.session.runtime_helpers import RESOLVE_WORKSPACE_PATH_HELPER, RuntimeHelperScript
+from ....sandbox.session.sandbox_client import BaseSandboxClient, BaseSandboxClientOptions
+from ....sandbox.snapshot import SnapshotBase, SnapshotSpec, resolve_snapshot
+from ....sandbox.types import ExecResult, User
+from ....sandbox.util.tar_utils import UnsafeTarMemberError, validate_tarfile
+
+DEFAULT_BOXLITE_WORKSPACE_ROOT = "/workspace"
+_DEFAULT_MANIFEST_ROOT = cast(str, Manifest.model_fields["root"].default)
+
+
+def _resolve_manifest_root(manifest: Manifest | None) -> Manifest:
+    if manifest is None:
+        return Manifest(root=DEFAULT_BOXLITE_WORKSPACE_ROOT)
+    if manifest.root == _DEFAULT_MANIFEST_ROOT:
+        return manifest.model_copy(update={"root": DEFAULT_BOXLITE_WORKSPACE_ROOT})
+    return manifest
+
+
+def _to_bytes(value: Any) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes | bytearray):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return str(value).encode("utf-8")
+
+
+class BoxliteSandboxClientOptions(BaseSandboxClientOptions):
+    """Client options for the BoxLite sandbox backend."""
+
+    type: Literal["boxlite"] = "boxlite"
+    image: str | None = None
+    rootfs_path: str | None = None
+    cpus: int | None = None
+    memory_mib: int | None = None
+    auto_remove: bool = True
+    name: str | None = None
+    reuse_existing: bool = False
+    env: dict[str, str] | None = None
+
+    def __init__(
+        self,
+        image: str | None = None,
+        rootfs_path: str | None = None,
+        cpus: int | None = None,
+        memory_mib: int | None = None,
+        auto_remove: bool = True,
+        name: str | None = None,
+        reuse_existing: bool = False,
+        env: dict[str, str] | None = None,
+        *,
+        type: Literal["boxlite"] = "boxlite",
+    ) -> None:
+        super().__init__(
+            type=type,
+            image=image,
+            rootfs_path=rootfs_path,
+            cpus=cpus,
+            memory_mib=memory_mib,
+            auto_remove=auto_remove,
+            name=name,
+            reuse_existing=reuse_existing,
+            env=env,
+        )
+
+
+class BoxliteSandboxSessionState(SandboxSessionState):
+    """Serializable state for a BoxLite-backed session."""
+
+    type: Literal["boxlite"] = "boxlite"
+    box_id: str = ""
+    image: str | None = None
+    rootfs_path: str | None = None
+    cpus: int | None = None
+    memory_mib: int | None = None
+    auto_remove: bool = True
+    name: str | None = None
+    env: dict[str, str] | None = None
+
+
+class BoxliteSandboxSession(BaseSandboxSession):
+    """SandboxSession implementation backed by a BoxLite SimpleBox."""
+
+    state: BoxliteSandboxSessionState
+    _box: SimpleBox | None
+
+    def __init__(
+        self,
+        *,
+        state: BoxliteSandboxSessionState,
+        box: SimpleBox | None = None,
+    ) -> None:
+        self.state = state
+        self._box = box
+
+    @classmethod
+    def from_state(
+        cls,
+        state: BoxliteSandboxSessionState,
+        *,
+        box: SimpleBox | None = None,
+    ) -> BoxliteSandboxSession:
+        return cls(state=state, box=box)
+
+    def supports_pty(self) -> bool:
+        return False
+
+    def _reject_user_arg(self, *, op: Literal["exec", "read", "write"], user: str | User) -> None:
+        user_name = user.name if isinstance(user, User) else user
+        raise ConfigurationError(
+            message=(
+                "BoxliteSandboxSession does not support sandbox-local users; "
+                f"`{op}` must be called without `user`"
+            ),
+            error_code=ErrorCode.SANDBOX_CONFIG_INVALID,
+            op=op,
+            context={"backend": "boxlite", "user": user_name},
+        )
+
+    def _prepare_exec_command(
+        self,
+        *command: str | Path,
+        shell: bool | list[str],
+        user: str | User | None,
+    ) -> list[str]:
+        if user is not None:
+            self._reject_user_arg(op="exec", user=user)
+        return super()._prepare_exec_command(*command, shell=shell, user=user)
+
+    async def _validate_path_access(self, path: Path | str, *, for_write: bool = False) -> Path:
+        return await self._validate_remote_path_access(path, for_write=for_write)
+
+    def _runtime_helpers(self) -> tuple[RuntimeHelperScript, ...]:
+        return (RESOLVE_WORKSPACE_PATH_HELPER,)
+
+    def _validate_tar_bytes(self, raw: bytes) -> None:
+        try:
+            with tarfile.open(fileobj=io.BytesIO(raw), mode="r:*") as tar:
+                validate_tarfile(tar)
+        except UnsafeTarMemberError as err:
+            raise ValueError(str(err)) from err
+        except (tarfile.TarError, OSError) as err:
+            raise ValueError("invalid tar stream") from err
+
+    async def _ensure_box(self) -> SimpleBox:
+        box = self._box
+        if box is not None:
+            return box
+
+        box = SimpleBox(
+            image=self.state.image,
+            rootfs_path=self.state.rootfs_path,
+            cpus=self.state.cpus,
+            memory_mib=self.state.memory_mib,
+            auto_remove=self.state.auto_remove,
+            name=self.state.name,
+        )
+        await box.start()
+        self._box = box
+        try:
+            self.state.box_id = box.id
+        except Exception:
+            self.state.box_id = self.state.name or ""
+        return box
+
+    async def _prepare_backend_workspace(self) -> None:
+        root = PurePosixPath(os.path.normpath(self.state.manifest.root))
+        try:
+            box = await self._ensure_box()
+            result = await box.exec("mkdir", "-p", "--", root.as_posix())
+        except Exception as err:
+            raise WorkspaceStartError(path=Path(str(root)), cause=err) from err
+
+        exit_code = int(getattr(result, "exit_code", 0) or 0)
+        if exit_code != 0:
+            raise WorkspaceStartError(
+                path=Path(str(root)),
+                context={
+                    "exit_code": exit_code,
+                    "stdout": _to_bytes(getattr(result, "stdout", b"")).decode(
+                        "utf-8", errors="replace"
+                    ),
+                    "stderr": _to_bytes(getattr(result, "stderr", b"")).decode(
+                        "utf-8", errors="replace"
+                    ),
+                },
+            )
+
+    async def running(self) -> bool:
+        box = self._box
+        if box is None:
+            return False
+        try:
+            info = box.info()
+        except Exception:
+            return False
+        state = getattr(info, "state", None) or getattr(info, "status", None)
+        if state is None:
+            return True
+        return str(state).lower() in {"running", "up", "started"}
+
+    async def shutdown(self) -> None:
+        box = self._box
+        if box is None:
+            return
+        try:
+            await box.__aexit__(None, None, None)
+        except Exception:
+            pass
+        finally:
+            self._box = None
+
+    async def _exec_internal(
+        self,
+        *command: str | Path,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        box = await self._ensure_box()
+        normalized = [str(part) for part in command]
+        if not normalized:
+            return ExecResult(stdout=b"", stderr=b"", exit_code=0)
+
+        try:
+            result = await asyncio.wait_for(
+                box.exec(
+                    normalized[0],
+                    *normalized[1:],
+                    cwd=self.state.manifest.root,
+                ),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError as err:
+            raise ExecTimeoutError(command=normalized, timeout_s=timeout, cause=err) from err
+        except ExecTimeoutError:
+            raise
+        except Exception as err:
+            raise ExecTransportError(
+                command=normalized,
+                context={"backend": "boxlite", "box_id": self.state.box_id},
+                cause=err,
+            ) from err
+
+        return ExecResult(
+            stdout=_to_bytes(getattr(result, "stdout", b"")),
+            stderr=_to_bytes(getattr(result, "stderr", b"")),
+            exit_code=int(getattr(result, "exit_code", 0) or 0),
+        )
+
+    async def read(self, path: Path, *, user: str | User | None = None) -> io.IOBase:
+        if user is not None:
+            self._reject_user_arg(op="read", user=user)
+
+        normalized_path = await self._validate_path_access(path)
+        cmd = ("sh", "-c", 'base64 "$1" || exit 1', "--", str(normalized_path))
+        try:
+            result = await self._exec_internal(*cmd)
+        except Exception as err:
+            raise WorkspaceArchiveReadError(path=normalized_path, cause=err) from err
+
+        if result.exit_code != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace") if result.stderr else ""
+            if "No such file" in stderr or "not found" in stderr.lower():
+                raise WorkspaceReadNotFoundError(path=normalized_path)
+            raise WorkspaceArchiveReadError(
+                path=normalized_path,
+                cause=ExecNonZeroError(
+                    result,
+                    command=cmd,
+                    context={"backend": "boxlite", "box_id": self.state.box_id},
+                ),
+            )
+
+        try:
+            payload = base64.b64decode(result.stdout)
+        except Exception as err:
+            raise WorkspaceArchiveReadError(path=normalized_path, cause=err) from err
+        return io.BytesIO(payload)
+
+    async def write(
+        self,
+        path: Path,
+        data: io.IOBase,
+        *,
+        user: str | User | None = None,
+    ) -> None:
+        if user is not None:
+            self._reject_user_arg(op="write", user=user)
+
+        normalized_path = await self._validate_path_access(path, for_write=True)
+        payload = data.read()
+        if isinstance(payload, str):
+            payload = payload.encode("utf-8")
+        if not isinstance(payload, bytes | bytearray):
+            raise WorkspaceWriteTypeError(
+                path=normalized_path,
+                actual_type=type(payload).__name__,
+            )
+
+        encoded = base64.b64encode(bytes(payload)).decode("ascii")
+        parent = str(PurePosixPath(str(normalized_path)).parent)
+        cmd = (
+            "sh",
+            "-c",
+            'mkdir -p "$1" && printf "%s" "$2" | base64 -d > "$3"',
+            "--",
+            parent,
+            encoded,
+            str(normalized_path),
+        )
+        try:
+            result = await self._exec_internal(*cmd)
+        except Exception as err:
+            raise WorkspaceArchiveWriteError(path=normalized_path, cause=err) from err
+
+        if result.exit_code != 0:
+            raise WorkspaceArchiveWriteError(
+                path=normalized_path,
+                cause=ExecNonZeroError(
+                    result,
+                    command=cmd,
+                    context={"backend": "boxlite", "box_id": self.state.box_id},
+                ),
+            )
+
+    async def persist_workspace(self) -> io.IOBase:
+        root = Path(self.state.manifest.root)
+        archive_path = f"/tmp/openai-agents-{self.state.session_id.hex}.tar"
+        excludes = [
+            f"--exclude=./{rel_path.as_posix()}"
+            for rel_path in sorted(
+                self._persist_workspace_skip_relpaths(),
+                key=lambda item: item.as_posix(),
+            )
+        ]
+        tar_cmd = ("tar", "cf", archive_path, *excludes, ".")
+        try:
+            result = await self.exec(*tar_cmd, shell=False)
+            if not result.ok():
+                raise WorkspaceArchiveReadError(
+                    path=root,
+                    cause=ExecNonZeroError(
+                        result,
+                        command=tar_cmd,
+                        context={"backend": "boxlite", "box_id": self.state.box_id},
+                    ),
+                )
+            buf = await self.read(Path(archive_path))
+            return buf
+        except WorkspaceArchiveReadError:
+            raise
+        except Exception as err:
+            raise WorkspaceArchiveReadError(path=root, cause=err) from err
+        finally:
+            try:
+                await self._exec_internal("rm", "-f", archive_path)
+            except Exception:
+                pass
+
+    async def hydrate_workspace(self, data: io.IOBase) -> None:
+        raw = data.read()
+        if isinstance(raw, str):
+            raw = raw.encode("utf-8")
+        if not isinstance(raw, bytes | bytearray):
+            raise WorkspaceWriteTypeError(
+                path=Path(self.state.manifest.root),
+                actual_type=type(raw).__name__,
+            )
+
+        root = Path(self.state.manifest.root)
+        archive_path = f"/tmp/openai-agents-{self.state.session_id.hex}.tar"
+        try:
+            self._validate_tar_bytes(bytes(raw))
+            await self.mkdir(root, parents=True)
+            await self.write(Path(archive_path), io.BytesIO(bytes(raw)))
+            tar_cmd = ("tar", "xf", archive_path, "-C", str(root))
+            result = await self.exec(*tar_cmd, shell=False)
+            if not result.ok():
+                raise WorkspaceArchiveWriteError(
+                    path=root,
+                    cause=ExecNonZeroError(
+                        result,
+                        command=tar_cmd,
+                        context={"backend": "boxlite", "box_id": self.state.box_id},
+                    ),
+                )
+        except WorkspaceArchiveWriteError:
+            raise
+        except Exception as err:
+            raise WorkspaceArchiveWriteError(path=root, cause=err) from err
+        finally:
+            try:
+                await self._exec_internal("rm", "-f", archive_path)
+            except Exception:
+                pass
+
+
+class BoxliteSandboxClient(BaseSandboxClient[BoxliteSandboxClientOptions]):
+    """BoxLite-backed sandbox client."""
+
+    backend_id = "boxlite"
+    _instrumentation: Instrumentation
+
+    def __init__(
+        self,
+        *,
+        instrumentation: Instrumentation | None = None,
+        dependencies: Dependencies | None = None,
+    ) -> None:
+        super().__init__()
+        self._instrumentation = instrumentation or Instrumentation()
+        self._dependencies = dependencies
+
+    def _build_state(
+        self,
+        options: BoxliteSandboxClientOptions,
+        *,
+        manifest: Manifest,
+        snapshot: SnapshotBase,
+        session_id: uuid.UUID,
+    ) -> BoxliteSandboxSessionState:
+        return BoxliteSandboxSessionState(
+            session_id=session_id,
+            manifest=manifest,
+            snapshot=snapshot,
+            image=options.image,
+            rootfs_path=options.rootfs_path,
+            cpus=options.cpus,
+            memory_mib=options.memory_mib,
+            auto_remove=options.auto_remove,
+            name=options.name,
+            env=dict(options.env or {}) or None,
+        )
+
+    async def create(
+        self,
+        *,
+        snapshot: SnapshotSpec | SnapshotBase | None = None,
+        manifest: Manifest | None = None,
+        options: BoxliteSandboxClientOptions,
+    ) -> SandboxSession:
+        if not options.image and not options.rootfs_path:
+            raise ConfigurationError(
+                message="BoxliteSandboxClientOptions requires `image` or `rootfs_path`",
+                error_code=ErrorCode.SANDBOX_CONFIG_INVALID,
+                op="start",
+                context={"backend": "boxlite"},
+            )
+        resolved_manifest = _resolve_manifest_root(manifest)
+        session_id = uuid.uuid4()
+        snapshot_instance = resolve_snapshot(snapshot, str(session_id))
+        state = self._build_state(
+            options,
+            manifest=resolved_manifest,
+            snapshot=snapshot_instance,
+            session_id=session_id,
+        )
+        inner = BoxliteSandboxSession.from_state(state)
+        await inner._ensure_box()
+        return self._wrap_session(inner, instrumentation=self._instrumentation)
+
+    async def delete(self, session: SandboxSession) -> SandboxSession:
+        inner = session._inner
+        if not isinstance(inner, BoxliteSandboxSession):
+            raise TypeError("BoxliteSandboxClient.delete expects a BoxliteSandboxSession")
+        try:
+            await inner.shutdown()
+        except Exception:
+            pass
+        return session
+
+    async def resume(self, state: SandboxSessionState) -> SandboxSession:
+        if not isinstance(state, BoxliteSandboxSessionState):
+            raise TypeError("BoxliteSandboxClient.resume expects a BoxliteSandboxSessionState")
+        state.workspace_root_ready = False
+        inner = BoxliteSandboxSession.from_state(state)
+        await inner._ensure_box()
+        return self._wrap_session(inner, instrumentation=self._instrumentation)
+
+    def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
+        return BoxliteSandboxSessionState.model_validate(payload)
+
+
+__all__ = [
+    "BoxliteSandboxClient",
+    "BoxliteSandboxClientOptions",
+    "BoxliteSandboxSession",
+    "BoxliteSandboxSessionState",
+    "DEFAULT_BOXLITE_WORKSPACE_ROOT",
+]

--- a/tests/extensions/test_sandbox_boxlite.py
+++ b/tests/extensions/test_sandbox_boxlite.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+class _FakeExecResult:
+    def __init__(self, *, stdout: bytes = b"", stderr: bytes = b"", exit_code: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+
+
+class _FakeSimpleBox:
+    """Minimal stand-in for boxlite.SimpleBox used in tests."""
+
+    instances: list[_FakeSimpleBox] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.started = False
+        self.closed = False
+        self.id = "fake-box-id"
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        _FakeSimpleBox.instances.append(self)
+
+    async def start(self) -> _FakeSimpleBox:
+        self.started = True
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.closed = True
+
+    def info(self) -> types.SimpleNamespace:
+        return types.SimpleNamespace(state="running")
+
+    async def exec(self, *args: Any, **kwargs: Any) -> _FakeExecResult:
+        self.calls.append((args, kwargs))
+        return _FakeExecResult(stdout=b"hi", exit_code=0)
+
+
+@pytest.fixture(autouse=True)
+def _install_fake_boxlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_module = types.ModuleType("boxlite")
+    fake_module.SimpleBox = _FakeSimpleBox  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "boxlite", fake_module)
+    _FakeSimpleBox.instances = []
+
+    for mod_name in (
+        "agents.extensions.sandbox.boxlite.sandbox",
+        "agents.extensions.sandbox.boxlite",
+    ):
+        sys.modules.pop(mod_name, None)
+    importlib.import_module("agents.extensions.sandbox.boxlite")
+
+
+def _load_module() -> Any:
+    return importlib.import_module("agents.extensions.sandbox.boxlite.sandbox")
+
+
+def test_options_serialize_includes_type() -> None:
+    mod = _load_module()
+    opts = mod.BoxliteSandboxClientOptions(image="alpine:latest", cpus=2)
+    data = opts.model_dump(mode="json")
+    assert data["type"] == "boxlite"
+    assert data["image"] == "alpine:latest"
+    assert data["cpus"] == 2
+
+
+def test_session_state_roundtrip_via_registry() -> None:
+    mod = _load_module()
+    from agents.sandbox.manifest import Manifest
+    from agents.sandbox.session import SandboxSessionState
+    from agents.sandbox.snapshot import NoopSnapshot
+
+    state = mod.BoxliteSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=NoopSnapshot(id="snapshot"),
+        image="alpine:latest",
+    )
+    payload = state.model_dump(mode="json")
+    assert payload["type"] == "boxlite"
+
+    restored = SandboxSessionState.parse(payload)
+    assert isinstance(restored, mod.BoxliteSandboxSessionState)
+    assert restored.image == "alpine:latest"
+
+
+@pytest.mark.asyncio
+async def test_create_requires_image_or_rootfs() -> None:
+    mod = _load_module()
+    from agents.sandbox.errors import ConfigurationError
+
+    client = mod.BoxliteSandboxClient()
+    with pytest.raises(ConfigurationError):
+        await client.create(options=mod.BoxliteSandboxClientOptions())
+
+
+@pytest.mark.asyncio
+async def test_internal_command_converts_result() -> None:
+    mod = _load_module()
+    from agents.sandbox.manifest import Manifest
+    from agents.sandbox.snapshot import NoopSnapshot
+
+    state = mod.BoxliteSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=NoopSnapshot(id="snapshot"),
+        image="alpine:latest",
+    )
+    session = mod.BoxliteSandboxSession.from_state(state)
+    result = await session._exec_internal("echo", "hello")
+    assert result.exit_code == 0
+    assert result.stdout == b"hi"
+    box = _FakeSimpleBox.instances[-1]
+    assert box.started is True
+    assert box.calls and box.calls[0][0] == ("echo", "hello")
+
+
+@pytest.mark.asyncio
+async def test_running_reports_true_when_box_info_running() -> None:
+    mod = _load_module()
+    from agents.sandbox.manifest import Manifest
+    from agents.sandbox.snapshot import NoopSnapshot
+
+    state = mod.BoxliteSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=NoopSnapshot(id="snapshot"),
+        image="alpine:latest",
+    )
+    session = mod.BoxliteSandboxSession.from_state(state)
+    assert await session.running() is False
+    await session._ensure_box()
+    assert await session.running() is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_the_box() -> None:
+    mod = _load_module()
+    from agents.sandbox.manifest import Manifest
+    from agents.sandbox.snapshot import NoopSnapshot
+
+    state = mod.BoxliteSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=NoopSnapshot(id="snapshot"),
+        image="alpine:latest",
+    )
+    session = mod.BoxliteSandboxSession.from_state(state)
+    await session._ensure_box()
+    box = _FakeSimpleBox.instances[-1]
+    await session.shutdown()
+    assert box.closed is True
+
+
+@pytest.mark.asyncio
+async def test_read_base64_decodes_stdout() -> None:
+    import base64 as _b64
+    import pathlib
+
+    mod = _load_module()
+    from agents.sandbox.manifest import Manifest
+    from agents.sandbox.snapshot import NoopSnapshot
+
+    class _Box(_FakeSimpleBox):
+        async def exec(self, *args: Any, **kwargs: Any) -> _FakeExecResult:
+            self.calls.append((args, kwargs))
+            return _FakeExecResult(stdout=_b64.b64encode(b"payload"), exit_code=0)
+
+    state = mod.BoxliteSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=NoopSnapshot(id="snapshot"),
+        image="alpine:latest",
+    )
+    session = mod.BoxliteSandboxSession.from_state(state, box=_Box())
+    buf = await session.read(pathlib.Path("/workspace/file.txt"))
+    assert isinstance(buf, io.BytesIO)
+    assert buf.read() == b"payload"

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,31 @@ wheels = [
 ]
 
 [[package]]
+name = "boxlite"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/2a/ce1d378a9c59cba841163ef5e27985eb0b0fab8948a9e05edc47addf6418/boxlite-0.8.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:c71441955f36685b4dda595afb69aab6291c0916f5f457f287d4e5c1bb4723be", size = 34296300, upload-time = "2026-04-02T11:01:37.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/82/234b948a0c77fdf3065492fd880c947616b6a18500b2462a6ccadcf74b7d/boxlite-0.8.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d98860dfe382f01d4f4bf5337969a880e3d8d2d9520aa342cb13344175ad4381", size = 36286129, upload-time = "2026-04-02T11:01:40.976Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/6f17f651784110b0581ca3223cdb9646e73337761be1c13e971e33227c8b/boxlite-0.8.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4e40ee214f0451ca993f6524cf9313b53fb5a95a30df4059621bca03b7903ee5", size = 32379685, upload-time = "2026-04-02T11:01:43.766Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b0/9f856436299e01a52104cac7cf43f7a5ad0418032b01417c7745396e3d86/boxlite-0.8.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:7f91cbc9675ae41a8858c3ac1056141100741f4eeb3838ec76e3a5af1b88f5a3", size = 34296886, upload-time = "2026-04-02T11:01:46.451Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/4c68a0334746a14b226f9949be903a48be4d1a79b243dbf1dd37d27a4b48/boxlite-0.8.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7b88ade99ae005fc68f84b265dba88f142ff9cdf6f50563e60328863728db6f1", size = 36285542, upload-time = "2026-04-02T11:01:49.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/04/c844fd5b58a1a6ddcf20961f185ce39ecd6382c3694295454e986cebda6d/boxlite-0.8.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:42925f57532c4fed1ec47acba4649703eb63a86de7457af81be433547d1415f0", size = 32379257, upload-time = "2026-04-02T11:01:51.816Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d0/c8036da6041e159b1b286fa1c5cc1548263be2f3bd2119beb248493d8be8/boxlite-0.8.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:95c50dacb01755650021a84b6d88089970524a26e35170202fc602af8010d627", size = 34294066, upload-time = "2026-04-02T11:01:54.531Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/ea99ae3c6dcd6175888420604c2f316273f4706e9a8035a6b563bb3d97ed/boxlite-0.8.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b94914de6c714b5eebab193f82a3b20162c49992a938b55bb03c3575fe8d8e6b", size = 36274983, upload-time = "2026-04-02T11:01:57.434Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/9a/363b8f185bf887ece70abc69ae4e294e45cd385aabbe9ff3703beba0e6c9/boxlite-0.8.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:827b7d7d65dddd10c475afe5edb94db0eb34ec0067cd899a5d9107b8b804d546", size = 32376800, upload-time = "2026-04-02T11:02:00.322Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3a/5ba99e68957bf1acb43b8f12ceb5111fed90a67639034252cd6ddfa9c003/boxlite-0.8.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:65a6d3f7f1eaa4bd8fb4703d6dbf3403167478b1dd5be9d1e589466e83c3e730", size = 34294278, upload-time = "2026-04-02T11:02:02.757Z" },
+    { url = "https://files.pythonhosted.org/packages/68/36/6f2919d8cf79a8260938b9d0fac9afab586e6d28ae5f0a52cf3ceb68a75b/boxlite-0.8.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9b29c2b91a1b1e869df50702cc19d101578a97e7ac823ec73f8242b77937fa2d", size = 36274095, upload-time = "2026-04-02T11:02:05.502Z" },
+    { url = "https://files.pythonhosted.org/packages/02/36/0e56a5ecf89a82923b2d78faa2117503a5318a1050ce5bba1a6a60b6582d/boxlite-0.8.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:56e15e724e8491ce8529e57bd691d5afc5e855af2569bc2303c40849cc6bce44", size = 32375933, upload-time = "2026-04-02T11:02:08.48Z" },
+    { url = "https://files.pythonhosted.org/packages/74/7c/085b6a7dd032b1c9c33a195c91668fc59dd14f18287e0dabcfe455da3537/boxlite-0.8.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:13066929107776dd0bf41beda48be8f5a8de5c76fb91bad37a42fc4b4c3e0988", size = 34294166, upload-time = "2026-04-02T11:02:11.073Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/86/ef91d47845160933c7f79134d5aed0d4d17f0edba1240ecdfb9cde5e4580/boxlite-0.8.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:29a51c979632d9a7d09f696d77305774b60b975bfd91aca79af941b516e041ed", size = 36275704, upload-time = "2026-04-02T11:02:13.672Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e4/99cd86a9eb90724adf356649284bacff80d8bb48ed1ed02654bf70ba4625/boxlite-0.8.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:af88caa5fb6f6166cb0f55ec45c8de5331e13455aa542046efa2809a969b6ae6", size = 32372787, upload-time = "2026-04-02T11:02:16.079Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a1/761430becf22917f910062509d50755652e7634c2ac096bfd4f486f9739c/boxlite-0.8.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:5c0999a0e47d9ede99598aa6888e0314076a52fb4366bc923c5e39408ed73e92", size = 34293175, upload-time = "2026-04-02T11:02:19.181Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2f/8295cbf15e5f6fa013760d7bc1128b7106ee40aa4da4076a42fe1690e8f4/boxlite-0.8.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d631a8a0ae60e16aa626d8f0562adb0fae4779847be1f9aebcc14076e19813b2", size = 36276827, upload-time = "2026-04-02T11:02:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c5/bc327b2a3ea18e173cd81eafb5e9db84c40a558e4e5513b7f4b946a16f5f/boxlite-0.8.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:16249ec7471652326118a38862c550170cba0c5f9a896f5a06958f7cc9a6022a", size = 32371802, upload-time = "2026-04-02T11:02:25.141Z" },
+]
+
+[[package]]
 name = "bracex"
 version = "2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2449,6 +2474,9 @@ blaxel = [
     { name = "aiohttp" },
     { name = "blaxel" },
 ]
+boxlite = [
+    { name = "boxlite" },
+]
 cloudflare = [
     { name = "aiohttp" },
 ]
@@ -2552,6 +2580,7 @@ requires-dist = [
     { name = "asyncpg", marker = "extra == 'sqlalchemy'", specifier = ">=0.29.0" },
     { name = "blaxel", marker = "extra == 'blaxel'", specifier = ">=0.2.50" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.34" },
+    { name = "boxlite", marker = "extra == 'boxlite'", specifier = ">=0.8.2" },
     { name = "cryptography", marker = "extra == 'encrypt'", specifier = ">=45.0,<46" },
     { name = "dapr", marker = "extra == 'dapr'", specifier = ">=1.16.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.155.0" },
@@ -2581,7 +2610,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'realtime'", specifier = ">=15.0,<16" },
     { name = "websockets", marker = "extra == 'voice'", specifier = ">=15.0,<16" },
 ]
-provides-extras = ["voice", "viz", "litellm", "any-llm", "realtime", "sqlalchemy", "encrypt", "redis", "dapr", "mongodb", "docker", "blaxel", "daytona", "cloudflare", "e2b", "modal", "runloop", "vercel", "s3", "temporal"]
+provides-extras = ["voice", "viz", "litellm", "any-llm", "realtime", "sqlalchemy", "encrypt", "redis", "dapr", "mongodb", "docker", "blaxel", "daytona", "cloudflare", "e2b", "modal", "runloop", "vercel", "boxlite", "s3", "temporal"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Adds `BoxliteSandboxClient` / `BoxliteSandboxClientOptions` / `BoxliteSandboxSession` / `BoxliteSandboxSessionState` under `src/agents/extensions/sandbox/boxlite/`, backed by `boxlite.SimpleBox` (local-first micro-VM sandbox with hardware isolation — https://github.com/boxlite-ai/boxlite).
- Wires the new backend into `src/agents/extensions/sandbox/__init__.py` with the standard optional-import guard (`_HAS_BOXLITE`) and conditional `__all__` extension, matching the pattern used by the other cloud backends.
- Declares the optional extra `boxlite = ["boxlite>=0.8.2"]` in `pyproject.toml` plus a mypy `ignore_missing_imports` override.
- Implements the six required `BaseSandboxSession` overrides: `_exec_internal` via `box.exec`; `read`/`write` via base64-over-exec; `persist_workspace`/`hydrate_workspace` via tar-over-exec; `running` via `box.info().state`.

## Test plan
- [x] `make format`
- [x] `make lint`
- [x] `uv run mypy src/agents/extensions/sandbox/boxlite tests/extensions/test_sandbox_boxlite.py` — clean
- [x] `uv run pytest tests/extensions/test_sandbox_boxlite.py` — 7/7 passing (options serialization, state round-trip via registry, create validation, exec translation, running probe, shutdown, base64 read)
- [ ] Manual smoke test on a KVM/HVF host with `pip install boxlite` and a real `python:slim` box