### PR TITLE
fix(tracing): skip 'Trace already exists' warning under NoOpTrace

### DIFF
--- a/src/agents/tracing/create.py
+++ b/src/agents/tracing/create.py
@@ -22,7 +22,7 @@ from .span_data import (
     TurnSpanData,
 )
 from .spans import Span
-from .traces import Trace
+from .traces import NoOpTrace, Trace
 
 if TYPE_CHECKING:
     from openai.types.responses import Response
@@ -61,7 +61,10 @@ def trace(
         The newly created trace object.
     """
     current_trace = get_trace_provider().get_current_trace()
-    if current_trace:
+    # Skip the "trace already exists" warning when the active trace is a no-op
+    # (e.g. tracing is globally disabled). Nesting another trace inside a no-op
+    # parent is harmless and the warning is misleading noise.
+    if current_trace and not isinstance(current_trace, NoOpTrace):
         logger.warning(
             "Trace already exists. Creating a new trace, but this is probably a mistake."
         )

--- a/tests/tracing/test_trace_warning_noise.py
+++ b/tests/tracing/test_trace_warning_noise.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+
+from agents.tracing import trace
+from agents.tracing.scope import Scope
+from agents.tracing.setup import GLOBAL_TRACE_PROVIDER, set_trace_provider
+from agents.tracing.provider import DefaultTraceProvider
+from agents.tracing.traces import NoOpTrace
+
+
+def test_nested_trace_under_noop_does_not_warn(caplog, monkeypatch) -> None:
+    """When tracing is disabled and the outer trace is a NoOpTrace, creating an
+    inner trace must not emit the misleading 'Trace already exists' warning."""
+    Scope.set_current_trace(None)
+    monkeypatch.setenv("OPENAI_AGENTS_DISABLE_TRACING", "1")
+    set_trace_provider(DefaultTraceProvider())
+    try:
+        with trace("outer") as outer:
+            assert isinstance(outer, NoOpTrace)
+            with caplog.at_level(logging.WARNING, logger="openai.agents"):
+                with trace("inner") as inner:
+                    assert isinstance(inner, NoOpTrace)
+        warnings = [r for r in caplog.records if "Trace already exists" in r.getMessage()]
+        assert warnings == [], (
+            "Nested trace warning should not fire when outer trace is a NoOpTrace, "
+            f"but got: {[r.getMessage() for r in warnings]}"
+        )
+    finally:
+        Scope.set_current_trace(None)
+        # Restore previous global provider so we don't leak state between tests.
+        if GLOBAL_TRACE_PROVIDER is not None:
+            set_trace_provider(GLOBAL_TRACE_PROVIDER)


### PR DESCRIPTION
## Summary

When tracing is globally disabled (for example via `OPENAI_AGENTS_DISABLE_TRACING=1`), entering a nested `with trace(...)` block currently logs the misleading warning:

> `Trace already exists. Creating a new trace, but this is probably a mistake.`

But the outer trace in that case is a `NoOpTrace` — nesting another trace inside it is harmless, not a programming mistake. The warning is pure noise that's especially confusing for users who explicitly disabled tracing to keep logs quiet.

This skips the warning when the current trace is a `NoOpTrace`. Real `TraceImpl`/`ReattachedTrace` parents still trigger the warning as before.

### Repro
```python
import os
os.environ["OPENAI_AGENTS_DISABLE_TRACING"] = "1"
from agents.tracing import trace

with trace("outer"):       # NoOpTrace
    with trace("inner"):   # logs "Trace already exists..." today
        pass
```

## Test plan
- [x] New test `tests/tracing/test_trace_warning_noise.py::test_nested_trace_under_noop_does_not_warn` fails on `main` and passes with this fix.
- [x] Full `tests/tracing/` and `tests/test_trace*.py` suites pass (77 passed).