### PR TITLE
fix(result): drop reasoning items orphaned by dropped tool calls

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -102,12 +102,16 @@ def drop_orphan_function_calls(
 ) -> list[TResponseInputItem]:
     """
     Remove tool call items that do not have corresponding outputs so resumptions or retries do not
-    replay stale tool calls.
+    replay stale tool calls. Reasoning items that immediately precede a tool call dropped by this
+    pass are also removed, since the Responses API rejects reasoning items that are not followed
+    by their associated model-emitted item (``Item 'rs_...' of type 'reasoning' was provided
+    without its required following item``).
     """
 
     completed_call_ids = _completed_call_ids_by_type(items)
     matched_anonymous_tool_search_calls = _matched_anonymous_tool_search_call_indexes(items)
 
+    dropped_indexes: set[int] = set()
     filtered: list[TResponseInputItem] = []
     for index, entry in enumerate(items):
         if not isinstance(entry, dict):
@@ -134,7 +138,45 @@ def drop_orphan_function_calls(
             and index in matched_anonymous_tool_search_calls
         ):
             filtered.append(entry)
-    return filtered
+            continue
+        # Tool call entry will be dropped; record so we can also drop preceding reasoning items.
+        dropped_indexes.add(index)
+
+    if not dropped_indexes:
+        return filtered
+    return _drop_reasoning_items_preceding_dropped_calls(items, dropped_indexes)
+
+
+def _drop_reasoning_items_preceding_dropped_calls(
+    items: list[TResponseInputItem],
+    dropped_indexes: set[int],
+) -> list[TResponseInputItem]:
+    """Drop reasoning items whose tied tool call was just dropped as orphan.
+
+    A reasoning item is considered tied to the next non-reasoning model-emitted item. If that
+    item was dropped, the reasoning item is now dangling and would be rejected by the Responses
+    API with ``reasoning was provided without its required following item``.
+    """
+    drop_reasoning: set[int] = set()
+    for index in range(len(items) - 1, -1, -1):
+        entry = items[index]
+        if (
+            not isinstance(entry, dict)
+            or entry.get("type") != "reasoning"
+            or index in dropped_indexes
+        ):
+            continue
+        for next_index in range(index + 1, len(items)):
+            if next_index in drop_reasoning:
+                continue
+            next_entry = items[next_index]
+            if isinstance(next_entry, dict) and next_entry.get("type") == "reasoning":
+                continue
+            if next_index in dropped_indexes:
+                drop_reasoning.add(index)
+            break
+    excluded = dropped_indexes | drop_reasoning
+    return [entry for idx, entry in enumerate(items) if idx not in excluded]
 
 
 def ensure_input_item_format(item: TResponseInputItem) -> TResponseInputItem:

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -73,6 +73,67 @@ def test_drop_orphan_function_calls_preserves_non_mapping_entries() -> None:
     )
 
 
+def test_drop_orphan_function_calls_drops_reasoning_preceding_dropped_tool_call() -> None:
+    # Regression: reasoning items tied to a now-dropped orphan tool call would otherwise be
+    # forwarded to the API and trigger
+    # ``Item 'rs_...' of type 'reasoning' was provided without its required following item``.
+    payload: list[Any] = [
+        cast(TResponseInputItem, {"role": "user", "content": "hi"}),
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_orphan_a", "summary": []}),
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_orphan_b", "summary": []}),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "function_call",
+                "call_id": "orphan_call",
+                "name": "orphan",
+                "arguments": "{}",
+            },
+        ),
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_paired", "summary": []}),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "function_call",
+                "call_id": "paired_call",
+                "name": "paired",
+                "arguments": "{}",
+            },
+        ),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call_output", "call_id": "paired_call", "output": "ok"},
+        ),
+    ]
+
+    filtered = run_items.drop_orphan_function_calls(cast(list[TResponseInputItem], payload))
+
+    reasoning_ids = [
+        entry.get("id")
+        for entry in filtered
+        if isinstance(entry, dict) and entry.get("type") == "reasoning"
+    ]
+    assert reasoning_ids == ["rs_paired"]
+    assert not any(
+        isinstance(entry, dict)
+        and entry.get("type") == "function_call"
+        and entry.get("call_id") == "orphan_call"
+        for entry in filtered
+    )
+
+
+def test_drop_orphan_function_calls_keeps_lone_reasoning_when_no_tool_calls_dropped() -> None:
+    # Server-managed conversations (or compaction) may forward standalone reasoning items whose
+    # required following item lives in the server-side conversation. We must not drop those.
+    payload: list[Any] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_lone", "summary": []}),
+    ]
+
+    filtered = run_items.drop_orphan_function_calls(cast(list[TResponseInputItem], payload))
+
+    assert filtered == payload
+
+
 def test_drop_orphan_function_calls_handles_tool_search_calls() -> None:
     payload: list[Any] = [
         cast(


### PR DESCRIPTION
## Summary

When `drop_orphan_function_calls` removes an unpaired tool call from the items being sent to the Responses API, any reasoning items that immediately precede it become dangling. Forwarding them triggers errors like:

```
Item 'rs_...' of type 'reasoning' was provided without its required following item
```

This is the symptom reported in #985 (CodeInterpreter + handoff with reasoning models) and reproduced in #2020 (multi-agent handoff with `gpt-5` reasoning).

The fix tracks which tool-call indexes are dropped during the existing pass and removes the reasoning items that were tied to them before returning. A reasoning item is considered tied to the next non-reasoning item; if that next item was dropped, the reasoning chain is now dangling and is stripped.

Lone reasoning items (e.g. server-managed conversations where the required following item lives on the server, or the ``omit`` reasoning policy that strips standalone reasoning trace inputs) are still preserved when no tool calls are dropped, so the existing tracker behavior is unchanged.

## Test plan

- [x] New regression test `test_drop_orphan_function_calls_drops_reasoning_preceding_dropped_tool_call` covers the dropped-orphan-tool-call -> dangling-reasoning-items chain (mirrors #2020).
- [x] New regression test `test_drop_orphan_function_calls_keeps_lone_reasoning_when_no_tool_calls_dropped` confirms server-managed conversations still keep standalone reasoning items.
- [x] Existing `tests/test_run_internal_items.py` (19 tests), `tests/test_agent_runner*.py`, `tests/test_handoff*.py`, and `tests/test_server_conversation_tracker.py` all pass.
- [x] Full `pytest tests/` sweep (excluding optional `realtime`/`voice`/`mcp`/`sandbox` extras): 3332 passed, 28 skipped.