### PR TITLE
fix: tighten LocalSnapshot restorable checks

### DIFF
--- a/src/agents/sandbox/snapshot.py
+++ b/src/agents/sandbox/snapshot.py
@@ -121,7 +121,7 @@ class LocalSnapshot(SnapshotBase):
 
     async def restorable(self, *, dependencies: Dependencies | None = None) -> bool:
         _ = dependencies
-        return self._path().exists()
+        return self._path().is_file()
 
     def _path(self) -> Path:
         return self.base_path / self._filename()

--- a/tests/sandbox/test_snapshot.py
+++ b/tests/sandbox/test_snapshot.py
@@ -158,6 +158,23 @@ def test_snapshot_exclude_unset_preserves_type_discriminator() -> None:
     }
 
 
+@pytest.mark.asyncio
+async def test_local_snapshot_restorable_requires_file(tmp_path: Path) -> None:
+    snapshot = LocalSnapshot(id="local-snapshot", base_path=tmp_path)
+    snapshot_path = tmp_path / "local-snapshot.tar"
+
+    assert await snapshot.restorable() is False
+
+    snapshot_path.mkdir()
+
+    assert await snapshot.restorable() is False
+
+    snapshot_path.rmdir()
+    snapshot_path.write_bytes(b"workspace")
+
+    assert await snapshot.restorable() is True
+
+
 def test_snapshot_parse_uses_registered_custom_snapshot_type() -> None:
     parsed = SnapshotBase.parse({"type": "test-noop", "id": "registered"})
 


### PR DESCRIPTION
## Summary
- treat a local snapshot as restorable only when the stored path is a file
- avoid reporting directories as restorable snapshots
- add coverage for the missing path, directory, and file cases

## Testing
- `uv run ruff check src/agents/sandbox/snapshot.py tests/sandbox/test_snapshot.py`
- `uv run python -c "import asyncio, tempfile; from pathlib import Path; from agents.sandbox.snapshot import LocalSnapshot; p=Path(tempfile.mkdtemp()); s=LocalSnapshot(id='snap', base_path=p); assert asyncio.run(s.restorable()) is False; (p/'snap.tar').mkdir(); assert asyncio.run(s.restorable()) is False; (p/'snap.tar').rmdir(); (p/'snap.tar').write_bytes(b'x'); assert asyncio.run(s.restorable()) is True"`

Signed-off-by: matthewflint 277024436+matthewflint@users.noreply.github.com