### PR TITLE
fix(run): skip CompactionItem silently in stream queue helper

### DIFF
--- a/src/agents/run_internal/streaming.py
+++ b/src/agents/run_internal/streaming.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 
 from ..items import (
+    CompactionItem,
     HandoffCallItem,
     HandoffOutputItem,
     MCPApprovalRequestItem,
@@ -54,6 +55,8 @@ def stream_step_items_to_queue(
             event = RunItemStreamEvent(item=item, name="mcp_list_tools")
         elif isinstance(item, ToolApprovalItem):
             event = None  # approvals represent interruptions, not streamed items
+        elif isinstance(item, CompactionItem):
+            event = None  # compaction items are session bookkeeping, not streamed items
         else:
             logger.warning("Unexpected item type: %s", type(item))
             event = None

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -36,6 +36,7 @@ from agents import Agent, HandoffCallItem, Runner, function_tool
 from agents.extensions.handoff_filters import remove_all_tools
 from agents.handoffs import handoff
 from agents.items import (
+    CompactionItem,
     MCPApprovalRequestItem,
     MCPApprovalResponseItem,
     MCPListToolsItem,
@@ -232,6 +233,26 @@ def test_stream_step_items_to_queue_emits_helper_events_and_skips_approvals(
         "mcp_list_tools",
     ]
     assert "Unexpected item type" in caplog.text
+
+
+def test_stream_step_items_to_queue_skips_compaction_items_silently(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """CompactionItem is a session-bookkeeping RunItem with no public stream
+    event name; it must be skipped silently rather than logged as unexpected."""
+    agent = Agent(name="StreamHelper")
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+
+    compaction_item = CompactionItem(
+        agent=agent,
+        raw_item=cast(Any, {"type": "compaction", "summary": "compacted"}),
+    )
+
+    with caplog.at_level("WARNING", logger="openai.agents"):
+        stream_step_items_to_queue([compaction_item], queue)
+
+    assert queue.empty()
+    assert "Unexpected item type" not in caplog.text
 
 
 def test_stream_step_result_to_queue_uses_new_step_items() -> None:


### PR DESCRIPTION
## Summary

`stream_step_items_to_queue` in `src/agents/run_internal/streaming.py` falls through to the `else: logger.warning("Unexpected item type: %s")` branch for `CompactionItem`, even though `CompactionItem` is an explicit member of the `RunItem` union (`src/agents/items.py`).

`CompactionItem` is produced by `turn_resolution.process_model_responses` (see `src/agents/run_internal/turn_resolution.py:1632`) when the responses API emits compaction output, and these items can be passed to `stream_step_items_to_queue` via `stream_step_result_to_queue(step_result, queue)` from `run_loop.py`. They are session-bookkeeping artifacts with no public stream event name in `stream_events.RunItemStreamEvent` — so they should be skipped silently like `ToolApprovalItem`, not logged as unexpected.

## Change

- Add an `elif isinstance(item, CompactionItem)` branch that sets `event = None` (parallel to the existing `ToolApprovalItem` branch).
- Add focused regression test `test_stream_step_items_to_queue_skips_compaction_items_silently`: queue stays empty, no `"Unexpected item type"` warning is logged.

## Test plan

- [x] New test `test_stream_step_items_to_queue_skips_compaction_items_silently` fails before the fix and passes after.
- [x] Full `tests/test_stream_events.py` (8 tests) green.
- [x] Full `tests/test_agent_runner_streamed.py` (47 tests) green.
- [x] Diff is 24 lines (3 src + 21 test).