### PR TITLE
fix: make ToolContext hashable to match RunContextWrapper

### DIFF
--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -32,7 +32,7 @@ def _assert_must_pass_tool_arguments() -> str:
 _MISSING = object()
 
 
-@dataclass
+@dataclass(eq=False)
 class ToolContext(RunContextWrapper[TContext]):
     """The context of a tool call."""
 

--- a/tests/test_tool_context.py
+++ b/tests/test_tool_context.py
@@ -12,6 +12,23 @@ from agents.usage import Usage
 from tests.utils.hitl import make_context_wrapper
 
 
+def test_tool_context_is_hashable_like_run_context_wrapper() -> None:
+    # RunContextWrapper is declared with @dataclass(eq=False) so instances remain
+    # hashable by identity. ToolContext inherits from it and must preserve that
+    # contract; a bare @dataclass on the subclass would set __hash__ = None.
+    parent: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    child: ToolContext[dict[str, object]] = ToolContext(
+        context={},
+        tool_name="t",
+        tool_call_id="call-hash",
+        tool_arguments="{}",
+    )
+
+    assert hash(parent) == hash(parent)
+    assert hash(child) == hash(child)
+    assert {child: "value"}[child] == "value"
+
+
 def test_tool_context_requires_fields() -> None:
     ctx: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Summary

`ToolContext` (`src/agents/tool_context.py`) is decorated with bare `@dataclass`, which defaults to `eq=True` and therefore sets `__hash__ = None`, making instances unhashable. Its parent `RunContextWrapper` (`src/agents/run_context.py`) is decorated `@dataclass(eq=False)` and is hashable by identity. The subclass silently dropped the parent's hashability contract, so user code that puts a tool context into a `set`, `dict` key, `WeakKeyDictionary`, `lru_cache`, etc. — a reasonable thing to do given the parent supports it — fails with `TypeError: unhashable type: 'ToolContext'`.

Repro against `main` / v0.15.1:

```python
from agents.run_context import RunContextWrapper
from agents.tool_context import ToolContext

hash(RunContextWrapper(context=None))                                            # OK
hash(ToolContext(context=None, tool_name="t", tool_call_id="c", tool_arguments="{}"))
# TypeError: unhashable type: 'ToolContext'
```

Fix: switch the decorator to `@dataclass(eq=False)` so the subclass preserves the parent's identity-based hashing. This is a one-line change with no behavior impact for code that does not rely on hashing — `ToolContext` already defines its own `__init__`, so the dataclass-generated `__eq__` was the only thing the bare decorator was adding, and identity equality is what the parent intentionally uses.

### Test plan

- Added `tests/test_tool_context.py::test_tool_context_is_hashable_like_run_context_wrapper` covering `hash(ToolContext(...))`, equality of repeated hashes, and use as a dict key.
- `uv run pytest tests/test_tool_context.py -v` — all 15 tests pass.
- `make format`, `make lint` — clean.
- `make typecheck` — no new errors in the touched files (pre-existing errors in voice/sandbox modules are unrelated).
- `make tests` — same 12 pre-existing failures as `main` (sandbox/runloop and voice modules); no new failures.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass