### PR TITLE
fix(computer): preserve data URL screenshots from driver

### DIFF
--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -159,7 +159,7 @@ class ComputerAction:
                 ),
             )
 
-            image_url = f"data:image/png;base64,{output}" if output else ""
+            image_url = cls._build_image_url(output)
             if span and config.trace_include_sensitive_data:
                 span.span_data.output = image_url
 
@@ -305,6 +305,16 @@ class ComputerAction:
         if not keys:
             return None
         return cast(list[str], keys)
+
+    @staticmethod
+    def _build_image_url(output: str) -> str:
+        """Wrap raw base64 PNG output in a data URL, tolerating drivers that already do so."""
+        if not output:
+            return ""
+        if output.startswith("data:image/"):
+            # Driver already returned a data URL; avoid double-prefixing it.
+            return output
+        return f"data:image/png;base64,{output}"
 
     @classmethod
     def _filter_supported_kwargs(

--- a/tests/test_computer_action.py
+++ b/tests/test_computer_action.py
@@ -594,6 +594,39 @@ async def test_execute_invokes_hooks_and_returns_tool_call_output() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_does_not_double_prefix_data_url_screenshot() -> None:
+    """Drivers that already return a data URL should not be double-wrapped into a broken URL."""
+    pre_encoded = "data:image/png;base64,iVBORw0KGgo="
+    computer = LoggingComputer(screenshot_return=pre_encoded)
+    comptool = ComputerTool(computer=computer)
+    tool_call = ResponseComputerToolCall(
+        id="tool_dataurl",
+        type="computer_call",
+        action=ActionClick(type="click", x=1, y=2, button="left"),
+        call_id="tool_dataurl",
+        pending_safety_checks=[],
+        status="completed",
+    )
+    tool_run = ToolRunComputerAction(tool_call=tool_call, computer_tool=comptool)
+    agent = Agent(name="dataurl_agent", tools=[comptool])
+
+    output_item = await ComputerAction.execute(
+        agent=agent,
+        action=tool_run,
+        hooks=RunHooks[Any](),
+        context_wrapper=RunContextWrapper(context=None),
+        config=RunConfig(),
+    )
+
+    assert isinstance(output_item, ToolCallOutputItem)
+    # The output URL must be the original data URL, not double-prefixed.
+    assert output_item.output == pre_encoded
+    raw = cast(dict[str, Any], output_item.raw_item)
+    assert raw["output"]["image_url"] == pre_encoded
+    assert "data:image/png;base64,data:" not in raw["output"]["image_url"]
+
+
+@pytest.mark.asyncio
 async def test_execute_emits_function_span() -> None:
     computer = LoggingComputer(screenshot_return="trace_img")
     comptool = ComputerTool(computer=computer)


### PR DESCRIPTION
## Summary
- `ComputerAction.execute` always wraps the driver's screenshot string in `data:image/png;base64,<...>`. When a `Computer`/`AsyncComputer` implementation already returns a fully-formed data URL (e.g. drivers that re-use a generic image helper, or vendor SDKs that hand back data URLs), the result is `data:image/png;base64,data:image/png;base64,<payload>`, which is not a valid URL and renders as nothing in the model output.
- Detect an existing `data:image/...` prefix and pass it through unchanged. Empty output still yields `""` for backwards compat.
- Logic moved into a small `_build_image_url` helper to keep the hot path readable and testable.

## Test plan
- [x] `pytest tests/test_computer_action.py tests/test_computer_tool_lifecycle.py` (37 passed)
- [x] New regression: `test_execute_does_not_double_prefix_data_url_screenshot` fails on `main` and passes with the fix.
- [x] `ruff check` on touched files.