### PR TITLE
fix(sessions): treat negative SQLiteSession get_items limits as empty

### DIFF
--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -211,6 +211,12 @@ class SQLiteSession(SessionABC):
         """
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        # SQLite treats a negative LIMIT as "no limit", which would silently return
+        # the full conversation history when the caller asked for a bounded slice.
+        # Match the explicit limit=0 contract instead and short-circuit to an empty list.
+        if session_limit is not None and session_limit <= 0:
+            return []
+
         def _get_items_sync():
             with self._locked_connection() as conn:
                 if session_limit is None:

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -384,6 +384,14 @@ async def test_sqlite_session_get_items_with_limit():
         latest_0 = await session.get_items(limit=0)
         assert len(latest_0) == 0
 
+        # Negative limits must not silently return the full history. SQLite treats
+        # ``LIMIT -1`` as "no limit", so without an explicit guard a caller asking for
+        # ``limit=-1`` would get every message instead of an empty slice.
+        latest_neg_one = await session.get_items(limit=-1)
+        assert latest_neg_one == []
+        latest_neg_many = await session.get_items(limit=-100)
+        assert latest_neg_many == []
+
         session.close()
 
 


### PR DESCRIPTION
## Summary

`SQLiteSession.get_items(limit=-1)` silently returned the entire conversation history because SQLite treats a negative `LIMIT` value as "no limit". That breaks the contract suggested by `limit=0` (which returns an empty list) and is dangerous for callers that compute the limit arithmetically (e.g. `remaining = budget - already_seen`) and accidentally pass a negative value — they get the full history back instead of an empty slice.

This change short-circuits `get_items` when the resolved limit is `<= 0` and returns `[]` without touching the database. Behavior for `None` (return all) and positive limits is unchanged.

## Repro (before fix)

```python
session = SQLiteSession("test", db_path)
await session.add_items([{"role": "user", "content": f"msg{i}"} for i in range(5)])
print(len(await session.get_items(limit=-1)))    # prints 5 (bug, should be 0)
print(len(await session.get_items(limit=-100)))  # prints 5 (bug, should be 0)
print(len(await session.get_items(limit=0)))     # prints 0 (already correct)
```

## Test plan

- [x] Added negative-limit assertions to `tests/memory/test_session.py::test_sqlite_session_get_items_with_limit` (limit=-1 and limit=-100 both expect `[]`).
- [x] New assertions FAIL on `main` and PASS with the fix applied.
- [x] Full `tests/memory/` suite still green (119 passed).
- [x] `ruff check` and `ruff format --check` clean on the touched files.