### PR TITLE
fix(sandbox): reap killed subprocess on UnixLocal exec timeout

### DIFF
--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -242,11 +242,17 @@ class UnixLocalSandboxSession(BaseSandboxSession):
             try:
                 stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
             except asyncio.TimeoutError as e:
-                try:
-                    # process tree cleanup
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except Exception:
-                    pass
+                # Avoid signaling a pid that has already exited and may have been
+                # reused: a stale `os.killpg(proc.pid, ...)` could otherwise hit an
+                # unrelated process group on systems with rapid pid wraparound.
+                if proc.returncode is None and proc.pid is not None:
+                    with suppress(ProcessLookupError):
+                        os.killpg(proc.pid, signal.SIGKILL)
+                # Reap the killed subprocess so asyncio releases its transport
+                # (pipes, child-watcher entry); otherwise the SubprocessTransport
+                # can outlive this call and surface as a delayed GC warning.
+                with suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=5.0)
                 raise ExecTimeoutError(command=command, timeout_s=timeout, cause=e) from e
         except ExecTimeoutError:
             raise

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import asyncio
+import os
 import signal
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
 from agents.sandbox.errors import ExecTimeoutError, PtySessionNotFoundError
 from agents.sandbox.manifest import Manifest
-from agents.sandbox.sandboxes import unix_local as unix_local_module
 from agents.sandbox.sandboxes.unix_local import (
     UnixLocalSandboxClient,
     UnixLocalSandboxSession,
@@ -263,20 +265,18 @@ class TestUnixLocalExecTimeoutCleanup:
 
         # Capture the asyncio.subprocess.Process used by _exec_internal so we can
         # assert it was reaped (returncode populated) after the timeout fires.
-        captured: list[object] = []
-        original_create = unix_local_module.asyncio.create_subprocess_exec
+        captured: list[asyncio.subprocess.Process] = []
+        original_create = asyncio.create_subprocess_exec
 
-        async def _capture_create(*args: object, **kwargs: object) -> object:
-            proc = await original_create(*args, **kwargs)  # type: ignore[arg-type]
+        async def _capture_create(
+            *args: Any, **kwargs: Any
+        ) -> asyncio.subprocess.Process:
+            proc = await original_create(*args, **kwargs)
             captured.append(proc)
             return proc
 
         async with await client.create(manifest=manifest, snapshot=None, options=None) as session:
-            with patch.object(
-                unix_local_module.asyncio,
-                "create_subprocess_exec",
-                _capture_create,
-            ):
+            with patch.object(asyncio, "create_subprocess_exec", _capture_create):
                 with pytest.raises(ExecTimeoutError):
                     await session.exec("sh", "-c", "sleep 30", timeout=0.1)
 
@@ -284,8 +284,8 @@ class TestUnixLocalExecTimeoutCleanup:
         proc = captured[0]
         # Without the explicit reap-after-kill the asyncio.Process can outlive
         # _exec_internal with returncode still None, leaking the transport.
-        assert proc.returncode is not None  # type: ignore[attr-defined]
-        assert proc.returncode != 0  # killed by SIGKILL  # type: ignore[attr-defined]
+        assert proc.returncode is not None
+        assert proc.returncode != 0  # killed by SIGKILL
 
     @pytest.mark.asyncio
     async def test_timeout_skips_killpg_for_already_exited_pid(
@@ -301,25 +301,30 @@ class TestUnixLocalExecTimeoutCleanup:
         def _record_killpg(pid: int, sig: int) -> None:
             killpg_calls.append(pid)
 
-        monkeypatch.setattr(unix_local_module.os, "killpg", _record_killpg)
+        monkeypatch.setattr(os, "killpg", _record_killpg)
 
-        original_wait_for = unix_local_module.asyncio.wait_for
+        original_wait_for = asyncio.wait_for
 
-        async def _wait_for_with_simulated_exit(awaitable: object, timeout: float | None) -> object:
+        async def _wait_for_with_simulated_exit(
+            awaitable: Any, timeout: float | None
+        ) -> Any:
             # First call (proc.communicate) — race the timeout: let the
             # subprocess exit naturally and *then* surface a TimeoutError.
+            # Use asyncio.TimeoutError explicitly: on Python 3.10 it is a
+            # distinct class from the builtin TimeoutError, and the source's
+            # `except asyncio.TimeoutError` clause must catch what we raise.
             if not killpg_calls and timeout is not None and timeout < 1.0:
                 # Drive the subprocess to completion (sh -c "true" returns fast),
                 # then raise to enter the timeout handler.
                 try:
-                    await original_wait_for(awaitable, timeout=5.0)  # type: ignore[arg-type]
+                    await original_wait_for(awaitable, timeout=5.0)
                 except Exception:
                     pass
-                raise TimeoutError
-            return await original_wait_for(awaitable, timeout=timeout)  # type: ignore[arg-type]
+                raise asyncio.TimeoutError
+            return await original_wait_for(awaitable, timeout=timeout)
 
         async with await client.create(manifest=manifest, snapshot=None, options=None) as session:
-            with patch.object(unix_local_module.asyncio, "wait_for", _wait_for_with_simulated_exit):
+            with patch.object(asyncio, "wait_for", _wait_for_with_simulated_exit):
                 with pytest.raises(ExecTimeoutError):
                     await session.exec("sh", "-c", "true", timeout=0.05)
 

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import signal
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from agents.sandbox.errors import PtySessionNotFoundError
+from agents.sandbox.errors import ExecTimeoutError, PtySessionNotFoundError
 from agents.sandbox.manifest import Manifest
+from agents.sandbox.sandboxes import unix_local as unix_local_module
 from agents.sandbox.sandboxes.unix_local import (
     UnixLocalSandboxClient,
     UnixLocalSandboxSession,
@@ -249,3 +251,76 @@ class TestUnixLocalUserScopedFilesystem:
         assert session.exec_commands[0][4:6] == ("sh", "-lc")
         assert session.exec_commands[0][-2:] == (str(target), "0")
         assert not any(part.startswith("rm ") for part in session.exec_commands[0])
+
+
+class TestUnixLocalExecTimeoutCleanup:
+    @pytest.mark.asyncio
+    async def test_timeout_reaps_subprocess_so_returncode_is_set(self, tmp_path: Path) -> None:
+        """After timeout, the killed subprocess must be awaited so its
+        returncode is populated and the asyncio transport is released."""
+        client = UnixLocalSandboxClient()
+        manifest = Manifest(root=str(tmp_path / "workspace"))
+
+        # Capture the asyncio.subprocess.Process used by _exec_internal so we can
+        # assert it was reaped (returncode populated) after the timeout fires.
+        captured: list[object] = []
+        original_create = unix_local_module.asyncio.create_subprocess_exec
+
+        async def _capture_create(*args: object, **kwargs: object) -> object:
+            proc = await original_create(*args, **kwargs)  # type: ignore[arg-type]
+            captured.append(proc)
+            return proc
+
+        async with await client.create(manifest=manifest, snapshot=None, options=None) as session:
+            with patch.object(
+                unix_local_module.asyncio,
+                "create_subprocess_exec",
+                _capture_create,
+            ):
+                with pytest.raises(ExecTimeoutError):
+                    await session.exec("sh", "-c", "sleep 30", timeout=0.1)
+
+        assert len(captured) == 1
+        proc = captured[0]
+        # Without the explicit reap-after-kill the asyncio.Process can outlive
+        # _exec_internal with returncode still None, leaking the transport.
+        assert proc.returncode is not None  # type: ignore[attr-defined]
+        assert proc.returncode != 0  # killed by SIGKILL  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_timeout_skips_killpg_for_already_exited_pid(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the subprocess exited before the timeout handler runs, we must not
+        signal its (potentially reused) pid."""
+        client = UnixLocalSandboxClient()
+        manifest = Manifest(root=str(tmp_path / "workspace"))
+
+        killpg_calls: list[int] = []
+
+        def _record_killpg(pid: int, sig: int) -> None:
+            killpg_calls.append(pid)
+
+        monkeypatch.setattr(unix_local_module.os, "killpg", _record_killpg)
+
+        original_wait_for = unix_local_module.asyncio.wait_for
+
+        async def _wait_for_with_simulated_exit(awaitable: object, timeout: float | None) -> object:
+            # First call (proc.communicate) — race the timeout: let the
+            # subprocess exit naturally and *then* surface a TimeoutError.
+            if not killpg_calls and timeout is not None and timeout < 1.0:
+                # Drive the subprocess to completion (sh -c "true" returns fast),
+                # then raise to enter the timeout handler.
+                try:
+                    await original_wait_for(awaitable, timeout=5.0)  # type: ignore[arg-type]
+                except Exception:
+                    pass
+                raise TimeoutError
+            return await original_wait_for(awaitable, timeout=timeout)  # type: ignore[arg-type]
+
+        async with await client.create(manifest=manifest, snapshot=None, options=None) as session:
+            with patch.object(unix_local_module.asyncio, "wait_for", _wait_for_with_simulated_exit):
+                with pytest.raises(ExecTimeoutError):
+                    await session.exec("sh", "-c", "true", timeout=0.05)
+
+        assert killpg_calls == []

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -268,9 +268,7 @@ class TestUnixLocalExecTimeoutCleanup:
         captured: list[asyncio.subprocess.Process] = []
         original_create = asyncio.create_subprocess_exec
 
-        async def _capture_create(
-            *args: Any, **kwargs: Any
-        ) -> asyncio.subprocess.Process:
+        async def _capture_create(*args: Any, **kwargs: Any) -> asyncio.subprocess.Process:
             proc = await original_create(*args, **kwargs)
             captured.append(proc)
             return proc
@@ -305,9 +303,7 @@ class TestUnixLocalExecTimeoutCleanup:
 
         original_wait_for = asyncio.wait_for
 
-        async def _wait_for_with_simulated_exit(
-            awaitable: Any, timeout: float | None
-        ) -> Any:
+        async def _wait_for_with_simulated_exit(awaitable: Any, timeout: float | None) -> Any:
             # First call (proc.communicate) — race the timeout: let the
             # subprocess exit naturally and *then* surface a TimeoutError.
             # Use asyncio.TimeoutError explicitly: on Python 3.10 it is a


### PR DESCRIPTION
## Summary

`UnixLocalSandboxSession._exec_internal` handles `asyncio.TimeoutError` by SIGKILL-ing the subprocess group, but never awaits the killed `asyncio.subprocess.Process`. Two issues fall out of that:

1. **Transport not torn down inside the failing call.** Because `proc.wait()` is never awaited, `proc.returncode` stays `None` and the underlying `SubprocessTransport` (pipes + child-watcher entry) hangs around until GC eventually finds it. Repeated timeouts queue up live transports for the lifetime of the event loop.
2. **Stale-pid signal.** `os.killpg(proc.pid, SIGKILL)` runs unconditionally. If the process happened to exit between `wait_for` cancellation and the kill, the pid may already have been reused, and we'd send `SIGKILL` to an unrelated process group. The `except Exception: pass` masks this.

The fix mirrors what `_terminate_pty_entry` already does for PTY entries (`if process.returncode is None ... ProcessLookupError suppressed`):

- Only signal when `proc.returncode is None` (and `proc.pid is not None`).
- Narrow the swallowed exception to `ProcessLookupError` instead of `Exception`.
- After the kill, `await asyncio.wait_for(proc.wait(), timeout=5.0)` so asyncio actually closes the transport before `ExecTimeoutError` is raised.

Two regression tests cover both behaviors:
- `test_timeout_reaps_subprocess_so_returncode_is_set` captures the asyncio Process used by `_exec_internal` and asserts `returncode` is populated after the timeout fires (fails on main: `returncode is None`).
- `test_timeout_skips_killpg_for_already_exited_pid` simulates the "process exited just before the timeout handler" race and asserts no `killpg` is issued (fails on main: a stale `killpg` is recorded).

## Test plan

- [x] `pytest tests/sandbox/test_unix_local.py -v` (all 10 pass)
- [x] `pytest tests/sandbox/` (765 passed, 19 skipped)
- [x] `ruff check` + `ruff format --check`
- [x] `pyright src/agents/sandbox/sandboxes/unix_local.py tests/sandbox/test_unix_local.py`
- [x] Both new tests fail on `main` (bug repros), pass with the fix