### PR TITLE
fix(sessions): return [] for non-positive limits in OpenAIConversationsSession

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -83,6 +83,10 @@ class OpenAIConversationsSession(SessionABC):
             ):
                 # calling model_dump() to make this serializable
                 all_items.append(item.model_dump(exclude_unset=True))
+        elif session_limit <= 0:
+            # Match SQLiteSession semantics: a non-positive limit yields no history,
+            # without issuing an upstream request that would otherwise reject limit=0.
+            return []
         else:
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
@@ -91,7 +95,7 @@ class OpenAIConversationsSession(SessionABC):
             ):
                 # calling model_dump() to make this serializable
                 all_items.append(item.model_dump(exclude_unset=True))
-                if session_limit is not None and len(all_items) >= session_limit:
+                if len(all_items) >= session_limit:
                     break
             all_items.reverse()
 

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -473,3 +473,35 @@ class TestOpenAIConversationsSessionSettings:
 
         assert session.session_settings is not None
         assert session.session_settings.limit == 5
+
+    @pytest.mark.asyncio
+    async def test_get_items_with_zero_limit_returns_empty(self, mock_openai_client):
+        """get_items(limit=0) should return [] without iterating remote items.
+
+        Matches SQLiteSession semantics for SessionSettings(limit=0).
+        """
+
+        class _FakeAsyncIter:
+            def __init__(self, items):
+                self.items = items
+
+            def __aiter__(self):
+                async def _gen():
+                    for x in self.items:
+                        yield x
+
+                return _gen()
+
+        item = MagicMock()
+        item.model_dump.return_value = {"id": "a", "role": "assistant", "content": "hi"}
+        mock_openai_client.conversations.items.list = MagicMock(
+            return_value=_FakeAsyncIter([item, item, item])
+        )
+
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        assert await session.get_items(limit=0) == []
+        # No upstream list call should be issued for a non-positive limit.
+        mock_openai_client.conversations.items.list.assert_not_called()


### PR DESCRIPTION
## Summary

`OpenAIConversationsSession.get_items(limit=0)` returned **1 item instead of `[]`**. The break check (`len(all_items) >= session_limit`) only ran *after* the first `append`, so the first upstream item leaked through any time `limit <= 0`.

`SQLiteSession` already returns `[]` for `SessionSettings(limit=0)` (see `tests/memory/test_session.py::test_session_memory_with_limit` and `tests/memory/test_session_limit.py`), so this also fixes a cross-backend semantic skew that would silently change session contents depending on which store was wired in.

The fix short-circuits non-positive limits *before* issuing the upstream `conversations.items.list` call:

```python
elif session_limit <= 0:
    # Match SQLiteSession semantics: a non-positive limit yields no history,
    # without issuing an upstream request that would otherwise reject limit=0.
    return []
```

This also avoids sending `limit=0` to the OpenAI Conversations API, which would otherwise reject the request.

## Test plan

- [x] New test `test_get_items_with_zero_limit_returns_empty` covers the fix and asserts the upstream `list` call is not made
- [x] All existing memory tests pass: `pytest tests/memory/ -q` -> 120 passed
- [x] Repro confirmed pre-fix: returned 1 item; post-fix: returns 0