### PR TITLE
fix(run): preserve failed status across apply_patch operations

### DIFF
--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -827,8 +827,10 @@ class ApplyPatchAction:
                     awaited = await result if inspect.isawaitable(result) else result
                     normalized = normalize_apply_patch_result(awaited)
                     if normalized:
-                        if normalized.status in {"completed", "failed"}:
-                            status = normalized.status
+                        if normalized.status == "failed":
+                            status = "failed"
+                        elif normalized.status == "completed" and status != "failed":
+                            status = "completed"
                         if normalized.output:
                             operation_outputs.append(normalized.output)
                 output_text = "\n".join(operation_outputs)

--- a/tests/test_apply_patch_tool.py
+++ b/tests/test_apply_patch_tool.py
@@ -386,3 +386,53 @@ async def test_apply_patch_tool_on_approval_callback_auto_rejects() -> None:
     assert isinstance(result, ToolCallOutputItem)
     assert HITL_REJECTION_MSG in result.output
     assert len(editor.operations) == 0  # Should not have executed
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_failed_status_not_overwritten_by_later_completed_op() -> None:
+    """If any operation reports `failed`, the overall apply_patch status must remain `failed`,
+    even when subsequent operations succeed."""
+
+    class MixedStatusEditor(RecordingEditor):
+        def update_file(self, operation: ApplyPatchOperation) -> ApplyPatchResult:
+            self.operations.append(operation)
+            return ApplyPatchResult(status="failed", output=f"Failed {operation.path}")
+
+        def create_file(self, operation: ApplyPatchOperation) -> ApplyPatchResult:
+            self.operations.append(operation)
+            return ApplyPatchResult(status="completed", output=f"Created {operation.path}")
+
+    @dataclass
+    class MultiOpCall:
+        type: str
+        call_id: str
+        operations: list[dict[str, Any]]
+
+    editor = MixedStatusEditor()
+    tool = ApplyPatchTool(editor=editor)
+    multi_call = MultiOpCall(
+        type="apply_patch_call",
+        call_id="call_multi",
+        operations=[
+            {"type": "update_file", "path": "a.md", "diff": "-x\n+y\n"},
+            {"type": "create_file", "path": "b.md", "diff": "+hi\n"},
+        ],
+    )
+    agent = Agent(name="patcher", tools=[tool])
+    context_wrapper = make_context_wrapper()
+    tool_run = ToolRunApplyPatchCall(tool_call=multi_call, apply_patch_tool=tool)
+
+    result = await ApplyPatchAction.execute(
+        agent=agent,
+        call=tool_run,
+        hooks=RunHooks[Any](),
+        context_wrapper=context_wrapper,
+        config=RunConfig(),
+    )
+
+    assert isinstance(result, ToolCallOutputItem)
+    raw_item = cast(dict[str, Any], result.raw_item)
+    # The first op failed; the second succeeded. Overall status must reflect the failure.
+    assert raw_item["status"] == "failed"
+    assert "Failed a.md" in result.output
+    assert "Created b.md" in result.output


### PR DESCRIPTION
## Summary

`ApplyPatchAction.execute` walks through every operation in an `apply_patch` call and tracks an overall `status` for the resulting `apply_patch_call_output`. The previous logic was:

```python
if normalized.status in {"completed", "failed"}:
    status = normalized.status
```

This unconditionally overwrites the running status with the latest editor result. If a multi-op call had a failed operation followed by a successful one, the failure was silently lost: the raw_item reported `"completed"` even though one of the operations failed. That contradicts the exception path in the same method (which forces `"failed"`) and would feed misleading status back to the model.

This change makes failure sticky: once any operation fails, the overall status stays `"failed"`. A `"completed"` result can only set the status when no prior failure has been recorded.

## Test plan

- [x] New regression test `test_apply_patch_failed_status_not_overwritten_by_later_completed_op` exercises a 2-op call where op1 fails and op2 succeeds; it fails on `main` and passes after the fix.
- [x] Full `tests/test_apply_patch_tool.py` suite (11 tests) passes.
- [x] `tests/test_hitl_error_scenarios.py` (which exercises apply_patch HITL flows) still passes.