### PR TITLE
fix: #3171 reject corrupt Dapr session state updates

### DIFF
--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -177,7 +177,7 @@ class DaprSession(SessionABC):
         """Deserialize a JSON string to an item. Can be overridden by subclasses."""
         return json.loads(item)  # type: ignore[no-any-return]
 
-    def _decode_messages(self, data: bytes | None) -> list[Any]:
+    def _decode_messages(self, data: bytes | None, *, strict: bool = False) -> list[Any]:
         if not data:
             return []
         try:
@@ -185,9 +185,22 @@ class DaprSession(SessionABC):
             messages = json.loads(messages_json)
             if isinstance(messages, list):
                 return list(messages)
-        except (json.JSONDecodeError, UnicodeDecodeError):
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            if strict:
+                raise ValueError(
+                    "The stored Dapr session messages are not valid JSON and cannot be "
+                    "safely updated."
+                ) from error
             return []
+        if strict:
+            raise ValueError(
+                "The stored Dapr session messages must be a JSON list and cannot be safely updated."
+            )
         return []
+
+    def _decode_messages_for_update(self, data: bytes | None) -> list[Any]:
+        """Decode aggregate state before an operation that rewrites it."""
+        return self._decode_messages(data, strict=True)
 
     def _calculate_retry_delay(self, attempt: int) -> float:
         base: float = _RETRY_BASE_DELAY_SECONDS * (2 ** max(0, attempt - 1))
@@ -290,7 +303,7 @@ class DaprSession(SessionABC):
                     key=self._messages_key,
                     state_metadata=self._get_read_metadata(),
                 )
-                existing_messages = self._decode_messages(response.data)
+                existing_messages = self._decode_messages_for_update(response.data)
                 updated_messages = existing_messages + serialized_items
                 messages_json = json.dumps(updated_messages, separators=(",", ":"))
                 etag = response.etag

--- a/tests/extensions/memory/test_dapr_session.py
+++ b/tests/extensions/memory/test_dapr_session.py
@@ -669,32 +669,40 @@ async def test_internal_client_ownership(fake_dapr_client: FakeDaprClient):
         assert fake_dapr_client._closed is True
 
 
-async def test_corrupted_data_handling(fake_dapr_client: FakeDaprClient):
-    """Test that corrupted JSON data is handled gracefully."""
+@pytest.mark.parametrize(
+    "raw_state",
+    [
+        b"invalid json data",
+        b"\xff",
+        json.dumps({"some": "object"}).encode("utf-8"),
+    ],
+)
+async def test_add_items_rejects_corrupted_aggregate_state(
+    fake_dapr_client: FakeDaprClient,
+    raw_state: bytes,
+):
+    """Test that corrupted aggregate state is not overwritten by add_items."""
     session = await _create_test_session(fake_dapr_client, "corruption_test")
 
     try:
         await session.clear_session()
 
-        # Add some valid data first
+        # Add some valid data first.
         await session.add_items([{"role": "user", "content": "valid message"}])
 
-        # Inject corrupted data directly into state store
+        # Inject corrupted data directly into state store.
         messages_key = "corruption_test:messages"
-        fake_dapr_client._state[messages_key] = b"invalid json data"
+        fake_dapr_client._state[messages_key] = raw_state
 
-        # get_items should handle corrupted data gracefully
+        # get_items should handle corrupted data gracefully.
         items = await session.get_items()
         assert len(items) == 0  # Corrupted data returns empty list
 
-        # Should be able to add new valid items after corruption
+        # add_items should not overwrite the corrupted aggregate state.
         valid_item: TResponseInputItem = {"role": "user", "content": "valid after corruption"}
-        await session.add_items([valid_item])
-
-        # Should now have valid items
-        items = await session.get_items()
-        assert len(items) == 1
-        assert items[0].get("content") == "valid after corruption"
+        with pytest.raises(ValueError, match="stored Dapr session messages"):
+            await session.add_items([valid_item])
+        assert fake_dapr_client._state[messages_key] == raw_state
 
     finally:
         await session.close()


### PR DESCRIPTION
### Summary

- Make `DaprSession.add_items()` decode existing aggregate messages state strictly before rewriting it.
- Preserve the current tolerant `get_items()` behavior for corrupted aggregate state, but fail fast on update when the stored messages value is malformed JSON, invalid UTF-8, or valid JSON that is not a list.
- Add regression coverage to verify corrupted aggregate state is not overwritten while missing state and valid appends still work.

### Test plan

- `uv run pytest tests/extensions/memory/test_dapr_session.py -k "corrupted_aggregate_state or messages_not_list_handling or direct_ops"`
- `uv run pytest tests/extensions/memory/test_dapr_session.py`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3171

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
