### PR TITLE
docs: add structured agent audit workflow example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,7 +16,7 @@ Check out a variety of sample implementations of the SDK in the examples section
     -   Forcing tool use with different behaviors (`examples/agent_patterns/forcing_tool_use.py`)
     -   Input/output guardrails
     -   LLM as a judge
-    -   Structured agent audits with typed artifacts and severity-ranked reports (`examples/agent_patterns/structured_agent_audit.py`)
+    -   Structured agent audits with typed artifacts, playbooks, rubrics, and severity-ranked reports (`examples/agent_patterns/structured_agent_audit.py`)
     -   Routing
     -   Streaming guardrails
     -   Human-in-the-loop with tool approval and state serialization (`examples/agent_patterns/human_in_the_loop.py`)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,6 +16,7 @@ Check out a variety of sample implementations of the SDK in the examples section
     -   Forcing tool use with different behaviors (`examples/agent_patterns/forcing_tool_use.py`)
     -   Input/output guardrails
     -   LLM as a judge
+    -   Structured agent audits with typed artifacts and severity-ranked reports (`examples/agent_patterns/structured_agent_audit.py`)
     -   Routing
     -   Streaming guardrails
     -   Human-in-the-loop with tool approval and state serialization (`examples/agent_patterns/human_in_the_loop.py`)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,6 +17,7 @@ Check out a variety of sample implementations of the SDK in the examples section
     -   Input/output guardrails
     -   LLM as a judge
     -   Structured agent audits with typed artifacts, playbooks, rubrics, and severity-ranked reports (`examples/agent_patterns/structured_agent_audit.py`)
+    -   A cookbook for structured agent audits, including guardrail and tracing composition (`docs/structured_agent_audits.md`)
     -   Routing
     -   Streaming guardrails
     -   Human-in-the-loop with tool approval and state serialization (`examples/agent_patterns/human_in_the_loop.py`)

--- a/docs/structured_agent_audits.md
+++ b/docs/structured_agent_audits.md
@@ -1,0 +1,154 @@
+# Structured Agent Audits
+
+This guide shows how to build evidence-first runtime audits with the Agents SDK using typed,
+multi-stage workflows instead of a single freeform review prompt.
+
+The reference implementation lives in:
+
+- `examples/agent_patterns/structured_agent_audit.py`
+- `examples/agent_patterns/structured_agent_audit_with_guardrails.py`
+
+## Why use this pattern
+
+This pattern is useful when you are not trying to solve the user's domain task, but instead need to
+inspect the agent system itself.
+
+Typical cases include:
+
+- wrapper regression, where a wrapped agent behaves worse than the underlying model
+- tool-discipline failures, where the agent should have used a tool but skipped it
+- stale evidence reuse, where old observations reappear as if they were current
+- hidden mutation layers, where retry/repair/rendering logic changes otherwise good answers
+- memory contamination, where recalled or distilled content pollutes later turns
+
+## Core idea
+
+Keep the workflow typed from end to end. Instead of letting the model improvise a diagnosis in one
+pass, break the audit into structured artifacts:
+
+1. `AuditScope`
+2. `EvidencePack`
+3. `FailureMap`
+4. `AuditReport`
+
+Each stage narrows ambiguity for the next one.
+
+## Included guidance layers
+
+The example also carries three reusable guidance layers:
+
+- **Playbooks**: choose the failure mode you want to focus on
+- **Rubric**: define what the audit should inspect
+- **Schema**: make the final report shape explicit and machine-readable
+
+## Available playbooks
+
+The example currently includes:
+
+- `wrapper_regression`
+- `memory_contamination`
+- `tool_discipline`
+- `rendering_transport`
+- `hidden_agent_layers`
+
+Use playbooks when you already know the dominant failure surface and want the audit to start with a
+clear lens.
+
+## Basic usage
+
+```python
+from examples.agent_patterns.structured_agent_audit import run_structured_agent_audit
+
+report = await run_structured_agent_audit(
+    "Audit an agent runtime that started skipping tools after memory and answer-shaping layers were added.",
+    playbook="wrapper_regression",
+)
+
+print(report.model_dump_json(indent=2))
+```
+
+## Combining with tracing and guardrails
+
+If you want the audit itself to be observable and enforceable, use the guardrailed variant:
+
+```python
+from examples.agent_patterns.structured_agent_audit_with_guardrails import (
+    build_guardrailed_audit_agents,
+)
+from examples.agent_patterns.structured_agent_audit import run_structured_agent_audit
+from agents import trace
+
+agents = build_guardrailed_audit_agents()
+
+with trace(
+    "Structured agent audit with guardrails",
+    metadata={"playbook": "tool_discipline"},
+):
+    report = await run_structured_agent_audit(
+        "Audit an agent that answers without fresh tool evidence.",
+        agents=agents,
+        playbook="tool_discipline",
+    )
+```
+
+The guardrail in that variant trips when the report contains high-severity findings without a
+matching fix plan.
+
+## Example output shape
+
+The final report is intentionally structured for both humans and machines:
+
+```json
+{
+  "executive_verdict": {
+    "overall_health": "high_risk",
+    "primary_failure_mode": "Wrapper layers amplify stale evidence and skip fresh probes.",
+    "most_urgent_fix": "Move tool-discipline guarantees into code."
+  },
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Prompt-only tool enforcement",
+      "symptom": "The wrapper answers without fresh tool evidence.",
+      "source_layer": "tool_selection",
+      "root_cause": "Tool use is encouraged in prompts but not enforced in code.",
+      "recommended_fix": "Require tool execution before final answer generation for operational questions."
+    }
+  ],
+  "conflict_map": [
+    {
+      "from_layer": "active_recall",
+      "to_layer": "tool_selection",
+      "conflict_type": "stale_state",
+      "note": "Recalled stale facts bias tool choice away from fresh probes."
+    }
+  ],
+  "ordered_fix_plan": [
+    {
+      "order": 1,
+      "goal": "Enforce fresh probes in code",
+      "why_now": "This removes the highest-confidence failure mode first.",
+      "expected_effect": "Operational answers stop bypassing live evidence."
+    }
+  ]
+}
+```
+
+## Design guidance
+
+This pattern works best when:
+
+- evidence collection is explicit, not implied
+- severity is part of the structured output
+- fix ordering is included in the report itself
+- code/config controls are preferred over prompt-only controls
+- the final prose summary is rendered from typed data rather than generated independently
+
+## Where to extend it
+
+Good next steps include:
+
+- adding domain-specific evidence sources
+- attaching trace or run identifiers to each evidence item
+- enriching the report schema with confidence scores or contradictory evidence
+- connecting the report to downstream remediation workflows

