### PR TITLE
fix(mcp): rename duplicate tool names across MCP servers instead of raising an error

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -237,10 +237,20 @@ class MCPUtil:
                 name_counts[tool.name] = name_counts.get(tool.name, 0) + 1
         duplicate_names = {name for name, count in name_counts.items() if count > 1}
 
+        # Collect the names already claimed by the agent's non-MCP tools so that we can
+        # detect collisions between a renamed MCP tool and an existing agent tool.
+        agent_tool_names: set[str] = {
+            name
+            for t in agent.tools
+            if isinstance((name := getattr(t, "name", None)), str) and name
+        }
+
         # Compute the final name each tool will receive after any prefix is applied, then
         # verify the result is still globally unique.  Prefixing can itself introduce
         # collisions (e.g. server "A" + tool "B_C" and server "A_B" + tool "C" both
-        # produce "A_B_C"), so we must detect that before proceeding.
+        # produce "A_B_C"), so we must detect that before proceeding.  We also check
+        # against existing agent tool names so that a prefixed MCP tool cannot silently
+        # shadow a locally-defined tool.
         final_name_counts: dict[str, int] = {}
         for server, server_tools in per_server:
             for tool in server_tools:
@@ -248,11 +258,14 @@ class MCPUtil:
                 final_name_counts[final] = final_name_counts.get(final, 0) + 1
 
         post_rename_duplicates = {n for n, c in final_name_counts.items() if c > 1}
-        if post_rename_duplicates:
+        # Also flag any MCP final name that collides with an existing agent tool.
+        agent_collisions = {n for n in final_name_counts if n in agent_tool_names}
+        all_collisions = post_rename_duplicates | agent_collisions
+        if all_collisions:
             raise UserError(
                 "Tool name collision could not be resolved automatically by prefixing with the "
                 "server name. The following names remain ambiguous after renaming: "
-                f"{sorted(post_rename_duplicates)}. Rename the conflicting MCP tools or servers "
+                f"{sorted(all_collisions)}. Rename the conflicting MCP tools or servers "
                 "to make all tool names unique."
             )
 

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import dataclasses
 import functools
 import inspect
 import json
@@ -211,9 +212,14 @@ class MCPUtil:
         agent: AgentBase,
         failure_error_function: ToolErrorFunction | None = default_tool_error_function,
     ) -> list[Tool]:
-        """Get all function tools from a list of MCP servers."""
-        tools = []
-        tool_names: set[str] = set()
+        """Get all function tools from a list of MCP servers.
+
+        When multiple servers expose tools with the same name, the conflicting tools are
+        automatically renamed to ``{server_name}_{tool_name}`` so that all tools remain
+        uniquely identifiable.  A warning is logged for every renamed tool.
+        """
+        # Collect tools per server first so we can detect cross-server name collisions.
+        per_server: list[tuple[MCPServer, list[Tool]]] = []
         for server in servers:
             server_tools = await cls.get_function_tools(
                 server,
@@ -222,14 +228,26 @@ class MCPUtil:
                 agent,
                 failure_error_function=failure_error_function,
             )
-            server_tool_names = {tool.name for tool in server_tools}
-            if len(server_tool_names & tool_names) > 0:
-                raise UserError(
-                    f"Duplicate tool names found across MCP servers: "
-                    f"{server_tool_names & tool_names}"
-                )
-            tool_names.update(server_tool_names)
-            tools.extend(server_tools)
+            per_server.append((server, server_tools))
+
+        # Determine which tool names appear in more than one server.
+        name_counts: dict[str, int] = {}
+        for _server, server_tools in per_server:
+            for tool in server_tools:
+                name_counts[tool.name] = name_counts.get(tool.name, 0) + 1
+        duplicate_names = {name for name, count in name_counts.items() if count > 1}
+
+        tools: list[Tool] = []
+        for server, server_tools in per_server:
+            for tool in server_tools:
+                if tool.name in duplicate_names:
+                    prefixed_name = f"{server.name}_{tool.name}"
+                    logger.warning(
+                        f"Duplicate tool name '{tool.name}' found across MCP servers. "
+                        f"Renaming to '{prefixed_name}' for server '{server.name}'."
+                    )
+                    tool = dataclasses.replace(tool, name=prefixed_name)
+                tools.append(tool)
 
         return tools
 

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -237,6 +237,25 @@ class MCPUtil:
                 name_counts[tool.name] = name_counts.get(tool.name, 0) + 1
         duplicate_names = {name for name, count in name_counts.items() if count > 1}
 
