### PR TITLE
fix(visualization): dedupe Handoff target nodes in get_all_nodes

### DIFF
--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -78,11 +78,13 @@ def get_all_nodes(
 
     for handoff in agent.handoffs:
         if isinstance(handoff, Handoff):
-            parts.append(
-                f'"{handoff.agent_name}" [label="{handoff.agent_name}", '
-                f"shape=box, style=filled, style=rounded, "
-                f"fillcolor=lightyellow, width=1.5, height=0.8];"
-            )
+            if handoff.agent_name not in visited:
+                visited.add(handoff.agent_name)
+                parts.append(
+                    f'"{handoff.agent_name}" [label="{handoff.agent_name}", '
+                    f"shape=box, style=filled, style=rounded, "
+                    f"fillcolor=lightyellow, width=1.5, height=0.8];"
+                )
         if isinstance(handoff, Agent):
             if handoff.name not in visited:
                 parts.append(

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -242,3 +242,37 @@ def test_draw_graph_with_real_handoff_object():
     assert '"ParentAgent" -> "ChildAgent";' in graph.source
     # Parent has handoffs, so should NOT connect directly to __end__
     assert '"ParentAgent" -> "__end__"' not in graph.source
+
+
+def test_handoff_node_not_duplicated_when_referenced_multiple_times():
+    """A Handoff target referenced from multiple parents should appear once.
+
+    Regression test: prior to the fix, ``get_all_nodes`` emitted a node
+    declaration for ``Handoff.agent_name`` on every visit, producing duplicate
+    DOT entries when the same handoff target was reachable from multiple
+    branches of the graph.
+    """
+    child = Agent(name="SharedChild", instructions="c")
+    h1 = handoff(child)
+    h2 = handoff(child)
+
+    parent_a = Agent(name="ParentA", instructions="a", handoffs=[h1])
+    parent_b = Agent(name="ParentB", instructions="b", handoffs=[h2])
+    root = Agent(name="Root", instructions="r", handoffs=[parent_a, parent_b])
+
+    nodes = get_all_nodes(root)
+
+    # The child node declaration should appear exactly once, regardless of
+    # how many parents handoff to it.
+    assert nodes.count('"SharedChild" [label="SharedChild"') == 1
+
+
+def test_handoff_node_not_duplicated_when_also_in_handoffs_as_agent():
+    """A handoff target referenced as both Handoff and Agent should appear once."""
+    child = Agent(name="DualChild", instructions="c")
+    h = handoff(child)
+    parent = Agent(name="Parent", instructions="p", handoffs=[h, child])
+
+    nodes = get_all_nodes(parent)
+
+    assert nodes.count('"DualChild" [label="DualChild"') == 1


### PR DESCRIPTION
## Summary

When the same `Handoff` `agent_name` is reachable from multiple parents in an agent graph (or appears as both a `Handoff` and an `Agent` in the same `handoffs` list), `get_all_nodes` previously emitted a node declaration on every encounter. This produced duplicate DOT node entries in the rendered graph.

The `Agent` branch of the same loop already guards against this with a `visited` check; this PR extends the same protection to the `Handoff` branch by recording the handoff's `agent_name` in `visited` and skipping subsequent emissions.

## Repro (before fix)

```python
from agents import Agent, handoff
from agents.extensions.visualization import get_all_nodes

child = Agent(name="Child", instructions="c")
parent_a = Agent(name="A", handoffs=[handoff(child)], instructions="a")
parent_b = Agent(name="B", handoffs=[handoff(child)], instructions="b")
root = Agent(name="Root", handoffs=[parent_a, parent_b], instructions="r")

print(get_all_nodes(root).count('"Child" [label="Child"'))  # 2 (should be 1)
```

## Test plan

- [x] Added `test_handoff_node_not_duplicated_when_referenced_multiple_times` covering the diamond / shared-handoff case.
- [x] Added `test_handoff_node_not_duplicated_when_also_in_handoffs_as_agent` covering the mixed `Handoff` + `Agent` case.
- [x] All existing `tests/test_visualization.py` cases (8) still pass.