### PR TITLE
fix: preserve tool guardrail results across handoffs in SingleStepResult

### DIFF
--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -341,6 +341,8 @@ async def execute_handoffs(
     run_config: RunConfig,
     server_manages_conversation: bool = False,
     nest_handoff_history_fn: Callable[..., HandoffInputData] | None = None,
+    tool_input_guardrail_results: list[ToolInputGuardrailResult] | None = None,
+    tool_output_guardrail_results: list[ToolOutputGuardrailResult] | None = None,
 ) -> SingleStepResult:
     """Execute a handoff and prepare the next turn for the new agent."""
 
@@ -511,8 +513,8 @@ async def execute_handoffs(
         pre_step_items=pre_step_items,
         new_step_items=new_step_items,
         next_step=NextStepHandoff(new_agent),
-        tool_input_guardrail_results=[],
-        tool_output_guardrail_results=[],
+        tool_input_guardrail_results=list(tool_input_guardrail_results or []),
+        tool_output_guardrail_results=list(tool_output_guardrail_results or []),
         session_step_items=session_step_items,
     )
 
@@ -659,6 +661,8 @@ async def execute_tools_and_side_effects(
             context_wrapper=context_wrapper,
             run_config=run_config,
             server_manages_conversation=server_manages_conversation,
+            tool_input_guardrail_results=tool_input_guardrail_results,
+            tool_output_guardrail_results=tool_output_guardrail_results,
         )
 
     tool_final_output = await _maybe_finalize_from_tool_results(
@@ -1434,6 +1438,8 @@ async def resolve_interrupted_turn(
             run_config=run_config,
             server_manages_conversation=server_manages_conversation,
             nest_handoff_history_fn=nest_history,
+            tool_input_guardrail_results=tool_input_guardrail_results,
+            tool_output_guardrail_results=tool_output_guardrail_results,
         )
 
     tool_final_output = await _maybe_finalize_from_tool_results(

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -3393,6 +3393,46 @@ async def test_execute_handoffs_uses_public_agent_for_ignored_extra_handoffs():
 
 
 @pytest.mark.asyncio
+async def test_execute_handoffs_preserves_tool_input_guardrail_results():
+    """Tool input guardrail results from concurrent function calls must survive a handoff."""
+
+    def guardrail(data) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info="checked")
+
+    guardrail_obj: ToolInputGuardrail[Any] = ToolInputGuardrail(guardrail_function=guardrail)
+
+    def _echo(value: str) -> str:
+        return value
+
+    guarded_tool = function_tool(
+        _echo,
+        name_override="guarded",
+        tool_input_guardrails=[guardrail_obj],
+    )
+    target = Agent(name="target")
+    public_agent = Agent(name="triage", tools=[guarded_tool], handoffs=[target])
+    execution_agent = public_agent.clone()
+    set_public_agent(execution_agent, public_agent)
+    response = ModelResponse(
+        output=[
+            get_function_tool_call("guarded", json.dumps({"value": "hi"}), call_id="c1"),
+            get_handoff_tool_call(target),
+        ],
+        usage=Usage(),
+        response_id="resp",
+    )
+
+    result = await get_execute_result(execution_agent, response)
+
+    assert isinstance(result.next_step, NextStepHandoff)
+    assert result.tool_input_guardrail_results, (
+        "Tool input guardrail results should not be dropped when a handoff fires alongside "
+        "a function tool call."
+    )
+    assert result.tool_input_guardrail_results[0].output.output_info == "checked"
+
+
+@pytest.mark.asyncio
 async def test_execute_tools_emits_hosted_mcp_rejection_response():
     """Hosted MCP rejections without callbacks should emit approval responses."""
 


### PR DESCRIPTION
## Summary
- When a model response contains both function tool calls and a handoff, `execute_handoffs` was returning an empty `tool_input_guardrail_results` / `tool_output_guardrail_results` list, silently dropping any guardrail results produced by the function tools that ran before the handoff was dispatched.
- The aggregator in `run.py` extends the run-wide guardrail-result lists from each `turn_result`, so dropping these on a handoff turn means `RunResult.tool_input_guardrail_results` (and the output equivalent) is missing entries that the caller paid to compute and explicitly opted into.
- Thread the guardrail results from `execute_tools_and_side_effects` and `resolve_interrupted_turn` through to the `SingleStepResult` returned by `execute_handoffs`.

## Test plan
- [x] New test `test_execute_handoffs_preserves_tool_input_guardrail_results` covers a single response containing a guarded function tool call alongside a handoff and asserts the guardrail result survives the handoff.
- [x] Existing `tests/test_run_step_execution.py` (87 tests), `tests/test_run_step_processing.py`, `tests/test_handoff_tool.py`, `tests/test_process_model_response.py`, `tests/test_extension_filters.py`, `tests/test_agent_runner.py` all pass.