### PR TITLE
fix(mcp): isolate strict schema conversion from non-strict fallback

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -492,8 +492,13 @@ class MCPUtil:
             schema["properties"] = {}
 
         if convert_schemas_to_strict:
+            # ``ensure_strict_json_schema`` mutates the schema in place and may raise
+            # partway through, leaving strict-mode artifacts (e.g. ``required`` or
+            # ``additionalProperties: false``) on a schema we still serve as
+            # non-strict. Convert a separate copy so the non-strict fallback keeps
+            # the original schema intact.
             try:
-                schema = ensure_strict_json_schema(schema)
+                schema = ensure_strict_json_schema(copy.deepcopy(schema))
                 is_strict = True
             except Exception as e:
                 logger.info(f"Error converting MCP schema to strict mode: {e}")

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1597,6 +1597,30 @@ def test_to_function_tool_does_not_mutate_mcp_input_schema():
     assert tool.inputSchema == {"type": "object", "description": "Test tool"}
 
 
+def test_to_function_tool_failed_strict_conversion_keeps_original_schema():
+    # ``ensure_strict_json_schema`` mutates the schema in place. Until this is
+    # isolated, a partially-mutated schema would be served as non-strict, leaking
+    # strict-mode artifacts (e.g. ``required`` and ``additionalProperties: false``)
+    # on a tool that is_strict=False.
+    schema = {
+        "type": "object",
+        "properties": {
+            "x": {"type": "object", "additionalProperties": True},
+        },
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == {
+        "type": "object",
+        "properties": {
+            "x": {"type": "object", "additionalProperties": True},
+        },
+    }
+
+
 class StructuredContentTestServer(FakeMCPServer):
     """Test server that allows setting both content and structured content for testing."""
 


### PR DESCRIPTION
## Summary

`ensure_strict_json_schema` mutates the input schema in place and may raise partway through (e.g. when a nested object has `additionalProperties: true`). When that happens, `MCPUtil.to_function_tool` catches the exception and proceeds with `is_strict=False` — but the schema it serves to the model has already been partially mutated, leaking strict-mode artifacts like `additionalProperties: false` and `required: [...]` onto a tool we explicitly mark as non-strict.

Repro on `main`:

```python
schema = {
    "type": "object",
    "properties": {"x": {"type": "object", "additionalProperties": True}},
}
tool = MCPTool(name="test_tool", inputSchema=schema)
ft = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
# ft.strict_json_schema == False  (correct: conversion failed)
# ft.params_json_schema now contains the mutations from the failed conversion:
#   {"type": "object", "properties": {...}, "additionalProperties": False, "required": ["x"]}
```

The fix passes a fresh `copy.deepcopy(schema)` to `ensure_strict_json_schema`, so a partial in-place mutation cannot leak into the non-strict fallback.

## Test

`tests/mcp/test_mcp_util.py::test_to_function_tool_failed_strict_conversion_keeps_original_schema` — fails on main with the partially-mutated schema, passes after this change.