### PR TITLE
feat(lifecycle): expose tool_call_id to on_tool_start/on_tool_end hooks

### DIFF
--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -1,3 +1,5 @@
+import inspect
+from collections.abc import Awaitable, Callable
 from typing import Any, Generic
 
 from typing_extensions import TypeVar
@@ -8,6 +10,32 @@ from .run_context import AgentHookContext, RunContextWrapper, TContext
 from .tool import Tool
 
 TAgent = TypeVar("TAgent", bound=AgentBase, default=AgentBase)
+
+
+def _hook_supports_tool_call_id(method: Callable[..., Any]) -> bool:
+    """Return True iff ``method`` accepts a ``tool_call_id`` keyword argument."""
+    try:
+        params = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        return True
+    if "tool_call_id" in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+def _invoke_tool_hook(
+    method: Callable[..., Awaitable[None]],
+    *args: Any,
+    tool_call_id: str | None,
+) -> Awaitable[None]:
+    """Invoke a tool lifecycle hook, passing ``tool_call_id`` only when supported.
+
+    Lets us extend ``on_tool_start``/``on_tool_end`` without breaking subclasses
+    whose overrides predate the new keyword argument.
+    """
+    if tool_call_id is not None and _hook_supports_tool_call_id(method):
+        return method(*args, tool_call_id=tool_call_id)
+    return method(*args)
 
 
 class RunHooksBase(Generic[TContext, TAgent]):
@@ -72,8 +100,14 @@ class RunHooksBase(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         agent: TAgent,
         tool: Tool,
+        *,
+        tool_call_id: str | None = None,
     ) -> None:
         """Called immediately before a local tool is invoked.
+
+        ``tool_call_id`` identifies the underlying tool-call so subclasses can
+        correlate parallel ``on_tool_start``/``on_tool_end`` invocations. It is
+        the same id exposed by ``ToolContext.tool_call_id`` for function tools.
 
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
@@ -88,8 +122,14 @@ class RunHooksBase(Generic[TContext, TAgent]):
         agent: TAgent,
         tool: Tool,
         result: str,
+        *,
+        tool_call_id: str | None = None,
     ) -> None:
         """Called immediately after a local tool is invoked.
+
+        ``tool_call_id`` identifies the underlying tool-call so subclasses can
+        correlate parallel ``on_tool_start``/``on_tool_end`` invocations. It is
+        the same id exposed by ``ToolContext.tool_call_id`` for function tools.
 
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
@@ -146,8 +186,14 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         agent: TAgent,
         tool: Tool,
+        *,
+        tool_call_id: str | None = None,
     ) -> None:
         """Called immediately before a local tool is invoked.
+
+        ``tool_call_id`` identifies the underlying tool-call so subclasses can
+        correlate parallel ``on_tool_start``/``on_tool_end`` invocations. It is
+        the same id exposed by ``ToolContext.tool_call_id`` for function tools.
 
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
@@ -162,8 +208,14 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         agent: TAgent,
         tool: Tool,
         result: str,
+        *,
+        tool_call_id: str | None = None,
     ) -> None:
         """Called immediately after a local tool is invoked.
+
+        ``tool_call_id`` identifies the underlying tool-call so subclasses can
+        correlate parallel ``on_tool_start``/``on_tool_end`` invocations. It is
+        the same id exposed by ``ToolContext.tool_call_id`` for function tools.
 
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,

--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -21,6 +21,7 @@ from .._tool_identity import get_mapping_or_attr, get_tool_trace_name_for_tool
 from ..agent import Agent
 from ..exceptions import ModelBehaviorError
 from ..items import RunItem, ToolCallOutputItem
+from ..lifecycle import _invoke_tool_hook
 from ..logger import logger
 from ..run_config import RunConfig
 from ..run_context import RunContextWrapper
@@ -120,10 +121,23 @@ class ComputerAction:
                 tool=action.computer_tool, run_context=context_wrapper
             )
             agent_hooks = agent.hooks
