### PR TITLE
fix(usage): preserve existing request_usage_entries on Usage.add

### DIFF
--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -196,8 +196,13 @@ class Usage:
         )
 
         # Automatically preserve request_usage_entries.
-        # If the other Usage represents a single request with tokens, record it.
-        if other.requests == 1 and other.total_tokens > 0:
+        # If the other Usage already has individual request breakdowns, merge them
+        # (this preserves nested token details that would otherwise be discarded
+        # when synthesizing an entry from only the top-level fields).
+        if other.request_usage_entries:
+            self.request_usage_entries.extend(other.request_usage_entries)
+        elif other.requests == 1 and other.total_tokens > 0:
+            # Otherwise, if the other Usage represents a single request with tokens, record it.
             input_details = other.input_tokens_details or InputTokensDetails(cached_tokens=0)
             output_details = other.output_tokens_details or OutputTokensDetails(reasoning_tokens=0)
             request_usage = RequestUsage(
@@ -208,9 +213,6 @@ class Usage:
                 output_tokens_details=output_details,
             )
             self.request_usage_entries.append(request_usage)
-        elif other.request_usage_entries:
-            # If the other Usage already has individual request breakdowns, merge them.
-            self.request_usage_entries.extend(other.request_usage_entries)
 
 
 def _serialize_usage_details(details: Any, default: dict[str, int]) -> dict[str, Any]:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -246,6 +246,39 @@ def test_usage_add_with_pre_existing_request_usage_entries():
     assert u1.request_usage_entries[1].input_tokens == 50
 
 
+def test_usage_add_preserves_existing_entries_when_top_level_also_set():
+    """When `other` has both top-level single-request fields AND pre-populated
+    `request_usage_entries`, the existing entries (which carry the authoritative
+    nested token details) must not be discarded in favor of a synthesized entry
+    built from only the top-level fields.
+    """
+    u1 = Usage()
+    u2 = Usage(
+        requests=1,
+        input_tokens=100,
+        output_tokens=50,
+        total_tokens=150,
+        request_usage_entries=[
+            RequestUsage(
+                input_tokens=100,
+                output_tokens=50,
+                total_tokens=150,
+                input_tokens_details=InputTokensDetails(cached_tokens=10),
+                output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
+            )
+        ],
+    )
+
+    u1.add(u2)
+
+    # The pre-populated entry must be preserved — including its nested details —
+    # rather than being replaced by a synthesized entry with zeroed-out details.
+    assert len(u1.request_usage_entries) == 1
+    entry = u1.request_usage_entries[0]
+    assert entry.input_tokens_details.cached_tokens == 10
+    assert entry.output_tokens_details.reasoning_tokens == 5
+
+
 def test_usage_request_usage_entries_default_empty():
     """Test that request_usage_entries defaults to an empty list."""
     u = Usage()


### PR DESCRIPTION
## Summary

`Usage.add(other)` discards any pre-populated `other.request_usage_entries` when `other` also has `requests == 1` and `total_tokens > 0`, replacing them with a freshly synthesized entry built from only the top-level fields. Nested details such as `cached_tokens` / `reasoning_tokens` carried by the existing entries are silently lost.

The two branches in `add()` were ordered so the synthesizer wins over an explicit per-request breakdown. The fix swaps them: if `other` already has an authoritative breakdown, merge it; otherwise fall back to synthesizing one from the top-level fields.

## Repro (before the fix)

```python
u1 = Usage()
u2 = Usage(
    requests=1, input_tokens=100, output_tokens=50, total_tokens=150,
    request_usage_entries=[
        RequestUsage(
            input_tokens=100, output_tokens=50, total_tokens=150,
            input_tokens_details=InputTokensDetails(cached_tokens=10),
            output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
        )
    ],
)
u1.add(u2)
# u1.request_usage_entries[0].input_tokens_details.cached_tokens == 0   (was 10)
# u1.request_usage_entries[0].output_tokens_details.reasoning_tokens == 0   (was 5)
```

## Changes

- `src/agents/usage.py` — reorder the `add()` branches so an explicit `request_usage_entries` list is preferred over a synthesized entry built from top-level fields.
- `tests/test_usage.py` — regression test (`test_usage_add_preserves_existing_entries_when_top_level_also_set`).

## Test plan

- [x] New regression test fails on `main`, passes after the fix.
- [x] Full `tests/test_usage.py` passes (14/14).
- [x] `tests/test_agent_runner_streamed.py::test_streamed_run_preserves_request_usage_entries_after_retry` and the conversation-locked variant still pass — these exercise the synthesize path with `requests == 2`, which the fix does not touch.
- [x] `ruff check` clean on touched files.