### PR TITLE
fix(tracing): swallow cross-context errors in Scope.reset_current_*

### DIFF
--- a/src/agents/tracing/scope.py
+++ b/src/agents/tracing/scope.py
@@ -32,7 +32,13 @@ class Scope:
 
     @classmethod
     def reset_current_span(cls, token: "contextvars.Token[Span[Any] | None]") -> None:
-        _current_span.reset(token)
+        try:
+            _current_span.reset(token)
+        except ValueError:
+            # Token was created in a different Context (e.g. span finished from
+            # a different asyncio task than where it was started). Resetting is
+            # a best-effort cleanup; log and continue rather than propagating.
+            logger.debug("Skipping span reset: token created in a different Context")
 
     @classmethod
     def get_current_trace(cls) -> "Trace | None":
@@ -46,4 +52,10 @@ class Scope:
     @classmethod
     def reset_current_trace(cls, token: "contextvars.Token[Trace | None]") -> None:
         logger.debug("Resetting current trace")
-        _current_trace.reset(token)
+        try:
+            _current_trace.reset(token)
+        except ValueError:
+            # Token was created in a different Context (e.g. trace finished
+            # from a different asyncio task than where it was started).
+            # Resetting is a best-effort cleanup; log and continue.
+            logger.debug("Skipping trace reset: token created in a different Context")

--- a/tests/tracing/test_scope_reset.py
+++ b/tests/tracing/test_scope_reset.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+
+from agents.tracing.scope import Scope
+
+
+def test_reset_current_span_swallows_cross_context_value_error() -> None:
+    # Create a token in a child Context, then attempt to reset it from the
+    # parent Context to mimic a span finishing in a different asyncio task
+    # than the one that started it.
+    captured: dict[str, contextvars.Token] = {}
+
+    def grab_token() -> None:
+        captured["token"] = Scope.set_current_span(None)
+
+    contextvars.copy_context().run(grab_token)
+
+    # No ValueError should propagate even though the token was created in a
+    # different Context.
+    Scope.reset_current_span(captured["token"])
+
+
+def test_reset_current_trace_swallows_cross_context_value_error() -> None:
+    captured: dict[str, contextvars.Token] = {}
+
+    def grab_token() -> None:
+        captured["token"] = Scope.set_current_trace(None)
+
+    contextvars.copy_context().run(grab_token)
+
+    Scope.reset_current_trace(captured["token"])
+
+
+def test_reset_current_span_in_different_asyncio_task() -> None:
+    # Replicates the production failure mode: token created in task A,
+    # reset attempted from task B.
+    async def main() -> None:
+        captured: dict[str, contextvars.Token] = {}
+
+        async def setter() -> None:
+            captured["token"] = Scope.set_current_span(None)
+
+        await asyncio.create_task(setter())
+
+        async def resetter() -> None:
+            Scope.reset_current_span(captured["token"])
+
+        await asyncio.create_task(resetter())
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

`Scope.reset_current_span` and `Scope.reset_current_trace` call `contextvars.Token.reset()`, which raises `ValueError: <Token> was created in a different Context` when the token was created in a different `Context` than the one performing the reset. This happens in real-world scenarios such as:

- A span/trace started in one asyncio task and finished from a different task (sibling tasks, fan-out/fan-in patterns).
- An async generator wrapped in a span/trace getting finalized by GC from a task other than the one that opened it.
- Cross-thread `finish(reset_current=True)` from custom orchestration.

Wave 4 fixed the closely related `NoOpTrace.__exit__` `GeneratorExit` case (#3225) and `SpanImpl`/`NoOpSpan`/`TraceImpl`/`ReattachedTrace` already gate `reset_current` on `GeneratorExit`. This PR adds the same defense-in-depth at the `Scope` layer so any remaining call path (programmatic `finish(reset_current=True)` from a sibling task, GC, etc.) does not propagate `ValueError` to user code.

The reset is best-effort cleanup -- the new value of the contextvar in the current Context isn't governed by the foreign token anyway -- so logging and continuing is the correct behavior. If the token is from the current Context, the existing fast path is unchanged.

## Changes

- `src/agents/tracing/scope.py` (+12/-2): wrap `_current_span.reset(token)` and `_current_trace.reset(token)` in `try/except ValueError` with a debug log.
- `tests/tracing/test_scope_reset.py` (+52): three focused tests covering the `Context`-mismatch case for spans, traces, and the asyncio cross-task scenario.

## Test plan

- [x] New `tests/tracing/test_scope_reset.py` (3 tests) reproduces the production failure mode and verifies the fix.
- [x] Existing `tests/tracing/` (37 tests), `tests/test_tracing.py` (18), `tests/test_agent_tracing.py` (23), and `tests/test_tracing_provider_safe_debug.py` (1) all pass -- 76/76 green locally on Python 3.13.