### PR TITLE
fix: #3170 clean up git repo temp clones on failure

### DIFF
--- a/src/agents/sandbox/entries/artifacts.py
+++ b/src/agents/sandbox/entries/artifacts.py
@@ -652,41 +652,44 @@ class GitRepo(BaseEntry):
         url = f"https://{self.host}/{self.repo}.git"
 
         _ = await session.exec("rm", "-rf", "--", tmp_dir, shell=False)
-        clone_error: ExecResult | None = None
-        if self._looks_like_commit_ref(self.ref):
-            clone = await self._fetch_commit_ref(session=session, url=url, tmp_dir=tmp_dir)
-            if not clone.ok():
-                clone_error = clone
-                _ = await session.exec("rm", "-rf", "--", tmp_dir, shell=False)
+        try:
+            clone_error: ExecResult | None = None
+            if self._looks_like_commit_ref(self.ref):
+                clone = await self._fetch_commit_ref(session=session, url=url, tmp_dir=tmp_dir)
+                if not clone.ok():
+                    clone_error = clone
+                    _ = await session.exec("rm", "-rf", "--", tmp_dir, shell=False)
+                    clone = await self._clone_named_ref(session=session, url=url, tmp_dir=tmp_dir)
+            else:
                 clone = await self._clone_named_ref(session=session, url=url, tmp_dir=tmp_dir)
