### PR TITLE
sandbox: delimit custom SandboxAgent instructions in rendered prompt

### DIFF
--- a/src/agents/sandbox/runtime_agent_preparation.py
+++ b/src/agents/sandbox/runtime_agent_preparation.py
@@ -178,7 +178,12 @@ def build_sandbox_instructions(
                 agent=public_agent,
             )
             if additional:
-                parts.append(additional)
+                # Wrap caller-supplied instructions in a delimited section so
+                # they read as app-specific guidance in the rendered prompt
+                # rather than appearing nested inside the SDK's "Tool
+                # Guidelines > Shell commands" section that comes from the
+                # base prompt above.
+                parts.append(f"# Agent instructions\n\n{additional}")
 
         for capability in capabilities:
             fragment = await capability.instructions(manifest)


### PR DESCRIPTION
`build_sandbox_instructions` concatenated the caller's instructions between the SDK base prompt (which ends with a *Tool Guidelines > Shell commands* section) and the per-capability fragments (which add more shell guidance). In the rendered prompt the app-specific instructions read as if they're nested inside the SDK's shell-commands section.

Wrap the additional instructions in an `# Agent instructions` markdown heading so they appear as a standalone, clearly delimited section between the SDK base and the capability fragments.

Fixes #3043