### PR TITLE
[sandbox] Raise Phase 2 memory consolidation turn limit

### DIFF
--- a/src/agents/sandbox/memory/phase_two.py
+++ b/src/agents/sandbox/memory/phase_two.py
@@ -34,4 +34,4 @@ async def run_phase_two(
         selection=selection,
         extra_prompt=config.extra_prompt,
     )
-    await Runner.run(agent, prompt, run_config=run_config)
+    await Runner.run(agent, prompt, run_config=run_config, max_turns=500)


### PR DESCRIPTION
### Summary

- Phase 2 sandbox memory consolidation can need more than the default runner turn cap when rewriting memory files.
- Pass `max_turns=500` for the Phase 2 consolidation agent only.

