### PR TITLE
feat: cap parallel function tool calls

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -170,6 +170,14 @@ class ModelSettings:
     to enable server-side compaction when the rendered context crosses a token threshold.
     """
 
+    max_parallel_tool_calls: int | None = None
+    """Maximum number of local function tool calls to execute concurrently.
+
+    Set to ``None`` to preserve the current behavior, which allows all function tool calls
+    from a turn to run in parallel. This is enforced by the SDK and does not change the
+    model provider's ``parallel_tool_calls`` setting.
+    """
+
     def resolve(self, override: ModelSettings | None) -> ModelSettings:
         """Produce a new ModelSettings by overlaying any non-None values from the
         override on top of this instance."""

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1358,6 +1358,7 @@ class _FunctionToolBatchExecutor:
         hooks: RunHooks[Any],
         context_wrapper: RunContextWrapper[Any],
         config: RunConfig,
+        max_parallel_tool_calls: int | None,
         isolate_parallel_failures: bool | None,
     ) -> None:
         self.execution_agent = bindings.execution_agent
@@ -1366,6 +1367,7 @@ class _FunctionToolBatchExecutor:
         self.hooks = hooks
         self.context_wrapper = context_wrapper
         self.config = config
+        self.max_parallel_tool_calls = max_parallel_tool_calls
         self.isolate_parallel_failures = (
             len(tool_runs) > 1 if isolate_parallel_failures is None else isolate_parallel_failures
         )
@@ -1406,11 +1408,11 @@ class _FunctionToolBatchExecutor:
             if function_tool_id not in enabled_function_tool_ids:
                 self.available_function_tools.append(tool_run.function_tool)
                 enabled_function_tool_ids.add(function_tool_id)
-        for order, tool_run in enumerate(self.tool_runs):
-            self._create_tool_task(tool_run, order)
+        pending_tool_runs = list(enumerate(self.tool_runs))
+        self._fill_tool_task_slots(pending_tool_runs)
 
         try:
-            await self._drain_pending_tasks()
+            await self._drain_pending_tasks(pending_tool_runs)
         except asyncio.CancelledError as exc:
             if self.propagating_failure is exc:
                 raise
@@ -1422,6 +1424,18 @@ class _FunctionToolBatchExecutor:
             self.tool_input_guardrail_results,
             self.tool_output_guardrail_results,
         )
+
+    def _fill_tool_task_slots(self, pending_tool_runs: list[tuple[int, ToolRunFunction]]) -> None:
+        max_parallel_tool_calls = self.max_parallel_tool_calls
+        available_slots = (
+            len(pending_tool_runs)
+            if max_parallel_tool_calls is None
+            else max_parallel_tool_calls - len(self.pending_tasks)
+        )
+        while available_slots > 0 and pending_tool_runs:
+            order, tool_run = pending_tool_runs.pop(0)
+            self._create_tool_task(tool_run, order)
+            available_slots -= 1
 
     def _create_tool_task(self, tool_run: ToolRunFunction, order: int) -> None:
         task_state = _FunctionToolTaskState(tool_run=tool_run, order=order)
@@ -1435,7 +1449,10 @@ class _FunctionToolBatchExecutor:
         self.task_states[task] = task_state
         self.pending_tasks.add(task)
 
-    async def _drain_pending_tasks(self) -> None:
+    async def _drain_pending_tasks(
+        self,
+        pending_tool_runs: list[tuple[int, ToolRunFunction]],
+    ) -> None:
         while self.pending_tasks:
             done_tasks, self.pending_tasks = await asyncio.wait(
                 self.pending_tasks,
@@ -1448,6 +1465,7 @@ class _FunctionToolBatchExecutor:
             )
             if failure is not None:
                 await self._raise_failure_after_draining_siblings(failure)
+            self._fill_tool_task_slots(pending_tool_runs)
 
     async def _raise_failure_after_draining_siblings(
         self,
@@ -1899,17 +1917,22 @@ async def execute_function_tool_calls(
     hooks: RunHooks[Any],
     context_wrapper: RunContextWrapper[Any],
     config: RunConfig,
+    max_parallel_tool_calls: int | None = None,
     isolate_parallel_failures: bool | None = None,
 ) -> tuple[
     list[FunctionToolResult], list[ToolInputGuardrailResult], list[ToolOutputGuardrailResult]
 ]:
     """Execute function tool calls with approvals, guardrails, and hooks."""
+    if max_parallel_tool_calls is not None and max_parallel_tool_calls < 1:
+        raise UserError("max_parallel_tool_calls must be at least 1")
+
     return await _FunctionToolBatchExecutor(
         bindings=bindings,
         tool_runs=tool_runs,
         hooks=hooks,
         context_wrapper=context_wrapper,
         config=config,
+        max_parallel_tool_calls=max_parallel_tool_calls,
         isolate_parallel_failures=isolate_parallel_failures,
     ).execute()
 
@@ -2245,6 +2268,9 @@ async def execute_approved_tools(
             hooks=hooks,
             context_wrapper=context_wrapper,
             config=run_config,
+            max_parallel_tool_calls=agent.model_settings.resolve(
+                run_config.model_settings
+            ).max_parallel_tool_calls,
         )
         for result in function_results:
             if isinstance(result.run_item, RunItemBase):

--- a/src/agents/run_internal/tool_planning.py
+++ b/src/agents/run_internal/tool_planning.py
@@ -558,6 +558,9 @@ async def _execute_tool_plan(
 ]:
     """Execute tool runs captured in a ToolExecutionPlan."""
     public_agent = bindings.public_agent
+    max_parallel_tool_calls = bindings.execution_agent.model_settings.resolve(
+        run_config.model_settings
+    ).max_parallel_tool_calls
     isolate_function_tool_failures = len(plan.function_runs) > 1 or (
         parallel
         and (
@@ -583,6 +586,7 @@ async def _execute_tool_plan(
                 hooks=hooks,
                 context_wrapper=context_wrapper,
                 config=run_config,
+                max_parallel_tool_calls=max_parallel_tool_calls,
                 isolate_parallel_failures=isolate_function_tool_failures,
             ),
             execute_computer_actions(
@@ -632,6 +636,7 @@ async def _execute_tool_plan(
             hooks=hooks,
             context_wrapper=context_wrapper,
             config=run_config,
+            max_parallel_tool_calls=max_parallel_tool_calls,
             isolate_parallel_failures=isolate_function_tool_failures,
         )
         computer_results = await execute_computer_actions(

--- a/tests/model_settings/test_serialization.py
+++ b/tests/model_settings/test_serialization.py
@@ -76,6 +76,7 @@ def test_all_fields_serialization() -> None:
             ),
         ),
         context_management=[{"type": "compaction", "compact_threshold": 200000}],
+        max_parallel_tool_calls=2,
     )
 
     # Verify that every single field is set to a non-None value

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -29,6 +29,7 @@ from agents import (
     ModelBehaviorError,
     ModelRefusalError,
     ModelResponse,
+    ModelSettings,
     RunConfig,
     RunContextWrapper,
     RunHooks,
@@ -230,6 +231,44 @@ async def test_plaintext_agent_with_tool_call_is_run_again():
     assert_item_is_function_tool_call_output(items[2], "123")
 
     assert isinstance(result.next_step, NextStepRunAgain)
+
+
+@pytest.mark.asyncio
+async def test_max_parallel_tool_calls_limits_function_tool_concurrency():
+    active_count = 0
+    max_seen_count = 0
+
+    async def tracked_tool() -> str:
+        nonlocal active_count, max_seen_count
+        active_count += 1
+        max_seen_count = max(max_seen_count, active_count)
+        await asyncio.sleep(0.01)
+        active_count -= 1
+        return "ok"
+
+    tool = function_tool(tracked_tool, name_override="tracked_tool")
+    agent = Agent(
+        name="test",
+        tools=[tool],
+        model_settings=ModelSettings(max_parallel_tool_calls=2),
+    )
+    response = ModelResponse(
+        output=[
+            get_function_tool_call("tracked_tool", "{}", call_id="call_1"),
+            get_function_tool_call("tracked_tool", "{}", call_id="call_2"),
+            get_function_tool_call("tracked_tool", "{}", call_id="call_3"),
+        ],
+        usage=Usage(),
+        response_id="resp",
+    )
+
+    result = await get_execute_result(agent, response)
+
+    assert active_count == 0
+    assert max_seen_count == 2
+    assert (
+        len([item for item in result.generated_items if isinstance(item, ToolCallOutputItem)]) == 3
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds `ModelSettings.max_parallel_tool_calls` as an SDK-side limit for concurrent local function tool execution.
- Preserves the current default by leaving the cap unset, and keeps provider `parallel_tool_calls` behavior separate.
- Applies the cap to normal tool execution and approved tool resumption.

Fixes #1859

## Test plan
- `uv run ruff format src/agents/model_settings.py src/agents/run_internal/tool_execution.py src/agents/run_internal/tool_planning.py tests/test_run_step_execution.py tests/model_settings/test_serialization.py`
- `uv run ruff check src/agents/model_settings.py src/agents/run_internal/tool_execution.py src/agents/run_internal/tool_planning.py tests/test_run_step_execution.py tests/model_settings/test_serialization.py tests/test_source_compat_constructors.py`
- `uv run pytest tests/test_run_step_execution.py::test_max_parallel_tool_calls_limits_function_tool_concurrency tests/model_settings/test_serialization.py::test_all_fields_serialization tests/test_source_compat_constructors.py::test_model_settings_context_management_append_preserves_retry_position -q`
- `uv run pytest tests/test_run_step_execution.py tests/model_settings/test_serialization.py tests/test_source_compat_constructors.py -q`
- `make lint`
- `uv run mypy src/agents/model_settings.py src/agents/run_internal/tool_execution.py src/agents/run_internal/tool_planning.py`