### PR TITLE
fix: #3269 Validate MCP static tool filter configuration

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -633,19 +633,52 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         self, tools: list[MCPTool], static_filter: ToolFilterStatic
     ) -> list[MCPTool]:
         """Apply static tool filtering based on allowlist and blocklist."""
+        valid_keys = {"allowed_tool_names", "blocked_tool_names"}
+        invalid_keys = sorted(set(static_filter) - valid_keys)
+        if invalid_keys:
+            raise UserError(
+                "Invalid tool_filter static configuration: "
+                f"unexpected keys {invalid_keys!r}; expected only "
+                "'allowed_tool_names' and 'blocked_tool_names'."
+            )
+
         filtered_tools = tools
 
         # Apply allowed_tool_names filter (whitelist)
         if "allowed_tool_names" in static_filter:
-            allowed_names = static_filter["allowed_tool_names"]
+            allowed_names = self._validate_static_tool_filter_names(
+                static_filter["allowed_tool_names"],
+                key="allowed_tool_names",
+            )
             filtered_tools = [t for t in filtered_tools if t.name in allowed_names]
 
         # Apply blocked_tool_names filter (blacklist)
         if "blocked_tool_names" in static_filter:
-            blocked_names = static_filter["blocked_tool_names"]
+            blocked_names = self._validate_static_tool_filter_names(
+                static_filter["blocked_tool_names"],
+                key="blocked_tool_names",
+            )
             filtered_tools = [t for t in filtered_tools if t.name not in blocked_names]
 
         return filtered_tools
+
+    @staticmethod
+    def _validate_static_tool_filter_names(value: object, *, key: str) -> list[str]:
+        if not isinstance(value, list):
+            raise UserError(
+                f"Invalid tool_filter.{key}: expected a list of strings, "
+                f"got {type(value).__name__}."
+            )
+
+        tool_names: list[str] = []
+        for index, tool_name in enumerate(value):
+            if not isinstance(tool_name, str):
+                raise UserError(
+                    f"Invalid tool_filter.{key}[{index}]: expected a string, "
+                    f"got {type(tool_name).__name__}."
+                )
+            tool_names.append(tool_name)
+        return tool_names
 
     async def _apply_dynamic_tool_filter(
         self,

--- a/tests/mcp/test_tool_filtering.py
+++ b/tests/mcp/test_tool_filtering.py
@@ -5,11 +5,13 @@ FakeMCPServer delegates filtering logic to the real _MCPServerWithClientSession 
 """
 
 import asyncio
+from typing import Any, cast
 
 import pytest
 from mcp import Tool as MCPTool
 
 from agents import Agent
+from agents.exceptions import UserError
 from agents.mcp import ToolFilterContext, create_static_tool_filter
 from agents.run_context import RunContextWrapper
 
@@ -75,6 +77,46 @@ async def test_static_tool_filtering():
     tools = await server.list_tools(run_context, agent)
     assert len(tools) == 1
     assert tools[0].name == "tool1"
+
+
+@pytest.mark.asyncio
+async def test_static_tool_filtering_rejects_unknown_keys():
+    """Test that misspelled static filter keys fail closed."""
+    server = FakeMCPServer(server_name="test_server")
+    server.add_tool("read", {})
+    server.add_tool("delete", {})
+
+    run_context = create_test_context()
+    agent = create_test_agent()
+
+    server.tool_filter = cast(Any, {"allowed_tools": ["read"]})
+    with pytest.raises(UserError, match="unexpected keys"):
+        await server.list_tools(run_context, agent)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_filter", "message"),
+    [
+        ({"allowed_tool_names": "read"}, "expected a list of strings"),
+        ({"blocked_tool_names": [123]}, "expected a string"),
+    ],
+)
+async def test_static_tool_filtering_rejects_invalid_tool_name_lists(
+    tool_filter: dict[str, object],
+    message: str,
+):
+    """Test that malformed static filter values fail closed."""
+    server = FakeMCPServer(server_name="test_server")
+    server.add_tool("read", {})
+    server.add_tool("delete", {})
+
+    run_context = create_test_context()
+    agent = create_test_agent()
+
+    server.tool_filter = cast(Any, tool_filter)
+    with pytest.raises(UserError, match=message):
+        await server.list_tools(run_context, agent)
 
 
 # === Dynamic Tool Filtering Core Tests ===


### PR DESCRIPTION
### Summary

Reject invalid static MCP `tool_filter` dictionaries instead of silently ignoring them. This makes misspelled allowlist/blocklist keys fail closed with `UserError`, and also validates that `allowed_tool_names` and `blocked_tool_names` are lists of strings.

The existing valid allowlist/blocklist behavior is unchanged.

### Test plan

- `./.venv/bin/python -B -m pytest tests/mcp/test_tool_filtering.py`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3269

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass