### PR TITLE
fix(tracing): preserve falsy outputs in FunctionSpanData export

### DIFF
--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -161,7 +161,7 @@ class FunctionSpanData(SpanData):
             "type": self.type,
             "name": self.name,
             "input": self.input,
-            "output": str(self.output) if self.output else None,
+            "output": str(self.output) if self.output is not None else None,
             "mcp_data": self.mcp_data,
         }
 

--- a/tests/tracing/test_function_span_data.py
+++ b/tests/tracing/test_function_span_data.py
@@ -1,0 +1,27 @@
+"""Regression tests for FunctionSpanData export.
+
+Falsy tool outputs (e.g. ``False``, ``0``, ``""``, ``[]``) must be preserved
+in the exported payload instead of being silently coerced to ``None``.
+"""
+
+import pytest
+
+from agents.tracing.span_data import FunctionSpanData
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        (False, "False"),
+        (0, "0"),
+        (0.0, "0.0"),
+        ("", ""),
+        ([], "[]"),
+        ({}, "{}"),
+        (None, None),
+        ("real", "real"),
+    ],
+)
+def test_function_span_data_preserves_falsy_outputs(output, expected) -> None:
+    span = FunctionSpanData(name="t", input="x", output=output)
+    assert span.export()["output"] == expected


### PR DESCRIPTION
## Summary

`FunctionSpanData.export()` gated stringification with `if self.output`, which silently coerces legitimate falsy tool outputs to `None` before they reach the trace dashboard.

```python
# src/agents/tracing/span_data.py (current)
"output": str(self.output) if self.output else None,
```

So a tool that returns `False`, `0`, `0.0`, `""`, `[]`, or `{}` shows up in the trace as `None`, indistinguishable from a tool that returned nothing. This is a long-standing inconsistency: every other span type with an `output` field passes the value through unchanged. Only `FunctionSpanData` has the `if self.output` short-circuit.

The fix is one character: use `is not None` so only an actually-missing output renders as `None`.

```python
"output": str(self.output) if self.output is not None else None,
```

## Repro

```python
from agents.tracing.span_data import FunctionSpanData
for output in [False, 0, 0.0, "", [], {}, None, "real"]:
    print(output, "->", FunctionSpanData(name="t", input="x", output=output).export()["output"])
# Before: every falsy value -> None
# After:  False -> "False", 0 -> "0", "" -> "", [] -> "[]", {} -> "{}", None -> None, "real" -> "real"
```

## Test plan

- [x] New parametrized test in `tests/tracing/test_function_span_data.py` covers `False`, `0`, `0.0`, `""`, `[]`, `{}`, `None`, and a normal string.
- [x] Test fails on `main` (6/8 cases) and passes with the fix (8/8).
- [x] Full tracing test suite green: `pytest tests/tracing/ tests/test_tracing.py tests/test_trace_processor.py` -> 102 passed.
- [x] `ruff check` and `ruff format --check` clean on changed files.