### PR TITLE
fix(run): guard attach_usage_to_span against slot-based span data

### DIFF
--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -145,9 +145,17 @@ def attach_usage_to_span(
         span.span_data.usage = task_usage_to_span_data(usage)
         return
 
+    # Span data classes like FunctionSpanData / GenerationSpanData / ResponseSpanData
+    # do not declare a "metadata" slot, so blindly assigning to it would raise
+    # AttributeError on strictly slot-based subclasses. Skip the fallback in that case.
+    if not hasattr(span.span_data, "metadata"):
+        return
     metadata = dict(getattr(span.span_data, "metadata", None) or {})
     metadata["usage"] = total_usage_to_span_metadata(usage)
-    span.span_data.metadata = metadata
+    try:
+        span.span_data.metadata = metadata
+    except AttributeError:
+        return
 
 
 def should_cancel_parallel_model_task_on_input_guardrail_trip() -> bool:

--- a/tests/test_attach_usage_to_span_slots.py
+++ b/tests/test_attach_usage_to_span_slots.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agents.run_internal.agent_runner_helpers import attach_usage_to_span
+from agents.tracing.span_data import FunctionSpanData
+from agents.tracing.spans import NoOpSpan
+from agents.usage import Usage
+
+
+class _StrictSlotsSpanData:
+    """Mimics a strictly slot-based span data class without a metadata slot.
+
+    FunctionSpanData / GenerationSpanData / ResponseSpanData declare __slots__
+    that omit metadata. They currently inherit __dict__ from SpanData, which
+    masks the issue, but a strictly slot-based class triggers the AttributeError
+    that attach_usage_to_span must defend against.
+    """
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @property
+    def type(self) -> str:
+        return "function"
+
+
+class _FakeSpan:
+    def __init__(self, span_data: Any) -> None:
+        self.span_data = span_data
+
+
+def _usage() -> Usage:
+    return Usage(requests=1, input_tokens=10, output_tokens=5, total_tokens=15)
+
+
+def test_attach_usage_to_span_does_not_raise_on_strict_slot_span_data() -> None:
+    span = _FakeSpan(_StrictSlotsSpanData(name="tool"))
+    # Must not raise AttributeError despite the missing "metadata" slot.
+    attach_usage_to_span(span, _usage())
+
+
+def test_attach_usage_to_span_function_span_data_no_raise() -> None:
+    span = NoOpSpan(FunctionSpanData(name="tool", input="in", output="out"))
+    attach_usage_to_span(span, _usage())


### PR DESCRIPTION
## Summary

`attach_usage_to_span` falls through to a metadata-fallback branch for any span whose `span_data.type` is not `"task"` or `"turn"`:

```python
metadata = dict(getattr(span.span_data, "metadata", None) or {})
metadata["usage"] = total_usage_to_span_metadata(usage)
span.span_data.metadata = metadata
```

`FunctionSpanData`, `GenerationSpanData`, and `ResponseSpanData` all declare `__slots__` that **omit** `metadata`. Today they happen to inherit a `__dict__` from `SpanData(abc.ABC)`, which masks the issue, but a strictly slot-based span data class (or any future tightening of the SpanData base) would `AttributeError` on the assignment. This guards the path so a future caller passing a non-task / non-turn span cannot crash the run.

The function is currently only invoked with `TaskSpanData` / `TurnSpanData`, so this is a latent crash, not an active one — purely defensive.

## Changes

- `hasattr(span.span_data, "metadata")` short-circuit before building the metadata dict
- `try/except AttributeError` around the assignment as a belt-and-braces guard
- New focused unit test (`tests/test_attach_usage_to_span_slots.py`) constructs both a `FunctionSpanData`-backed `NoOpSpan` and a strictly-slot stub class, asserting `attach_usage_to_span` does not raise

10 source-line diff. Verified: test fails on `main` (`AttributeError: '_StrictSlotsSpanData' object has no attribute 'metadata' and no __dict__ for setting new attributes`), passes with the fix.

## Test plan

- [x] New tests pass: `pytest tests/test_attach_usage_to_span_slots.py`
- [x] Existing run_internal tests still pass: `pytest tests/test_run_internal_items.py tests/test_run_internal_approvals.py tests/test_run_internal_error_handlers.py tests/test_usage.py`
- [x] Reproduction confirmed: tests fail without the fix