### PR TITLE
fix: tighten tar and zip member validation

### DIFF
--- a/src/agents/sandbox/session/archive_extraction.py
+++ b/src/agents/sandbox/session/archive_extraction.py
@@ -7,12 +7,12 @@ import tempfile
 import zipfile
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Literal, cast
 
 from ..errors import ExecNonZeroError, WorkspaceArchiveWriteError
 from ..files import EntryKind, FileEntry
-from ..util.tar_utils import UnsafeTarMemberError, safe_tar_member_rel_path
+from ..util.tar_utils import UnsafeTarMemberError, safe_tar_member_rel_path, validate_tarfile
 
 
 class UnsafeZipMemberError(ValueError):
@@ -46,6 +46,7 @@ class WorkspaceArchiveExtractor:
         child_entry_cache: dict[Path, dict[str, EntryKind]] = {}
         try:
             with tarfile.open(fileobj=data, mode="r:*") as archive:
+                validate_tarfile(archive, allow_symlinks=False)
                 for member in archive.getmembers():
                     rel_path = safe_tar_member_rel_path(member)
                     if rel_path is None:
@@ -112,6 +113,7 @@ class WorkspaceArchiveExtractor:
         try:
             with zipfile_compatible_stream(data) as zip_data:
                 with zipfile.ZipFile(zip_data) as archive:
+                    validate_zipfile(archive)
                     for member in archive.infolist():
                         rel_path = safe_zip_member_rel_path(member)
                         if rel_path is None:
@@ -281,6 +283,12 @@ def safe_zip_member_rel_path(member: zipfile.ZipInfo) -> Path | None:
     if member.filename in ("", ".", "./"):
         return None
 
+    windows_path = PureWindowsPath(member.filename)
+    if windows_path.drive:
+        raise UnsafeZipMemberError(member=member.filename, reason="windows drive path")
+    if "\\" in member.filename:
+        raise UnsafeZipMemberError(member=member.filename, reason="windows path separator")
+
     rel = PurePosixPath(member.filename)
     if rel.is_absolute():
         raise UnsafeZipMemberError(member=member.filename, reason="absolute path")
@@ -292,6 +300,36 @@ def safe_zip_member_rel_path(member: zipfile.ZipInfo) -> Path | None:
         raise UnsafeZipMemberError(member=member.filename, reason="link member not allowed")
 
     return Path(*rel.parts)
+
+
+def validate_zipfile(archive: zipfile.ZipFile) -> None:
+    members_by_rel_path: dict[Path, zipfile.ZipInfo] = {}
+    members: list[tuple[zipfile.ZipInfo, Path]] = []
+
+    for member in archive.infolist():
+        rel_path = safe_zip_member_rel_path(member)
+        if rel_path is None:
+            continue
+
+        previous = members_by_rel_path.get(rel_path)
+        if previous is not None and not (previous.is_dir() and member.is_dir()):
+            raise UnsafeZipMemberError(
+                member=member.filename,
+                reason=f"duplicate archive path: {rel_path.as_posix()}",
+            )
+        members_by_rel_path[rel_path] = member
+        members.append((member, rel_path))
+
+    for member, rel_path in members:
+        for parent in rel_path.parents:
+            if parent == Path():
+                break
+            parent_member = members_by_rel_path.get(parent)
+            if parent_member is not None and not parent_member.is_dir():
+                raise UnsafeZipMemberError(
+                    member=member.filename,
+                    reason=f"archive path descends through non-directory: {parent.as_posix()}",
+                )
 
 
 class _ZipFileStreamAdapter(io.IOBase):

--- a/src/agents/sandbox/util/tar_utils.py
+++ b/src/agents/sandbox/util/tar_utils.py
@@ -7,7 +7,7 @@ import shutil
 import tarfile
 import tempfile
 from collections.abc import Iterable
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
 class UnsafeTarMemberError(ValueError):
@@ -27,6 +27,14 @@ def _validate_archive_root_member(member: tarfile.TarInfo) -> None:
     raise UnsafeTarMemberError(member=member.name, reason="archive root member must be directory")
 
 
