### PR TITLE
fix: redact MCP invalid JSON errors when tool logging is disabled

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -379,13 +379,13 @@ class MCPUtil:
         try:
             json_data: dict[str, Any] = json.loads(input_json) if input_json else {}
         except Exception as e:
+            error_message = f"Invalid JSON input for tool {tool.name}"
             if _debug.DONT_LOG_TOOL_DATA:
-                logger.debug(f"Invalid JSON input for tool {tool.name}")
+                logger.debug(error_message)
             else:
-                logger.debug(f"Invalid JSON input for tool {tool.name}: {input_json}")
-            raise ModelBehaviorError(
-                f"Invalid JSON input for tool {tool.name}: {input_json}"
-            ) from e
+                error_message = f"{error_message}: {input_json}"
+                logger.debug(error_message)
+            raise ModelBehaviorError(error_message) from e
 
         if _debug.DONT_LOG_TOOL_DATA:
             logger.debug(f"Invoking MCP tool {tool.name}")

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -376,17 +376,21 @@ class MCPUtil:
         meta: dict[str, Any] | None = None,
     ) -> ToolOutput:
         """Invoke an MCP tool and return the result as ToolOutput."""
+        json_decode_error: Exception | None = None
         try:
             json_data: dict[str, Any] = json.loads(input_json) if input_json else {}
         except Exception as e:
+            json_decode_error = e
+
+        if json_decode_error is not None:
             error_message = f"Invalid JSON input for tool {tool.name}"
             if _debug.DONT_LOG_TOOL_DATA:
                 logger.debug(error_message)
-                raise ModelBehaviorError(error_message) from None
+                raise ModelBehaviorError(error_message)
             else:
                 error_message = f"{error_message}: {input_json}"
                 logger.debug(error_message)
-            raise ModelBehaviorError(error_message) from e
+            raise ModelBehaviorError(error_message) from json_decode_error
 
         if _debug.DONT_LOG_TOOL_DATA:
             logger.debug(f"Invoking MCP tool {tool.name}")

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -382,6 +382,7 @@ class MCPUtil:
             error_message = f"Invalid JSON input for tool {tool.name}"
             if _debug.DONT_LOG_TOOL_DATA:
                 logger.debug(error_message)
+                raise ModelBehaviorError(error_message) from None
             else:
                 error_message = f"{error_message}: {input_json}"
                 logger.debug(error_message)

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -241,6 +241,7 @@ async def test_mcp_invoke_bad_json_redacts_payload_when_dont_log_tool_data(
         await MCPUtil.invoke_mcp_tool(server, tool, ctx, bad_json)
 
     assert str(exc_info.value) == "Invalid JSON input for tool test_tool_1"
+    assert exc_info.value.__cause__ is None
     assert "SECRET_TOKEN_123" not in str(exc_info.value)
     assert "SECRET_TOKEN_123" not in caplog.text
 
@@ -263,6 +264,8 @@ async def test_mcp_invoke_bad_json_includes_payload_when_tool_logging_enabled(
         await MCPUtil.invoke_mcp_tool(server, tool, ctx, bad_json)
 
     assert str(exc_info.value) == f"Invalid JSON input for tool test_tool_1: {bad_json}"
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+    assert exc_info.value.__cause__.doc == bad_json
     assert "SECRET_TOKEN_123" in str(exc_info.value)
     assert "SECRET_TOKEN_123" in caplog.text
 

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -242,6 +242,7 @@ async def test_mcp_invoke_bad_json_redacts_payload_when_dont_log_tool_data(
 
     assert str(exc_info.value) == "Invalid JSON input for tool test_tool_1"
     assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
     assert "SECRET_TOKEN_123" not in str(exc_info.value)
     assert "SECRET_TOKEN_123" not in caplog.text
 

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -9,6 +9,7 @@ from inline_snapshot import snapshot
 from mcp.types import CallToolResult, ImageContent, TextContent, Tool as MCPTool
 from pydantic import BaseModel, TypeAdapter
 
+import agents._debug as _debug
 from agents import Agent, FunctionTool, RunContextWrapper, default_tool_error_function
 from agents.exceptions import AgentsException, MCPToolCancellationError, ModelBehaviorError
 from agents.mcp import MCPServer, MCPUtil
@@ -220,6 +221,50 @@ async def test_mcp_invoke_bad_json_errors(caplog: pytest.LogCaptureFixture):
         await MCPUtil.invoke_mcp_tool(server, tool, ctx, "not_json")
 
     assert "Invalid JSON input for tool test_tool_1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_invoke_bad_json_redacts_payload_when_dont_log_tool_data(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", True)
+
+    server = FakeMCPServer()
+    server.add_tool("test_tool_1", {})
+
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="test_tool_1", inputSchema={})
+    bad_json = '{"secret":"SECRET_TOKEN_123"'
+
+    with pytest.raises(ModelBehaviorError) as exc_info:
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, bad_json)
+
+    assert str(exc_info.value) == "Invalid JSON input for tool test_tool_1"
+    assert "SECRET_TOKEN_123" not in str(exc_info.value)
+    assert "SECRET_TOKEN_123" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_invoke_bad_json_includes_payload_when_tool_logging_enabled(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    server = FakeMCPServer()
+    server.add_tool("test_tool_1", {})
+
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="test_tool_1", inputSchema={})
+    bad_json = '{"secret":"SECRET_TOKEN_123"'
+
+    with pytest.raises(ModelBehaviorError) as exc_info:
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, bad_json)
+
+    assert str(exc_info.value) == f"Invalid JSON input for tool test_tool_1: {bad_json}"
+    assert "SECRET_TOKEN_123" in str(exc_info.value)
+    assert "SECRET_TOKEN_123" in caplog.text
 
 
 class CrashingFakeMCPServer(FakeMCPServer):


### PR DESCRIPTION
### Summary

Redacts malformed MCP tool input from `ModelBehaviorError` in `src/agents/mcp/util.py` when `DONT_LOG_TOOL_DATA` is enabled.

Previously, `invoke_mcp_tool()` suppressed debug logging in no-tool-data mode but still embedded the raw `input_json` in the raised exception, which could leak secrets through logs, traces, or error reporting pipelines. This change makes the exception path follow the same redaction policy as logging, while preserving the existing full-payload behavior when tool-data logging is explicitly enabled.

Also adds regression coverage in `tests/mcp/test_mcp_util.py` for both redacted and non-redacted modes.

### Test plan

- Ran the repository verification stack via `bash .agents/skills/code-change-verification/scripts/run.sh`
- Verified targeted MCP bad-JSON tests in `tests/mcp/test_mcp_util.py`
- Confirmed full repository checks passed, including format, lint, typecheck, and tests

### Issue number

Closes #3087

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
