### PR TITLE
fix(run): expose pydantic raw_item fields in resume debug payload

### DIFF
--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -314,6 +314,13 @@ def describe_run_state_step(step: object | None) -> str | int | None:
     return type(step).__name__
 
 
+def _raw_item_field(raw_item: Any, key: str) -> Any:
+    """Read a field from a raw item, supporting both dict and Pydantic shapes."""
+    if isinstance(raw_item, Mapping):
+        return raw_item.get(key)
+    return getattr(raw_item, key, None)
+
+
 def build_generated_items_details(
     items: list[RunItem],
     *,
@@ -323,13 +330,14 @@ def build_generated_items_details(
     details: list[dict[str, object]] = []
     for idx, item in enumerate(items):
         item_info: dict[str, object] = {"index": idx, "type": item.type}
-        if hasattr(item, "raw_item") and isinstance(item.raw_item, dict):
-            item_info["raw_type"] = item.raw_item.get("type")
-            item_info["name"] = item.raw_item.get("name")
-            item_info["call_id"] = item.raw_item.get("call_id")
+        raw_item = getattr(item, "raw_item", None)
+        if raw_item is not None:
+            item_info["raw_type"] = _raw_item_field(raw_item, "type")
+            item_info["name"] = _raw_item_field(raw_item, "name")
+            item_info["call_id"] = _raw_item_field(raw_item, "call_id")
             if item.type == "tool_call_output_item" and include_tool_output:
-                output_str = str(item.raw_item.get("output", ""))[:100]
-                item_info["output"] = output_str
+                output_value = _raw_item_field(raw_item, "output")
+                item_info["output"] = str(output_value if output_value is not None else "")[:100]
         details.append(item_info)
     return details
 

--- a/tests/test_build_generated_items_details.py
+++ b/tests/test_build_generated_items_details.py
@@ -1,0 +1,77 @@
+"""Tests for build_generated_items_details debug helper."""
+
+from __future__ import annotations
+
+from openai.types.responses import ResponseFunctionToolCall
+
+from agents import Agent
+from agents.items import ToolCallItem, ToolCallOutputItem
+from agents.run_internal.agent_runner_helpers import build_generated_items_details
+
+
+def test_extracts_pydantic_tool_call_metadata() -> None:
+    """Pydantic raw_items expose name/call_id/type to debug logging."""
+    agent = Agent(name="test")
+    raw = ResponseFunctionToolCall(
+        id="fc_1",
+        type="function_call",
+        call_id="call_1",
+        name="do_thing",
+        arguments="{}",
+        status="completed",
+    )
+    items = [ToolCallItem(agent=agent, raw_item=raw)]
+
+    details = build_generated_items_details(items, include_tool_output=True)
+
+    assert len(details) == 1
+    entry = details[0]
+    assert entry["index"] == 0
+    assert entry["type"] == "tool_call_item"
+    assert entry["raw_type"] == "function_call"
+    assert entry["name"] == "do_thing"
+    assert entry["call_id"] == "call_1"
+
+
+def test_extracts_dict_tool_call_output_with_truncation() -> None:
+    """Dict raw_items keep working and tool_call_output_item exposes output."""
+    agent = Agent(name="test")
+    long_output = "x" * 250
+    items = [
+        ToolCallOutputItem(
+            agent=agent,
+            raw_item={
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": long_output,
+            },
+            output=long_output,
+        )
+    ]
+
+    details = build_generated_items_details(items, include_tool_output=True)
+
+    assert details[0]["raw_type"] == "function_call_output"
+    assert details[0]["call_id"] == "call_1"
+    assert details[0]["output"] == "x" * 100
+
+
+def test_omits_output_when_include_tool_output_false() -> None:
+    """When include_tool_output=False, output field is not added."""
+    agent = Agent(name="test")
+    items = [
+        ToolCallOutputItem(
+            agent=agent,
+            raw_item={
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": "result",
+            },
+            output="result",
+        )
+    ]
+
+    details = build_generated_items_details(items, include_tool_output=False)
+
+    assert "output" not in details[0]
+    assert details[0]["call_id"] == "call_1"


### PR DESCRIPTION
## Summary

`build_generated_items_details` (used by `build_resumed_stream_debug_extra` to log resume payloads) only populated `raw_type`/`name`/`call_id`/`output` when `item.raw_item` was a `dict`. Most `RunItem` subclasses keep the typed Pydantic model on `raw_item` (e.g. `ToolCallItem.raw_item: ResponseFunctionToolCall`, `HandoffCallItem.raw_item: ResponseFunctionToolCall`, `ReasoningItem.raw_item: ResponseReasoningItem`), so the debug log silently dropped those fields for the typed cases — `ToolCallItem` resumes were logged as just `{"index": 0, "type": "tool_call_item"}`.

## Fix

Read the fields generically through a small `_raw_item_field` helper that handles both `Mapping`-shaped raw items and Pydantic model attributes. Behaviour for dict raw items is preserved (including the 100-char output truncation).

## Test plan

- [x] New `tests/test_build_generated_items_details.py` covers Pydantic and dict shapes plus the `include_tool_output=False` case. The Pydantic test fails on `main` (`KeyError: 'raw_type'`) and passes with the fix.
- [x] `pytest tests/test_server_conversation_tracker.py tests/models/test_agent_registration.py tests/test_run_state.py` (224 tests) passes.
- [x] `ruff check` and `ruff format --check` clean.