### PR TITLE
fix(mcp): make duplicate tool errors deterministic

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -223,10 +223,11 @@ class MCPUtil:
                 failure_error_function=failure_error_function,
             )
             server_tool_names = {tool.name for tool in server_tools}
-            if len(server_tool_names & tool_names) > 0:
+            duplicate_tool_names = sorted(server_tool_names & tool_names)
+            if duplicate_tool_names:
                 raise UserError(
-                    f"Duplicate tool names found across MCP servers: "
-                    f"{server_tool_names & tool_names}"
+                    "Duplicate tool names found across MCP servers: "
+                    f"{', '.join(duplicate_tool_names)}"
                 )
             tool_names.update(server_tool_names)
             tools.extend(server_tools)

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -11,7 +11,12 @@ from pydantic import BaseModel, TypeAdapter
 
 import agents._debug as _debug
 from agents import Agent, FunctionTool, RunContextWrapper, default_tool_error_function
-from agents.exceptions import AgentsException, MCPToolCancellationError, ModelBehaviorError
+from agents.exceptions import (
+    AgentsException,
+    MCPToolCancellationError,
+    ModelBehaviorError,
+    UserError,
+)
 from agents.mcp import MCPServer, MCPUtil
 from agents.tool_context import ToolContext
 
@@ -81,6 +86,25 @@ async def test_get_all_function_tools():
     tools = await MCPUtil.get_all_function_tools(servers, True, run_context, agent)
     assert len(tools) == 5
     assert all(tool.name in names for tool in tools)
+
+
+@pytest.mark.asyncio
+async def test_get_all_function_tools_duplicate_error_is_deterministic():
+    server1 = FakeMCPServer(server_name="server_1")
+    server1.add_tool("zeta", {})
+    server1.add_tool("alpha", {})
+
+    server2 = FakeMCPServer(server_name="server_2")
+    server2.add_tool("alpha", {})
+    server2.add_tool("zeta", {})
+
+    run_context = RunContextWrapper(context=None)
+    agent = Agent(name="test_agent", instructions="Test agent")
+
+    with pytest.raises(UserError) as exc_info:
+        await MCPUtil.get_all_function_tools([server1, server2], False, run_context, agent)
+
+    assert str(exc_info.value) == "Duplicate tool names found across MCP servers: alpha, zeta"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Sort duplicate MCP tool names before formatting the duplicate-name `UserError`.
- Replace raw set formatting with a deterministic comma-separated list.
- Add regression coverage with multiple duplicate names.

## Verification
- `uv run pytest tests/mcp/test_mcp_util.py -q`
- `uv run ruff check src/agents/mcp/util.py tests/mcp/test_mcp_util.py`

## PR overlap check
- Searched open PRs for `MCP duplicate tool names deterministic error`; no existing open PR covers this specific fix.