### PR TITLE
fix: omit chat completions store by default

### DIFF
--- a/src/agents/models/chatcmpl_helpers.py
+++ b/src/agents/models/chatcmpl_helpers.py
@@ -29,9 +29,7 @@ class ChatCmplHelpers:
 
     @classmethod
     def get_store_param(cls, client: AsyncOpenAI, model_settings: ModelSettings) -> bool | None:
-        # Match the behavior of Responses where store is True when not given
-        default_store = True if cls.is_openai(client) else None
-        return model_settings.store if model_settings.store is not None else default_store
+        return model_settings.store
 
     @classmethod
     def get_stream_options_param(

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -577,12 +577,12 @@ async def test_fetch_response_stream(monkeypatch) -> None:
 
 
 def test_store_param():
-    """Should default to True for OpenAI API calls, and False otherwise."""
+    """Should omit store unless it is explicitly set."""
 
     model_settings = ModelSettings()
     client = AsyncOpenAI()
-    assert ChatCmplHelpers.get_store_param(client, model_settings) is True, (
-        "Should default to True for OpenAI API calls"
+    assert ChatCmplHelpers.get_store_param(client, model_settings) is None, (
+        "Should omit store when not specified for Chat Completions"
     )
 
     model_settings = ModelSettings(store=False)


### PR DESCRIPTION
### Summary

Fixes Chat Completions `store` default handling so `ModelSettings(store=None)` no longer sends `store=True` for the official OpenAI client.

`ModelSettings.store` documents that Chat Completions is disabled when not specified, but `ChatCmplHelpers.get_store_param()` previously opted official OpenAI clients into `store=True`. This change returns the explicit setting as-is, preserving explicit `store=True` and `store=False` while omitting the parameter when unset.

### Test plan

- `uv run pytest tests/models/test_openai_chatcompletions.py -k 'store_param or fetch_response'`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3103

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
