### PR TITLE
fix: use integer output_index instead of boolean in streaming handler

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -419,7 +419,7 @@ class ChatCmplStreamHandler:
                     yield ResponseContentPartAddedEvent(
                         content_index=state.refusal_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
-                        output_index=(1 if state.reasoning_content_index_and_output else 0),
+                        output_index=(1 if state.reasoning_content_index_and_output is not None else 0),
                         part=ResponseOutputRefusal(
                             refusal="",
                             type="refusal",

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -341,16 +341,14 @@ class ChatCmplStreamHandler:
                     # Notify consumers of the start of a new output message + first content part
                     yield ResponseOutputItemAddedEvent(
                         item=assistant_item,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=1 if state.reasoning_content_index_and_output is not None else 0,  # fixed: was bool
                         type="response.output_item.added",
                         sequence_number=sequence_number.get_and_increment(),
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.text_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=1 if state.reasoning_content_index_and_output is not None else 0,  # fixed: was bool
                         part=ResponseOutputText(
                             text="",
                             type="output_text",
@@ -374,8 +372,7 @@ class ChatCmplStreamHandler:
                     content_index=state.text_content_index_and_output[0],
                     delta=delta.content,
                     item_id=FAKE_RESPONSES_ID,
-                    output_index=state.reasoning_content_index_and_output
-                    is not None,  # fixed 0 -> 0 or 1
+                    output_index=1 if state.reasoning_content_index_and_output is not None else 0,  # fixed: was bool
                     type="response.output_text.delta",
                     sequence_number=sequence_number.get_and_increment(),
                     logprobs=delta_logprobs,
@@ -415,8 +412,7 @@ class ChatCmplStreamHandler:
                     # Notify downstream that assistant message + first content part are starting
                     yield ResponseOutputItemAddedEvent(
                         item=assistant_item,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=1 if state.reasoning_content_index_and_output is not None else 0,  # fixed: was bool
                         type="response.output_item.added",
                         sequence_number=sequence_number.get_and_increment(),
                     )
@@ -436,8 +432,7 @@ class ChatCmplStreamHandler:
                     content_index=state.refusal_content_index_and_output[0],
                     delta=delta.refusal,
                     item_id=FAKE_RESPONSES_ID,
-                    output_index=state.reasoning_content_index_and_output
-                    is not None,  # fixed 0 -> 0 or 1
+                    output_index=1 if state.reasoning_content_index_and_output is not None else 0,  # fixed: was bool
                     type="response.refusal.delta",
                     sequence_number=sequence_number.get_and_increment(),
                 )
@@ -603,8 +598,7 @@ class ChatCmplStreamHandler:
             yield ResponseContentPartDoneEvent(
                 content_index=state.text_content_index_and_output[0],
                 item_id=FAKE_RESPONSES_ID,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=1 if state.reasoning_content_index_and_output is not None else 0,  # fixed: was bool
                 part=state.text_content_index_and_output[1],
                 type="response.content_part.done",
                 sequence_number=sequence_number.get_and_increment(),
@@ -616,8 +610,7 @@ class ChatCmplStreamHandler:
             yield ResponseContentPartDoneEvent(
                 content_index=state.refusal_content_index_and_output[0],
                 item_id=FAKE_RESPONSES_ID,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=1 if state.reasoning_content_index_and_output is not None else 0,  # fixed: was bool
                 part=state.refusal_content_index_and_output[1],
                 type="response.content_part.done",
                 sequence_number=sequence_number.get_and_increment(),
@@ -747,8 +740,7 @@ class ChatCmplStreamHandler:
             # send a ResponseOutputItemDone for the assistant message
             yield ResponseOutputItemDoneEvent(
                 item=assistant_msg,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=1 if state.reasoning_content_index_and_output is not None else 0,  # fixed: was bool
                 type="response.output_item.done",
                 sequence_number=sequence_number.get_and_increment(),
             )


### PR DESCRIPTION
## Problem

The Chat Completions streaming handler uses a boolean expression for :



This produces / instead of integer /. While Python treats bool as int subclass, downstream JSON consumers and event snapshots can observe the wrong type.

## Solution

Replace all 8 occurrences with explicit integer expression:



## Testing

Verified no remaining boolean expressions for output_index in chatcmpl_stream_handler.py.

Fixes #3109