### PR TITLE
fix: #3109 stabilize chat completions stream output indexes

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -65,8 +65,6 @@ class StreamingState:
     function_calls: dict[int, ResponseFunctionToolCall] = field(default_factory=dict)
     # Fields for real-time function call streaming
     function_call_streaming: dict[int, bool] = field(default_factory=dict)
-    # Stable output indexes for function calls, including fallback calls.
-    function_call_output_idx: dict[int, int] = field(default_factory=dict)
     # Store accumulated thinking text and signature for Anthropic compatibility
     thinking_text: str = ""
     thinking_signature: str | None = None
@@ -84,7 +82,120 @@ class SequenceNumber:
         return num
 
 
+@dataclass
+class _StreamOutputLayout:
+    """Tracks output slots that have been exposed to stream consumers."""
+
+    assistant_message_output_idx: int | None = None
+    function_call_output_idxs: dict[int, int] = field(default_factory=dict)
+
+    @staticmethod
+    def _reasoning_output_count(state: StreamingState) -> int:
+        return 1 if state.reasoning_content_index_and_output is not None else 0
+
+    def assistant_message_output_index(self, state: StreamingState) -> int:
+        if self.assistant_message_output_idx is None:
+            output_index = self._reasoning_output_count(state)
+            if self.function_call_output_idxs:
+                output_index += len(state.function_calls)
+            self.assistant_message_output_idx = output_index
+
+        return self.assistant_message_output_idx
+
+    def function_call_output_index(
+        self,
+        state: StreamingState,
+        function_call_index: int,
+    ) -> int:
+        if function_call_index in self.function_call_output_idxs:
+            return self.function_call_output_idxs[function_call_index]
+
+        function_call_indices = list(state.function_calls)
+        try:
+            function_call_offset = function_call_indices.index(function_call_index)
+        except ValueError as exc:
+            raise KeyError(
+                f"Function call index {function_call_index} has not been tracked"
+            ) from exc
+
+        output_index = self._reasoning_output_count(state)
+        if self.assistant_message_output_idx is None:
+            output_index += function_call_offset
+        else:
+            function_calls_before_message = (
+                self.assistant_message_output_idx - self._reasoning_output_count(state)
+            )
+            if function_call_offset < function_calls_before_message:
+                output_index += function_call_offset
+            else:
+                output_index += function_call_offset + 1
+
+        self.function_call_output_idxs[function_call_index] = output_index
+        return output_index
+
+    def function_calls_before_message(
+        self,
+        state: StreamingState,
+    ) -> list[ResponseFunctionToolCall]:
+        if self.assistant_message_output_idx is None:
+            return []
+
+        function_call_count = self.assistant_message_output_idx - self._reasoning_output_count(
+            state
+        )
+        return list(state.function_calls.values())[:function_call_count]
+
+    def function_calls_after_message(
+        self,
+        state: StreamingState,
+    ) -> list[ResponseFunctionToolCall]:
+        if self.assistant_message_output_idx is None:
+            return list(state.function_calls.values())
+
+        function_call_count = self.assistant_message_output_idx - self._reasoning_output_count(
+            state
+        )
+        return list(state.function_calls.values())[function_call_count:]
+
+
 class ChatCmplStreamHandler:
