### PR TITLE
fix(mcp): deduplicate servers in MCPServerManager

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -154,8 +154,8 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
         suppress_cancelled_error: bool = True,
         connect_in_parallel: bool = False,
     ) -> None:
-        self._all_servers = list(servers)
-        self._active_servers = list(servers)
+        self._all_servers = self._unique_servers(servers)
+        self._active_servers = list(self._all_servers)
         self.connect_timeout_seconds = connect_timeout_seconds
         self.cleanup_timeout_seconds = cleanup_timeout_seconds
         self.drop_failed_servers = drop_failed_servers

--- a/tests/mcp/test_mcp_server_manager.py
+++ b/tests/mcp/test_mcp_server_manager.py
@@ -353,6 +353,21 @@ async def test_manager_reconnect_all_avoids_duplicate_connections() -> None:
 
 
 @pytest.mark.asyncio
+async def test_manager_deduplicates_repeated_servers() -> None:
+    """A server passed multiple times must only connect/cleanup once and
+    appear once in active_servers."""
+
+    server = CleanupAwareServer()
+
+    async with MCPServerManager([server, server]) as manager:
+        assert manager.active_servers == [server]
+        assert manager.all_servers == [server]
+        assert server.connect_calls == 1
+
+    assert server.cleanup_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_manager_strict_reconnect_refreshes_active_servers() -> None:
     server_a = FlakyServer(failures=1)
     server_b = FlakyServer(failures=2)


### PR DESCRIPTION
## Summary
- `MCPServerManager.__init__` stored `list(servers)` as `_all_servers` without deduplication. The connect path is fine because `_servers_to_connect` calls `_unique_servers`, but `cleanup_all()` and `_refresh_active_servers()` iterate `_all_servers` directly.
- Result: passing the same server instance twice (easy to do when composing manager configs) calls `cleanup()` twice on a single underlying connection, surfaces the server twice in `active_servers`, and triggers a spurious `Duplicate tool names found across MCP servers` error from `MCPUtil.get_all_function_tools` because each duplicate emits the same tool list.
- Fix: deduplicate at construction time using the existing `_unique_servers` helper, so all downstream callers see a canonical list.

## Repro (before this PR)
```python
server = CleanupAwareServer()
async with MCPServerManager([server, server]) as manager:
    assert manager.active_servers == [server]   # FAILS: returns [server, server]
    assert server.connect_calls == 1
assert server.cleanup_calls == 1                 # FAILS: cleanup_calls == 2
```

## Test plan
- [x] Added `test_manager_deduplicates_repeated_servers` covering connect-once, single entry in `active_servers`/`all_servers`, and cleanup-once semantics.
- [x] Existing `tests/mcp/test_mcp_server_manager.py` (22 tests) still pass.
- [x] Full `tests/mcp/` suite (209 tests) still passes.