### PR TITLE
fix: #3274 limit sandbox archive extraction

### DIFF
--- a/docs/sandbox/guide.md
+++ b/docs/sandbox/guide.md
@@ -481,6 +481,28 @@ These options only matter when the runner is creating a fresh sandbox session:
 
 `concurrency_limits` controls how much sandbox materialization work can run in parallel. Use `SandboxConcurrencyLimits(manifest_entries=..., local_dir_files=...)` when large manifests or local directory copies need tighter resource control. Set either value to `None` to disable that specific limit.
 
+`archive_limits` controls SDK-side resource checks for `BaseSandboxSession.extract()` archive writes. The default, `archive_limits=None`, preserves the historical behavior and does not enforce SDK archive resource limits. Use `SandboxArchiveLimits()` to enable the SDK default thresholds, or pass explicit values such as `SandboxArchiveLimits(max_input_bytes=..., max_extracted_bytes=..., max_members=...)`. Set an individual field to `None` to disable only that limit.
+
+A direct `session.extract(..., archive_limits=SandboxArchiveLimits(...))` call can override the session default for that extraction. Set all fields to `None` to disable all SDK archive limits for that call.
+
+```python
+from agents.run import RunConfig
+from agents.sandbox import SandboxArchiveLimits, SandboxRunConfig
+
+run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=client,
+        archive_limits=SandboxArchiveLimits(),
+    )
+)
+
+await session.extract(
+    "bundle.tar",
+    archive_stream,
+    archive_limits=SandboxArchiveLimits(max_input_bytes=None, max_members=200_000),
+)
+```
+
 A few implications are worth keeping in mind:
 
 - Fresh sessions: `manifest=` and `snapshot=` only apply when the runner is creating a fresh sandbox session.

--- a/docs/sandbox/guide.md
+++ b/docs/sandbox/guide.md
@@ -481,28 +481,6 @@ These options only matter when the runner is creating a fresh sandbox session:
 
 `concurrency_limits` controls how much sandbox materialization work can run in parallel. Use `SandboxConcurrencyLimits(manifest_entries=..., local_dir_files=...)` when large manifests or local directory copies need tighter resource control. Set either value to `None` to disable that specific limit.
 
-`archive_limits` controls SDK-side resource checks for `BaseSandboxSession.extract()` archive writes. The default, `archive_limits=None`, preserves the historical behavior and does not enforce SDK archive resource limits. Use `SandboxArchiveLimits()` to enable the SDK default thresholds, or pass explicit values such as `SandboxArchiveLimits(max_input_bytes=..., max_extracted_bytes=..., max_members=...)`. Set an individual field to `None` to disable only that limit.
-
-A direct `session.extract(..., archive_limits=SandboxArchiveLimits(...))` call can override the session default for that extraction. Set all fields to `None` to disable all SDK archive limits for that call.
-
-```python
-from agents.run import RunConfig
-from agents.sandbox import SandboxArchiveLimits, SandboxRunConfig
-
-run_config = RunConfig(
-    sandbox=SandboxRunConfig(
-        client=client,
-        archive_limits=SandboxArchiveLimits(),
-    )
-)
-
-await session.extract(
-    "bundle.tar",
-    archive_stream,
-    archive_limits=SandboxArchiveLimits(max_input_bytes=None, max_members=200_000),
-)
-```
-
 A few implications are worth keeping in mind:
 
 - Fresh sessions: `manifest=` and `snapshot=` only apply when the runner is creating a fresh sandbox session.

--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
 DEFAULT_MAX_TURNS = 10
 DEFAULT_MAX_MANIFEST_ENTRY_CONCURRENCY = 4
 DEFAULT_MAX_LOCAL_DIR_FILE_CONCURRENCY = 4
+DEFAULT_MAX_ARCHIVE_INPUT_BYTES = 1024 * 1024 * 1024
+DEFAULT_MAX_ARCHIVE_EXTRACTED_BYTES = 4 * 1024 * 1024 * 1024
+DEFAULT_MAX_ARCHIVE_MEMBERS = 100_000
 
 
 def _default_trace_include_sensitive_data() -> bool:
@@ -130,6 +133,40 @@ class SandboxConcurrencyLimits:
 
 
 @dataclass
+class SandboxArchiveLimits:
+    """Resource limits for sandbox archive extraction."""
+
+    max_input_bytes: int | None = DEFAULT_MAX_ARCHIVE_INPUT_BYTES
+    """Maximum archive input bytes accepted by `BaseSandboxSession.extract()`.
+
+    Set to `None` to disable this input-size limit.
+    """
+
+    max_extracted_bytes: int | None = DEFAULT_MAX_ARCHIVE_EXTRACTED_BYTES
+    """Maximum declared bytes that an archive may extract.
+
+    Set to `None` to disable this extracted-size limit.
+    """
+
+    max_members: int | None = DEFAULT_MAX_ARCHIVE_MEMBERS
+    """Maximum number of extractable archive members.
+
+    Set to `None` to disable this member-count limit.
+    """
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        if self.max_input_bytes is not None and self.max_input_bytes < 1:
+            raise ValueError("archive_limits.max_input_bytes must be at least 1")
+        if self.max_extracted_bytes is not None and self.max_extracted_bytes < 1:
+            raise ValueError("archive_limits.max_extracted_bytes must be at least 1")
+        if self.max_members is not None and self.max_members < 1:
+            raise ValueError("archive_limits.max_members must be at least 1")
+
+
+@dataclass
 class SandboxRunConfig:
     """Grouped sandbox runtime configuration for `Runner`."""
 
@@ -153,6 +190,13 @@ class SandboxRunConfig:
 
     concurrency_limits: SandboxConcurrencyLimits = field(default_factory=SandboxConcurrencyLimits)
     """Concurrency limits for sandbox materialization work."""
+
+    archive_limits: SandboxArchiveLimits | None = None
+    """Resource limits for sandbox archive extraction.
+
+    Set to `None` to preserve the default behavior with no SDK archive resource limits.
+    Use `SandboxArchiveLimits()` to enable SDK defaults.
+    """
 
 
 @dataclass
