### PR TITLE
fix(sessions): treat negative AsyncSQLiteSession get_items limits as empty

### DIFF
--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -112,6 +112,11 @@ class AsyncSQLiteSession(SessionABC):
         Returns:
             List of input items representing the conversation history
         """
+        # SQLite treats a negative LIMIT as "no limit", which would silently return
+        # the full conversation history when the caller asked for a bounded slice.
+        # Match the explicit limit=0 contract instead and short-circuit to an empty list.
+        if limit is not None and limit <= 0:
+            return []
 
         async with self._locked_connection() as conn:
             if limit is None:

--- a/tests/extensions/memory/test_async_sqlite_session.py
+++ b/tests/extensions/memory/test_async_sqlite_session.py
@@ -96,6 +96,12 @@ async def test_async_sqlite_session_get_items_limit():
         none = await session.get_items(limit=0)
         assert none == []
 
+        # Negative limits must not silently return the full history. SQLite treats
+        # ``LIMIT -1`` as "no limit", so without an explicit guard a caller asking for
+        # ``limit=-1`` would get every message instead of an empty slice.
+        assert await session.get_items(limit=-1) == []
+        assert await session.get_items(limit=-100) == []
+
         await session.close()
 
 


### PR DESCRIPTION
## Summary

`AsyncSQLiteSession.get_items(limit=-1)` silently returned the entire conversation history because SQLite treats a negative `LIMIT` value as "no limit". That breaks the contract suggested by `limit=0` (which returns an empty list) and is dangerous for callers that compute the limit arithmetically (e.g. `remaining = budget - already_seen`) and accidentally pass a negative value -- they get the full history back instead of an empty slice.

This mirrors the fix that landed for the synchronous `SQLiteSession` in #3219 to the async extension. The fix short-circuits `get_items` when the limit is `<= 0` and returns `[]` without touching the database. Behavior for `None` (return all) and positive limits is unchanged.

## Repro (before fix)

```python
session = AsyncSQLiteSession("test", db_path)
await session.add_items([{"role": "user", "content": f"msg{i}"} for i in range(5)])
print(len(await session.get_items(limit=-1)))    # prints 5 (bug, should be 0)
print(len(await session.get_items(limit=-100)))  # prints 5 (bug, should be 0)
print(len(await session.get_items(limit=0)))     # prints 0 (already correct)
```

The async case is arguably worse than the sync case: because async `get_items` reverses rows after the SQLite read (`rows[::-1]`), `limit=-1` not only returns the full history but returns it in reverse chronological order, silently violating the documented "latest N items in chronological order" contract.

## Test plan

- [x] Added negative-limit assertions to `tests/extensions/memory/test_async_sqlite_session.py::test_async_sqlite_session_get_items_limit` (limit=-1 and limit=-100 both expect `[]`).
- [x] New assertions FAIL on `main` and PASS with the fix applied.
- [x] Full `tests/extensions/memory/` and `tests/memory/` suite still green (298 passed).
- [x] `ruff check` and `ruff format --check` clean on the touched files.