### PR TITLE
fix: reject failed responses stream terminals

### DIFF
--- a/src/agents/exceptions.py
+++ b/src/agents/exceptions.py
@@ -16,6 +16,16 @@ if TYPE_CHECKING:
 
 from .util._pretty_print import pretty_print_run_error_details
 
+_DRAIN_STREAM_EVENTS_ATTR = "_agents_drain_queued_stream_events"
+
+
+def _mark_error_to_drain_stream_events(error: Exception) -> None:
+    setattr(error, _DRAIN_STREAM_EVENTS_ATTR, True)
+
+
+def _should_drain_stream_events_before_raising(error: Exception) -> bool:
+    return bool(getattr(error, _DRAIN_STREAM_EVENTS_ATTR, False))
+
 
 @dataclass
 class RunErrorDetails:

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -29,6 +29,10 @@ from ...items import ItemHelpers, ModelResponse, TResponseInputItem, TResponseSt
 from ...logger import logger
 from ...model_settings import ModelSettings
 from ...models._openai_retry import get_openai_retry_advice
+from ...models._response_terminal import (
+    response_error_event_failure_error,
+    response_terminal_failure_error,
+)
 from ...models._retry_runtime import should_disable_provider_managed_retries
 from ...models.chatcmpl_converter import Converter
 from ...models.chatcmpl_helpers import HEADERS, HEADERS_OVERRIDE, ChatCmplHelpers
@@ -421,17 +425,29 @@ class AnyLLMModel(Model):
             )
 
             final_response: Response | None = None
+            terminal_failure_error: ModelBehaviorError | None = None
             try:
                 async for chunk in stream:
+                    chunk_type = getattr(chunk, "type", None)
                     if isinstance(chunk, ResponseCompletedEvent):
                         final_response = chunk.response
-                    elif getattr(chunk, "type", None) in {"response.failed", "response.incomplete"}:
+                    elif chunk_type in {"response.failed", "response.incomplete"}:
                         terminal_response = getattr(chunk, "response", None)
-                        if isinstance(terminal_response, Response):
-                            final_response = terminal_response
+                        terminal_failure_error = response_terminal_failure_error(
+                            cast(str, chunk_type),
+                            terminal_response if isinstance(terminal_response, Response) else None,
+                        )
+                    elif chunk_type in {"error", "response.error"}:
+                        terminal_failure_error = response_error_event_failure_error(
+                            cast(str, chunk_type),
+                            chunk,
+                        )
                     yield chunk
             finally:
                 await self._maybe_aclose(stream)
+
+            if terminal_failure_error is not None:
+                raise terminal_failure_error
 
             if tracing.include_data() and final_response:
                 span_response.span_data.response = final_response

--- a/src/agents/models/_response_terminal.py
+++ b/src/agents/models/_response_terminal.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from typing import Any
+
 from openai.types.responses import Response