+def _raise_if_windows_member_path(member_name: str) -> None:
+    windows_path = PureWindowsPath(member_name)
+    if windows_path.drive:
+        raise UnsafeTarMemberError(member=member_name, reason="windows drive path")
+    if "\\" in member_name:
+        raise UnsafeTarMemberError(member=member_name, reason="windows path separator")
+
+
 def safe_tar_member_rel_path(
     member: tarfile.TarInfo,
     *,
@@ -37,6 +45,7 @@ def safe_tar_member_rel_path(
     if member.name in ("", ".", "./"):
         _validate_archive_root_member(member)
         return None
+    _raise_if_windows_member_path(member.name)
     rel = PurePosixPath(member.name)
     if rel.is_absolute():
         raise UnsafeTarMemberError(member=member.name, reason="absolute path")
@@ -189,6 +198,7 @@ def validate_tarfile(
     reject_symlink_rel_paths: Iterable[str | Path] = (),
     skip_rel_paths: Iterable[str | Path] = (),
     root_name: str | None = None,
+    allow_symlinks: bool = True,
 ) -> None:
     """Validate a workspace tar before handing it to a local or remote extractor.
 
@@ -212,7 +222,7 @@ def validate_tarfile(
             root_name=root_name,
         ):
             continue
-        rel_path = safe_tar_member_rel_path(member, allow_symlinks=True)
+        rel_path = safe_tar_member_rel_path(member, allow_symlinks=allow_symlinks)
         if rel_path is None:
             continue
 
@@ -241,6 +251,12 @@ def validate_tarfile(
                 raise UnsafeTarMemberError(
                     member=member.name,
                     reason=f"archive path descends through symlink: {parent.as_posix()}",
+                )
+            parent_member = members_by_rel_path.get(parent)
+            if parent_member is not None and not parent_member.isdir():
+                raise UnsafeTarMemberError(
+                    member=member.name,
+                    reason=f"archive path descends through non-directory: {parent.as_posix()}",
                 )
 
 

--- a/tests/sandbox/test_extract.py
+++ b/tests/sandbox/test_extract.py
@@ -134,6 +134,28 @@ def _zip_bytes(*, members: dict[str, bytes]) -> io.BytesIO:
     return buf
 
 
+async def _assert_extract_rejects_member(
+    tmp_path: Path,
+    archive_name: str,
+    data: io.IOBase,
+    *,
+    expected_member: str,
+    expected_reason: str,
+) -> Path:
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        workspace = Path(session.state.manifest.root)
+        with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
+            await session.extract(archive_name, data)
+
+        assert exc_info.value.context["member"] == expected_member
+        assert exc_info.value.context["reason"] == expected_reason
+        return workspace
+    finally:
+        await session.shutdown()
+
+
 @pytest.mark.asyncio
 async def test_extract_tar_writes_archive_and_unpacks_contents(tmp_path: Path) -> None:
     session = _build_session(tmp_path)
@@ -298,6 +320,86 @@ async def test_extract_zip_rejects_symlinked_parent_paths(tmp_path: Path) -> Non
         assert not (outside / "hello.txt").exists()
     finally:
         await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_extract_tar_rejects_windows_drive_member_paths(tmp_path: Path) -> None:
+    await _assert_extract_rejects_member(
+        tmp_path,
+        "bundle.tar",
+        _tar_bytes(members={"C:/tmp/evil.txt": b"evil"}),
+        expected_member="C:/tmp/evil.txt",
+        expected_reason="windows drive path",
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_zip_rejects_windows_drive_member_paths(tmp_path: Path) -> None:
+    await _assert_extract_rejects_member(
+        tmp_path,
+        "bundle.zip",
+        _zip_bytes(members={r"C:\tmp\evil.txt": b"evil"}),
+        expected_member=r"C:\tmp\evil.txt",
+        expected_reason="windows drive path",
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_tar_rejects_windows_separator_member_paths(tmp_path: Path) -> None:
+    await _assert_extract_rejects_member(
+        tmp_path,
+        "bundle.tar",
+        _tar_bytes(members={r"..\evil.txt": b"evil"}),
+        expected_member=r"..\evil.txt",
+        expected_reason="windows path separator",
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_zip_rejects_windows_separator_member_paths(tmp_path: Path) -> None:
+    await _assert_extract_rejects_member(
+        tmp_path,
+        "bundle.zip",
+        _zip_bytes(members={r"\evil.txt": b"evil"}),
+        expected_member=r"\evil.txt",
+        expected_reason="windows path separator",
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_tar_rejects_member_under_non_directory_member(tmp_path: Path) -> None:
+    workspace = await _assert_extract_rejects_member(
+        tmp_path,
+        "bundle.tar",
+        _tar_bytes(
+            members={
+                "nested/hello.txt": b"hello from tar",
+                "nested": b"not a directory",
+            }
+        ),
+        expected_member="nested/hello.txt",
+        expected_reason="archive path descends through non-directory: nested",
+    )
+
+    assert not (workspace / "nested").exists()
+
+
+@pytest.mark.asyncio
+async def test_extract_zip_rejects_member_under_non_directory_member(tmp_path: Path) -> None:
+    workspace = await _assert_extract_rejects_member(
+        tmp_path,
+        "bundle.zip",
+        _zip_bytes(
+            members={
+                "nested/hello.txt": b"hello from zip",
+                "nested": b"not a directory",
+            }
+        ),
+        expected_member="nested/hello.txt",
+        expected_reason="archive path descends through non-directory: nested",
+    )
+
+    assert not (workspace / "nested").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_tar_utils.py
+++ b/tests/sandbox/test_tar_utils.py
@@ -112,6 +112,35 @@ def test_validate_tar_bytes_rejects_root_symlink() -> None:
         validate_tar_bytes(raw)
 
 
+@pytest.mark.parametrize("member_name", ["C:/tmp/evil.txt", r"C:\tmp\evil.txt"])
+def test_validate_tar_bytes_rejects_windows_drive_member_paths(member_name: str) -> None:
+    raw = _tar_bytes(_file(member_name, b"evil"))
+
+    with pytest.raises(UnsafeTarMemberError, match="windows drive path"):
+        validate_tar_bytes(raw)
+
+
+@pytest.mark.parametrize("member_name", [r"..\evil.txt", r"\evil.txt", r"nested\evil.txt"])
+def test_validate_tar_bytes_rejects_windows_separator_member_paths(member_name: str) -> None:
+    raw = _tar_bytes(_file(member_name, b"evil"))
+
+    with pytest.raises(UnsafeTarMemberError, match="windows path separator"):
+        validate_tar_bytes(raw)
+
+
+def test_validate_tar_bytes_rejects_member_under_non_directory_member() -> None:
+    raw = _tar_bytes(
+        _file("nested/hello.txt", b"hello"),
+        _file("nested", b"not a directory"),
+    )
+
+    with pytest.raises(
+        UnsafeTarMemberError,
+        match="archive path descends through non-directory: nested",
+    ):
+        validate_tar_bytes(raw)
+
+
 def test_strip_tar_member_prefix_returns_workspace_relative_archive() -> None:
     raw = _tar_bytes(
         _dir("workspace"),


### PR DESCRIPTION
## Summary

Tighten tar/zip archive member validation before extraction.

Changes:
- reject Windows drive-qualified member paths like `C:\tmp\file.txt`
- reject backslash-separated member paths like `..\evil.txt`
- reject entries nested below a non-directory archive member
- add focused tar/zip regression coverage

## Why

These archive paths can be interpreted differently across platforms, especially on Windows. Validating them before extraction keeps sandbox archive handling consistent and avoids relying on platform-specific `Path` behavior.

## Tests

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-dev --with pytest --with pytest-asyncio pytest tests/sandbox/test_tar_utils.py tests/sandbox/test_extract.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-dev --with ruff ruff check src/agents/sandbox/util/tar_utils.py src/agents/sandbox/session/archive_extraction.py tests/sandbox/test_tar_utils.py tests/sandbox/test_extract.py`
- `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile src/agents/sandbox/util/tar_utils.py src/agents/sandbox/session/archive_extraction.py tests/sandbox/test_tar_utils.py tests/sandbox/test_extract.py`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-dev --with pytest --with pytest-asyncio --with aiohttp --with docker --with inline-snapshot pytest tests/sandbox -q`