@@ -316,6 +360,7 @@ __all__ = [
     "ReasoningItemIdPolicy",
     "RunConfig",
     "RunOptions",
+    "SandboxArchiveLimits",
     "SandboxConcurrencyLimits",
     "SandboxRunConfig",
     "ToolExecutionConfig",

--- a/src/agents/sandbox/__init__.py
+++ b/src/agents/sandbox/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..run_config import SandboxConcurrencyLimits, SandboxRunConfig
+from ..run_config import SandboxArchiveLimits, SandboxConcurrencyLimits, SandboxRunConfig
 from .capabilities import Capability
 from .config import MemoryGenerateConfig, MemoryLayoutConfig, MemoryReadConfig
 from .entries import Dir, LocalFile
@@ -50,6 +50,7 @@ __all__ = [
     "RemoteSnapshotSpec",
     "Permissions",
     "SandboxAgent",
+    "SandboxArchiveLimits",
     "SandboxPathGrant",
     "SandboxConcurrencyLimits",
     "SandboxError",

--- a/src/agents/sandbox/runtime_session_manager.py
+++ b/src/agents/sandbox/runtime_session_manager.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Generic, cast
 
 from ..agent import Agent
-from ..run_config import SandboxConcurrencyLimits, SandboxRunConfig
+from ..run_config import SandboxArchiveLimits, SandboxConcurrencyLimits, SandboxRunConfig
 from ..run_context import TContext
 from ..run_state import (
     RunState,
@@ -286,10 +286,12 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
     ) -> _SandboxSessionResources:
         sandbox_config = self._require_sandbox_config()
         concurrency_limits = self._resolve_concurrency_limits()
+        archive_limits = self._resolve_archive_limits()
         if sandbox_config.session is not None:
-            self._configure_session_materialization(
+            self._configure_session(
                 sandbox_config.session,
                 concurrency_limits=concurrency_limits,
+                archive_limits=archive_limits,
             )
             running = await sandbox_config.session.running()
             manifest_update = self._process_live_session_manifest(
@@ -341,9 +343,10 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
             )
             with span_cm:
                 resumed_session = await client.resume(explicit_state)
-            self._configure_session_materialization(
+            self._configure_session(
                 resumed_session,
                 concurrency_limits=concurrency_limits,
+                archive_limits=archive_limits,
             )
             return _SandboxSessionResources(
                 session=resumed_session,
@@ -383,9 +386,10 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
                 manifest=effective_manifest,
                 options=options,
             )
-        self._configure_session_materialization(
+        self._configure_session(
             session,
             concurrency_limits=concurrency_limits,
+            archive_limits=archive_limits,
         )
         self._ensure_session_manifest_has_run_as_user(session=session, agent=agent)
         return _SandboxSessionResources(session=session, client=client, owns_session=True)
@@ -396,13 +400,22 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
         limits.validate()
         return limits
 
-    def _configure_session_materialization(
+    def _resolve_archive_limits(self) -> SandboxArchiveLimits | None:
+        sandbox_config = self._require_sandbox_config()
+        limits = sandbox_config.archive_limits
+        if limits is not None:
+            limits.validate()
+        return limits
+
+    def _configure_session(
         self,
         session: BaseSandboxSession,
         *,
         concurrency_limits: SandboxConcurrencyLimits,
+        archive_limits: SandboxArchiveLimits | None,
     ) -> None:
         session._set_concurrency_limits(concurrency_limits)
+        session._set_archive_limits(archive_limits)
 
     def _resume_state_payload_for_agent(
         self,

--- a/src/agents/sandbox/session/archive_extraction.py
+++ b/src/agents/sandbox/session/archive_extraction.py
@@ -12,7 +12,7 @@ from typing import Literal, cast
 
 from ..errors import ExecNonZeroError, WorkspaceArchiveWriteError
 from ..files import EntryKind, FileEntry
-from ..util.tar_utils import UnsafeTarMemberError, safe_tar_member_rel_path, validate_tarfile
+from ..util.tar_utils import UnsafeTarMemberError, safe_tar_member_rel_path
 
 MAX_ARCHIVE_MEMBERS = 10_000
 MAX_ARCHIVE_EXTRACTED_BYTES = 512 * 1024 * 1024
@@ -66,11 +66,12 @@ class WorkspaceArchiveExtractor:
     ) -> None:
         child_entry_cache: dict[Path, dict[str, EntryKind]] = {}
         try:
-            with tarfile.open(fileobj=data, mode="r:*") as archive:
-                members = archive.getmembers()
-                validate_tarfile(archive, allow_symlinks=False)
-                validate_tar_archive_resource_limits(members)
-                for member in members:
+            with tarfile.open(fileobj=data, mode="r|*") as archive:
+                validate_tar_archive_for_extraction(archive)
+
+            data.seek(0)
+            with tarfile.open(fileobj=data, mode="r|*") as archive:
+                for member in archive:
                     rel_path = safe_tar_member_rel_path(member)
                     if rel_path is None:
                         continue
@@ -368,10 +369,12 @@ def _check_archive_extracted_bytes(*, total: int, member: str) -> None:
         )
 
 
-def validate_tar_archive_resource_limits(members: list[tarfile.TarInfo]) -> None:
+def validate_tar_archive_for_extraction(archive: tarfile.TarFile) -> None:
+    members_by_rel_path: dict[Path, tarfile.TarInfo] = {}
     member_count = 0
     extracted_bytes = 0
-    for member in members:
+
+    for member in archive:
         rel_path = safe_tar_member_rel_path(member)
         if rel_path is None:
             continue
@@ -381,6 +384,39 @@ def validate_tar_archive_resource_limits(members: list[tarfile.TarInfo]) -> None
         if member.isreg():
             extracted_bytes += max(member.size, 0)
             _check_archive_extracted_bytes(total=extracted_bytes, member=member.name)
+
+        previous = members_by_rel_path.get(rel_path)
+        if previous is not None and not (previous.isdir() and member.isdir()):
+            raise UnsafeTarMemberError(
+                member=member.name,
+                reason=f"duplicate archive path: {rel_path.as_posix()}",
+            )
+
+        for parent in rel_path.parents:
+            if parent == Path():
+                break
+            parent_member = members_by_rel_path.get(parent)
+            if parent_member is not None and not parent_member.isdir():
+                raise UnsafeTarMemberError(
+                    member=member.name,
+                    reason=f"archive path descends through non-directory: {parent.as_posix()}",
+                )
+
+        if not member.isdir():
+            for existing_rel_path, existing_member in members_by_rel_path.items():
+                if _is_descendant(existing_rel_path, rel_path):
+                    raise UnsafeTarMemberError(
+                        member=existing_member.name,
+                        reason=(
+                            f"archive path descends through non-directory: {rel_path.as_posix()}"
+                        ),
+                    )
+
+        members_by_rel_path[rel_path] = member
+
+
+def _is_descendant(path: Path, parent: Path) -> bool:
+    return len(path.parts) > len(parent.parts) and path.parts[: len(parent.parts)] == parent.parts
 
 
 def validate_zipfile(archive: zipfile.ZipFile) -> None:

--- a/src/agents/sandbox/session/archive_extraction.py
+++ b/src/agents/sandbox/session/archive_extraction.py
@@ -391,6 +391,7 @@ def validate_tar_archive_for_extraction(
     archive_limits: SandboxArchiveLimits | None = None,
 ) -> None:
     members_by_rel_path: dict[Path, tarfile.TarInfo] = {}
+    descendant_by_parent_path: dict[Path, tarfile.TarInfo] = {}
     member_count = 0
     extracted_bytes = 0
 
@@ -431,20 +432,18 @@ def validate_tar_archive_for_extraction(
                 )
 
         if not member.isdir():
-            for existing_rel_path, existing_member in members_by_rel_path.items():
-                if _is_descendant(existing_rel_path, rel_path):
-                    raise UnsafeTarMemberError(
-                        member=existing_member.name,
-                        reason=(
-                            f"archive path descends through non-directory: {rel_path.as_posix()}"
-                        ),
-                    )
+            descendant = descendant_by_parent_path.get(rel_path)
+            if descendant is not None:
+                raise UnsafeTarMemberError(
+                    member=descendant.name,
+                    reason=f"archive path descends through non-directory: {rel_path.as_posix()}",
+                )
 
         members_by_rel_path[rel_path] = member
-
-
-def _is_descendant(path: Path, parent: Path) -> bool:
-    return len(path.parts) > len(parent.parts) and path.parts[: len(parent.parts)] == parent.parts
+        for parent in rel_path.parents:
+            if parent == Path():
+                break
+            descendant_by_parent_path.setdefault(parent, member)
 
 
 def validate_zipfile(

--- a/src/agents/sandbox/session/archive_extraction.py
+++ b/src/agents/sandbox/session/archive_extraction.py
@@ -10,12 +10,10 @@ from contextlib import contextmanager
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Literal, cast
 
+from ...run_config import SandboxArchiveLimits
 from ..errors import ExecNonZeroError, WorkspaceArchiveWriteError
 from ..files import EntryKind, FileEntry
 from ..util.tar_utils import UnsafeTarMemberError, safe_tar_member_rel_path
-
-MAX_ARCHIVE_MEMBERS = 10_000
-MAX_ARCHIVE_EXTRACTED_BYTES = 512 * 1024 * 1024
 
 
 class UnsafeZipMemberError(ValueError):
@@ -63,11 +61,12 @@ class WorkspaceArchiveExtractor:
         archive_path: Path,
         destination_root: Path,
         data: io.IOBase,
+        archive_limits: SandboxArchiveLimits | None = None,
     ) -> None:
         child_entry_cache: dict[Path, dict[str, EntryKind]] = {}
         try:
             with tarfile.open(fileobj=data, mode="r|*") as archive:
-                validate_tar_archive_for_extraction(archive)
+                validate_tar_archive_for_extraction(archive, archive_limits=archive_limits)
 
             data.seek(0)
             with tarfile.open(fileobj=data, mode="r|*") as archive:
@@ -138,12 +137,13 @@ class WorkspaceArchiveExtractor:
         archive_path: Path,
         destination_root: Path,
         data: io.IOBase,
+        archive_limits: SandboxArchiveLimits | None = None,
     ) -> None:
         child_entry_cache: dict[Path, dict[str, EntryKind]] = {}
         try:
             with zipfile_compatible_stream(data) as zip_data:
                 with zipfile.ZipFile(zip_data) as archive:
-                    validate_zipfile(archive)
+                    validate_zipfile(archive, archive_limits=archive_limits)
                     for member in archive.infolist():
                         rel_path = safe_zip_member_rel_path(member)
                         if rel_path is None:
@@ -349,27 +349,47 @@ def _archive_resource_limit_context(error: ArchiveResourceLimitError) -> dict[st
     return context
 
 
-def _check_archive_member_count(*, count: int, member: str) -> None:
-    if count > MAX_ARCHIVE_MEMBERS:
+def _check_archive_member_count(
+    *,
+    count: int,
+    member: str,
+    archive_limits: SandboxArchiveLimits | None,
+) -> None:
+    if archive_limits is None or archive_limits.max_members is None:
+        return
+
+    if count > archive_limits.max_members:
         raise ArchiveResourceLimitError(
             reason="archive member count exceeds limit",
-            limit=MAX_ARCHIVE_MEMBERS,
+            limit=archive_limits.max_members,
             actual=count,
             member=member,
         )
 
 
-def _check_archive_extracted_bytes(*, total: int, member: str) -> None:
-    if total > MAX_ARCHIVE_EXTRACTED_BYTES:
+def _check_archive_extracted_bytes(
+    *,
+    total: int,
+    member: str,
+    archive_limits: SandboxArchiveLimits | None,
+) -> None:
+    if archive_limits is None or archive_limits.max_extracted_bytes is None:
+        return
+
+    if total > archive_limits.max_extracted_bytes:
         raise ArchiveResourceLimitError(
             reason="archive extracted size exceeds limit",
-            limit=MAX_ARCHIVE_EXTRACTED_BYTES,
+            limit=archive_limits.max_extracted_bytes,
             actual=total,
             member=member,
         )
 
 
-def validate_tar_archive_for_extraction(archive: tarfile.TarFile) -> None:
+def validate_tar_archive_for_extraction(
+    archive: tarfile.TarFile,
+    *,
+    archive_limits: SandboxArchiveLimits | None = None,
+) -> None:
     members_by_rel_path: dict[Path, tarfile.TarInfo] = {}
     member_count = 0
     extracted_bytes = 0
@@ -380,10 +400,18 @@ def validate_tar_archive_for_extraction(archive: tarfile.TarFile) -> None:
             continue
 
         member_count += 1
-        _check_archive_member_count(count=member_count, member=member.name)
+        _check_archive_member_count(
+            count=member_count,
+            member=member.name,
+            archive_limits=archive_limits,
+        )
         if member.isreg():
             extracted_bytes += max(member.size, 0)
-            _check_archive_extracted_bytes(total=extracted_bytes, member=member.name)
+            _check_archive_extracted_bytes(
+                total=extracted_bytes,
+                member=member.name,
+                archive_limits=archive_limits,
+            )
 
         previous = members_by_rel_path.get(rel_path)
         if previous is not None and not (previous.isdir() and member.isdir()):
@@ -419,7 +447,11 @@ def _is_descendant(path: Path, parent: Path) -> bool:
     return len(path.parts) > len(parent.parts) and path.parts[: len(parent.parts)] == parent.parts
 
 
-def validate_zipfile(archive: zipfile.ZipFile) -> None:
+def validate_zipfile(
+    archive: zipfile.ZipFile,
+    *,
+    archive_limits: SandboxArchiveLimits | None = None,
+) -> None:
     members_by_rel_path: dict[Path, zipfile.ZipInfo] = {}
     members: list[tuple[zipfile.ZipInfo, Path]] = []
     extracted_bytes = 0
@@ -429,9 +461,17 @@ def validate_zipfile(archive: zipfile.ZipFile) -> None:
         if rel_path is None:
             continue
 
-        _check_archive_member_count(count=len(members) + 1, member=member.filename)
+        _check_archive_member_count(
+            count=len(members) + 1,
+            member=member.filename,
+            archive_limits=archive_limits,
+        )
         extracted_bytes += max(member.file_size, 0)
-        _check_archive_extracted_bytes(total=extracted_bytes, member=member.filename)
+        _check_archive_extracted_bytes(
+            total=extracted_bytes,
+            member=member.filename,
+            archive_limits=archive_limits,
+        )
 
         previous = members_by_rel_path.get(rel_path)
         if previous is not None and not (previous.is_dir() and member.is_dir()):

--- a/src/agents/sandbox/session/archive_extraction.py
+++ b/src/agents/sandbox/session/archive_extraction.py
@@ -14,6 +14,9 @@ from ..errors import ExecNonZeroError, WorkspaceArchiveWriteError
 from ..files import EntryKind, FileEntry
 from ..util.tar_utils import UnsafeTarMemberError, safe_tar_member_rel_path, validate_tarfile
 
+MAX_ARCHIVE_MEMBERS = 10_000
+MAX_ARCHIVE_EXTRACTED_BYTES = 512 * 1024 * 1024
+
 
 class UnsafeZipMemberError(ValueError):
     """Raised when a zip member would escape or violate archive extraction rules."""
@@ -22,6 +25,24 @@ class UnsafeZipMemberError(ValueError):
         super().__init__(f"unsafe zip member {member!r}: {reason}")
         self.member = member
         self.reason = reason
+
+
+class ArchiveResourceLimitError(ValueError):
+    """Raised when an archive exceeds extraction resource limits."""
+
+    def __init__(
+        self,
+        *,
+        reason: str,
+        limit: int,
+        actual: int,
+        member: str | None = None,
+    ) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.limit = limit
+        self.actual = actual
+        self.member = member
 
 
 class WorkspaceArchiveExtractor:
@@ -46,8 +67,10 @@ class WorkspaceArchiveExtractor:
         child_entry_cache: dict[Path, dict[str, EntryKind]] = {}
         try:
             with tarfile.open(fileobj=data, mode="r:*") as archive:
+                members = archive.getmembers()
                 validate_tarfile(archive, allow_symlinks=False)
-                for member in archive.getmembers():
+                validate_tar_archive_resource_limits(members)
+                for member in members:
                     rel_path = safe_tar_member_rel_path(member)
                     if rel_path is None:
                         continue
@@ -97,6 +120,12 @@ class WorkspaceArchiveExtractor:
             raise WorkspaceArchiveWriteError(
                 path=archive_path,
                 context={"member": e.member, "reason": e.reason},
+                cause=e,
+            ) from e
+        except ArchiveResourceLimitError as e:
+            raise WorkspaceArchiveWriteError(
+                path=archive_path,
+                context=_archive_resource_limit_context(e),
                 cause=e,
             ) from e
         except (tarfile.TarError, OSError) as e:
@@ -156,6 +185,12 @@ class WorkspaceArchiveExtractor:
             raise WorkspaceArchiveWriteError(
                 path=archive_path,
                 context={"member": e.member, "reason": e.reason},
+                cause=e,
+            ) from e
+        except ArchiveResourceLimitError as e:
+            raise WorkspaceArchiveWriteError(
+                path=archive_path,
+                context=_archive_resource_limit_context(e),
                 cause=e,
             ) from e
         except ValueError as e:
@@ -302,14 +337,65 @@ def safe_zip_member_rel_path(member: zipfile.ZipInfo) -> Path | None:
     return Path(*rel.parts)
 
 
+def _archive_resource_limit_context(error: ArchiveResourceLimitError) -> dict[str, object]:
+    context: dict[str, object] = {
+        "reason": error.reason,
+        "limit": error.limit,
+        "actual": error.actual,
+    }
+    if error.member is not None:
+        context["member"] = error.member
+    return context
+
+
+def _check_archive_member_count(*, count: int, member: str) -> None:
+    if count > MAX_ARCHIVE_MEMBERS:
+        raise ArchiveResourceLimitError(
+            reason="archive member count exceeds limit",
+            limit=MAX_ARCHIVE_MEMBERS,
+            actual=count,
+            member=member,
+        )
+
+
+def _check_archive_extracted_bytes(*, total: int, member: str) -> None:
+    if total > MAX_ARCHIVE_EXTRACTED_BYTES:
+        raise ArchiveResourceLimitError(
+            reason="archive extracted size exceeds limit",
+            limit=MAX_ARCHIVE_EXTRACTED_BYTES,
+            actual=total,
+            member=member,
+        )
+
+
+def validate_tar_archive_resource_limits(members: list[tarfile.TarInfo]) -> None:
+    member_count = 0
+    extracted_bytes = 0
+    for member in members:
+        rel_path = safe_tar_member_rel_path(member)
+        if rel_path is None:
+            continue
+
+        member_count += 1
+        _check_archive_member_count(count=member_count, member=member.name)
+        if member.isreg():
+            extracted_bytes += max(member.size, 0)
+            _check_archive_extracted_bytes(total=extracted_bytes, member=member.name)
+
+
 def validate_zipfile(archive: zipfile.ZipFile) -> None:
     members_by_rel_path: dict[Path, zipfile.ZipInfo] = {}
     members: list[tuple[zipfile.ZipInfo, Path]] = []
+    extracted_bytes = 0
 
     for member in archive.infolist():
         rel_path = safe_zip_member_rel_path(member)
         if rel_path is None:
             continue
+
+        _check_archive_member_count(count=len(members) + 1, member=member.filename)
+        extracted_bytes += max(member.file_size, 0)
+        _check_archive_extracted_bytes(total=extracted_bytes, member=member.filename)
 
         previous = members_by_rel_path.get(rel_path)
         if previous is not None and not (previous.is_dir() and member.is_dir()):

--- a/src/agents/sandbox/session/archive_ops.py
+++ b/src/agents/sandbox/session/archive_ops.py
@@ -5,14 +5,12 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
+from ...run_config import SandboxArchiveLimits
 from ..errors import InvalidCompressionSchemeError, WorkspaceArchiveWriteError
 from .archive_extraction import WorkspaceArchiveExtractor, safe_zip_member_rel_path
 
 if TYPE_CHECKING:
     from .base_sandbox_session import BaseSandboxSession
-
-
-MAX_ARCHIVE_INPUT_BYTES = 512 * 1024 * 1024
 
 
 async def extract_archive(
@@ -21,7 +19,11 @@ async def extract_archive(
     data: io.IOBase,
     *,
     compression_scheme: Literal["tar", "zip"] | None = None,
+    archive_limits: SandboxArchiveLimits | None = None,
 ) -> None:
+    if archive_limits is not None:
+        archive_limits.validate()
+
     if isinstance(path, str):
         path = Path(path)
 
@@ -39,7 +41,7 @@ async def extract_archive(
     # extraction step consume the stream, and zip extraction may require seeking.
     spool = tempfile.SpooledTemporaryFile(max_size=16 * 1024 * 1024, mode="w+b")
     try:
-        _copy_limited_archive(data, spool, path=normalized_path)
+        _copy_archive(data, spool, path=normalized_path, archive_limits=archive_limits)
         spool.seek(0)
         await session.write(normalized_path, spool)
         spool.seek(0)
@@ -49,12 +51,14 @@ async def extract_archive(
                 archive_path=normalized_path,
                 destination_root=destination_root,
                 data=spool,
+                archive_limits=archive_limits,
             )
         else:
             await session._extract_zip_archive(
                 archive_path=normalized_path,
                 destination_root=destination_root,
                 data=spool,
+                archive_limits=archive_limits,
             )
     finally:
         spool.close()
@@ -66,12 +70,14 @@ async def extract_tar_archive(
     archive_path: Path,
     destination_root: Path,
     data: io.IOBase,
+    archive_limits: SandboxArchiveLimits | None = None,
 ) -> None:
     extractor = _build_workspace_archive_extractor(session)
     await extractor.extract_tar_archive(
         archive_path=archive_path,
         destination_root=destination_root,
         data=data,
+        archive_limits=archive_limits,
     )
 
 
@@ -81,28 +87,37 @@ async def extract_zip_archive(
     archive_path: Path,
     destination_root: Path,
     data: io.IOBase,
+    archive_limits: SandboxArchiveLimits | None = None,
 ) -> None:
     extractor = _build_workspace_archive_extractor(session)
     await extractor.extract_zip_archive(
         archive_path=archive_path,
         destination_root=destination_root,
         data=data,
+        archive_limits=archive_limits,
     )
 
 
-def _copy_limited_archive(data: io.IOBase, out: io.IOBase, *, path: Path) -> None:
+def _copy_archive(
+    data: io.IOBase,
+    out: io.IOBase,
+    *,
+    path: Path,
+    archive_limits: SandboxArchiveLimits | None,
+) -> None:
+    max_input_bytes = archive_limits.max_input_bytes if archive_limits is not None else None
     total = 0
     while True:
         chunk = data.read(io.DEFAULT_BUFFER_SIZE)
         if chunk in ("", b""):
             return
         total += len(chunk)
-        if total > MAX_ARCHIVE_INPUT_BYTES:
+        if max_input_bytes is not None and total > max_input_bytes:
             raise WorkspaceArchiveWriteError(
                 path=path,
                 context={
                     "reason": "archive input size exceeds limit",
-                    "limit": MAX_ARCHIVE_INPUT_BYTES,
+                    "limit": max_input_bytes,
                     "actual": total,
                 },
             )

--- a/src/agents/sandbox/session/archive_ops.py
+++ b/src/agents/sandbox/session/archive_ops.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import io
-import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
-from ..errors import InvalidCompressionSchemeError
+from ..errors import InvalidCompressionSchemeError, WorkspaceArchiveWriteError
 from .archive_extraction import WorkspaceArchiveExtractor, safe_zip_member_rel_path
 
 if TYPE_CHECKING:
     from .base_sandbox_session import BaseSandboxSession
+
+
+MAX_ARCHIVE_INPUT_BYTES = 512 * 1024 * 1024
 
 
 async def extract_archive(
@@ -37,7 +39,7 @@ async def extract_archive(
     # extraction step consume the stream, and zip extraction may require seeking.
     spool = tempfile.SpooledTemporaryFile(max_size=16 * 1024 * 1024, mode="w+b")
     try:
-        shutil.copyfileobj(data, spool)
+        _copy_limited_archive(data, spool, path=normalized_path)
         spool.seek(0)
         await session.write(normalized_path, spool)
         spool.seek(0)
@@ -86,6 +88,25 @@ async def extract_zip_archive(
         destination_root=destination_root,
         data=data,
     )
+
+
+def _copy_limited_archive(data: io.IOBase, out: io.IOBase, *, path: Path) -> None:
+    total = 0
+    while True:
+        chunk = data.read(io.DEFAULT_BUFFER_SIZE)
+        if chunk in ("", b""):
+            return
+        total += len(chunk)
+        if total > MAX_ARCHIVE_INPUT_BYTES:
+            raise WorkspaceArchiveWriteError(
+                path=path,
+                context={
+                    "reason": "archive input size exceeds limit",
+                    "limit": MAX_ARCHIVE_INPUT_BYTES,
+                    "actual": total,
+                },
+            )
+        out.write(chunk)
 
 
 def _build_workspace_archive_extractor(session: BaseSandboxSession) -> WorkspaceArchiveExtractor:

--- a/src/agents/sandbox/session/base_sandbox_session.py
+++ b/src/agents/sandbox/session/base_sandbox_session.py
@@ -11,6 +11,7 @@ from ...editor import ApplyPatchOperation
 from ...run_config import (
     DEFAULT_MAX_LOCAL_DIR_FILE_CONCURRENCY,
     DEFAULT_MAX_MANIFEST_ENTRY_CONCURRENCY,
+    SandboxArchiveLimits,
     SandboxConcurrencyLimits,
 )
 from ..apply_patch import PatchFormat, WorkspaceEditor
@@ -119,6 +120,7 @@ class BaseSandboxSession(abc.ABC):
     _start_workspace_root_ready: bool | None = None
     _max_manifest_entry_concurrency: int | None = DEFAULT_MAX_MANIFEST_ENTRY_CONCURRENCY
     _max_local_dir_file_concurrency: int | None = DEFAULT_MAX_LOCAL_DIR_FILE_CONCURRENCY
+    _archive_limits: SandboxArchiveLimits | None = None
 
     async def start(self) -> None:
         try:
@@ -141,6 +143,11 @@ class BaseSandboxSession(abc.ABC):
         limits.validate()
         self._max_manifest_entry_concurrency = limits.manifest_entries
         self._max_local_dir_file_concurrency = limits.local_dir_files
+
+    def _set_archive_limits(self, limits: SandboxArchiveLimits | None) -> None:
+        if limits is not None:
+            limits.validate()
+        self._archive_limits = limits
 
     async def _ensure_backend_started(self) -> None:
         """Start, reconnect, or recreate the backend before workspace setup runs."""
@@ -965,6 +972,7 @@ class BaseSandboxSession(abc.ABC):
         data: io.IOBase,
         *,
         compression_scheme: Literal["tar", "zip"] | None = None,
+        archive_limits: SandboxArchiveLimits | None = None,
     ) -> None:
         """
         Write a compressed archive to a destination on the remote.
@@ -974,12 +982,21 @@ class BaseSandboxSession(abc.ABC):
         :param data: a file-like io stream.
         :param compression_scheme: either "tar" or "zip". If not provided,
             it will try to infer from the path.
+        :param archive_limits: optional per-call archive resource limits. If omitted,
+            the session default is used.
         """
+        if archive_limits is not None:
+            archive_limits.validate()
+        effective_archive_limits = (
+            archive_limits if archive_limits is not None else self._archive_limits
+        )
+
         await archive_ops.extract_archive(
             self,
             path,
             data,
             compression_scheme=compression_scheme,
+            archive_limits=effective_archive_limits,
         )
 
     async def apply_patch(
@@ -1005,12 +1022,14 @@ class BaseSandboxSession(abc.ABC):
         archive_path: Path,
         destination_root: Path,
         data: io.IOBase,
+        archive_limits: SandboxArchiveLimits | None = None,
     ) -> None:
         await archive_ops.extract_tar_archive(
             self,
             archive_path=archive_path,
             destination_root=destination_root,
             data=data,
+            archive_limits=archive_limits,
         )
 
     async def _extract_zip_archive(
@@ -1019,12 +1038,14 @@ class BaseSandboxSession(abc.ABC):
         archive_path: Path,
         destination_root: Path,
         data: io.IOBase,
+        archive_limits: SandboxArchiveLimits | None = None,
     ) -> None:
         await archive_ops.extract_zip_archive(
             self,
             archive_path=archive_path,
             destination_root=destination_root,
             data=data,
+            archive_limits=archive_limits,
         )
 
     @staticmethod

--- a/src/agents/sandbox/session/sandbox_session.py
+++ b/src/agents/sandbox/session/sandbox_session.py
@@ -10,7 +10,7 @@ from functools import wraps
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
-from ...run_config import SandboxConcurrencyLimits
+from ...run_config import SandboxArchiveLimits, SandboxConcurrencyLimits
 from ...tracing import Span, custom_span, get_current_trace
 from ..errors import OpName, SandboxError
 from ..files import FileEntry
@@ -266,6 +266,10 @@ class SandboxSession(BaseSandboxSession):
     def _set_concurrency_limits(self, limits: SandboxConcurrencyLimits) -> None:
         super()._set_concurrency_limits(limits)
         self._inner._set_concurrency_limits(limits)
+
+    def _set_archive_limits(self, limits: SandboxArchiveLimits | None) -> None:
+        super()._set_archive_limits(limits)
+        self._inner._set_archive_limits(limits)
 
     def normalize_path(self, path: Path | str, *, for_write: bool = False) -> Path:
         return self._inner.normalize_path(path, for_write=for_write)

--- a/tests/sandbox/test_compatibility_guards.py
+++ b/tests/sandbox/test_compatibility_guards.py
@@ -13,7 +13,7 @@ import agents.sandbox.capabilities as capabilities_package
 import agents.sandbox.entries as entries_package
 import agents.sandbox.session as session_package
 from agents import Agent
-from agents.run_config import SandboxConcurrencyLimits, SandboxRunConfig
+from agents.run_config import SandboxArchiveLimits, SandboxConcurrencyLimits, SandboxRunConfig
 from agents.run_context import RunContextWrapper
 from agents.run_state import RunState
 from agents.sandbox import Manifest
@@ -112,6 +112,7 @@ def test_core_sandbox_public_export_surface_is_stable() -> None:
             "RemoteSnapshotSpec",
             "Permissions",
             "SandboxAgent",
+            "SandboxArchiveLimits",
             "SandboxPathGrant",
             "SandboxConcurrencyLimits",
             "SandboxError",
@@ -350,6 +351,11 @@ def test_sandbox_dataclass_constructor_field_order_is_stable() -> None:
         "manifest_entries",
         "local_dir_files",
     )
+    assert _dataclass_field_names(SandboxArchiveLimits) == (
+        "max_input_bytes",
+        "max_extracted_bytes",
+        "max_members",
+    )
     assert _dataclass_field_names(SandboxRunConfig) == (
         "client",
         "options",
@@ -358,6 +364,7 @@ def test_sandbox_dataclass_constructor_field_order_is_stable() -> None:
         "manifest",
         "snapshot",
         "concurrency_limits",
+        "archive_limits",
     )
 
 

--- a/tests/sandbox/test_extract.py
+++ b/tests/sandbox/test_extract.py
@@ -16,6 +16,7 @@ from agents.sandbox.sandboxes.unix_local import (
     UnixLocalSandboxSession,
     UnixLocalSandboxSessionState,
 )
+from agents.sandbox.session import archive_extraction, archive_ops
 from agents.sandbox.session.archive_extraction import zipfile_compatible_stream
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.snapshot import NoopSnapshot
@@ -188,6 +189,128 @@ async def test_extract_zip_writes_archive_and_unpacks_contents(tmp_path: Path) -
     workspace = Path(session.state.manifest.root)
     assert (workspace / "bundle.zip").is_file()
     assert (workspace / "nested" / "hello.txt").read_text(encoding="utf-8") == "hello from zip"
+
+
+@pytest.mark.asyncio
+async def test_extract_rejects_archive_input_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(archive_ops, "MAX_ARCHIVE_INPUT_BYTES", 4)
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
+            await session.extract("bundle.zip", _ChunkedBinaryStream([b"123", b"45"]))
+
+        assert exc_info.value.context["reason"] == "archive input size exceeds limit"
+        assert exc_info.value.context["limit"] == 4
+        assert exc_info.value.context["actual"] == 5
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert not (workspace / "bundle.zip").exists()
+
+
+@pytest.mark.asyncio
+async def test_extract_tar_rejects_extracted_bytes_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_EXTRACTED_BYTES", 4)
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
+            await session.extract("bundle.tar", _tar_bytes(members={"large.txt": b"12345"}))
+
+        assert exc_info.value.context["member"] == "large.txt"
+        assert exc_info.value.context["reason"] == "archive extracted size exceeds limit"
+        assert exc_info.value.context["limit"] == 4
+        assert exc_info.value.context["actual"] == 5
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert not (workspace / "large.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_extract_zip_rejects_extracted_bytes_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_EXTRACTED_BYTES", 4)
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
+            await session.extract("bundle.zip", _zip_bytes(members={"large.txt": b"12345"}))
+
+        assert exc_info.value.context["member"] == "large.txt"
+        assert exc_info.value.context["reason"] == "archive extracted size exceeds limit"
+        assert exc_info.value.context["limit"] == 4
+        assert exc_info.value.context["actual"] == 5
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert not (workspace / "large.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_extract_tar_rejects_member_count_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_MEMBERS", 1)
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
+            await session.extract(
+                "bundle.tar",
+                _tar_bytes(members={"one.txt": b"1", "two.txt": b"2"}),
+            )
+
+        assert exc_info.value.context["member"] == "two.txt"
+        assert exc_info.value.context["reason"] == "archive member count exceeds limit"
+        assert exc_info.value.context["limit"] == 1
+        assert exc_info.value.context["actual"] == 2
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert not (workspace / "one.txt").exists()
+    assert not (workspace / "two.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_extract_zip_rejects_member_count_over_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_MEMBERS", 1)
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
+            await session.extract(
+                "bundle.zip",
+                _zip_bytes(members={"one.txt": b"1", "two.txt": b"2"}),
+            )
+
+        assert exc_info.value.context["member"] == "two.txt"
+        assert exc_info.value.context["reason"] == "archive member count exceeds limit"
+        assert exc_info.value.context["limit"] == 1
+        assert exc_info.value.context["actual"] == 2
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert not (workspace / "one.txt").exists()
+    assert not (workspace / "two.txt").exists()
 
 
 class _NoSeekableZipStream(io.IOBase):

--- a/tests/sandbox/test_extract.py
+++ b/tests/sandbox/test_extract.py
@@ -265,14 +265,18 @@ async def test_extract_tar_rejects_member_count_over_limit(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_MEMBERS", 1)
+    data = _tar_bytes(members={"one.txt": b"1", "two.txt": b"2"})
+
+    def fail_getmembers(_self: tarfile.TarFile) -> list[tarfile.TarInfo]:
+        raise AssertionError("tar extraction should not materialize all members")
+
+    monkeypatch.setattr(tarfile.TarFile, "getmembers", fail_getmembers)
+
     session = _build_session(tmp_path)
     await session.start()
     try:
         with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
-            await session.extract(
-                "bundle.tar",
-                _tar_bytes(members={"one.txt": b"1", "two.txt": b"2"}),
-            )
+            await session.extract("bundle.tar", data)
 
         assert exc_info.value.context["member"] == "two.txt"
         assert exc_info.value.context["reason"] == "archive member count exceeds limit"

--- a/tests/sandbox/test_extract.py
+++ b/tests/sandbox/test_extract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from agents.sandbox import SandboxArchiveLimits
 from agents.sandbox.entries import GCSMount, InContainerMountStrategy, MountpointMountPattern
 from agents.sandbox.errors import InvalidManifestPathError, WorkspaceArchiveWriteError
 from agents.sandbox.files import EntryKind, FileEntry
@@ -16,7 +17,6 @@ from agents.sandbox.sandboxes.unix_local import (
     UnixLocalSandboxSession,
     UnixLocalSandboxSessionState,
 )
-from agents.sandbox.session import archive_extraction, archive_ops
 from agents.sandbox.session.archive_extraction import zipfile_compatible_stream
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.snapshot import NoopSnapshot
@@ -192,16 +192,65 @@ async def test_extract_zip_writes_archive_and_unpacks_contents(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_extract_rejects_archive_input_over_limit(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_extract_default_archive_limits_none_preserves_no_resource_limit_behavior(
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(archive_ops, "MAX_ARCHIVE_INPUT_BYTES", 4)
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        await session.extract(
+            "bundle.tar",
+            _tar_bytes(members={"one.txt": b"1", "two.txt": b"2"}),
+        )
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert (workspace / "one.txt").read_text(encoding="utf-8") == "1"
+    assert (workspace / "two.txt").read_text(encoding="utf-8") == "2"
+
+
+def test_sandbox_archive_limits_defaults_enable_sdk_thresholds() -> None:
+    limits = SandboxArchiveLimits()
+
+    assert limits.max_input_bytes == 1024 * 1024 * 1024
+    assert limits.max_extracted_bytes == 4 * 1024 * 1024 * 1024
+    assert limits.max_members == 100_000
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"max_input_bytes": 0}, "archive_limits.max_input_bytes must be at least 1"),
+        ({"max_extracted_bytes": 0}, "archive_limits.max_extracted_bytes must be at least 1"),
+        ({"max_members": 0}, "archive_limits.max_members must be at least 1"),
+    ],
+)
+def test_sandbox_archive_limits_rejects_non_positive_values(
+    kwargs: dict[str, int],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        SandboxArchiveLimits(**kwargs)
+
+    assert str(exc_info.value) == message
+
+
+@pytest.mark.asyncio
+async def test_extract_rejects_archive_input_over_limit(tmp_path: Path) -> None:
     session = _build_session(tmp_path)
     await session.start()
     try:
         with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
-            await session.extract("bundle.zip", _ChunkedBinaryStream([b"123", b"45"]))
+            await session.extract(
+                "bundle.zip",
+                _ChunkedBinaryStream([b"123", b"45"]),
+                archive_limits=SandboxArchiveLimits(
+                    max_input_bytes=4,
+                    max_extracted_bytes=None,
+                    max_members=None,
+                ),
+            )
 
         assert exc_info.value.context["reason"] == "archive input size exceeds limit"
         assert exc_info.value.context["limit"] == 4
@@ -215,15 +264,21 @@ async def test_extract_rejects_archive_input_over_limit(
 
 @pytest.mark.asyncio
 async def test_extract_tar_rejects_extracted_bytes_over_limit(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_EXTRACTED_BYTES", 4)
     session = _build_session(tmp_path)
     await session.start()
     try:
         with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
-            await session.extract("bundle.tar", _tar_bytes(members={"large.txt": b"12345"}))
+            await session.extract(
+                "bundle.tar",
+                _tar_bytes(members={"large.txt": b"12345"}),
+                archive_limits=SandboxArchiveLimits(
+                    max_input_bytes=None,
+                    max_extracted_bytes=4,
+                    max_members=None,
+                ),
+            )
 
         assert exc_info.value.context["member"] == "large.txt"
         assert exc_info.value.context["reason"] == "archive extracted size exceeds limit"
@@ -238,15 +293,21 @@ async def test_extract_tar_rejects_extracted_bytes_over_limit(
 
 @pytest.mark.asyncio
 async def test_extract_zip_rejects_extracted_bytes_over_limit(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_EXTRACTED_BYTES", 4)
     session = _build_session(tmp_path)
     await session.start()
     try:
         with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
-            await session.extract("bundle.zip", _zip_bytes(members={"large.txt": b"12345"}))
+            await session.extract(
+                "bundle.zip",
+                _zip_bytes(members={"large.txt": b"12345"}),
+                archive_limits=SandboxArchiveLimits(
+                    max_input_bytes=None,
+                    max_extracted_bytes=4,
+                    max_members=None,
+                ),
+            )
 
         assert exc_info.value.context["member"] == "large.txt"
         assert exc_info.value.context["reason"] == "archive extracted size exceeds limit"
@@ -264,7 +325,6 @@ async def test_extract_tar_rejects_member_count_over_limit(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_MEMBERS", 1)
     data = _tar_bytes(members={"one.txt": b"1", "two.txt": b"2"})
 
     def fail_getmembers(_self: tarfile.TarFile) -> list[tarfile.TarInfo]:
@@ -276,7 +336,15 @@ async def test_extract_tar_rejects_member_count_over_limit(
     await session.start()
     try:
         with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
-            await session.extract("bundle.tar", data)
+            await session.extract(
+                "bundle.tar",
+                data,
+                archive_limits=SandboxArchiveLimits(
+                    max_input_bytes=None,
+                    max_extracted_bytes=None,
+                    max_members=1,
+                ),
+            )
 
         assert exc_info.value.context["member"] == "two.txt"
         assert exc_info.value.context["reason"] == "archive member count exceeds limit"
@@ -292,10 +360,8 @@ async def test_extract_tar_rejects_member_count_over_limit(
 
 @pytest.mark.asyncio
 async def test_extract_zip_rejects_member_count_over_limit(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(archive_extraction, "MAX_ARCHIVE_MEMBERS", 1)
     session = _build_session(tmp_path)
     await session.start()
     try:
@@ -303,6 +369,11 @@ async def test_extract_zip_rejects_member_count_over_limit(
             await session.extract(
                 "bundle.zip",
                 _zip_bytes(members={"one.txt": b"1", "two.txt": b"2"}),
+                archive_limits=SandboxArchiveLimits(
+                    max_input_bytes=None,
+                    max_extracted_bytes=None,
+                    max_members=1,
+                ),
             )
 
         assert exc_info.value.context["member"] == "two.txt"
@@ -315,6 +386,128 @@ async def test_extract_zip_rejects_member_count_over_limit(
     workspace = Path(session.state.manifest.root)
     assert not (workspace / "one.txt").exists()
     assert not (workspace / "two.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_extract_archive_limits_none_disables_only_selected_limits(
+    tmp_path: Path,
+) -> None:
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        await session.extract(
+            "bundle.tar",
+            _tar_bytes(members={"large.txt": b"12345"}),
+            archive_limits=SandboxArchiveLimits(
+                max_input_bytes=None,
+                max_extracted_bytes=None,
+                max_members=1,
+            ),
+        )
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert (workspace / "large.txt").read_text(encoding="utf-8") == "12345"
+
+
+@pytest.mark.asyncio
+async def test_extract_archive_limits_per_call_override_session_default(
+    tmp_path: Path,
+) -> None:
+    session = _build_session(tmp_path)
+    session._set_archive_limits(
+        SandboxArchiveLimits(max_input_bytes=None, max_extracted_bytes=None, max_members=1)
+    )
+    await session.start()
+    try:
+        await session.extract(
+            "bundle.tar",
+            _tar_bytes(members={"one.txt": b"1", "two.txt": b"2"}),
+            archive_limits=SandboxArchiveLimits(
+                max_input_bytes=None,
+                max_extracted_bytes=None,
+                max_members=2,
+            ),
+        )
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert (workspace / "one.txt").read_text(encoding="utf-8") == "1"
+    assert (workspace / "two.txt").read_text(encoding="utf-8") == "2"
+
+
+@pytest.mark.asyncio
+async def test_extract_uses_session_default_archive_limits(
+    tmp_path: Path,
+) -> None:
+    session = _build_session(tmp_path)
+    session._set_archive_limits(
+        SandboxArchiveLimits(max_input_bytes=None, max_extracted_bytes=None, max_members=1)
+    )
+    await session.start()
+    try:
+        with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
+            await session.extract(
+                "bundle.tar",
+                _tar_bytes(members={"one.txt": b"1", "two.txt": b"2"}),
+            )
+
+        assert exc_info.value.context["member"] == "two.txt"
+        assert exc_info.value.context["reason"] == "archive member count exceeds limit"
+        assert exc_info.value.context["limit"] == 1
+        assert exc_info.value.context["actual"] == 2
+    finally:
+        await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_extract_archive_limits_object_with_all_none_overrides_session_default(
+    tmp_path: Path,
+) -> None:
+    session = _build_session(tmp_path)
+    session._set_archive_limits(
+        SandboxArchiveLimits(max_input_bytes=None, max_extracted_bytes=None, max_members=1)
+    )
+    await session.start()
+    try:
+        await session.extract(
+            "bundle.tar",
+            _tar_bytes(members={"one.txt": b"1", "two.txt": b"2"}),
+            archive_limits=SandboxArchiveLimits(
+                max_input_bytes=None,
+                max_extracted_bytes=None,
+                max_members=None,
+            ),
+        )
+    finally:
+        await session.shutdown()
+
+    workspace = Path(session.state.manifest.root)
+    assert (workspace / "one.txt").read_text(encoding="utf-8") == "1"
+    assert (workspace / "two.txt").read_text(encoding="utf-8") == "2"
+
+
+@pytest.mark.asyncio
+async def test_extract_rejects_invalid_per_call_archive_limits(
+    tmp_path: Path,
+) -> None:
+    limits = SandboxArchiveLimits(max_input_bytes=1)
+    limits.max_input_bytes = 0
+    session = _build_session(tmp_path)
+    await session.start()
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            await session.extract(
+                "bundle.tar",
+                _tar_bytes(members={"one.txt": b"1"}),
+                archive_limits=limits,
+            )
+
+        assert str(exc_info.value) == "archive_limits.max_input_bytes must be at least 1"
+    finally:
+        await session.shutdown()
 
 
 class _NoSeekableZipStream(io.IOBase):

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -34,6 +34,7 @@ from agents.sandbox import (
     Manifest,
     Permissions,
     SandboxAgent,
+    SandboxArchiveLimits,
     SandboxConcurrencyLimits,
     SandboxPathGrant,
     SandboxRunConfig,
@@ -114,11 +115,16 @@ class _FakeSession(BaseSandboxSession):
         self.stop_calls = 0
         self.shutdown_calls = 0
         self.close_dependency_calls = 0
+        self.archive_limit_values: list[SandboxArchiveLimits | None] = []
         self.concurrency_limit_values: list[SandboxConcurrencyLimits] = []
 
     def _set_concurrency_limits(self, limits: SandboxConcurrencyLimits) -> None:
         super()._set_concurrency_limits(limits)
         self.concurrency_limit_values.append(limits)
+
+    def _set_archive_limits(self, limits: SandboxArchiveLimits | None) -> None:
+        super()._set_archive_limits(limits)
+        self.archive_limit_values.append(limits)
 
     async def start(self) -> None:
         self.start_calls += 1
@@ -2844,6 +2850,95 @@ async def test_session_manager_passes_concurrency_limits_from_run_config(
     assert live_session.concurrency_limit_values == [
         SandboxConcurrencyLimits(manifest_entries=2, local_dir_files=3)
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["create", "resume", "live_session"])
+async def test_session_manager_passes_archive_limits_from_run_config(
+    source: str,
+) -> None:
+    agent = SandboxAgent(name="worker", model=FakeModel(), instructions="Worker.")
+    live_session = _FakeSession(Manifest())
+    client = _FakeClient(live_session)
+    archive_limits = SandboxArchiveLimits(
+        max_input_bytes=10,
+        max_extracted_bytes=20,
+        max_members=30,
+    )
+
+    if source == "live_session":
+        sandbox_config = SandboxRunConfig(
+            session=live_session,
+            archive_limits=archive_limits,
+        )
+    elif source == "resume":
+        sandbox_config = SandboxRunConfig(
+            client=client,
+            session_state=TestSessionState(
+                manifest=Manifest(),
+                snapshot=NoopSnapshot(id="resume"),
+            ),
+            options={"image": "sandbox"},
+            archive_limits=archive_limits,
+        )
+    else:
+        sandbox_config = SandboxRunConfig(
+            client=client,
+            options={"image": "sandbox"},
+            archive_limits=archive_limits,
+        )
+
+    manager = SandboxRuntimeSessionManager(
+        starting_agent=agent,
+        sandbox_config=sandbox_config,
+        run_state=None,
+    )
+
+    manager.acquire_agent(agent)
+    await manager.ensure_session(agent=agent, capabilities=[], is_resumed_state=source == "resume")
+
+    assert live_session.archive_limit_values == [archive_limits]
+
+
+@pytest.mark.asyncio
+async def test_session_manager_default_archive_limits_preserves_no_resource_limits() -> None:
+    agent = SandboxAgent(name="worker", model=FakeModel(), instructions="Worker.")
+    live_session = _FakeSession(Manifest())
+    client = _FakeClient(live_session)
+    manager = SandboxRuntimeSessionManager(
+        starting_agent=agent,
+        sandbox_config=SandboxRunConfig(client=client, options={"image": "sandbox"}),
+        run_state=None,
+    )
+
+    manager.acquire_agent(agent)
+    await manager.ensure_session(agent=agent, capabilities=[], is_resumed_state=False)
+
+    assert live_session.archive_limit_values == [None]
+
+
+@pytest.mark.asyncio
+async def test_session_manager_rejects_invalid_archive_limits() -> None:
+    agent = SandboxAgent(name="worker", model=FakeModel(), instructions="Worker.")
+    client = _FakeClient(_FakeSession(Manifest()))
+    limits = SandboxArchiveLimits(max_input_bytes=1)
+    limits.max_input_bytes = 0
+    manager = SandboxRuntimeSessionManager(
+        starting_agent=agent,
+        sandbox_config=SandboxRunConfig(
+            client=client,
+            options={"image": "sandbox"},
+            archive_limits=limits,
+        ),
+        run_state=None,
+    )
+
+    manager.acquire_agent(agent)
+    with pytest.raises(ValueError) as exc_info:
+        await manager.ensure_session(agent=agent, capabilities=[], is_resumed_state=False)
+
+    assert str(exc_info.value) == "archive_limits.max_input_bytes must be at least 1"
+    assert client.create_kwargs is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary


- Add an archive input byte limit to public `extract_archive()`.
- Preflight tar/zip member count and declared extracted-byte totals before writing extracted payloads.
- Add small-limit regression tests for input size, tar/zip extracted bytes, and tar/zip member count.

### Test plan

- `uv run pytest tests/sandbox/test_extract.py -k "extract"`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3274

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
