### PR TITLE
fix: Responses context-management extra_args collision

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -854,7 +854,11 @@ class OpenAIResponsesModel(Model):
             "metadata": self._non_null_or_omit(model_settings.metadata),
             "context_management": self._non_null_or_omit(model_settings.context_management),
         }
-        duplicate_extra_arg_keys = sorted(set(create_kwargs).intersection(extra_args))
+        duplicate_extra_arg_keys = sorted(
+            k
+            for k in extra_args
+            if k in create_kwargs and not _is_openai_omitted_value(create_kwargs[k])
+        )
         if duplicate_extra_arg_keys:
             if len(duplicate_extra_arg_keys) == 1:
                 key = duplicate_extra_arg_keys[0]

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -869,6 +869,30 @@ def test_build_response_create_kwargs_includes_context_management():
 
 
 @pytest.mark.allow_call_model_methods
+def test_build_response_create_kwargs_allows_extra_arg_when_explicit_arg_is_omitted():
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+    context_management: list[ContextManagement] = [
+        {"type": "compaction", "compact_threshold": 200000}
+    ]
+
+    kwargs = model._build_response_create_kwargs(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(extra_args={"context_management": context_management}),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        previous_response_id=None,
+        conversation_id=None,
+        stream=False,
+        prompt=None,
+    )
+
+    assert kwargs["context_management"] == context_management
+
+
+@pytest.mark.allow_call_model_methods
 def test_build_response_create_kwargs_rejects_duplicate_context_management_extra_args():
     client = DummyWSClient()
     model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]


### PR DESCRIPTION
### Summary

Fix a false duplicate-argument error when a Responses request parameter is supplied through `ModelSettings.extra_args` and the first-class request field is only present as OpenAI's `omit` sentinel.

### Test plan

- `make format`
- `make lint`
- `uv run pytest tests/models/test_openai_responses.py::test_build_response_create_kwargs_allows_extra_arg_when_explicit_arg_is_omitted tests/models/test_openai_responses.py::test_build_response_create_kwargs_rejects_duplicate_context_management_extra_args tests/models/test_openai_responses.py::test_build_response_create_kwargs_rejects_duplicate_extra_args_keys -q`
- `uv run mypy src/agents/models/openai_responses.py tests/models/test_openai_responses.py`
- `uv run pyright src/agents/models/openai_responses.py tests/models/test_openai_responses.py`
- `git diff --check`

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass where not blocked by unrelated local-only failures
