### PR TITLE
fix: #3273 validate git repo subpaths

### DIFF
--- a/src/agents/sandbox/entries/artifacts.py
+++ b/src/agents/sandbox/entries/artifacts.py
@@ -8,7 +8,7 @@ import re
 import stat
 import uuid
 from collections.abc import Awaitable, Callable, Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field, field_serializer, field_validator
@@ -17,6 +17,7 @@ from ..errors import (
     GitCloneError,
     GitCopyError,
     GitMissingInImageError,
+    GitSubpathError,
     LocalChecksumError,
     LocalDirReadError,
     LocalFileReadError,
@@ -786,9 +787,7 @@ class GitRepo(BaseEntry):
                     context={"repo": self.repo, "subpath": self.subpath},
                 )
 
-            git_src_root: str = tmp_dir
-            if self.subpath is not None:
-                git_src_root = f"{tmp_dir}/{self.subpath.lstrip('/')}"
+            git_src_root = self._git_src_root(tmp_dir)
 
             # Copy into destination in the container.
             await session.mkdir(dest, parents=True)
@@ -813,6 +812,24 @@ class GitRepo(BaseEntry):
     @staticmethod
     def _looks_like_commit_ref(ref: str) -> bool:
         return _COMMIT_REF_RE.fullmatch(ref) is not None
+
+    def _git_src_root(self, tmp_dir: str) -> str:
+        if self.subpath is None:
+            return tmp_dir
+
+        subpath = self.subpath
+        posix_subpath = PurePosixPath(subpath)
+        windows_subpath = PureWindowsPath(subpath)
+        if subpath == "" or posix_subpath.as_posix() == ".":
+            raise GitSubpathError(repo=self.repo, subpath=subpath, reason="empty")
+        if posix_subpath.is_absolute():
+            raise GitSubpathError(repo=self.repo, subpath=subpath, reason="absolute")
+        if "\\" in subpath or windows_subpath.drive:
+            raise GitSubpathError(repo=self.repo, subpath=subpath, reason="windows_path")
+        if ".." in posix_subpath.parts:
+            raise GitSubpathError(repo=self.repo, subpath=subpath, reason="parent_traversal")
+
+        return f"{tmp_dir}/{posix_subpath.as_posix()}"
 
     async def _clone_named_ref(
         self,

--- a/src/agents/sandbox/entries/artifacts.py
+++ b/src/agents/sandbox/entries/artifacts.py
@@ -754,6 +754,8 @@ class GitRepo(BaseEntry):
         dest: Path,
         base_dir: Path,
     ) -> list[MaterializedFile]:
+        git_subpath = self._validate_subpath()
+
         # Ensure git exists in the container.
         git_check = await session.exec("command -v git >/dev/null 2>&1")
         if not git_check.ok():
@@ -787,7 +789,7 @@ class GitRepo(BaseEntry):
                     context={"repo": self.repo, "subpath": self.subpath},
                 )
 
-            git_src_root = self._git_src_root(tmp_dir)
+            git_src_root = self._git_src_root(tmp_dir, git_subpath)
 
             # Copy into destination in the container.
             await session.mkdir(dest, parents=True)
@@ -813,9 +815,9 @@ class GitRepo(BaseEntry):
     def _looks_like_commit_ref(ref: str) -> bool:
         return _COMMIT_REF_RE.fullmatch(ref) is not None
 
-    def _git_src_root(self, tmp_dir: str) -> str:
+    def _validate_subpath(self) -> PurePosixPath | None:
         if self.subpath is None:
-            return tmp_dir
+            return None
 
         subpath = self.subpath
         posix_subpath = PurePosixPath(subpath)
@@ -829,7 +831,12 @@ class GitRepo(BaseEntry):
         if ".." in posix_subpath.parts:
             raise GitSubpathError(repo=self.repo, subpath=subpath, reason="parent_traversal")
 
-        return f"{tmp_dir}/{posix_subpath.as_posix()}"
+        return posix_subpath
+
+    def _git_src_root(self, tmp_dir: str, subpath: PurePosixPath | None) -> str:
+        if subpath is None:
+            return tmp_dir
+        return f"{tmp_dir}/{subpath.as_posix()}"
 
     async def _clone_named_ref(
         self,

--- a/src/agents/sandbox/errors.py
+++ b/src/agents/sandbox/errors.py
@@ -41,6 +41,7 @@ class ErrorCode(str, Enum):
 
     GIT_MISSING_IN_IMAGE = "git_missing_in_image"
     GIT_CLONE_ERROR = "git_clone_error"
+    GIT_SUBPATH_ERROR = "git_subpath_error"
     GIT_COPY_ERROR = "git_copy_error"
 
     MOUNT_MISSING_TOOL = "mount_missing_tool"
@@ -666,6 +667,32 @@ class GitCloneError(GitArtifactError):
             error_code=ErrorCode.GIT_CLONE_ERROR,
             op="materialize",
             context={"url": url, "ref": ref, "stderr": stderr, **_as_context(context)},
+            cause=cause,
+        )
+
+
+class GitSubpathError(GitArtifactError):
+    """Git repository subpath was invalid for artifact materialization."""
+
+    def __init__(
+        self,
+        *,
+        repo: str,
+        subpath: str,
+        reason: Literal["absolute", "empty", "parent_traversal", "windows_path"],
+        context: Mapping[str, object] | None = None,
+        cause: BaseException | None = None,
+    ) -> None:
+        super().__init__(
+            message=f"git repo subpath must be a relative path inside the repository: {subpath}",
+            error_code=ErrorCode.GIT_SUBPATH_ERROR,
+            op="materialize",
+            context={
+                "repo": repo,
+                "subpath": subpath,
+                "reason": reason,
+                **_as_context(context),
+            },
             cause=cause,
         )
 

--- a/tests/sandbox/test_entries.py
+++ b/tests/sandbox/test_entries.py
@@ -931,7 +931,7 @@ async def test_git_repo_rejects_invalid_subpath_before_copy(
     subpath: str,
     reason: str,
 ) -> None:
-    session = _GitFailureSession(fail_on="copy")
+    session = _GitFailureSession(fail_on="clone")
     repo = GitRepo(repo="openai/example", ref="main", subpath=subpath)
 
     with pytest.raises(GitSubpathError) as excinfo:
@@ -939,7 +939,7 @@ async def test_git_repo_rejects_invalid_subpath_before_copy(
 
     assert excinfo.value.context["reason"] == reason
     assert excinfo.value.context["subpath"] == subpath
-    assert not any(call[:1] == ("cp",) for call in session.exec_calls)
+    assert session.exec_calls == []
 
 
 @pytest.mark.asyncio
@@ -951,7 +951,7 @@ async def test_git_repo_allows_relative_subpath_copy() -> None:
 
     copy_call = next(call for call in session.exec_calls if call[:1] == ("cp",))
     assert copy_call[3].endswith("/docs/reference/.")
-    assert copy_call[4] == "/workspace/repo/"
+    assert copy_call[4].replace("\\", "/") == "/workspace/repo/"
 
 
 def _git_temp_cleanup_calls(session: _RecordingSession) -> list[tuple[str, ...]]:

--- a/tests/sandbox/test_entries.py
+++ b/tests/sandbox/test_entries.py
@@ -22,6 +22,7 @@ from agents.sandbox.errors import (
     ExecNonZeroError,
     GitCloneError,
     GitCopyError,
+    GitSubpathError,
     InvalidManifestPathError,
     LocalDirReadError,
     LocalFileReadError,
@@ -911,6 +912,46 @@ async def test_git_repo_uses_fetch_checkout_path_for_commit_refs() -> None:
         and call[-1] == "FETCH_HEAD"
         for call in session.exec_calls
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("subpath", "reason"),
+    [
+        ("", "empty"),
+        (".", "empty"),
+        ("/docs", "absolute"),
+        ("../outside", "parent_traversal"),
+        ("docs/../../outside", "parent_traversal"),
+        ("C:/repo", "windows_path"),
+        ("docs\\outside", "windows_path"),
+    ],
+)
+async def test_git_repo_rejects_invalid_subpath_before_copy(
+    subpath: str,
+    reason: str,
+) -> None:
+    session = _GitFailureSession(fail_on="copy")
+    repo = GitRepo(repo="openai/example", ref="main", subpath=subpath)
+
+    with pytest.raises(GitSubpathError) as excinfo:
+        await repo.apply(session, Path("/workspace/repo"), Path("/ignored"))
+
+    assert excinfo.value.context["reason"] == reason
+    assert excinfo.value.context["subpath"] == subpath
+    assert not any(call[:1] == ("cp",) for call in session.exec_calls)
+
+
+@pytest.mark.asyncio
+async def test_git_repo_allows_relative_subpath_copy() -> None:
+    session = _RecordingSession()
+    repo = GitRepo(repo="openai/example", ref="main", subpath="docs/reference")
+
+    await repo.apply(session, Path("/workspace/repo"), Path("/ignored"))
+
+    copy_call = next(call for call in session.exec_calls if call[:1] == ("cp",))
+    assert copy_call[3].endswith("/docs/reference/.")
+    assert copy_call[4] == "/workspace/repo/"
 
 
 def _git_temp_cleanup_calls(session: _RecordingSession) -> list[tuple[str, ...]]:


### PR DESCRIPTION
### Summary

- Add validation for `GitRepo.subpath` before copying from the cloned repository.
- Reject empty, absolute, Windows-style, and parent traversal subpaths with a structured `GitSubpathError`.
- Add regression tests covering invalid subpaths and a valid relative subpath.

### Test plan

- `uv run pytest tests/sandbox/test_entries.py -k "git_repo"`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3273

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
