### PR TITLE
fix: filter custom_tool_call types in remove_all_tools handoff filter

### DIFF
--- a/src/agents/extensions/handoff_filters.py
+++ b/src/agents/extensions/handoff_filters.py
@@ -96,6 +96,8 @@ def _remove_tool_types_from_input(
         "shell_call_output",
         "apply_patch_call",
         "apply_patch_call_output",
+        "custom_tool_call",
+        "custom_tool_call_output",
     ]
 
     filtered_items: list[TResponseInputItem] = []

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -1041,6 +1041,8 @@ def test_removes_hosted_tool_types_from_input_history() -> None:
         "shell_call_output",
         "apply_patch_call",
         "apply_patch_call_output",
+        "custom_tool_call",
+        "custom_tool_call_output",
     ]
     input_items: list[TResponseInputItem] = [_get_message_input_item("Hello")]
     for t in hosted_types:


### PR DESCRIPTION
 ## Summary
  - `remove_all_tools` strips hosted tool types from raw input history before a handoff so the next agent does not see the
   previous agent's tool plumbing. The hosted-types list omitted `custom_tool_call` and `custom_tool_call_output`, so
  custom tool calls (produced by `CustomTool` / `ResponseCustomToolCall`) leaked through after a handoff.
  - Add both types to the filter list in `src/agents/extensions/handoff_filters.py`.
  - Extend `test_removes_hosted_tool_types_from_input_history` to cover the two new types — without the source change the
  test fails.

  ## Test plan
  - [x] `uv run pytest tests/test_extension_filters.py` — 36 passed
  - [x] `uv run ruff check` — clean
  - [x] `uv run ruff format --check` — clean