+        # Compute the final name each tool will receive after any prefix is applied, then
+        # verify the result is still globally unique.  Prefixing can itself introduce
+        # collisions (e.g. server "A" + tool "B_C" and server "A_B" + tool "C" both
+        # produce "A_B_C"), so we must detect that before proceeding.
+        final_name_counts: dict[str, int] = {}
+        for server, server_tools in per_server:
+            for tool in server_tools:
+                final = f"{server.name}_{tool.name}" if tool.name in duplicate_names else tool.name
+                final_name_counts[final] = final_name_counts.get(final, 0) + 1
+
+        post_rename_duplicates = {n for n, c in final_name_counts.items() if c > 1}
+        if post_rename_duplicates:
+            raise UserError(
+                "Tool name collision could not be resolved automatically by prefixing with the "
+                "server name. The following names remain ambiguous after renaming: "
+                f"{sorted(post_rename_duplicates)}. Rename the conflicting MCP tools or servers "
+                "to make all tool names unique."
+            )
+
         tools: list[Tool] = []
         for server, server_tools in per_server:
             for tool in server_tools:

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -9,7 +9,7 @@ from inline_snapshot import snapshot
 from mcp.types import CallToolResult, ImageContent, TextContent, Tool as MCPTool
 from pydantic import BaseModel, TypeAdapter
 
-from agents import Agent, FunctionTool, RunContextWrapper, default_tool_error_function
+from agents import Agent, FunctionTool, RunContextWrapper, default_tool_error_function, function_tool
 from agents.exceptions import AgentsException, MCPToolCancellationError, ModelBehaviorError
 from agents.mcp import MCPServer, MCPUtil
 from agents.tool_context import ToolContext
@@ -119,6 +119,33 @@ async def test_get_all_function_tools_post_rename_collision_raises():
 
     with pytest.raises(UserError, match="A_B_C"):
         await MCPUtil.get_all_function_tools([server1, server2, server3], False, run_context, agent)
+
+
+@pytest.mark.asyncio
+async def test_get_all_function_tools_rename_collides_with_agent_tool_raises():
+    """A prefixed MCP tool name that matches an existing agent.tools name must raise UserError.
+
+    Example: two MCP servers both expose "run", so they become "serverA_run".  But the
+    agent already has a local function tool called "serverA_run".  That collision is not
+    detectable from MCP names alone and must be caught via the agent_tool_names check.
+    """
+    from agents.exceptions import UserError
+
+    server1 = FakeMCPServer(server_name="serverA")
+    server1.add_tool("run", {})
+
+    server2 = FakeMCPServer(server_name="serverB")
+    server2.add_tool("run", {})
+
+    @function_tool(name_override="serverA_run")
+    def local_serverA_run() -> str:
+        return "local"
+
+    run_context = RunContextWrapper(context=None)
+    agent = Agent(name="test_agent", tools=[local_serverA_run])
+
+    with pytest.raises(UserError, match="serverA_run"):
+        await MCPUtil.get_all_function_tools([server1, server2], False, run_context, agent)
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -91,6 +91,37 @@ async def test_get_all_function_tools_duplicate_invokes_original_tool_name():
 
 
 @pytest.mark.asyncio
