### PR TITLE
test: cover guardrail name fallback to function __name__

### DIFF
--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -228,6 +228,7 @@ async def test_input_guardrail_decorators():
     )
     assert not result.output.tripwire_triggered
     assert result.output.output_info == "test_1"
+    assert guardrail.get_name() == "decorated_input_guardrail"
 
     guardrail = decorated_named_input_guardrail
     result = await guardrail.run(
@@ -266,6 +267,7 @@ async def test_output_guardrail_decorators():
     )
     assert not result.output.tripwire_triggered
     assert result.output.output_info == "test_3"
+    assert guardrail.get_name() == "decorated_output_guardrail"
 
     guardrail = decorated_named_output_guardrail
     result = await guardrail.run(

--- a/tests/test_tool_guardrails.py
+++ b/tests/test_tool_guardrails.py
@@ -261,6 +261,7 @@ async def test_tool_input_guardrail_decorators():
     result = await guardrail.run(data)
     assert result.behavior["type"] == "allow"
     assert result.output_info == "test_1"
+    assert guardrail.get_name() == "decorated_input_guardrail"
 
     # Test named decorator
     guardrail = decorated_named_input_guardrail
@@ -294,6 +295,7 @@ async def test_tool_output_guardrail_decorators():
     result = await guardrail.run(data)
     assert result.behavior["type"] == "allow"
     assert result.output_info == "test_3"
+    assert guardrail.get_name() == "decorated_output_guardrail"
 
     # Test named decorator
     guardrail = decorated_named_output_guardrail


### PR DESCRIPTION
## Summary
  Adds regression coverage for the guardrail `name` fallback behavior introduced in #1053.

  When `@input_guardrail`, `@output_guardrail`, `@tool_input_guardrail`, or `@tool_output_guardrail` are used without an
  explicit `name=`, `get_name()` should return the decorated function's `__name__`. The existing tests only verified the
  explicit-name path, leaving the fallback uncovered.

  ## Changes
  - `tests/test_guardrails.py`: assert `get_name() == "decorated_input_guardrail"` / `"decorated_output_guardrail"` for
  the unnamed decorators.
  - `tests/test_tool_guardrails.py`: same assertion for `tool_input_guardrail` / `tool_output_guardrail`.

  No runtime code changes.

  ## Test plan
  - [x] `uv run pytest tests/test_guardrails.py tests/test_tool_guardrails.py` — 53 passed
  - [x] `uv run ruff format --check` clean
  - [x] `uv run ruff check` clean