### PR TITLE
fix(codex): guard non-mapping todo_list entries in coerce_thread_item

### DIFF
--- a/src/agents/extensions/experimental/codex/items.py
+++ b/src/agents/extensions/experimental/codex/items.py
@@ -168,6 +168,17 @@ def _coerce_mcp_tool_call_error(
     return McpToolCallError(message=cast(str, raw.get("message", "")))
 
 
+def _coerce_todo_item(raw: TodoItem | Mapping[str, Any]) -> TodoItem:
+    if isinstance(raw, TodoItem):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise TypeError("TodoItem must be a mapping.")
+    return TodoItem(
+        text=cast(str, raw.get("text", "")),
+        completed=bool(raw.get("completed")),
+    )
+
+
 def coerce_thread_item(raw: ThreadItem | Mapping[str, Any]) -> ThreadItem:
     if isinstance(raw, _DictLike):
         return raw
@@ -225,10 +236,7 @@ def coerce_thread_item(raw: ThreadItem | Mapping[str, Any]) -> ThreadItem:
         )
     if item_type == "todo_list":
         items_raw = raw.get("items", [])
-        items = [
-            TodoItem(text=cast(str, item.get("text", "")), completed=bool(item.get("completed")))
-            for item in cast(list[Mapping[str, Any]], items_raw)
-        ]
+        items = [_coerce_todo_item(item) for item in items_raw]
         return TodoListItem(id=cast(str, raw["id"]), items=items)
     if item_type == "error":
         return ErrorItem(

--- a/tests/extensions/experiemental/codex/test_payloads.py
+++ b/tests/extensions/experiemental/codex/test_payloads.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from agents.extensions.experimental.codex.items import AgentMessageItem, TodoItem, TodoListItem
+from agents.extensions.experimental.codex.items import (
+    AgentMessageItem,
+    TodoItem,
+    TodoListItem,
+    coerce_thread_item,
+)
 
 
 def test_dict_like_supports_mapping_access_for_dataclass_fields() -> None:
@@ -43,3 +48,18 @@ def test_dict_like_as_dict_recursively_converts_nested_dataclasses() -> None:
         ],
         "type": "todo_list",
     }
+
+
+def test_coerce_thread_item_todo_list_rejects_non_mapping_entries() -> None:
+    # Mirror the guard used by file_change/mcp_tool_call coercion so malformed
+    # entries surface a clean TypeError instead of an AttributeError.
+    with pytest.raises(TypeError, match="TodoItem must be a mapping"):
+        coerce_thread_item({"type": "todo_list", "id": "todo-1", "items": [None]})
+
+
+def test_coerce_thread_item_todo_list_passes_through_existing_items() -> None:
+    existing = TodoItem(text="already", completed=True)
+    result = coerce_thread_item({"type": "todo_list", "id": "todo-1", "items": [existing]})
+
+    assert isinstance(result, TodoListItem)
+    assert result.items == [existing]


### PR DESCRIPTION
## Summary

The `todo_list` branch in `coerce_thread_item` iterates `raw["items"]` and calls `item.get(...)` directly, without checking that each entry is a `Mapping`. A malformed event like `{"type": "todo_list", "id": "x", "items": [None]}` therefore crashes with a raw `AttributeError: 'NoneType' object has no attribute 'get'` instead of the clean `TypeError` that the sibling branches (`file_change`, `mcp_tool_call`) already surface through their `_coerce_*` helpers.

Add a matching `_coerce_todo_item` helper that:

- pass-throughs existing `TodoItem` instances (consistent with `_coerce_file_update_change` / `_coerce_mcp_tool_call_*`),
- rejects non-mapping entries with `TypeError("TodoItem must be a mapping.")`,
- preserves the existing `text` / `completed` defaults.

Net change: ~16 lines in `items.py`, +22 lines of tests.

## Test plan

- [x] `pytest tests/extensions/experiemental/codex/test_payloads.py -v` — new tests fail on `main` with `AttributeError`, pass after the fix.
- [x] `pytest tests/extensions/experiemental` — all 129 tests pass.
- [x] `ruff check` and `ruff format --check` clean on both files.