### PR TITLE
fix(run): raise clear error when handoff is_enabled is invalid type

### DIFF
--- a/src/agents/run_internal/turn_preparation.py
+++ b/src/agents/run_internal/turn_preparation.py
@@ -98,6 +98,12 @@ async def get_handoffs(agent: Agent[Any], context_wrapper: RunContextWrapper[Any
         attr = handoff_obj.is_enabled
         if isinstance(attr, bool):
             return attr
+        if not callable(attr):
+            raise UserError(
+                f"Handoff is_enabled must be a bool or a callable that takes "
+                f"(context, agent) and returns a bool, got {type(attr).__name__} "
+                f"for handoff to {handoff_obj.agent_name!r}."
+            )
         res = attr(context_wrapper, agent)
         if inspect.isawaitable(res):
             return bool(await res)

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -382,3 +382,23 @@ async def test_handoff_is_enabled_filtering_integration():
     agent_names = {h.agent_name for h in filtered_handoffs}
     assert agent_names == {"agent_1", "agent_3"}
     assert "agent_2" not in agent_names
+
+
+@pytest.mark.asyncio
+async def test_handoff_is_enabled_invalid_type_raises_user_error():
+    """A clear UserError is raised when is_enabled is neither bool nor callable.
+
+    Without this guard the runner crashed with a confusing
+    'X object is not callable' TypeError, which surfaces deep in asyncio.gather
+    and gives no hint that the cause is a misconfigured handoff.
+    """
+    target = Agent(name="target")
+    bad_handoff = handoff(target)
+    # Bypass the dataclass type hint to mimic a misconfiguration at runtime.
+    object.__setattr__(bad_handoff, "is_enabled", "yes")  # type: ignore[arg-type]
+
+    main_agent = Agent(name="main_agent", handoffs=[bad_handoff])
+    context_wrapper = RunContextWrapper(main_agent)
+
+    with pytest.raises(UserError, match="is_enabled"):
+        await get_handoffs(main_agent, context_wrapper)


### PR DESCRIPTION
## Summary

When a handoff's `is_enabled` is mistakenly set to a value that is neither `bool` nor a callable (e.g. a string like `"yes"`), the runner crashed deep inside `asyncio.gather` with `TypeError: 'str' object is not callable`. The traceback gave no hint that the cause was a misconfigured handoff, and a single bad value broke the entire run.

This adds an explicit type check in `get_handoffs` that raises `UserError` naming the offending handoff's target agent, so the misconfiguration is easy to locate.

## Test plan

- [x] New test `test_handoff_is_enabled_invalid_type_raises_user_error` exercises the bad-value path and asserts a `UserError` is raised.
- [x] Existing handoff and run-step tests still pass (`tests/test_handoff_tool.py`, `tests/test_run_step_processing.py`, `tests/test_run_step_execution.py`, `tests/test_agent_runner.py`).