### PR TITLE
chore: harden uv dependency resolution

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,8 +36,9 @@ jobs:
           fi
       - name: Setup uv
         if: steps.docs-only.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
       - name: Install dependencies
         if: steps.docs-only.outputs.skip != 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
       - name: Install dependencies
         run: make sync

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -21,8 +21,9 @@ jobs:
           fetch-depth: 0
           ref: main
       - name: Setup uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
       - name: Fetch tags
         run: git fetch origin --tags --prune

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,9 @@ jobs:
         run: ./.github/scripts/detect-changes.sh code "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
       - name: Setup uv
         if: steps.changes.outputs.run == 'true'
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'
@@ -50,8 +51,9 @@ jobs:
         run: ./.github/scripts/detect-changes.sh code "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
       - name: Setup uv
         if: steps.changes.outputs.run == 'true'
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'
@@ -84,8 +86,9 @@ jobs:
         run: ./.github/scripts/detect-changes.sh code "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
       - name: Setup uv
         if: steps.changes.outputs.run == 'true'
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -117,8 +120,9 @@ jobs:
         run: ./.github/scripts/detect-changes.sh code "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
       - name: Setup uv
         if: steps.changes.outputs.run == 'true'
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
           python-version: "3.13"
       - name: Install dependencies
@@ -143,8 +147,9 @@ jobs:
         run: ./.github/scripts/detect-changes.sh docs "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
       - name: Setup uv
         if: steps.changes.outputs.run == 'true'
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -48,8 +48,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # setup-uv v8.1.0; uv 0.11.7
         with:
+          version: "0.11.7"
           enable-cache: true
       - name: Install dependencies
         run: make sync

--- a/examples/sandbox/tutorials/Dockerfile
+++ b/examples/sandbox/tutorials/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.14-slim
+COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -8,6 +9,6 @@ RUN apt-get update \
         ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --no-cache-dir pypdf uv
+RUN uv pip install --system --no-cache-dir --index-strategy first-index --exclude-newer "7 days" pypdf
 
 WORKDIR /workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,3 +208,11 @@ markers = [
 
 [tool.inline-snapshot]
 format-command = "ruff format --stdin-filename {filename}"
+
+[tool.uv]
+exclude-newer = "7 days"
+index-strategy = "first-index"
+
+[tool.uv.pip]
+exclude-newer = "7 days"
+index-strategy = "first-index"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-04-16T16:59:13.484567446Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiofiles"
 version = "24.1.0"


### PR DESCRIPTION
This pull request hardens package-manager dependency resolution for this public repository. It adds uv age-gate and safe index policy, pins GitHub Actions setup for uv to an immutable action release, and explicitly installs uv 0.11.7 in CI so the relative `exclude-newer = "7 days"` policy is supported.

## What changed

- Add `[tool.uv]` and `[tool.uv.pip]` policy with `exclude-newer = "7 days"` and `index-strategy = "first-index"`.
- Refresh `uv.lock` so the lock records the resolved cutoff for the configured 7-day policy.
- Pin `astral-sh/setup-uv` to an immutable `setup-uv v8.1.0` commit and document the action and uv package versions inline.
- Update the sandbox tutorial Docker image to copy a digest-pinned uv binary and install Python dependencies with `uv pip install --system` using age-gate and safe index controls.

## Why

This reduces package-compromise and dependency-confusion risk for CI, local lock resolution, and the tutorial container build without changing the SDK public API.

## Verification

- Package-manager audit completed with no unsuppressed follow-up items.
- `uv build`
- Docker build for `examples/sandbox/tutorials/Dockerfile`
- `make typecheck`
- `make tests`

Note: the full helper script that runs typecheck and tests concurrently reproduced an existing timing-sensitive test failure on the unchanged baseline worktree. Running the project checks sequentially passed.
