### PR TITLE
fix(handoffs): await on_handoff callables with async __call__

### DIFF
--- a/src/agents/handoffs/__init__.py
+++ b/src/agents/handoffs/__init__.py
@@ -291,16 +291,14 @@ def handoff(
                 partial=False,
             )
             input_func = cast(OnHandoffWithInput[THandoffInput], on_handoff)
-            if inspect.iscoroutinefunction(input_func):
-                await input_func(ctx, validated_input)
-            else:
-                input_func(ctx, validated_input)
+            result = input_func(ctx, validated_input)
+            if inspect.isawaitable(result):
+                await result
         elif on_handoff is not None:
             no_input_func = cast(OnHandoffWithoutInput, on_handoff)
-            if inspect.iscoroutinefunction(no_input_func):
-                await no_input_func(ctx)
-            else:
-                no_input_func(ctx)
+            result = no_input_func(ctx)
+            if inspect.isawaitable(result):
+                await result
 
         return agent
 

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -202,6 +202,42 @@ async def test_async_on_handoff_without_input_called():
 
 
 @pytest.mark.asyncio
+async def test_callable_class_with_async_dunder_call_is_awaited():
+    """Callable instances whose ``__call__`` is async must be awaited.
+
+    ``inspect.iscoroutinefunction`` returns ``False`` for the instance itself, so the
+    previous implementation invoked it without awaiting and silently dropped the
+    coroutine.
+    """
+
+    class WithInput:
+        def __init__(self) -> None:
+            self.calls: list[Foo] = []
+
+        async def __call__(self, ctx: RunContextWrapper[Any], input: Foo) -> None:
+            self.calls.append(input)
+
+    class NoInput:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, ctx: RunContextWrapper[Any]) -> None:
+            self.calls += 1
+
+    agent = Agent(name="test")
+
+    with_input_cb = WithInput()
+    obj_with = handoff(agent, input_type=Foo, on_handoff=with_input_cb)
+    await obj_with.on_invoke_handoff(RunContextWrapper(agent), Foo(bar="baz").model_dump_json())
+    assert with_input_cb.calls == [Foo(bar="baz")]
+
+    no_input_cb = NoInput()
+    obj_no = handoff(agent, on_handoff=no_input_cb)
+    await obj_no.on_invoke_handoff(RunContextWrapper(agent), "")
+    assert no_input_cb.calls == 1
+
+
+@pytest.mark.asyncio
 async def test_invalid_on_handoff_raises_error():
     was_called = False
 


### PR DESCRIPTION
## Summary

`handoff(on_handoff=...)` accepts any callable, but the dispatch in
`src/agents/handoffs/__init__.py` decided whether to `await` based on
`inspect.iscoroutinefunction(on_handoff)`. That predicate returns `False` for
class instances whose `__call__` is `async def`, so for callbacks such as

```python
class MyHook:
    async def __call__(self, ctx, input):
        ...

handoff(agent, input_type=Foo, on_handoff=MyHook())
```

the runtime called `MyHook()(ctx, input)`, got a coroutine back, and discarded
it without awaiting. Result: the user's `on_handoff` never executed and Python
emitted `RuntimeWarning: coroutine '__call__' was never awaited`.

The fix mirrors the pattern already used elsewhere in the codebase (e.g.
`Handoff._is_enabled`, `tool.py`): invoke the callable, then `await` the
result iff it's awaitable. Sync callables remain synchronous; native async
functions and async-`__call__` instances are now awaited correctly.

## Test plan

- [x] New test `test_callable_class_with_async_dunder_call_is_awaited` covers
  both the `input_type`-bearing branch and the no-input branch.
- [x] `pytest tests/test_handoff_tool.py tests/test_handoff_history_duplication.py tests/test_handoff_prompt.py` (28 passed).
- [x] `ruff check` + `ruff format --check` clean on the touched files.
- [x] Confirmed the new test fails on `main` with the documented RuntimeWarning before applying the fix.