### PR TITLE
fix(run): raise UserError when error handler dict has include_in_history without final_output

### DIFF
--- a/src/agents/run_internal/error_handlers.py
+++ b/src/agents/run_internal/error_handlers.py
@@ -162,5 +162,10 @@ async def resolve_run_error_handler_result(
                 return RunErrorHandlerResult(**result)
             except TypeError as exc:
                 raise UserError("Invalid run error handler result.") from exc
+        if "include_in_history" in result:
+            raise UserError(
+                "Invalid run error handler result: 'include_in_history' provided "
+                "without 'final_output'."
+            )
         return RunErrorHandlerResult(final_output=result)
     return RunErrorHandlerResult(final_output=result)

--- a/tests/test_run_internal_error_handlers.py
+++ b/tests/test_run_internal_error_handlers.py
@@ -118,3 +118,16 @@ async def test_resolve_run_error_handler_result_covers_async_and_validation_path
             context_wrapper=context_wrapper,
             run_data=run_data,
         )
+
+    # A dict with only `include_in_history` is almost certainly a partial config
+    # (forgot final_output) rather than an intentional raw mapping payload, so
+    # surface a clear error instead of silently treating the dict as final_output.
+    with pytest.raises(UserError, match="include_in_history"):
+        await run_error_handlers.resolve_run_error_handler_result(
+            error_handlers={
+                "max_turns": lambda _handler_input: {"include_in_history": False}
+            },
+            error=error,
+            context_wrapper=context_wrapper,
+            run_data=run_data,
+        )


### PR DESCRIPTION
## Summary

`resolve_run_error_handler_result` silently mishandled a run error handler that returned `{\"include_in_history\": False}` (a plausible user typo where `final_output` was forgotten): the whole dict was treated as the raw `final_output` value and `include_in_history` defaulted to `True` — exactly the opposite of the user's intent.

This mirrors the existing extra-keys validation path: when `final_output` IS present, unknown keys raise `UserError`. The new check applies the same rule when `final_output` is absent but the reserved key `include_in_history` is present.

## Repro

```python
result = await resolve_run_error_handler_result(
    error_handlers={\"max_turns\": lambda _i: {\"include_in_history\": False}},
    error=MaxTurnsExceeded(\"too many turns\"),
    context_wrapper=ctx,
    run_data=run_data,
)
# Before: RunErrorHandlerResult(final_output={\"include_in_history\": False}, include_in_history=True)
# After:  raises UserError(\"... 'include_in_history' provided without 'final_output'.\")
```

## Test plan

- [x] New assertion in `test_resolve_run_error_handler_result_covers_async_and_validation_paths` — fails on `main`, passes with the fix.
- [x] `tests/test_run_internal_error_handlers.py` and `tests/test_run_error_details.py` still pass.
- [x] `tests/test_max_turns.py` still passes.

## Diff size

5 source lines + 13 test lines.