### PR TITLE
fix(computer): exclude Computer instances from provider duck-typing

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -1914,9 +1914,13 @@ def function_tool(
 
 
 def _is_computer_provider(candidate: object) -> bool:
-    return isinstance(candidate, ComputerProvider) or (
-        hasattr(candidate, "create") and callable(candidate.create)
-    )
+    if isinstance(candidate, ComputerProvider):
+        return True
+    if isinstance(candidate, Computer | AsyncComputer):
+        # A resolved computer instance is never a provider, even if a subclass
+        # happens to expose a callable `create` attribute.
+        return False
+    return hasattr(candidate, "create") and callable(candidate.create)
 
 
 def _validate_function_tool_timeout_config(tool: FunctionTool) -> None:

--- a/tests/test_computer_tool_lifecycle.py
+++ b/tests/test_computer_tool_lifecycle.py
@@ -133,6 +133,24 @@ async def test_runner_disposes_computer_after_run() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_computer_with_create_attribute_returns_instance() -> None:
+    """A Computer subclass with a callable `create` attribute is not a provider."""
+
+    class ComputerWithCreate(FakeComputer):
+        def create(self, *args: Any, **kwargs: Any) -> str:
+            return "user-helper"
+
+    computer = ComputerWithCreate("with-create")
+    tool = ComputerTool(computer=computer)
+    ctx = RunContextWrapper(context=None)
+
+    resolved = await resolve_computer(tool=tool, run_context=ctx)
+
+    assert resolved is computer
+    await dispose_resolved_computers(run_context=ctx)
+
+
+@pytest.mark.asyncio
 async def test_streamed_run_disposes_computer_after_completion() -> None:
     created = FakeComputer("streaming")
     create = AsyncMock(return_value=created)


### PR DESCRIPTION
## Summary

`_is_computer_provider` in `src/agents/tool.py` checks for `ComputerProvider` via `isinstance` **or** any object that exposes a callable `create` attribute. A user-defined `Computer`/`AsyncComputer` subclass that happens to define a `create` method (e.g. an internal helper named `create_window`, `create_session`, etc., or any helper named `create`) is misclassified as a provider.

When this happens, `resolve_computer` enters the provider branch and crashes:

```
AttributeError: 'MyComputer' object has no attribute 'dispose'
```

at `disposer: ComputerDispose[Any] | None = lifecycle.dispose if lifecycle else None`.

## Fix

Short-circuit `_is_computer_provider` for already-resolved `Computer | AsyncComputer` instances — they are never providers, regardless of whether a subclass exposes a `create` attribute.

## Test plan

- [x] New regression test `test_resolve_computer_with_create_attribute_returns_instance` fails on `main` with `AttributeError` and passes with the fix.
- [x] Existing 37 computer-tool tests still pass (`tests/test_computer_tool_lifecycle.py`, `tests/test_computer_action.py`).