### PR TITLE
feat: allow disabling max_turns with None

### DIFF
--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -38,7 +38,7 @@ The runner then runs a loop:
     1. If the LLM returns a `final_output`, the loop ends and we return the result.
     2. If the LLM does a handoff, we update the current agent and input, and re-run the loop.
     3. If the LLM produces tool calls, we run those tool calls, append the results, and re-run the loop.
-3. If we exceed the `max_turns` passed, we raise a [`MaxTurnsExceeded`][agents.exceptions.MaxTurnsExceeded] exception.
+3. If we exceed the `max_turns` passed, we raise a [`MaxTurnsExceeded`][agents.exceptions.MaxTurnsExceeded] exception. Pass `max_turns=None` to disable this turn limit.
 
 !!! note
 
@@ -500,7 +500,7 @@ You can use the Agents SDK [DBOS](https://dbos.dev/) integration to run reliable
 The SDK raises exceptions in certain cases. The full list is in [`agents.exceptions`][]. As an overview:
 
 -   [`AgentsException`][agents.exceptions.AgentsException]: This is the base class for all exceptions raised within the SDK. It serves as a generic type from which all other specific exceptions are derived.
--   [`MaxTurnsExceeded`][agents.exceptions.MaxTurnsExceeded]: This exception is raised when the agent's run exceeds the `max_turns` limit passed to the `Runner.run`, `Runner.run_sync`, or `Runner.run_streamed` methods. It indicates that the agent could not complete its task within the specified number of interaction turns.
+-   [`MaxTurnsExceeded`][agents.exceptions.MaxTurnsExceeded]: This exception is raised when the agent's run exceeds the `max_turns` limit passed to the `Runner.run`, `Runner.run_sync`, or `Runner.run_streamed` methods. It indicates that the agent could not complete its task within the specified number of interaction turns. Set `max_turns=None` to disable the limit.
 -   [`ModelBehaviorError`][agents.exceptions.ModelBehaviorError]: This exception occurs when the underlying model (LLM) produces unexpected or invalid outputs. This can include:
     -   Malformed JSON: When the model provides a malformed JSON structure for tool calls or in its direct output, especially if a specific `output_type` is defined.
     -   Unexpected tool-related failures: When the model fails to use tools in an expected manner

--- a/src/agents/repl.py
+++ b/src/agents/repl.py
@@ -17,7 +17,7 @@ async def run_demo_loop(
     *,
     stream: bool = True,
     context: TContext | None = None,
-    max_turns: int = DEFAULT_MAX_TURNS,
+    max_turns: int | None = DEFAULT_MAX_TURNS,
 ) -> None:
     """Run a simple REPL loop with the given agent.
 
@@ -29,7 +29,8 @@ async def run_demo_loop(
         agent: The starting agent to run.
         stream: Whether to stream the agent output.
         context: Additional context information to pass to the runner.
-        max_turns: Maximum number of turns for the runner to iterate.
+        max_turns: Maximum number of turns for the runner to iterate. Pass ``None`` to disable
+            the turn limit.
     """
 
     current_agent = agent

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -362,8 +362,8 @@ class RunResult(RunResultBase):
         default=None, init=False, repr=False
     )
     """How reasoning IDs should be represented when converting to input history."""
-    max_turns: int = 10
-    """The maximum number of turns allowed for this run."""
+    max_turns: int | None = 10
+    """The maximum number of turns allowed for this run, or ``None`` for no limit."""
     interruptions: list[ToolApprovalItem] = field(default_factory=list)
     """Pending tool approval requests (interruptions) for this run."""
 
@@ -457,8 +457,8 @@ class RunResultStreaming(RunResultBase):
     current_turn: int
     """The current turn number."""
 
-    max_turns: int
-    """The maximum number of turns the agent can run for."""
+    max_turns: int | None
+    """The maximum number of turns the agent can run for, or ``None`` for no limit."""
 
     final_output: Any
     """The final output of the agent. This is None until the agent has finished running."""
@@ -791,7 +791,11 @@ class RunResultStreaming(RunResultBase):
         )
 
     def _check_errors(self):
-        if self.current_turn > self.max_turns and not self._max_turns_handled:
+        if (
+            self.max_turns is not None
+            and self.current_turn > self.max_turns
+            and not self._max_turns_handled
+        ):
             max_turns_exc = MaxTurnsExceeded(f"Max turns ({self.max_turns}) exceeded")
             max_turns_exc.run_data = self._create_error_details()
             self._stored_exception = max_turns_exc

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -198,7 +198,7 @@ class Runner:
         input: str | list[TResponseInputItem] | RunState[TContext],
         *,
         context: TContext | None = None,
-        max_turns: int = DEFAULT_MAX_TURNS,
+        max_turns: int | None = DEFAULT_MAX_TURNS,
         hooks: RunHooks[TContext] | None = None,
         run_config: RunConfig | None = None,
         error_handlers: RunErrorHandlers[TContext] | None = None,
@@ -234,6 +234,7 @@ class Runner:
             context: The context to run the agent with.
             max_turns: The maximum number of turns to run the agent for. A turn is
                 defined as one AI invocation (including any tool calls that might occur).
+                Pass ``None`` to disable the turn limit.
             hooks: An object that receives callbacks on various lifecycle events.
             run_config: Global settings for the entire agent run.
             error_handlers: Error handlers keyed by error kind. Currently supports max_turns.
@@ -278,7 +279,7 @@ class Runner:
         input: str | list[TResponseInputItem] | RunState[TContext],
         *,
         context: TContext | None = None,
-        max_turns: int = DEFAULT_MAX_TURNS,
+        max_turns: int | None = DEFAULT_MAX_TURNS,
         hooks: RunHooks[TContext] | None = None,
         run_config: RunConfig | None = None,
         error_handlers: RunErrorHandlers[TContext] | None = None,
@@ -319,6 +320,7 @@ class Runner:
             context: The context to run the agent with.
             max_turns: The maximum number of turns to run the agent for. A turn is
                 defined as one AI invocation (including any tool calls that might occur).
+                Pass ``None`` to disable the turn limit.
             hooks: An object that receives callbacks on various lifecycle events.
             run_config: Global settings for the entire agent run.
             error_handlers: Error handlers keyed by error kind. Currently supports max_turns.
@@ -355,7 +357,7 @@ class Runner:
         starting_agent: Agent[TContext],
         input: str | list[TResponseInputItem] | RunState[TContext],
         context: TContext | None = None,
-        max_turns: int = DEFAULT_MAX_TURNS,
+        max_turns: int | None = DEFAULT_MAX_TURNS,
         hooks: RunHooks[TContext] | None = None,
         run_config: RunConfig | None = None,
         previous_response_id: str | None = None,
@@ -395,6 +397,7 @@ class Runner:
             context: The context to run the agent with.
             max_turns: The maximum number of turns to run the agent for. A turn is
                 defined as one AI invocation (including any tool calls that might occur).
+                Pass ``None`` to disable the turn limit.
             hooks: An object that receives callbacks on various lifecycle events.
             run_config: Global settings for the entire agent run.
             error_handlers: Error handlers keyed by error kind. Currently supports max_turns.
@@ -1039,7 +1042,7 @@ class AgentRunner:
                         ]
 
                     current_turn += 1
-                    if current_turn > max_turns:
+                    if max_turns is not None and current_turn > max_turns:
                         _error_tracing.attach_error_to_span(
                             current_span,
                             SpanError(

--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -262,8 +262,8 @@ class RunOptions(TypedDict, Generic[TContext]):
     context: NotRequired[TContext | None]
     """The context for the run."""
 
-    max_turns: NotRequired[int]
-    """The maximum number of turns to run for."""
+    max_turns: NotRequired[int | None]
+    """The maximum number of turns to run for. Set to ``None`` to disable the limit."""
 
     hooks: NotRequired[RunHooks[TContext] | None]
     """Lifecycle hooks for the run."""

--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -385,7 +385,7 @@ def build_interruption_result(
     interruptions: list[ToolApprovalItem],
     processed_response: ProcessedResponse | None,
     tool_use_tracker: AgentToolUseTracker,
-    max_turns: int,
+    max_turns: int | None,
     current_turn: int,
     generated_items: list[RunItem],
     run_state: RunState | None,

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -440,7 +440,7 @@ async def start_streaming(
     starting_input: str | list[TResponseInputItem],
     streamed_result: RunResultStreaming,
     starting_agent: Agent[TContext],
-    max_turns: int,
+    max_turns: int | None,
     hooks: RunHooks[TContext],
     context_wrapper: RunContextWrapper[TContext],
     run_config: RunConfig,
@@ -877,7 +877,7 @@ async def start_streaming(
             if run_state:
                 run_state._current_turn_persisted_item_count = 0
 
-            if current_turn > max_turns:
+            if max_turns is not None and current_turn > max_turns:
                 _error_tracing.attach_error_to_span(
                     current_span,
                     SpanError(

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -128,7 +128,7 @@ ContextDeserializer = Callable[[Mapping[str, Any]], Any]
 # 3. to_json() always emits CURRENT_SCHEMA_VERSION.
 # 4. Forward compatibility is intentionally fail-fast (older SDKs reject newer or unsupported
 #    versions).
-CURRENT_SCHEMA_VERSION = "1.9"
+CURRENT_SCHEMA_VERSION = "1.10"
 # Keep this mapping in chronological order. Every schema bump must add a one-line summary here.
 SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
     "1.0": "Initial RunState snapshot format for HITL pause/resume flows.",
@@ -144,6 +144,7 @@ SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
     ),
     "1.8": "Persists SDK-generated prompt cache keys across resume flows.",
     "1.9": "Persists pending custom tool calls and tool origin metadata across resume flows.",
+    "1.10": "Allows serialized RunState snapshots to disable max_turns with null.",
 }
 SUPPORTED_SCHEMA_VERSIONS = frozenset(SCHEMA_VERSION_SUMMARIES)
 
@@ -219,8 +220,8 @@ class RunState(Generic[TContext, TAgent]):
     _session_items: list[RunItem] = field(default_factory=list)
     """Full, unfiltered run items for session history."""
 
-    _max_turns: int = 10
-    """Maximum allowed turns before forcing termination."""
+    _max_turns: int | None = 10
+    """Maximum allowed turns before forcing termination, or ``None`` for no limit."""
 
     _conversation_id: str | None = None
     """Conversation identifier for server-managed conversation tracking."""
@@ -281,7 +282,7 @@ class RunState(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         original_input: str | list[Any],
         starting_agent: TAgent,
-        max_turns: int = 10,
+        max_turns: int | None = 10,
         *,
         conversation_id: str | None = None,
         previous_response_id: str | None = None,

--- a/tests/test_max_turns.py
+++ b/tests/test_max_turns.py
@@ -52,6 +52,33 @@ async def test_non_streamed_max_turns():
 
 
 @pytest.mark.asyncio
+async def test_non_streamed_max_turns_none_disables_limit():
+    model = FakeModel()
+    agent = Agent(
+        name="test_1",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+    )
+
+    func_output = json.dumps({"a": "b"})
+
+    model.add_multiple_turn_outputs(
+        [
+            [get_text_message("1"), get_function_tool_call("some_function", func_output)],
+            [get_text_message("2"), get_function_tool_call("some_function", func_output)],
+            [get_text_message("3"), get_function_tool_call("some_function", func_output)],
+            [get_text_message("4"), get_function_tool_call("some_function", func_output)],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = await Runner.run(agent, input="user_message", max_turns=None)
+
+    assert result.final_output == "done"
+    assert result.max_turns is None
+
+
+@pytest.mark.asyncio
 async def test_streamed_max_turns():
     model = FakeModel()
     agent = Agent(
@@ -89,6 +116,34 @@ async def test_streamed_max_turns():
         output = Runner.run_streamed(agent, input="user_message", max_turns=3)
         async for _ in output.stream_events():
             pass
+
+
+@pytest.mark.asyncio
+async def test_streamed_max_turns_none_disables_limit():
+    model = FakeModel()
+    agent = Agent(
+        name="test_1",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+    )
+    func_output = json.dumps({"a": "b"})
+
+    model.add_multiple_turn_outputs(
+        [
+            [get_text_message("1"), get_function_tool_call("some_function", func_output)],
+            [get_text_message("2"), get_function_tool_call("some_function", func_output)],
+            [get_text_message("3"), get_function_tool_call("some_function", func_output)],
+            [get_text_message("4"), get_function_tool_call("some_function", func_output)],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="user_message", max_turns=None)
+    async for _ in result.stream_events():
+        pass
+
+    assert result.final_output == "done"
+    assert result.max_turns is None
 
 
 class Foo(TypedDict):

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -222,7 +222,7 @@ def make_state(
     *,
     context: RunContextWrapper[TContext],
     original_input: str | list[Any] = "input",
-    max_turns: int = 3,
+    max_turns: int | None = 3,
 ) -> RunState[TContext, Agent[Any]]:
     """Create a RunState with common defaults used across tests."""
 
@@ -308,6 +308,19 @@ class TestRunState:
         str_data = state.to_string()
         assert isinstance(str_data, str)
         assert json.loads(str_data) == json_data
+
+    @pytest.mark.asyncio
+    async def test_max_turns_none_round_trips(self):
+        """RunState should preserve disabled max_turns across serialization."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="Agent1")
+        state = make_state(agent, context=context, original_input="input1", max_turns=None)
+
+        json_data = state.to_json()
+        assert json_data["max_turns"] is None
+
+        restored = await RunState.from_json(agent, json_data)
+        assert restored._max_turns is None
 
     @pytest.mark.asyncio
     async def test_from_json_restores_duplicate_name_current_agent_by_identity(self):
@@ -4505,6 +4518,7 @@ class TestRunStateSerializationEdgeCases:
                 "1.6",
                 "1.7",
                 "1.8",
+                "1.9",
                 CURRENT_SCHEMA_VERSION,
             }
         )

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -107,7 +107,7 @@ def make_run_state(
     *,
     context: RunContextWrapper[TContext] | dict[str, Any] | None = None,
     original_input: Any = "input",
-    max_turns: int = 3,
+    max_turns: int | None = 3,
 ) -> RunState[TContext, Agent[Any]]:
     """Create a RunState with sensible defaults for tests."""
 


### PR DESCRIPTION
This pull request adds support for passing `max_turns=None` to disable the Agents SDK run turn limit while preserving the existing default of `DEFAULT_MAX_TURNS` (`10`) when `max_turns` is omitted.

It updates the sync and streaming run loops to skip max-turn enforcement when the value is `None`, broadens the relevant public and internal types, persists `None` through `RunState` serialization with schema version `1.10`, and documents the new behavior in `docs/running_agents.md`. Regression coverage was added for non-streamed runs, streamed runs, and RunState round-tripping. There are no untracked files in this change.