### PR TITLE
fix(models): allow extra_args when chat completions kwarg is omitted

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
-from openai import AsyncOpenAI, AsyncStream, Omit, omit
+from openai import AsyncOpenAI, AsyncStream, NotGiven, Omit, omit
 from openai.types import ChatModel
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
@@ -423,8 +423,11 @@ class OpenAIChatCompletionsModel(Model):
             "extra_body": model_settings.extra_body,
             "metadata": self._non_null_or_omit(model_settings.metadata),
         }
+        extra_args = model_settings.extra_args or {}
         duplicate_extra_arg_keys = sorted(
-            set(create_kwargs).intersection(model_settings.extra_args or {})
+            k
+            for k in extra_args
+            if k in create_kwargs and not isinstance(create_kwargs[k], Omit | NotGiven)
         )
         if duplicate_extra_arg_keys:
             if len(duplicate_extra_arg_keys) == 1:
@@ -436,7 +439,7 @@ class OpenAIChatCompletionsModel(Model):
             raise TypeError(
                 f"chat.completions.create() got multiple values for keyword arguments {keys}"
             )
-        create_kwargs.update(model_settings.extra_args or {})
+        create_kwargs.update(extra_args)
 
         ret = await self._get_client().chat.completions.create(**create_kwargs)
 

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -428,6 +428,28 @@ async def test_fetch_response_non_stream(monkeypatch) -> None:
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_fetch_response_allows_extra_arg_when_explicit_arg_is_omitted() -> None:
+    """A user-supplied extra_arg whose first-class field is only present as the
+    `omit` sentinel should pass through, not raise a duplicate-argument error."""
+    kwargs = await _run_chat_completions_model_with_custom_base_url(
+        model_settings=ModelSettings(extra_args={"temperature": 0.25})
+    )
+    assert kwargs["temperature"] == 0.25
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_fetch_response_rejects_duplicate_extra_args_with_explicit_value() -> None:
+    """When the first-class field has an explicit (non-omit) value, a colliding
+    extra_arg key should still raise a TypeError to surface the conflict."""
+    with pytest.raises(TypeError, match="multiple values.*temperature"):
+        await _run_chat_completions_model_with_custom_base_url(
+            model_settings=ModelSettings(temperature=0.5, extra_args={"temperature": 0.25})
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_custom_base_url_prompt_cache_key_uses_model_settings_only() -> None:
     default_kwargs = await _run_chat_completions_model_with_custom_base_url()
     explicit_kwargs = await _run_chat_completions_model_with_custom_base_url(


### PR DESCRIPTION
## Summary

Mirror of #3185 (Responses API fix) for the Chat Completions path.

When a user supplies a first-class request parameter (e.g. `temperature`, `top_p`, `max_tokens`, `metadata`, ...) through `ModelSettings.extra_args` *without* also setting the corresponding `ModelSettings` field, the chat completions path falsely raises:

```
TypeError: chat.completions.create() got multiple values for keyword argument 'temperature'
```

This happens because the field in `create_kwargs` resolves to OpenAI's `omit` sentinel (not absent), and the duplicate-key check uses a plain `set` intersection. The Responses API path had the same bug, fixed in #3185 by skipping keys whose first-class value is `Omit`/`NotGiven`. The same pattern still exists in `openai_chatcompletions.py::_fetch_response` — this PR applies the same fix here.

### Behavior change

- Before: `ModelSettings(extra_args={"temperature": 0.25})` raised TypeError unless `temperature` was also `None`-by-default normalization.
- After: the `extra_args` value passes through.
- Genuine collisions (e.g. `ModelSettings(temperature=0.5, extra_args={"temperature": 0.25})`) still raise TypeError as before.

## Test plan

- [x] `uv run pytest tests/models/test_openai_chatcompletions.py tests/models/test_openai_chatcompletions_stream.py tests/models/test_openai_chatcompletions_converter.py tests/models/test_kwargs_functionality.py` (59 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] New tests:
  - `test_fetch_response_allows_extra_arg_when_explicit_arg_is_omitted` — fails on main, passes after fix
  - `test_fetch_response_rejects_duplicate_extra_args_with_explicit_value` — guards regression on the genuine-collision case

## Issue number

N/A (parallel of #3185 for chat completions)

## Checks

- [x] I've added new tests
- [ ] I've added/updated the relevant documentation (none needed)
- [x] I've run `make lint` / `make format` equivalent (`ruff check` / `ruff format --check`)
- [x] I've made sure tests pass