-        else:
-            clone = await self._clone_named_ref(session=session, url=url, tmp_dir=tmp_dir)
-        if not clone.ok():
-            if clone_error is not None:
-                clone = clone_error
-            raise GitCloneError(
-                url=url,
-                ref=self.ref,
-                stderr=clone.stderr.decode("utf-8", errors="replace"),
-                context={"repo": self.repo, "subpath": self.subpath},
+            if not clone.ok():
+                if clone_error is not None:
+                    clone = clone_error
+                raise GitCloneError(
+                    url=url,
+                    ref=self.ref,
+                    stderr=clone.stderr.decode("utf-8", errors="replace"),
+                    context={"repo": self.repo, "subpath": self.subpath},
+                )
+
+            git_src_root: str = tmp_dir
+            if self.subpath is not None:
+                git_src_root = f"{tmp_dir}/{self.subpath.lstrip('/')}"
+
+            # Copy into destination in the container.
+            await session.mkdir(dest, parents=True)
+            copy = await session.exec(
+                "cp", "-R", "--", f"{git_src_root}/.", f"{dest}/", shell=False
             )
-
-        git_src_root: str = tmp_dir
-        if self.subpath is not None:
-            git_src_root = f"{tmp_dir}/{self.subpath.lstrip('/')}"
-
-        # Copy into destination in the container.
-        await session.mkdir(dest, parents=True)
-        copy = await session.exec("cp", "-R", "--", f"{git_src_root}/.", f"{dest}/", shell=False)
-        if not copy.ok():
-            raise GitCopyError(
-                src_root=git_src_root,
-                dest=dest,
-                stderr=copy.stderr.decode("utf-8", errors="replace"),
-                context={"repo": self.repo, "ref": self.ref, "subpath": self.subpath},
-            )
-
-        _ = await session.exec("rm", "-rf", "--", tmp_dir, shell=False)
+            if not copy.ok():
+                raise GitCopyError(
+                    src_root=git_src_root,
+                    dest=dest,
+                    stderr=copy.stderr.decode("utf-8", errors="replace"),
+                    context={"repo": self.repo, "ref": self.ref, "subpath": self.subpath},
+                )
+        finally:
+            _ = await session.exec("rm", "-rf", "--", tmp_dir, shell=False)
         await self._apply_metadata(session, dest)
 
         # Receipt: leave checksums empty for now. (Computing them would

--- a/tests/sandbox/test_entries.py
+++ b/tests/sandbox/test_entries.py
@@ -13,6 +13,8 @@ from agents.sandbox import SandboxConcurrencyLimits
 from agents.sandbox.entries import Dir, File, GitRepo, LocalDir, LocalFile, resolve_workspace_path
 from agents.sandbox.errors import (
     ExecNonZeroError,
+    GitCloneError,
+    GitCopyError,
     InvalidManifestPathError,
     LocalDirReadError,
     LocalFileReadError,
@@ -78,6 +80,28 @@ class _GitRefSession(_RecordingSession):
             return ExecResult(stdout=b"/usr/bin/git\n", stderr=b"", exit_code=0)
         if cmd[:2] == ("git", "clone"):
             return ExecResult(stdout=b"", stderr=b"unexpected clone path", exit_code=1)
+        return ExecResult(stdout=b"", stderr=b"", exit_code=0)
+
+
+class _GitFailureSession(_RecordingSession):
+    def __init__(self, *, fail_on: str) -> None:
+        super().__init__()
+        self.fail_on = fail_on
+
+    async def _exec_internal(
+        self,
+        *command: str | Path,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        _ = timeout
+        cmd = tuple(str(part) for part in command)
+        self.exec_calls.append(cmd)
+        if cmd == ("command -v git >/dev/null 2>&1",):
+            return ExecResult(stdout=b"/usr/bin/git\n", stderr=b"", exit_code=0)
+        if self.fail_on == "clone" and cmd[:2] == ("git", "clone"):
+            return ExecResult(stdout=b"", stderr=b"clone failed", exit_code=1)
+        if self.fail_on == "copy" and cmd[:1] == ("cp",):
+            return ExecResult(stdout=b"", stderr=b"copy failed", exit_code=1)
         return ExecResult(stdout=b"", stderr=b"", exit_code=0)
 
 
@@ -669,6 +693,48 @@ async def test_git_repo_uses_fetch_checkout_path_for_commit_refs() -> None:
         and call[3:5] == ("checkout", "--detach")
         and call[-1] == "FETCH_HEAD"
         for call in session.exec_calls
+    )
+
+
+def _git_temp_cleanup_calls(session: _RecordingSession) -> list[tuple[str, ...]]:
+    return [call for call in session.exec_calls if call[:3] == ("rm", "-rf", "--")]
+
+
+def _git_temp_cleanup_call_indices(session: _RecordingSession) -> list[int]:
+    return [i for i, call in enumerate(session.exec_calls) if call[:3] == ("rm", "-rf", "--")]
+
+
+@pytest.mark.asyncio
+async def test_git_repo_cleans_temp_clone_after_copy_failure() -> None:
+    session = _GitFailureSession(fail_on="copy")
+    repo = GitRepo(repo="openai/example", ref="main")
+
+    with pytest.raises(GitCopyError):
+        await repo.apply(session, Path("/workspace/repo"), Path("/ignored"))
+
+    cleanup_calls = _git_temp_cleanup_calls(session)
+    cleanup_indices = _git_temp_cleanup_call_indices(session)
+    assert len(cleanup_calls) == 2
+    assert cleanup_calls[0] == cleanup_calls[1]
+    assert cleanup_indices[1] > next(
+        i for i, call in enumerate(session.exec_calls) if call[:1] == ("cp",)
+    )
+
+
+@pytest.mark.asyncio
+async def test_git_repo_cleans_temp_clone_after_clone_failure() -> None:
+    session = _GitFailureSession(fail_on="clone")
+    repo = GitRepo(repo="openai/example", ref="main")
+
+    with pytest.raises(GitCloneError):
+        await repo.apply(session, Path("/workspace/repo"), Path("/ignored"))
+
+    cleanup_calls = _git_temp_cleanup_calls(session)
+    cleanup_indices = _git_temp_cleanup_call_indices(session)
+    assert len(cleanup_calls) == 2
+    assert cleanup_calls[0] == cleanup_calls[1]
+    assert cleanup_indices[1] > next(
+        i for i, call in enumerate(session.exec_calls) if call[:2] == ("git", "clone")
     )
 
 


### PR DESCRIPTION
### Summary

- Ensure `GitRepo.apply()` removes its temporary clone directory from the sandbox even when clone/copy phases fail.
- Add regression coverage for both copy failure and clone failure cleanup paths.

### Test plan

- `uv run pytest tests/sandbox/test_entries.py -q` 
- `bash .agents/skills/code-change-verification/scripts/run.sh` 
### Issue number

Closes #3170

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass