### PR TITLE
feat(items): add convenience accessors for tool call items

### DIFF
--- a/docs/sandbox/guide.md
+++ b/docs/sandbox/guide.md
@@ -205,6 +205,7 @@ By default, `SandboxAgent.capabilities` uses `Capabilities.default()`, which inc
 For skills, choose the source based on how you want them materialized:
 
 - `Skills(lazy_from=LocalDirLazySkillSource(...))` is a good default for larger local skill directories because the model can discover the index first and load only what it needs.
+- `LocalDirLazySkillSource(source=LocalDir(...))` reads from the host filesystem, not from a path that already exists inside the sandbox image or workspace. If you mount skills into the sandbox at `/skills`, still pass the original host directory to `LocalDir(...)`.
 - `Skills(from_=LocalDir(src=...))` is better for a small local bundle you want staged up front.
 - `Skills(from_=GitRepo(repo=..., ref=...))` is the right fit when the skills themselves should come from a repository.
 

--- a/docs/sandbox_agents.md
+++ b/docs/sandbox_agents.md
@@ -65,6 +65,8 @@ def build_agent(model: str) -> SandboxAgent[None]:
         capabilities=Capabilities.default() + [
             Skills(
                 lazy_from=LocalDirLazySkillSource(
+                    # This is a host path. The lazy loader copies skills into `.agents/`
+                    # on demand, so do not point this at an in-sandbox path such as `/skills`.
                     source=LocalDir(src=HOST_SKILLS_DIR),
                 )
             ),

--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -362,6 +362,28 @@ class ToolCallItem(RunItemBase[Any]):
     tool_origin: ToolOrigin | None = None
     """Optional metadata describing the source of a function-tool-backed item."""
 
+    @property
+    def tool_name(self) -> str | None:
+        """Return the tool name from the raw item when available."""
+        if isinstance(self.raw_item, dict):
+            candidate = self.raw_item.get("name") or self.raw_item.get("tool_name")
+        else:
+            candidate = getattr(self.raw_item, "name", None) or getattr(
+                self.raw_item, "tool_name", None
+            )
+        return str(candidate) if candidate is not None else None
+
+    @property
+    def call_id(self) -> str | None:
+        """Return the call identifier from the raw item when available."""
+        if isinstance(self.raw_item, dict):
+            candidate = self.raw_item.get("call_id") or self.raw_item.get("id")
+        else:
+            candidate = getattr(self.raw_item, "call_id", None) or getattr(
+                self.raw_item, "id", None
+            )
+        return str(candidate) if candidate is not None else None
+
 
 ToolCallOutputTypes: TypeAlias = (
     FunctionCallOutput
@@ -388,6 +410,17 @@ class ToolCallOutputItem(RunItemBase[Any]):
 
     tool_origin: ToolOrigin | None = None
     """Optional metadata describing the source of a function-tool-backed item."""
+
+    @property
+    def call_id(self) -> str | None:
+        """Return the call identifier from the raw item when available."""
+        if isinstance(self.raw_item, dict):
+            candidate = self.raw_item.get("call_id") or self.raw_item.get("id")
+        else:
+            candidate = getattr(self.raw_item, "call_id", None) or getattr(
+                self.raw_item, "id", None
+            )
+        return str(candidate) if candidate is not None else None
 
     def to_input_item(self) -> TResponseInputItem:
         """Converts the tool output into an input item for the next model turn.

--- a/src/agents/sandbox/capabilities/skills.py
+++ b/src/agents/sandbox/capabilities/skills.py
@@ -173,8 +173,17 @@ class LocalDirLazySkillSource(LazySkillSource):
         src_root = self._src_root()
         if src_root is None:
             raise SkillsConfigError(
-                message="lazy skill source directory is unavailable",
-                context={"skill_name": skill_name},
+                message=(
+                    "lazy skill source directory is unavailable; "
+                    "LocalDirLazySkillSource expects a host filesystem path, not a path "
+                    "inside the sandbox"
+                ),
+                context={
+                    "skill_name": skill_name,
+                    "configured_source_path": None
+                    if self.source.src is None
+                    else str(self.source.src),
+                },
             )
 
         matches = [

--- a/tests/sandbox/capabilities/test_skills_capability.py
+++ b/tests/sandbox/capabilities/test_skills_capability.py
@@ -556,8 +556,18 @@ class TestSkillsLazyLoading:
         )
         capability.bind(_SkillsSession(Manifest(root=str(workspace_root))))
 
-        with pytest.raises(SkillsConfigError):
+        with pytest.raises(SkillsConfigError) as exc_info:
             await capability.load_skill("missing-skill")
+
+        assert (
+            exc_info.value.message
+            == "lazy skill source directory is unavailable; "
+            "LocalDirLazySkillSource expects a host filesystem path, not a path inside the sandbox"
+        )
+        assert exc_info.value.context == {
+            "skill_name": "missing-skill",
+            "configured_source_path": str(tmp_path / "missing-skills"),
+        }
 
     @pytest.mark.asyncio
     async def test_load_skill_rejects_ambiguous_skill_name(self, tmp_path: Path) -> None:

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -15,6 +15,7 @@ from agents.exceptions import AgentsException
 from agents.items import (
     ReasoningItem,
     ToolCallItem,
+    ToolCallOutputItem,
     ToolSearchCallItem,
     ToolSearchOutputItem,
     TResponseInputItem,
@@ -487,6 +488,52 @@ def test_run_item_to_input_item_omits_tool_call_metadata() -> None:
     assert result_dict["type"] == "function_call"
     assert "description" not in result_dict
     assert "title" not in result_dict
+
+
+def test_tool_call_item_exposes_convenience_properties_for_typed_raw_items() -> None:
+    agent = Agent(name="A")
+    item = ToolCallItem(
+        agent=agent,
+        raw_item=ResponseFunctionToolCall(
+            id="fc_123",
+            call_id="call_123",
+            name="lookup_account",
+            arguments="{}",
+            type="function_call",
+            status="completed",
+        ),
+    )
+
+    assert item.tool_name == "lookup_account"
+    assert item.call_id == "call_123"
+
+
+def test_tool_call_item_exposes_convenience_properties_for_dict_raw_items() -> None:
+    agent = Agent(name="A")
+    item = ToolCallItem(
+        agent=agent,
+        raw_item={
+            "id": "fc_456",
+            "call_id": "call_456",
+            "name": "lookup_account",
+            "arguments": "{}",
+            "type": "function_call",
+        },
+    )
+
+    assert item.tool_name == "lookup_account"
+    assert item.call_id == "call_456"
+
+
+def test_tool_call_output_item_exposes_call_id_for_dict_raw_items() -> None:
+    agent = Agent(name="A")
+    item = ToolCallOutputItem(
+        agent=agent,
+        raw_item={"type": "function_call_output", "call_id": "call_456", "output": "ok"},
+        output="ok",
+    )
+
+    assert item.call_id == "call_456"
 
 
 def test_normalize_input_items_for_api_strips_internal_tool_call_metadata() -> None:


### PR DESCRIPTION
## Summary
- add `tool_name` and `call_id` convenience properties to `ToolCallItem`
- add a `call_id` convenience property to `ToolCallOutputItem`
- cover the new accessors with focused run-item tests

## Testing
- `PYTHONPATH=src /Users/ubl/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_run_internal_items.py`

Closes #2886