### PR TITLE
fix(sessions): persist output_tokens_details when input details are None

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -1322,17 +1322,15 @@ class AdvancedSQLiteSession(SQLiteSession):
                         self._logger.warning(f"Failed to serialize input tokens details: {e}")
                         input_details_json = None
 
-                    if (
-                        hasattr(usage_data, "output_tokens_details")
-                        and usage_data.output_tokens_details
-                    ):
-                        try:
-                            output_details_json = json.dumps(
-                                usage_data.output_tokens_details.__dict__
-                            )
-                        except (TypeError, ValueError) as e:
-                            self._logger.warning(f"Failed to serialize output tokens details: {e}")
-                            output_details_json = None
+                if (
+                    hasattr(usage_data, "output_tokens_details")
+                    and usage_data.output_tokens_details
+                ):
+                    try:
+                        output_details_json = json.dumps(usage_data.output_tokens_details.__dict__)
+                    except (TypeError, ValueError) as e:
+                        self._logger.warning(f"Failed to serialize output tokens details: {e}")
+                        output_details_json = None
 
                 with closing(conn.cursor()) as cursor:
                     cursor.execute(

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1394,3 +1394,31 @@ async def test_concurrent_add_items_preserves_message_structure_for_file_db():
         assert len(rows) == len(expected_contents)
 
         session.close()
+
+
+async def test_output_tokens_details_persisted_when_input_details_missing():
+    """Regression: output_tokens_details must persist even if input_tokens_details is None.
+
+    Previously the output serialization branch was nested inside the input branch,
+    silently dropping output_tokens_details whenever input_tokens_details was falsy
+    (e.g., when a provider populated only output details).
+    """
+    session = AdvancedSQLiteSession(session_id="output_only_usage", create_tables=True)
+    usage = Usage(
+        requests=1,
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=42),
+    )
+    # Mimic providers that bypass validation and leave input_tokens_details unset.
+    object.__setattr__(usage, "input_tokens_details", None)
+
+    await session.add_items([{"role": "user", "content": "hi"}])
+    await session.store_run_usage(create_mock_run_result(usage))
+
+    turn_usage = await session.get_turn_usage(1)
+    assert isinstance(turn_usage, dict)
+    assert turn_usage["output_tokens_details"] == {"reasoning_tokens": 42}
+    assert turn_usage["input_tokens_details"] is None
+    session.close()


### PR DESCRIPTION
## Summary

In `AdvancedSQLiteSession._update_turn_usage_internal`, the `output_tokens_details` serialization branch was nested inside the `input_tokens_details` branch. This meant whenever `input_tokens_details` was falsy (e.g., providers that bypass validation via `model_construct` and populate only output details), `output_tokens_details` was silently dropped from `turn_usage` rows.

This is similar in spirit to the Redis `created_at` regression in #3202: a metadata field that should always round-trip is instead silently lost in a specific code path.

## Fix

De-nest the output branch so each detail field is serialized independently. The two `if` blocks are now siblings rather than parent/child.

## Test plan

- [x] Added `test_output_tokens_details_persisted_when_input_details_missing` covering the regression: a `Usage` with `input_tokens_details=None` and a populated `OutputTokensDetails(reasoning_tokens=42)`. Before the fix this asserted `None`; after the fix it persists `{"reasoning_tokens": 42}`.
- [x] All 36 existing tests in `test_advanced_sqlite_session.py` continue to pass.
- [x] `ruff check` and `ruff format --check` pass.