### PR TITLE
fix: make Permissions hashable to match User and Group

### DIFF
--- a/src/agents/sandbox/types.py
+++ b/src/agents/sandbox/types.py
@@ -124,6 +124,9 @@ class Permissions(BaseModel):
             return NotImplemented
         return self.to_mode() == other.to_mode()
 
+    def __hash__(self) -> int:
+        return hash(self.to_mode())
+
 
 class FileMode(IntEnum):
     ALL = 0o7

--- a/tests/sandbox/test_types.py
+++ b/tests/sandbox/test_types.py
@@ -1,0 +1,22 @@
+from agents.sandbox.types import Group, Permissions, User
+
+
+def test_permissions_is_hashable() -> None:
+    # ``Permissions`` overrides ``__eq__``; without a matching ``__hash__`` Pydantic v2
+    # would set ``__hash__ = None``, breaking sets and dict keys for what is otherwise
+    # a value-like type. Sibling classes ``User`` and ``Group`` already define both.
+    perms = Permissions.from_mode(0o755)
+    other = Permissions.from_mode(0o755)
+    different = Permissions.from_mode(0o644)
+
+    assert hash(perms) == hash(other)
+    assert hash(perms) != hash(different)
+    assert {perms, other, different} == {perms, different}
+    assert {perms: "value"}[other] == "value"
+
+
+def test_user_and_group_remain_hashable() -> None:
+    # Regression guard for the sibling classes whose hashability the Permissions fix
+    # mirrors.
+    assert hash(User(name="alice")) == hash(User(name="alice"))
+    assert hash(Group(name="admin", users=[])) == hash(Group(name="admin", users=[]))


### PR DESCRIPTION
### Summary

`Permissions` (`src/agents/sandbox/types.py`) overrides `__eq__` but does not define `__hash__`. Pydantic v2 reacts to this by setting `__hash__ = None`, so instances are unhashable. The sibling classes `User` and `Group` in the same module already define both methods, and `Permissions` is part of a public, documented sandbox API — it is returned from `sandbox.ls()` as `FileEntry.permissions` and is exported from `agents.sandbox`.

The asymmetry is the most likely failure mode: user code that processes file metadata reasonably expects all three classes to be hashable, so natural patterns like

```python
unique_modes = {entry.permissions for entry in await sandbox.ls("/workspace")}

groups: dict[Permissions, list[FileEntry]] = {}

@functools.lru_cache
def is_world_writable(p: Permissions) -> bool: ...
```

raise `TypeError: unhashable type: 'Permissions'`. The same family of bug as #3097 (`ToolContext` hashability), in a different module.

Fix: define `__hash__` in terms of the canonical mode integer, mirroring the existing `__eq__` semantics (`self.to_mode() == other.to_mode()`).

```python
def __hash__(self) -> int:
    return hash(self.to_mode())
```

### Test plan

- Added `tests/sandbox/test_types.py` with two tests:
  - `test_permissions_is_hashable` — covers `hash()`, set membership, dict keys, and equality of hashes for permissions with the same mode.
  - `test_user_and_group_remain_hashable` — regression guard for the sibling classes whose contract this fix mirrors.
- Verified the new test fails on `main` with `TypeError: unhashable type: 'Permissions'` and passes after the fix.
- `make format`, `make lint` — clean.
- `make typecheck` — no new errors in the touched files.
- `make tests` — same pre-existing failures as `main` (voice / sandbox runloop modules), no new failures introduced.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass