### PR TITLE
fix(mcp): reject non-object tool input JSON

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -378,7 +378,7 @@ class MCPUtil:
         """Invoke an MCP tool and return the result as ToolOutput."""
         json_decode_error: Exception | None = None
         try:
-            json_data: dict[str, Any] = json.loads(input_json) if input_json else {}
+            json_data = json.loads(input_json) if input_json else {}
         except Exception as e:
             json_decode_error = e
 
@@ -391,6 +391,11 @@ class MCPUtil:
                 error_message = f"{error_message}: {input_json}"
                 logger.debug(error_message)
             raise ModelBehaviorError(error_message) from json_decode_error
+
+        if not isinstance(json_data, dict):
+            raise ModelBehaviorError(
+                f"Invalid JSON input for tool {tool.name}: expected a JSON object"
+            )
 
         if _debug.DONT_LOG_TOOL_DATA:
             logger.debug(f"Invoking MCP tool {tool.name}")

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -306,6 +306,21 @@ async def test_mcp_invoke_bad_json_includes_payload_when_tool_logging_enabled(
     assert "SECRET_TOKEN_123" in caplog.text
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_json", ["[]", '"value"', "123", "null"])
+async def test_mcp_invoke_rejects_non_object_json_input(input_json: str):
+    server = FakeMCPServer()
+    server.add_tool("test_tool_1", {})
+
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="test_tool_1", inputSchema={})
+
+    with pytest.raises(ModelBehaviorError, match="expected a JSON object"):
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, input_json)
+
+    assert server.tool_calls == []
+
+
 class CrashingFakeMCPServer(FakeMCPServer):
     async def call_tool(
         self,


### PR DESCRIPTION
## Summary
- Reject JSON arrays, strings, numbers, and null before invoking an MCP tool.
- Keep empty input mapped to `{}` for the existing no-argument tool path.
- Add regression coverage that verifies invalid non-object JSON never reaches `server.call_tool`.

## Verification
- `uv run pytest tests/mcp/test_mcp_util.py -q`
- `uv run ruff check src/agents/mcp/util.py tests/mcp/test_mcp_util.py`

## PR overlap check
- Searched open PRs for `MCP non-object JSON expected object call_tool`; no existing open PR covers this specific fix.