### PR TITLE
fix(realtime): preserve existing transcript over stale delta accumulator

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -362,7 +362,7 @@ class RealtimeSession(RealtimeModelListener):
 
                                 # If still missing and this is an assistant item, fall back to
                                 # accumulated transcript deltas tracked during the turn.
-                                if incoming_item.role == "assistant":
+                                if not preserved and incoming_item.role == "assistant":
                                     preserved = self._item_transcripts.get(incoming_item.item_id)
 
                                 if preserved:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2447,3 +2447,41 @@ class TestTranscriptPreservation:
         preserved_item = cast(AssistantMessageItem, session._history[0])
         assert isinstance(preserved_item.content[0], AssistantAudio)
         assert preserved_item.content[0].transcript == "partial transcript"
+
+    @pytest.mark.asyncio
+    async def test_existing_transcript_not_overwritten_by_stale_deltas(
+        self, mock_model, mock_agent
+    ):
+        """Existing transcripts must take precedence over leftover delta accumulators.
+
+        ``_item_transcripts`` is keyed by item_id and persists across updates within a
+        turn. When the model retrieves an item without a transcript, the merge should
+        fall back to deltas only when no existing transcript is present – otherwise
+        the complete transcript already in history would be clobbered by partial
+        (or stale) delta state.
+        """
+        session = RealtimeSession(mock_model, mock_agent, None)
+
+        # History already has the completed transcript for the item.
+        initial_item = AssistantMessageItem(
+            item_id="assist_3",
+            role="assistant",
+            content=[AssistantAudio(audio=None, transcript="Final complete transcript")],
+        )
+        session._history = [initial_item]
+
+        # Simulate stale/leftover delta state for the same item id.
+        session._item_transcripts["assist_3"] = "stale partial"
+
+        # Update arrives without transcript populated; merge must keep the existing
+        # complete transcript rather than reverting to the stale delta accumulator.
+        update_without_transcript = AssistantMessageItem(
+            item_id="assist_3",
+            role="assistant",
+            content=[AssistantAudio(audio=None, transcript=None)],
+        )
+        await session.on_event(RealtimeModelItemUpdatedEvent(item=update_without_transcript))
+
+        preserved_item = cast(AssistantMessageItem, session._history[0])
+        assert isinstance(preserved_item.content[0], AssistantAudio)
+        assert preserved_item.content[0].transcript == "Final complete transcript"


### PR DESCRIPTION
## Summary

While merging a `RealtimeModelItemUpdatedEvent` whose incoming content lacks a transcript, `RealtimeSession` looked up the existing item to preserve its transcript, then unconditionally reassigned the local `preserved` variable from the in-flight `_item_transcripts` delta accumulator for assistant items.

That contradicted the adjacent comment ("If still missing and this is an assistant item, fall back to ...") and meant a stale or partial delta still buffered for the same `item_id` would clobber the complete transcript already in history. In practice this surfaced when the platform retrieves an item (e.g. after `conversation.item.truncated`) without a transcript while delta state from the same turn was still around.

The one-line fix adds the missing `not preserved` guard so the delta fallback only fires when the existing item really has nothing. The existing two preservation tests still pass; the new regression test fails on `main` and passes with the fix.

```diff
- if incoming_item.role == "assistant":
+ if not preserved and incoming_item.role == "assistant":
      preserved = self._item_transcripts.get(incoming_item.item_id)
```

## Test plan

- [x] `pytest tests/realtime/test_session.py::TestTranscriptPreservation` (3 passed, including new regression test)
- [x] `pytest tests/realtime/` (233 passed, no regressions)
- [x] Confirmed new test fails on `main` without the fix (`assert 'stale partial' == 'Final complete transcript'`)