### PR TITLE
fix: reject non-object function tool input JSON

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -1450,13 +1450,18 @@ def _build_handled_function_tool_error_handler(
 def _parse_function_tool_json_input(*, tool_name: str, input_json: str) -> dict[str, Any]:
     """Decode raw tool arguments with consistent diagnostics."""
     try:
-        return json.loads(input_json) if input_json else {}
+        parsed = json.loads(input_json) if input_json else {}
     except Exception as exc:
         if _debug.DONT_LOG_TOOL_DATA:
             logger.debug(f"Invalid JSON input for tool {tool_name}")
         else:
             logger.debug(f"Invalid JSON input for tool {tool_name}: {input_json}")
         raise ModelBehaviorError(f"Invalid JSON input for tool {tool_name}: {input_json}") from exc
+
+    if not isinstance(parsed, dict):
+        raise ModelBehaviorError(f"Invalid JSON input for tool {tool_name}: expected a JSON object")
+
+    return parsed
 
 
 def _log_function_tool_invocation(*, tool_name: str, input_json: str) -> None:

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -733,6 +733,33 @@ async def test_copied_function_tool_invalid_input_uses_current_name(copy_style: 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("input_json", ["[]", '"value"', "123", "null", "true"])
+async def test_function_tool_rejects_non_object_json_input(input_json: str) -> None:
+    def echo(value: str) -> str:
+        return value
+
+    tool = function_tool(
+        echo,
+        name_override="echo_tool",
+        failure_error_function=None,
+    )
+
+    with pytest.raises(
+        ModelBehaviorError,
+        match="Invalid JSON input for tool echo_tool: expected a JSON object",
+    ):
+        await tool.on_invoke_tool(
+            ToolContext(
+                None,
+                tool_name="echo_tool",
+                tool_call_id="1",
+                tool_arguments=input_json,
+            ),
+            input_json,
+        )
+
+
+@pytest.mark.asyncio
 async def test_default_failure_error_function_survives_deepcopy() -> None:
     def boom() -> None:
         raise RuntimeError("kapow")


### PR DESCRIPTION
### Summary

Mirror the MCP fix in #3135 for the function-tool path. When the model emits a JSON array or scalar (e.g. `[1, 2, 3]`, `"foo"`, `null`) instead of an object as tool arguments, `**unpack` into the pydantic params model raises a raw `TypeError`. That `TypeError` is not matched by `_extract_tool_argument_json_error` (which only matches `ModelBehaviorError` whose message starts with `"Invalid JSON input for tool"`), so the `default_tool_error_function` "please try again with valid JSON" retry path is bypassed and the run fails with a confusing error instead of asking the model to fix its arguments.

This validates the parsed JSON shape inside `_parse_function_tool_json_input` and raises a clean `ModelBehaviorError` for non-object input, matching the MCP precedent. Affects both the standard runtime tool path and the realtime tool path (both reach the same parser).

### Test plan

- New parametrized test `test_function_tool_rejects_non_object_json_input` covering JSON arrays, strings, numbers, null, and bool — each must raise `ModelBehaviorError` with `"expected a JSON object"`.
- `uv run pytest tests/test_function_tool.py tests/test_run_step_execution.py tests/test_function_tool_decorator.py tests/test_agent_as_tool.py` — 191 passed.
- `uv run ruff check src/agents/tool.py tests/test_function_tool.py` — All checks passed.

### Issue number

N/A — found while reviewing function-tool error handling consistency with #3135.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no doc changes needed)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass