### PR TITLE
fix: reject string-like shell commands

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -619,8 +619,12 @@ def coerce_shell_call(tool_call: Any) -> ShellCallData:
         raise ModelBehaviorError("Shell call is missing an action payload.")
 
     commands_value = get_mapping_or_attr(action_payload, "commands")
-    if not isinstance(commands_value, Sequence):
-        raise ModelBehaviorError("Shell call action is missing commands.")
+    if isinstance(commands_value, str | bytes | bytearray) or not isinstance(
+        commands_value, Sequence
+    ):
+        raise ModelBehaviorError(
+            "Shell call action commands must be a sequence of command strings."
+        )
     commands: list[str] = []
     for entry in commands_value:
         if entry is None:

--- a/tests/test_shell_call_serialization.py
+++ b/tests/test_shell_call_serialization.py
@@ -29,6 +29,16 @@ def test_coerce_shell_call_requires_commands() -> None:
         run_loop.coerce_shell_call(tool_call)
 
 
+@pytest.mark.parametrize("commands", ["echo hi", b"echo hi", bytearray(b"echo hi")])
+def test_coerce_shell_call_rejects_string_like_commands(commands: object) -> None:
+    tool_call = {"call_id": "shell-3", "action": {"commands": commands}}
+    with pytest.raises(
+        ModelBehaviorError,
+        match="Shell call action commands must be a sequence of command strings.",
+    ):
+        run_loop.coerce_shell_call(tool_call)
+
+
 def test_normalize_shell_output_handles_timeout() -> None:
     entry = {
         "stdout": "",


### PR DESCRIPTION
### Summary

This pull request fixes shell call command normalization when the model returns a string-like `action.commands` payload.

- reject top-level `str`, `bytes`, and `bytearray` values in `coerce_shell_call()` instead of treating them as generic sequences
- raise a clear `ModelBehaviorError` before malformed payloads can be split into character-by-character commands
- add regression coverage for string-like `commands` payloads while keeping valid list-based shell calls unchanged

### Test plan

- `uv run pytest tests/test_shell_call_serialization.py`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3091

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
