### PR TITLE
docs+test: clarify response_include comment and add context_management resolve tests

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -132,9 +132,8 @@ class ModelSettings:
     """Whether to include usage chunk.
     Only available for Chat Completions API."""
 
-    # TODO: revisit ResponseIncludable | str if ResponseIncludable covers more cases
-    # We've added str to support missing ones like
-    # "web_search_call.action.sources" etc.
+    # The str union is intentional: it lets callers pass server-supported include flags
+    # that the local SDK enum has not yet added, keeping the field forward-compatible.
     response_include: list[ResponseIncludable | str] | None = None
     """Additional output data to include in the model response.
     [include parameter](https://platform.openai.com/docs/api-reference/responses/create#responses-create-include)"""

--- a/tests/model_settings/test_serialization.py
+++ b/tests/model_settings/test_serialization.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import fields
 
+from openai.types.responses.response_create_params import ContextManagement
 from openai.types.shared import Reasoning
 from pydantic import TypeAdapter
 from pydantic_core import to_json
@@ -311,3 +312,29 @@ def test_retry_backoff_validate_python_preserves_falsey_values() -> None:
         "multiplier": None,
         "jitter": False,
     }
+
+
+def test_context_management_resolve_overrides_base() -> None:
+    """Test that context_management from override fully replaces the base value."""
+    base_entry: ContextManagement = {"type": "compaction", "compact_threshold": 100000}
+    override_entry: ContextManagement = {"type": "compaction", "compact_threshold": 200000}
+
+    base_settings = ModelSettings(context_management=[base_entry])
+    override_settings = ModelSettings(context_management=[override_entry])
+
+    resolved = base_settings.resolve(override_settings)
+
+    assert resolved.context_management == [override_entry]
+
+
+def test_context_management_resolve_preserves_base_when_override_is_none() -> None:
+    """Test that base context_management is kept when override does not set it."""
+    entry: ContextManagement = {"type": "compaction", "compact_threshold": 100000}
+
+    base_settings = ModelSettings(context_management=[entry])
+    override_settings = ModelSettings(temperature=0.5)
+
+    resolved = base_settings.resolve(override_settings)
+
+    assert resolved.context_management == [entry]
+    assert resolved.temperature == 0.5


### PR DESCRIPTION
## Summary
- Replace stale TODO in `ModelSettings.response_include` with a clear note that
  `| str` is intentional for forward compatibility with future server-supported
  include flags. Wording now matches the rationale already in `openai_responses.py`.
- Add two tests pinning `resolve()` behaviour for the `context_management` field
  (introduced in #3128): override wins when both sides set it; base is preserved
  when override omits it.

## Test plan
- [x] `python -m pytest tests/model_settings/test_serialization.py` — 15 passed
- [x] `python -m pytest tests/test_source_compat_constructors.py` — 14 passed

## Related
Follows up on #3128 (feat: add context management model setting).