### PR TITLE
feat: unique fake responses ids

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -33,7 +33,7 @@ from ...models._retry_runtime import should_disable_provider_managed_retries
 from ...models.chatcmpl_converter import Converter
 from ...models.chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
 from ...models.chatcmpl_stream_handler import ChatCmplStreamHandler
-from ...models.fake_id import FAKE_RESPONSES_ID
+from ...models.fake_id import is_fake_responses_id, make_fake_responses_id
 from ...models.interface import Model, ModelTracing
 from ...models.openai_responses import (
     Converter as OpenAIResponsesConverter,
@@ -746,7 +746,7 @@ class AnyLLMModel(Model):
             responses_tool_choice = "auto"
 
         response = Response(
-            id=FAKE_RESPONSES_ID,
+            id=make_fake_responses_id(),
             created_at=time.time(),
             model=self.model,
             object="response",
@@ -1132,7 +1132,7 @@ class AnyLLMModel(Model):
         for key, item_value in value.items():
             if key == "provider_data":
                 continue
-            if key == "id" and item_value == FAKE_RESPONSES_ID:
+            if key == "id" and is_fake_responses_id(item_value):
                 continue
             if item_value is None:
                 continue

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -46,7 +46,7 @@ from ...models._retry_runtime import should_disable_provider_managed_retries
 from ...models.chatcmpl_converter import Converter
 from ...models.chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
 from ...models.chatcmpl_stream_handler import ChatCmplStreamHandler
-from ...models.fake_id import FAKE_RESPONSES_ID
+from ...models.fake_id import make_fake_responses_id
 from ...models.interface import Model, ModelTracing
 from ...models.openai_responses import Converter as OpenAIResponsesConverter
 from ...models.reasoning_content_replay import ShouldReplayReasoningContent
@@ -560,7 +560,7 @@ class LitellmModel(Model):
             responses_tool_choice = "auto"
 
         response = Response(
-            id=FAKE_RESPONSES_ID,
+            id=make_fake_responses_id(),
             created_at=time.time(),
             model=self.model,
             object="response",

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -54,7 +54,7 @@ from ..tool import (
     ensure_function_tool_supports_responses_only_features,
     ensure_tool_choice_supports_backend,
 )
-from .fake_id import FAKE_RESPONSES_ID
+from .fake_id import make_fake_responses_id
 from .reasoning_content_replay import (
     ReasoningContentReplayContext,
     ReasoningContentSource,
@@ -132,7 +132,7 @@ class Converter:
         # So we use hasattr to check for reasoning_content and thinking_blocks
         if hasattr(message, "reasoning_content") and message.reasoning_content:
             reasoning_kwargs: dict[str, Any] = {
-                "id": FAKE_RESPONSES_ID,
+                "id": make_fake_responses_id(),
                 "summary": [Summary(text=message.reasoning_content, type="summary_text")],
                 "type": "reasoning",
             }
@@ -166,7 +166,7 @@ class Converter:
             items.append(reasoning_item)
 
         message_kwargs: dict[str, Any] = {
-            "id": FAKE_RESPONSES_ID,
+            "id": make_fake_responses_id(),
             "content": [],
             "role": "assistant",
             "type": "message",
@@ -199,7 +199,7 @@ class Converter:
                 if tool_call.type == "function":
                     # Create base function call item
                     func_call_kwargs: dict[str, Any] = {
-                        "id": FAKE_RESPONSES_ID,
+                        "id": make_fake_responses_id(),
                         "call_id": tool_call.id,
                         "arguments": tool_call.function.arguments,
                         "name": tool_call.function.name,

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -71,8 +71,8 @@ class StreamingState:
     thinking_signature: str | None = None
     # Store provider data for all output items
     provider_data: dict[str, Any] = field(default_factory=dict)
-    # Pre-generated ID for the assistant message item (shared across all its events).
-    message_item_id: str = field(default_factory=make_fake_responses_id)
+    # Pre-generated ID for the assistant output message item (one per streaming response).
+    output_message_id: str = field(default_factory=make_fake_responses_id)
 
 
 class SequenceNumber:
@@ -332,7 +332,7 @@ class ChatCmplStreamHandler:
                     )
                     # Start a new assistant message stream
                     assistant_item = ResponseOutputMessage(
-                        id=state.message_item_id,
+                        id=state.output_message_id,
                         content=[],
                         role="assistant",
                         type="message",
@@ -350,7 +350,7 @@ class ChatCmplStreamHandler:
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.text_content_index_and_output[0],
-                        item_id=state.message_item_id,
+                        item_id=state.output_message_id,
                         output_index=state.reasoning_content_index_and_output
                         is not None,  # fixed 0 -> 0 or 1
                         part=ResponseOutputText(
@@ -375,7 +375,7 @@ class ChatCmplStreamHandler:
                 yield ResponseTextDeltaEvent(
                     content_index=state.text_content_index_and_output[0],
                     delta=delta.content,
-                    item_id=state.message_item_id,
+                    item_id=state.output_message_id,
                     output_index=state.reasoning_content_index_and_output
                     is not None,  # fixed 0 -> 0 or 1
                     type="response.output_text.delta",
@@ -406,7 +406,7 @@ class ChatCmplStreamHandler:
                     )
                     # Start a new assistant message if one doesn't exist yet (in-progress)
                     assistant_item = ResponseOutputMessage(
-                        id=state.message_item_id,
+                        id=state.output_message_id,
                         content=[],
                         role="assistant",
                         type="message",
@@ -424,7 +424,7 @@ class ChatCmplStreamHandler:
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.refusal_content_index_and_output[0],
-                        item_id=state.message_item_id,
+                        item_id=state.output_message_id,
                         output_index=(1 if state.reasoning_content_index_and_output else 0),
                         part=ResponseOutputRefusal(
                             refusal="",
@@ -437,7 +437,7 @@ class ChatCmplStreamHandler:
                 yield ResponseRefusalDeltaEvent(
                     content_index=state.refusal_content_index_and_output[0],
                     delta=delta.refusal,
-                    item_id=state.message_item_id,
+                    item_id=state.output_message_id,
                     output_index=state.reasoning_content_index_and_output
                     is not None,  # fixed 0 -> 0 or 1
                     type="response.refusal.delta",
@@ -604,7 +604,7 @@ class ChatCmplStreamHandler:
             # Send end event for this content part
             yield ResponseContentPartDoneEvent(
                 content_index=state.text_content_index_and_output[0],
-                item_id=state.message_item_id,
+                item_id=state.output_message_id,
                 output_index=state.reasoning_content_index_and_output
                 is not None,  # fixed 0 -> 0 or 1
                 part=state.text_content_index_and_output[1],
@@ -617,7 +617,7 @@ class ChatCmplStreamHandler:
             # Send end event for this content part
             yield ResponseContentPartDoneEvent(
                 content_index=state.refusal_content_index_and_output[0],
-                item_id=state.message_item_id,
+                item_id=state.output_message_id,
                 output_index=state.reasoning_content_index_and_output
                 is not None,  # fixed 0 -> 0 or 1
                 part=state.refusal_content_index_and_output[1],
@@ -732,7 +732,7 @@ class ChatCmplStreamHandler:
         # include text or refusal content if they exist
         if state.text_content_index_and_output or state.refusal_content_index_and_output:
             assistant_msg = ResponseOutputMessage(
-                id=state.message_item_id,
+                id=state.output_message_id,
                 content=[],
                 role="assistant",
                 type="message",

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -44,7 +44,7 @@ from openai.types.responses.response_usage import InputTokensDetails, OutputToke
 
 from ..items import TResponseStreamEvent
 from .chatcmpl_helpers import ChatCmplHelpers
-from .fake_id import FAKE_RESPONSES_ID
+from .fake_id import make_fake_responses_id
 
 
 # Define a Part class for internal use
@@ -71,6 +71,8 @@ class StreamingState:
     thinking_signature: str | None = None
     # Store provider data for all output items
     provider_data: dict[str, Any] = field(default_factory=dict)
+    # Pre-generated ID for the assistant message item (shared across all its events).
+    message_item_id: str = field(default_factory=make_fake_responses_id)
 
 
 class SequenceNumber:
@@ -103,7 +105,7 @@ class ChatCmplStreamHandler:
             return
 
         yield ResponseReasoningSummaryPartDoneEvent(
-            item_id=FAKE_RESPONSES_ID,
+            item_id=reasoning_item.id,
             output_index=0,
             summary_index=summary_index,
             part=DoneEventPart(
@@ -129,7 +131,7 @@ class ChatCmplStreamHandler:
             yield from cls._finish_reasoning_summary_part(state, sequence_number)
         elif reasoning_item.content is not None:
             yield ResponseReasoningTextDoneEvent(
-                item_id=FAKE_RESPONSES_ID,
+                item_id=reasoning_item.id,
                 output_index=0,
                 content_index=0,
                 text=reasoning_item.content[0].text,
@@ -211,7 +213,7 @@ class ChatCmplStreamHandler:
                 reasoning_content = delta.reasoning_content
                 if reasoning_content and not state.reasoning_content_index_and_output:
                     reasoning_item = ResponseReasoningItem(
-                        id=FAKE_RESPONSES_ID,
+                        id=make_fake_responses_id(),
                         summary=[],
                         type="reasoning",
                     )
@@ -233,7 +235,7 @@ class ChatCmplStreamHandler:
                         state.active_reasoning_summary_index = summary_index
 
                         yield ResponseReasoningSummaryPartAddedEvent(
-                            item_id=FAKE_RESPONSES_ID,
+                            item_id=reasoning_item.id,
                             output_index=0,
                             summary_index=summary_index,
                             part=AddedEventPart(text="", type="summary_text"),
@@ -245,7 +247,7 @@ class ChatCmplStreamHandler:
 
                     yield ResponseReasoningSummaryTextDeltaEvent(
                         delta=reasoning_content,
-                        item_id=FAKE_RESPONSES_ID,
+                        item_id=reasoning_item.id,
                         output_index=0,
                         summary_index=summary_index,
                         type="response.reasoning_summary_text.delta",
@@ -262,7 +264,7 @@ class ChatCmplStreamHandler:
                 reasoning_text = delta.reasoning
                 if reasoning_text and not state.reasoning_content_index_and_output:
                     reasoning_item = ResponseReasoningItem(
-                        id=FAKE_RESPONSES_ID,
+                        id=make_fake_responses_id(),
                         summary=[],
                         content=[Content(text="", type="reasoning_text")],
                         type="reasoning",
@@ -280,7 +282,7 @@ class ChatCmplStreamHandler:
                 if reasoning_text and state.reasoning_content_index_and_output:
                     yield ResponseReasoningTextDeltaEvent(
                         delta=reasoning_text,
-                        item_id=FAKE_RESPONSES_ID,
+                        item_id=state.reasoning_content_index_and_output[1].id,
                         output_index=0,
                         content_index=0,
                         type="response.reasoning_text.delta",
@@ -330,7 +332,7 @@ class ChatCmplStreamHandler:
                     )
                     # Start a new assistant message stream
                     assistant_item = ResponseOutputMessage(
-                        id=FAKE_RESPONSES_ID,
+                        id=state.message_item_id,
                         content=[],
                         role="assistant",
                         type="message",
@@ -348,7 +350,7 @@ class ChatCmplStreamHandler:
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.text_content_index_and_output[0],
-                        item_id=FAKE_RESPONSES_ID,
+                        item_id=state.message_item_id,
                         output_index=state.reasoning_content_index_and_output
                         is not None,  # fixed 0 -> 0 or 1
                         part=ResponseOutputText(
@@ -373,7 +375,7 @@ class ChatCmplStreamHandler:
                 yield ResponseTextDeltaEvent(
                     content_index=state.text_content_index_and_output[0],
                     delta=delta.content,
-                    item_id=FAKE_RESPONSES_ID,
+                    item_id=state.message_item_id,
                     output_index=state.reasoning_content_index_and_output
                     is not None,  # fixed 0 -> 0 or 1
                     type="response.output_text.delta",
@@ -404,7 +406,7 @@ class ChatCmplStreamHandler:
                     )
                     # Start a new assistant message if one doesn't exist yet (in-progress)
                     assistant_item = ResponseOutputMessage(
-                        id=FAKE_RESPONSES_ID,
+                        id=state.message_item_id,
                         content=[],
                         role="assistant",
                         type="message",
@@ -422,7 +424,7 @@ class ChatCmplStreamHandler:
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.refusal_content_index_and_output[0],
-                        item_id=FAKE_RESPONSES_ID,
+                        item_id=state.message_item_id,
                         output_index=(1 if state.reasoning_content_index_and_output else 0),
                         part=ResponseOutputRefusal(
                             refusal="",
@@ -435,7 +437,7 @@ class ChatCmplStreamHandler:
                 yield ResponseRefusalDeltaEvent(
                     content_index=state.refusal_content_index_and_output[0],
                     delta=delta.refusal,
-                    item_id=FAKE_RESPONSES_ID,
+                    item_id=state.message_item_id,
                     output_index=state.reasoning_content_index_and_output
                     is not None,  # fixed 0 -> 0 or 1
                     type="response.refusal.delta",
@@ -449,7 +451,7 @@ class ChatCmplStreamHandler:
                 for tc_delta in delta.tool_calls:
                     if tc_delta.index not in state.function_calls:
                         state.function_calls[tc_delta.index] = ResponseFunctionToolCall(
-                            id=FAKE_RESPONSES_ID,
+                            id=make_fake_responses_id(),
                             arguments="",
                             name="",
                             type="function_call",
@@ -549,7 +551,7 @@ class ChatCmplStreamHandler:
 
                         # Send initial function call added event
                         func_call_item = ResponseFunctionToolCall(
-                            id=FAKE_RESPONSES_ID,
+                            id=function_call.id,
                             call_id=function_call.call_id,
                             arguments="",  # Start with empty arguments
                             name=function_call.name,
@@ -584,7 +586,7 @@ class ChatCmplStreamHandler:
                         output_index = state.function_call_output_idx[tc_delta.index]
                         yield ResponseFunctionCallArgumentsDeltaEvent(
                             delta=tc_function.arguments,
-                            item_id=FAKE_RESPONSES_ID,
+                            item_id=function_call.id,
                             output_index=output_index,
                             type="response.function_call_arguments.delta",
                             sequence_number=sequence_number.get_and_increment(),
@@ -602,7 +604,7 @@ class ChatCmplStreamHandler:
             # Send end event for this content part
             yield ResponseContentPartDoneEvent(
                 content_index=state.text_content_index_and_output[0],
-                item_id=FAKE_RESPONSES_ID,
+                item_id=state.message_item_id,
                 output_index=state.reasoning_content_index_and_output
                 is not None,  # fixed 0 -> 0 or 1
                 part=state.text_content_index_and_output[1],
@@ -615,7 +617,7 @@ class ChatCmplStreamHandler:
             # Send end event for this content part
             yield ResponseContentPartDoneEvent(
                 content_index=state.refusal_content_index_and_output[0],
-                item_id=FAKE_RESPONSES_ID,
+                item_id=state.message_item_id,
                 output_index=state.reasoning_content_index_and_output
                 is not None,  # fixed 0 -> 0 or 1
                 part=state.refusal_content_index_and_output[1],
@@ -631,7 +633,7 @@ class ChatCmplStreamHandler:
 
                 # Build function call kwargs, include provider_data if present
                 func_call_kwargs: dict[str, Any] = {
-                    "id": FAKE_RESPONSES_ID,
+                    "id": function_call.id,
                     "call_id": function_call.call_id,
                     "arguments": function_call.arguments,
                     "name": function_call.name,
@@ -671,7 +673,7 @@ class ChatCmplStreamHandler:
 
                 # Build function call kwargs, include provider_data if present
                 fallback_func_call_kwargs: dict[str, Any] = {
-                    "id": FAKE_RESPONSES_ID,
+                    "id": function_call.id,
                     "call_id": function_call.call_id,
                     "arguments": function_call.arguments,
                     "name": function_call.name,
@@ -696,7 +698,7 @@ class ChatCmplStreamHandler:
                 )
                 yield ResponseFunctionCallArgumentsDeltaEvent(
                     delta=function_call.arguments,
-                    item_id=FAKE_RESPONSES_ID,
+                    item_id=function_call.id,
                     output_index=fallback_starting_index,
                     type="response.function_call_arguments.delta",
                     sequence_number=sequence_number.get_and_increment(),
@@ -730,7 +732,7 @@ class ChatCmplStreamHandler:
         # include text or refusal content if they exist
         if state.text_content_index_and_output or state.refusal_content_index_and_output:
             assistant_msg = ResponseOutputMessage(
-                id=FAKE_RESPONSES_ID,
+                id=state.message_item_id,
                 content=[],
                 role="assistant",
                 type="message",

--- a/src/agents/models/fake_id.py
+++ b/src/agents/models/fake_id.py
@@ -1,5 +1,17 @@
-FAKE_RESPONSES_ID = "__fake_id__"
-"""This is a placeholder ID used to fill in the `id` field in Responses API related objects. It's
-useful when you're creating Responses objects from non-Responses APIs, e.g. the OpenAI Chat
-Completions API or other LLM providers.
-"""
+import uuid
+
+_FAKE_ID_PREFIX = "__fake__id__"
+
+
+def make_fake_responses_id() -> str:
+    """Return a unique placeholder ID for use when a real Responses API ID is unavailable.
+
+    The returned value is prefixed with ``__fake__id__`` followed by a UUID4, making it both
+    recognisable as synthetic and unique across calls.
+    """
+    return f"{_FAKE_ID_PREFIX}{uuid.uuid4()}"
+
+
+def is_fake_responses_id(value: object) -> bool:
+    """Return True if *value* is a placeholder ID created by :func:`make_fake_responses_id`."""
+    return isinstance(value, str) and value.startswith(_FAKE_ID_PREFIX)

--- a/src/agents/models/fake_id.py
+++ b/src/agents/models/fake_id.py
@@ -1,17 +1,19 @@
 import uuid
 
-_FAKE_ID_PREFIX = "__fake__id__"
+_FAKE_RESPONSES_ID_PREFIX = "__fake__id__"
 
 
 def make_fake_responses_id() -> str:
-    """Return a unique placeholder ID for use when a real Responses API ID is unavailable.
+    """Return a unique placeholder ID to fill in the `id` field in Responses
+    API responses and output items. Intended for creating these Responses objects
+    from non-Responses APIs, e.g. the OpenAI Chat Completions API or other LLM providers.
 
     The returned value is prefixed with ``__fake__id__`` followed by a UUID4, making it both
-    recognisable as synthetic and unique across calls.
+    recognizable as synthetic and unique across calls.
     """
-    return f"{_FAKE_ID_PREFIX}{uuid.uuid4()}"
+    return f"{_FAKE_RESPONSES_ID_PREFIX}{uuid.uuid4()}"
 
 
 def is_fake_responses_id(value: object) -> bool:
     """Return True if *value* is a placeholder ID created by :func:`make_fake_responses_id`."""
-    return isinstance(value, str) and value.startswith(_FAKE_ID_PREFIX)
+    return isinstance(value, str) and value.startswith(_FAKE_RESPONSES_ID_PREFIX)

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -36,7 +36,7 @@ from ._retry_runtime import should_disable_provider_managed_retries
 from .chatcmpl_converter import Converter
 from .chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
 from .chatcmpl_stream_handler import ChatCmplStreamHandler
-from .fake_id import FAKE_RESPONSES_ID
+from .fake_id import make_fake_responses_id
 from .interface import Model, ModelTracing
 from .openai_responses import Converter as OpenAIResponsesConverter
 from .reasoning_content_replay import ShouldReplayReasoningContent
@@ -457,7 +457,7 @@ class OpenAIChatCompletionsModel(Model):
             responses_tool_choice = "auto"
 
         response = Response(
-            id=FAKE_RESPONSES_ID,
+            id=make_fake_responses_id(),
             created_at=time.time(),
             model=self.model,
             object="response",

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -842,7 +842,8 @@ class OpenAIResponsesModel(Model):
         Only items with truthy provider_data are processed.
         This function handles the following incompatibilities:
         - provider_data: Removes fields specific to other providers (e.g., Gemini, Claude).
-        - Fake IDs: Removes temporary placeholder IDs (detected via is_fake_responses_id) that should not be sent to OpenAI.
+        - Fake IDs: Removes placeholder IDs (detected via is_fake_responses_id)
+          that should not be sent to OpenAI.
         - Reasoning items: Filters out provider-specific reasoning items entirely.
         """
         # Early return optimization: if no item has provider_data, return unchanged.

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -71,7 +71,7 @@ from ._retry_runtime import (
     should_disable_provider_managed_retries,
     should_disable_websocket_pre_event_retries,
 )
-from .fake_id import FAKE_RESPONSES_ID
+from .fake_id import is_fake_responses_id
 from .interface import Model, ModelTracing
 from .openai_client_utils import is_official_openai_base_url, is_official_openai_client
 
@@ -842,7 +842,7 @@ class OpenAIResponsesModel(Model):
         Only items with truthy provider_data are processed.
         This function handles the following incompatibilities:
         - provider_data: Removes fields specific to other providers (e.g., Gemini, Claude).
-        - Fake IDs: Removes temporary IDs (FAKE_RESPONSES_ID) that should not be sent to OpenAI.
+        - Fake IDs: Removes temporary placeholder IDs (detected via is_fake_responses_id) that should not be sent to OpenAI.
         - Reasoning items: Filters out provider-specific reasoning items entirely.
         """
         # Early return optimization: if no item has provider_data, return unchanged.
@@ -869,7 +869,7 @@ class OpenAIResponsesModel(Model):
             return None
 
         # Remove fake response ID.
-        if item.get("id") == FAKE_RESPONSES_ID:
+        if is_fake_responses_id(item.get("id")):
             del item["id"]
 
         # Remove provider_data field.

--- a/src/agents/run_internal/error_handlers.py
+++ b/src/agents/run_internal/error_handlers.py
@@ -16,7 +16,7 @@ from ..items import (
     RunItem,
     TResponseInputItem,
 )
-from ..models.fake_id import FAKE_RESPONSES_ID
+from ..models.fake_id import make_fake_responses_id
 from ..run_context import RunContextWrapper, TContext
 from ..run_error_handlers import (
     RunErrorData,
@@ -109,7 +109,7 @@ def validate_handler_final_output(agent: Agent[Any], final_output: Any) -> Any:
 
 def create_message_output_item(agent: Agent[Any], output_text: str) -> MessageOutputItem:
     message = ResponseOutputMessage(
-        id=FAKE_RESPONSES_ID,
+        id=make_fake_responses_id(),
         type="message",
         role="assistant",
         content=[

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 from ..agent_tool_state import drop_agent_tool_run_result
 from ..items import ItemHelpers, RunItem, ToolCallOutputItem, TResponseInputItem
-from ..models.fake_id import FAKE_RESPONSES_ID
+from ..models.fake_id import is_fake_responses_id
 from ..tool import DEFAULT_APPROVAL_REJECTION_MESSAGE
 
 REJECTION_MESSAGE = DEFAULT_APPROVAL_REJECTION_MESSAGE
@@ -234,7 +234,7 @@ def _dedupe_key(item: TResponseInputItem) -> str | None:
     if role is not None or item_type == "message":
         return None
     item_id = payload.get("id")
-    if item_id == FAKE_RESPONSES_ID:
+    if is_fake_responses_id(item_id):
         # Ignore placeholder IDs so call_id-based dedupe remains possible.
         item_id = None
     if isinstance(item_id, str):

--- a/src/agents/run_internal/oai_conversation.py
+++ b/src/agents/run_internal/oai_conversation.py
@@ -17,7 +17,7 @@ from ..items import (
     _output_item_to_input_item,
 )
 from ..logger import logger
-from ..models.fake_id import FAKE_RESPONSES_ID
+from ..models.fake_id import is_fake_responses_id
 from .items import (
     ReasoningItemIdPolicy,
     drop_orphan_function_calls,
@@ -34,7 +34,7 @@ from .items import (
 
 def _normalize_server_item_id(value: Any) -> str | None:
     """Return a stable server item id, ignoring placeholder IDs."""
-    if value == FAKE_RESPONSES_ID:
+    if is_fake_responses_id(value):
         # Fake IDs are placeholders from non-Responses providers; ignore them for dedupe.
         return None
     return value if isinstance(value, str) else None

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -36,7 +36,7 @@ from agents import (
 )
 from agents.exceptions import UserError
 from agents.models.chatcmpl_helpers import HEADERS_OVERRIDE
-from agents.models.fake_id import FAKE_RESPONSES_ID
+from agents.models.fake_id import make_fake_responses_id
 
 
 class FakeAnyLLMProvider:
@@ -668,7 +668,7 @@ async def test_any_llm_responses_path_sanitizes_replayed_items_before_validation
         [
             {"role": "user", "content": "What's the weather in Tokyo?"},
             {
-                "id": FAKE_RESPONSES_ID,
+                "id": make_fake_responses_id(),
                 "summary": [
                     {"text": "I should call the weather tool first.", "type": "summary_text"}
                 ],
@@ -678,7 +678,7 @@ async def test_any_llm_responses_path_sanitizes_replayed_items_before_validation
                 "provider_data": {"model": "anthropic/fake-responses-model"},
             },
             {
-                "id": FAKE_RESPONSES_ID,
+                "id": make_fake_responses_id(),
                 "arguments": '{"city": "Tokyo"}',
                 "call_id": "call_weather_123",
                 "name": "get_weather",

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -24,6 +24,7 @@ from openai.types.responses import (
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.extensions.models.litellm_provider import LitellmProvider
 from agents.model_settings import ModelSettings
+from agents.models.fake_id import is_fake_responses_id
 from agents.models.interface import ModelTracing
 
 
@@ -127,6 +128,18 @@ async def test_stream_response_yields_events_for_text_content(monkeypatch) -> No
     assert completed_resp.usage.input_tokens_details.cached_tokens == 6
     assert completed_resp.usage.output_tokens_details.reasoning_tokens == 2
 
+    # Verify all events reference the same synthetic output message ID.
+    msg_id = output_events[1].item.id  # response.output_item.added
+    assert is_fake_responses_id(msg_id)
+    assert output_events[2].item_id == msg_id  # response.content_part.added
+    assert output_events[3].item_id == msg_id  # first response.output_text.delta
+    assert output_events[4].item_id == msg_id  # second response.output_text.delta
+    assert output_events[5].item_id == msg_id  # response.content_part.done
+    assert output_events[6].item.id == msg_id  # response.output_item.done
+    # Exactly one output message in the completed response, carrying the same ID.
+    assert len(completed_resp.output) == 1
+    assert completed_resp.output[0].id == msg_id
+
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
@@ -206,6 +219,18 @@ async def test_stream_response_yields_events_for_refusal_content(monkeypatch) ->
     refusal_part = completed_resp.output[0].content[0]
     assert isinstance(refusal_part, ResponseOutputRefusal)
     assert refusal_part.refusal == "NoThanks"
+
+    # Verify all events reference the same synthetic output message ID.
+    msg_id = output_events[1].item.id  # response.output_item.added
+    assert is_fake_responses_id(msg_id)
+    assert output_events[2].item_id == msg_id  # response.content_part.added
+    assert output_events[3].item_id == msg_id  # first response.refusal.delta
+    assert output_events[4].item_id == msg_id  # second response.refusal.delta
+    assert output_events[5].item_id == msg_id  # response.content_part.done
+    assert output_events[6].item.id == msg_id  # response.output_item.done
+    # Exactly one output message in the completed response, carrying the same ID.
+    assert len(completed_resp.output) == 1
+    assert completed_resp.output[0].id == msg_id
 
 
 @pytest.mark.allow_call_model_methods
@@ -301,6 +326,16 @@ async def test_stream_response_yields_events_for_tool_call(monkeypatch) -> None:
     assert isinstance(final_fn, ResponseFunctionToolCall)
     assert final_fn.name == "my_func"
     assert final_fn.arguments == "arg1arg2"
+
+    # Verify all function-call events share the same synthetic item ID.
+    fn_id = output_events[1].item.id  # response.output_item.added
+    assert is_fake_responses_id(fn_id)
+    assert output_events[2].item_id == fn_id  # first response.function_call_arguments.delta
+    assert output_events[3].item_id == fn_id  # second response.function_call_arguments.delta
+    assert output_events[4].item.id == fn_id  # response.output_item.done
+    # The completed response also carries the same ID.
+    completed_resp = output_events[5].response
+    assert completed_resp.output[0].id == fn_id
 
 
 @pytest.mark.allow_call_model_methods
@@ -417,3 +452,13 @@ async def test_stream_response_yields_real_time_function_call_arguments(monkeypa
     assert isinstance(added_event.item, ResponseFunctionToolCall)
     assert added_event.item.name == "generate_code"
     assert added_event.item.call_id == "litellm-call-456"
+
+    # Verify all events reference the same synthetic item ID.
+    fn_id = added_event.item.id
+    assert is_fake_responses_id(fn_id)
+    for delta_event in function_args_delta_events:
+        assert delta_event.item_id == fn_id
+    done_events = [e for e in output_events if e.type == "response.output_item.done"]
+    assert done_events[0].item.id == fn_id
+    completed_event = next(e for e in output_events if e.type == "response.completed")
+    assert completed_event.response.output[0].id == fn_id

--- a/tests/test_gemini_thought_signatures_stream.py
+++ b/tests/test_gemini_thought_signatures_stream.py
@@ -21,6 +21,7 @@ from openai.types.chat.chat_completion_chunk import (
 from openai.types.responses import Response
 
 from agents.models.chatcmpl_stream_handler import ChatCmplStreamHandler
+from agents.models.fake_id import is_fake_responses_id
 
 # ========== Helper Functions ==========
 
@@ -168,6 +169,20 @@ async def test_stream_captures_litellmprovider_specific_fields_thought_signature
     assert provider_data["model"] == "gemini/gemini-3-pro"
     assert provider_data["response_id"] == "chunk-id-123"
 
+    # Verify the added event and done event share the same synthetic item ID.
+    added_events = [e for e in events if e.type == "response.output_item.added"]
+    func_added = [
+        e for e in added_events if hasattr(e.item, "type") and e.item.type == "function_call"
+    ]
+    assert len(func_added) == 1
+    assert is_fake_responses_id(func_added[0].item.id)
+    assert func_added[0].item.id == func_done[0].item.id
+
+    # All argument delta events reference that same ID.
+    delta_events = [e for e in events if e.type == "response.function_call_arguments.delta"]
+    for e in delta_events:
+        assert e.item_id == func_done[0].item.id
+
 
 @pytest.mark.asyncio
 async def test_stream_captures_google_extra_content_thought_signature():
@@ -208,3 +223,17 @@ async def test_stream_captures_google_extra_content_thought_signature():
     assert provider_data.get("thought_signature") == "google_sig_456"
     assert provider_data["model"] == "gemini/gemini-3-pro"
     assert provider_data["response_id"] == "chunk-id-123"
+
+    # Verify the added event and done event share the same synthetic item ID.
+    added_events = [e for e in events if e.type == "response.output_item.added"]
+    func_added = [
+        e for e in added_events if hasattr(e.item, "type") and e.item.type == "function_call"
+    ]
+    assert len(func_added) == 1
+    assert is_fake_responses_id(func_added[0].item.id)
+    assert func_added[0].item.id == func_done[0].item.id
+
+    # All argument delta events reference that same ID.
+    delta_events = [e for e in events if e.type == "response.function_call_arguments.delta"]
+    for e in delta_events:
+        assert e.item_id == func_done[0].item.id

--- a/tests/test_openai_chatcompletions.py
+++ b/tests/test_openai_chatcompletions.py
@@ -43,7 +43,7 @@ from agents import (
 )
 from agents.models._retry_runtime import provider_managed_retries_disabled
 from agents.models.chatcmpl_helpers import HEADERS_OVERRIDE, ChatCmplHelpers
-from agents.models.fake_id import FAKE_RESPONSES_ID
+from agents.models.fake_id import is_fake_responses_id
 
 
 async def _run_chat_completions_model_with_custom_base_url(
@@ -568,7 +568,7 @@ async def test_fetch_response_stream(monkeypatch) -> None:
     assert completions.kwargs["stream_options"] is omit
     # Response is a proper openai Response
     assert isinstance(response, Response)
-    assert response.id == FAKE_RESPONSES_ID
+    assert is_fake_responses_id(response.id)
     assert response.model == "gpt-4"
     assert response.object == "response"
     assert response.output == []

--- a/tests/test_openai_chatcompletions_converter.py
+++ b/tests/test_openai_chatcompletions_converter.py
@@ -44,7 +44,7 @@ from agents.agent_output import AgentOutputSchema
 from agents.exceptions import UserError
 from agents.items import TResponseInputItem
 from agents.models.chatcmpl_converter import Converter
-from agents.models.fake_id import FAKE_RESPONSES_ID
+from agents.models.fake_id import is_fake_responses_id
 
 
 def test_message_to_output_items_with_text_only():
@@ -57,7 +57,7 @@ def test_message_to_output_items_with_text_only():
     # Expect exactly one output item (the message)
     assert len(items) == 1
     message_item = cast(ResponseOutputMessage, items[0])
-    assert message_item.id == FAKE_RESPONSES_ID
+    assert is_fake_responses_id(message_item.id)
     assert message_item.role == "assistant"
     assert message_item.type == "message"
     assert message_item.status == "completed"
@@ -101,7 +101,7 @@ def test_message_to_output_items_with_tool_call():
     message_item = cast(ResponseOutputMessage, items[0])
     assert isinstance(message_item, ResponseOutputMessage)
     fn_call_item = cast(ResponseFunctionToolCall, items[1])
-    assert fn_call_item.id == FAKE_RESPONSES_ID
+    assert is_fake_responses_id(fn_call_item.id)
     assert fn_call_item.call_id == tool_call.id
     assert fn_call_item.name == tool_call.function.name
     assert fn_call_item.arguments == tool_call.function.arguments

--- a/tests/test_openai_chatcompletions_stream.py
+++ b/tests/test_openai_chatcompletions_stream.py
@@ -28,6 +28,7 @@ from openai.types.responses import (
 )
 
 from agents.model_settings import ModelSettings
+from agents.models.fake_id import is_fake_responses_id
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
@@ -538,7 +539,7 @@ async def test_stream_response_yields_real_time_function_call_arguments(monkeypa
     expected_deltas = ['{"filename": "', 'test.py", "content": "', 'print(hello)"}']
     for i, delta_event in enumerate(function_args_delta_events):
         assert delta_event.delta == expected_deltas[i]
-        assert delta_event.item_id == "__fake_id__"  # FAKE_RESPONSES_ID
+        assert is_fake_responses_id(delta_event.item_id)  # synthetic per-item UUID
         assert delta_event.output_index == 0
 
     # Verify completion event has full arguments

--- a/tests/test_openai_chatcompletions_stream.py
+++ b/tests/test_openai_chatcompletions_stream.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+from typing import Any, cast
 
 import pytest
 from openai.types.chat.chat_completion_chunk import (
@@ -25,9 +26,11 @@ from openai.types.responses import (
     ResponseOutputMessage,
     ResponseOutputRefusal,
     ResponseOutputText,
+    ResponseReasoningItem,
 )
 
 from agents.model_settings import ModelSettings
+from agents.models.chatcmpl_stream_handler import ChatCmplStreamHandler
 from agents.models.fake_id import is_fake_responses_id
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
@@ -133,6 +136,18 @@ async def test_stream_response_yields_events_for_text_content(monkeypatch) -> No
     assert completed_resp.usage.total_tokens == 12
     assert completed_resp.usage.input_tokens_details.cached_tokens == 2
     assert completed_resp.usage.output_tokens_details.reasoning_tokens == 3
+
+    # Verify all events reference the same synthetic output message ID.
+    msg_id = output_events[1].item.id  # response.output_item.added
+    assert is_fake_responses_id(msg_id)
+    assert output_events[2].item_id == msg_id  # response.content_part.added
+    assert output_events[3].item_id == msg_id  # first response.output_text.delta
+    assert output_events[4].item_id == msg_id  # second response.output_text.delta
+    assert output_events[5].item_id == msg_id  # response.content_part.done
+    assert output_events[6].item.id == msg_id  # response.output_item.done
+    # Exactly one output message in the completed response, carrying the same ID.
+    assert len(completed_resp.output) == 1
+    assert completed_resp.output[0].id == msg_id
 
 
 @pytest.mark.allow_call_model_methods
@@ -321,6 +336,18 @@ async def test_stream_response_yields_events_for_refusal_content(monkeypatch) ->
     assert isinstance(refusal_part, ResponseOutputRefusal)
     assert refusal_part.refusal == "NoThanks"
 
+    # Verify all events reference the same synthetic output message ID.
+    msg_id = output_events[1].item.id  # response.output_item.added
+    assert is_fake_responses_id(msg_id)
+    assert output_events[2].item_id == msg_id  # response.content_part.added
+    assert output_events[3].item_id == msg_id  # first response.refusal.delta
+    assert output_events[4].item_id == msg_id  # second response.refusal.delta
+    assert output_events[5].item_id == msg_id  # response.content_part.done
+    assert output_events[6].item.id == msg_id  # response.output_item.done
+    # Exactly one output message in the completed response, carrying the same ID.
+    assert len(completed_resp.output) == 1
+    assert completed_resp.output[0].id == msg_id
+
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
@@ -415,6 +442,16 @@ async def test_stream_response_yields_events_for_tool_call(monkeypatch) -> None:
     assert isinstance(final_fn, ResponseFunctionToolCall)
     assert final_fn.name == "my_func"
     assert final_fn.arguments == "arg1arg2"
+
+    # Verify all function-call events share the same synthetic item ID.
+    fn_id = output_events[1].item.id  # response.output_item.added
+    assert is_fake_responses_id(fn_id)
+    assert output_events[2].item_id == fn_id  # first response.function_call_arguments.delta
+    assert output_events[3].item_id == fn_id  # second response.function_call_arguments.delta
+    assert output_events[4].item.id == fn_id  # response.output_item.done
+    # The single completed output also carries the same ID.
+    completed_resp = output_events[5].response
+    assert completed_resp.output[0].id == fn_id
 
 
 @pytest.mark.allow_call_model_methods
@@ -535,22 +572,244 @@ async def test_stream_response_yields_real_time_function_call_arguments(monkeypa
     assert added_event.item.call_id == "tool-call-123"
     assert added_event.item.arguments == ""  # Should be empty at start
 
-    # Verify real-time argument streaming
+    # Verify real-time argument streaming with a consistent ID across all events.
+    fn_id = added_event.item.id
+    assert is_fake_responses_id(fn_id)
     expected_deltas = ['{"filename": "', 'test.py", "content": "', 'print(hello)"}']
     for i, delta_event in enumerate(function_args_delta_events):
         assert delta_event.delta == expected_deltas[i]
-        assert is_fake_responses_id(delta_event.item_id)  # synthetic per-item UUID
+        assert delta_event.item_id == fn_id  # every delta references the same item ID
         assert delta_event.output_index == 0
 
-    # Verify completion event has full arguments
+    # Verify completion event has full arguments and consistent ID.
     done_event = output_item_done_events[0]
     assert isinstance(done_event.item, ResponseFunctionToolCall)
     assert done_event.item.name == "write_file"
     assert done_event.item.arguments == '{"filename": "test.py", "content": "print(hello)"}'
+    assert done_event.item.id == fn_id  # done event carries the same item ID
 
-    # Verify final response
+    # Verify final response and consistent ID.
     completed_event = completed_events[0]
     function_call_output = completed_event.response.output[0]
     assert isinstance(function_call_output, ResponseFunctionToolCall)
     assert function_call_output.name == "write_file"
     assert function_call_output.arguments == '{"filename": "test.py", "content": "print(hello)"}'
+    assert function_call_output.id == fn_id  # completed response carries the same ID
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_multiple_tool_calls_have_distinct_ids(monkeypatch) -> None:
+    """
+    Validate that two parallel tool calls each receive their own unique synthetic ID,
+    and that events for different calls never share an ID.
+    """
+    tool_call_0_chunk1 = ChoiceDeltaToolCall(
+        index=0,
+        id="call-id-0",
+        function=ChoiceDeltaToolCallFunction(name="func_a", arguments=""),
+        type="function",
+    )
+    tool_call_0_chunk2 = ChoiceDeltaToolCall(
+        index=0,
+        function=ChoiceDeltaToolCallFunction(arguments='{"x": 1}'),
+        type="function",
+    )
+    tool_call_1_chunk1 = ChoiceDeltaToolCall(
+        index=1,
+        id="call-id-1",
+        function=ChoiceDeltaToolCallFunction(name="func_b", arguments=""),
+        type="function",
+    )
+    tool_call_1_chunk2 = ChoiceDeltaToolCall(
+        index=1,
+        function=ChoiceDeltaToolCallFunction(arguments='{"y": 2}'),
+        type="function",
+    )
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[
+            Choice(
+                index=0,
+                delta=ChoiceDelta(tool_calls=[tool_call_0_chunk1, tool_call_1_chunk1]),
+            )
+        ],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[
+            Choice(
+                index=0,
+                delta=ChoiceDelta(tool_calls=[tool_call_0_chunk2, tool_call_1_chunk2]),
+            )
+        ],
+        usage=CompletionUsage(completion_tokens=2, prompt_tokens=2, total_tokens=4),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for c in (chunk1, chunk2):
+            yield c
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    output_events = []
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        output_events.append(event)
+
+    added_events = [e for e in output_events if e.type == "response.output_item.added"]
+    done_events = [e for e in output_events if e.type == "response.output_item.done"]
+    delta_events = [e for e in output_events if e.type == "response.function_call_arguments.delta"]
+
+    assert len(added_events) == 2
+    assert len(done_events) == 2
+    assert len(delta_events) == 2
+
+    # Map function name → synthetic item ID from the added events.
+    id_by_name: dict[str, str] = {e.item.name: e.item.id for e in added_events}
+    assert set(id_by_name.keys()) == {"func_a", "func_b"}
+    fn_a_id = id_by_name["func_a"]
+    fn_b_id = id_by_name["func_b"]
+
+    # Both IDs must be synthetic and distinct from each other.
+    assert is_fake_responses_id(fn_a_id)
+    assert is_fake_responses_id(fn_b_id)
+    assert fn_a_id != fn_b_id
+
+    # Each done event must carry its own call's ID.
+    done_by_name: dict[str, str] = {e.item.name: e.item.id for e in done_events}
+    assert done_by_name["func_a"] == fn_a_id
+    assert done_by_name["func_b"] == fn_b_id
+
+    # All argument deltas must reference one of the two call IDs (both must appear).
+    delta_item_ids = {e.item_id for e in delta_events}
+    assert delta_item_ids == {fn_a_id, fn_b_id}
+
+    # The completed response output carries both IDs.
+    completed_resp = next(e for e in output_events if e.type == "response.completed").response
+    completed_ids = {
+        item.id for item in completed_resp.output if isinstance(item, ResponseFunctionToolCall)
+    }
+    assert completed_ids == {fn_a_id, fn_b_id}
+
+
+@pytest.mark.asyncio
+async def test_stream_response_reasoning_and_text_have_distinct_ids() -> None:
+    """
+    Validate that a stream containing both a reasoning item and a text message assigns
+    distinct synthetic IDs to each, and that all events for each item consistently
+    use that item's ID.
+    """
+    # Chunk 1: reasoning content delta (provider extension field).
+    delta1 = ChoiceDelta()
+    cast(Any, delta1).reasoning_content = "thinking about it"
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=delta1)],
+    )
+    # Chunk 2: regular text content delta.
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="Hello"))],
+        usage=CompletionUsage(completion_tokens=2, prompt_tokens=2, total_tokens=4),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for c in (chunk1, chunk2):
+            yield c
+
+    response = Response(
+        id="resp-id",
+        created_at=0,
+        model="fake-model",
+        object="response",
+        output=[],
+        tool_choice="none",
+        tools=[],
+        parallel_tool_calls=False,
+    )
+    events = []
+    async for event in ChatCmplStreamHandler.handle_stream(
+        response,
+        fake_stream(),  # type: ignore[arg-type]
+    ):
+        events.append(event)
+
+    added_events = [e for e in events if e.type == "response.output_item.added"]
+    reasoning_added = next(e for e in added_events if e.item.type == "reasoning")
+    message_added = next(e for e in added_events if e.item.type == "message")
+
+    reasoning_id = reasoning_added.item.id
+    message_id = message_added.item.id
+
+    # Both IDs must be synthetic and distinct from each other.
+    assert is_fake_responses_id(reasoning_id)
+    assert is_fake_responses_id(message_id)
+    assert reasoning_id != message_id
+
+    # All reasoning delta events reference reasoning_id.
+    reasoning_delta_events = [
+        e
+        for e in events
+        if e.type in ("response.reasoning_summary_text.delta", "response.reasoning_text.delta")
+    ]
+    assert reasoning_delta_events, "expected at least one reasoning delta"
+    for e in reasoning_delta_events:
+        assert e.item_id == reasoning_id
+
+    # All text delta events reference message_id.
+    text_delta_events = [e for e in events if e.type == "response.output_text.delta"]
+    assert text_delta_events
+    for e in text_delta_events:
+        assert e.item_id == message_id
+
+    # Content part added/done events reference message_id.
+    content_part_events = [
+        e for e in events if e.type in ("response.content_part.added", "response.content_part.done")
+    ]
+    for e in content_part_events:
+        assert e.item_id == message_id
+
+    # The completed response carries both items with matching IDs.
+    completed = next(e for e in events if e.type == "response.completed").response
+    reasoning_out = next(
+        item for item in completed.output if isinstance(item, ResponseReasoningItem)
+    )
+    message_out = next(item for item in completed.output if isinstance(item, ResponseOutputMessage))
+    assert reasoning_out.id == reasoning_id
+    assert message_out.id == message_id

--- a/tests/test_remove_openai_responses_api_incompatible_fields.py
+++ b/tests/test_remove_openai_responses_api_incompatible_fields.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agents.models.fake_id import FAKE_RESPONSES_ID
+from agents.models.fake_id import make_fake_responses_id
 from agents.models.openai_responses import OpenAIResponsesModel
 
 
@@ -75,11 +75,11 @@ class TestRemoveOpenAIResponsesAPIIncompatibleFields:
         assert "provider_data" not in result[1]
 
     def test_removes_fake_responses_id(self, model: OpenAIResponsesModel):
-        """Items with id equal to FAKE_RESPONSES_ID should have their id removed."""
+        """Items with a placeholder fake ID should have their id removed."""
         list_input = [
             {
                 "type": "message",
-                "id": FAKE_RESPONSES_ID,
+                "id": make_fake_responses_id(),
                 "content": "hello",
                 "provider_data": {"model": "gemini/gemini-3"},
             },
@@ -92,7 +92,7 @@ class TestRemoveOpenAIResponsesAPIIncompatibleFields:
         assert result[0]["content"] == "hello"
 
     def test_preserves_real_ids(self, model: OpenAIResponsesModel):
-        """Real IDs (not FAKE_RESPONSES_ID) should be preserved."""
+        """Real IDs (not placeholder fake IDs) should be preserved."""
         list_input = [
             {
                 "type": "message",
@@ -132,7 +132,7 @@ class TestRemoveOpenAIResponsesAPIIncompatibleFields:
             },
             {
                 "type": "message",
-                "id": FAKE_RESPONSES_ID,
+                "id": make_fake_responses_id(),
                 "content": "The weather is 72F",
                 "provider_data": {"model": "gemini/gemini-3"},
             },

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -20,7 +20,7 @@ from agents.items import (
     TResponseInputItem,
     coerce_tool_search_output_raw_item,
 )
-from agents.models.fake_id import FAKE_RESPONSES_ID
+from agents.models.fake_id import make_fake_responses_id
 from agents.result import RunResult
 from agents.run_context import RunContextWrapper
 from agents.run_internal import items as run_items
@@ -272,7 +272,7 @@ def test_deduplicate_input_items_handles_fake_ids_and_approval_request_ids() -> 
             TResponseInputItem,
             {
                 "type": "function_call_output",
-                "id": FAKE_RESPONSES_ID,
+                "id": make_fake_responses_id(),
                 "call_id": "call-1",
                 "output": "first",
             },
@@ -281,7 +281,7 @@ def test_deduplicate_input_items_handles_fake_ids_and_approval_request_ids() -> 
             TResponseInputItem,
             {
                 "type": "function_call_output",
-                "id": FAKE_RESPONSES_ID,
+                "id": make_fake_responses_id(),
                 "call_id": "call-1",
                 "output": "latest",
             },

--- a/tests/test_server_conversation_tracker.py
+++ b/tests/test_server_conversation_tracker.py
@@ -16,7 +16,7 @@ from agents.items import (
     TResponseInputItem,
 )
 from agents.lifecycle import RunHooks
-from agents.models.fake_id import FAKE_RESPONSES_ID
+from agents.models.fake_id import make_fake_responses_id
 from agents.result import RunResultStreaming
 from agents.run_config import ModelInputData, RunConfig
 from agents.run_context import RunContextWrapper
@@ -701,13 +701,13 @@ def test_prepare_input_does_not_skip_fake_response_ids() -> None:
     tracker = OpenAIServerConversationTracker(conversation_id="conv5", previous_response_id=None)
 
     model_response = object.__new__(ModelResponse)
-    model_response.output = [cast(Any, {"id": FAKE_RESPONSES_ID, "type": "message"})]
+    model_response.output = [cast(Any, {"id": make_fake_responses_id(), "type": "message"})]
     model_response.usage = Usage()
     model_response.response_id = "resp-3"
 
     tracker.track_server_items(model_response)
 
-    raw_item = {"id": FAKE_RESPONSES_ID, "type": "message", "content": "hello"}
+    raw_item = {"id": make_fake_responses_id(), "type": "message", "content": "hello"}
     generated_items = [DummyRunItem(raw_item)]
 
     prepared = tracker.prepare_input(


### PR DESCRIPTION
# Summary
I replaced the static fake id used to simulate a Responses API Response id or ResponseOutputItem id with a unique id. The unique ID includes a prefix that identifies it as fake. The fake id pattern is used for all conversions of ChatCompletions API output into Responses API format

Previously when using ChatCompletions APIs, every output message had the same ID value. You can imagine why this is annoying and problematic. Now all output items and responses have unique ids that are identifiable as fake (not created by the real OpenAI Responses API).

The only major complication came up with streaming responses. Here I added an output_message_id to the streaming state. This allows all ResponseOutputMessage events in a streaming response have the same fake id. 
My understanding of the vision for the chat completions conversion is that every ChatCompletions streaming response is converted to produce a single Responses API ResponseOutputMessage item. Special attention from the reviewer on this point is appreciated.

Example:
Old -> `'__fake_id__'`
New -> `'__fake_id__63456181-ca62-4520-9767-7d081aafac46'`

# Test Plan
Updated the tests to check the new fake ids. 

For streaming checks, I added checks that ensured that all events associated with the same ResponseOutputMessage or function call or reasoning all have the same ID. The same is done for litellm.  any_llm tests mock the whole ChatCmplStreamHandler.handle_stream() so no changed needed.
 I added a new test to make sure that multiple function calls in a single streaming response get different but consistent ids.

For future work, it might make sense to break the streaming tests into tests for ChatCmplStreamHandler.handle_stream() doing most of the work and lighter tests for .stream_response() in chat_completions, litlellm, any_llm  respectively.
