### PR TITLE
fix(mcp): surface CallToolResult.isError as a tool error

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -658,6 +658,28 @@ class MCPUtil:
         else:
             logger.debug(f"MCP tool {tool_name_for_display} returned {result}")
 
+        # Per the MCP spec, a server signals tool-execution failure by returning a
+        # CallToolResult with isError=True (rather than raising). Surface this through
+        # the FunctionTool failure pipeline so the model sees a structured error
+        # result instead of a fake "successful" output.
+        if getattr(result, "isError", False):
+            error_text = ""
+            for item in getattr(result, "content", None) or []:
+                if getattr(item, "type", None) == "text":
+                    error_text = item.text
+                    break
+            logger.warning(
+                f"MCP tool {tool_name_for_display} on server '{server.name}' "
+                f"returned isError=True: {error_text}"
+            )
+            raise AgentsException(
+                f"MCP tool {tool_name_for_display} on server '{server.name}' "
+                f"reported an error: {error_text}"
+                if error_text
+                else f"MCP tool {tool_name_for_display} on server '{server.name}' "
+                f"reported an error."
+            )
+
         # If structured content is requested and available, use it exclusively
         tool_output: ToolOutput
         if server.use_structured_content and result.structuredContent:

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -977,6 +977,58 @@ async def test_mcp_invocation_mcp_error_reraises(caplog: pytest.LogCaptureFixtur
 
 
 @pytest.mark.asyncio
+async def test_mcp_invocation_is_error_result_surfaces_as_tool_error(
+    caplog: pytest.LogCaptureFixture,
+):
+    """An MCP CallToolResult with ``isError=True`` represents a tool execution failure
+    (per the MCP spec). It must be surfaced through the FunctionTool failure pipeline
+    rather than silently returned as a successful output, otherwise the model sees a
+    fake "success" containing the error text and may proceed as if nothing went wrong.
+    """
+    caplog.set_level(logging.WARNING)
+
+    class IsErrorFakeMCPServer(FakeMCPServer):
+        async def call_tool(
+            self,
+            tool_name: str,
+            arguments: dict[str, Any] | None,
+            meta: dict[str, Any] | None = None,
+        ) -> CallToolResult:
+            return CallToolResult(
+                content=[TextContent(type="text", text="db connection refused")],
+                isError=True,
+            )
+
+    server = IsErrorFakeMCPServer()
+    server.add_tool("query", {})
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="query", inputSchema={})
+
+    # invoke_mcp_tool itself raises AgentsException so the failure pipeline can shape it
+    with pytest.raises(AgentsException) as exc_info:
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
+    assert "db connection refused" in str(exc_info.value)
+    assert "isError=True" in caplog.text
+
+    # Via FunctionTool with the default failure_error_function the error becomes a
+    # string result, not an apparent successful tool output.
+    mcp_tool = MCPTool(name="query", inputSchema={})
+    agent = Agent(name="test-agent")
+    function_tool = MCPUtil.to_function_tool(
+        mcp_tool, server, convert_schemas_to_strict=False, agent=agent
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="query",
+        tool_call_id="test_call_is_error",
+        tool_arguments="{}",
+    )
+    result = await function_tool.on_invoke_tool(tool_context, "{}")
+    assert isinstance(result, str)
+    assert "db connection refused" in result or "error" in result.lower()
+
+
+@pytest.mark.asyncio
 async def test_mcp_tool_graceful_error_handling(caplog: pytest.LogCaptureFixture):
     """Test that MCP tool errors are handled gracefully when invoked via FunctionTool.
 


### PR DESCRIPTION
## Summary
- Per the MCP spec, a server signals tool-execution failure by returning a `CallToolResult` with `isError=True` rather than raising. The current `invoke_mcp_tool` ignores this field, so the model sees the error content as if it were a successful tool output and proceeds as if nothing went wrong.
- Surface `isError=True` through the FunctionTool failure pipeline by raising `AgentsException`, matching the existing handling for `McpError` transport failures. The default `failure_error_function` will format it into a model-visible tool error; callers using `failure_error_function=None` get the raised exception as documented.
- Refs #2165 (closed-stale, never fixed).

## Diff size
~22 lines in `src/agents/mcp/util.py`, ~52-line focused test in `tests/mcp/test_mcp_util.py`.

## Test plan
- [x] New test `test_mcp_invocation_is_error_result_surfaces_as_tool_error` fails on `main` (DID NOT RAISE) and passes with the fix
- [x] Full `tests/mcp/` suite passes (209 tests)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)