+    @staticmethod
+    def _merged_provider_data(
+        state: StreamingState,
+        function_call: ResponseFunctionToolCall,
+    ) -> dict[str, Any] | None:
+        if not (
+            state.provider_data
+            or (hasattr(function_call, "provider_data") and function_call.provider_data)
+        ):
+            return None
+
+        merged_provider_data = state.provider_data.copy() if state.provider_data else {}
+        if hasattr(function_call, "provider_data") and function_call.provider_data:
+            merged_provider_data.update(function_call.provider_data)
+        return merged_provider_data
+
+    @classmethod
+    def _function_call_item(
+        cls,
+        state: StreamingState,
+        function_call: ResponseFunctionToolCall,
+        *,
+        arguments: str,
+    ) -> ResponseFunctionToolCall:
+        function_call_kwargs: dict[str, Any] = {
+            "id": FAKE_RESPONSES_ID,
+            "call_id": function_call.call_id,
+            "arguments": arguments,
+            "name": function_call.name,
+            "type": "function_call",
+        }
+
+        if merged_provider_data := cls._merged_provider_data(state, function_call):
+            function_call_kwargs["provider_data"] = merged_provider_data
+
+        return ResponseFunctionToolCall(**function_call_kwargs)
+
     @classmethod
     def _finish_reasoning_summary_part(
         cls,
@@ -146,17 +257,6 @@ class ChatCmplStreamHandler:
         )
         state.reasoning_item_done = True
 
