### PR TITLE
fix(tracing): keep BatchTraceProcessor worker alive on exporter errors

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -600,8 +600,17 @@ class BatchTraceProcessor(TracingProcessor):
                 if not items_to_export:
                     break
 
-                # Export the batch
-                self._exporter.export(items_to_export)
+                # Export the batch. Catch any exception so a misbehaving exporter
+                # cannot kill the background worker thread and silently strand all
+                # subsequent spans in the queue.
+                try:
+                    self._exporter.export(items_to_export)
+                except Exception as exc:
+                    logger.error(
+                        "[non-fatal] Tracing: exporter raised %s; dropping batch of %d items",
+                        exc,
+                        len(items_to_export),
+                    )
 
 
 # Lazily initialized defaults to avoid creating network clients or threading

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -201,9 +201,7 @@ def test_batch_trace_processor_survives_exporter_exception():
     time.sleep(0.3)
 
     assert processor._worker_thread is not None
-    assert processor._worker_thread.is_alive(), (
-        "Worker thread must survive an exporter exception"
-    )
+    assert processor._worker_thread.is_alive(), "Worker thread must survive an exporter exception"
 
     processor.shutdown(timeout=2.0)
 

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -172,6 +172,46 @@ def test_batch_trace_processor_shutdown_flushes(mocked_exporter):
     assert total_exported == 2, "All items in the queue should be exported upon shutdown"
 
 
+def test_batch_trace_processor_survives_exporter_exception():
+    """A failing exporter must not kill the background worker thread.
+
+    Previously, an exception raised inside ``exporter.export`` propagated out of
+    ``_export_batches`` and killed the ``_run`` thread, causing all subsequent
+    spans to silently accumulate in the queue until it filled up.
+    """
+
+    class FlakyExporter(TracingExporter):
+        def __init__(self) -> None:
+            self.call_count = 0
+            self.exported: list[Trace | Span[Any]] = []
+
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            self.call_count += 1
+            if self.call_count == 1:
+                raise RuntimeError("simulated exporter failure")
+            self.exported.extend(items)
+
+    exporter = FlakyExporter()
+    processor = BatchTraceProcessor(exporter, schedule_delay=0.05, max_batch_size=1)
+    processor.on_span_end(get_span(processor))
+    processor.on_span_end(get_span(processor))
+    processor.on_span_end(get_span(processor))
+
+    # Give the worker time to encounter the failure and continue processing.
+    time.sleep(0.3)
+
+    assert processor._worker_thread is not None
+    assert processor._worker_thread.is_alive(), (
+        "Worker thread must survive an exporter exception"
+    )
+
+    processor.shutdown(timeout=2.0)
+
+    # First batch raised; the remaining two items must still have been exported.
+    assert len(exporter.exported) == 2
+    assert exporter.call_count >= 3
+
+
 def test_batch_trace_processor_scheduled_export(mocked_exporter):
     """
     Tests that items are automatically exported when the schedule_delay expires.


### PR DESCRIPTION
## Summary

If the user-supplied exporter raises (transient bug, network library throws, etc.), the exception escapes `BatchTraceProcessor._export_batches` and kills the background `_run` thread.

Once the worker dies, subsequent `on_span_end` / `on_trace_start` calls just enqueue items that are never exported — they sit in the queue until it hits `max_queue_size` (8192 by default) and are then silently dropped via `queue.Full`.

The fix wraps the `self._exporter.export(...)` call in a try/except and logs the failure non-fatally, so a single bad batch no longer takes the entire processor down.

## Repro (before this PR)

```python
class FlakyExporter(TracingExporter):
    def __init__(self): self.n = 0
    def export(self, items):
        self.n += 1
        if self.n == 1:
            raise RuntimeError("boom")

p = BatchTraceProcessor(FlakyExporter(), schedule_delay=0.05, max_batch_size=1)
p.on_span_end(make_span()); p.on_span_end(make_span()); p.on_span_end(make_span())
time.sleep(0.3)
assert p._worker_thread.is_alive()  # FAILS on main; passes after this PR
```

## Test plan

- [x] New test `test_batch_trace_processor_survives_exporter_exception` fails on main, passes with the fix
- [x] All 46 existing tests in `tests/test_trace_processor.py` still pass
- [x] All 95 tracing tests (`tests/tracing/`, `tests/test_trace_processor.py`, `tests/test_tracing.py`) still pass
- [x] `ruff check` clean