### PR TITLE
Fix: remove unset fields from calls to Responses API

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -72,6 +72,9 @@ def run_item_to_input_item(
         return None
     to_input = getattr(run_item, "to_input_item", None)
     input_item = to_input() if callable(to_input) else cast(TResponseInputItem, run_item.raw_item)
+    if isinstance(input_item, dict) and input_item.get("status") is None:
+        input_item = dict(input_item)
+        input_item.pop("status", None)
     if (
         _should_omit_reasoning_item_ids(reasoning_item_id_policy)
         and run_item.type == "reasoning_item"

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -73,8 +73,7 @@ def run_item_to_input_item(
     to_input = getattr(run_item, "to_input_item", None)
     input_item = to_input() if callable(to_input) else cast(TResponseInputItem, run_item.raw_item)
     if isinstance(input_item, dict) and input_item.get("status") is None:
-        input_item = dict(input_item)
-        input_item.pop("status", None)
+        input_item = {k: v for k, v in input_item.items() if k!= "status"}
     if (
         _should_omit_reasoning_item_ids(reasoning_item_id_policy)
         and run_item.type == "reasoning_item"

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -73,7 +73,7 @@ def run_item_to_input_item(
     to_input = getattr(run_item, "to_input_item", None)
     input_item = to_input() if callable(to_input) else cast(TResponseInputItem, run_item.raw_item)
     if isinstance(input_item, dict) and input_item.get("status") is None:
-        input_item = {k: v for k, v in input_item.items() if k!= "status"}
+        input_item = {k: v for k, v in input_item.items() if k != "status"}
     if (
         _should_omit_reasoning_item_ids(reasoning_item_id_policy)
         and run_item.type == "reasoning_item"


### PR DESCRIPTION
Fixes a bug, very similar to #1883 ,  where GPT5 reasoning items contain a status=None field, causing the responses API to reject the request. 

Issue
When using GPT-5, **with sessions disabled and reasoning enabled**,  the first turn works normally, but on the second turn, reasoning items include an extra field status=None. When this field is passed back to the Responses API, the request fails with the following error:
```Error getting response: Error code: 400 - {'error': {'message': "Unknown parameter: 'input[1].status'.", 'type': 'invalid_request_error', 'param': 'input[1].status', 'code': 'unknown_parameter'}}. (request_id: req_xxxxx)```

The original patch in PR #1883 , was fixing the issue when sessions were enabled but with sessions disabled a different code path is executed: `run_item_to_input_item()` converts the items in-memory and uses the raw_item dict which still contains the `status` field, that then is passed to the API. 

Solution:
Remove the field "status" if set and empty in `run_item_to_input_item()`


This update aligns with the approach in #1883 but solves it for the new code path.
