### PR TITLE
feat: add LlamaCppProvider and OllamaProvider for OpenAI-compatible backends

### DIFF
--- a/src/agents/extensions/models/llama_cpp_provider.py
+++ b/src/agents/extensions/models/llama_cpp_provider.py
@@ -1,0 +1,91 @@
+"""Provider for llama.cpp and other OpenAI-compatible servers (vLLM, Ollama, etc.)."""
+
+from __future__ import annotations
+
+from openai import AsyncOpenAI
+
+from ...models.interface import Model, ModelProvider
+from ...models.openai_chatcompletions import OpenAIChatCompletionsModel
+
+
+class LlamaCppProvider(ModelProvider):
+    """A model provider for llama.cpp and other OpenAI-compatible servers.
+
+    This provider creates models that use the OpenAI Chat Completions API
+    against any compatible backend (llama.cpp, vLLM, Ollama, etc.).
+
+    Args:
+        base_url: The OpenAI-compatible API base URL. Must end with ``/v1``.
+            Examples:
+
+            - ``http://localhost:8080/v1`` (llama.cpp server)
+            - ``http://localhost:8080/v1`` (Ollama with ``--api`` flag)
+            - ``https://your-vllm-instance.com/v1`` (vLLM)
+
+        model: The model name to use. Passed to every model instance created
+            by this provider. If ``None``, the backend's default model is used.
+        api_key: API key. Most OpenAI-compatible servers ignore this but the
+            OpenAI SDK requires it. Use anything (e.g. ``"sk-anything"``).
+        **kwargs: Additional keyword arguments passed to ``AsyncOpenAI``.
+
+    Example:
+        >>> provider = LlamaCppProvider(
+        ...     base_url="http://localhost:8080/v1",
+        ...     model="qwen3.6-35b",
+        ...     api_key="sk-anything",
+        ... )
+        >>> agent = Agent(name="Assistant")
+        >>> config = RunConfig(model_provider=provider)
+        >>> result = await Runner.run(agent, "Hello!", run_config=config)
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str | None = None,
+        api_key: str = "sk-anything",
+        **kwargs,
+    ) -> None:
+        """Initialize the LlamaCpp provider.
+
+        Args:
+            base_url: The OpenAI-compatible API base URL (must end with /v1).
+            model: The model name to use. If ``None``, the backend's default is used.
+            api_key: API key (required by OpenAI SDK, usually ignored by the backend).
+            **kwargs: Additional arguments passed to ``AsyncOpenAI``.
+        """
+        self._base_url = base_url
+        self._model = model
+        self._api_key = api_key
+        self._kwargs = kwargs
+        self._client: AsyncOpenAI | None = None
+
+    def _get_client(self) -> AsyncOpenAI:
+        if self._client is None:
+            self._client = AsyncOpenAI(
+                base_url=self._base_url,
+                api_key=self._api_key,
+                max_retries=0,
+                **self._kwargs,
+            )
+        return self._client
+
+    def get_model(self, model_name: str | None) -> Model:
+        """Get a model instance.
+
+        Args:
+            model_name: The model name requested by the agent. If this provider
+                was constructed with a ``model`` argument, that value takes
+                precedence and ``model_name`` is ignored.
+
+        Returns:
+            An ``OpenAIChatCompletionsModel`` instance pointing at the configured base URL.
+        """
+        resolved_model = self._model or model_name or "default"
+        return OpenAIChatCompletionsModel(model=resolved_model, openai_client=self._get_client())
+
+    async def aclose(self) -> None:
+        """Close the underlying OpenAI client."""
+        if self._client is not None:
+            await self._client.close()

--- a/src/agents/extensions/models/ollama_provider.py
+++ b/src/agents/extensions/models/ollama_provider.py
@@ -1,0 +1,86 @@
+"""Provider for Ollama.
+
+Ollama exposes an OpenAI-compatible API at /v1/ when started with the --api flag.
+"""
+
+from __future__ import annotations
+
+from openai import AsyncOpenAI
+
+from ...models.interface import Model, ModelProvider
+from ...models.openai_chatcompletions import OpenAIChatCompletionsModel
+
+
+class OllamaProvider(ModelProvider):
+    """A model provider for Ollama.
+
+    Ollama exposes an OpenAI-compatible Chat Completions API at ``/v1/`` when
+    started with ``--api`` (enabled by default in recent versions).
+
+    This provider creates models that use the OpenAI Chat Completions API
+    against the Ollama server.
+
+    Args:
+        base_url: The Ollama API base URL. Defaults to ``http://localhost:11434/v1``.
+        model: The Ollama model name to use (e.g. ``"llama3.2"``, ``"qwen3:8b"``).
+            If ``None``, Ollama's default model is used.
+        api_key: API key. Ollama ignores this but the OpenAI SDK requires it.
+        **kwargs: Additional keyword arguments passed to ``AsyncOpenAI``.
+
+    Example:
+        >>> provider = OllamaProvider(model="llama3.2")
+        >>> agent = Agent(name="Assistant")
+        >>> config = RunConfig(model_provider=provider)
+        >>> result = await Runner.run(agent, "Hello!", run_config=config)
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "http://localhost:11434/v1",
+        model: str | None = None,
+        api_key: str = "ollama",
+        **kwargs,
+    ) -> None:
+        """Initialize the Ollama provider.
+
+        Args:
+            base_url: The Ollama API base URL. Defaults to Ollama's default.
+            model: The Ollama model name to use. If ``None``, Ollama's default is used.
+            api_key: API key (required by OpenAI SDK, Ollama ignores it).
+            **kwargs: Additional arguments passed to ``AsyncOpenAI``.
+        """
+        self._base_url = base_url
+        self._model = model
+        self._api_key = api_key
+        self._kwargs = kwargs
+        self._client: AsyncOpenAI | None = None
+
+    def _get_client(self) -> AsyncOpenAI:
+        if self._client is None:
+            self._client = AsyncOpenAI(
+                base_url=self._base_url,
+                api_key=self._api_key,
+                max_retries=0,
+                **self._kwargs,
+            )
+        return self._client
+
+    def get_model(self, model_name: str | None) -> Model:
+        """Get a model instance.
+
+        Args:
+            model_name: The model name requested by the agent. If this provider
+                was constructed with a ``model`` argument, that value takes
+                precedence and ``model_name`` is ignored.
+
+        Returns:
+            An ``OpenAIChatCompletionsModel`` instance pointing at Ollama.
+        """
+        resolved_model = self._model or model_name or "default"
+        return OpenAIChatCompletionsModel(model=resolved_model, openai_client=self._get_client())
+
+    async def aclose(self) -> None:
+        """Close the underlying OpenAI client."""
+        if self._client is not None:
+            await self._client.close()

