### PR TITLE
fix: #3174 count valid encrypted session items for limits

### DIFF
--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -38,7 +38,7 @@ from typing_extensions import TypedDict
 
 from ...items import TResponseInputItem
 from ...memory.session import SessionABC
-from ...memory.session_settings import SessionSettings
+from ...memory.session_settings import SessionSettings, resolve_session_limit
 
 
 class EncryptedEnvelope(TypedDict):
@@ -170,14 +170,31 @@ class EncryptedSession(SessionABC):
         except (InvalidToken, KeyError):
             return None
 
-    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
-        encrypted_items = await self.underlying_session.get_items(limit)
+    def _unwrap_valid_items(
+        self, encrypted_items: list[TResponseInputItem]
+    ) -> list[TResponseInputItem]:
         valid_items: list[TResponseInputItem] = []
         for enc in encrypted_items:
             item = self._unwrap(enc)
             if item is not None:
                 valid_items.append(item)
         return valid_items
+
+    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+        effective_limit = resolve_session_limit(limit, self.session_settings)
+        if effective_limit is not None and effective_limit > 0:
+            window = effective_limit
+            while True:
+                encrypted_items = await self.underlying_session.get_items(window)
+                valid_items = self._unwrap_valid_items(encrypted_items)
+                if len(valid_items) >= effective_limit:
+                    return valid_items[-effective_limit:]
+                if len(encrypted_items) < window:
+                    return valid_items
+                window *= 2
+
+        encrypted_items = await self.underlying_session.get_items(limit)
+        return self._unwrap_valid_items(encrypted_items)
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
         wrapped: list[EncryptedEnvelope] = [self._wrap(it) for it in items]

--- a/tests/extensions/memory/test_encrypt_session.py
+++ b/tests/extensions/memory/test_encrypt_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -9,13 +10,20 @@ pytest.importorskip("cryptography")  # Skip tests if cryptography is not install
 
 from cryptography.fernet import Fernet
 
-from agents import Agent, Runner, SQLiteSession, TResponseInputItem
+from agents import Agent, Runner, SessionSettings, SQLiteSession, TResponseInputItem
 from agents.extensions.memory.encrypt_session import EncryptedSession
 from tests.fake_model import FakeModel
 from tests.test_responses import get_text_message
 
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
+
+
+def _invalid_encrypted_envelope() -> TResponseInputItem:
+    return cast(
+        TResponseInputItem,
+        {"__enc__": 1, "v": 1, "kid": "hkdf-v1", "payload": "not-a-valid-token"},
+    )
 
 
 @pytest.fixture
@@ -280,6 +288,79 @@ async def test_encrypted_session_get_items_limit(
     assert len(limited) == 2
     assert limited[0].get("content") == "Message 3"  # Latest 2
     assert limited[1].get("content") == "Message 4"
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_get_items_limit_skips_invalid_latest_envelope(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """Test that limit counts valid decrypted items, not encrypted envelopes."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    await session.add_items([{"role": "user", "content": "older valid"}])
+    await underlying_session.add_items([_invalid_encrypted_envelope()])
+
+    all_items = await session.get_items()
+    assert [item.get("content") for item in all_items] == ["older valid"]
+
+    limited = await session.get_items(limit=1)
+    assert [item.get("content") for item in limited] == ["older valid"]
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_get_items_limit_returns_latest_valid_items_after_invalids(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """Test that invalid envelopes do not hide earlier valid items from limit."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    await session.add_items(
+        [
+            {"role": "user", "content": "valid 0"},
+            {"role": "assistant", "content": "valid 1"},
+        ]
+    )
+    await underlying_session.add_items([_invalid_encrypted_envelope()])
+    await session.add_items([{"role": "user", "content": "valid 2"}])
+
+    limited = await session.get_items(limit=2)
+    assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_get_items_session_settings_limit_skips_invalid_envelopes(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """Test that session settings limit counts valid decrypted items."""
+    underlying_session.session_settings = SessionSettings(limit=3)
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    await session.add_items(
+        [
+            {"role": "user", "content": "valid 0"},
+            {"role": "assistant", "content": "valid 1"},
+            {"role": "user", "content": "valid 2"},
+        ]
+    )
+    await underlying_session.add_items([_invalid_encrypted_envelope()])
+
+    items = await session.get_items()
+    assert [item.get("content") for item in items] == ["valid 0", "valid 1", "valid 2"]
 
     underlying_session.close()
 


### PR DESCRIPTION
### Summary

- Make positive effective `EncryptedSession.get_items()` limits count valid decrypted items instead of raw encrypted envelopes, whether the limit is passed explicitly or comes from the wrapped session's `SessionSettings`.
- Expand the underlying fetch window when invalid, expired, or undecryptable envelopes are encountered, stopping once enough valid items are found or the underlying history is exhausted.
- Add regression coverage for explicit limits, `SessionSettings(limit=...)`, invalid latest envelopes, and mixed valid/invalid ordering.

This keeps `limit=None` with no configured limit and `limit<=0` on the previous direct delegation path. Negative `limit` semantics are a separate cross-backend session-limit consistency issue and are intentionally out of scope here.

### Test plan

- `uv run pytest tests/extensions/memory/test_encrypt_session.py -k "session_settings_limit_skips_invalid_envelopes or limit_skips_invalid_latest_envelope or latest_valid_items_after_invalids or get_items_limit"`
- `uv run pytest tests/extensions/memory/test_encrypt_session.py`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3174

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass