### PR TITLE
fix(realtime): #2940 emit history_added / history_updated on transcript_delta

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -306,6 +306,7 @@ class RealtimeSession(RealtimeModelListener):
                 self._item_guardrail_run_counts[item_id] = 0
 
             self._item_transcripts[item_id] += event.delta
+            prev_len = len(self._history)
             self._history = self._get_new_history(
                 self._history,
                 AssistantMessageItem(
@@ -313,6 +314,18 @@ class RealtimeSession(RealtimeModelListener):
                     content=[AssistantAudio(transcript=self._item_transcripts[item_id])],
                 ),
             )
+            # Surface a high-level history event so UIs that follow the
+            # documented `history_added` / `history_updated` contract see live
+            # partial-transcript changes. Mirrors the pattern already used for
+            # `input_audio_transcription_completed` above. (closes #2940)
+            if len(self._history) > prev_len and len(self._history) > 0:
+                await self._put_event(
+                    RealtimeHistoryAdded(info=self._event_info, item=self._history[-1])
+                )
+            else:
+                await self._put_event(
+                    RealtimeHistoryUpdated(info=self._event_info, history=self._history)
+                )
 
             # Check if we should run guardrails based on debounce threshold
             current_length = len(self._item_transcripts[item_id])


### PR DESCRIPTION
Closes #2940.

## Bug

`RealtimeSession.on_event` updates `self._history` on `transcript_delta` but only forwards the raw model event to the queue. UIs that follow the documented `history_added` / `history_updated` contract therefore never see live partial-transcript changes — even though the session history has already changed.

The repro in the issue shows that after a single `RealtimeModelTranscriptDeltaEvent`, the queue carries the raw event but no `RealtimeHistoryAdded` / `RealtimeHistoryUpdated`.

## Fix

Mirror the pattern already used for `input_audio_transcription_completed` (lines 283-294 of the same file): capture the pre-update history length, apply `_get_new_history`, and emit:

- `RealtimeHistoryAdded` if a brand-new item was appended (first transcript delta for an item), or
- `RealtimeHistoryUpdated` otherwise (subsequent partial-transcript update).

```diff
         elif event.type == "transcript_delta":
             item_id = event.item_id
             if item_id not in self._item_transcripts:
                 self._item_transcripts[item_id] = ""
                 self._item_guardrail_run_counts[item_id] = 0

             self._item_transcripts[item_id] += event.delta
+            prev_len = len(self._history)
             self._history = self._get_new_history(
                 self._history,
                 AssistantMessageItem(
                     item_id=item_id,
                     content=[AssistantAudio(transcript=self._item_transcripts[item_id])],
                 ),
             )
+            if len(self._history) > prev_len and len(self._history) > 0:
+                await self._put_event(
+                    RealtimeHistoryAdded(info=self._event_info, item=self._history[-1])
+                )
+            else:
+                await self._put_event(
+                    RealtimeHistoryUpdated(info=self._event_info, history=self._history)
+                )
```

Both events are already imported (lines 36-37) and used elsewhere in the file. No new state, no public-API change.

`+13 / 0`. Guardrail-debounce logic below this block is unaffected.

---

Contributed by [kcolbchain](https://kcolbchain.com).