+
+from ..exceptions import ModelBehaviorError, _mark_error_to_drain_stream_events
 
 
 def format_response_terminal_failure(
@@ -25,3 +29,36 @@ def format_response_terminal_failure(
     if details:
         message = f"{message} {'; '.join(details)}."
     return message
+
+
+def format_response_error_event(event_type: str, event: Any) -> str:
+    message = f"Responses stream ended with terminal event `{event_type}`."
+    details: list[str] = []
+    code = getattr(event, "code", None)
+    if code:
+        details.append(f"code={code}")
+    error_message = getattr(event, "message", None)
+    if error_message:
+        details.append(f"message={error_message}")
+    param = getattr(event, "param", None)
+    if param:
+        details.append(f"param={param}")
+
+    if details:
+        message = f"{message} {'; '.join(details)}."
+    return message
+
+
+def response_terminal_failure_error(
+    event_type: str,
+    response: Response | None,
+) -> ModelBehaviorError:
+    error = ModelBehaviorError(format_response_terminal_failure(event_type, response))
+    _mark_error_to_drain_stream_events(error)
+    return error
+
+
+def response_error_event_failure_error(event_type: str, event: Any) -> ModelBehaviorError:
+    error = ModelBehaviorError(format_response_error_event(event_type, event))
+    _mark_error_to_drain_stream_events(error)
+    return error

--- a/src/agents/models/_response_terminal.py
+++ b/src/agents/models/_response_terminal.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from openai.types.responses import Response
+
+
+def format_response_terminal_failure(
+    event_type: str,
+    response: Response | None,
+) -> str:
+    message = f"Responses stream ended with terminal event `{event_type}`."
+    if response is None:
+        return message
+
+    details: list[str] = []
+    status = getattr(response, "status", None)
+    if status:
+        details.append(f"status={status}")
+    error = getattr(response, "error", None)
+    if error:
+        details.append(f"error={error}")
+    incomplete_details = getattr(response, "incomplete_details", None)
+    if incomplete_details:
+        details.append(f"incomplete_details={incomplete_details}")
+
+    if details:
+        message = f"{message} {'; '.join(details)}."
+    return message

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -68,6 +68,7 @@ from ..usage import Usage, model_usage_to_span_usage
 from ..util._json import _to_dump_compatible
 from ..version import __version__
 from ._openai_retry import get_openai_retry_advice
+from ._response_terminal import format_response_terminal_failure
 from ._retry_runtime import (
     should_disable_provider_managed_retries,
     should_disable_websocket_pre_event_retries,
@@ -182,30 +183,6 @@ def _construct_response_stream_event_from_payload(
         ResponseStreamEvent,
         construct_type(type_=ResponseStreamEvent, value=dict(payload)),
     )
-
-
-def format_response_terminal_failure(
-    event_type: str,
-    response: Response | None,
-) -> str:
-    message = f"Responses stream ended with terminal event `{event_type}`."
-    if response is None:
-        return message
-
-    details: list[str] = []
-    status = getattr(response, "status", None)
-    if status:
-        details.append(f"status={status}")
-    error = getattr(response, "error", None)
-    if error:
-        details.append(f"error={error}")
-    incomplete_details = getattr(response, "incomplete_details", None)
-    if incomplete_details:
-        details.append(f"incomplete_details={incomplete_details}")
-
-    if details:
-        message = f"{message} {'; '.join(details)}."
-    return message
 
 
 @dataclass(frozen=True)

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -39,7 +39,7 @@ from .._tool_identity import (
 )
 from ..agent_output import AgentOutputSchemaBase
 from ..computer import AsyncComputer, Computer
-from ..exceptions import UserError
+from ..exceptions import ModelBehaviorError, UserError
 from ..handoffs import Handoff
 from ..items import ItemHelpers, ModelResponse, TResponseInputItem
 from ..logger import logger
@@ -182,6 +182,30 @@ def _construct_response_stream_event_from_payload(
         ResponseStreamEvent,
         construct_type(type_=ResponseStreamEvent, value=dict(payload)),
     )
+
+
+def format_response_terminal_failure(
+    event_type: str,
+    response: Response | None,
+) -> str:
+    message = f"Responses stream ended with terminal event `{event_type}`."
+    if response is None:
+        return message
+
+    details: list[str] = []
+    status = getattr(response, "status", None)
+    if status:
+        details.append(f"status={status}")
+    error = getattr(response, "error", None)
+    if error:
+        details.append(f"error={error}")
+    incomplete_details = getattr(response, "incomplete_details", None)
+    if incomplete_details:
+        details.append(f"incomplete_details={incomplete_details}")
+
+    if details:
+        message = f"{message} {'; '.join(details)}."
+    return message
 
 
 @dataclass(frozen=True)
@@ -555,6 +579,7 @@ class OpenAIResponsesModel(Model):
                 )
 
                 final_response: Response | None = None
+                terminal_failure_error: ModelBehaviorError | None = None
                 yielded_terminal_event = False
                 close_stream_in_background = False
                 try:
@@ -567,8 +592,14 @@ class OpenAIResponsesModel(Model):
                             "response.incomplete",
                         }:
                             terminal_response = getattr(chunk, "response", None)
-                            if isinstance(terminal_response, Response):
-                                final_response = terminal_response
+                            terminal_failure_error = ModelBehaviorError(
+                                format_response_terminal_failure(
+                                    cast(str, chunk_type),
+                                    terminal_response
+                                    if isinstance(terminal_response, Response)
+                                    else None,
+                                )
+                            )
                         if chunk_type in {
                             "response.completed",
                             "response.failed",
@@ -592,6 +623,8 @@ class OpenAIResponsesModel(Model):
                                 )
                             else:
                                 raise
+                if terminal_failure_error is not None:
+                    raise terminal_failure_error
 
                 if final_response and tracing.include_data():
                     span_response.span_data.response = final_response
@@ -1089,8 +1122,12 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
             elif event_type in {"response.incomplete", "response.failed"}:
                 terminal_event_type = cast(str, event_type)
                 terminal_response = getattr(event, "response", None)
-                if isinstance(terminal_response, Response):
-                    final_response = terminal_response
+                raise ModelBehaviorError(
+                    format_response_terminal_failure(
+                        terminal_event_type,
+                        terminal_response if isinstance(terminal_response, Response) else None,
+                    )
+                )
 
         if final_response is None:
             terminal_event_hint = (

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -68,7 +68,7 @@ from ..usage import Usage, model_usage_to_span_usage
 from ..util._json import _to_dump_compatible
 from ..version import __version__
 from ._openai_retry import get_openai_retry_advice
-from ._response_terminal import format_response_terminal_failure
+from ._response_terminal import response_error_event_failure_error, response_terminal_failure_error
 from ._retry_runtime import (
     should_disable_provider_managed_retries,
     should_disable_websocket_pre_event_retries,
@@ -569,18 +569,22 @@ class OpenAIResponsesModel(Model):
                             "response.incomplete",
                         }:
                             terminal_response = getattr(chunk, "response", None)
-                            terminal_failure_error = ModelBehaviorError(
-                                format_response_terminal_failure(
-                                    cast(str, chunk_type),
-                                    terminal_response
-                                    if isinstance(terminal_response, Response)
-                                    else None,
-                                )
+                            terminal_failure_error = response_terminal_failure_error(
+                                cast(str, chunk_type),
+                                terminal_response
+                                if isinstance(terminal_response, Response)
+                                else None,
+                            )
+                        elif chunk_type in {"error", "response.error"}:
+                            terminal_failure_error = response_error_event_failure_error(
+                                cast(str, chunk_type),
+                                chunk,
                             )
                         if chunk_type in {
                             "response.completed",
                             "response.failed",
                             "response.incomplete",
+                            "error",
                             "response.error",
                         }:
                             yielded_terminal_event = True
@@ -1099,11 +1103,9 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
             elif event_type in {"response.incomplete", "response.failed"}:
                 terminal_event_type = cast(str, event_type)
                 terminal_response = getattr(event, "response", None)
-                raise ModelBehaviorError(
-                    format_response_terminal_failure(
-                        terminal_event_type,
-                        terminal_response if isinstance(terminal_response, Response) else None,
-                    )
+                raise response_terminal_failure_error(
+                    terminal_event_type,
+                    terminal_response if isinstance(terminal_response, Response) else None,
                 )
 
         if final_response is None:

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -18,6 +18,7 @@ from .exceptions import (
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
     RunErrorDetails,
+    _should_drain_stream_events_before_raising,
 )
 from .guardrail import InputGuardrailResult, OutputGuardrailResult
 from .items import (
@@ -705,7 +706,12 @@ class RunResultStreaming(RunResultBase):
         try:
             while True:
                 self._check_errors()
-                should_drain_queued_events = isinstance(self._stored_exception, MaxTurnsExceeded)
+                should_drain_queued_events = isinstance(
+                    self._stored_exception, MaxTurnsExceeded
+                ) or (
+                    self._stored_exception is not None
+                    and _should_drain_stream_events_before_raising(self._stored_exception)
+                )
                 if self._stored_exception and (
                     not should_drain_queued_events or self._event_queue.empty()
                 ):

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -58,7 +58,7 @@ from ..items import (
 from ..lifecycle import RunHooks
 from ..logger import logger
 from ..memory import Session
-from ..models.openai_responses import format_response_terminal_failure
+from ..models._response_terminal import format_response_terminal_failure
 from ..result import RunResultStreaming
 from ..run_config import ReasoningItemIdPolicy, RunConfig
 from ..run_context import AgentHookContext, RunContextWrapper, TContext

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -58,7 +58,10 @@ from ..items import (
 from ..lifecycle import RunHooks
 from ..logger import logger
 from ..memory import Session
-from ..models._response_terminal import format_response_terminal_failure
+from ..models._response_terminal import (
+    response_error_event_failure_error,
+    response_terminal_failure_error,
+)
 from ..result import RunResultStreaming
 from ..run_config import ReasoningItemIdPolicy, RunConfig
 from ..run_context import AgentHookContext, RunContextWrapper, TContext
@@ -1487,12 +1490,12 @@ async def run_single_turn_streamed(
         elif getattr(event, "type", None) in {"response.incomplete", "response.failed"}:
             event_type = cast(str, event.type)
             maybe_response = getattr(event, "response", None)
-            raise ModelBehaviorError(
-                format_response_terminal_failure(
-                    event_type,
-                    maybe_response if isinstance(maybe_response, Response) else None,
-                )
+            raise response_terminal_failure_error(
+                event_type,
+                maybe_response if isinstance(maybe_response, Response) else None,
             )
+        elif getattr(event, "type", None) in {"error", "response.error"}:
+            raise response_error_event_failure_error(cast(str, event.type), event)
 
         if terminal_response is not None:
             if is_completed_event and not terminal_response.output and streamed_response_output:

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -58,6 +58,7 @@ from ..items import (
 from ..lifecycle import RunHooks
 from ..logger import logger
 from ..memory import Session
+from ..models.openai_responses import format_response_terminal_failure
 from ..result import RunResultStreaming
 from ..run_config import ReasoningItemIdPolicy, RunConfig
 from ..run_context import AgentHookContext, RunContextWrapper, TContext
@@ -1484,9 +1485,14 @@ async def run_single_turn_streamed(
             is_completed_event = True
             terminal_response = event.response
         elif getattr(event, "type", None) in {"response.incomplete", "response.failed"}:
+            event_type = cast(str, event.type)
             maybe_response = getattr(event, "response", None)
-            if isinstance(maybe_response, Response):
-                terminal_response = maybe_response
+            raise ModelBehaviorError(
+                format_response_terminal_failure(
+                    event_type,
+                    maybe_response if isinstance(maybe_response, Response) else None,
+                )
+            )
 
         if terminal_response is not None:
             if is_completed_event and not terminal_response.output and streamed_response_output:

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -17,6 +17,9 @@ from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import ChoiceDelta
 from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
 from openai.types.responses import Response, ResponseCompletedEvent, ResponseOutputMessage
+from openai.types.responses.response_error_event import ResponseErrorEvent
+from openai.types.responses.response_failed_event import ResponseFailedEvent
+from openai.types.responses.response_incomplete_event import ResponseIncompleteEvent
 from openai.types.responses.response_output_text import ResponseOutputText
 from openai.types.responses.response_usage import (
     InputTokensDetails,
@@ -28,6 +31,7 @@ from pydantic import BaseModel
 from agents import (
     Agent,
     Handoff,
+    ModelBehaviorError,
     ModelSettings,
     ModelTracing,
     Tool,
@@ -532,6 +536,91 @@ async def test_any_llm_stream_passthrough_uses_responses_when_supported(monkeypa
     assert provider.responses_calls == []
     assert provider.private_responses_calls[0]["params"].previous_response_id == "resp_prev"
     assert provider.private_responses_calls[0]["params"].conversation == "conv_123"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("terminal_event_type", "terminal_event_cls"),
+    [
+        ("response.incomplete", ResponseIncompleteEvent),
+        ("response.failed", ResponseFailedEvent),
+    ],
+)
+async def test_any_llm_responses_stream_rejects_failed_terminal_events(
+    monkeypatch,
+    terminal_event_type: str,
+    terminal_event_cls: type[Any],
+) -> None:
+    async def response_stream() -> AsyncIterator[Any]:
+        yield terminal_event_cls(
+            type=terminal_event_type,
+            response=_response("partial", response_id="resp-terminal"),
+            sequence_number=1,
+        )
+
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=response_stream())
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    AnyLLMModel = module.AnyLLMModel
+
+    model = AnyLLMModel(model="openai/gpt-5.4-mini")
+    events = []
+    with pytest.raises(ModelBehaviorError, match=terminal_event_type):
+        async for event in model.stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        ):
+            events.append(event)
+
+    assert len(events) == 1
+    assert events[0].type == terminal_event_type
+    assert events[0].response.id == "resp-terminal"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_rejects_error_event(monkeypatch) -> None:
+    async def response_stream() -> AsyncIterator[ResponseErrorEvent]:
+        yield ResponseErrorEvent(
+            type="error",
+            code="invalid_request_error",
+            message="bad request",
+            param=None,
+            sequence_number=1,
+        )
+
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=response_stream())
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    AnyLLMModel = module.AnyLLMModel
+
+    model = AnyLLMModel(model="openai/gpt-5.4-mini")
+    events = []
+    with pytest.raises(ModelBehaviorError, match="invalid_request_error"):
+        async for event in model.stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        ):
+            events.append(event)
+
+    assert len(events) == 1
+    assert events[0].type == "error"
+    assert events[0].code == "invalid_request_error"
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import httpx
 import pytest
 from openai import NOT_GIVEN, APIConnectionError, RateLimitError, omit
-from openai.types.responses import ResponseCompletedEvent
+from openai.types.responses import ResponseCompletedEvent, ResponseErrorEvent
 from openai.types.shared.reasoning import Reasoning
 
 from agents import (
@@ -1768,6 +1768,56 @@ async def test_websocket_model_stream_response_rejects_failed_terminal_response_
     assert len(events) == 1
     assert events[0].type == terminal_event_type
     assert cast(Any, events[0]).response.id == "resp-terminal"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_rejects_response_error_terminal_event(monkeypatch):
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=object())  # type: ignore[arg-type]
+
+    async def dummy_fetch_response(
+        system_instructions,
+        input,
+        model_settings,
+        tools,
+        output_schema,
+        handoffs,
+        previous_response_id,
+        conversation_id,
+        stream,
+        prompt,
+    ):
+        class DummyStream:
+            async def __aiter__(self):
+                yield ResponseErrorEvent(
+                    type="error",
+                    code="invalid_request_error",
+                    message="bad request",
+                    param=None,
+                    sequence_number=0,
+                )
+
+        return DummyStream()
+
+    monkeypatch.setattr(model, "_fetch_response", dummy_fetch_response)
+
+    events = []
+    with pytest.raises(ModelBehaviorError, match="invalid_request_error"):
+        async for event in model.stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        ):
+            events.append(event)
+
+    assert len(events) == 1
+    assert events[0].type == "error"
+    assert events[0].code == "invalid_request_error"
+    assert events[0].message == "bad request"
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -23,7 +23,7 @@ from agents import (
     __version__,
     trace,
 )
-from agents.exceptions import UserError
+from agents.exceptions import ModelBehaviorError, UserError
 from agents.models._retry_runtime import (
     provider_managed_retries_disabled,
     websocket_pre_event_retries_disabled,
@@ -1709,7 +1709,7 @@ async def test_websocket_model_stream_response_yields_typed_events(monkeypatch):
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 @pytest.mark.parametrize("terminal_event_type", ["response.incomplete", "response.failed"])
-async def test_websocket_model_get_response_accepts_terminal_response_payload_events(
+async def test_websocket_model_get_response_rejects_failed_terminal_response_payload_events(
     monkeypatch, terminal_event_type: str
 ):
     client = DummyWSClient()
@@ -1723,23 +1723,22 @@ async def test_websocket_model_get_response_accepts_terminal_response_payload_ev
 
     monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
 
-    response = await model.get_response(
-        system_instructions=None,
-        input="hi",
-        model_settings=ModelSettings(),
-        tools=[],
-        output_schema=None,
-        handoffs=[],
-        tracing=ModelTracing.DISABLED,
-    )
-
-    assert response.response_id == "resp-terminal"
+    with pytest.raises(ModelBehaviorError, match=terminal_event_type):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
 
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 @pytest.mark.parametrize("terminal_event_type", ["response.incomplete", "response.failed"])
-async def test_websocket_model_stream_response_accepts_terminal_response_payload_events(
+async def test_websocket_model_stream_response_rejects_failed_terminal_response_payload_events(
     monkeypatch, terminal_event_type: str
 ):
     client = DummyWSClient()
@@ -1754,16 +1753,17 @@ async def test_websocket_model_stream_response_accepts_terminal_response_payload
     monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
 
     events = []
-    async for event in model.stream_response(
-        system_instructions=None,
-        input="hi",
-        model_settings=ModelSettings(),
-        tools=[],
-        output_schema=None,
-        handoffs=[],
-        tracing=ModelTracing.DISABLED,
-    ):
-        events.append(event)
+    with pytest.raises(ModelBehaviorError, match=terminal_event_type):
+        async for event in model.stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        ):
+            events.append(event)
 
     assert len(events) == 1
     assert events[0].type == terminal_event_type

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -24,6 +24,7 @@ from agents import (
     InputGuardrail,
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
+    ModelBehaviorError,
     ModelRetrySettings,
     ModelSettings,
     OpenAIResponsesWSModel,
@@ -144,7 +145,7 @@ async def test_simple_first_run():
         ("response.failed", ResponseFailedEvent),
     ],
 )
-async def test_streamed_run_accepts_terminal_response_payload_events(
+async def test_streamed_run_rejects_failed_terminal_response_payload_events(
     terminal_event_type: str, terminal_event_cls: type[Any]
 ) -> None:
     class TerminalPayloadFakeModel(FakeModel):
@@ -187,12 +188,12 @@ async def test_streamed_run_accepts_terminal_response_payload_events(
     agent = Agent(name="test", model=model)
 
     result = Runner.run_streamed(agent, input="test")
-    async for _ in result.stream_events():
-        pass
+    with pytest.raises(ModelBehaviorError, match=terminal_event_type):
+        async for _ in result.stream_events():
+            pass
 
-    assert result.final_output == "partial final"
-    assert len(result.raw_responses) == 1
-    assert result.raw_responses[0].response_id == "resp-partial"
+    assert result.final_output is None
+    assert result.raw_responses == []
 
 
 @pytest.mark.asyncio
@@ -323,7 +324,7 @@ async def test_streamed_run_preserves_request_usage_entries_after_conversation_l
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 @pytest.mark.parametrize("terminal_event_type", ["response.incomplete", "response.failed"])
-async def test_streamed_run_accepts_terminal_response_payload_events_from_ws_model(
+async def test_streamed_run_rejects_failed_terminal_response_payload_events_from_ws_model(
     monkeypatch, terminal_event_type: str
 ) -> None:
     class DummyWSConnection:
@@ -372,12 +373,12 @@ async def test_streamed_run_accepts_terminal_response_payload_events_from_ws_mod
 
     agent = Agent(name="test", model=model)
     result = Runner.run_streamed(agent, input="test")
-    async for _ in result.stream_events():
-        pass
+    with pytest.raises(ModelBehaviorError, match=terminal_event_type):
+        async for _ in result.stream_events():
+            pass
 
-    assert result.final_output == "partial final"
-    assert len(result.raw_responses) == 1
-    assert result.raw_responses[0].response_id == "resp-ws"
+    assert result.final_output is None
+    assert result.raw_responses == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -9,6 +9,7 @@ import pytest
 from openai import APIConnectionError, BadRequestError
 from openai.types.responses import (
     ResponseCompletedEvent,
+    ResponseErrorEvent,
     ResponseFailedEvent,
     ResponseFunctionToolCall,
     ResponseIncompleteEvent,
@@ -42,7 +43,7 @@ from agents.memory.openai_conversations_session import OpenAIConversationsSessio
 from agents.run import RunConfig
 from agents.run_internal import run_loop
 from agents.run_internal.run_loop import QueueCompleteSentinel
-from agents.stream_events import AgentUpdatedStreamEvent, StreamEvent
+from agents.stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent, StreamEvent
 from agents.usage import Usage
 
 from .fake_model import FakeModel, get_response_obj
@@ -188,10 +189,71 @@ async def test_streamed_run_rejects_failed_terminal_response_payload_events(
     agent = Agent(name="test", model=model)
 
     result = Runner.run_streamed(agent, input="test")
+    stream_events: list[StreamEvent] = []
     with pytest.raises(ModelBehaviorError, match=terminal_event_type):
-        async for _ in result.stream_events():
-            pass
+        async for event in result.stream_events():
+            stream_events.append(event)
 
+    assert len(stream_events) == 2
+    assert isinstance(stream_events[0], AgentUpdatedStreamEvent)
+    assert isinstance(stream_events[1], RawResponsesStreamEvent)
+    assert stream_events[1].data.type == terminal_event_type
+    assert result.final_output is None
+    assert result.raw_responses == []
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_rejects_response_error_terminal_event() -> None:
+    class TerminalErrorFakeModel(FakeModel):
+        async def stream_response(
+            self,
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            *,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        ):
+            self.last_turn_args = {
+                "system_instructions": system_instructions,
+                "input": input,
+                "model_settings": model_settings,
+                "tools": tools,
+                "output_schema": output_schema,
+                "previous_response_id": previous_response_id,
+                "conversation_id": conversation_id,
+            }
+            if self.first_turn_args is None:
+                self.first_turn_args = self.last_turn_args.copy()
+
+            yield ResponseErrorEvent(
+                type="error",
+                code="invalid_request_error",
+                message="bad request",
+                param=None,
+                sequence_number=0,
+            )
+
+    model = TerminalErrorFakeModel()
+    agent = Agent(name="test", model=model)
+
+    result = Runner.run_streamed(agent, input="test")
+    stream_events: list[StreamEvent] = []
+    with pytest.raises(ModelBehaviorError, match="error"):
+        async for event in result.stream_events():
+            stream_events.append(event)
+
+    assert len(stream_events) == 2
+    assert isinstance(stream_events[0], AgentUpdatedStreamEvent)
+    assert isinstance(stream_events[1], RawResponsesStreamEvent)
+    assert stream_events[1].data.type == "error"
+    assert stream_events[1].data.code == "invalid_request_error"
+    assert stream_events[1].data.message == "bad request"
     assert result.final_output is None
     assert result.raw_responses == []
 
@@ -373,10 +435,15 @@ async def test_streamed_run_rejects_failed_terminal_response_payload_events_from
 
     agent = Agent(name="test", model=model)
     result = Runner.run_streamed(agent, input="test")
+    stream_events: list[StreamEvent] = []
     with pytest.raises(ModelBehaviorError, match=terminal_event_type):
-        async for _ in result.stream_events():
-            pass
+        async for event in result.stream_events():
+            stream_events.append(event)
 
+    assert len(stream_events) == 2
+    assert isinstance(stream_events[0], AgentUpdatedStreamEvent)
+    assert isinstance(stream_events[1], RawResponsesStreamEvent)
+    assert stream_events[1].data.type == terminal_event_type
     assert result.final_output is None
     assert result.raw_responses == []
 

--- a/tests/test_responses_tracing.py
+++ b/tests/test_responses_tracing.py
@@ -4,7 +4,7 @@ from openai import AsyncOpenAI
 from openai.types.responses import ResponseCompletedEvent
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
-from agents import ModelSettings, ModelTracing, OpenAIResponsesModel, trace
+from agents import ModelBehaviorError, ModelSettings, ModelTracing, OpenAIResponsesModel, trace
 from agents.tracing.span_data import ResponseSpanData
 from tests import fake_model
 
@@ -322,41 +322,38 @@ async def test_stream_response_failed_or_incomplete_terminal_event_creates_trace
 
         monkeypatch.setattr(model, "_fetch_response", dummy_fetch_response)
 
-        async for _ in model.stream_response(
-            "instr",
-            "input",
-            ModelSettings(),
-            [],
-            None,
-            [],
-            ModelTracing.ENABLED,
-            previous_response_id=None,
-        ):
-            pass
+        with pytest.raises(ModelBehaviorError, match=terminal_event_type):
+            async for _ in model.stream_response(
+                "instr",
+                "input",
+                ModelSettings(),
+                [],
+                None,
+                [],
+                ModelTracing.ENABLED,
+                previous_response_id=None,
+            ):
+                pass
 
-    assert fetch_normalized_spans() == snapshot(
-        [
-            {
-                "workflow_name": "test",
-                "children": [
-                    {
-                        "type": "response",
+    assert fetch_normalized_spans() == [
+        {
+            "workflow_name": "test",
+            "children": [
+                {
+                    "type": "response",
+                    "error": {
+                        "message": "Error streaming response",
                         "data": {
-                            "response_id": "dummy-id-terminal",
-                            "usage": {
-                                "requests": 1,
-                                "input_tokens": 0,
-                                "output_tokens": 0,
-                                "total_tokens": 0,
-                                "input_tokens_details": {"cached_tokens": 0},
-                                "output_tokens_details": {"reasoning_tokens": 0},
-                            },
+                            "error": (
+                                f"Responses stream ended with terminal event "
+                                f"`{terminal_event_type}`."
+                            )
                         },
-                    }
-                ],
-            }
-        ]
-    )
+                    },
+                }
+            ],
+        }
+    ]
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

Rejects Responses streaming terminal events with `response.failed` or `response.incomplete` instead of converting their payloads into successful final model responses.

The streamed runner still exposes the raw terminal event before failing, but it no longer turns failed or incomplete payloads into `ModelResponse` or `final_output`. The websocket `get_response()` path now raises the same `ModelBehaviorError` for these terminal event types.

### Test plan

- `uv run pytest tests/models/test_openai_responses.py tests/test_agent_runner_streamed.py tests/test_responses_tracing.py -k 'rejects_failed_terminal_response_payload_events or failed_or_incomplete_terminal_event_creates_trace'`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3106

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