-    @staticmethod
-    def _function_call_starting_index(state: StreamingState) -> int:
-        starting_index = 0
-        if state.reasoning_content_index_and_output:
-            starting_index += 1
-        if state.text_content_index_and_output:
-            starting_index += 1
-        if state.refusal_content_index_and_output:
-            starting_index += 1
-        return starting_index
-
     @classmethod
     async def handle_stream(
         cls,
@@ -175,6 +275,7 @@ class ChatCmplStreamHandler:
         """
         usage: CompletionUsage | None = None
         state = StreamingState()
+        output_layout = _StreamOutputLayout()
         sequence_number = SequenceNumber()
         async for chunk in stream:
             if not state.started:
@@ -353,16 +454,14 @@ class ChatCmplStreamHandler:
                     # Notify consumers of the start of a new output message + first content part
                     yield ResponseOutputItemAddedEvent(
                         item=assistant_item,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=output_layout.assistant_message_output_index(state),
                         type="response.output_item.added",
                         sequence_number=sequence_number.get_and_increment(),
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.text_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=output_layout.assistant_message_output_index(state),
                         part=ResponseOutputText(
                             text="",
                             type="output_text",
@@ -386,8 +485,7 @@ class ChatCmplStreamHandler:
                     content_index=state.text_content_index_and_output[0],
                     delta=delta.content,
                     item_id=FAKE_RESPONSES_ID,
-                    output_index=state.reasoning_content_index_and_output
-                    is not None,  # fixed 0 -> 0 or 1
+                    output_index=output_layout.assistant_message_output_index(state),
                     type="response.output_text.delta",
                     sequence_number=sequence_number.get_and_increment(),
                     logprobs=delta_logprobs,
@@ -427,15 +525,14 @@ class ChatCmplStreamHandler:
                     # Notify downstream that assistant message + first content part are starting
                     yield ResponseOutputItemAddedEvent(
                         item=assistant_item,
-                        output_index=state.reasoning_content_index_and_output
-                        is not None,  # fixed 0 -> 0 or 1
+                        output_index=output_layout.assistant_message_output_index(state),
                         type="response.output_item.added",
                         sequence_number=sequence_number.get_and_increment(),
                     )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.refusal_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
-                        output_index=(1 if state.reasoning_content_index_and_output else 0),
+                        output_index=output_layout.assistant_message_output_index(state),
                         part=ResponseOutputRefusal(
                             refusal="",
                             type="refusal",
@@ -448,8 +545,7 @@ class ChatCmplStreamHandler:
                     content_index=state.refusal_content_index_and_output[0],
                     delta=delta.refusal,
                     item_id=FAKE_RESPONSES_ID,
-                    output_index=state.reasoning_content_index_and_output
-                    is not None,  # fixed 0 -> 0 or 1
+                    output_index=output_layout.assistant_message_output_index(state),
                     type="response.refusal.delta",
                     sequence_number=sequence_number.get_and_increment(),
                 )
@@ -468,10 +564,6 @@ class ChatCmplStreamHandler:
                             call_id="",
                         )
                         state.function_call_streaming[tc_delta.index] = False
-                        state.function_call_output_idx[tc_delta.index] = (
-                            cls._function_call_starting_index(state)
-                            + len(state.function_call_output_idx)
-                        )
 
                     tc_function = tc_delta.function
 
@@ -543,34 +635,20 @@ class ChatCmplStreamHandler:
                         and function_call.name
                         and function_call.call_id
                     ):
-                        output_index = state.function_call_output_idx[tc_delta.index]
+                        output_index = output_layout.function_call_output_index(
+                            state, tc_delta.index
+                        )
 
                         # Mark this function call as streaming.
                         state.function_call_streaming[tc_delta.index] = True
 
                         # Send initial function call added event
-                        func_call_item = ResponseFunctionToolCall(
-                            id=FAKE_RESPONSES_ID,
-                            call_id=function_call.call_id,
-                            arguments="",  # Start with empty arguments
-                            name=function_call.name,
-                            type="function_call",
-                        )
-                        # Merge provider_data from state and function_call (e.g. thought_signature)
-                        if state.provider_data or (
-                            hasattr(function_call, "provider_data") and function_call.provider_data
-                        ):
-                            merged_provider_data = (
-                                state.provider_data.copy() if state.provider_data else {}
-                            )
-                            if (
-                                hasattr(function_call, "provider_data")
-                                and function_call.provider_data
-                            ):
-                                merged_provider_data.update(function_call.provider_data)
-                            func_call_item.provider_data = merged_provider_data  # type: ignore[attr-defined]
                         yield ResponseOutputItemAddedEvent(
-                            item=func_call_item,
+                            item=cls._function_call_item(
+                                state,
+                                function_call,
+                                arguments="",
+                            ),
                             output_index=output_index,
                             type="response.output_item.added",
                             sequence_number=sequence_number.get_and_increment(),
@@ -582,7 +660,9 @@ class ChatCmplStreamHandler:
                         and tc_function
                         and tc_function.arguments
                     ):
-                        output_index = state.function_call_output_idx[tc_delta.index]
+                        output_index = output_layout.function_call_output_index(
+                            state, tc_delta.index
+                        )
                         yield ResponseFunctionCallArgumentsDeltaEvent(
                             delta=tc_function.arguments,
                             item_id=FAKE_RESPONSES_ID,
@@ -599,8 +679,7 @@ class ChatCmplStreamHandler:
             yield ResponseContentPartDoneEvent(
                 content_index=state.text_content_index_and_output[0],
                 item_id=FAKE_RESPONSES_ID,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=output_layout.assistant_message_output_index(state),
                 part=state.text_content_index_and_output[1],
                 type="response.content_part.done",
                 sequence_number=sequence_number.get_and_increment(),
@@ -611,8 +690,7 @@ class ChatCmplStreamHandler:
             yield ResponseContentPartDoneEvent(
                 content_index=state.refusal_content_index_and_output[0],
                 item_id=FAKE_RESPONSES_ID,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=output_layout.assistant_message_output_index(state),
                 part=state.refusal_content_index_and_output[1],
                 type="response.content_part.done",
                 sequence_number=sequence_number.get_and_increment(),
@@ -622,28 +700,14 @@ class ChatCmplStreamHandler:
         for index, function_call in state.function_calls.items():
             if state.function_call_streaming.get(index, False):
                 # Function call was streamed, just send the completion event
-                output_index = state.function_call_output_idx[index]
-
-                # Build function call kwargs, include provider_data if present
-                func_call_kwargs: dict[str, Any] = {
-                    "id": FAKE_RESPONSES_ID,
-                    "call_id": function_call.call_id,
-                    "arguments": function_call.arguments,
-                    "name": function_call.name,
-                    "type": "function_call",
-                }
-
-                # Merge provider_data from state and function_call (e.g. thought_signature)
-                if state.provider_data or (
-                    hasattr(function_call, "provider_data") and function_call.provider_data
-                ):
-                    merged_provider_data = state.provider_data.copy() if state.provider_data else {}
-                    if hasattr(function_call, "provider_data") and function_call.provider_data:
-                        merged_provider_data.update(function_call.provider_data)
-                    func_call_kwargs["provider_data"] = merged_provider_data
+                output_index = output_layout.function_call_output_index(state, index)
 
                 yield ResponseOutputItemDoneEvent(
-                    item=ResponseFunctionToolCall(**func_call_kwargs),
+                    item=cls._function_call_item(
+                        state,
+                        function_call,
+                        arguments=function_call.arguments,
+                    ),
                     output_index=output_index,
                     type="response.output_item.done",
                     sequence_number=sequence_number.get_and_increment(),
@@ -651,29 +715,16 @@ class ChatCmplStreamHandler:
             else:
                 # Function call was not streamed (fallback to old behavior)
                 # This handles edge cases where function name never arrived
-                output_index = state.function_call_output_idx[index]
-
-                # Build function call kwargs, include provider_data if present
-                fallback_func_call_kwargs: dict[str, Any] = {
-                    "id": FAKE_RESPONSES_ID,
-                    "call_id": function_call.call_id,
-                    "arguments": function_call.arguments,
-                    "name": function_call.name,
-                    "type": "function_call",
-                }
-
-                # Merge provider_data from state and function_call (e.g. thought_signature)
-                if state.provider_data or (
-                    hasattr(function_call, "provider_data") and function_call.provider_data
-                ):
-                    merged_provider_data = state.provider_data.copy() if state.provider_data else {}
-                    if hasattr(function_call, "provider_data") and function_call.provider_data:
-                        merged_provider_data.update(function_call.provider_data)
-                    fallback_func_call_kwargs["provider_data"] = merged_provider_data
+                output_index = output_layout.function_call_output_index(state, index)
+                fallback_func_call_item = cls._function_call_item(
+                    state,
+                    function_call,
+                    arguments=function_call.arguments,
+                )
 
                 # Send all events at once (backward compatibility)
                 yield ResponseOutputItemAddedEvent(
-                    item=ResponseFunctionToolCall(**fallback_func_call_kwargs),
+                    item=fallback_func_call_item,
                     output_index=output_index,
                     type="response.output_item.added",
                     sequence_number=sequence_number.get_and_increment(),
@@ -686,7 +737,7 @@ class ChatCmplStreamHandler:
                     sequence_number=sequence_number.get_and_increment(),
                 )
                 yield ResponseOutputItemDoneEvent(
-                    item=ResponseFunctionToolCall(**fallback_func_call_kwargs),
+                    item=fallback_func_call_item,
                     output_index=output_index,
                     type="response.output_item.done",
                     sequence_number=sequence_number.get_and_increment(),
@@ -711,6 +762,8 @@ class ChatCmplStreamHandler:
                 reasoning_item.encrypted_content = state.thinking_signature
             outputs.append(reasoning_item)
 
+        outputs.extend(output_layout.function_calls_before_message(state))
+
         # include text or refusal content if they exist
         if state.text_content_index_and_output or state.refusal_content_index_and_output:
             assistant_msg = ResponseOutputMessage(
@@ -731,14 +784,12 @@ class ChatCmplStreamHandler:
             # send a ResponseOutputItemDone for the assistant message
             yield ResponseOutputItemDoneEvent(
                 item=assistant_msg,
-                output_index=state.reasoning_content_index_and_output
-                is not None,  # fixed 0 -> 0 or 1
+                output_index=output_layout.assistant_message_output_index(state),
                 type="response.output_item.done",
                 sequence_number=sequence_number.get_and_increment(),
             )
 
-        for function_call in state.function_calls.values():
-            outputs.append(function_call)
+        outputs.extend(output_layout.function_calls_after_message(state))
 
         final_response = response.model_copy()
         final_response.output = outputs

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -758,3 +758,308 @@ async def test_fallback_function_call_keeps_index_before_streamed_call(monkeypat
     assert added_by_name == {"fallback_first": 0, "streamed_second": 1}
     assert delta_indexes == [1, 0]
     assert done_by_name == {"streamed_second": 1, "fallback_first": 0}
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_fallback_function_call_before_text_uses_final_output_index(
+    monkeypatch,
+) -> None:
+    fallback_call = ChoiceDeltaToolCall(
+        index=0,
+        function=ChoiceDeltaToolCallFunction(name="first_tool", arguments='{"a": 1}'),
+        type="function",
+    )
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[fallback_call]))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="answer"))],
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in (chunk1, chunk2):
+            yield chunk
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        response = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return response, fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    output_events = []
+
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        output_events.append(event)
+
+    added_events = [event for event in output_events if event.type == "response.output_item.added"]
+    delta_events = [
+        event for event in output_events if event.type == "response.function_call_arguments.delta"
+    ]
+    done_events = [event for event in output_events if event.type == "response.output_item.done"]
+    completed_event = next(event for event in output_events if event.type == "response.completed")
+
+    added_message_event = next(
+        event for event in added_events if isinstance(event.item, ResponseOutputMessage)
+    )
+    added_tool_event = next(
+        event for event in added_events if isinstance(event.item, ResponseFunctionToolCall)
+    )
+    done_message_event = next(
+        event for event in done_events if isinstance(event.item, ResponseOutputMessage)
+    )
+    done_tool_event = next(
+        event for event in done_events if isinstance(event.item, ResponseFunctionToolCall)
+    )
+
+    assert added_message_event.output_index == 0
+    assert added_tool_event.output_index == 1
+    assert [event.output_index for event in delta_events] == [1]
+    assert done_message_event.output_index == 0
+    assert done_tool_event.output_index == 1
+    assert isinstance(completed_event.response.output[0], ResponseOutputMessage)
+    assert isinstance(completed_event.response.output[1], ResponseFunctionToolCall)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_streamed_function_call_before_text_keeps_realtime_order(
+    monkeypatch,
+) -> None:
+    streamed_call_start = ChoiceDeltaToolCall(
+        index=0,
+        id="tool-call-1",
+        function=ChoiceDeltaToolCallFunction(name="first_tool", arguments=""),
+        type="function",
+    )
+    streamed_call_args = ChoiceDeltaToolCall(
+        index=0,
+        function=ChoiceDeltaToolCallFunction(arguments='{"a": 1}'),
+        type="function",
+    )
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[streamed_call_start]))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[streamed_call_args]))],
+    )
+    chunk3 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="answer"))],
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in (chunk1, chunk2, chunk3):
+            yield chunk
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        response = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return response, fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    output_events = []
+
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        output_events.append(event)
+
+    added_events = [event for event in output_events if event.type == "response.output_item.added"]
+    delta_events = [
+        event for event in output_events if event.type == "response.function_call_arguments.delta"
+    ]
+    done_events = [event for event in output_events if event.type == "response.output_item.done"]
+    completed_event = next(event for event in output_events if event.type == "response.completed")
+
+    added_message_event = next(
+        event for event in added_events if isinstance(event.item, ResponseOutputMessage)
+    )
+    added_tool_event = next(
+        event for event in added_events if isinstance(event.item, ResponseFunctionToolCall)
+    )
+    done_message_event = next(
+        event for event in done_events if isinstance(event.item, ResponseOutputMessage)
+    )
+    done_tool_event = next(
+        event for event in done_events if isinstance(event.item, ResponseFunctionToolCall)
+    )
+
+    assert added_tool_event.output_index == 0
+    assert added_message_event.output_index == 1
+    assert [event.output_index for event in delta_events] == [0]
+    assert done_tool_event.output_index == 0
+    assert done_message_event.output_index == 1
+    assert isinstance(completed_event.response.output[0], ResponseFunctionToolCall)
+    assert isinstance(completed_event.response.output[1], ResponseOutputMessage)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_mixed_function_calls_before_text_keep_tracked_order(
+    monkeypatch,
+) -> None:
+    fallback_first = ChoiceDeltaToolCall(
+        index=0,
+        function=ChoiceDeltaToolCallFunction(name="fallback_first", arguments='{"a": 1}'),
+        type="function",
+    )
+    streamed_second_start = ChoiceDeltaToolCall(
+        index=1,
+        id="tool-call-2",
+        function=ChoiceDeltaToolCallFunction(name="streamed_second", arguments=""),
+        type="function",
+    )
+    streamed_second_args = ChoiceDeltaToolCall(
+        index=1,
+        function=ChoiceDeltaToolCallFunction(arguments='{"b": 2}'),
+        type="function",
+    )
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[fallback_first]))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[streamed_second_start]))],
+    )
+    chunk3 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[streamed_second_args]))],
+    )
+    chunk4 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="answer"))],
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in (chunk1, chunk2, chunk3, chunk4):
+            yield chunk
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        response = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return response, fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    output_events = []
+
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        output_events.append(event)
+
+    added_events = [event for event in output_events if event.type == "response.output_item.added"]
+    delta_events = [
+        event for event in output_events if event.type == "response.function_call_arguments.delta"
+    ]
+    completed_event = next(event for event in output_events if event.type == "response.completed")
+
+    added_message_event = next(
+        event for event in added_events if isinstance(event.item, ResponseOutputMessage)
+    )
+    added_tool_indexes = {
+        event.item.name: event.output_index
+        for event in added_events
+        if isinstance(event.item, ResponseFunctionToolCall)
+    }
+
+    assert added_tool_indexes == {"streamed_second": 1, "fallback_first": 0}
+    assert added_message_event.output_index == 2
+    assert {event.delta: event.output_index for event in delta_events} == {
+        '{"b": 2}': 1,
+        '{"a": 1}': 0,
+    }
+    assert isinstance(completed_event.response.output[0], ResponseFunctionToolCall)
+    assert isinstance(completed_event.response.output[1], ResponseFunctionToolCall)
+    assert isinstance(completed_event.response.output[2], ResponseOutputMessage)

--- a/tests/models/test_reasoning_content.py
+++ b/tests/models/test_reasoning_content.py
@@ -160,6 +160,24 @@ async def test_stream_response_yields_events_for_reasoning_content(monkeypatch) 
     assert content_delta_events[0].delta == "The answer"
     assert content_delta_events[1].delta == " is 42"
 
+    assistant_message_index_events = []
+    for event in output_events:
+        event_any = cast(Any, event)
+        if event.type in {"response.output_item.added", "response.output_item.done"}:
+            if event_any.item.type == "message":
+                assistant_message_index_events.append(event_any)
+        elif event.type in {
+            "response.content_part.added",
+            "response.output_text.delta",
+            "response.content_part.done",
+        }:
+            assistant_message_index_events.append(event_any)
+
+    assert assistant_message_index_events
+    for event in assistant_message_index_events:
+        assert event.output_index == 1
+        assert type(event.output_index) is int
+
     # verify the final response contains both types of content
     response_event = output_events[-1]
     assert response_event.type == "response.completed"


### PR DESCRIPTION
This pull request fixes #3109 Chat Completions streaming output index allocation for fallback and streamed function calls.

The Chat Completions streaming adapter could reuse or misalign `output_index` values when function calls arrived before assistant text, or when reasoning output preceded assistant message events. The fix centralizes stream output slot allocation in a small internal layout helper so streamed function-call events keep their real-time behavior while final `response.completed.response.output` order stays aligned with the emitted stream indexes.

It also removes the boolean `output_index` path for assistant message events after reasoning output and adds regression coverage for fallback-only, streamed, mixed function-call, late-text, and reasoning-before-text cases.