### PR TITLE
fix(tool): route non-object JSON inputs through the JSON-error path

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -1394,9 +1394,17 @@ def _extract_tool_argument_json_error(error: Exception) -> json.JSONDecodeError 
 
 
 def _is_tool_argument_input_error(error: Exception) -> bool:
-    """Return True when an error represents an invalid-JSON-input failure for a function tool."""
-    return isinstance(error, ModelBehaviorError) and str(error).startswith(
-        "Invalid JSON input for tool"
+    """Return True when an error represents a non-object JSON input for a function tool.
+
+    Only the non-object case is matched here: schema validation failures share the
+    `Invalid JSON input for tool` prefix and should continue to flow through the
+    regular validation path rather than be reported as JSON parse errors.
+    """
+    if not isinstance(error, ModelBehaviorError):
+        return False
+    text = str(error)
+    return text.startswith("Invalid JSON input for tool") and text.endswith(
+        "expected a JSON object"
     )
 
 

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -1393,6 +1393,13 @@ def _extract_tool_argument_json_error(error: Exception) -> json.JSONDecodeError 
     return _extract_json_decode_error(error)
 
 
+def _is_tool_argument_input_error(error: Exception) -> bool:
+    """Return True when an error represents an invalid-JSON-input failure for a function tool."""
+    return isinstance(error, ModelBehaviorError) and str(error).startswith(
+        "Invalid JSON input for tool"
+    )
+
+
 def _build_handled_function_tool_error_handler(
     *,
     span_message: str,
@@ -1413,6 +1420,11 @@ def _build_handled_function_tool_error_handler(
         if json_decode_error is not None and span_message_for_json_decode_error is not None:
             resolved_span_message = span_message_for_json_decode_error
             span_error_detail = str(json_decode_error)
+        elif span_message_for_json_decode_error is not None and _is_tool_argument_input_error(
+            error
+        ):
+            resolved_span_message = span_message_for_json_decode_error
+            span_error_detail = str(error)
         else:
             resolved_span_message = span_message
             span_error_detail = str(error)
@@ -1491,6 +1503,12 @@ def default_tool_error_function(ctx: RunContextWrapper[Any], error: Exception) -
             "An error occurred while parsing tool arguments. "
             "Please try again with valid JSON. "
             f"Error: {json_decode_error}"
+        )
+    if _is_tool_argument_input_error(error):
+        return (
+            "An error occurred while parsing tool arguments. "
+            "Please try again with valid JSON. "
+            f"Error: {error}"
         )
     return f"An error occurred while running the tool. Please try again. Error: {str(error)}"
 

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -845,6 +845,31 @@ async def test_function_tool_bad_json_includes_payload_when_tool_logging_enabled
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("input_json", ["[]", '"value"', "123", "null", "true"])
+async def test_default_error_function_treats_non_object_input_as_json_error(
+    input_json: str,
+) -> None:
+    def echo(value: str) -> str:
+        return value
+
+    tool = function_tool(echo, name_override="echo_tool")
+
+    result = await tool.on_invoke_tool(
+        ToolContext(
+            None,
+            tool_name="echo_tool",
+            tool_call_id="1",
+            tool_arguments=input_json,
+        ),
+        input_json,
+    )
+
+    assert isinstance(result, str)
+    assert result.startswith("An error occurred while parsing tool arguments.")
+    assert "expected a JSON object" in result
+
+
+@pytest.mark.asyncio
 async def test_default_failure_error_function_survives_deepcopy() -> None:
     def boom() -> None:
         raise RuntimeError("kapow")

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -870,6 +870,32 @@ async def test_default_error_function_treats_non_object_input_as_json_error(
 
 
 @pytest.mark.asyncio
+async def test_default_error_function_does_not_route_schema_validation_as_json_error() -> None:
+    # Schema validation errors share the `Invalid JSON input for tool` prefix
+    # but should continue to flow through the generic error path, not the
+    # "An error occurred while parsing tool arguments" path used for malformed
+    # JSON / non-object inputs.
+    def echo(value: str) -> str:
+        return value
+
+    tool = function_tool(echo, name_override="echo_tool")
+
+    result = await tool.on_invoke_tool(
+        ToolContext(
+            None,
+            tool_name="echo_tool",
+            tool_call_id="1",
+            tool_arguments='{"value": 123}',
+        ),
+        '{"wrong_field": "x"}',
+    )
+
+    assert isinstance(result, str)
+    assert "Invalid JSON input for tool" in result
+    assert not result.startswith("An error occurred while parsing tool arguments.")
+
+
+@pytest.mark.asyncio
 async def test_default_failure_error_function_survives_deepcopy() -> None:
     def boom() -> None:
         raise RuntimeError("kapow")


### PR DESCRIPTION
## Summary

PR #3166 added a `ModelBehaviorError` raised when function tool input
JSON decodes to a non-object value (e.g. `[]`, `\"value\"`, `123`, `null`,
`true`). The new error is correctly raised, but it isn't routed through
the JSON-input error branches that were already in place for genuine
`JSONDecodeError`s, because no `JSONDecodeError` is attached as a
cause/context.

That has two visible effects today:

1. The default failure formatter (`default_tool_error_function`) returns
   the generic `\"An error occurred while running the tool. Please try
   again. Error: ...\"` string instead of the more helpful `\"An error
   occurred while parsing tool arguments. Please try again with valid
   JSON. Error: ...\"` hint that tells the model to fix its arguments.
2. Trace spans show `\"Error running tool (non-fatal)\"` instead of the
   JSON-input-specific `\"Error running tool\"` span.

This PR adds a tiny `_is_tool_argument_input_error` helper that detects
the structural `\"Invalid JSON input for tool ...\"` `ModelBehaviorError`
and routes both `default_tool_error_function` and
`_build_handled_function_tool_error_handler` through the JSON-input
branch when no underlying decode error is attached. The existing
`_extract_tool_argument_json_error` path is unchanged for the genuine
`JSONDecodeError` case.

A parametrized regression test confirms the default failure formatter
returns the JSON-arguments hint for the same non-object inputs the
existing `test_function_tool_rejects_non_object_json_input` test covers.

## Test plan

- [x] `pytest tests/test_function_tool.py tests/test_function_tool_decorator.py tests/test_function_schema.py` (92 passed)
- [x] `pytest tests/test_tool_metadata.py tests/test_tool_origin.py tests/test_custom_tool.py tests/test_tool_use_behavior.py tests/test_tool_context.py tests/test_tool_converter.py tests/test_tool_guardrails.py tests/test_agent_tool_input.py` (72 passed)
- [x] `ruff check` and `ruff format --check` clean