### PR TITLE
Add Sylex Search MCP SSE example

### DIFF
--- a/examples/mcp/sylex_search_example/README.md
+++ b/examples/mcp/sylex_search_example/README.md
@@ -1,0 +1,56 @@
+# MCP Sylex Search Example
+
+This example connects an agent to [Sylex Search](https://sylex.ai) — a curated
+catalog of 11,000+ AI tools, libraries, and SaaS products — via its public MCP
+SSE endpoint.
+
+The agent uses the Sylex Search tools to answer questions about AI products
+without making web requests or calling external search APIs. All results come
+from a deterministic full-text index, so responses are fast and reproducible.
+
+## What it demonstrates
+
+- Connecting to a **remote SSE MCP server** using `MCPServerSse`
+- Writing agent **instructions** that guide tool selection across multiple MCP
+  tools
+- Running the agent against several research queries in sequence
+
+## Sylex Search tools used
+
+| Tool | Purpose |
+|---|---|
+| `search.discover` | Keyword search across the product catalog |
+| `search.details` | Full details for a specific product |
+| `search.compare` | Side-by-side comparison of multiple products |
+| `search.alternatives` | Find similar products to a known one |
+
+The server also exposes `search.categories`, `search.feedback`,
+`manage.register`, `manage.claim`, `manage.update`, and `manage.list_mcp` — see
+the [Sylex Search docs](https://sylex.ai) for the full tool reference.
+
+## Prerequisites
+
+- `OPENAI_API_KEY` set for the model calls.
+- No Sylex API key required — the endpoint is public.
+
+## Run it
+
+```bash
+uv run python examples/mcp/sylex_search_example/main.py
+```
+
+## Example output
+
+```
+Query: What are some good vector database options for a Python project?
+======================================================================
+Based on the Sylex catalog, here are strong vector database options for Python:
+
+1. **Chroma** — Open-source embedding database built for LLM apps, with a
+   native Python client and in-process or server mode.
+2. **Qdrant** — High-performance vector search engine with a Python SDK,
+   supports filtering and payload indexing.
+3. **Weaviate** — Open-source vector database with GraphQL and REST APIs,
+   strong Python integration.
+...
+```

--- a/examples/mcp/sylex_search_example/main.py
+++ b/examples/mcp/sylex_search_example/main.py
@@ -1,0 +1,68 @@
+"""
+Sylex Search MCP Example
+
+Demonstrates how to use Sylex Search — a curated catalog of 11,000+ AI tools
+and products — as an MCP tool source inside an OpenAI Agents SDK agent.
+
+The agent searches the catalog to answer questions about AI products without
+making any web requests or LLM-powered search calls. All results come from the
+deterministic Sylex FTS index over SSE.
+
+Run:
+    uv run python examples/mcp/sylex_search_example/main.py
+"""
+
+import asyncio
+
+from agents import Agent, Runner, gen_trace_id, trace
+from agents.mcp import MCPServerSse
+
+# Public Sylex Search SSE endpoint — no auth required.
+SYLEX_SSE_URL = "https://mcp-server-production-38c9.up.railway.app/sse"
+
+
+async def run_search_queries(agent: Agent) -> None:
+    queries = [
+        "What are some good vector database options for a Python project?",
+        "Find me open-source alternatives to Pinecone for storing embeddings.",
+        "Compare LangChain and LlamaIndex for building RAG pipelines.",
+    ]
+
+    for query in queries:
+        print(f"\n{'=' * 60}")
+        print(f"Query: {query}")
+        print("=" * 60)
+        result = await Runner.run(agent, query)
+        print(result.final_output)
+
+
+async def main() -> None:
+    async with MCPServerSse(
+        name="Sylex Search",
+        params={"url": SYLEX_SSE_URL},
+    ) as server:
+        agent = Agent(
+            name="Product Research Agent",
+            instructions=(
+                "You are a helpful AI product research assistant. "
+                "Use the Sylex Search MCP tools to look up AI tools, libraries, "
+                "and products from the catalog. "
+                "When answering questions:\n"
+                "1. Use search.discover to find relevant products by keyword.\n"
+                "2. Use search.details to fetch full details for promising results.\n"
+                "3. Use search.compare to contrast multiple options side by side.\n"
+                "4. Use search.alternatives to find similar tools to a known product.\n"
+                "Always cite the product names and brief descriptions from the catalog "
+                "in your final answer."
+            ),
+            mcp_servers=[server],
+        )
+
+        trace_id = gen_trace_id()
+        with trace(workflow_name="Sylex Search MCP Example", trace_id=trace_id):
+            print(f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n")
+            await run_search_queries(agent)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Adds `examples/mcp/sylex_search_example/` — a minimal, runnable example showing how to connect an agent to [Sylex Search](https://sylex.ai) via its public SSE MCP endpoint
- Sylex Search is a curated catalog of 11,000+ AI tools and products; the MCP server exposes 10 tools (`search.discover`, `search.details`, `search.compare`, `search.alternatives`, etc.)
- No authentication required — the endpoint is public and free to use
- Follows the same pattern as `examples/mcp/sse_remote_example/` (remote `MCPServerSse`, no local server subprocess)

## Files changed

| File | Description |
|---|---|
| `examples/mcp/sylex_search_example/main.py` | Agent that runs three product-research queries against the Sylex catalog |
| `examples/mcp/sylex_search_example/README.md` | Setup and run instructions, tool reference table, sample output |

## Test plan

- [ ] `uv run python examples/mcp/sylex_search_example/main.py` completes with product catalog results
- [ ] `OPENAI_API_KEY` is the only prerequisite — no Sylex key needed
- [ ] Existing examples are unaffected (no shared code modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)