--- a/examples/agent_patterns/README.md
+++ b/examples/agent_patterns/README.md
@@ -42,8 +42,8 @@ See the [`llm_as_a_judge.py`](./llm_as_a_judge.py) file for an example of this.
 ## Structured agent audits
 
 You can also use deterministic, typed stages to audit an agent runtime itself. This pattern is
-useful when you want structured scope, evidence, failure mapping, and an ordered fix plan instead
-of a freeform review.
+useful when you want structured scope, evidence, failure mapping, an ordered fix plan, and explicit
+playbook / rubric / schema guidance instead of a freeform review.
 
 See the [`structured_agent_audit.py`](./structured_agent_audit.py) file for an example of this.
 

--- a/examples/agent_patterns/README.md
+++ b/examples/agent_patterns/README.md
@@ -46,6 +46,8 @@ useful when you want structured scope, evidence, failure mapping, an ordered fix
 playbook / rubric / schema guidance instead of a freeform review.
 
 See the [`structured_agent_audit.py`](./structured_agent_audit.py) file for an example of this.
+See the [`structured_agent_audit_with_guardrails.py`](./structured_agent_audit_with_guardrails.py)
+file for a tracing + output-guardrail variant.
 
 ## Parallelization
 

--- a/examples/agent_patterns/README.md
+++ b/examples/agent_patterns/README.md
@@ -39,6 +39,14 @@ For example, you could use an LLM to generate an outline for a story, and then u
 
 See the [`llm_as_a_judge.py`](./llm_as_a_judge.py) file for an example of this.
 
