### PR TITLE
fix(realtime): preserve output_audio content parts in output_item events

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -1023,7 +1023,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 for part in raw_content:
                     if not isinstance(part, dict):
                         continue
-                    if part.get("type") == "audio":
+                    if part.get("type") in ("audio", "output_audio"):
                         converted_content.append(
                             {
                                 "type": "audio",

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -569,6 +569,40 @@ class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
         assert item.content[0].type == "text"
         assert item.content[0].text == "test data"
 
+    @pytest.mark.asyncio
+    async def test_output_audio_content_type_normalized(self, model):
+        """GA-style output_audio content parts on response.output_item.* are preserved.
+
+        OpenAI's GA assistant message content uses `output_audio` (not `audio`).
+        The dict-based fast path must normalize this to the SDK's `audio` type so
+        the audio + transcript reach listeners.
+        """
+        listener = AsyncMock()
+        model.add_listener(listener)
+
+        msg_added = {
+            "type": "response.output_item.added",
+            "item": {
+                "id": "audio_item_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_audio", "audio": "base64data", "transcript": "hi"},
+                ],
+            },
+        }
+        await model._handle_ws_event(msg_added)
+
+        item_updated_calls = [
+            call for call in listener.on_event.call_args_list if call[0][0].type == "item_updated"
+        ]
+        assert len(item_updated_calls) >= 1
+        item = item_updated_calls[0][0][0].item
+        assert item.type == "message"
+        assert len(item.content) == 1
+        assert item.content[0].type == "audio"
+        assert item.content[0].transcript == "hi"
+
     # Note: response.created/done require full OpenAI response payload which is
     # out-of-scope for unit tests here; covered indirectly via other branches.
 


### PR DESCRIPTION
## Summary

The dict-based fast path in `_handle_ws_event` for `response.output_item.added` / `response.output_item.done` only matched part type `"audio"`. GA-style assistant messages emit `"output_audio"` (matching the official literal `Literal["output_text", "output_audio"]` on `openai.types.realtime.realtime_conversation_item_assistant_message.Content`), so audio content + transcript were silently dropped from listeners on these events.

The other early conversion site (`_ConversionHelper.conversation_item_to_realtime_message_item` at L1588) already maps `output_audio` → `audio`; the dict-path was inconsistent.

This PR accepts both `"audio"` and `"output_audio"` and normalizes to the SDK's `"audio"` type, mirroring how `output_text`/`text` are already handled in the same block.

## Changes

- `src/agents/realtime/openai_realtime.py`: 1-line tuple change in `_handle_ws_event`'s message-content normalization.
- `tests/realtime/test_openai_realtime.py`: focused regression test asserting `output_audio` parts reach listeners with `type="audio"` and the transcript preserved.

Diff: 2 files, +35/-1.

## Test plan

- [x] New test `test_output_audio_content_type_normalized` fails on `main`, passes after fix.
- [x] Full `tests/realtime/` suite (233 tests) passes.
- [x] `ruff check` clean.