### PR TITLE
fix(agent_output): return "None" from name() when output_type is None

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -181,12 +181,15 @@ def _is_subclass_of_base_model_or_dict(t: Any) -> bool:
 
 
 def _type_to_str(t: type[Any]) -> str:
+    if t is None:
+        return "None"
+
     origin = get_origin(t)
     args = get_args(t)
 
     if origin is None:
         # It's a simple type like `str`, `int`, etc.
-        return t.__name__
+        return getattr(t, "__name__", str(t))
     elif args:
         args_str = ", ".join(_type_to_str(arg) for arg in args)
         return f"{origin.__name__}[{args_str}]"

--- a/tests/test_output_tool.py
+++ b/tests/test_output_tool.py
@@ -107,6 +107,14 @@ def test_plain_text_obj_doesnt_produce_schema():
         output_wrapper.json_schema()
 
 
+def test_name_returns_string_for_none_output_type():
+    # AgentOutputSchema accepts ``None`` as a plain-text marker; ``name()`` must not crash on it.
+    output_wrapper = AgentOutputSchema(output_type=None)  # type: ignore[arg-type]
+    assert output_wrapper.is_plain_text()
+    assert isinstance(output_wrapper.name(), str)
+    assert output_wrapper.name() == "None"
+
+
 def test_structured_output_is_strict():
     output_wrapper = AgentOutputSchema(output_type=Foo)
     assert output_wrapper.is_strict_json_schema()


### PR DESCRIPTION
## Summary
- `AgentOutputSchema.__init__` accepts `output_type=None` as a plain-text marker (alongside `str`) and the constructor handles it explicitly, but `name()` crashes with `AttributeError: 'NoneType' object has no attribute '__name__'` because `_type_to_str` dereferences `t.__name__` unconditionally.
- Special-case `None` in `_type_to_str` so it returns the string `"None"`, mirroring how `str` already returns `"str"`.
- Also use `getattr(t, "__name__", str(t))` for the simple-type branch so any other unusual non-`type` object falls back to its `repr` instead of crashing.

## Repro
```python
from agents.agent_output import AgentOutputSchema
AgentOutputSchema(None).name()  # AttributeError on main, returns "None" with this fix
```

## Test plan
- [x] New `test_name_returns_string_for_none_output_type` fails on `main` with the original `AttributeError` and passes with this fix.
- [x] Existing `tests/test_output_tool.py`, `tests/test_agent_tool_input.py`, `tests/test_agent_tool_state.py`, and the openai chat/responses converter tests still pass (106 tests green).