### PR TITLE
fix(sessions): skip corrupt docs in MongoDBSession.pop_item

### DIFF
--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -324,21 +324,26 @@ class MongoDBSession(SessionABC):
 
         Returns:
             The most recent item if it exists, ``None`` if the session is empty.
+
+        Corrupt documents (invalid JSON, missing/non-string ``message_data``)
+        are silently discarded and the next-most-recent item is returned.  This
+        matches :meth:`get_items`, which also skips corrupt documents, so a
+        single bad row cannot make a non-empty session look empty to callers.
         """
         await self._ensure_indexes()
 
-        doc = await self._messages.find_one_and_delete(
-            {"session_id": self.session_id},
-            sort=[("seq", -1)],
-        )
-
-        if doc is None:
-            return None
-
-        try:
-            return await self._deserialize_item(doc["message_data"])
-        except (json.JSONDecodeError, KeyError, TypeError):
-            return None
+        while True:
+            doc = await self._messages.find_one_and_delete(
+                {"session_id": self.session_id},
+                sort=[("seq", -1)],
+            )
+            if doc is None:
+                return None
+            try:
+                return await self._deserialize_item(doc["message_data"])
+            except (json.JSONDecodeError, KeyError, TypeError):
+                # Corrupt — drop it and try the next-most-recent document.
+                continue
 
     async def clear_session(self) -> None:
         """Clear all items for this session."""

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -515,6 +515,51 @@ async def test_non_string_message_data_is_skipped(session: MongoDBSession) -> No
     assert items[0].get("content") == "valid"
 
 
+async def test_pop_item_skips_corrupt_most_recent(session: MongoDBSession) -> None:
+    """pop_item must skip a corrupt most-recent document and return the next valid one."""
+    await session.add_items([{"role": "user", "content": "valid"}])
+
+    # Inject a corrupt document with a higher seq so it sorts as "most recent".
+    bad_doc = {
+        "_id": FakeObjectId(),
+        "session_id": session.session_id,
+        "seq": 999,
+        "message_data": "not valid json {{{",
+    }
+    session._messages._docs[id(bad_doc["_id"])] = bad_doc
+
+    popped = await session.pop_item()
+    assert popped is not None
+    assert popped.get("content") == "valid"
+
+    # Both the corrupt doc and the valid one are now gone.
+    assert await session.get_items() == []
+
+
+async def test_pop_item_returns_none_when_only_corrupt_docs_remain(
+    session: MongoDBSession,
+) -> None:
+    """pop_item must drop every corrupt doc and return None when nothing valid remains."""
+    bad1 = {
+        "_id": FakeObjectId(),
+        "session_id": session.session_id,
+        "seq": 1,
+        "message_data": "garbage",
+    }
+    bad2 = {
+        "_id": FakeObjectId(),
+        "session_id": session.session_id,
+        "seq": 2,
+        "message_data": 42,  # non-string — TypeError
+    }
+    session._messages._docs[id(bad1["_id"])] = bad1
+    session._messages._docs[id(bad2["_id"])] = bad2
+
+    assert await session.pop_item() is None
+    # Both corrupt docs must have been removed in the process.
+    assert session._messages._docs == {}
+
+
 # ---------------------------------------------------------------------------
 # Index initialisation (idempotency)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`MongoDBSession.pop_item` returns `None` from two distinct conditions:

1. The session is empty.
2. The most-recent document's `message_data` fails to deserialize (invalid JSON, missing field, or non-string type — the same `(JSONDecodeError, KeyError, TypeError)` triple that `get_items` already swallows).

In the second case the corrupt document is removed by `find_one_and_delete` and the caller sees `None`, even though valid older messages still exist. A loop that pops items until empty therefore stops one item early and leaves history behind.

This mirrors the behavior `get_items` already provides — it silently skips corrupt rows and keeps reading valid ones — so `pop_item` should do the same to stay consistent.

## Fix

Wrap the pop in a `while True` loop that discards corrupt documents and re-pops the next-most-recent until a valid item is decoded or the session is genuinely empty. The fix is local to `pop_item` and adds five lines of behavior plus a docstring note.

## Test plan

- [x] `tests/extensions/memory/test_mongodb_session.py::test_pop_item_skips_corrupt_most_recent` — corrupt latest + valid older returns the older item and leaves the collection empty.
- [x] `tests/extensions/memory/test_mongodb_session.py::test_pop_item_returns_none_when_only_corrupt_docs_remain` — all-corrupt session drains every bad row before returning `None`.
- [x] All 31 existing `MongoDBSession` tests still pass (33 total now).
- [x] `ruff check` / `ruff format --check` clean.