### PR TITLE
fix(realtime): validate RealtimeAgent fields in __post_init__

### DIFF
--- a/src/agents/realtime/agent.py
+++ b/src/agents/realtime/agent.py
@@ -79,11 +79,39 @@ class RealtimeAgent(AgentBase, Generic[TContext]):
     """A class that receives callbacks on various lifecycle events for this agent.
     """
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str):
+            raise TypeError(f"RealtimeAgent name must be a string, got {type(self.name).__name__}")
+        if not isinstance(self.tools, list):
+            raise TypeError(f"RealtimeAgent tools must be a list, got {type(self.tools).__name__}")
+        if not isinstance(self.handoffs, list):
+            raise TypeError(
+                f"RealtimeAgent handoffs must be a list, got {type(self.handoffs).__name__}"
+            )
+        if (
+            self.instructions is not None
+            and not isinstance(self.instructions, str)
+            and not callable(self.instructions)
+        ):
+            raise TypeError(
+                f"RealtimeAgent instructions must be a string, callable, or None, "
+                f"got {type(self.instructions).__name__}"
+            )
+
     def clone(self, **kwargs: Any) -> RealtimeAgent[TContext]:
-        """Make a copy of the agent, with the given arguments changed. For example, you could do:
-        ```
-        new_agent = agent.clone(instructions="New instructions")
-        ```
+        """Make a copy of the agent, with the given arguments changed.
+
+        Notes:
+            - Uses `dataclasses.replace`, which performs a **shallow copy**.
+            - Mutable attributes like `tools` and `handoffs` are shallow-copied:
+              new list objects are created only if overridden, but their contents
+              (tool functions and handoff objects) are shared with the original.
+            - To modify these independently, pass new lists when calling `clone()`.
+
+        Example:
+            ```python
+            new_agent = agent.clone(instructions="New instructions")
+            ```
         """
         return dataclasses.replace(self, **kwargs)
 

--- a/tests/realtime/test_agent.py
+++ b/tests/realtime/test_agent.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from agents import RunContextWrapper
@@ -41,8 +43,10 @@ def test_post_init_rejects_invalid_field_types() -> None:
 def test_clone_does_not_mutate_original_lists() -> None:
     """Cloning with a new list must not affect the original agent's lists."""
     original = RealtimeAgent(name="orig", tools=[], handoffs=[])
-    cloned = original.clone(tools=["t1"])  # type: ignore[list-item]
+    new_tools: list[Any] = ["t1"]
+    cloned = original.clone(tools=new_tools)
     assert original.tools == []
-    assert cloned.tools == ["t1"]
+    assert len(cloned.tools) == 1
+    assert cloned.tools is not original.tools
     # Shared reference when not overridden (documented shallow-copy behavior).
     assert cloned.handoffs is original.handoffs

--- a/tests/realtime/test_agent.py
+++ b/tests/realtime/test_agent.py
@@ -25,3 +25,24 @@ async def test_dynamic_instructions():
     agent = RealtimeAgent(name="test", instructions=_instructions)
     instructions = await agent.get_system_prompt(RunContextWrapper(context=None))
     assert instructions == "Dynamic"
+
+
+def test_post_init_rejects_invalid_field_types() -> None:
+    with pytest.raises(TypeError, match="RealtimeAgent name must be a string"):
+        RealtimeAgent(name=1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="RealtimeAgent tools must be a list"):
+        RealtimeAgent(name="x", tools="nope")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="RealtimeAgent handoffs must be a list"):
+        RealtimeAgent(name="x", handoffs="nope")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="RealtimeAgent instructions must be"):
+        RealtimeAgent(name="x", instructions=123)  # type: ignore[arg-type]
+
+
+def test_clone_does_not_mutate_original_lists() -> None:
+    """Cloning with a new list must not affect the original agent's lists."""
+    original = RealtimeAgent(name="orig", tools=[], handoffs=[])
+    cloned = original.clone(tools=["t1"])  # type: ignore[list-item]
+    assert original.tools == []
+    assert cloned.tools == ["t1"]
+    # Shared reference when not overridden (documented shallow-copy behavior).
+    assert cloned.handoffs is original.handoffs


### PR DESCRIPTION
## Summary
- `Agent.__post_init__` raises `TypeError` for invalid `name`, `tools`, `handoffs`, `instructions`, etc., but `RealtimeAgent` had no such guard, so misuse silently produced cryptic downstream errors (e.g. `tools="not_a_list"` accepted at construction).
- This PR mirrors the most common validations from `Agent` onto `RealtimeAgent`, so misuse fails fast at construction with the same kind of message users already see for `Agent`.
- Also documents the shallow-copy semantics of `RealtimeAgent.clone()` to match `Agent.clone()`'s docstring (no behavior change to `clone`).

## Test plan
- [x] New test `test_post_init_rejects_invalid_field_types` covers `name`, `tools`, `handoffs`, `instructions`.
- [x] New test `test_clone_does_not_mutate_original_lists` pins down shallow-copy semantics now described in the docstring.
- [x] Full `tests/realtime/` suite passes (234 tests).
- [x] `ruff check` and `ruff format` clean.