### PR TITLE
fix(handoffs): preserve HandoffInputData.input_items in remove_all_tools

### DIFF
--- a/src/agents/extensions/handoff_filters.py
+++ b/src/agents/extensions/handoff_filters.py
@@ -45,9 +45,7 @@ def remove_all_tools(handoff_input_data: HandoffInputData) -> HandoffInputData:
     # nest_handoff_history) don't drop or re-introduce tool items.
     existing_input_items = handoff_input_data.input_items
     filtered_input_items = (
-        _remove_tools_from_items(existing_input_items)
-        if existing_input_items is not None
-        else None
+        _remove_tools_from_items(existing_input_items) if existing_input_items is not None else None
     )
 
     return handoff_input_data.clone(

--- a/src/agents/extensions/handoff_filters.py
+++ b/src/agents/extensions/handoff_filters.py
@@ -41,12 +41,20 @@ def remove_all_tools(handoff_input_data: HandoffInputData) -> HandoffInputData:
     )
     filtered_pre_handoff_items = _remove_tools_from_items(handoff_input_data.pre_handoff_items)
     filtered_new_items = _remove_tools_from_items(new_items)
+    # Preserve and filter input_items so chained filters (e.g. after
+    # nest_handoff_history) don't drop or re-introduce tool items.
+    existing_input_items = handoff_input_data.input_items
+    filtered_input_items = (
+        _remove_tools_from_items(existing_input_items)
+        if existing_input_items is not None
+        else None
+    )
 
-    return HandoffInputData(
+    return handoff_input_data.clone(
         input_history=filtered_history,
         pre_handoff_items=filtered_pre_handoff_items,
         new_items=filtered_new_items,
-        run_context=handoff_input_data.run_context,
+        input_items=filtered_input_items,
     )
 
 

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -1072,3 +1072,31 @@ def test_removes_tool_approval_from_new_items() -> None:
     filtered_data = remove_all_tools(handoff_input_data)
     assert len(filtered_data.pre_handoff_items) == 1
     assert len(filtered_data.new_items) == 1
+
+
+def test_remove_all_tools_preserves_and_filters_input_items() -> None:
+    """remove_all_tools must preserve HandoffInputData.input_items and strip tools from it.
+
+    The model-input pipeline reads ``input_items`` when set (e.g. after
+    nest_handoff_history populates it). The filter previously rebuilt
+    HandoffInputData via the constructor and silently dropped this field,
+    which caused tool calls to leak into the next agent when filters were
+    chained.
+    """
+    base = handoff_data(
+        pre_handoff_items=(_get_message_output_run_item("kept"),),
+        new_items=(_get_message_output_run_item("also kept"),),
+    )
+    data_with_input_items = base.clone(
+        input_items=(
+            _get_tool_output_run_item("World"),
+            _get_message_output_run_item("Hello"),
+        ),
+    )
+    filtered_data = remove_all_tools(data_with_input_items)
+    # input_items must still be set (not dropped) and tool items removed.
+    assert filtered_data.input_items is not None
+    assert len(filtered_data.input_items) == 1
+    # Other fields remain filtered as before.
+    assert len(filtered_data.pre_handoff_items) == 1
+    assert len(filtered_data.new_items) == 1


### PR DESCRIPTION
## Summary

`remove_all_tools` rebuilds `HandoffInputData` via its constructor and silently drops the `input_items` field. The model-input pipeline (`turn_resolution.py:484`, `:500`) reads `input_items` when set — for example after `nest_handoff_history` populates it — so chained filters previously caused tool calls to leak into the next agent's input.

This switches to `handoff_input_data.clone(...)` (which preserves all fields) and also strips tool RunItems from `input_items` so the field remains consistent with the rest of the filtered data.

## Repro

```python
from agents.extensions.handoff_filters import nest_handoff_history, remove_all_tools

nested = nest_handoff_history(data)        # populates nested.input_items
filtered = remove_all_tools(nested)
assert filtered.input_items is not None    # fails on main, passes with fix
```

## Test plan

- [x] New unit test `test_remove_all_tools_preserves_and_filters_input_items` fails on `main` (`AssertionError: assert None is not None`) and passes with the fix.
- [x] All 37 existing tests in `tests/test_extension_filters.py` continue to pass.
- [x] `tests/test_handoff_prompt.py` continues to pass.