### PR TITLE
fix(encrypted-session): skip envelopes with malformed payloads

### DIFF
--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -164,10 +164,13 @@ class EncryptedSession(SessionABC):
             return cast(TResponseInputItem, item)
 
         try:
-            token = item["payload"].encode("utf-8")
+            payload = item["payload"]
+            if not isinstance(payload, str):
+                return None
+            token = payload.encode("utf-8")
             plaintext = self.cipher.decrypt(token, ttl=self.ttl)
             return cast(TResponseInputItem, _from_json_bytes(plaintext))
-        except (InvalidToken, KeyError):
+        except (InvalidToken, KeyError, ValueError, UnicodeDecodeError):
             return None
 
     def _unwrap_valid_items(

--- a/tests/extensions/memory/test_encrypt_session.py
+++ b/tests/extensions/memory/test_encrypt_session.py
@@ -365,6 +365,60 @@ async def test_encrypted_session_get_items_session_settings_limit_skips_invalid_
     underlying_session.close()
 
 
+@pytest.mark.parametrize(
+    "bad_payload",
+    [12345, None, ["not", "a", "string"], {"nested": "dict"}],
+)
+async def test_encrypted_session_get_items_skips_envelope_with_non_string_payload(
+    encryption_key: str, underlying_session: SQLiteSession, bad_payload
+):
+    """Malformed envelopes whose payload is not a string must be skipped, not crash."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    await session.add_items([{"role": "user", "content": "valid"}])
+    malformed = cast(
+        TResponseInputItem,
+        {"__enc__": 1, "v": 1, "kid": "hkdf-v1", "payload": bad_payload},
+    )
+    await underlying_session.add_items([malformed])
+
+    items = await session.get_items()
+    assert [item.get("content") for item in items] == ["valid"]
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_pop_item_skips_envelope_with_non_string_payload(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """pop_item must not crash on a malformed envelope below a valid one."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    malformed = cast(
+        TResponseInputItem,
+        {"__enc__": 1, "v": 1, "kid": "hkdf-v1", "payload": None},
+    )
+    await underlying_session.add_items([malformed])
+    await session.add_items([{"role": "user", "content": "valid"}])
+
+    popped = await session.pop_item()
+    assert popped is not None
+    assert popped.get("content") == "valid"
+
+    # Loop drains the malformed envelope without raising.
+    assert await session.pop_item() is None
+
+    underlying_session.close()
+
+
 async def test_encrypted_session_unicode_content(
     encryption_key: str, underlying_session: SQLiteSession
 ):


### PR DESCRIPTION
## Summary

`EncryptedSession._unwrap` assumes `item["payload"]` is always a string and only catches `InvalidToken` / `KeyError`. If a stored envelope has a non-string payload (e.g. `None`, `int`, `list` — possible under storage corruption, type confusion at the DB layer, or manual injection), `payload.encode("utf-8")` raises `AttributeError` and breaks **both** `get_items` and `pop_item` for the entire session — there is no recovery short of `clear_session`.

This is the same shape of bug as #3174 (fixed in #3175 for invalid Fernet tokens), but for a different failure mode: malformed envelope shape rather than invalid ciphertext.

### Repro (before the fix)

```python
session = EncryptedSession(session_id="s", underlying_session=sqlite, encryption_key=key)
await session.add_items([{"role": "user", "content": "Hello"}])
await sqlite.add_items([{"__enc__": 1, "v": 1, "kid": "hkdf-v1", "payload": None}])

await session.get_items()  # AttributeError: 'NoneType' object has no attribute 'encode'
await session.pop_item()   # same crash on second pop
```

### Fix

- Validate `payload` is a `str` before calling `.encode("utf-8")`; otherwise return `None` (skip).
- Broaden the swallowed exception set to include `ValueError` (covers `json.JSONDecodeError` if the decrypted plaintext is not valid JSON) and `UnicodeDecodeError`.

Treats malformed envelopes the same way invalid/expired envelopes are already treated (silently skip), matching the documented behavior in the module docstring: "When TTL expires, expired items are silently skipped."

7-line source change.

## Test plan

- [x] Add parametrized regression test covering `int`, `None`, `list`, and `dict` payloads on `get_items` (4 cases).
- [x] Add regression test covering `pop_item` with a malformed envelope underneath a valid one — must return the valid item, then drain to `None` instead of raising.
- [x] All 24 tests in `tests/extensions/memory/test_encrypt_session.py` pass (19 existing + 5 new).
- [x] Confirmed new tests fail without the source fix (AttributeError).
- [x] `ruff check` clean on changed files.