### PR TITLE
fix(sessions): short-circuit non-positive limits in SQLAlchemy get_items

### DIFF
--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -288,6 +288,9 @@ class SQLAlchemySession(SessionABC):
 
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        if session_limit is not None and session_limit <= 0:
+            return []
+
         async with self._session_factory() as sess:
             if session_limit is None:
                 stmt = (

--- a/tests/extensions/memory/test_sqlalchemy_session.py
+++ b/tests/extensions/memory/test_sqlalchemy_session.py
@@ -184,6 +184,44 @@ async def test_get_items_with_limit(agent: Agent):
     assert len(more_than_all) == 4
 
 
+async def test_get_items_with_non_positive_limit(agent: Agent):
+    """Non-positive limits short-circuit before issuing SQL.
+
+    Without the early return, SQLite silently treats a negative LIMIT as
+    "no limit" and returns every row, while Postgres raises an error.
+    """
+    session = SQLAlchemySession.from_url(
+        "non_positive_limit_test", url=DB_URL, create_tables=True
+    )
+    await session.add_items(
+        [
+            {"role": "user", "content": "1"},
+            {"role": "assistant", "content": "2"},
+        ]
+    )
+
+    assert await session.get_items(limit=0) == []
+    assert await session.get_items(limit=-1) == []
+    assert await session.get_items(limit=-100) == []
+
+    # session_settings.limit set to a non-positive value also yields [].
+    from agents.memory.session_settings import SessionSettings
+
+    session_with_neg = SQLAlchemySession.from_url(
+        "non_positive_settings_limit_test",
+        url=DB_URL,
+        create_tables=True,
+        session_settings=SessionSettings(limit=-5),
+    )
+    await session_with_neg.add_items(
+        [
+            {"role": "user", "content": "x"},
+            {"role": "assistant", "content": "y"},
+        ]
+    )
+    assert await session_with_neg.get_items() == []
+
+
 async def test_pop_from_empty_session():
     """Test that pop_item returns None on an empty session."""
     session = SQLAlchemySession.from_url("empty_session", url=DB_URL, create_tables=True)


### PR DESCRIPTION
## Summary

`SQLAlchemySession.get_items()` forwards the resolved limit straight to SQL `LIMIT`, which has dialect-dependent behavior for non-positive values:

- **SQLite** silently treats a negative LIMIT as "unlimited" and returns every row.
- **PostgreSQL** rejects it with `ERROR: LIMIT must not be negative`.
- **MySQL** rejects it with a syntax error.

This means `get_items(limit=-1)` (or `SessionSettings(limit=-1)`) silently returns all history on SQLite and crashes on Postgres/MySQL.

`RedisSession` already guards this case (PR #3219) and `MongoDBSession` does the same. This PR aligns `SQLAlchemySession` with that canonical behavior: return `[]` early when the resolved limit is `<= 0`.

## Changes

- `src/agents/extensions/memory/sqlalchemy_session.py`: 3-line guard in `get_items` that short-circuits when `session_limit <= 0`, before any SQL is issued.
- `tests/extensions/memory/test_sqlalchemy_session.py`: focused test covering `limit=0`, `limit=-1`, `limit=-100`, and `SessionSettings(limit=-5)`.

## Test plan

- [x] `pytest tests/extensions/memory/test_sqlalchemy_session.py` — 28 passed (1 new test, 27 existing)
- [x] New test fails on `main` (returns 2 items instead of `[]` for negative limits on SQLite) and passes on this branch
- [x] Behavior now matches `RedisSession` (#3219) and `MongoDBSession`