### PR TITLE
fix(realtime): normalize non-string audio formats in length calc

### DIFF
--- a/src/agents/realtime/_util.py
+++ b/src/agents/realtime/_util.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 from .config import RealtimeAudioFormat
 
 PCM16_SAMPLE_RATE_HZ = 24_000
@@ -7,13 +10,30 @@ PCM16_SAMPLE_WIDTH_BYTES = 2
 G711_SAMPLE_RATE_HZ = 8_000
 
 
+def _extract_format_type(format: RealtimeAudioFormat | None) -> str | None:
+    """Extract the type string from any supported format representation."""
+    if format is None:
+        return None
+    if isinstance(format, str):
+        return format.lower()
+    if isinstance(format, Mapping):
+        type_value = format.get("type")
+        return type_value.lower() if isinstance(type_value, str) else None
+    # OpenAIRealtimeAudioFormats pydantic models expose a `type` attribute.
+    type_attr: Any = getattr(format, "type", None)
+    return type_attr.lower() if isinstance(type_attr, str) else None
+
+
 def calculate_audio_length_ms(format: RealtimeAudioFormat | None, audio_bytes: bytes) -> float:
     if not audio_bytes:
         return 0.0
 
-    normalized_format = format.lower() if isinstance(format, str) else None
+    normalized_format = _extract_format_type(format)
 
-    if normalized_format and normalized_format.startswith("g711"):
+    if normalized_format and (
+        normalized_format.startswith("g711")
+        or normalized_format in ("audio/pcmu", "audio/pcma")
+    ):
         return (len(audio_bytes) / G711_SAMPLE_RATE_HZ) * 1000
 
     samples = len(audio_bytes) / PCM16_SAMPLE_WIDTH_BYTES

--- a/tests/realtime/test_audio_length_format_normalization.py
+++ b/tests/realtime/test_audio_length_format_normalization.py
@@ -1,0 +1,49 @@
+"""Tests for audio length calculation format normalization.
+
+`calculate_audio_length_ms` must correctly identify g711 audio regardless of
+how the format was supplied (string, mapping, or pydantic model). Previously
+non-string formats fell through to the PCM16 path, computing a wrong duration
+for g711 audio.
+"""
+
+from openai.types.realtime.realtime_audio_formats import AudioPCM, AudioPCMA, AudioPCMU
+
+from agents.realtime._util import calculate_audio_length_ms
+
+
+def test_calculate_audio_length_ms_pydantic_g711_models() -> None:
+    # 8 bytes of g711 audio at 8 kHz -> 1 ms
+    assert calculate_audio_length_ms(AudioPCMU(type="audio/pcmu"), b"a" * 8) == 1.0
+    assert calculate_audio_length_ms(AudioPCMA(type="audio/pcma"), b"a" * 8) == 1.0
+
+
+def test_calculate_audio_length_ms_pydantic_pcm_model() -> None:
+    # 48 bytes of pcm16 at 24 kHz / 2 bytes per sample -> 1 ms
+    assert calculate_audio_length_ms(AudioPCM(type="audio/pcm", rate=24000), b"a" * 48) == 1.0
+
+
+def test_calculate_audio_length_ms_mapping_formats() -> None:
+    assert calculate_audio_length_ms({"type": "audio/pcmu"}, b"a" * 8) == 1.0
+    assert calculate_audio_length_ms({"type": "audio/pcma"}, b"a" * 8) == 1.0
+    assert calculate_audio_length_ms({"type": "audio/pcm"}, b"a" * 48) == 1.0
+
+
+def test_calculate_audio_length_ms_audio_pcmu_string_alias() -> None:
+    # The raw API string "audio/pcmu" should also be recognized as g711.
+    assert calculate_audio_length_ms("audio/pcmu", b"a" * 8) == 1.0
+    assert calculate_audio_length_ms("audio/pcma", b"a" * 8) == 1.0
+
+
+def test_calculate_audio_length_ms_uppercase_string() -> None:
+    # Case-insensitive g711 detection.
+    assert calculate_audio_length_ms("G711_ULAW", b"a" * 8) == 1.0
+
+
+def test_calculate_audio_length_ms_unknown_mapping_falls_back_to_pcm() -> None:
+    # Unknown formats keep the historical PCM16 fallback for backward compat.
+    assert calculate_audio_length_ms({"type": "audio/unknown"}, b"a" * 48) == 1.0
+
+
+def test_calculate_audio_length_ms_empty_bytes_zero() -> None:
+    assert calculate_audio_length_ms(AudioPCMU(type="audio/pcmu"), b"") == 0.0
+    assert calculate_audio_length_ms(None, b"") == 0.0


### PR DESCRIPTION
## Summary

`calculate_audio_length_ms` (in `src/agents/realtime/_util.py`) only inspected the `format` argument when it was a `str`. The `RealtimeAudioFormat` type alias also accepts:

- the `OpenAIRealtimeAudioFormats` pydantic models (`AudioPCM`, `AudioPCMU`, `AudioPCMA`)
- `Mapping[str, Any]` such as `{"type": "audio/pcmu"}`

In both cases the function fell through to the PCM16 branch and computed duration at 24 kHz with a 2-byte sample width. For g711 audio that overstates the length by ~6x, which feeds the wrong `elapsed_ms` and `audio_length_ms` into `ModelAudioTracker` / `RealtimePlaybackTracker` and ultimately breaks interrupt truncation timing whenever a caller wires the format through as anything other than the canonical `pcm16` / `g711_ulaw` / `g711_alaw` strings.

This PR:

- Adds `_extract_format_type` to read the format type from strings, mappings, and pydantic models uniformly.
- Recognizes the wire-format aliases `audio/pcmu` / `audio/pcma` (returned by `_normalize_audio_format` for some payloads) as g711.
- Preserves the historical behavior: empty bytes return `0.0`, unknown formats fall back to PCM16, and case-insensitive matching is retained.

The fix is a 22-line surgical change in `_util.py` plus a focused test module covering pydantic models, mappings, the `audio/pcmu` alias, uppercase strings, unknown-format fallback, and empty bytes.

## Test plan

- [x] `pytest tests/realtime/test_audio_length_format_normalization.py` (new, 7 cases, all pass)
- [x] `pytest tests/realtime` full suite still green (239 passed)
- [x] Existing `test_calculate_audio_length_ms_pure_function` (in `test_openai_realtime.py`) still passes — string-input behavior unchanged