### PR TITLE
fix(realtime): expose max_output_tokens on RealtimeSessionModelSettings

### DIFF
--- a/src/agents/realtime/config.py
+++ b/src/agents/realtime/config.py
@@ -169,6 +169,13 @@ class RealtimeSessionModelSettings(TypedDict):
     speed: NotRequired[float]
     """The speed of the model's responses."""
 
+    max_output_tokens: NotRequired[int | Literal["inf"]]
+    """Maximum number of output tokens for a single assistant response, inclusive of tool calls.
+
+    Provide an integer between 1 and 4096 to limit output tokens, or ``"inf"`` for the maximum
+    available tokens for a given model. Defaults to ``"inf"`` server-side.
+    """
+
     input_audio_format: NotRequired[RealtimeAudioFormat | OpenAIRealtimeAudioFormats]
     """The format for input audio streams."""
 

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -1509,6 +1509,19 @@ class TestSendEventAndConfig(TestOpenAIRealtimeWebSocketModel):
         assert payload["parallel_tool_calls"] is False
         assert payload["reasoning"] == {"effort": "low"}
 
+    def test_session_config_passes_max_output_tokens(self, model):
+        # Integer cap is forwarded verbatim to the server payload.
+        cfg = model._get_session_config({"max_output_tokens": 256})
+        assert cfg.max_output_tokens == 256
+
+        # The "inf" sentinel is preserved (e.g., to override an earlier cap).
+        cfg_inf = model._get_session_config({"max_output_tokens": "inf"})
+        assert cfg_inf.max_output_tokens == "inf"
+
+        # Omitting the key leaves the field unset so the server default applies.
+        cfg_default = model._get_session_config({})
+        assert cfg_default.max_output_tokens is None
+
     def test_session_config_allows_tool_search_as_named_function_tool_choice(self, model):
         cfg = model._get_session_config(
             {


### PR DESCRIPTION
## Summary

`OpenAIRealtimeWebSocketModel._get_session_config` already reads `max_output_tokens` from the settings dict and forwards it to `RealtimeSessionCreateRequest.max_output_tokens` (see `src/agents/realtime/openai_realtime.py:1474`), but the field was never declared on `RealtimeSessionModelSettings`. Type-checked callers had to cast through `Any` (or use `# type: ignore`) just to limit per-response output tokens, even though the OpenAI Realtime API supports the field natively.

This patch adds `max_output_tokens: NotRequired[int | Literal["inf"]]` to the TypedDict so callers can pass either an integer cap or the `"inf"` sentinel directly. No runtime change is required: the existing forwarding logic already handles both shapes.

## Test plan

- [x] New `test_session_config_passes_max_output_tokens` covers integer caps, the `"inf"` sentinel, and the unset (server-default) case via `_get_session_config`.
- [x] `pytest tests/realtime/` -> 233 passed.
- [x] `ruff check` / `ruff format --check` clean on touched files.