### PR TITLE
fix(voice): stop AudioInput.to_base64() from mutating caller's buffer

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -62,13 +62,14 @@ class AudioInput:
     def to_base64(self) -> str:
         """Returns the audio data as a base64 encoded string."""
         if self.buffer.dtype == np.float32:
-            # convert to int16
-            self.buffer = np.clip(self.buffer, -1.0, 1.0)
-            self.buffer = (self.buffer * 32767).astype(np.int16)
-        elif self.buffer.dtype != np.int16:
+            # convert to int16 without mutating the caller's buffer
+            int16_buffer = (np.clip(self.buffer, -1.0, 1.0) * 32767).astype(np.int16)
+        elif self.buffer.dtype == np.int16:
+            int16_buffer = self.buffer
+        else:
             raise UserError("Buffer must be a numpy array of int16 or float32")
 
-        return base64.b64encode(self.buffer.tobytes()).decode("utf-8")
+        return base64.b64encode(int16_buffer.tobytes()).decode("utf-8")
 
 
 class StreamedAudioInput:

--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -5,6 +5,7 @@ import base64
 import io
 import wave
 from dataclasses import dataclass
+from typing import cast
 
 from ..exceptions import UserError
 from .imports import np, npt
@@ -65,7 +66,7 @@ class AudioInput:
             # convert to int16 without mutating the caller's buffer
             int16_buffer = (np.clip(self.buffer, -1.0, 1.0) * 32767).astype(np.int16)
         elif self.buffer.dtype == np.int16:
-            int16_buffer = self.buffer
+            int16_buffer = cast("npt.NDArray[np.int16]", self.buffer)
         else:
             raise UserError("Buffer must be a numpy array of int16 or float32")
 

--- a/tests/voice/test_input.py
+++ b/tests/voice/test_input.py
@@ -102,6 +102,20 @@ class TestAudioInput:
             assert wav_file.getframerate() == DEFAULT_SAMPLE_RATE
             assert wav_file.getnframes() == len(buffer)
 
+    def test_audio_input_to_base64_does_not_mutate_float32_buffer(self):
+        # Regression: to_base64() previously rebound self.buffer to int16,
+        # silently corrupting any caller-held reference to the original float32 array.
+        buffer = np.sin(2 * np.pi * 440 * np.linspace(0, 1, 100)).astype(np.float32)
+        original = buffer.copy()
+
+        audio_input = AudioInput(buffer=buffer)
+        audio_input.to_base64()
+
+        assert audio_input.buffer.dtype == np.float32
+        assert np.array_equal(audio_input.buffer, original)
+        # Calling it twice should still work and return the same encoding.
+        assert audio_input.to_base64() == audio_input.to_base64()
+
 
 class TestStreamedAudioInput:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`AudioInput.to_base64()` currently rebinds `self.buffer` to an int16 array when the input is float32:

```python
def to_base64(self) -> str:
    if self.buffer.dtype == np.float32:
        # convert to int16
        self.buffer = np.clip(self.buffer, -1.0, 1.0)
        self.buffer = (self.buffer * 32767).astype(np.int16)
    ...
```

This silently corrupts any reference the caller still holds to the original float32 buffer. A user who creates an `AudioInput`, calls `to_base64()` (e.g. for tracing), and then inspects `audio_input.buffer` again will find an int16 array where they put a float32 one — different dtype, different values.

The companion `_buffer_to_audio_file()` already does the conversion via a local rebinding (the parameter `buffer` is shadowed inside the function), so `to_audio_file()` does not have this bug. This PR aligns `to_base64()` with that pattern: do the int16 conversion into a local variable and leave `self.buffer` untouched.

## Changes

- `src/agents/voice/input.py`: rewrite `to_base64()` to convert into a local `int16_buffer` instead of mutating `self.buffer`.
- `tests/voice/test_input.py`: add a regression test asserting `audio_input.buffer.dtype` and contents are unchanged after `to_base64()`, and that calling it twice produces the same encoding.

Diff is 25 lines total.

## Test plan

- [x] `pytest tests/voice/` — all 31 tests pass
- [x] Regression test fails on `main`, passes with this change
- [x] `ruff check` clean