### PR TITLE
docs: realtime guardrail fallback behavior

### DIFF
--- a/docs/realtime/guide.md
+++ b/docs/realtime/guide.md
@@ -261,6 +261,12 @@ agent = RealtimeAgent(
 )
 ```
 
+When a realtime output guardrail trips, the session interrupts the active response, forces
+`response.cancel`, emits `guardrail_tripped`, and sends a follow-up user message that names the
+triggered guardrail so the model can produce a replacement response. Your audio player should still
+listen for `audio_interrupted` and stop local playback immediately, because guardrails run on
+debounced transcript text and some audio may already be buffered when the tripwire fires.
+
 ## SIP and telephony
 
 The Python SDK includes a first-class SIP attach flow via [`OpenAIRealtimeSIPModel`][agents.realtime.openai_realtime.OpenAIRealtimeSIPModel].

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1764,8 +1764,14 @@ class TestGuardrailFunctionality:
 
         # Should have triggered guardrail and interrupted
         assert mock_model.interrupts_called == 1
+        interrupt_event = next(
+            event
+            for event in mock_model.sent_events
+            if isinstance(event, RealtimeModelSendInterrupt)
+        )
+        assert interrupt_event.force_response_cancel is True
         assert len(mock_model.sent_messages) == 1
-        assert "triggered_guardrail" in mock_model.sent_messages[0]
+        assert mock_model.sent_messages[0] == "guardrail triggered: triggered_guardrail"
 
         # Should have emitted guardrail_tripped event
         events = []


### PR DESCRIPTION
Refs #1912

## Summary

- Clarify the realtime output-guardrail flow in the guide: interrupt active response, force `response.cancel`, emit `guardrail_tripped`, and send a follow-up message for a replacement response.
- Call out that applications should stop local audio playback on `audio_interrupted`, since guardrails run on debounced transcript text.
- Strengthen the realtime guardrail test to assert that guardrail-triggered interrupts use `force_response_cancel=True` and send the exact follow-up user input.

## Verification

- `PYTHONPATH=src python -m pytest tests\realtime\test_session.py -q` -> 72 passed
- `python -m ruff check tests\realtime\test_session.py` -> passed
- `git diff --check` -> passed
- AANA code-change guardrail: pass / accept, AIx 1.0, no violations

I also tried `PYTHONPATH=src PYTHONUTF8=1 python -m mkdocs build --strict`; it still aborts on pre-existing repo-wide docs warnings across nav/i18n/autoref pages. A non-strict full docs build did not complete within the local 2-minute timeout while building the full multilingual/reference site.
