### PR TITLE
feat: #2886 add convenience properties (tool_name, call_id) to tool items

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -362,6 +362,20 @@ class ToolCallItem(RunItemBase[Any]):
     tool_origin: ToolOrigin | None = None
     """Optional metadata describing the source of a function-tool-backed item."""
 
+    @property
+    def tool_name(self) -> str | None:
+        """Return the tool name from the raw item, if available."""
+        if isinstance(self.raw_item, dict):
+            return self.raw_item.get("name")
+        return getattr(self.raw_item, "name", None)
+
+    @property
+    def call_id(self) -> str | None:
+        """Return the call identifier from the raw item, if available."""
+        if isinstance(self.raw_item, dict):
+            return self.raw_item.get("call_id") or self.raw_item.get("id")
+        return getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
+
 
 ToolCallOutputTypes: TypeAlias = (
     FunctionCallOutput
@@ -388,6 +402,14 @@ class ToolCallOutputItem(RunItemBase[Any]):
 
     tool_origin: ToolOrigin | None = None
     """Optional metadata describing the source of a function-tool-backed item."""
+
+    @property
+    def call_id(self) -> str | None:
+        """Return the call identifier from the raw item, if available."""
+        if isinstance(self.raw_item, dict):
+            cid = self.raw_item.get("call_id") or self.raw_item.get("id")
+            return str(cid) if cid is not None else None
+        return getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
 
     def to_input_item(self) -> TResponseInputItem:
         """Converts the tool output into an input item for the next model turn.

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -615,3 +615,106 @@ def test_tool_call_item_to_input_item_keeps_payload_api_safe() -> None:
     assert result_dict["type"] == "function_call"
     assert "title" not in result_dict
     assert "description" not in result_dict
+
+
+def test_tool_call_item_tool_name_from_function_call() -> None:
+    """ToolCallItem.tool_name should return the name attribute from a typed raw item."""
+    agent = Agent(name="test")
+    raw = ResponseFunctionToolCall(
+        id="fc1",
+        call_id="call_1",
+        name="my_tool",
+        arguments="{}",
+        type="function_call",
+    )
+    item = ToolCallItem(agent=agent, raw_item=raw)
+    assert item.tool_name == "my_tool"
+
+
+def test_tool_call_item_tool_name_from_dict() -> None:
+    """ToolCallItem.tool_name should return the 'name' key from a dict raw item."""
+    agent = Agent(name="test")
+    raw: dict[str, Any] = {
+        "type": "function_call",
+        "name": "dict_tool",
+        "call_id": "call_1",
+        "arguments": "{}",
+    }
+    item = ToolCallItem(agent=agent, raw_item=raw)
+    assert item.tool_name == "dict_tool"
+
+
+def test_tool_call_item_tool_name_returns_none_when_missing() -> None:
+    """ToolCallItem.tool_name should be None when the raw item has no name attribute."""
+    agent = Agent(name="test")
+    raw = ResponseFileSearchToolCall(
+        id="fs1",
+        queries=["q"],
+        status="completed",
+        type="file_search_call",
+    )
+    item = ToolCallItem(agent=agent, raw_item=raw)
+    assert item.tool_name is None
+
+
+def test_tool_call_item_call_id_from_function_call() -> None:
+    """ToolCallItem.call_id should return the call_id attribute from a typed raw item."""
+    agent = Agent(name="test")
+    raw = ResponseFunctionToolCall(
+        id="fc1",
+        call_id="call_abc",
+        name="t",
+        arguments="{}",
+        type="function_call",
+    )
+    item = ToolCallItem(agent=agent, raw_item=raw)
+    assert item.call_id == "call_abc"
+
+
+def test_tool_call_item_call_id_falls_back_to_id() -> None:
+    """ToolCallItem.call_id should fall back to id when call_id is absent."""
+    agent = Agent(name="test")
+    raw = ResponseFileSearchToolCall(
+        id="fs_xyz",
+        queries=["q"],
+        status="completed",
+        type="file_search_call",
+    )
+    item = ToolCallItem(agent=agent, raw_item=raw)
+    assert item.call_id == "fs_xyz"
+
+
+def test_tool_call_item_call_id_from_dict() -> None:
+    """ToolCallItem.call_id should return the 'call_id' key from a dict raw item."""
+    agent = Agent(name="test")
+    raw: dict[str, Any] = {
+        "type": "function_call",
+        "name": "t",
+        "call_id": "call_dict_id",
+        "arguments": "{}",
+    }
+    item = ToolCallItem(agent=agent, raw_item=raw)
+    assert item.call_id == "call_dict_id"
+
+
+def test_tool_call_output_item_call_id_from_function_call_output() -> None:
+    """ToolCallOutputItem.call_id should return call_id from the FunctionCallOutput dict."""
+    agent = Agent(name="test")
+    raw = {
+        "type": "function_call_output",
+        "call_id": "call_out_1",
+        "output": "ok",
+    }
+    item = ToolCallOutputItem(agent=agent, raw_item=raw, output="ok")
+    assert item.call_id == "call_out_1"
+
+
+def test_tool_call_output_item_call_id_returns_none_when_missing() -> None:
+    """ToolCallOutputItem.call_id should be None when neither call_id nor id are present."""
+    agent = Agent(name="test")
+    raw = {
+        "type": "function_call_output",
+        "output": "ok",
+    }
+    item = ToolCallOutputItem(agent=agent, raw_item=raw, output="ok")
+    assert item.call_id is None


### PR DESCRIPTION
### Summary

\`ToolApprovalItem\` exposes ergonomic \`tool_name\` / \`call_id\` accessors for inspecting tool calls without poking at \`raw_item\` internals. \`ToolCallItem\` and \`ToolCallOutputItem\` lacked the same convenience, forcing callers to write \`getattr(item.raw_item, "name", None)\` chains and \`isinstance\` switches just to do basic things like "get all outputs for tool X".

This PR adds three new properties on \`src/agents/items.py\`, all following the same pattern as the existing \`ToolApprovalItem._extract_call_id\`:

- \`ToolCallItem.tool_name\` — pulls \`.name\` (or \`["name"]\`) off the raw item, \`None\` for hosted tools that don't carry a name.
- \`ToolCallItem.call_id\` — pulls \`.call_id\` (or \`["call_id"]\`), falling back to \`.id\`.
- \`ToolCallOutputItem.call_id\` — same fallback chain on the output item.

All changes are additive and backward-compatible. \`ToolCallOutputItem.tool_name\` is intentionally left out — its raw \`FunctionCallOutput\` doesn't carry the tool name, and threading it through at construction time would touch the runner, which the issue itself flags as a separate concern.

### Test plan

Added 8 unit tests in \`tests/test_items_helpers.py\` covering:

- \`tool_name\` from a typed \`ResponseFunctionToolCall\`, from a dict raw item, and the \`None\` case for hosted-tool raw items (\`ResponseFileSearchToolCall\`).
- \`call_id\` from a typed raw item, the \`call_id\` → \`id\` fallback path, and the dict path.
- \`ToolCallOutputItem.call_id\` from a \`function_call_output\` dict and the \`None\` case when neither key is present.

Verified locally:

- \`uv run ruff format\` — pass
- \`uv run ruff check\` — pass
- \`uv run mypy src/agents/items.py tests/test_items_helpers.py\` — pass
- \`uv run pyright --project pyrightconfig.json src/agents/items.py tests/test_items_helpers.py\` — pass
- \`uv run pytest tests/test_items_helpers.py\` — 34 passed (26 existing + 8 new)
- Broader sweep of \`-k "tool_call or items_helpers or run_step or tool_approval"\` — 217 passed; 2 unrelated tracing tests (\`test_tracing_errors[_streamed].py::test_tool_call_error\`) fail on clean \`main\` too, so they aren't caused by this change.

### Issue number

Closes #2886

### Note

PR #2887 by @DanielCufino opened the same day with the same surface, but it has been a stale draft for ten days, has merge conflicts against \`main\`, and ships zero tests. This PR is rebased on current \`main\` and adds the missing test coverage. Happy to defer to the original if maintainers prefer.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (auto-generated \`docs/ref/items.md\` picks up the new docstrings via \`mkdocstrings\`)
- [x] I've run \`make lint\` and \`make format\`
- [x] I've made sure tests pass