### PR TITLE
fix(tracing): dedupe re-registered processors in SynchronousMultiTracingProcessor

### DIFF
--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -54,8 +54,15 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
     def add_tracing_processor(self, tracing_processor: TracingProcessor):
         """
         Add a processor to the list of processors. Each processor will receive all traces/spans.
+
+        Re-registering the same processor instance is a no-op so callers (e.g. fork-safe
+        re-init, hot-reload, or composite providers) cannot accidentally cause every span
+        to be exported twice.
         """
         with self._lock:
+            for existing in self._processors:
+                if existing is tracing_processor:
+                    return
             self._processors += (tracing_processor,)
 
     def set_processors(self, processors: list[TracingProcessor]):

--- a/tests/tracing/test_processor_dedupe.py
+++ b/tests/tracing/test_processor_dedupe.py
@@ -1,0 +1,69 @@
+"""Tests for `SynchronousMultiTracingProcessor` deduplication on re-registration.
+
+Re-registering the same processor instance must not cause every span/trace event to
+be delivered twice — that would double-export traces (and double-bill, on metered
+backends) for callers that re-run setup (fork-safe re-init, hot-reload, composite
+providers, test fixtures that call `add_trace_processor` more than once).
+"""
+
+from unittest.mock import MagicMock
+
+from agents.tracing.provider import SynchronousMultiTracingProcessor
+
+
+def test_add_tracing_processor_dedupes_same_instance() -> None:
+    multi = SynchronousMultiTracingProcessor()
+    proc = MagicMock()
+
+    multi.add_tracing_processor(proc)
+    multi.add_tracing_processor(proc)  # re-register same instance
+
+    multi.on_trace_start(MagicMock())
+    multi.on_span_end(MagicMock())
+
+    assert proc.on_trace_start.call_count == 1
+    assert proc.on_span_end.call_count == 1
+
+
+def test_add_tracing_processor_keeps_distinct_instances() -> None:
+    multi = SynchronousMultiTracingProcessor()
+    proc_a = MagicMock()
+    proc_b = MagicMock()
+
+    multi.add_tracing_processor(proc_a)
+    multi.add_tracing_processor(proc_b)
+    multi.add_tracing_processor(proc_a)  # duplicate of A only
+
+    multi.on_span_end(MagicMock())
+
+    assert proc_a.on_span_end.call_count == 1
+    assert proc_b.on_span_end.call_count == 1
+
+
+def test_add_tracing_processor_dedupes_by_identity_not_equality() -> None:
+    """Two distinct instances that compare equal still both register."""
+
+    class EqProcessor:
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, EqProcessor)
+
+        def __hash__(self) -> int:
+            return 0
+
+        def on_trace_start(self, trace: object) -> None: ...
+        def on_trace_end(self, trace: object) -> None: ...
+        def on_span_start(self, span: object) -> None: ...
+        def on_span_end(self, span: object) -> None: ...
+        def shutdown(self) -> None: ...
+        def force_flush(self) -> None: ...
+
+    multi = SynchronousMultiTracingProcessor()
+    proc_a = EqProcessor()
+    proc_b = EqProcessor()
+    assert proc_a == proc_b  # equal but distinct identities
+
+    multi.add_tracing_processor(proc_a)
+    multi.add_tracing_processor(proc_b)
+
+    # Both should be present because dedupe is by identity (`is`), not equality.
+    assert len(multi._processors) == 2


### PR DESCRIPTION
## Summary

`SynchronousMultiTracingProcessor.add_tracing_processor` appends to its internal tuple unconditionally:

```python
# src/agents/tracing/provider.py (current)
def add_tracing_processor(self, tracing_processor: TracingProcessor):
    with self._lock:
        self._processors += (tracing_processor,)
```

So calling `register_processor(p)` twice with the same processor instance silently double-registers it, and every subsequent `on_trace_start` / `on_span_start` / `on_span_end` / `shutdown` / `force_flush` is delivered to that processor **twice**. On the default `BatchTraceProcessor` -> `BackendSpanExporter` path that means every span is exported twice and counted twice on metered backends.

This bites a few realistic call patterns:

- **Fork-safe re-init** -- a child process calls `add_trace_processor` again to re-establish handlers after `os.fork()` while the parent processor reference is still held.
- **Hot-reload / dev servers** -- module re-import re-runs setup code (uvicorn `--reload`, Streamlit, Jupyter `%autoreload`), so the same processor singleton gets registered each reload.
- **Composite providers** -- libraries that wrap `TraceProvider` and forward `register_processor` to multiple backends can end up routing the same processor twice when the user also registers it directly.
- **Test fixtures** -- shared-session fixtures that ensure a processor is registered re-add it across tests.

## Repro

```python
from unittest.mock import MagicMock
from agents.tracing.provider import SynchronousMultiTracingProcessor

m = SynchronousMultiTracingProcessor()
p = MagicMock()
m.add_tracing_processor(p)
m.add_tracing_processor(p)   # same instance again
m.on_span_end(MagicMock())
print(p.on_span_end.call_count)  # before: 2, after: 1
```

## Fix

Identity-check (`is`) before appending so re-registering the same instance is a silent no-op. Distinct instances that happen to compare equal still both register, preserving the existing convention that processors are addressed by identity.

```python
with self._lock:
    for existing in self._processors:
        if existing is tracing_processor:
            return
    self._processors += (tracing_processor,)
```

7-line surgical change in `provider.py`. No public API change.

## Test plan

- [x] `tests/tracing/test_processor_dedupe.py` (3 focused tests):
  - same-instance re-registration delivers events once
  - distinct instances both still register
  - equality-but-not-identity instances both register (dedupe is by `is`, not `==`)
- [x] Two of the new tests **fail on `main`** (`assert 2 == 1`) and pass with the fix; the equality test is a regression guard.
- [x] Full tracing suite green: `pytest tests/tracing tests/test_trace*.py` -> **79 passed** (76 prior + 3 new) on Python 3.13.5.
- [x] `ruff check` and `ruff format --check` clean on both changed files.