### PR TITLE
fix(tool_execution): preserve explicit timeout_ms=0 in coerce_shell_call

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -633,11 +633,11 @@ def coerce_shell_call(tool_call: Any) -> ShellCallData:
     if not commands:
         raise ModelBehaviorError("Shell call action must include at least one command.")
 
-    timeout_value = (
-        get_mapping_or_attr(action_payload, "timeout_ms")
-        or get_mapping_or_attr(action_payload, "timeoutMs")
-        or get_mapping_or_attr(action_payload, "timeout")
-    )
+    timeout_value = get_mapping_or_attr(action_payload, "timeout_ms")
+    if timeout_value is None:
+        timeout_value = get_mapping_or_attr(action_payload, "timeoutMs")
+    if timeout_value is None:
+        timeout_value = get_mapping_or_attr(action_payload, "timeout")
     timeout_ms = int(timeout_value) if isinstance(timeout_value, int | float) else None
 
     max_length_value = get_mapping_or_attr(action_payload, "max_output_length")

--- a/tests/test_shell_call_serialization.py
+++ b/tests/test_shell_call_serialization.py
@@ -23,6 +23,29 @@ def test_coerce_shell_call_reads_max_output_length() -> None:
     assert result.action.max_output_length == 512
 
 
+def test_coerce_shell_call_preserves_zero_timeout_and_canonical_field_precedence() -> None:
+    # `timeout_ms` is the canonical field; an explicit value (including 0) must be honored
+    # even when a fallback alias like `timeout` is also present in the payload.
+    tool_call = {
+        "call_id": "shell-zero",
+        "action": {
+            "commands": ["ls"],
+            "timeout_ms": 0,
+            "timeout": 5000,
+        },
+    }
+    result = run_loop.coerce_shell_call(tool_call)
+    assert result.action.timeout_ms == 0
+
+    # Falling back to the legacy `timeout` field still works when `timeout_ms` is absent.
+    fallback_call = {
+        "call_id": "shell-fallback",
+        "action": {"commands": ["ls"], "timeout": 5000},
+    }
+    fallback_result = run_loop.coerce_shell_call(fallback_call)
+    assert fallback_result.action.timeout_ms == 5000
+
+
 def test_coerce_shell_call_requires_commands() -> None:
     tool_call = {"call_id": "shell-2", "action": {"commands": []}}
     with pytest.raises(ModelBehaviorError):


### PR DESCRIPTION
## Summary

`coerce_shell_call` reads the timeout from the action payload using a chained `or` expression that walks `timeout_ms` → `timeoutMs` → `timeout`. Because Python `or` short-circuits on falsy values, an explicit `timeout_ms=0` from the model is silently dropped: the canonical key is skipped, a fallback alias (or `None`) wins, and the executor sees a different deadline than the caller specified.

This mirrors the existing handling for `max_output_length`, which already uses `is None` checks so an explicit 0 is preserved. Switching the timeout lookup to the same pattern keeps backward compatibility — fallbacks still apply when `timeout_ms` is genuinely absent — while honouring the canonical key whenever the model sends it.

## Test

Added `test_coerce_shell_call_preserves_zero_timeout_and_canonical_field_precedence` in `tests/test_shell_call_serialization.py`:
- `{"timeout_ms": 0, "timeout": 5000}` → result must be `0` (regression case; was `5000`).
- `{"timeout": 5000}` (no canonical key) → result must be `5000` (backward-compat).

The new test fails on `main` and passes with the fix. Existing `tests/test_shell_call_serialization.py` and `tests/sandbox/` suites continue to pass (`tests/sandbox/`: 763 passed, 19 skipped).