### PR TITLE
fix(realtime): skip invalid input_text parts in user input conversion

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -1641,8 +1641,12 @@ class _ConversionHelper:
                     t = item.get("type")
                     if t == "input_text":
                         _txt = item.get("text")
-                        text_val = _txt if isinstance(_txt, str) else None
-                        content.append(Content(type="input_text", text=text_val))
+                        # Skip parts with missing/non-string text rather than
+                        # forwarding text=None, which produces an invalid item
+                        # the realtime API will reject.
+                        if not isinstance(_txt, str):
+                            continue
+                        content.append(Content(type="input_text", text=_txt))
                     elif t == "input_image":
                         iu = item.get("image_url")
                         if isinstance(iu, str) and iu:

--- a/tests/realtime/test_openai_realtime_conversions.py
+++ b/tests/realtime/test_openai_realtime_conversions.py
@@ -69,6 +69,31 @@ def test_convert_user_input_to_conversation_item_dict_and_str():
     assert item2.content[0].type == "input_text"
 
 
+def test_convert_user_input_dict_skips_invalid_input_text_parts():
+    """input_text parts with missing/non-string text must be skipped, not
+    forwarded as Content(text=None) which the realtime API rejects."""
+    dict_input_any = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {"type": "input_text"},  # missing text
+            {"type": "input_text", "text": 123},  # non-string text
+            {"type": "input_text", "text": "ok"},  # valid
+        ],
+    }
+    event = RealtimeModelSendUserInput(
+        user_input=cast(RealtimeModelUserInputMessage, dict_input_any)
+    )
+    item = cast(
+        RealtimeConversationItemUserMessage,
+        _ConversionHelper.convert_user_input_to_conversation_item(event),
+    )
+    assert item.content is not None
+    assert len(item.content) == 1
+    assert item.content[0].type == "input_text"
+    assert item.content[0].text == "ok"
+
+
 def test_convert_tracing_config_variants():
     from agents.realtime.openai_realtime import _ConversionHelper as CH
 


### PR DESCRIPTION
## Summary

When a `RealtimeModelSendUserInput` event carries a dict `user_input` whose `content` includes an `input_text` part with a missing or non-string `text` field, `_ConversionHelper.convert_user_input_to_conversation_item` currently appends a `Content(type="input_text", text=None)` item. The realtime API rejects such payloads.

This change skips those parts entirely, matching the existing forward-compat behaviour for `input_image` with an invalid `image_url`. Only well-formed parts reach the wire.

## Test plan

- [x] Added `test_convert_user_input_dict_skips_invalid_input_text_parts` covering missing-text and non-string-text cases plus a valid sibling (only the valid one survives).
- [x] `pytest tests/realtime` — 233 passed.
- [x] `ruff check` clean on touched files.