### PR TITLE
fix(realtime): raise UserError for input_type without on_handoff

### DIFF
--- a/src/agents/realtime/handoffs.py
+++ b/src/agents/realtime/handoffs.py
@@ -88,9 +88,8 @@ def realtime_handoff(
 
     Note: input_filter is not supported for RealtimeAgent handoffs.
     """
-    assert (on_handoff and input_type) or not (on_handoff and input_type), (
-        "You must provide either both on_handoff and input_type, or neither"
-    )
+    if input_type is not None and on_handoff is None:
+        raise UserError("You must provide on_handoff when input_type is provided")
     type_adapter: TypeAdapter[Any] | None
     if input_type is not None:
         assert callable(on_handoff), "on_handoff must be callable"

--- a/tests/realtime/test_realtime_handoffs.py
+++ b/tests/realtime/test_realtime_handoffs.py
@@ -129,6 +129,14 @@ def test_realtime_handoff_invalid_param_counts_raise():
         realtime_handoff(rt, on_handoff=bad1)  # type: ignore[arg-type]
 
 
+def test_realtime_handoff_input_type_requires_on_handoff():
+    """input_type without on_handoff must raise UserError, not silently produce a broken handoff."""
+    rt = RealtimeAgent(name="x")
+
+    with pytest.raises(UserError):
+        realtime_handoff(rt, input_type=int)  # type: ignore[call-overload]
+
+
 @pytest.mark.asyncio
 async def test_realtime_handoff_missing_input_json_raises_model_error():
     rt = RealtimeAgent(name="x")


### PR DESCRIPTION
## Summary

The validation guard at the top of \`realtime_handoff()\` is a tautology:

\`\`\`python
assert (on_handoff and input_type) or not (on_handoff and input_type), (
    "You must provide either both on_handoff and input_type, or neither"
)
\`\`\`

\`(X) or not (X)\` is always \`True\`, so the assertion never fires. When a caller does \`realtime_handoff(agent, input_type=int)\` (input_type without on_handoff), the function falls through to a less helpful \`assert callable(on_handoff)\` further down, or — under \`python -O\` where assertions are stripped — silently constructs a \`Handoff\` whose \`on_invoke_handoff\` callable hits a confusing \`TypeError: None is not a callable object\` at first invocation.

This mirrors the same pattern in \`agents/handoffs/__init__.py\` line 255, but the realtime path was the only one missed when Wave 7 cleaned things up around #3243. Replace the dead assertion with an explicit \`UserError\` so the contract documented by the overloads (input_type only with on_handoff) is enforced uniformly, including under \`-O\`.

## Test plan

- [x] \`pytest tests/realtime -q\` -> 233 passed
- [x] New test \`test_realtime_handoff_input_type_requires_on_handoff\` fails on main (\`AssertionError\` from the secondary guard) and passes after the fix (\`UserError\`)
- [x] Existing \`test_realtime_handoff_invalid_param_counts_raise\` still passes — same UserError surface area for arity mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)