+async def test_get_all_function_tools_post_rename_collision_raises():
+    """When prefixing still produces a collision, a UserError should be raised.
+
+    Concretely: server "A" has tool "B_C" and server "A_B" has tool "C".
+    A third server exposes both "B_C" and "C" so that both names are in the
+    duplicate set and get prefixed:
+      server "A"   + "B_C" → "A_B_C"
+      server "A_B" + "C"   → "A_B_C"   ← collision → must raise UserError
+    """
+    from agents.exceptions import UserError
+
+    server1 = FakeMCPServer(server_name="A")
+    server1.add_tool("B_C", {})
+
+    server2 = FakeMCPServer(server_name="A_B")
+    server2.add_tool("C", {})
+
+    # A third server exposes both names, making both "B_C" and "C" duplicates
+    # that will receive the prefix treatment.
+    server3 = FakeMCPServer(server_name="extra")
+    server3.add_tool("B_C", {})
+    server3.add_tool("C", {})
+
+    run_context = RunContextWrapper(context=None)
+    agent = Agent(name="test_agent", instructions="Test agent")
+
+    with pytest.raises(UserError, match="A_B_C"):
+        await MCPUtil.get_all_function_tools([server1, server2, server3], False, run_context, agent)
+
+
+@pytest.mark.asyncio
 async def test_get_all_function_tools():
     """Test that the get_all_function_tools function returns all function tools from a list of MCP
     servers.

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -36,6 +36,61 @@ def _convertible_schema() -> dict[str, Any]:
 
 
 @pytest.mark.asyncio
+async def test_get_all_function_tools_duplicate_names_are_prefixed():
+    """Duplicate tool names across MCP servers should be renamed with a server prefix rather
+    than raising an error, so that all tools remain reachable.
+    """
+    server1 = FakeMCPServer(server_name="serverA")
+    server1.add_tool("run", {})
+    server1.add_tool("unique_a", {})
+
+    server2 = FakeMCPServer(server_name="serverB")
+    server2.add_tool("run", {})
+    server2.add_tool("unique_b", {})
+
+    run_context = RunContextWrapper(context=None)
+    agent = Agent(name="test_agent", instructions="Test agent")
+
+    tools = await MCPUtil.get_all_function_tools([server1, server2], False, run_context, agent)
+    assert len(tools) == 4
+
+    tool_names = {tool.name for tool in tools}
+    # The conflicting "run" tools should be renamed; unique tools remain unchanged.
+    assert "serverA_run" in tool_names
+    assert "serverB_run" in tool_names
+    assert "unique_a" in tool_names
+    assert "unique_b" in tool_names
+    assert "run" not in tool_names
+
+
+@pytest.mark.asyncio
+async def test_get_all_function_tools_duplicate_invokes_original_tool_name():
+    """When a duplicate tool is renamed, invoking it should still call the server with the
+    original (un-prefixed) tool name.
+    """
+    server1 = FakeMCPServer(server_name="serverA")
+    server1.add_tool("run", {})
+
+    server2 = FakeMCPServer(server_name="serverB")
+    server2.add_tool("run", {})
+
+    run_context = RunContextWrapper(context=None)
+    agent = Agent(name="test_agent", instructions="Test agent")
+
+    tools = await MCPUtil.get_all_function_tools([server1, server2], False, run_context, agent)
+
+    from agents.tool_context import ToolContext
+
+    serverA_tool = next(t for t in tools if t.name == "serverA_run")
+    ctx = ToolContext(context=None, tool_name="serverA_run", tool_call_id="c1", tool_arguments="{}")
+    await serverA_tool.on_invoke_tool(ctx, "{}")
+
+    # The underlying server should have been called with the original name "run"
+    assert server1.tool_calls == ["run"]
+    assert server2.tool_calls == []
+
+
+@pytest.mark.asyncio
 async def test_get_all_function_tools():
     """Test that the get_all_function_tools function returns all function tools from a list of MCP
     servers.


### PR DESCRIPTION
When multiple MCP servers exposed tools with the same name, `MCPUtil.get_all_function_tools` in `src/agents/mcp/util.py` raised a `UserError` and refused to proceed. This was overly strict: the conflict is resolvable and users should be able to use tools from both servers simultaneously.

The fix changes the collision-handling logic to rename conflicting tools to `{server_name}_{tool_name}` rather than aborting. Only tools whose names actually collide across servers get prefixed; tools with unique names are left untouched. A `logger.warning` is emitted for every renamed tool so the rename is visible in logs without being fatal.

The underlying server call still uses the original (unprefixed) tool name, so the server protocol is unaffected. `dataclasses.replace` is used to create a new `Tool` instance with the prefixed name, leaving the original object intact.

Two new tests in `tests/mcp/test_mcp_util.py` cover the rename behavior: one checks that the returned tool names are correctly prefixed and that unique names are preserved, and another verifies that invoking a renamed tool dispatches to the server with the original tool name.

Fixes #1167
