### PR TITLE
fix(realtime): treat None audio.input/audio.output as unset

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -1358,13 +1358,16 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
 
         audio_config = model_settings.get("audio")
         audio_config_mapping = audio_config if isinstance(audio_config, Mapping) else None
+        # ``audio.input``/``audio.output`` may be omitted or explicitly None; coerce
+        # both to an empty mapping so callers can opt out of one channel without
+        # tripping the membership checks below.
         input_audio_config: Mapping[str, Any] = (
-            cast(Mapping[str, Any], audio_config_mapping.get("input", {}))
+            cast(Mapping[str, Any], audio_config_mapping.get("input") or {})
             if audio_config_mapping
             else {}
         )
         output_audio_config: Mapping[str, Any] = (
-            cast(Mapping[str, Any], audio_config_mapping.get("output", {}))
+            cast(Mapping[str, Any], audio_config_mapping.get("output") or {})
             if audio_config_mapping
             else {}
         )

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -1530,6 +1530,19 @@ class TestSendEventAndConfig(TestOpenAIRealtimeWebSocketModel):
         assert cfg.audio.output is not None
         assert cfg.audio.output.format is None
 
+    def test_session_config_treats_none_audio_channels_as_unset(self, model):
+        # ``audio.input``/``audio.output`` may be omitted by callers that only
+        # want to override the other channel; an explicit ``None`` should be
+        # equivalent to leaving the key off rather than crashing on the
+        # membership checks inside ``_get_session_config``.
+        cfg = model._get_session_config({"audio": {"input": None, "output": None}})
+        assert cfg.audio is not None
+        assert cfg.audio.input is not None
+        assert cfg.audio.input.format is not None
+        assert cfg.audio.input.format.type == "audio/pcm"
+        assert cfg.audio.output is not None
+        assert cfg.audio.output.voice == "ash"
+
     def test_session_config_respects_audio_block_and_output_modalities(self, model):
         settings = {
             "input_audio_format": "pcm16",


### PR DESCRIPTION
## Summary

`OpenAIRealtimeWebSocketModel._get_session_config` pulls `audio["input"]` and `audio["output"]` out of the model settings and then runs membership tests on them (e.g. `if "noise_reduction" in input_audio_config:` at `src/agents/realtime/openai_realtime.py:1386`). The current default-coalescing uses `audio_config_mapping.get("input", {})`, which only swaps in the empty mapping when the key is absent — an explicit `None` slips through and trips the next `in` check with:

```
TypeError: argument of type 'NoneType' is not iterable
```

That bites callers who only want to override one channel and leave the other unset (for example `audio={"output": {...}, "input": None}`), or who clear an inherited override by setting it to `None`. The session payload never gets built.

This patch coerces a `None` channel to an empty mapping (`get("input") or {}`), so it behaves like an omitted key. Existing fallbacks — `DEFAULT_MODEL_SETTINGS`, top-level `input_audio_format`/`output_audio_format`, etc. — then populate the missing side normally. The change is confined to the two coalescing expressions; downstream logic is untouched.

## Test plan

- [x] New `test_session_config_treats_none_audio_channels_as_unset` builds the config with both channels set to `None` and asserts the input PCM format and default `"ash"` voice are restored from the defaults. Without the fix the test raises `TypeError` from line 1386.
- [x] `pytest tests/realtime` -> 233 passed.
- [x] `ruff check` / `ruff format --check` clean on the touched files.