### PR TITLE
fix(run): guard get_session_id_if_available against non-string session_id

### DIFF
--- a/src/agents/run_internal/run_grouping.py
+++ b/src/agents/run_internal/run_grouping.py
@@ -55,5 +55,7 @@ def get_session_id_if_available(session: Session | None) -> str | None:
         session_id = session.session_id
     except Exception:
         return None
+    if not isinstance(session_id, str):
+        return None
     session_id = session_id.strip()
     return session_id if session_id else None

--- a/tests/test_run_grouping.py
+++ b/tests/test_run_grouping.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from agents.memory.session import Session
+from agents.run_internal.run_grouping import (
+    get_session_id_if_available,
+    resolve_run_grouping,
+)
+
+
+class _StubSession:
+    session_settings = None
+
+    def __init__(self, session_id: Any) -> None:
+        self.session_id = session_id
+
+
+def test_get_session_id_handles_non_string_session_id() -> None:
+    """A misbehaving session whose session_id is None or non-string falls back."""
+    assert get_session_id_if_available(cast(Session, _StubSession(None))) is None
+    assert get_session_id_if_available(cast(Session, _StubSession(12345))) is None
+
+
+def test_get_session_id_handles_blank_and_valid() -> None:
+    assert get_session_id_if_available(cast(Session, _StubSession("   "))) is None
+    assert get_session_id_if_available(cast(Session, _StubSession("  sess-1  "))) == "sess-1"
+    assert get_session_id_if_available(None) is None
+
+
+def test_resolve_run_grouping_falls_back_when_session_id_invalid() -> None:
+    kind, value = resolve_run_grouping(
+        conversation_id=None,
+        session=cast(Session, _StubSession(None)),
+        group_id="grp-1",
+    )
+    assert (kind, value) == ("group", "grp-1")


### PR DESCRIPTION
## Summary

`get_session_id_if_available` reads `session.session_id` from a third-party `Session` Protocol implementation, then unconditionally calls `.strip()` on it. The `try/except Exception` only wraps the attribute access — if the attribute returns `None` or a non-string value (a misbehaving but type-consistent implementation), `.strip()` raises `AttributeError` and crashes the runner during prompt-cache-key resolution (`prompt_cache_key.py` calls `resolve_run_grouping` on every run).

The fix adds an `isinstance(session_id, str)` check so a malformed session falls back to the next grouping tier (`group_id` or a generated `run-<uuid>`) instead of breaking the run.

## Changes

- `src/agents/run_internal/run_grouping.py`: 2-line `isinstance` guard before `.strip()`.
- `tests/test_run_grouping.py`: new file covering the None / non-string / blank / valid / fallback paths (no prior test coverage existed for this module).

## Test plan

- [x] `pytest tests/test_run_grouping.py` — 3 tests pass
- [x] `pytest tests/test_tool_use_tracker.py tests/test_prompt_cache_key.py` — no regressions (22 tests pass)
- [x] `ruff check`, `ruff format --check`, `mypy` all clean