+            tool_call_id = action.tool_call.call_id
             await asyncio.gather(
-                hooks.on_tool_start(context_wrapper, agent, action.computer_tool),
+                _invoke_tool_hook(
+                    hooks.on_tool_start,
+                    context_wrapper,
+                    agent,
+                    action.computer_tool,
+                    tool_call_id=tool_call_id,
+                ),
                 (
-                    agent_hooks.on_tool_start(context_wrapper, agent, action.computer_tool)
+                    _invoke_tool_hook(
+                        agent_hooks.on_tool_start,
+                        context_wrapper,
+                        agent,
+                        action.computer_tool,
+                        tool_call_id=tool_call_id,
+                    )
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -151,9 +165,23 @@ class ComputerAction:
                 raise
 
             await asyncio.gather(
-                hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output),
+                _invoke_tool_hook(
+                    hooks.on_tool_end,
+                    context_wrapper,
+                    agent,
+                    action.computer_tool,
+                    output,
+                    tool_call_id=tool_call_id,
+                ),
                 (
-                    agent_hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output)
+                    _invoke_tool_hook(
+                        agent_hooks.on_tool_end,
+                        context_wrapper,
+                        agent,
+                        action.computer_tool,
+                        output,
+                        tool_call_id=tool_call_id,
+                    )
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -374,10 +402,23 @@ class LocalShellAction:
     ) -> RunItem:
         """Run a local shell tool call and wrap the result as a ToolCallOutputItem."""
         agent_hooks = agent.hooks
+        tool_call_id = call.tool_call.call_id
         await asyncio.gather(
-            hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool),
+            _invoke_tool_hook(
+                hooks.on_tool_start,
+                context_wrapper,
+                agent,
+                call.local_shell_tool,
+                tool_call_id=tool_call_id,
+            ),
             (
-                agent_hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool)
+                _invoke_tool_hook(
+                    agent_hooks.on_tool_start,
+                    context_wrapper,
+                    agent,
+                    call.local_shell_tool,
+                    tool_call_id=tool_call_id,
+                )
                 if agent_hooks
                 else _coro.noop_coroutine()
             ),
@@ -391,9 +432,23 @@ class LocalShellAction:
         result = await output if inspect.isawaitable(output) else output
 
         await asyncio.gather(
-            hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result),
+            _invoke_tool_hook(
+                hooks.on_tool_end,
+                context_wrapper,
+                agent,
+                call.local_shell_tool,
+                result,
+                tool_call_id=tool_call_id,
+            ),
             (
-                agent_hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result)
+                _invoke_tool_hook(
+                    agent_hooks.on_tool_end,
+                    context_wrapper,
+                    agent,
+                    call.local_shell_tool,
+                    result,
+                    tool_call_id=tool_call_id,
+                )
                 if agent_hooks
                 else _coro.noop_coroutine()
             ),
