### PR TITLE
feat(lifecycle): expose current tool call id

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -262,7 +262,7 @@ Typical hook timing:
 -   `on_agent_start` / `on_agent_end`: when a specific agent begins or finishes producing a final output.
 -   `on_llm_start` / `on_llm_end`: immediately around each model call.
 -   `on_tool_start` / `on_tool_end`: around each local tool invocation.
-    For function tools, the hook `context` is typically a `ToolContext`, so you can inspect tool-call metadata such as `tool_call_id`.
+    Use `context.current_tool_call_id` when you only need the call ID. For function tools, the hook `context` is typically a `ToolContext`, so you can also inspect tool-call metadata such as `tool_name` and `tool_arguments`.
 -   `on_handoff`: when control moves from one agent to another.
 
 Use `RunHooks` when you want a single observer for the whole workflow, and `AgentHooks` when one agent needs custom side effects.

--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -75,6 +75,7 @@ class RunHooksBase(Generic[TContext, TAgent]):
     ) -> None:
         """Called immediately before a local tool is invoked.
 
+        Use ``context.current_tool_call_id`` to read the call ID when one is available.
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
         and ``tool_arguments``. Other local tool families may provide a plain
@@ -91,6 +92,7 @@ class RunHooksBase(Generic[TContext, TAgent]):
     ) -> None:
         """Called immediately after a local tool is invoked.
 
+        Use ``context.current_tool_call_id`` to read the call ID when one is available.
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
         and ``tool_arguments``. Other local tool families may provide a plain
@@ -149,6 +151,7 @@ class AgentHooksBase(Generic[TContext, TAgent]):
     ) -> None:
         """Called immediately before a local tool is invoked.
 
+        Use ``context.current_tool_call_id`` to read the call ID when one is available.
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
         and ``tool_arguments``. Other local tool families may provide a plain
@@ -165,6 +168,7 @@ class AgentHooksBase(Generic[TContext, TAgent]):
     ) -> None:
         """Called immediately after a local tool is invoked.
 
+        Use ``context.current_tool_call_id`` to read the call ID when one is available.
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
         and ``tool_arguments``. Other local tool families may provide a plain

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -61,6 +61,16 @@ class RunContextWrapper(Generic[TContext]):
     tool_input: Any | None = None
     """Structured input for the current agent tool run, when available."""
 
+    @property
+    def current_tool_call_id(self) -> str | None:
+        """The active tool call ID when this context represents a tool invocation.
+
+        Function and custom tool hooks receive a ``ToolContext`` subclass that carries the
+        model-provided call ID. Other hook contexts, including local tool types without call IDs,
+        return ``None``.
+        """
+        return self._to_str_or_none(getattr(self, "tool_call_id", None))
+
     @staticmethod
     def _to_str_or_none(value: Any) -> str | None:
         if isinstance(value, str):

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -354,6 +354,48 @@ async def test_run_hooks_count_tool_and_handoff_invocations():
 
 
 @pytest.mark.asyncio
+async def test_run_tool_hooks_expose_current_tool_call_id_without_cast():
+    hook_events: list[tuple[str, str | None]] = []
+
+    class CurrentToolCallIdHooks(RunHooks):
+        async def on_tool_start(
+            self,
+            context: RunContextWrapper[TContext],
+            agent: Agent[TContext],
+            tool: Tool,
+        ) -> None:
+            hook_events.append(("start", context.current_tool_call_id))
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[TContext],
+            agent: Agent[TContext],
+            tool: Tool,
+            result: str,
+        ) -> None:
+            hook_events.append(("end", context.current_tool_call_id))
+
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("some_function", json.dumps({"a": "b"}))],
+            [get_text_message("done")],
+        ]
+    )
+
+    await Runner.run(agent, input="user_message", hooks=CurrentToolCallIdHooks())
+
+    assert [event for event, _ in hook_events] == ["start", "end"]
+    assert hook_events[0][1] is not None
+    assert hook_events[0][1] == hook_events[1][1]
+
+
+@pytest.mark.asyncio
 async def test_streamed_run_hooks_count_tool_and_handoff_invocations():
     hooks = RunHooksForTests()
     model = FakeModel()

--- a/tests/test_tool_context.py
+++ b/tests/test_tool_context.py
@@ -35,6 +35,12 @@ def test_tool_context_requires_fields() -> None:
         ToolContext.from_agent_context(ctx, tool_call_id="call-1")
 
 
+def test_run_context_wrapper_current_tool_call_id_defaults_to_none() -> None:
+    ctx: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+
+    assert ctx.current_tool_call_id is None
+
+
 def test_tool_context_missing_defaults_raise() -> None:
     base_ctx: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
     with pytest.raises(ValueError):
@@ -64,6 +70,7 @@ def test_tool_context_from_agent_context_populates_fields() -> None:
 
     assert tool_ctx.tool_name == "test_tool"
     assert tool_ctx.tool_call_id == "call-123"
+    assert tool_ctx.current_tool_call_id == "call-123"
     assert tool_ctx.tool_arguments == '{"a": 1}'
     assert tool_ctx.agent is agent
 


### PR DESCRIPTION
Withdrawn after re-checking the linked issue history.

This was intended to address #1849 by adding `RunContextWrapper.current_tool_call_id`, but #2915 already proposed a very similar parent-level solution and the maintainer response was that the project does not want to add this to the parent context level for now. The current accepted direction appears to be the already-merged documentation/test clarification from #2687 plus casts where needed until a future major-version typing change.

Validation that had been run locally before withdrawing:
- `uv run pytest tests/test_tool_context.py tests/test_run_hooks.py -q`
- `uv run ruff check src/agents/run_context.py src/agents/lifecycle.py tests/test_tool_context.py tests/test_run_hooks.py`
- `uv run pytest tests/test_tool_context.py tests/test_run_hooks.py tests/test_agent_hooks.py tests/test_global_hooks.py -q`