### PR TITLE
feat(retry): add retry_policies.rate_limit() convenience policy

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -418,6 +418,7 @@ The SDK exports ready-made helpers on `retry_policies`:
 | `retry_policies.network_error()` | Matches transient transport and timeout failures. |
 | `retry_policies.http_status([...])` | Matches selected HTTP status codes. |
 | `retry_policies.retry_after()` | Retries only when a retry-after hint is available, using that delay. |
+| `retry_policies.rate_limit()` | Retries on HTTP 429, honoring `Retry-After` headers; falls back to the configured backoff when no header is present. |
 | `retry_policies.any(...)` | Retries when any nested policy opts in. |
 | `retry_policies.all(...)` | Retries only when every nested policy opts in. |
 

--- a/examples/basic/rate_limit_retry.py
+++ b/examples/basic/rate_limit_retry.py
@@ -1,0 +1,42 @@
+"""Example: retrying on HTTP 429 rate-limit errors.
+
+``retry_policies.rate_limit()`` is a ready-made helper that retries on HTTP 429
+responses only.  When the server includes a ``Retry-After`` or
+``Retry-After-Ms`` header the runner waits exactly that long before the next
+attempt.  If no header is present the runner falls back to the configured
+backoff schedule (exponential by default).
+
+For deeper provider integration you can combine it with
+``retry_policies.provider_suggested()`` so the runner also honours explicit
+provider retry advice and safety approvals.
+"""
+
+import asyncio
+
+from agents import Agent, ModelRetrySettings, ModelSettings, RunConfig, Runner, retry_policies
+
+
+async def main() -> None:
+    agent = Agent(name="Assistant", instructions="You are a helpful assistant.")
+
+    # Minimal: retry up to 4 times on HTTP 429, obeying any Retry-After header.
+    rate_limit_policy = retry_policies.rate_limit()
+
+    result = await Runner.run(
+        agent,
+        input="Say hello.",
+        run_config=RunConfig(
+            model_settings=ModelSettings(
+                retry=ModelRetrySettings(
+                    max_retries=4,
+                    policy=rate_limit_policy,
+                )
+            )
+        ),
+    )
+
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agents/retry.py
+++ b/src/agents/retry.py
@@ -357,5 +357,33 @@ class _RetryPolicies:
             ),
         )
 
+    def rate_limit(self) -> RetryPolicy:
+        """Retry on HTTP 429 (Too Many Requests), honoring ``Retry-After`` headers.
+
+        When the server returns a ``Retry-After`` or ``Retry-After-Ms`` header the
+        policy returns that delay so the runner waits the prescribed cool-down period.
+        When no header is present the decision carries no explicit delay and the runner
+        falls back to the configured :attr:`ModelRetrySettings.backoff` schedule.
+
+        This is a ready-made convenience for the common rate-limit scenario.
+        Combine with :meth:`provider_suggested` via :meth:`any` for deeper provider
+        integration (e.g. ``retry_policies.any(retry_policies.rate_limit(),
+        retry_policies.provider_suggested())``).
+        """
+
+        def policy(context: RetryPolicyContext) -> bool | RetryDecision:
+            if context.normalized.status_code != 429:
+                return False
+            delay = context.normalized.retry_after
+            if delay is None and context.provider_advice is not None:
+                delay = context.provider_advice.retry_after
+            return RetryDecision(retry=True, delay=delay)
+
+        return _mark_retry_capabilities(
+            policy,
+            retries_safe_transport_errors=False,
+            retries_all_transient_errors=False,
+        )
+
 
 retry_policies = _RetryPolicies()

--- a/tests/test_model_retry.py
+++ b/tests/test_model_retry.py
@@ -2357,3 +2357,223 @@ async def test_stream_response_with_retry_closes_current_stream_when_consumer_st
     await outer_stream.aclose()
 
     assert stream.close_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# retry_policies.rate_limit() unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_policies_rate_limit_retries_on_429_no_header() -> None:
