### PR TITLE
fix: fix duplicate key logic

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -854,7 +854,9 @@ class OpenAIResponsesModel(Model):
             "metadata": self._non_null_or_omit(model_settings.metadata),
             "context_management": self._non_null_or_omit(model_settings.context_management),
         }
-        duplicate_extra_arg_keys = sorted(set(create_kwargs).intersection(extra_args))
+        duplicate_extra_arg_keys = sorted(
+            k for k in extra_args if k in create_kwargs and create_kwargs[k] is not omit
+        )
         if duplicate_extra_arg_keys:
             if len(duplicate_extra_arg_keys) == 1:
                 key = duplicate_extra_arg_keys[0]


### PR DESCRIPTION
This commit fixes a false duplicate-key error when sandbox compaction and context_management are both active.

Repro:

```python
import asyncio
from agents import ModelSettings, Runner
from agents.run import RunConfig
from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
from agents.extensions.sandbox import BlaxelSandboxClient, BlaxelSandboxClientOptions

async def main():

    agent = SandboxAgent(
        name="Sandboxed agent",
        model="gpt-5.4",
        instructions=(
            "You have access to a sandbox environment. You can execute commands, manage files, and inspect processes inside the sandbox."
        ),
        model_settings=ModelSettings(tool_choice="auto"),
        default_manifest=Manifest(root="/blaxel"),
    )

    client = BlaxelSandboxClient()
    run_config = RunConfig(
        sandbox=SandboxRunConfig(
            client=client,
            options=BlaxelSandboxClientOptions(
                name="sbx1",
                image="blaxel/base-image",
                region="us-pdx-1",
                memory=4096,
            ),
        )
    )

    result = await Runner.run(agent, "Install Go in the sandbox.", run_config=run_config)
    print(result.final_output)

    await client.close()

if __name__ == "__main__":
    asyncio.run(main())
```

Result:

```
ERROR:    openai.agents - Error getting response: responses.create() got multiple values for keyword argument
```

Issue: Because "context_management" is always present as a key in `create_kwargs` (regardless of whether its value is omit), any agent using the sandbox with compaction enabled would always trigger the guard and raise:

```
TypeError: responses.create() got multiple values for keyword argument 'context_management'
```

Affected versions: reproduced on openai-agents 0.16.0