### PR TITLE
fix(strict-schema): preserve chained $ref during sibling-key expansion

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -135,9 +135,12 @@ def _ensure_strict_json_schema(
                 f"Expected `$ref: {ref}` to resolved to a dictionary but got {resolved}"
             )
 
+        # Pop the current `$ref` first so that if the resolved schema is itself a `$ref`
+        # (chained refs), we preserve it for the recursive expansion below instead of
+        # silently dropping it.
+        json_schema.pop("$ref")
         # properties from the json schema take priority over the ones on the `$ref`
         json_schema.update({**resolved, **json_schema})
-        json_schema.pop("$ref")
         # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied
         # we call `_ensure_strict_json_schema` again to fix the inlined schema and ensure it's valid
         return _ensure_strict_json_schema(json_schema, path=path, root=root)

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -124,3 +124,22 @@ def test_invalid_ref_format():
     schema = {"type": "object", "properties": {"a": {"$ref": "invalid", "description": "desc"}}}
     with pytest.raises(ValueError):
         ensure_strict_json_schema(schema)
+
+
+def test_chained_ref_with_sibling_keys_is_resolved():
+    # When a $ref points to a definition that is itself just a $ref (a chained alias),
+    # and the original $ref has sibling keys (like "description"), the chain must be
+    # fully resolved instead of silently dropping the inner $ref and losing the type.
+    schema = {
+        "$defs": {
+            "Inner": {"type": "string"},
+            "Outer": {"$ref": "#/$defs/Inner"},
+        },
+        "type": "object",
+        "properties": {"a": {"$ref": "#/$defs/Outer", "description": "desc"}},
+    }
+    result = ensure_strict_json_schema(schema)
+    a_schema = result["properties"]["a"]
+    assert a_schema["type"] == "string"
+    assert a_schema["description"] == "desc"
+    assert "$ref" not in a_schema


### PR DESCRIPTION
## Summary

When a `$ref` pointing to an alias definition (a `$ref`-only schema that itself points to another definition) had sibling keys like `description`, `ensure_strict_json_schema` silently dropped the inner `$ref` and lost the underlying type. The merge `{**resolved, **json_schema}` ran while `json_schema` still contained its own `$ref`, so the resolved schema's `$ref` was overwritten by the original (now-stale) `$ref`, and the subsequent `pop("$ref")` then removed it entirely.

This is a small, surgical fix: pop the original `$ref` from the schema before the merge so the resolved schema's `$ref` (if any) survives into the recursive expansion call. The recursive call then fully resolves the chain.

### Repro (failed before fix)

```python
schema = {
    "$defs": {
        "Inner": {"type": "string"},
        "Outer": {"$ref": "#/$defs/Inner"},
    },
    "type": "object",
    "properties": {"a": {"$ref": "#/$defs/Outer", "description": "desc"}},
}
ensure_strict_json_schema(schema)
# Before: properties.a == {"description": "desc"}    -- type lost
# After:  properties.a == {"description": "desc", "type": "string"}
```

This pattern arises naturally when Pydantic models reference other models that are themselves thin aliases (e.g. `RootModel`, generic aliases, type aliases that emit single-key `$ref` definitions).

## Test plan

- [x] New regression test `test_chained_ref_with_sibling_keys_is_resolved` in `tests/test_strict_schema.py` fails before the fix and passes after.
- [x] All existing `tests/test_strict_schema.py` and `tests/test_strict_schema_oneof.py` tests still pass (19 passed).
- [x] Broader related suites unaffected: `tests/test_function_schema.py`, `tests/test_agent_runner.py`, `tests/test_function_tool.py`, `tests/mcp/test_mcp_util.py` (305 total passed, 0 failed).