### PR TITLE
fix: restore UnixLocal PTY terminal signal defaults

### DIFF
--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -69,6 +69,7 @@ from ..workspace_paths import _raise_if_filesystem_root
 _DEFAULT_WORKSPACE_PREFIX = "sandbox-local-"
 _DEFAULT_MANIFEST_ROOT = cast(str, Manifest.model_fields["root"].default)
 _PTY_READ_CHUNK_BYTES = 16_384
+_PTY_CHILD_SIGNAL_DEFAULTS = (signal.SIGINT, signal.SIGQUIT)
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,11 @@ logger = logging.getLogger(__name__)
 def _close_fd_quietly(fd: int) -> None:
     with suppress(OSError):
         os.close(fd)
+
+
+def _restore_pty_child_signal_defaults() -> None:
+    for signum in _PTY_CHILD_SIGNAL_DEFAULTS:
+        signal.signal(signum, signal.SIG_DFL)
 
 
 class UnixLocalSandboxSessionState(SandboxSessionState):
@@ -283,9 +289,9 @@ class UnixLocalSandboxSession(BaseSandboxSession):
             def _preexec() -> None:
                 os.setsid()
                 fcntl.ioctl(secondary_fd, termios.TIOCSCTTY, 0)
-                # PTY children should always treat Ctrl-C as an interrupt even if the parent
-                # process temporarily ignores SIGINT under the test runner.
-                signal.signal(signal.SIGINT, signal.SIG_DFL)
+                # PTY children should use default terminal signal behavior even if the parent
+                # process temporarily ignores signals under the test runner.
+                _restore_pty_child_signal_defaults()
 
             try:
                 process = await asyncio.create_subprocess_exec(

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -107,15 +107,22 @@ class TestUnixLocalPty:
             with pytest.raises(PtySessionNotFoundError):
                 await session.pty_write_stdin(session_id=started.process_id, chars="")
 
+    @pytest.mark.parametrize(
+        ("signum", "chars"),
+        [
+            pytest.param(signal.SIGINT, "\x03", id="sigint"),
+            pytest.param(signal.SIGQUIT, "\x1c", id="sigquit"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_pty_ctrl_c_interrupts_even_if_parent_ignores_sigint(
-        self, tmp_path: Path
+    async def test_pty_terminal_signals_interrupt_even_if_parent_ignores_signal(
+        self, tmp_path: Path, signum: signal.Signals, chars: str
     ) -> None:
         client = UnixLocalSandboxClient()
         manifest = Manifest(root=str(tmp_path / "workspace"))
-        previous_handler = signal.getsignal(signal.SIGINT)
+        previous_handler = signal.getsignal(signum)
 
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signum, signal.SIG_IGN)
         try:
             async with await client.create(
                 manifest=manifest, snapshot=None, options=None
@@ -131,14 +138,14 @@ class TestUnixLocalPty:
 
                 interrupted = await session.pty_write_stdin(
                     session_id=started.process_id,
-                    chars="\x03",
+                    chars=chars,
                     yield_time_s=5.5,
                 )
 
                 assert interrupted.process_id is None
-                assert interrupted.exit_code == -2
+                assert interrupted.exit_code == -signum
         finally:
-            signal.signal(signal.SIGINT, previous_handler)
+            signal.signal(signum, previous_handler)
 
     @pytest.mark.asyncio
     async def test_non_tty_pty_session_rejects_stdin_and_can_still_be_polled(


### PR DESCRIPTION
This pull request fixes UnixLocal PTY child signal inheritance for terminal-generated interrupts. After #3075 restored `SIGINT`, this follow-up centralizes PTY child signal restoration and also resets `SIGQUIT` to `SIG_DFL`, so Ctrl-\ is not ignored when the parent process temporarily ignores `SIGQUIT`.

The change updates `src/agents/sandbox/sandboxes/unix_local.py` and extends `tests/sandbox/test_unix_local.py` with parametrized regression coverage for both `SIGINT` and `SIGQUIT`. There are no untracked files.