### PR TITLE
fix(run): cancel sibling guardrail tasks when one raises

### DIFF
--- a/src/agents/run_internal/guardrails.py
+++ b/src/agents/run_internal/guardrails.py
@@ -124,20 +124,29 @@ async def run_input_guardrails(
 
     guardrail_results: list[InputGuardrailResult] = []
 
-    for done in asyncio.as_completed(guardrail_tasks):
-        result = await done
-        if result.output.tripwire_triggered:
-            for t in guardrail_tasks:
-                t.cancel()
-            await asyncio.gather(*guardrail_tasks, return_exceptions=True)
-            _error_tracing.attach_error_to_current_span(
-                SpanError(
-                    message="Guardrail tripwire triggered",
-                    data={"guardrail": result.guardrail.get_name()},
+    try:
+        for done in asyncio.as_completed(guardrail_tasks):
+            result = await done
+            if result.output.tripwire_triggered:
+                for t in guardrail_tasks:
+                    t.cancel()
+                await asyncio.gather(*guardrail_tasks, return_exceptions=True)
+                _error_tracing.attach_error_to_current_span(
+                    SpanError(
+                        message="Guardrail tripwire triggered",
+                        data={"guardrail": result.guardrail.get_name()},
+                    )
                 )
-            )
-            raise InputGuardrailTripwireTriggered(result)
-        guardrail_results.append(result)
+                raise InputGuardrailTripwireTriggered(result)
+            guardrail_results.append(result)
+    except BaseException:
+        # On any error (including a guardrail raising or the caller being cancelled),
+        # cancel and await siblings so they don't leak past this function's return.
+        for t in guardrail_tasks:
+            if not t.done():
+                t.cancel()
+        await asyncio.gather(*guardrail_tasks, return_exceptions=True)
+        raise
 
     return guardrail_results
 
@@ -159,20 +168,29 @@ async def run_output_guardrails(
 
     guardrail_results: list[OutputGuardrailResult] = []
 
-    for done in asyncio.as_completed(guardrail_tasks):
-        result = await done
-        if result.output.tripwire_triggered:
-            for t in guardrail_tasks:
-                t.cancel()
-            await asyncio.gather(*guardrail_tasks, return_exceptions=True)
-            _error_tracing.attach_error_to_current_span(
-                SpanError(
-                    message="Guardrail tripwire triggered",
-                    data={"guardrail": result.guardrail.get_name()},
+    try:
+        for done in asyncio.as_completed(guardrail_tasks):
+            result = await done
+            if result.output.tripwire_triggered:
+                for t in guardrail_tasks:
+                    t.cancel()
+                await asyncio.gather(*guardrail_tasks, return_exceptions=True)
+                _error_tracing.attach_error_to_current_span(
+                    SpanError(
+                        message="Guardrail tripwire triggered",
+                        data={"guardrail": result.guardrail.get_name()},
+                    )
                 )
-            )
-            raise OutputGuardrailTripwireTriggered(result)
-        guardrail_results.append(result)
+                raise OutputGuardrailTripwireTriggered(result)
+            guardrail_results.append(result)
+    except BaseException:
+        # On any error (including a guardrail raising or the caller being cancelled),
+        # cancel and await siblings so they don't leak past this function's return.
+        for t in guardrail_tasks:
+            if not t.done():
+                t.cancel()
+        await asyncio.gather(*guardrail_tasks, return_exceptions=True)
+        raise
 
     return guardrail_results
 

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1701,3 +1701,77 @@ async def test_streaming_input_guardrail_exception_awaits_cancelled_siblings():
         )
 
     assert slow_cleanup_finished is True
+
+
+@pytest.mark.asyncio
+async def test_input_guardrail_raise_cancels_siblings():
+    """When one input guardrail raises a non-tripwire exception, sibling tasks
+    must be cancelled and awaited so they don't keep running past the function's return."""
+    from agents.run_internal.guardrails import run_input_guardrails
+
+    sibling_started = asyncio.Event()
+    sibling_completed = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+
+    async def slow_sibling_started_first(ctx, agent, input):
+        sibling_started.set()
+        try:
+            await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        sibling_completed.set()
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    async def raise_after_sibling_starts(ctx, agent, input):
+        await sibling_started.wait()
+        raise RuntimeError("boom")
+
+    g_slow = InputGuardrail(guardrail_function=slow_sibling_started_first)
+    g_raise = InputGuardrail(guardrail_function=raise_after_sibling_starts)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await run_input_guardrails(
+            Agent(name="t"), [g_slow, g_raise], "x", RunContextWrapper(context=None)
+        )
+
+    # By the time run_input_guardrails returns (via raise), the sibling must already
+    # have been cancelled and awaited. No additional sleep should be needed.
+    assert sibling_cancelled.is_set(), "Sibling task should have been cancelled"
+    assert not sibling_completed.is_set(), "Sibling task should not have completed"
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_raise_cancels_siblings():
+    """When one output guardrail raises a non-tripwire exception, sibling tasks
+    must be cancelled and awaited so they don't keep running past the function's return."""
+    from agents.run_internal.guardrails import run_output_guardrails
+
+    sibling_started = asyncio.Event()
+    sibling_completed = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+
+    async def slow_sibling_started_first(ctx, agent, agent_output):
+        sibling_started.set()
+        try:
+            await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        sibling_completed.set()
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    async def raise_after_sibling_starts(ctx, agent, agent_output):
+        await sibling_started.wait()
+        raise RuntimeError("boom")
+
+    g_slow = OutputGuardrail(guardrail_function=slow_sibling_started_first)
+    g_raise = OutputGuardrail(guardrail_function=raise_after_sibling_starts)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await run_output_guardrails(
+            [g_slow, g_raise], Agent(name="t"), "out", RunContextWrapper(context=None)
+        )
+
+    assert sibling_cancelled.is_set(), "Sibling task should have been cancelled"
+    assert not sibling_completed.is_set(), "Sibling task should not have completed"


### PR DESCRIPTION
## Summary

`run_input_guardrails` and `run_output_guardrails` in `src/agents/run_internal/guardrails.py` iterate guardrail tasks via `asyncio.as_completed` and only cancel siblings on the tripwire branch. If one guardrail raises a non-tripwire exception, the loop exits but unfinished sibling tasks are left scheduled and continue running past the function's return — wasting work, possibly producing observable side effects (e.g. an LLM-based guardrail finishing a network request after the caller already saw a different exception), and triggering `Task was destroyed but it is pending!` warnings at event-loop shutdown.

The fix wraps the `as_completed` loop in `try / except BaseException` and, on any exit that is not a normal return, cancels still-running siblings and `gather`s them (`return_exceptions=True`) before re-raising. This is distinct from #3187, which targets the tripwire branch of `run_output_guardrails`; this PR targets the *raise* branch in both functions.

## Repro

```python
async def raising(ctx, agent, input): raise RuntimeError("boom")
async def slow(ctx, agent, input):
    await asyncio.sleep(0.5)        # leaks past run_input_guardrails return
    print("oops, ran after caller raised")
    return GuardrailFunctionOutput(None, False)

await run_input_guardrails(agent, [InputGuardrail(slow), InputGuardrail(raising)], "x", ctx)
# raises RuntimeError, but `slow` keeps running.
```

## Test plan

- [x] New `test_input_guardrail_raise_cancels_siblings` — asserts the slow sibling is cancelled (not completed) by the time the raise propagates.
- [x] New `test_output_guardrail_raise_cancels_siblings` — same for output guardrails.
- [x] Existing 37 guardrail tests still pass (`tests/test_guardrails.py`).
- [x] `tests/test_runner_guardrail_resume.py`, `tests/test_stream_input_guardrail_timing.py`, `tests/test_tool_guardrails.py` still pass.
- [x] `ruff check` passes for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)