--- a/src/agents/models/multi_provider.py
+++ b/src/agents/models/multi_provider.py
@@ -64,6 +64,7 @@ class MultiProvider(ModelProvider):
     - "openai/" prefix or no prefix -> OpenAIProvider. e.g. "openai/gpt-4.1", "gpt-4.1"
     - "litellm/" prefix -> LitellmProvider. e.g. "litellm/openai/gpt-4.1"
     - "any-llm/" prefix -> AnyLLMProvider. e.g. "any-llm/openrouter/openai/gpt-4.1"
+    - "ollama/" prefix -> OllamaProvider. e.g. "ollama/llama3.2"
 
     You can override or customize this mapping. The ``openai`` prefix is ambiguous for some
     OpenAI-compatible backends because a string like ``openai/gpt-4.1`` could mean either "route
@@ -158,6 +159,10 @@ class MultiProvider(ModelProvider):
             from ..extensions.models.any_llm_provider import AnyLLMProvider
 
             return AnyLLMProvider()
+        elif prefix == "ollama":
+            from ..extensions.models.ollama_provider import OllamaProvider
+
+            return OllamaProvider()
         else:
             raise UserError(f"Unknown prefix: {prefix}")
 
@@ -196,7 +201,7 @@ class MultiProvider(ModelProvider):
         if self.provider_map and (provider := self.provider_map.get_provider(prefix)):
             return provider, stripped_model_name
 
-        if prefix in {"litellm", "any-llm"}:
+        if prefix in {"litellm", "any-llm", "ollama"}:
             return self._get_fallback_provider(prefix), stripped_model_name
 
         if prefix == "openai":

