### PR TITLE
fix(codex): normalize configured thread_id in _resolve_call_thread_id

### DIFF
--- a/src/agents/extensions/experimental/codex/codex_tool.py
+++ b/src/agents/extensions/experimental/codex/codex_tool.py
@@ -832,7 +832,7 @@ def _resolve_call_thread_id(
         if context_thread_id:
             return context_thread_id
 
-    return configured_thread_id
+    return _normalize_thread_id(configured_thread_id)
 
 
 def _read_thread_id_from_run_context(ctx: RunContextWrapper[Any], key: str) -> str | None:

--- a/tests/extensions/experiemental/codex/test_codex_tool.py
+++ b/tests/extensions/experiemental/codex/test_codex_tool.py
@@ -2032,3 +2032,39 @@ def test_codex_tool_coerce_options_rejects_empty_run_context_key() -> None:
                 "run_context_thread_id_key": " ",
             }
         )
+
+
+@pytest.mark.asyncio
+async def test_codex_tool_starts_new_thread_for_whitespace_configured_thread_id() -> None:
+    state = CodexMockState()
+    state.thread_id = "thread-new"
+    state.events = [
+        {"type": "thread.started", "thread_id": "thread-new"},
+        {
+            "type": "item.completed",
+            "item": {"id": "agent-1", "type": "agent_message", "text": "Codex done."},
+        },
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 1, "cached_input_tokens": 0, "output_tokens": 1},
+        },
+    ]
+
+    tool = codex_tool(
+        CodexToolOptions(codex=cast(Codex, FakeCodex(state)), thread_id="   "),
+    )
+    input_json = '{"inputs": [{"type": "text", "text": "Continue", "path": ""}]}'
+    context = ToolContext(
+        context=None,
+        tool_name=tool.name,
+        tool_call_id="call-1",
+        tool_arguments=input_json,
+    )
+
+    result = await tool.on_invoke_tool(context, input_json)
+
+    assert isinstance(result, CodexToolResult)
+    # Whitespace-only configured thread_id should not be passed to resume_thread.
+    assert state.resume_calls == 0
+    assert state.start_calls == 1
+    assert state.last_resumed_thread_id is None


### PR DESCRIPTION
## Summary
- ``codex_tool(thread_id="   ")`` (whitespace-only) ends up calling ``codex.resume_thread("   ")`` because the configured thread id is returned by ``_resolve_call_thread_id`` without going through ``_normalize_thread_id``. JSON-input thread ids and run-context thread ids are already normalized, so this is the only path that leaks unusable strings.
- Even passing a non-string thread_id silently propagates to ``Codex.resume_thread`` instead of raising the documented ``UserError``.
- Run ``configured_thread_id`` through the same ``_normalize_thread_id`` helper. Whitespace-only ids fall back to ``codex.start_thread`` and non-string ids raise ``UserError("Codex thread_id must be a string when provided.")``, matching the JSON-input contract.

## Test plan
- [x] Added ``test_codex_tool_starts_new_thread_for_whitespace_configured_thread_id`` exercising ``codex_tool(thread_id="   ")``; fails on ``main`` because ``resume_thread`` is invoked with the whitespace string, passes with this fix.
- [x] ``pytest tests/extensions/experiemental/codex`` (128 passed).