### PR TITLE
fix: #3115 block disabled function tools before execution

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1393,9 +1393,24 @@ class _FunctionToolBatchExecutor:
             self.execution_agent,
             self.context_wrapper,
         )
+        enabled_function_tool_ids = {id(tool) for tool in self.available_function_tools}
+        configured_function_tool_ids = {
+            id(tool) for tool in self.execution_agent.tools if isinstance(tool, FunctionTool)
+        }
         for tool_run in self.tool_runs:
-            if tool_run.function_tool not in self.available_function_tools:
+            function_tool = tool_run.function_tool
+            function_tool_id = id(function_tool)
+            if (
+                function_tool_id in configured_function_tool_ids
+                and function_tool_id not in enabled_function_tool_ids
+            ):
+                raise ModelBehaviorError(
+                    f"Tool {function_tool.name} is currently disabled for agent "
+                    f"{self.public_agent.name}."
+                )
+            if function_tool_id not in enabled_function_tool_ids:
                 self.available_function_tools.append(tool_run.function_tool)
+                enabled_function_tool_ids.add(function_tool_id)
         for order, tool_run in enumerate(self.tool_runs):
             self._create_tool_task(tool_run, order)
 

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 
 from agents import (
     Agent,
+    AgentBase,
     ApplyPatchTool,
     FunctionTool,
     HostedMCPTool,
@@ -1244,6 +1245,78 @@ async def test_execute_function_tool_calls_eager_task_factory_tracks_state_safel
         loop.set_task_factory(previous_task_factory)
 
     assert [result.output for result in function_results] == ["first", "second"]
+    assert input_guardrail_results == []
+    assert output_guardrail_results == []
+
+
+@pytest.mark.asyncio
+async def test_function_tool_disabled_before_execution_fails_before_starting_siblings() -> None:
+    enabled_checks: list[bool] = []
+    disabled_tool_invocations = 0
+    sibling_tool_invocations = 0
+
+    def _is_lookup_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase[Any]) -> bool:
+        enabled = not enabled_checks
+        enabled_checks.append(enabled)
+        return enabled
+
+    @function_tool(name_override="lookup_secret", is_enabled=_is_lookup_enabled)
+    def lookup_secret() -> str:
+        nonlocal disabled_tool_invocations
+        disabled_tool_invocations += 1
+        return "secret"
+
+    @function_tool(name_override="record_side_effect")
+    def record_side_effect() -> str:
+        nonlocal sibling_tool_invocations
+        sibling_tool_invocations += 1
+        return "recorded"
+
+    agent = Agent(name="test", tools=[lookup_secret, record_side_effect])
+    response = ModelResponse(
+        output=[
+            get_function_tool_call("lookup_secret", "{}", call_id="call-1"),
+            get_function_tool_call("record_side_effect", "{}", call_id="call-2"),
+        ],
+        usage=Usage(),
+        response_id=None,
+    )
+
+    with pytest.raises(ModelBehaviorError, match="lookup_secret is currently disabled"):
+        await get_execute_result(agent, response)
+
+    assert enabled_checks == [True, False]
+    assert disabled_tool_invocations == 0
+    assert sibling_tool_invocations == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_function_tool_calls_allows_non_agent_function_tool() -> None:
+    @function_tool(name_override="synthetic_tool")
+    def synthetic_tool() -> str:
+        return "synthetic-result"
+
+    tool_run = ToolRunFunction(
+        tool_call=cast(
+            ResponseFunctionToolCall,
+            get_function_tool_call("synthetic_tool", "{}", call_id="call-1"),
+        ),
+        function_tool=synthetic_tool,
+    )
+
+    (
+        function_results,
+        input_guardrail_results,
+        output_guardrail_results,
+    ) = await execute_function_tool_calls(
+        bindings=bind_public_agent(Agent(name="test", tools=[])),
+        tool_runs=[tool_run],
+        hooks=RunHooks(),
+        context_wrapper=RunContextWrapper(None),
+        config=RunConfig(),
+    )
+
+    assert [result.output for result in function_results] == ["synthetic-result"]
     assert input_guardrail_results == []
     assert output_guardrail_results == []
 


### PR DESCRIPTION
### Summary

This change prevents agent-configured `FunctionTool`s from executing when their dynamic `is_enabled` callback becomes false after the tool was exposed to the model but before execution starts.

The function tool executor now re-checks the currently enabled agent function tools before creating tool tasks. If the model called an agent-configured tool that is currently disabled, the run fails fast with `ModelBehaviorError` instead of invoking the tool. The check uses object identity for agent-configured tools so synthetic or adapter-provided `FunctionTool`s that are not present in `agent.tools` can still execute.

This keeps `is_enabled` aligned with its documented runtime gating semantics for permissions, feature flags, quotas, tenant policy, and other side-effect-sensitive tool access.

### Test plan

- `uv run pytest tests/test_run_step_execution.py -k "disabled_before_execution or non_agent_function_tool" -q`
- `uv run pytest tests/test_run_step_execution.py -q`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3115

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
