### PR TITLE
fix(litellm): avoid duplicating content and signed thinking blocks across parallel tool-call splits

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -661,13 +661,24 @@ class LitellmModel(Model):
                 # Extract tool calls from this assistant message
                 tool_calls = message.get("tool_calls", [])
                 if isinstance(tool_calls, list):
-                    for tool_call in tool_calls:
+                    for split_idx, tool_call in enumerate(tool_calls):
                         if isinstance(tool_call, dict):
                             tool_id = tool_call.get("id")
                             if tool_id:
-                                # Create a separate assistant message for each tool call
+                                # Create a separate assistant message for each tool call.
+                                # Only the first split keeps the assistant text/thinking
+                                # blocks/reasoning content; the rest carry tool_calls only,
+                                # to avoid duplicating signed thinking blocks (which
+                                # Anthropic rejects) and assistant text in history.
                                 single_tool_msg = cast(dict[str, Any], message.copy())
                                 single_tool_msg["tool_calls"] = [tool_call]
+                                if split_idx > 0:
+                                    for shared_field in (
+                                        "content",
+                                        "thinking_blocks",
+                                        "reasoning_content",
+                                    ):
+                                        single_tool_msg.pop(shared_field, None)
                                 tool_call_messages[tool_id] = (
                                     i,
                                     cast(ChatCompletionMessageParam, single_tool_msg),

--- a/tests/models/test_extended_thinking_message_order.py
+++ b/tests/models/test_extended_thinking_message_order.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from openai.types.chat import ChatCompletionMessageParam
 
 from agents.extensions.models.litellm_model import LitellmModel
@@ -220,15 +222,19 @@ class TestExtendedThinkingMessageOrder:
         history. Only the first split should retain content, thinking_blocks, and
         reasoning_content; subsequent splits should carry the tool_call alone.
         """
-        messages: list[ChatCompletionMessageParam] = [
-            {"role": "user", "content": "Search both"},
+        # Build the assistant message via cast so mypy doesn't reject the
+        # extra keys (`thinking_blocks`, `reasoning_content`) which are not
+        # part of the upstream ChatCompletionAssistantMessageParam TypedDict
+        # but are surfaced by litellm for Anthropic extended thinking.
+        assistant_msg = cast(
+            ChatCompletionMessageParam,
             {
                 "role": "assistant",
                 "content": "Looking up both queries.",
-                "thinking_blocks": [  # type: ignore[typeddict-unknown-key]
+                "thinking_blocks": [
                     {"type": "thinking", "thinking": "plan", "signature": "sig_abc"}
                 ],
-                "reasoning_content": "internal plan",  # type: ignore[typeddict-unknown-key]
+                "reasoning_content": "internal plan",
                 "tool_calls": [
                     {
                         "id": "call_1",
@@ -242,6 +248,10 @@ class TestExtendedThinkingMessageOrder:
                     },
                 ],
             },
+        )
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Search both"},
+            assistant_msg,
             {"role": "tool", "tool_call_id": "call_1", "content": "ok1"},
             {"role": "tool", "tool_call_id": "call_2", "content": "ok2"},
         ]
@@ -249,7 +259,7 @@ class TestExtendedThinkingMessageOrder:
         model = LitellmModel("claude-3-5-sonnet")
         result = model._fix_tool_message_ordering(messages)
 
-        assistants = [m for m in result if m.get("role") == "assistant"]
+        assistants = [cast(dict[str, Any], m) for m in result if m.get("role") == "assistant"]
         assert len(assistants) == 2
         # First split keeps the shared fields.
         assert assistants[0].get("content") == "Looking up both queries."
@@ -260,8 +270,8 @@ class TestExtendedThinkingMessageOrder:
         assert "thinking_blocks" not in assistants[1]
         assert "reasoning_content" not in assistants[1]
         # Tool calls are still split one-per-message.
-        assert assistants[0]["tool_calls"][0]["id"] == "call_1"  # type: ignore[index]
-        assert assistants[1]["tool_calls"][0]["id"] == "call_2"  # type: ignore[index]
+        assert assistants[0]["tool_calls"][0]["id"] == "call_1"
+        assert assistants[1]["tool_calls"][0]["id"] == "call_2"
 
     def test_empty_messages_list(self):
         """Test that empty message list is handled correctly."""

--- a/tests/models/test_extended_thinking_message_order.py
+++ b/tests/models/test_extended_thinking_message_order.py
@@ -212,6 +212,57 @@ class TestExtendedThinkingMessageOrder:
         assert result[4]["role"] == "tool"
         assert result[4]["tool_call_id"] == "call_2"
 
+    def test_split_does_not_duplicate_content_or_thinking(self):
+        """Splitting multi-tool assistant messages must not duplicate text/thinking blocks.
+
+        Anthropic's extended thinking API rejects requests that include the same signed
+        thinking block more than once, and duplicated assistant text corrupts conversation
+        history. Only the first split should retain content, thinking_blocks, and
+        reasoning_content; subsequent splits should carry the tool_call alone.
+        """
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Search both"},
+            {
+                "role": "assistant",
+                "content": "Looking up both queries.",
+                "thinking_blocks": [  # type: ignore[typeddict-unknown-key]
+                    {"type": "thinking", "thinking": "plan", "signature": "sig_abc"}
+                ],
+                "reasoning_content": "internal plan",  # type: ignore[typeddict-unknown-key]
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "s", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "s", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok1"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "ok2"},
+        ]
+
+        model = LitellmModel("claude-3-5-sonnet")
+        result = model._fix_tool_message_ordering(messages)
+
+        assistants = [m for m in result if m.get("role") == "assistant"]
+        assert len(assistants) == 2
+        # First split keeps the shared fields.
+        assert assistants[0].get("content") == "Looking up both queries."
+        assert "thinking_blocks" in assistants[0]
+        assert "reasoning_content" in assistants[0]
+        # Second split must NOT duplicate them.
+        assert "content" not in assistants[1]
+        assert "thinking_blocks" not in assistants[1]
+        assert "reasoning_content" not in assistants[1]
+        # Tool calls are still split one-per-message.
+        assert assistants[0]["tool_calls"][0]["id"] == "call_1"  # type: ignore[index]
+        assert assistants[1]["tool_calls"][0]["id"] == "call_2"  # type: ignore[index]
+
     def test_empty_messages_list(self):
         """Test that empty message list is handled correctly."""
         messages: list[ChatCompletionMessageParam] = []


### PR DESCRIPTION
## Summary

When `LitellmModel._fix_tool_message_ordering` splits an assistant message that has multiple `tool_calls` into one message per tool call, it copies the entire parent message into each split. That duplicates `content`, `thinking_blocks`, and `reasoning_content` across every split.

For Anthropic models with extended thinking, this is fatal: each thinking block carries a unique signature, and the API rejects requests that include the same signed block twice. It also corrupts conversation history by repeating the assistant's user-visible text whenever the model emits two or more parallel tool calls.

Keep those shared fields only on the first split; subsequent splits carry their `tool_calls` alone.

## Repro

Pass an assistant message with two parallel tool calls plus content/thinking blocks (which is what LiteLLM emits for Anthropic Claude models with parallel tool use + extended thinking) through `_fix_tool_message_ordering`. Before the fix, both split assistant messages contain the same `content` text and the same signed `thinking_blocks`; after the fix, only the first split carries them.

## Test plan

- [x] New unit test `test_split_does_not_duplicate_content_or_thinking` covers the regression.
- [x] All 9 pre-existing `test_extended_thinking_message_order.py` tests still pass.
- [x] All 25 LiteLLM-related tests pass.
- [x] `ruff check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)