@@ -467,9 +522,21 @@ class ShellAction:
                     return approval_item
 
             await asyncio.gather(
-                hooks.on_tool_start(context_wrapper, agent, shell_tool),
+                _invoke_tool_hook(
+                    hooks.on_tool_start,
+                    context_wrapper,
+                    agent,
+                    shell_tool,
+                    tool_call_id=shell_call.call_id,
+                ),
                 (
-                    agent_hooks.on_tool_start(context_wrapper, agent, shell_tool)
+                    _invoke_tool_hook(
+                        agent_hooks.on_tool_start,
+                        context_wrapper,
+                        agent,
+                        shell_tool,
+                        tool_call_id=shell_call.call_id,
+                    )
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -541,9 +608,23 @@ class ShellAction:
                 logger.error("Shell executor failed: %s", exc, exc_info=True)
 
             await asyncio.gather(
-                hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text),
+                _invoke_tool_hook(
+                    hooks.on_tool_end,
+                    context_wrapper,
+                    agent,
+                    call.shell_tool,
+                    output_text,
+                    tool_call_id=shell_call.call_id,
+                ),
                 (
-                    agent_hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text)
+                    _invoke_tool_hook(
+                        agent_hooks.on_tool_end,
+                        context_wrapper,
+                        agent,
+                        call.shell_tool,
+                        output_text,
+                        tool_call_id=shell_call.call_id,
+                    )
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -656,9 +737,21 @@ class CustomToolAction:
                     return approval_item
 
             await asyncio.gather(
-                hooks.on_tool_start(tool_context, agent, custom_tool),
+                _invoke_tool_hook(
+                    hooks.on_tool_start,
+                    tool_context,
+                    agent,
+                    custom_tool,
+                    tool_call_id=call_id,
+                ),
                 (
-                    agent_hooks.on_tool_start(tool_context, agent, custom_tool)
+                    _invoke_tool_hook(
+                        agent_hooks.on_tool_start,
+                        tool_context,
+                        agent,
+                        custom_tool,
+                        tool_call_id=call_id,
+                    )
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -687,9 +780,23 @@ class CustomToolAction:
                 logger.error("Custom tool failed: %s", exc, exc_info=True)
 
             await asyncio.gather(
-                hooks.on_tool_end(tool_context, agent, custom_tool, output_text),
+                _invoke_tool_hook(
+                    hooks.on_tool_end,
+                    tool_context,
+                    agent,
+                    custom_tool,
+                    output_text,
+                    tool_call_id=call_id,
+                ),
                 (
-                    agent_hooks.on_tool_end(tool_context, agent, custom_tool, output_text)
+                    _invoke_tool_hook(
+                        agent_hooks.on_tool_end,
+                        tool_context,
+                        agent,
+                        custom_tool,
+                        output_text,
+                        tool_call_id=call_id,
+                    )
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -798,9 +905,21 @@ class ApplyPatchAction:
                     return approval_item
 
             await asyncio.gather(
-                hooks.on_tool_start(context_wrapper, agent, apply_patch_tool),
+                _invoke_tool_hook(
+                    hooks.on_tool_start,
+                    context_wrapper,
+                    agent,
+                    apply_patch_tool,
+                    tool_call_id=call_id,
+                ),
                 (
-                    agent_hooks.on_tool_start(context_wrapper, agent, apply_patch_tool)
+                    _invoke_tool_hook(
+                        agent_hooks.on_tool_start,
+                        context_wrapper,
+                        agent,
+                        apply_patch_tool,
+                        tool_call_id=call_id,
+                    )
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -852,9 +971,23 @@ class ApplyPatchAction:
                 logger.error("Apply patch editor failed: %s", exc, exc_info=True)
 
             await asyncio.gather(
-                hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text),
+                _invoke_tool_hook(
+                    hooks.on_tool_end,
+                    context_wrapper,
+                    agent,
+                    apply_patch_tool,
+                    output_text,
+                    tool_call_id=call_id,
+                ),
                 (
-                    agent_hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text)
+                    _invoke_tool_hook(
+                        agent_hooks.on_tool_end,
+                        context_wrapper,
+                        agent,
+                        apply_patch_tool,
+                        output_text,
+                        tool_call_id=call_id,
+                    )
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -56,6 +56,7 @@ from ..items import (
     ToolApprovalItem,
     ToolCallOutputItem,
 )
+from ..lifecycle import _invoke_tool_hook
 from ..logger import logger
 from ..model_settings import ModelSettings
 from ..run_config import RunConfig, ToolErrorFormatterArgs
@@ -1716,9 +1717,21 @@ class _FunctionToolBatchExecutor:
             return rejected_message
 
         await asyncio.gather(
-            self.hooks.on_tool_start(tool_context, self.public_agent, func_tool),
+            _invoke_tool_hook(
+                self.hooks.on_tool_start,
+                tool_context,
+                self.public_agent,
+                func_tool,
+                tool_call_id=tool_context.tool_call_id,
+            ),
             (
-                agent_hooks.on_tool_start(tool_context, self.public_agent, func_tool)
+                _invoke_tool_hook(
+                    agent_hooks.on_tool_start,
+                    tool_context,
+                    self.public_agent,
+                    func_tool,
+                    tool_call_id=tool_context.tool_call_id,
+                )
                 if agent_hooks
                 else _coro.noop_coroutine()
             ),
@@ -1788,9 +1801,23 @@ class _FunctionToolBatchExecutor:
         )
 
         await asyncio.gather(
-            self.hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result),
+            _invoke_tool_hook(
+                self.hooks.on_tool_end,
+                tool_context,
+                self.public_agent,
+                func_tool,
+                final_result,
+                tool_call_id=tool_context.tool_call_id,
+            ),
             (
-                agent_hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result)
+                _invoke_tool_hook(
+                    agent_hooks.on_tool_end,
+                    tool_context,
+                    self.public_agent,
+                    func_tool,
+                    final_result,
+                    tool_call_id=tool_context.tool_call_id,
+                )
                 if agent_hooks
                 else _coro.noop_coroutine()
             ),

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -386,3 +386,99 @@ async def test_streamed_run_hooks_count_tool_and_handoff_invocations():
     assert hooks.events["on_agent_start"] == 2
     assert hooks.events["on_agent_end"] == 1
     assert len(hooks.tool_context_ids) == 2
+
+
+class _ToolCallIdHooks(RunHooks):
+    """Hooks that capture the new ``tool_call_id`` keyword for both start and end."""
+
+    def __init__(self) -> None:
+        self.start_ids: list[str | None] = []
+        self.end_ids: list[str | None] = []
+
+    async def on_tool_start(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: Agent[TContext],
+        tool: Tool,
+        *,
+        tool_call_id: str | None = None,
+    ) -> None:
+        self.start_ids.append(tool_call_id)
+
+    async def on_tool_end(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: Agent[TContext],
+        tool: Tool,
+        result: str,
+        *,
+        tool_call_id: str | None = None,
+    ) -> None:
+        self.end_ids.append(tool_call_id)
+
+
+@pytest.mark.asyncio
+async def test_run_hooks_receive_tool_call_id_for_parallel_calls():
+    """`on_tool_start`/`on_tool_end` receive matching `tool_call_id`s for parallel calls."""
+    hooks = _ToolCallIdHooks()
+    model = FakeModel()
+    agent = Agent(
+        name="A",
+        model=model,
+        tools=[get_function_tool("f", "result")],
+    )
+
+    model.add_multiple_turn_outputs(
+        [
+            [
+                get_function_tool_call("f", json.dumps({"x": 1}), call_id="call_a"),
+                get_function_tool_call("f", json.dumps({"x": 2}), call_id="call_b"),
+            ],
+            [get_text_message("done")],
+        ]
+    )
+    await Runner.run(agent, input="hi", hooks=hooks)
+
+    assert sorted(hooks.start_ids) == ["call_a", "call_b"]
+    assert sorted(hooks.end_ids) == ["call_a", "call_b"]
+
+
+class _LegacyToolHooks(RunHooks):
+    """Hooks whose overrides predate the `tool_call_id` keyword (backwards-compat)."""
+
+    def __init__(self) -> None:
+        self.start_calls = 0
+        self.end_calls = 0
+
+    async def on_tool_start(
+        self, context: RunContextWrapper[TContext], agent: Agent[TContext], tool: Tool
+    ) -> None:
+        self.start_calls += 1
+
+    async def on_tool_end(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: Agent[TContext],
+        tool: Tool,
+        result: str,
+    ) -> None:
+        self.end_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_legacy_tool_hook_signature_still_works():
+    """Existing subclasses that don't accept `tool_call_id` keep working."""
+    hooks = _LegacyToolHooks()
+    model = FakeModel()
+    agent = Agent(name="A", model=model, tools=[get_function_tool("f", "result")])
+
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("f", json.dumps({"x": 1}), call_id="call_legacy")],
+            [get_text_message("done")],
+        ]
+    )
+    await Runner.run(agent, input="hi", hooks=hooks)
+
+    assert hooks.start_calls == 1
+    assert hooks.end_calls == 1


### PR DESCRIPTION
## Summary

Closes #1849.

Lifecycle hooks (`on_tool_start`, `on_tool_end`) now receive an optional `tool_call_id: str | None` keyword argument so subclasses can correlate parallel tool starts with their respective ends. Today, when a single turn fires multiple tool calls in parallel, hooks have no way to tell which `on_tool_end` belongs to which `on_tool_start` (the bare `Tool` argument is shared and the `context` is sometimes a plain `RunContextWrapper`, not a `ToolContext`).

## Backwards compatibility

The new parameter is keyword-only with a default of `None`. Existing subclasses whose overrides do not declare `tool_call_id` keep working: a small dispatch helper (`_invoke_tool_hook`) introspects each hook's signature and only forwards the new keyword when the override accepts it (`tool_call_id` named parameter or `**kwargs`). A regression test exercises a legacy hook signature to lock this behavior in.

## Test plan

- `tests/test_run_hooks.py::test_run_hooks_receive_tool_call_id_for_parallel_calls` — runs an agent with two parallel function tool calls (`call_a`, `call_b`) and asserts both ids are captured in `on_tool_start` and `on_tool_end`.
- `tests/test_run_hooks.py::test_legacy_tool_hook_signature_still_works` — verifies subclasses without the new keyword keep working.
- All existing hook suites pass: `tests/test_run_hooks.py`, `tests/test_agent_hooks.py`, `tests/test_global_hooks.py`, `tests/test_agent_llm_hooks.py`, `tests/test_computer_tool_lifecycle.py` (34/34 green).
- Full non-extension test suite green (2228 passed).