### PR TITLE
fix(run): handle non-string session_id in prompt cache key resolver

### DIFF
--- a/src/agents/run_internal/run_grouping.py
+++ b/src/agents/run_internal/run_grouping.py
@@ -55,5 +55,7 @@ def get_session_id_if_available(session: Session | None) -> str | None:
         session_id = session.session_id
     except Exception:
         return None
+    if not isinstance(session_id, str):
+        return None
     session_id = session_id.strip()
     return session_id if session_id else None

--- a/tests/test_prompt_cache_key.py
+++ b/tests/test_prompt_cache_key.py
@@ -214,6 +214,29 @@ async def test_runner_uses_session_id_as_stable_prompt_cache_key_boundary() -> N
 
 
 @pytest.mark.asyncio
+async def test_runner_falls_back_when_session_id_is_not_a_string() -> None:
+    """A session whose session_id is None (or any non-str) must not crash key resolution.
+
+    The runner should fall through to the next grouping option (group_id, then per-run UUID)
+    instead of raising AttributeError when calling .strip() on a non-str session_id.
+    """
+    model = PromptCacheFakeModel()
+    model.set_next_output([get_text_message("done")])
+    agent = Agent(name="test", model=model)
+    session = SimpleListSession(session_id="placeholder")
+    # Simulate a session whose id has not yet been assigned (e.g. lazy DB-backed sessions).
+    session.session_id = None  # type: ignore[assignment]
+
+    await Runner.run(
+        agent, "hi", session=session, run_config=RunConfig(group_id="fallback-group")
+    )
+
+    prompt_cache_key = _sent_prompt_cache_key(model)
+    assert prompt_cache_key is not None
+    assert prompt_cache_key.startswith("agents-sdk:group:")
+
+
+@pytest.mark.asyncio
 async def test_streamed_runner_generates_prompt_cache_key_by_default() -> None:
     model = PromptCacheFakeModel()
     model.set_next_output([get_text_message("done")])


### PR DESCRIPTION
## Summary
- `get_session_id_if_available` calls `.strip()` on `session.session_id` without checking the type, so a custom `Session` subclass whose id has not yet been assigned (e.g. a lazy DB-backed session that returns `None` until the first write) raises `AttributeError: 'NoneType' object has no attribute 'strip'` and crashes the run loop.
- The intent of this helper is to fall through to the next grouping option (`group_id`, then a per-run UUID) when no stable session id exists. A non-string id should behave the same way as an empty string.
- Added an `isinstance(session_id, str)` guard before `.strip()` plus a focused regression test covering the through-the-runner path with `RunConfig(group_id=...)` fallback.

## Repro
```python
class LazyIdSession(Session):
    session_id = None  # not yet assigned
    ...

await Runner.run(agent, "hi", session=LazyIdSession())
# AttributeError: 'NoneType' object has no attribute 'strip'
#   at src/agents/run_internal/run_grouping.py:58 in get_session_id_if_available
```

## Test plan
- [x] New test `test_runner_falls_back_when_session_id_is_not_a_string` fails on `main` with the original `AttributeError` and passes with the fix.
- [x] Full `tests/test_prompt_cache_key.py` suite (14 tests) passes.
- [x] Broader `tests/ -k "session or grouping or cache"` (767 tests) passes with no regressions.
- [x] `ruff check` clean on the modified files.

The change is 2 lines of source + a single regression test (25 lines total).