### PR TITLE
fix(agent): normalize explicit tool_name in Agent.as_tool

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -565,7 +565,9 @@ class Agent(AgentBase, Generic[TContext]):
                 return True
             return issubclass(value, BaseModel)
 
-        tool_name_resolved = tool_name or _transforms.transform_string_function_style(self.name)
+        tool_name_resolved = _transforms.transform_string_function_style(
+            tool_name or self.name
+        )
         tool_description_resolved = tool_description or ""
         has_custom_parameters = parameters is not None
         include_schema = bool(include_input_schema and has_custom_parameters)

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -2747,3 +2747,24 @@ def test_replaced_agent_as_tool_preserves_agent_markers_for_build_agent_map() ->
     agent_map = _build_agent_map(parent_agent)
 
     assert agent_map["nested_agent"] is nested_agent
+
+
+def test_agent_as_tool_normalizes_explicit_tool_name() -> None:
+    """An explicit tool_name with invalid characters must be normalized.
+
+    The function calling API rejects names with spaces or special characters.
+    Without this transform, callers passing ``tool_name="My Tool!"`` would
+    get a tool whose ``.name`` is silently rejected by the model. The default
+    code path (``tool_name=None``) already normalizes via the agent name, so
+    this preserves parity for explicit names.
+    """
+    agent = Agent(name="nested")
+
+    spaced = agent.as_tool(tool_name="My Tool!", tool_description="x")
+    assert spaced.name == "my_tool_"
+
+    valid = agent.as_tool(tool_name="already_valid", tool_description="x")
+    assert valid.name == "already_valid"
+
+    fallback = agent.as_tool(tool_name=None, tool_description="x")
+    assert fallback.name == "nested"


### PR DESCRIPTION
## Summary

When `tool_name` is provided to `Agent.as_tool`, it is passed straight through to `FunctionTool.name`. The OpenAI function-calling API rejects names that contain spaces or other characters outside `[a-zA-Z0-9_-]`, so a caller doing `agent.as_tool(tool_name="My Tool!", ...)` ends up with a tool the model can never invoke.

The default branch (`tool_name=None`) already routes the agent name through `transform_string_function_style` to produce a valid identifier. This change applies the same transform when the caller supplies an explicit name so both code paths produce API-compatible names. Names that are already valid pass through unchanged (the transform is the identity for `[a-zA-Z0-9_]+`).

### Before

```python
agent = Agent(name="nested")
tool = agent.as_tool(tool_name="My Tool!", tool_description="...")
tool.name  # "My Tool!"  -> rejected by the model
```

### After

```python
tool = agent.as_tool(tool_name="My Tool!", tool_description="...")
tool.name  # "my_tool_"  (with the existing warning logged)

tool = agent.as_tool(tool_name="already_valid", tool_description="...")
tool.name  # "already_valid"  (unchanged)
```

## Test plan

- [x] New test `test_agent_as_tool_normalizes_explicit_tool_name` covers the spaced name, an already-valid name (passthrough), and the default `tool_name=None` path.
- [x] Existing `tests/test_agent_as_tool.py` (44 tests) still passes.
- [x] Full `tests/` suite (excluding unrelated runloop sandbox extension tests) passes: 3801 passed.