### PR TITLE
fix(sandbox): require https for daytona signed preview URLs

### DIFF
--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -343,8 +343,10 @@ class DaytonaSandboxSession(BaseSandboxSession):
             host = split.hostname
             if host is None:
                 raise ValueError("missing hostname")
-            port_value = split.port or (443 if split.scheme == "https" else 80)
-            return ExposedPortEndpoint(host=host, port=port_value, tls=split.scheme == "https")
+            if split.scheme != "https":
+                raise ValueError(f"non-https preview scheme: {split.scheme!r}")
+            port_value = split.port or 443
+            return ExposedPortEndpoint(host=host, port=port_value, tls=True)
         except Exception as e:
             raise ExposedPortUnavailableError(
                 port=port,

--- a/tests/extensions/sandbox/test_daytona.py
+++ b/tests/extensions/sandbox/test_daytona.py
@@ -905,6 +905,39 @@ class TestDaytonaSandbox:
         assert exc_info.value.context["detail"] == "invalid_preview_url"
 
     @pytest.mark.asyncio
+    async def test_resolve_exposed_port_rejects_non_https_preview_url(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify Daytona rejects plaintext preview URLs instead of silently downgrading TLS."""
+
+        daytona_module = _load_daytona_module(monkeypatch)
+
+        async with daytona_module.DaytonaSandboxClient() as client:
+            session = await client.create(
+                options=daytona_module.DaytonaSandboxClientOptions(exposed_ports=(4500,)),
+            )
+            sandbox = _FakeAsyncDaytona.current_sandbox
+            assert sandbox is not None
+
+            async def _http_preview_url(
+                port: int,
+                expires_in_seconds: int | None = None,
+            ) -> object:
+                _ = (port, expires_in_seconds)
+                return types.SimpleNamespace(
+                    url=f"http://{port}-token.daytonaproxy01.net/",
+                    token="signed-token",
+                )
+
+            sandbox.create_signed_preview_url = _http_preview_url  # type: ignore[method-assign]
+
+            with pytest.raises(daytona_module.ExposedPortUnavailableError) as exc_info:
+                await session.resolve_exposed_port(4500)
+
+        assert exc_info.value.context["detail"] == "invalid_preview_url"
+
+    @pytest.mark.asyncio
     async def test_normalize_path_rejects_workspace_escape_and_allows_absolute_in_root(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

`DaytonaSandboxSession._resolve_exposed_port` accepted any URL returned by `create_signed_preview_url` — including `http://...` — and silently exposed it as a non-TLS endpoint (`tls=False`, port 80). Daytona signed preview URLs are always HTTPS, so a non-https scheme indicates either a backend bug or a tampered response. Either way, downstream code would then connect over plaintext to a host derived from that URL.

This change rejects any preview URL whose scheme is not `https`, raising `ExposedPortUnavailableError` with the existing `invalid_preview_url` detail (same path already used for malformed URLs).

This is in the same vein as #3094 / #3172 / #3177 — defensive narrowing of what a sandbox backend will trust from the wire.

## Diff

- `src/agents/extensions/sandbox/daytona/sandbox.py`: 4 lines changed (require https, drop the http fallback for `tls`/port).
- `tests/extensions/sandbox/test_daytona.py`: new `test_resolve_exposed_port_rejects_non_https_preview_url` covering the regression.

## Test plan

- [x] New unit test `test_resolve_exposed_port_rejects_non_https_preview_url` fails on `main` and passes after the fix.
- [x] Full `tests/extensions/sandbox/test_daytona.py` suite (54 tests) passes.
- [x] `ruff check` and `ruff format --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)