### PR TITLE
fix(any-llm): avoid duplicating content and signed thinking blocks across parallel tool-call splits

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -1203,14 +1203,28 @@ class AnyLLMModel(Model):
             if message_dict.get("role") == "assistant" and message_dict.get("tool_calls"):
                 tool_calls = message_dict.get("tool_calls", [])
                 if isinstance(tool_calls, list):
+                    split_idx = 0
                     for tool_call in tool_calls:
                         if isinstance(tool_call, dict) and tool_call.get("id"):
+                            # Create a separate assistant message for each tool call.
+                            # Only the first split keeps the assistant text/thinking
+                            # blocks/reasoning content; the rest carry tool_calls only,
+                            # to avoid duplicating signed thinking blocks (which
+                            # Anthropic rejects) and assistant text in history.
                             single_tool_msg = message_dict.copy()
                             single_tool_msg["tool_calls"] = [tool_call]
+                            if split_idx > 0:
+                                for shared_field in (
+                                    "content",
+                                    "thinking_blocks",
+                                    "reasoning_content",
+                                ):
+                                    single_tool_msg.pop(shared_field, None)
                             tool_call_messages[str(tool_call["id"])] = (
                                 index,
                                 cast(ChatCompletionMessageParam, single_tool_msg),
                             )
+                            split_idx += 1
             elif message_dict.get("role") == "tool" and message_dict.get("tool_call_id"):
                 tool_result_messages[str(message_dict["tool_call_id"])] = (
                     index,

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -842,3 +842,57 @@ def test_any_llm_reasoning_objects_prefer_content_attributes_over_iterable_pairs
     delta = pytypes.SimpleNamespace(reasoning=Reasoning(content="用户"))
 
     assert _extract_any_llm_reasoning_text(delta) == "用户"
+
+
+def test_any_llm_split_does_not_duplicate_content_or_thinking(monkeypatch) -> None:
+    """Splitting multi-tool assistant messages must not duplicate text/thinking blocks.
+
+    Anthropic's extended thinking API rejects requests that include the same signed
+    thinking block more than once, and duplicated assistant text corrupts conversation
+    history. Only the first split should retain content, thinking_blocks, and
+    reasoning_content; subsequent splits should carry the tool_call alone.
+    """
+    provider = FakeAnyLLMProvider(supports_responses=False)
+    module, _ = _import_any_llm_module(monkeypatch, provider)
+    AnyLLMModel = module.AnyLLMModel
+
+    model = AnyLLMModel(model="anthropic/claude-3-5-sonnet")
+    messages: list[Any] = [
+        {"role": "user", "content": "Search both"},
+        {
+            "role": "assistant",
+            "content": "Looking up both queries.",
+            "thinking_blocks": [{"type": "thinking", "thinking": "plan", "signature": "sig_abc"}],
+            "reasoning_content": "internal plan",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "s", "arguments": "{}"},
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "s", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok1"},
+        {"role": "tool", "tool_call_id": "call_2", "content": "ok2"},
+    ]
+
+    result = model._fix_tool_message_ordering(messages)
+
+    assistants = [m for m in result if m.get("role") == "assistant"]
+    assert len(assistants) == 2
+    # First split keeps the shared fields.
+    assert assistants[0].get("content") == "Looking up both queries."
+    assert "thinking_blocks" in assistants[0]
+    assert "reasoning_content" in assistants[0]
+    # Second split must NOT duplicate them.
+    assert "content" not in assistants[1]
+    assert "thinking_blocks" not in assistants[1]
+    assert "reasoning_content" not in assistants[1]
+    # Tool calls are still split one-per-message.
+    assert assistants[0]["tool_calls"][0]["id"] == "call_1"
+    assert assistants[1]["tool_calls"][0]["id"] == "call_2"


### PR DESCRIPTION
## Summary

When `AnyLLMModel._fix_tool_message_ordering` splits an assistant message that has multiple `tool_calls` into one message per tool call, it copies the entire parent message into each split. That duplicates `content`, `thinking_blocks`, and `reasoning_content` across every split.

For Anthropic models with extended thinking, this is fatal: each thinking block carries a unique signature, and the API rejects requests that include the same signed block twice. It also corrupts conversation history by repeating the assistant's user-visible text whenever the model emits two or more parallel tool calls.

Keep those shared fields only on the first split; subsequent splits carry their `tool_calls` alone.

This mirrors the fix in #3215 for `litellm_model.py`. The same buggy code path was copied verbatim into `any_llm_model.py`, so the same regression applies whenever `AnyLLMModel` is used with Anthropic, Claude, or Gemini providers (the three providers gated by the reordering check on `any_llm_model.py:686`).

## Repro

Pass an assistant message with two parallel tool calls plus content/thinking blocks (which is what any-llm emits for Anthropic Claude models with parallel tool use + extended thinking) through `_fix_tool_message_ordering`. Before the fix, both split assistant messages contain the same `content` text and the same signed `thinking_blocks`; after the fix, only the first split carries them.

## Test plan

- [x] New unit test `test_any_llm_split_does_not_duplicate_content_or_thinking` covers the regression.
- [x] All 17 pre-existing `test_any_llm_model.py` tests still pass.
- [x] `ruff check` and `ruff format --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)