### PR TITLE
fix(realtime): send safe output guardrail feedback

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -13,6 +13,7 @@ from typing_extensions import assert_never
 from .._tool_identity import get_function_tool_lookup_key_for_tool
 from ..agent import Agent
 from ..exceptions import UserError
+from ..guardrail import OutputGuardrailResult
 from ..handoffs import Handoff
 from ..items import ToolApprovalItem
 from ..logger import logger
@@ -91,6 +92,32 @@ def _serialize_tool_output(output: Any) -> str:
         return json.dumps(output, ensure_ascii=False)
     except (TypeError, ValueError):
         return str(output)
+
+
+def _get_realtime_guardrail_feedback_message(
+    triggered_results: list[OutputGuardrailResult],
+) -> str:
+    guardrail_names = [result.guardrail.get_name() for result in triggered_results]
+    failure_details = [
+        {
+            "guardrail": result.guardrail.get_name(),
+            "output_info": result.output.output_info,
+        }
+        for result in triggered_results
+    ]
+    try:
+        failure_details_text = json.dumps(failure_details, default=str)
+    except (TypeError, ValueError):
+        failure_details_text = str(failure_details)
+
+    return (
+        "Your last answer was blocked by an output guardrail.\n"
+        f"Failed guardrail(s): {', '.join(guardrail_names)}.\n"
+        f"Failure details: {failure_details_text}.\n"
+        "Please respond again following policy. Apologize for not being able to answer "
+        "the question while avoiding the specific reason, then redirect the discussion "
+        "to an approved topic without inviting more discussion of the blocked content."
+    )
 
 
 class RealtimeSession(RealtimeModelListener):
@@ -955,11 +982,10 @@ class RealtimeSession(RealtimeModelListener):
             # Interrupt the model
             await self._model.send_event(RealtimeModelSendInterrupt(force_response_cancel=True))
 
-            # Send guardrail triggered message
-            guardrail_names = [result.guardrail.get_name() for result in triggered_results]
+            # Send feedback that asks the model to produce a safe replacement response.
             await self._model.send_event(
                 RealtimeModelSendUserInput(
-                    user_input=f"guardrail triggered: {', '.join(guardrail_names)}"
+                    user_input=_get_realtime_guardrail_feedback_message(triggered_results)
                 )
             )
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1765,7 +1765,16 @@ class TestGuardrailFunctionality:
         # Should have triggered guardrail and interrupted
         assert mock_model.interrupts_called == 1
         assert len(mock_model.sent_messages) == 1
+        assert "Your last answer was blocked by an output guardrail." in mock_model.sent_messages[0]
         assert "triggered_guardrail" in mock_model.sent_messages[0]
+        assert "test trigger" in mock_model.sent_messages[0]
+        assert "Please respond again following policy." in mock_model.sent_messages[0]
+        interrupt_event = next(
+            event
+            for event in mock_model.sent_events
+            if isinstance(event, RealtimeModelSendInterrupt)
+        )
+        assert interrupt_event.force_response_cancel is True
 
         # Should have emitted guardrail_tripped event
         events = []
@@ -1942,6 +1951,8 @@ class TestGuardrailFunctionality:
         assert len(mock_model.sent_messages) == 1
         message = mock_model.sent_messages[0]
         assert "guardrail_1" in message and "guardrail_2" in message
+        assert "Your last answer was blocked by an output guardrail." in message
+        assert "Please respond again following policy." in message
 
         # Should have emitted event with both guardrail results
         events = []
@@ -1971,6 +1982,7 @@ class TestGuardrailFunctionality:
 
         assert mock_model.interrupts_called == 1
         assert len(mock_model.sent_messages) == 1
+        assert "Your last answer was blocked by an output guardrail." in mock_model.sent_messages[0]
         assert "triggered_guardrail" in mock_model.sent_messages[0]
 
         events = []


### PR DESCRIPTION
## Summary
- Replaces the internal realtime output-guardrail follow-up prompt with a user-facing safe recovery instruction.
- Includes failed guardrail names and serialized output info so the model can recover without speaking the blocked content.
- Keeps the existing forced interrupt/cancel behavior and adds coverage that the interrupt is forced before the feedback message is sent.

Fixes #1912

## Test plan
- `uv run ruff format src/agents/realtime/session.py tests/realtime/test_session.py`
- `uv run ruff check src/agents/realtime/session.py tests/realtime/test_session.py`
- `uv run pytest tests/realtime/test_session.py -k guardrail -q`
- `uv run pytest tests/realtime/test_session.py -q`
- `uv run mypy src/agents/realtime/session.py tests/realtime/test_session.py`
- `make lint`