### PR TITLE
fix(apply_diff): drop all trailing blank lines in diff normalization

### DIFF
--- a/src/agents/apply_diff.py
+++ b/src/agents/apply_diff.py
@@ -67,7 +67,7 @@ def apply_diff(input: str, diff: str, mode: ApplyDiffMode = "default") -> str:
 
 def _normalize_diff_lines(diff: str) -> list[str]:
     lines = [line.rstrip("\r") for line in re.split(r"\r?\n", diff)]
-    if lines and lines[-1] == "":
+    while lines and lines[-1] == "":
         lines.pop()
     return lines
 

--- a/tests/test_apply_diff.py
+++ b/tests/test_apply_diff.py
@@ -62,3 +62,13 @@ def test_apply_diff_with_crlf_input_and_crlf_diff_preserves_crlf() -> None:
 def test_apply_diff_create_mode_preserves_crlf_newlines() -> None:
     diff = "\r\n".join(["+hello", "+world", "+"])
     assert apply_diff("", diff, mode="create") == "hello\r\nworld\r\n"
+
+
+def test_apply_diff_tolerates_trailing_blank_lines_in_diff() -> None:
+    # Diffs may arrive padded with multiple trailing newlines (e.g. an editor
+    # or transport that always appends a final newline plus an extra blank).
+    # Those trailing blanks should not be parsed as empty context lines that
+    # fail to match against the input.
+    input_text = "line1\nline2\n"
+    diff = "@@ line1\n-line2\n+updated\n\n\n"
+    assert apply_diff(input_text, diff) == "line1\nupdated\n"

--- a/tests/test_apply_diff_helpers.py
+++ b/tests/test_apply_diff_helpers.py
@@ -21,6 +21,12 @@ def test_normalize_diff_lines_drops_trailing_blank() -> None:
     assert _normalize_diff_lines("a\nb\n") == ["a", "b"]
 
 
+def test_normalize_diff_lines_drops_repeated_trailing_blanks() -> None:
+    assert _normalize_diff_lines("a\nb\n\n\n") == ["a", "b"]
+    assert _normalize_diff_lines("\n\n") == []
+    assert _normalize_diff_lines("a\n\nb\n\n") == ["a", "", "b"]
+
+
 def test_is_done_true_when_index_out_of_range() -> None:
     state = ParserState(lines=["line"], index=1)
     assert _is_done(state, [])


### PR DESCRIPTION
## Summary

`_normalize_diff_lines` only popped a single trailing blank entry, so a V4A diff padded with multiple trailing newlines (e.g. by an editor or transport that always appends an extra blank line) leaked an empty line into the parser. The update parser then treats that blank as an empty context line, raising `Invalid Context` against any input whose last block does not end with two consecutive blank lines.

Switch the trailing-blank check to a `while` loop so all trailing blanks are stripped, matching the intent of the existing single-blank case.

Repro before the fix:

```python
apply_diff('line1\nline2\n', '@@ line1\n-line2\n+updated\n\n\n')
# ValueError: Invalid Context 1:\nline2\n
```

After the fix this returns `'line1\nupdated\n'`.

## Test plan

- [x] `pytest tests/test_apply_diff.py tests/test_apply_diff_helpers.py tests/sandbox/test_apply_patch.py` (37 passed)
- [x] New tests fail on `main`, pass with the fix