### PR TITLE
fix: bound manifest description truncation

### DIFF
--- a/src/agents/sandbox/manifest_render.py
+++ b/src/agents/sandbox/manifest_render.py
@@ -13,6 +13,8 @@ MANIFEST_DESCRIPTION_TRUNCATION_MARKER_TEMPLATE = "... (truncated {omitted_chars
 def _truncate_manifest_description(description: str, max_chars: int | None) -> str:
     if max_chars is None or len(description) <= max_chars:
         return description
+    if max_chars <= 0:
+        return ""
 
     omitted_chars = len(description) - max_chars
     while True:
@@ -29,6 +31,15 @@ def _truncate_manifest_description(description: str, max_chars: int | None) -> s
         omitted_chars = actual_omitted_chars
 
     truncated = description[:keep_chars].rstrip() + marker
+    if len(marker) >= max_chars:
+        truncated = marker[:max_chars]
+        logger.warning(
+            f"Manifest description exceeded {max_chars} characters "
+            f"and was truncated to {len(truncated)} characters."
+        )
+        return truncated
+    if len(truncated) > max_chars:
+        truncated = truncated[:max_chars]
     logger.warning(
         f"Manifest description exceeded {max_chars} characters "
         f"and was truncated to {len(truncated)} characters."

--- a/tests/sandbox/test_manifest.py
+++ b/tests/sandbox/test_manifest.py
@@ -11,6 +11,7 @@ from agents.sandbox.entries import (
 )
 from agents.sandbox.errors import InvalidManifestPathError
 from agents.sandbox.manifest import Manifest
+from agents.sandbox.manifest_render import _truncate_manifest_description
 
 
 def test_manifest_rejects_nested_child_paths_that_escape_workspace() -> None:
@@ -168,3 +169,17 @@ def test_manifest_describe_preserves_tree_rendering_after_renderer_extract() -> 
     assert "/workspace/data" in description
     assert "repo/" in description
     assert "/workspace/repo/README.md" in description
+
+
+def test_manifest_description_truncation_respects_short_limits() -> None:
+    description = "0123456789" * 20
+
+    for max_chars in range(0, 40):
+        truncated = _truncate_manifest_description(description, max_chars)
+        assert len(truncated) <= max_chars
+
+
+def test_manifest_description_truncation_preserves_unbounded_description() -> None:
+    description = "short"
+
+    assert _truncate_manifest_description(description, None) == description


### PR DESCRIPTION
## Summary
- keep `_truncate_manifest_description()` within `max_chars`
- handle very small limits without returning an oversized marker
- add focused truncation coverage

## Testing
- `uv run pytest -s tests/sandbox/test_manifest.py -k "truncation"`
- `uv run ruff check src/agents/sandbox/manifest_render.py tests/sandbox/test_manifest.py`

Signed-off-by: matthewflint 277024436+matthewflint@users.noreply.github.com