+    raw_decision = retry_policies.rate_limit()(
+        RetryPolicyContext(
+            error=_status_error_without_code(429, "rate_limit"),
+            attempt=1,
+            max_retries=3,
+            stream=False,
+            normalized=ModelRetryNormalizedError(status_code=429),
+            provider_advice=None,
+        )
+    )
+    decision = await raw_decision if asyncio.iscoroutine(raw_decision) else raw_decision
+
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.delay is None
+
+
+@pytest.mark.asyncio
+async def test_retry_policies_rate_limit_uses_normalized_retry_after() -> None:
+    raw_decision = retry_policies.rate_limit()(
+        RetryPolicyContext(
+            error=_status_error_without_code(429, "rate_limit"),
+            attempt=1,
+            max_retries=3,
+            stream=False,
+            normalized=ModelRetryNormalizedError(status_code=429, retry_after=2.5),
+            provider_advice=None,
+        )
+    )
+    decision = await raw_decision if asyncio.iscoroutine(raw_decision) else raw_decision
+
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.delay == 2.5
+
+
+@pytest.mark.asyncio
+async def test_retry_policies_rate_limit_falls_back_to_provider_advice_retry_after() -> None:
+    raw_decision = retry_policies.rate_limit()(
+        RetryPolicyContext(
+            error=_status_error_without_code(429, "rate_limit"),
+            attempt=1,
+            max_retries=3,
+            stream=False,
+            normalized=ModelRetryNormalizedError(status_code=429, retry_after=None),
+            provider_advice=ModelRetryAdvice(retry_after=1.5),
+        )
+    )
+    decision = await raw_decision if asyncio.iscoroutine(raw_decision) else raw_decision
+
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.delay == 1.5
+
+
+@pytest.mark.asyncio
+async def test_retry_policies_rate_limit_prefers_normalized_over_provider_advice() -> None:
+    raw_decision = retry_policies.rate_limit()(
+        RetryPolicyContext(
+            error=_status_error_without_code(429, "rate_limit"),
+            attempt=1,
+            max_retries=3,
+            stream=False,
+            normalized=ModelRetryNormalizedError(status_code=429, retry_after=3.0),
+            provider_advice=ModelRetryAdvice(retry_after=9.0),
+        )
+    )
+    decision = await raw_decision if asyncio.iscoroutine(raw_decision) else raw_decision
+
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.delay == 3.0
+
+
+@pytest.mark.asyncio
+async def test_retry_policies_rate_limit_does_not_retry_non_429_status() -> None:
+    raw_decision = retry_policies.rate_limit()(
+        RetryPolicyContext(
+            error=_status_error(500),
+            attempt=1,
+            max_retries=3,
+            stream=False,
+            normalized=ModelRetryNormalizedError(status_code=500),
+            provider_advice=None,
+        )
+    )
+    decision = await raw_decision if asyncio.iscoroutine(raw_decision) else raw_decision
+
+    assert not decision
+
+
+@pytest.mark.asyncio
+async def test_retry_policies_rate_limit_does_not_retry_network_errors() -> None:
+    raw_decision = retry_policies.rate_limit()(
+        RetryPolicyContext(
+            error=_connection_error(),
+            attempt=1,
+            max_retries=3,
+            stream=False,
+            normalized=ModelRetryNormalizedError(is_network_error=True),
+            provider_advice=None,
+        )
+    )
+    decision = await raw_decision if asyncio.iscoroutine(raw_decision) else raw_decision
+
+    assert not decision
+
+
+@pytest.mark.asyncio
+async def test_get_response_with_retry_rate_limit_honors_retry_after_header(
+    monkeypatch,
+) -> None:
+    calls = 0
+    rewinds = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    async def rewind() -> None:
+        nonlocal rewinds
+        rewinds += 1
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            request = httpx.Request("POST", "https://example.com")
+            response = httpx.Response(
+                429,
+                request=request,
+                headers={"retry-after": "2"},
+                json={"error": {"code": "rate_limit_exceeded", "message": "rate limit"}},
+            )
+            raise APIStatusError(
+                "rate_limit_exceeded",
+                response=response,
+                body={"error": {"code": "rate_limit_exceeded", "message": "rate limit"}},
+            )
+        return ModelResponse(
+            output=[get_text_message("ok")],
+            usage=Usage(requests=1),
+            response_id="resp_rate_limit_header",
+        )
+
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=rewind,
+        retry_settings=ModelRetrySettings(
+            max_retries=1,
+            backoff=ModelRetryBackoffSettings(initial_delay=5.0, jitter=False),
+            policy=retry_policies.rate_limit(),
+        ),
+        get_retry_advice=lambda _request: None,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    assert calls == 2
+    assert rewinds == 1
+    assert sleeps == [2.0]
+    assert result.usage.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_get_response_with_retry_rate_limit_falls_back_to_backoff_without_header(
+    monkeypatch,
+) -> None:
+    calls = 0
+    rewinds = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    async def rewind() -> None:
+        nonlocal rewinds
+        rewinds += 1
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _status_error_without_code(429, "rate_limit")
+        return ModelResponse(
+            output=[get_text_message("ok")],
+            usage=Usage(requests=1),
+            response_id="resp_rate_limit_backoff",
+        )
+
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=rewind,
+        retry_settings=ModelRetrySettings(
+            max_retries=1,
+            backoff=ModelRetryBackoffSettings(initial_delay=0.5, jitter=False),
+            policy=retry_policies.rate_limit(),
+        ),
+        get_retry_advice=lambda _request: None,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    assert calls == 2
+    assert rewinds == 1
+    assert sleeps == [0.5]
+    assert result.usage.requests == 2


