### PR TITLE
fix: emit integer chat stream output indexes

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -84,6 +84,10 @@ class SequenceNumber:
 
 
 class ChatCmplStreamHandler:
+    @staticmethod
+    def _assistant_message_output_index(state: StreamingState) -> int:
+        return 1 if state.reasoning_content_index_and_output is not None else 0
+
     @classmethod
     def _finish_reasoning_summary_part(
         cls,
@@ -341,16 +345,14 @@ class ChatCmplStreamHandler:
                     # Notify consumers of the start of a new output message + first content part
                     yield ResponseOutputItemAddedEvent(
                         item=assistant_item,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=cls._assistant_message_output_index(state),
                         type="response.output_item.added",
                         sequence_number=sequence_number.get_and_increment(),
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.text_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=cls._assistant_message_output_index(state),
                         part=ResponseOutputText(
                             text="",
                             type="output_text",
@@ -374,8 +376,7 @@ class ChatCmplStreamHandler:
                     content_index=state.text_content_index_and_output[0],
                     delta=delta.content,
                     item_id=FAKE_RESPONSES_ID,
-                    output_index=state.reasoning_content_index_and_output
-                    is not None,  # fixed 0 -> 0 or 1
+                    output_index=cls._assistant_message_output_index(state),
                     type="response.output_text.delta",
                     sequence_number=sequence_number.get_and_increment(),
                     logprobs=delta_logprobs,
@@ -415,15 +416,14 @@ class ChatCmplStreamHandler:
                     # Notify downstream that assistant message + first content part are starting
                     yield ResponseOutputItemAddedEvent(
                         item=assistant_item,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=cls._assistant_message_output_index(state),
                         type="response.output_item.added",
                         sequence_number=sequence_number.get_and_increment(),
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.refusal_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
-                        output_index=(1 if state.reasoning_content_index_and_output else 0),
+                        output_index=cls._assistant_message_output_index(state),
                         part=ResponseOutputRefusal(
                             refusal="",
                             type="refusal",
@@ -436,8 +436,7 @@ class ChatCmplStreamHandler:
                     content_index=state.refusal_content_index_and_output[0],
                     delta=delta.refusal,
                     item_id=FAKE_RESPONSES_ID,
-                    output_index=state.reasoning_content_index_and_output
-                    is not None,  # fixed 0 -> 0 or 1
+                    output_index=cls._assistant_message_output_index(state),
                     type="response.refusal.delta",
                     sequence_number=sequence_number.get_and_increment(),
                 )
@@ -603,8 +602,7 @@ class ChatCmplStreamHandler:
             yield ResponseContentPartDoneEvent(
                 content_index=state.text_content_index_and_output[0],
                 item_id=FAKE_RESPONSES_ID,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=cls._assistant_message_output_index(state),
                 part=state.text_content_index_and_output[1],
                 type="response.content_part.done",
                 sequence_number=sequence_number.get_and_increment(),
@@ -616,8 +614,7 @@ class ChatCmplStreamHandler:
             yield ResponseContentPartDoneEvent(
                 content_index=state.refusal_content_index_and_output[0],
                 item_id=FAKE_RESPONSES_ID,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=cls._assistant_message_output_index(state),
                 part=state.refusal_content_index_and_output[1],
                 type="response.content_part.done",
                 sequence_number=sequence_number.get_and_increment(),
@@ -747,8 +744,7 @@ class ChatCmplStreamHandler:
             # send a ResponseOutputItemDone for the assistant message
             yield ResponseOutputItemDoneEvent(
                 item=assistant_msg,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=cls._assistant_message_output_index(state),
                 type="response.output_item.done",
                 sequence_number=sequence_number.get_and_increment(),
             )

--- a/tests/models/test_reasoning_content.py
+++ b/tests/models/test_reasoning_content.py
@@ -160,6 +160,24 @@ async def test_stream_response_yields_events_for_reasoning_content(monkeypatch) 
     assert content_delta_events[0].delta == "The answer"
     assert content_delta_events[1].delta == " is 42"
 
+    assistant_message_index_events = []
+    for event in output_events:
+        event_any = cast(Any, event)
+        if event.type in {"response.output_item.added", "response.output_item.done"}:
+            if event_any.item.type == "message":
+                assistant_message_index_events.append(event_any)
+        elif event.type in {
+            "response.content_part.added",
+            "response.output_text.delta",
+            "response.content_part.done",
+        }:
+            assistant_message_index_events.append(event_any)
+
+    assert assistant_message_index_events
+    for event in assistant_message_index_events:
+        assert event.output_index == 1
+        assert type(event.output_index) is int
+
     # verify the final response contains both types of content
     response_event = output_events[-1]
     assert response_event.type == "response.completed"


### PR DESCRIPTION

### Summary

Fixes Chat Completions streaming events so assistant message `output_index` values are emitted as integers instead of booleans when reasoning content precedes the message.

The stream handler now uses a shared helper to compute the assistant message output index and the reasoning-content regression test asserts that text/message events use `1` with exact `int` type, not `True`.

### Test plan

- `uv run pytest tests/models/test_reasoning_content.py -k 'stream_response_yields_events_for_reasoning_content'`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3109

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass