### PR TITLE
fix(mcp): avoid mutating tool input schemas

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -286,7 +286,7 @@ class MCPUtil:
         effective_failure_error_function = server._get_failure_error_function(
             failure_error_function
         )
-        schema, is_strict = tool.inputSchema, False
+        schema, is_strict = copy.deepcopy(tool.inputSchema), False
 
         # MCP spec doesn't require the inputSchema to have `properties`, but OpenAI spec does.
         if "properties" not in schema:

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1186,6 +1186,23 @@ async def test_util_adds_properties():
     )
 
 
+def test_to_function_tool_does_not_mutate_mcp_input_schema():
+    schema = {"type": "object", "description": "Test tool"}
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(
+        tool, FakeMCPServer(), convert_schemas_to_strict=False
+    )
+
+    assert function_tool.params_json_schema == {
+        "type": "object",
+        "description": "Test tool",
+        "properties": {},
+    }
+    assert schema == {"type": "object", "description": "Test tool"}
+    assert tool.inputSchema == {"type": "object", "description": "Test tool"}
+
+
 class StructuredContentTestServer(FakeMCPServer):
     """Test server that allows setting both content and structured content for testing."""
 

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1190,9 +1190,7 @@ def test_to_function_tool_does_not_mutate_mcp_input_schema():
     schema = {"type": "object", "description": "Test tool"}
     tool = MCPTool(name="test_tool", inputSchema=schema)
 
-    function_tool = MCPUtil.to_function_tool(
-        tool, FakeMCPServer(), convert_schemas_to_strict=False
-    )
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=False)
 
     assert function_tool.params_json_schema == {
         "type": "object",


### PR DESCRIPTION
## Summary
- Copy MCP tool input schemas before normalizing them for OpenAI function-tool compatibility.
- Add regression coverage showing missing `properties` is added only to the converted `FunctionTool`, not the original MCP tool schema.

## Verification
- `uv run pytest tests/mcp/test_mcp_util.py -q`
- `uv run ruff check src/agents/mcp/util.py tests/mcp/test_mcp_util.py`

## PR overlap check
- Searched open PRs for `MCP inputSchema mutation to_function_tool`; no existing open PR covers this specific fix.