### PR TITLE
fix(mcp): cache empty tools list instead of re-fetching every call

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -829,8 +829,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         assert session is not None
 
         try:
-            # Return from cache if caching is enabled, we have tools, and the cache is not dirty
-            if self.cache_tools_list and not self._cache_dirty and self._tools_list:
+            # Return from cache if caching is enabled, we have tools, and the cache is not dirty.
+            # Use `is not None` so that an empty tools list is still treated as cached
+            # (an empty list is a valid response that should not force a re-fetch every call).
+            if self.cache_tools_list and not self._cache_dirty and self._tools_list is not None:
                 tools = self._tools_list
             else:
                 # Fetch the tools from the server

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -61,3 +61,37 @@ async def test_server_caching_works(
         # Without invalidating the cache, calling list_tools() again should return the cached value
         result_tools = await server.list_tools(run_context, agent)
         assert result_tools == tools
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_server_caching_empty_tools_list(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    """An empty tools list should still be cached (regression: empty list was falsy, so the
+    cache check fell through and re-fetched on every call)."""
+    server = MCPServerStdio(
+        params={
+            "command": tee,
+        },
+        cache_tools_list=True,
+    )
+
+    mock_list_tools.return_value = ListToolsResult(tools=[])
+
+    async with server:
+        run_context = RunContextWrapper(context=None)
+        agent = Agent(name="test_agent", instructions="Test agent")
+
+        result_tools = await server.list_tools(run_context, agent)
+        assert result_tools == []
+        assert mock_list_tools.call_count == 1, "list_tools() should have been called once"
+
+        # Empty cached list should NOT trigger a re-fetch.
+        result_tools = await server.list_tools(run_context, agent)
+        assert result_tools == []
+        assert mock_list_tools.call_count == 1, (
+            "empty tools list should be cached and not re-fetched"
+        )


### PR DESCRIPTION
## Summary

When `cache_tools_list=True` and the MCP server reports zero tools, the cached `list_tools` result is an empty list `[]`. The cache check used a truthy test:

```python
if self.cache_tools_list and not self._cache_dirty and self._tools_list:
```

Because an empty list is falsy in Python, this branch is **never** taken when the server returns no tools, and the SDK silently falls through to a fresh `session.list_tools()` round-trip on every call — defeating caching for the empty-tools case and adding latency to every agent step.

## Fix

Switch the check to `self._tools_list is not None` so an empty list is honored as a valid cached response. 3-line code change.

## Test

Added `test_server_caching_empty_tools_list` to `tests/mcp/test_caching.py`, which mirrors the existing `test_server_caching_works` but with `tools=[]`. It asserts that `list_tools()` is only called once, even after a second invocation. The test fails on `main` (`call_count == 2`) and passes with the fix.

All 209 existing tests in `tests/mcp/` continue to pass.

## Test plan

- [x] `uv run pytest tests/mcp/ -x` — 209 passed
- [x] `uv run ruff check src/agents/mcp/server.py tests/mcp/test_caching.py` — clean
- [x] `uv run ruff format` — clean