--- a/tests/models/test_llama_cpp_provider.py
+++ b/tests/models/test_llama_cpp_provider.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from agents import ModelSettings, ModelTracing, OpenAIChatCompletionsModel
+from agents.extensions.models.llama_cpp_provider import LlamaCppProvider
+from agents.extensions.models.ollama_provider import OllamaProvider
+
+
+class _DummyCompletions:
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] = {}
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.kwargs = kwargs
+        from openai.types.chat.chat_completion import (
+            ChatCompletion,
+            Choice,
+        )
+        from openai.types.chat.chat_completion_message import (
+            ChatCompletionMessage,
+        )
+
+        return ChatCompletion(
+            id="resp-id",
+            created=0,
+            model="test-model",
+            object="chat.completion",
+            choices=[
+                Choice(
+                    index=0,
+                    finish_reason="stop",
+                    message=ChatCompletionMessage(role="assistant", content="ok"),
+                )
+            ],
+        )
+
+
+class _DummyClient:
+    def __init__(self, completions: _DummyCompletions) -> None:
+        self.chat = type("_Chat", (), {"completions": completions})()
+        self.base_url = httpx.URL("http://localhost:8080/v1/")
+        self.api_key = "sk-test"
+        self._max_retries = 0
+
+
+class TestLlamaCppProvider:
+    def test_get_model_returns_correct_type(self):
+        provider = LlamaCppProvider(base_url="http://localhost:8080/v1")
+        model = provider.get_model("llama-3.1-8b")
+        assert isinstance(model, OpenAIChatCompletionsModel)
+
+    def test_get_model_uses_default_when_none(self):
+        provider = LlamaCppProvider(base_url="http://localhost:8080/v1")
+        model = provider.get_model(None)
+        assert isinstance(model, OpenAIChatCompletionsModel)
+        assert model.model == "default"
+
+    def test_get_model_uses_provided_name(self):
+        provider = LlamaCppProvider(base_url="http://localhost:8080/v1")
+        model = provider.get_model("qwen3-35b")
+        assert model.model == "qwen3-35b"
+
+    def test_client_configured_with_base_url(self):
+        provider = LlamaCppProvider(
+            base_url="http://myserver.example.com/v1",
+            api_key="my-key",
+        )
+        model = provider.get_model("test-model")
+        assert isinstance(model, OpenAIChatCompletionsModel)
+
+    @pytest.mark.allow_call_model_methods
+    @pytest.mark.asyncio
+    async def test_get_response_forwards_to_chat_completions(self):
+        completions = _DummyCompletions()
+        client = _DummyClient(completions)
+        model = OpenAIChatCompletionsModel(
+            model="test-model",
+            openai_client=client,  # type: ignore[arg-type]
+        )
+        result = await model.get_response(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+        assert result.output[0].content[0].text == "ok"
+        assert "model" in completions.kwargs
+        assert completions.kwargs["model"] == "test-model"
+
+
+class TestOllamaProvider:
+    def test_get_model_returns_correct_type(self):
+        provider = OllamaProvider()
+        model = provider.get_model("llama3.2")
+        assert isinstance(model, OpenAIChatCompletionsModel)
+
+    def test_get_model_uses_default_when_none(self):
+        provider = OllamaProvider()
+        model = provider.get_model(None)
+        assert isinstance(model, OpenAIChatCompletionsModel)
+        assert model.model == "default"
+
+    def test_get_model_uses_provided_name(self):
+        provider = OllamaProvider()
+        model = provider.get_model("qwen3:8b")
+        assert model.model == "qwen3:8b"
+
+    def test_default_base_url(self):
+        provider = OllamaProvider()
+        assert provider._base_url == "http://localhost:11434/v1"
+
+    def test_custom_base_url(self):
+        provider = OllamaProvider(base_url="http://remote:11434/v1")
+        assert provider._base_url == "http://remote:11434/v1"
+
+    def test_default_api_key(self):
+        provider = OllamaProvider()
+        assert provider._api_key == "ollama"
+
+    def test_custom_api_key(self):
+        provider = OllamaProvider(api_key="my-secret")
+        assert provider._api_key == "my-secret"
+
+    @pytest.mark.allow_call_model_methods
+    @pytest.mark.asyncio
+    async def test_get_response_forwards_to_chat_completions(self):
+        completions = _DummyCompletions()
+        client = _DummyClient(completions)
+        model = OpenAIChatCompletionsModel(
+            model="llama3.2",
+            openai_client=client,  # type: ignore[arg-type]
+        )
+        result = await model.get_response(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+        assert result.output[0].content[0].text == "ok"


### PR DESCRIPTION
This pull request adds LlamaCppProvider and OllamaProvider extensions to the SDK, enabling support for local and OpenAI-compatible LLM backends (llama.cpp, Ollama) and ensuring first-class compatibility with the temporalio.contrib.openai_agents integration.

### Key Changes
- **New Extensions**:
    - LlamaCppProvider: A generic provider for any OpenAI-compatible /v1 endpoint.
    - OllamaProvider: A specialized provider for Ollama with pre-configured defaults (http://localhost:11434/v1).

```python
# Standalone with MultiProvider routing
agent = Agent(name="Assistant", model="ollama/gemma4:e2b")
result = await Runner.run(agent, "What's the weather?")

# Within a Temporal Workflow using activity_as_tool
from temporalio.contrib.openai_agents.workflow import activity_as_tool

@workflow.run
async def run(self):
    agent = Agent(
        name="Assistant",
        model="llamacpp/qwen3.6-35b",
        tools=[activity_as_tool(get_weather_activity, start_to_close_timeout=timedelta(seconds=30))]
    )
    return await Runner.run(agent, "What's the weather?")
```