### PR TITLE
docs: add Windows activation hint

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ python -m venv .venv
 Do this every time you start a new terminal session.
 
 ```bash
-source .venv/bin/activate
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 ```
 
 ### Install the Agents SDK


### PR DESCRIPTION
Closes #3065

## Problem
The quickstart guide shows how to activate the virtual environment but only mentions the Unix/Mac command.

## Fix
Added an inline comment showing the Windows equivalent command (`.venv\Scripts\activate`) for cross-platform clarity.