### PR TITLE
Reject string-like values for shell action commands

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -619,6 +619,10 @@ def coerce_shell_call(tool_call: Any) -> ShellCallData:
         raise ModelBehaviorError("Shell call is missing an action payload.")
 
     commands_value = get_mapping_or_attr(action_payload, "commands")
+    if isinstance(commands_value, (str, bytes, bytearray)):
+        raise ModelBehaviorError(
+            "Shell call action commands must be a list of strings, not a single string-like value."
+        )
     if not isinstance(commands_value, Sequence):
         raise ModelBehaviorError("Shell call action is missing commands.")
     commands: list[str] = []

--- a/tests/test_shell_call_serialization.py
+++ b/tests/test_shell_call_serialization.py
@@ -29,6 +29,13 @@ def test_coerce_shell_call_requires_commands() -> None:
         run_loop.coerce_shell_call(tool_call)
 
 
+def test_coerce_shell_call_rejects_string_like_commands() -> None:
+    for commands in ("echo hi", b"echo hi", bytearray(b"echo hi")):
+        tool_call = {"call_id": "shell-3", "action": {"commands": commands}}
+        with pytest.raises(ModelBehaviorError, match="list of strings"):
+            run_loop.coerce_shell_call(tool_call)
+
+
 def test_normalize_shell_output_handles_timeout() -> None:
     entry = {
         "stdout": "",


### PR DESCRIPTION
Summary:
- reject str/bytes/bytearray values for shell action commands in coerce_shell_call
- raise ModelBehaviorError instead of iterating character-by-character
- add regression coverage for string-like command payloads

Testing:
- uv run pytest tests/test_shell_call_serialization.py -q