+## Structured agent audits
+
+You can also use deterministic, typed stages to audit an agent runtime itself. This pattern is
+useful when you want structured scope, evidence, failure mapping, and an ordered fix plan instead
+of a freeform review.
+
+See the [`structured_agent_audit.py`](./structured_agent_audit.py) file for an example of this.
+
 ## Parallelization
 
 Running multiple agents in parallel is a common pattern. This can be useful for both latency (e.g. if you have multiple steps that don't depend on each other) and also for other reasons e.g. generating multiple responses and picking the best one.

--- a/examples/agent_patterns/structured_agent_audit.py
+++ b/examples/agent_patterns/structured_agent_audit.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from agents import Agent, Runner, trace
+from examples.auto_mode import input_with_fallback
+
+"""
+This example adapts a strict agent-wrapper audit pattern into the Agents SDK.
+It breaks the audit into four structured artifacts:
+
+1. scope
+2. evidence pack
+3. failure map
+4. final report
+
+The goal is to keep the workflow evidence-first and typed end-to-end.
+"""
+
+
+Severity = Literal["critical", "high", "medium", "low"]
+
+
+class AuditScope(BaseModel):
+    target_name: str
+    entrypoints: list[str]
+    model_stack: list[str]
+    symptoms: list[str]
+    time_window: str
+    layers_to_audit: list[str]
+
+
+class EvidenceItem(BaseModel):
+    kind: Literal["code", "log", "config", "test", "trace", "session"]
+    source: str
+    summary: str
+    time_scope: Literal["historical", "current", "mixed"]
+
+
+class EvidencePack(BaseModel):
+    evidence_pack: list[EvidenceItem]
+    missing_evidence: list[str] = Field(default_factory=list)
+
+
+class Finding(BaseModel):
+    severity: Severity
+    title: str
+    symptom: str
+    source_layer: str
+    root_cause: str
+    recommended_fix: str
+
+
+class ConflictEdge(BaseModel):
+    from_layer: str
+    to_layer: str
+    conflict_type: Literal[
+        "duplication",
+        "contradiction",
+        "stale_state",
+        "hidden_mutation",
+        "freeform_overwrite",
+    ]
+    note: str
+
+
+class FailureMap(BaseModel):
+    findings: list[Finding]
+    conflict_map: list[ConflictEdge] = Field(default_factory=list)
+
+
+class ExecutiveVerdict(BaseModel):
+    overall_health: Literal["critical", "high_risk", "unstable", "acceptable", "strong"]
+    primary_failure_mode: str
+    most_urgent_fix: str
+
+
+class OrderedFix(BaseModel):
+    order: int
+    goal: str
+    why_now: str
+    expected_effect: str
+
+
+class AuditReport(BaseModel):
+    executive_verdict: ExecutiveVerdict
+    findings: list[Finding]
+    conflict_map: list[ConflictEdge] = Field(default_factory=list)
+    ordered_fix_plan: list[OrderedFix]
+
+
+@dataclass
+class StructuredAuditAgents:
+    scope: Agent[AuditScope]
+    evidence: Agent[EvidencePack]
+    failure_map: Agent[FailureMap]
+    report: Agent[AuditReport]
+
+
+def build_audit_agents() -> StructuredAuditAgents:
+    scope_agent = Agent(
+        name="audit_scope_agent",
+        instructions=(
+            "You define the scope for auditing an agent runtime. "
+            "Focus on target system, entrypoints, model stack, symptoms, time window, "
+            "and the layers that should be audited."
+        ),
+        output_type=AuditScope,
+    )
+
+    evidence_agent = Agent(
+        name="audit_evidence_agent",
+        instructions=(
+            "You build an evidence pack for an agent-runtime audit. "
+            "Prefer direct evidence categories such as code, logs, configs, tests, traces, "
+            "or session artifacts. If something important is missing, list it explicitly."
+        ),
+        output_type=EvidencePack,
+    )
+
+    failure_map_agent = Agent(
+        name="audit_failure_map_agent",
+        instructions=(
+            "You diagnose wrapper failures in an agent system. "
+            "Look for tool-discipline failures, memory contamination, wrapper regression, "
+            "hidden mutation layers, and stale evidence reuse. "
+            "Produce severity-ranked findings and a conflict map."
+        ),
+        output_type=FailureMap,
+    )
+
+    report_agent = Agent(
+        name="audit_report_agent",
+        instructions=(
+            "You turn structured audit artifacts into a final report. "
+            "Lead with the executive verdict, then severity-ranked findings, then an ordered "
+            "fix plan. Prefer code and configuration fixes over prompt-only fixes."
+        ),
+        output_type=AuditReport,
+    )
+
+    return StructuredAuditAgents(
+        scope=scope_agent,
+        evidence=evidence_agent,
+        failure_map=failure_map_agent,
+        report=report_agent,
+    )
+
+
+async def run_structured_agent_audit(
+    audit_request: str, agents: StructuredAuditAgents | None = None
+) -> AuditReport:
+    agents = agents or build_audit_agents()
+
+    with trace("Structured agent audit"):
+        scope_result = await Runner.run(agents.scope, audit_request)
+        scope = scope_result.final_output
+
+        evidence_prompt = (
+            "Build an evidence pack for this audit.\n\n"
+            f"Audit request:\n{audit_request}\n\n"
+            f"Scope JSON:\n{scope.model_dump_json(indent=2)}"
+        )
+        evidence_result = await Runner.run(agents.evidence, evidence_prompt)
+        evidence = evidence_result.final_output
+
+        failure_prompt = (
+            "Build the failure map for this agent audit.\n\n"
+            f"Scope JSON:\n{scope.model_dump_json(indent=2)}\n\n"
+            f"Evidence JSON:\n{evidence.model_dump_json(indent=2)}"
+        )
+        failure_result = await Runner.run(agents.failure_map, failure_prompt)
+        failure_map = failure_result.final_output
+
+        report_prompt = (
+            "Build the final audit report.\n\n"
+            f"Scope JSON:\n{scope.model_dump_json(indent=2)}\n\n"
+            f"Evidence JSON:\n{evidence.model_dump_json(indent=2)}\n\n"
+            f"Failure map JSON:\n{failure_map.model_dump_json(indent=2)}"
+        )
+        report_result = await Runner.run(agents.report, report_prompt)
+        return report_result.final_output
+
+
+def render_report_summary(report: AuditReport) -> str:
+    lines = [
+        f"Overall health: {report.executive_verdict.overall_health}",
+        f"Primary failure mode: {report.executive_verdict.primary_failure_mode}",
+        f"Most urgent fix: {report.executive_verdict.most_urgent_fix}",
+        "",
+        "Findings:",
+    ]
+    for finding in report.findings:
+        lines.append(f"- [{finding.severity}] {finding.title}: {finding.recommended_fix}")
+
+    lines.append("")
+    lines.append("Fix plan:")
+    for fix in report.ordered_fix_plan:
+        lines.append(f"{fix.order}. {fix.goal} - {fix.expected_effect}")
+
+    return "\n".join(lines)
+
+
+async def main() -> None:
+    audit_request = input_with_fallback(
+        "What agent runtime do you want to audit? ",
+        (
+            "Audit a coding assistant wrapper that became less reliable after adding memory, "
+            "tool routing, and answer-shaping layers."
+        ),
+    )
+    report = await run_structured_agent_audit(audit_request)
+    print(report.model_dump_json(indent=2))
+    print()
+    print(render_report_summary(report))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/agent_patterns/structured_agent_audit.py
+++ b/examples/agent_patterns/structured_agent_audit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -23,6 +23,55 @@ The goal is to keep the workflow evidence-first and typed end-to-end.
 
 
 Severity = Literal["critical", "high", "medium", "low"]
+AuditPlaybook = Literal[
+    "wrapper_regression",
+    "memory_contamination",
+    "tool_discipline",
+    "rendering_transport",
+    "hidden_agent_layers",
+]
+
+
+AUDIT_PLAYBOOKS: dict[AuditPlaybook, str] = {
+    "wrapper_regression": (
+        "Use when the base model looks strong but the wrapped agent behaves worse. "
+        "Focus on wrapper layering, duplicated context injection, and orchestration drift."
+    ),
+    "memory_contamination": (
+        "Use when old topics or stale artifacts bleed into current turns. "
+        "Focus on memory admission, same-session reentry, and stale retrieval ordering."
+    ),
+    "tool_discipline": (
+        "Use when the agent should have used a tool but skipped it, or used the wrong tool. "
+        "Focus on code-enforced tool requirements, preflight probes, and stale evidence binding."
+    ),
+    "rendering_transport": (
+        "Use when the answer seems correct internally but is degraded by delivery or formatting layers. "
+        "Focus on payload shape assumptions, fallback rendering, and semantic mutation in transport."
+    ),
+    "hidden_agent_layers": (
+        "Use when hidden retry, recap, summarize, or repair loops mutate results. "
+        "Focus on hidden second-pass model calls and undocumented repair behaviors."
+    ),
+}
+
+
+AUDIT_RUBRIC = """
+Audit rubric:
+1. Context cleanliness: detect duplicated context, stale carryover, and same-session artifact reentry.
+2. Tool discipline: distinguish prompt-only tool suggestions from code-enforced tool requirements.
+3. Failure handling: inspect retries, repair loops, and semantic mutation during fallback.
+4. Memory admission: prefer evidence-backed durable facts over assistant self-talk.
+5. Answer shaping: check whether final responses are derived from structured evidence or decorative prose.
+6. Hidden agent layers: identify recap, repair, summarize, or transport logic behaving like undeclared agents.
+7. JSON vs freeform boundary: keep internal orchestration typed and structured whenever possible.
+
+Severity heuristics:
+- critical: confidently wrong operational behavior
+- high: repeated corruption of otherwise good evidence
+- medium: correctness often survives, but the system is fragile or noisy
+- low: mostly maintainability or cosmetic concerns
+""".strip()
 
 
 class AuditScope(BaseModel):
@@ -101,6 +150,10 @@ class StructuredAuditAgents:
     report: Agent[AuditReport]
 
 
+def audit_report_schema() -> dict[str, Any]:
+    return AuditReport.model_json_schema()
+
+
 def build_audit_agents() -> StructuredAuditAgents:
     scope_agent = Agent(
         name="audit_scope_agent",
@@ -152,17 +205,29 @@ def build_audit_agents() -> StructuredAuditAgents:
 
 
 async def run_structured_agent_audit(
-    audit_request: str, agents: StructuredAuditAgents | None = None
+    audit_request: str,
+    agents: StructuredAuditAgents | None = None,
+    playbook: AuditPlaybook = "wrapper_regression",
 ) -> AuditReport:
     agents = agents or build_audit_agents()
+    playbook_guidance = AUDIT_PLAYBOOKS[playbook]
+    schema_json = AuditReport.model_json_schema()
 
     with trace("Structured agent audit"):
-        scope_result = await Runner.run(agents.scope, audit_request)
+        scope_prompt = (
+            f"Audit request:\n{audit_request}\n\n"
+            f"Playbook: {playbook}\n"
+            f"Playbook guidance: {playbook_guidance}"
+        )
+        scope_result = await Runner.run(agents.scope, scope_prompt)
         scope = scope_result.final_output
 
         evidence_prompt = (
             "Build an evidence pack for this audit.\n\n"
             f"Audit request:\n{audit_request}\n\n"
+            f"Playbook: {playbook}\n"
+            f"Playbook guidance: {playbook_guidance}\n\n"
+            f"Rubric:\n{AUDIT_RUBRIC}\n\n"
             f"Scope JSON:\n{scope.model_dump_json(indent=2)}"
         )
         evidence_result = await Runner.run(agents.evidence, evidence_prompt)
@@ -170,6 +235,9 @@ async def run_structured_agent_audit(
 
         failure_prompt = (
             "Build the failure map for this agent audit.\n\n"
+            f"Playbook: {playbook}\n"
+            f"Playbook guidance: {playbook_guidance}\n\n"
+            f"Rubric:\n{AUDIT_RUBRIC}\n\n"
             f"Scope JSON:\n{scope.model_dump_json(indent=2)}\n\n"
             f"Evidence JSON:\n{evidence.model_dump_json(indent=2)}"
         )
@@ -178,12 +246,22 @@ async def run_structured_agent_audit(
 
         report_prompt = (
             "Build the final audit report.\n\n"
+            f"Playbook: {playbook}\n"
+            f"Playbook guidance: {playbook_guidance}\n\n"
+            f"Rubric:\n{AUDIT_RUBRIC}\n\n"
+            f"Report JSON schema:\n{json_dumps_pretty(schema_json)}\n\n"
             f"Scope JSON:\n{scope.model_dump_json(indent=2)}\n\n"
             f"Evidence JSON:\n{evidence.model_dump_json(indent=2)}\n\n"
             f"Failure map JSON:\n{failure_map.model_dump_json(indent=2)}"
         )
         report_result = await Runner.run(agents.report, report_prompt)
         return report_result.final_output
+
+
+def json_dumps_pretty(data: dict[str, Any]) -> str:
+    import json
+
+    return json.dumps(data, indent=2, sort_keys=True)
 
 
 def render_report_summary(report: AuditReport) -> str:

--- a/examples/agent_patterns/structured_agent_audit_with_guardrails.py
+++ b/examples/agent_patterns/structured_agent_audit_with_guardrails.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from agents import (
+    Agent,
+    GuardrailFunctionOutput,
+    OutputGuardrailTripwireTriggered,
+    RunContextWrapper,
+    output_guardrail,
+    trace,
+)
+from examples.agent_patterns.structured_agent_audit import (
+    AUDIT_PLAYBOOKS,
+    AuditPlaybook,
+    AuditReport,
+    StructuredAuditAgents,
+    build_audit_agents,
+    render_report_summary,
+    run_structured_agent_audit,
+)
+from examples.auto_mode import input_with_fallback
+
+"""
+This example shows how to combine the structured audit workflow with tracing metadata
+and an output guardrail on the final audit report.
+"""
+
+
+@output_guardrail
+async def actionable_report_guardrail(
+    context: RunContextWrapper[Any], agent: Agent[Any], output: AuditReport
+) -> GuardrailFunctionOutput:
+    severe_findings = [f for f in output.findings if f.severity in {"critical", "high"}]
+    missing_fix_plan = len(output.ordered_fix_plan) == 0
+    weak_fix_plan = len(output.ordered_fix_plan) < len(severe_findings)
+
+    return GuardrailFunctionOutput(
+        output_info={
+            "severe_findings": len(severe_findings),
+            "fix_plan_steps": len(output.ordered_fix_plan),
+            "missing_fix_plan": missing_fix_plan,
+            "weak_fix_plan": weak_fix_plan,
+        },
+        tripwire_triggered=bool(severe_findings) and (missing_fix_plan or weak_fix_plan),
+    )
+
+
+def build_guardrailed_audit_agents() -> StructuredAuditAgents:
+    agents = build_audit_agents()
+    guarded_report_agent = Agent(
+        name=agents.report.name,
+        instructions=agents.report.instructions,
+        output_type=AuditReport,
+        output_guardrails=[actionable_report_guardrail],
+    )
+    return StructuredAuditAgents(
+        scope=agents.scope,
+        evidence=agents.evidence,
+        failure_map=agents.failure_map,
+        report=guarded_report_agent,
+    )
+
+
+async def main(playbook: AuditPlaybook = "tool_discipline") -> None:
+    audit_request = input_with_fallback(
+        "What agent runtime do you want to audit? ",
+        (
+            "Audit an agent runtime that sometimes answers operational questions "
+            "without using required tools."
+        ),
+    )
+    agents = build_guardrailed_audit_agents()
+
+    with trace(
+        "Structured agent audit with guardrails",
+        metadata={
+            "example": "structured_agent_audit_with_guardrails",
+            "playbook": playbook,
+            "playbook_guidance": AUDIT_PLAYBOOKS[playbook],
+        },
+    ):
+        try:
+            report = await run_structured_agent_audit(
+                audit_request,
+                agents=agents,
+                playbook=playbook,
+            )
+        except OutputGuardrailTripwireTriggered as exc:
+            print("Guardrail tripped on the final audit report.")
+            print(exc.guardrail_result.output.output_info)
+            return
+
+    print(report.model_dump_json(indent=2))
+    print()
+    print(render_report_summary(report))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_example_workflows.py
+++ b/tests/test_example_workflows.py
@@ -43,6 +43,8 @@ from examples.sandbox.sandbox_agents_as_tools import (
 from examples.agent_patterns.structured_agent_audit import (
     AuditReport,
     AuditScope,
+    AUDIT_PLAYBOOKS,
+    AUDIT_RUBRIC,
     ConflictEdge,
     EvidenceItem,
     EvidencePack,
@@ -51,6 +53,7 @@ from examples.agent_patterns.structured_agent_audit import (
     Finding,
     OrderedFix,
     StructuredAuditAgents,
+    audit_report_schema,
     render_report_summary,
     run_structured_agent_audit,
 )
@@ -197,6 +200,10 @@ async def test_structured_agent_audit_workflow_chains_typed_artifacts() -> None:
     assert "Scope JSON" in evidence_model.last_turn_args["input"][0]["content"]
     assert "Evidence JSON" in failure_model.last_turn_args["input"][0]["content"]
     assert "Failure map JSON" in report_model.last_turn_args["input"][0]["content"]
+    assert "Playbook: wrapper_regression" in scope_model.last_turn_args["input"][0]["content"]
+    assert AUDIT_PLAYBOOKS["wrapper_regression"] in evidence_model.last_turn_args["input"][0]["content"]
+    assert "Audit rubric:" in failure_model.last_turn_args["input"][0]["content"]
+    assert "Report JSON schema:" in report_model.last_turn_args["input"][0]["content"]
 
 
 def test_render_report_summary_formats_findings_and_fixes() -> None:
@@ -239,6 +246,22 @@ def test_render_report_summary_formats_findings_and_fixes() -> None:
     assert "Overall health: high_risk" in summary
     assert "[high] Prompt-only tool enforcement" in summary
     assert "1. Move tool discipline into code gates" in summary
+
+
+def test_audit_report_schema_exposes_expected_shape() -> None:
+    schema = audit_report_schema()
+
+    assert schema["title"] == "AuditReport"
+    assert "properties" in schema
+    assert "executive_verdict" in schema["properties"]
+    assert "ordered_fix_plan" in schema["properties"]
+
+
+def test_audit_playbooks_and_rubric_include_core_guidance() -> None:
+    assert "tool_discipline" in AUDIT_PLAYBOOKS
+    assert "wrapper layering" in AUDIT_PLAYBOOKS["wrapper_regression"]
+    assert "Context cleanliness" in AUDIT_RUBRIC
+    assert "Severity heuristics" in AUDIT_RUBRIC
 
 
 def test_sandbox_basic_direct_run_imports_external_docker_sdk(

--- a/tests/test_example_workflows.py
+++ b/tests/test_example_workflows.py
@@ -46,6 +46,9 @@ from examples.agent_patterns.structured_agent_audit import (
     render_report_summary,
     run_structured_agent_audit,
 )
+from examples.agent_patterns.structured_agent_audit_with_guardrails import (
+    actionable_report_guardrail,
+)
 from examples.sandbox.basic import _import_docker_from_env
 from examples.sandbox.docker.docker_runner import (
     _format_tool_call,
@@ -275,6 +278,39 @@ def test_audit_playbooks_and_rubric_include_core_guidance() -> None:
     assert "wrapper layering" in AUDIT_PLAYBOOKS["wrapper_regression"]
     assert "Context cleanliness" in AUDIT_RUBRIC
     assert "Severity heuristics" in AUDIT_RUBRIC
+
+
+@pytest.mark.asyncio
+async def test_actionable_report_guardrail_trips_on_severe_findings_without_fix_plan() -> None:
+    report = AuditReport(
+        executive_verdict=ExecutiveVerdict(
+            overall_health="high_risk",
+            primary_failure_mode="Fresh probes are skipped.",
+            most_urgent_fix="Enforce tool use in code.",
+        ),
+        findings=[
+            Finding(
+                severity="critical",
+                title="Fresh probe bypass",
+                symptom="The agent answers operational questions without tools.",
+                source_layer="tool_selection",
+                root_cause="Prompt-only enforcement.",
+                recommended_fix="Require tool execution before final answer generation.",
+            )
+        ],
+        conflict_map=[],
+        ordered_fix_plan=[],
+    )
+
+    result = await actionable_report_guardrail.guardrail_function(
+        RunContextWrapper(context=None),
+        Agent(name="report_guardrail_agent"),
+        report,
+    )
+
+    assert result.tripwire_triggered is True
+    assert result.output_info["severe_findings"] == 1
+    assert result.output_info["missing_fix_plan"] is True
 
 
 def test_sandbox_basic_direct_run_imports_external_docker_sdk(

--- a/tests/test_example_workflows.py
+++ b/tests/test_example_workflows.py
@@ -40,6 +40,20 @@ from examples.sandbox.sandbox_agents_as_tools import (
     RolloutRiskReview,
     _structured_tool_output_extractor,
 )
+from examples.agent_patterns.structured_agent_audit import (
+    AuditReport,
+    AuditScope,
+    ConflictEdge,
+    EvidenceItem,
+    EvidencePack,
+    ExecutiveVerdict,
+    FailureMap,
+    Finding,
+    OrderedFix,
+    StructuredAuditAgents,
+    render_report_summary,
+    run_structured_agent_audit,
+)
 
 from .fake_model import FakeModel
 from .test_responses import (
@@ -49,6 +63,182 @@ from .test_responses import (
     get_text_input_item,
     get_text_message,
 )
+
+
+@pytest.mark.asyncio
+async def test_structured_agent_audit_workflow_chains_typed_artifacts() -> None:
+    scope_model = FakeModel()
+    scope_model.set_next_output(
+        [
+            get_final_output_message(
+                json.dumps(
+                    {
+                        "target_name": "wrapper-runtime",
+                        "entrypoints": ["cli"],
+                        "model_stack": ["gpt-4.1", "tool-router"],
+                        "symptoms": ["tool skips", "stale recall"],
+                        "time_window": "last 24h",
+                        "layers_to_audit": ["tool_selection", "active_recall"],
+                    }
+                )
+            )
+        ]
+    )
+
+    evidence_model = FakeModel()
+    evidence_model.set_next_output(
+        [
+            get_final_output_message(
+                json.dumps(
+                    {
+                        "evidence_pack": [
+                            {
+                                "kind": "code",
+                                "source": "runtime/router.py",
+                                "summary": "Tool selection silently falls back to markdown reasoning.",
+                                "time_scope": "current",
+                            }
+                        ],
+                        "missing_evidence": ["historical session trace"],
+                    }
+                )
+            )
+        ]
+    )
+
+    failure_model = FakeModel()
+    failure_model.set_next_output(
+        [
+            get_final_output_message(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "severity": "high",
+                                "title": "Prompt-only tool enforcement",
+                                "symptom": "The wrapper skips tools under pressure.",
+                                "source_layer": "tool_selection",
+                                "root_cause": "Tool use is instructed but not enforced in code.",
+                                "recommended_fix": "Require tool execution in code before final answer generation.",
+                            }
+                        ],
+                        "conflict_map": [
+                            {
+                                "from_layer": "active_recall",
+                                "to_layer": "tool_selection",
+                                "conflict_type": "stale_state",
+                                "note": "Stale recall biases tool choice toward old evidence.",
+                            }
+                        ],
+                    }
+                )
+            )
+        ]
+    )
+
+    report_model = FakeModel()
+    report_model.set_next_output(
+        [
+            get_final_output_message(
+                json.dumps(
+                    {
+                        "executive_verdict": {
+                            "overall_health": "high_risk",
+                            "primary_failure_mode": "Prompt-only controls drift under wrapper pressure.",
+                            "most_urgent_fix": "Enforce tool requirements in code.",
+                        },
+                        "findings": [
+                            {
+                                "severity": "high",
+                                "title": "Prompt-only tool enforcement",
+                                "symptom": "The wrapper skips tools under pressure.",
+                                "source_layer": "tool_selection",
+                                "root_cause": "Tool use is instructed but not enforced in code.",
+                                "recommended_fix": "Require tool execution in code before final answer generation.",
+                            }
+                        ],
+                        "conflict_map": [
+                            {
+                                "from_layer": "active_recall",
+                                "to_layer": "tool_selection",
+                                "conflict_type": "stale_state",
+                                "note": "Stale recall biases tool choice toward old evidence.",
+                            }
+                        ],
+                        "ordered_fix_plan": [
+                            {
+                                "order": 1,
+                                "goal": "Move tool discipline into code gates",
+                                "why_now": "This blocks the highest-impact correctness failure.",
+                                "expected_effect": "The wrapper can no longer answer without current-turn evidence.",
+                            }
+                        ],
+                    }
+                )
+            )
+        ]
+    )
+
+    agents = StructuredAuditAgents(
+        scope=Agent(name="scope", model=scope_model, output_type=AuditScope),
+        evidence=Agent(name="evidence", model=evidence_model, output_type=EvidencePack),
+        failure_map=Agent(name="failure_map", model=failure_model, output_type=FailureMap),
+        report=Agent(name="report", model=report_model, output_type=AuditReport),
+    )
+
+    report = await run_structured_agent_audit(
+        "Audit the runtime for wrapper regression and stale evidence reuse.",
+        agents=agents,
+    )
+
+    assert report.executive_verdict.overall_health == "high_risk"
+    assert report.findings[0].severity == "high"
+    assert report.ordered_fix_plan[0].order == 1
+    assert "Scope JSON" in evidence_model.last_turn_args["input"][0]["content"]
+    assert "Evidence JSON" in failure_model.last_turn_args["input"][0]["content"]
+    assert "Failure map JSON" in report_model.last_turn_args["input"][0]["content"]
+
+
+def test_render_report_summary_formats_findings_and_fixes() -> None:
+    report = AuditReport(
+        executive_verdict=ExecutiveVerdict(
+            overall_health="high_risk",
+            primary_failure_mode="Tool discipline collapses under wrapper pressure.",
+            most_urgent_fix="Enforce tool requirements in code.",
+        ),
+        findings=[
+            Finding(
+                severity="high",
+                title="Prompt-only tool enforcement",
+                symptom="The wrapper skips tools under pressure.",
+                source_layer="tool_selection",
+                root_cause="Tool use is instructed but not enforced in code.",
+                recommended_fix="Require tool execution in code before final answer generation.",
+            )
+        ],
+        conflict_map=[
+            ConflictEdge(
+                from_layer="active_recall",
+                to_layer="tool_selection",
+                conflict_type="stale_state",
+                note="Stale recall biases tool choice toward old evidence.",
+            )
+        ],
+        ordered_fix_plan=[
+            OrderedFix(
+                order=1,
+                goal="Move tool discipline into code gates",
+                why_now="This blocks the highest-impact correctness failure.",
+                expected_effect="The wrapper can no longer answer without current-turn evidence.",
+            )
+        ],
+    )
+
+    summary = render_report_summary(report)
+
+    assert "Overall health: high_risk" in summary
+    assert "[high] Prompt-only tool enforcement" in summary
+    assert "1. Move tool discipline into code gates" in summary
 
 
 def test_sandbox_basic_direct_run_imports_external_docker_sdk(

--- a/tests/test_example_workflows.py
+++ b/tests/test_example_workflows.py
@@ -30,23 +30,12 @@ from agents import (
 from agents.agent import ToolsToFinalOutputResult
 from agents.items import TResponseInputItem
 from agents.tool import FunctionToolResult, function_tool
-from examples.sandbox.basic import _import_docker_from_env
-from examples.sandbox.docker.docker_runner import (
-    _format_tool_call,
-    _format_tool_output,
-)
-from examples.sandbox.sandbox_agents_as_tools import (
-    PricingPacketReview,
-    RolloutRiskReview,
-    _structured_tool_output_extractor,
-)
 from examples.agent_patterns.structured_agent_audit import (
-    AuditReport,
-    AuditScope,
     AUDIT_PLAYBOOKS,
     AUDIT_RUBRIC,
+    AuditReport,
+    AuditScope,
     ConflictEdge,
-    EvidenceItem,
     EvidencePack,
     ExecutiveVerdict,
     FailureMap,
@@ -56,6 +45,16 @@ from examples.agent_patterns.structured_agent_audit import (
     audit_report_schema,
     render_report_summary,
     run_structured_agent_audit,
+)
+from examples.sandbox.basic import _import_docker_from_env
+from examples.sandbox.docker.docker_runner import (
+    _format_tool_call,
+    _format_tool_output,
+)
+from examples.sandbox.sandbox_agents_as_tools import (
+    PricingPacketReview,
+    RolloutRiskReview,
+    _structured_tool_output_extractor,
 )
 
 from .fake_model import FakeModel
@@ -98,7 +97,9 @@ async def test_structured_agent_audit_workflow_chains_typed_artifacts() -> None:
                             {
                                 "kind": "code",
                                 "source": "runtime/router.py",
-                                "summary": "Tool selection silently falls back to markdown reasoning.",
+                                "summary": (
+                                    "Tool selection silently falls back to markdown reasoning."
+                                ),
                                 "time_scope": "current",
                             }
                         ],
@@ -122,7 +123,9 @@ async def test_structured_agent_audit_workflow_chains_typed_artifacts() -> None:
                                 "symptom": "The wrapper skips tools under pressure.",
                                 "source_layer": "tool_selection",
                                 "root_cause": "Tool use is instructed but not enforced in code.",
-                                "recommended_fix": "Require tool execution in code before final answer generation.",
+                                "recommended_fix": (
+                                    "Require tool execution in code before final answer generation."
+                                ),
                             }
                         ],
                         "conflict_map": [
@@ -147,7 +150,9 @@ async def test_structured_agent_audit_workflow_chains_typed_artifacts() -> None:
                     {
                         "executive_verdict": {
                             "overall_health": "high_risk",
-                            "primary_failure_mode": "Prompt-only controls drift under wrapper pressure.",
+                            "primary_failure_mode": (
+                                "Prompt-only controls drift under wrapper pressure."
+                            ),
                             "most_urgent_fix": "Enforce tool requirements in code.",
                         },
                         "findings": [
@@ -157,7 +162,9 @@ async def test_structured_agent_audit_workflow_chains_typed_artifacts() -> None:
                                 "symptom": "The wrapper skips tools under pressure.",
                                 "source_layer": "tool_selection",
                                 "root_cause": "Tool use is instructed but not enforced in code.",
-                                "recommended_fix": "Require tool execution in code before final answer generation.",
+                                "recommended_fix": (
+                                    "Require tool execution in code before final answer generation."
+                                ),
                             }
                         ],
                         "conflict_map": [
@@ -173,7 +180,10 @@ async def test_structured_agent_audit_workflow_chains_typed_artifacts() -> None:
                                 "order": 1,
                                 "goal": "Move tool discipline into code gates",
                                 "why_now": "This blocks the highest-impact correctness failure.",
-                                "expected_effect": "The wrapper can no longer answer without current-turn evidence.",
+                                "expected_effect": (
+                                    "The wrapper can no longer answer without current-turn "
+                                    "evidence."
+                                ),
                             }
                         ],
                     }
@@ -201,7 +211,10 @@ async def test_structured_agent_audit_workflow_chains_typed_artifacts() -> None:
     assert "Evidence JSON" in failure_model.last_turn_args["input"][0]["content"]
     assert "Failure map JSON" in report_model.last_turn_args["input"][0]["content"]
     assert "Playbook: wrapper_regression" in scope_model.last_turn_args["input"][0]["content"]
-    assert AUDIT_PLAYBOOKS["wrapper_regression"] in evidence_model.last_turn_args["input"][0]["content"]
+    assert (
+        AUDIT_PLAYBOOKS["wrapper_regression"]
+        in evidence_model.last_turn_args["input"][0]["content"]
+    )
     assert "Audit rubric:" in failure_model.last_turn_args["input"][0]["content"]
     assert "Report JSON schema:" in report_model.last_turn_args["input"][0]["content"]
 


### PR DESCRIPTION
## Summary
- add a new `examples/agent_patterns/structured_agent_audit.py` example for building evidence-first agent runtime audits with the Agents SDK
- add `examples/agent_patterns/structured_agent_audit_with_guardrails.py` to show how to combine the audit workflow with tracing metadata and an output guardrail
- add a cookbook-style guide in `docs/structured_agent_audits.md`
- document the new pattern in `examples/agent_patterns/README.md` and `docs/examples.md`
- add workflow coverage in `tests/test_example_workflows.py`

## What this contributes
This PR adds a complete structured audit workflow pattern for agent runtimes.

Instead of relying on freeform review prose, the example shows how to break an audit into typed stages:
1. `AuditScope`
2. `EvidencePack`
3. `FailureMap`
4. `AuditReport`

In addition to the staged workflow itself, the contribution now includes:
- reusable audit playbooks for different failure modes
- an audit rubric for evaluating context cleanliness, tool discipline, failure handling, memory admission, answer shaping, hidden layers, and JSON-vs-freeform boundaries
- a JSON schema export for the final audit report shape
- a tracing + output-guardrail composition example
- a cookbook-style guide that explains when to use the pattern and how to extend it

## Why this is useful
This gives SDK users a concrete reference for building agent-runtime diagnostics that are:
- typed instead of improvised
- evidence-backed instead of vibe-based
- reproducible across runs
- explicit about severity and fix ordering
- easy to combine with other SDK primitives like tracing and guardrails

It is especially useful for teams investigating problems like:
- wrapper regression
- tool-discipline failures
- stale evidence reuse
- hidden mutation layers
- memory contamination
- protocol drift between structured and freeform layers

## Verification
I ran these locally and they passed:

```bash
python3 -m py_compile /tmp/openai-agents-python-api/examples/agent_patterns/structured_agent_audit.py /tmp/openai-agents-python-api/examples/agent_patterns/structured_agent_audit_with_guardrails.py /tmp/openai-agents-python-api/tests/test_example_workflows.py
cd /tmp/openai-agents-python-api && uv run ruff check examples/agent_patterns/structured_agent_audit.py examples/agent_patterns/structured_agent_audit_with_guardrails.py tests/test_example_workflows.py
cd /tmp/openai-agents-python-api && uv run pytest tests/test_example_workflows.py -k 'structured_agent_audit or render_report_summary or audit_report_schema or audit_playbooks or actionable_report_guardrail'
```

Result:
- ruff checks passed
- `5 passed, 22 deselected`
