### PR TITLE
fix(codex): coerce None text/path inputs in _normalize_input

### DIFF
--- a/src/agents/extensions/experimental/codex/thread.py
+++ b/src/agents/extensions/experimental/codex/thread.py
@@ -197,10 +197,10 @@ def _normalize_input(input: Input) -> tuple[str, list[str]]:
     images: list[str] = []
     for item in input:
         if item["type"] == "text":
-            text = item.get("text", "")
+            text = item.get("text") or ""
             prompt_parts.append(text)
         elif item["type"] == "local_image":
-            path = item.get("path", "")
+            path = item.get("path") or ""
             if path:
                 images.append(path)
 

--- a/tests/extensions/experiemental/codex/test_codex_exec_thread.py
+++ b/tests/extensions/experiemental/codex/test_codex_exec_thread.py
@@ -185,6 +185,25 @@ def test_normalize_input_merges_text_and_images() -> None:
     assert images == ["/tmp/a.png"]
 
 
+def test_normalize_input_coerces_none_text_and_path() -> None:
+    # Defensive: TypedDict shapes don't enforce non-None at runtime, so callers
+    # passing through serialized payloads can hand us None values. The previous
+    # ``item.get("text", "")`` only covered missing keys, leaving None to crash
+    # ``str.join``. Coerce None to "" to keep the helper total.
+    prompt, images = _normalize_input(
+        cast(
+            Any,
+            [
+                {"type": "text", "text": None},
+                {"type": "text", "text": "real"},
+                {"type": "local_image", "path": None},
+            ],
+        )
+    )
+    assert prompt == "\n\nreal"
+    assert images == []
+
+
 def test_normalize_env_stringifies_values() -> None:
     env = _normalize_env(CodexOptions(env=cast(dict[str, str], {"FOO": 1, 2: "bar"})))
     assert env == {"FOO": "1", "2": "bar"}


### PR DESCRIPTION
## Summary
- The ``UserInput`` TypedDict for ``Thread.run`` / ``Thread.run_streamed`` doesn't enforce non-None values at runtime, so callers passing serialized payloads (where empty strings get nulled out) hand ``_normalize_input`` items like ``{"type": "text", "text": None}``.
- ``item.get("text", "")`` only fills in missing keys, so an explicit None survives and crashes ``"\n\n".join(...)`` with ``TypeError: sequence item 0: expected str instance, NoneType found``. Same shape applies to ``path``.
- Switch to ``item.get("text") or ""`` / ``item.get("path") or ""`` so missing-or-None coerces cleanly to ``""``, keeping the helper total.

## Test plan
- [x] Added ``test_normalize_input_coerces_none_text_and_path`` exercising both None text and None path; fails on ``main`` with the TypeError above, passes with this fix.
- [x] ``pytest tests/extensions/experiemental/codex/test_codex_exec_thread.py`` (44 passed).