### PR TITLE
Add optional Shipgate scan for customer service example

### DIFF
--- a/examples/customer_service/README.md
+++ b/examples/customer_service/README.md
@@ -1,0 +1,22 @@
+# Customer Service Example
+
+This example demonstrates a multi-agent airline customer service flow with FAQ
+lookup and seat-update tools.
+
+## Optional release-readiness scan
+
+The included `shipgate.yaml` lets you run an advisory static scan of this
+example's tool surface before adapting it for production-like use.
+
+```bash
+pipx install agents-shipgate
+agents-shipgate scan -c examples/customer_service/shipgate.yaml --ci-mode advisory
+```
+
+Agents Shipgate reads local source and manifest files only. It does not execute
+the agent, call an LLM, call tools, connect to MCP servers, make scanner network
+calls, or collect telemetry.
+
+The scan is advisory for this example. It is intended to show which release
+metadata would need review before wiring a similar agent to real customer or
+airline systems.

--- a/examples/customer_service/shipgate.yaml
+++ b/examples/customer_service/shipgate.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/manifest-v0.1.json
+# Optional Agents Shipgate manifest for this example.
+version: "0.1"
+
+project:
+  name: customer_service
+
+agent:
+  name: airline-customer-service
+  declared_purpose:
+    - answer airline FAQ questions
+    - route customers to the right specialist agent
+    - update seat assignments in the local demo context
+  prohibited_actions: []
+
+environment:
+  target: local
+
+tool_sources:
+  - id: openai_sdk_main
+    type: openai_agents_sdk
+    path: main.py
+
+policies:
+  require_approval_for_tools: []
+  require_confirmation_for_tools:
+    - tool: update_seat
+      reason: "Customer-facing seat changes should be confirmed before release use."
+  require_idempotency_for_tools: []
+
+permissions:
+  scopes: []
+  notes: "This example updates only local demo context and does not model a real airline API credential."
+
+ci:
+  mode: advisory
+
+output:
+  directory: agents-shipgate-reports
+  formats:
+    - markdown
+    - json


### PR DESCRIPTION
This adds an optional static release-readiness example for `examples/customer_service`.

Why:
- The example demonstrates a customer-facing agent with tool calls and handoffs.
- Agents Shipgate gives users an advisory way to inspect the declared tool surface before adapting an example for production-like permissions.
- The check is local-first and does not execute the agent.

How to try it:

```bash
pipx install agents-shipgate
agents-shipgate scan -c examples/customer_service/shipgate.yaml --ci-mode advisory
```

Trust model:
- No agent execution.
- No LLM calls.
- No tool calls.
- No MCP server connections.
- No scanner network calls.
- No telemetry.

Result:
- Command run: `PYTHONPATH=/Users/pengfeihu/code/shipgate/src python -m agents_shipgate scan -c examples/customer_service/shipgate.yaml --ci-mode advisory --format json`
- Result summary: advisory exit 0; 0 critical, 1 high, 2 medium. The top finding is `SHIP-AUTH-MISSING-SCOPE` for `update_seat`, which is expected because this demo mutates local context and does not model a real airline API credential.

This PR intentionally does not add repo-wide CI. It is a scoped example/recipe so maintainers can decide whether release-readiness checks belong in project workflows later.