### PR TITLE
fix: #2940 emit RealtimeHistoryUpdated when transcript_delta updates history

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -313,6 +313,9 @@ class RealtimeSession(RealtimeModelListener):
                     content=[AssistantAudio(transcript=self._item_transcripts[item_id])],
                 ),
             )
+            await self._put_event(
+                RealtimeHistoryUpdated(info=self._event_info, history=self._history)
+            )
 
             # Check if we should run guardrails based on debounce threshold
             current_length = len(self._item_transcripts[item_id])

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -565,11 +565,13 @@ class TestEventHandling:
 
     @pytest.mark.asyncio
     async def test_ignored_events_only_generate_raw_events(self, mock_model, mock_agent):
-        """Test that ignored events (transcript_delta, connection_status, other) only generate raw
-        events"""
+        """Test that connection_status and other events only generate raw events.
+
+        transcript_delta now also emits RealtimeHistoryUpdated after updating history.
+        """
         session = RealtimeSession(mock_model, mock_agent, None)
 
-        # Test transcript delta (should be ignored per TODO comment)
+        # transcript_delta updates history and emits RealtimeHistoryUpdated
         transcript_event = RealtimeModelTranscriptDeltaEvent(
             item_id="item_1", delta="hello", response_id="resp_1"
         )
@@ -583,10 +585,20 @@ class TestEventHandling:
         other_event = RealtimeModelOtherEvent(data={"custom": "data"})
         await session.on_event(other_event)
 
-        # Should only have 3 raw events (no transformed events)
-        assert session._event_queue.qsize() == 3
+        # transcript_delta emits: 1 raw + 1 RealtimeHistoryUpdated
+        # connection_status and other each emit: 1 raw
+        assert session._event_queue.qsize() == 4
 
-        for _ in range(3):
+        # raw event for transcript_delta
+        event = await session._event_queue.get()
+        assert isinstance(event, RealtimeRawModelEvent)
+
+        # history updated from transcript_delta
+        event = await session._event_queue.get()
+        assert isinstance(event, RealtimeHistoryUpdated)
+
+        # raw events for connection_status and other
+        for _ in range(2):
             event = await session._event_queue.get()
             assert isinstance(event, RealtimeRawModelEvent)
 


### PR DESCRIPTION
## Problem

`RealtimeSession` accumulates transcript text and updates `self._history` on every `transcript_delta` event, but never emits `RealtimeHistoryUpdated`. UI consumers that follow the documented pattern of listening to `history_added` / `history_updated` events miss all live partial transcript changes.

Every other branch that mutates history (`item_updated`, `item_deleted`) correctly emits `RealtimeHistoryUpdated` — `transcript_delta` is the only one that doesn't.

## Fix

Emit `RealtimeHistoryUpdated` immediately after `_get_new_history` in the `transcript_delta` branch, consistent with the other branches.

Fixes #2940