### PR DESCRIPTION
## Summary

Fixes #782.

Adds `retry_policies.rate_limit()` — a ready-made helper that retries on HTTP 429 responses only, honouring `Retry-After` / `Retry-After-Ms` headers when present and falling back to the configured backoff schedule when absent.

---

## Motivation

Issue #782 reports that there is no concise way to express "retry rate-limit errors, wait the prescribed cool-down". The existing primitives require users to manually compose:

```python
retry_policies.any(
    retry_policies.http_status([429]),
    retry_policies.retry_after(),
)
```

This is both verbose and subtly wrong:
- `http_status([429])` fires on 429 but ignores the `Retry-After` header entirely.
- `retry_after()` honours the header but triggers on **any** error that carries one, not just 429s.

Neither alone captures the intended contract. Users need domain knowledge of the internals to compose them correctly.

---

## What this PR adds

```python
# After
from agents import ModelRetrySettings, ModelSettings, retry_policies

ModelSettings(
    retry=ModelRetrySettings(
        max_retries=4,
        policy=retry_policies.rate_limit(),
    )
)
```

The policy:
1. Returns `RetryDecision(retry=False)` for anything other than HTTP 429.
2. Returns `RetryDecision(retry=True, delay=<seconds>)` when a `Retry-After` header was parsed (via `context.normalized.retry_after`) or surfaced by provider advice — so the runner waits the prescribed cool-down.
3. Returns `RetryDecision(retry=True, delay=None)` when no header is present — the runner falls back to the configured backoff schedule.

Can be combined with `provider_suggested()` for deeper provider integration:
```python
retry_policies.any(retry_policies.rate_limit(), retry_policies.provider_suggested())
```

---

## Changes

| File | Change |
| --- | --- |
| `src/agents/retry.py` | New `rate_limit()` method on `_RetryPolicies` |
| `tests/test_model_retry.py` | 8 new tests (6 unit-level policy tests + 2 integration tests via `get_response_with_retry`) |
| `examples/basic/rate_limit_retry.py` | New minimal example |
| `docs/models/index.md` | New row in the ready-made helpers table |

---

## Tests

```
pytest tests/test_model_retry.py -q
60 passed in 0.36s
```

New tests cover:
- Retries on 429 with no header (`delay=None`)
- Uses `normalized.retry_after` delay when header is present
- Falls back to `provider_advice.retry_after` when normalized value is absent
- `normalized.retry_after` takes precedence over `provider_advice.retry_after`
- Does **not** retry on non-429 status codes (e.g. 500)
- Does **not** retry on network errors
- Integration: full `get_response_with_retry` run with 429+`Retry-After: 2` header → `sleep(2.0)` called
- Integration: full run with 429, no header → falls back to configured backoff delay

---

## Checklist

- [x] Implementation follows existing code style and uses `_mark_retry_capabilities`
- [x] All existing tests still pass
- [x] New tests added for all behaviour branches
- [x] Docs table updated
- [x] Example added
