### PR TITLE
fix(sandbox): require https for vercel exposed port domains

### DIFF
--- a/src/agents/extensions/sandbox/vercel/sandbox.py
+++ b/src/agents/extensions/sandbox/vercel/sandbox.py
@@ -460,18 +460,17 @@ class VercelSandboxSession(BaseSandboxSession):
 
         parsed = urlsplit(domain)
         host = parsed.hostname
-        if not host:
+        if not host or parsed.scheme != "https":
             raise ExposedPortUnavailableError(
                 port=port,
                 exposed_ports=self.state.exposed_ports,
                 reason="backend_unavailable",
                 context={"backend": "vercel", "domain": domain},
             )
-        tls = parsed.scheme == "https"
         return ExposedPortEndpoint(
             host=host,
-            port=parsed.port or (443 if tls else 80),
-            tls=tls,
+            port=parsed.port or 443,
+            tls=True,
         )
 
     async def read(self, path: Path, *, user: str | User | None = None) -> io.IOBase:

--- a/tests/extensions/sandbox/test_vercel.py
+++ b/tests/extensions/sandbox/test_vercel.py
@@ -16,7 +16,11 @@ from pydantic import BaseModel, PrivateAttr
 from agents.sandbox import Manifest, SandboxPathGrant
 from agents.sandbox.entries import File, InContainerMountStrategy, Mount, MountpointMountPattern
 from agents.sandbox.entries.mounts.base import InContainerMountAdapter
-from agents.sandbox.errors import ConfigurationError, InvalidManifestPathError
+from agents.sandbox.errors import (
+    ConfigurationError,
+    ExposedPortUnavailableError,
+    InvalidManifestPathError,
+)
 from agents.sandbox.manifest import Environment
 from agents.sandbox.materialization import MaterializedFile
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
@@ -539,6 +543,29 @@ async def test_vercel_exec_read_write_and_port_resolution(monkeypatch: pytest.Mo
         tls=True,
     )
     assert payload.read() == b"payload"
+
+
+@pytest.mark.asyncio
+async def test_vercel_resolve_exposed_port_rejects_non_https_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vercel_module = _load_vercel_module(monkeypatch)
+
+    state = vercel_module.VercelSandboxSessionState(
+        session_id="00000000-0000-0000-0000-000000000099",
+        manifest=Manifest(),
+        snapshot=NoopSnapshot(id="snapshot"),
+        sandbox_id="sandbox-http",
+        exposed_ports=(3000,),
+    )
+    sandbox = _FakeAsyncSandbox(
+        sandbox_id="sandbox-http",
+        routes=[{"port": 3000, "url": "http://3000-sandbox.vercel.run"}],
+    )
+    session = vercel_module.VercelSandboxSession.from_state(state, sandbox=sandbox)
+
+    with pytest.raises(ExposedPortUnavailableError):
+        await session.resolve_exposed_port(3000)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`VercelSandboxSession._resolve_exposed_port` accepted any URL returned by `sandbox.domain()` — including `http://` or schemeless — and silently exposed it as a non-TLS endpoint (`tls=False`, port 80). Vercel sandbox preview domains are always served over HTTPS, so a non-https scheme indicates either a backend bug or a tampered response. Either way, downstream code would then connect over plaintext to a host derived from that URL.

This change rejects any domain whose scheme is not `https`, raising `ExposedPortUnavailableError` via the same path already used for missing/invalid hostnames, and drops the conditional `http`/port-80 fallback.

This is in the same vein as #3206 (and earlier #3094 / #3172 / #3177) — defensive narrowing of what a sandbox backend will trust from the wire.

## Diff

- `src/agents/extensions/sandbox/vercel/sandbox.py`: 7 lines changed (require https in `_resolve_exposed_port`).
- `tests/extensions/sandbox/test_vercel.py`: new `test_vercel_resolve_exposed_port_rejects_non_https_domain` plus `ExposedPortUnavailableError` import.

## Test plan

- [x] New unit test `test_vercel_resolve_exposed_port_rejects_non_https_domain` fails on `main` and passes after the fix.
- [x] Full `tests/extensions/sandbox/test_vercel.py` suite (35 tests) passes.
- [x] `ruff check` and `ruff format --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)