### PR TITLE
docs: add missing space after period in MCPServerStdio docstring

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -233,7 +233,7 @@ class MCPServer(abc.ABC):
         """
         Args:
             use_structured_content: Whether to use `tool_result.structured_content` when calling an
-                MCP tool.Defaults to False for backwards compatibility - most MCP servers still
+                MCP tool. Defaults to False for backwards compatibility - most MCP servers still
                 include the structured content in the `tool_result.content`, and using it by
                 default will cause duplicate content. You can set this to True if you know the
                 server will not duplicate the structured content in the `tool_result.content`.


### PR DESCRIPTION
## Summary

`MCPServerStdio.__init__` (`src/agents/mcp/server.py` line 236) had a missing space in the `use_structured_content` parameter docstring:

```diff
-                MCP tool.Defaults to False for backwards compatibility - most MCP servers still
+                MCP tool. Defaults to False for backwards compatibility - most MCP servers still
```

The four sibling occurrences in the same file (lines 513, 1083, 1206, 1342) already had the correct spacing, so this stdio variant was the outlier.

## Why

Editors that surface docstrings on hover (Pylance, Pyright, Jedi, IDE tooltips) render the two sentences as one when the space is missing. Bringing the stdio class docstring in line with the rest also makes the file self-consistent.

## How to test

```bash
$ grep -c 'MCP tool\.Defaults' src/agents/mcp/server.py
0
$ grep -c 'MCP tool\. Defaults' src/agents/mcp/server.py
5
```

No behavioral change — pure documentation edit.

## Checklist

- [x] No code logic changed
- [x] Other 4 sibling docstrings already had the correct spacing — this PR only touches the one outlier
- [x] No tests needed (docstring-only change)