### PR TITLE
fix: #3280 streaming guardrail exception cleanup

### DIFF
--- a/src/agents/run_internal/guardrails.py
+++ b/src/agents/run_internal/guardrails.py
@@ -95,9 +95,11 @@ async def run_input_guardrails_with_queue(
                     _error_tracing.attach_error_to_current_span(span_error)
                 break
             queue.put_nowait(result)
-    except Exception:
+    except BaseException:
         for t in guardrail_tasks:
-            t.cancel()
+            if not t.done():
+                t.cancel()
+        await asyncio.gather(*guardrail_tasks, return_exceptions=True)
         raise
 
     streamed_result.input_guardrail_results = (

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -385,7 +385,7 @@ async def _run_output_guardrails_for_stream(
         raise
     except Exception:
         logger.error("Unexpected error in output guardrails", exc_info=True)
-        return []
+        raise
 
 
 async def _finalize_streamed_final_output(

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -1427,6 +1427,31 @@ async def test_output_guardrail_tripwire_raises_from_run_loop_task_before_stream
 
 
 @pytest.mark.asyncio
+async def test_output_guardrail_exception_raises_from_run_loop_task_before_stream_consumption():
+    def guardrail_function(
+        context: RunContextWrapper[Any], agent: Agent[Any], agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        raise RuntimeError("guardrail failed")
+
+    model = FakeModel(initial_output=[get_text_message("first_test")])
+
+    agent = Agent(
+        name="test",
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+        model=model,
+    )
+
+    result = Runner.run_streamed(agent, input="user_message")
+
+    assert result.run_loop_task is not None
+    with pytest.raises(RuntimeError, match="guardrail failed"):
+        await result.run_loop_task
+
+    assert result.final_output is None
+    assert result.is_complete is True
+
+
+@pytest.mark.asyncio
 async def test_run_input_guardrail_tripwire_triggered_causes_exception_streamed():
     def guardrail_function(
         context: RunContextWrapper[Any], agent: Agent[Any], input: Any

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -21,6 +21,8 @@ from agents import (
     function_tool,
 )
 from agents.guardrail import input_guardrail, output_guardrail
+from agents.result import RunResultStreaming
+from agents.run_internal.guardrails import run_input_guardrails_with_queue
 
 from .fake_model import FakeModel
 from .test_responses import get_function_tool_call, get_text_message
@@ -1640,3 +1642,62 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
     assert model.first_turn_args is None, (
         "Model should not have been called when guardrail triggered"
     )
+
+
+@pytest.mark.asyncio
+async def test_streaming_input_guardrail_exception_awaits_cancelled_siblings():
+    slow_started = asyncio.Event()
+    slow_cleanup_finished = False
+
+    async def slow_guardrail(
+        ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        nonlocal slow_cleanup_finished
+        slow_started.set()
+        try:
+            await asyncio.sleep(LONG_DELAY)
+            return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+        except asyncio.CancelledError:
+            await asyncio.sleep(SHORT_DELAY)
+            slow_cleanup_finished = True
+            raise
+
+    async def raising_guardrail(
+        ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        await slow_started.wait()
+        raise RuntimeError("guardrail failed")
+
+    agent = Agent(name="test_agent", model=FakeModel())
+    context = RunContextWrapper(context=None)
+    streamed_result = RunResultStreaming(
+        "test input",
+        [],
+        [],
+        None,
+        [],
+        [],
+        [],
+        [],
+        context,
+        agent,
+        0,
+        None,
+        None,
+        None,
+    )
+
+    with pytest.raises(RuntimeError, match="guardrail failed"):
+        await run_input_guardrails_with_queue(
+            agent=agent,
+            guardrails=[
+                InputGuardrail(guardrail_function=slow_guardrail),
+                InputGuardrail(guardrail_function=raising_guardrail),
+            ],
+            input="test input",
+            context=context,
+            streamed_result=streamed_result,
+            parent_span=None,
+        )
+
+    assert slow_cleanup_finished is True


### PR DESCRIPTION
### Summary

This pull request fixes two streaming guardrail exception handling paths:

- re-raises ordinary output guardrail exceptions from `_run_output_guardrails_for_stream()` instead of logging and treating them as no guardrail results
- awaits cancelled sibling tasks in `run_input_guardrails_with_queue()` before re-raising ordinary exceptions or cancellation

### Test plan

- `uv run pytest tests/test_guardrails.py -k "streaming_input_guardrail_exception_awaits_cancelled_siblings"`
- `uv run pytest tests/test_agent_runner_streamed.py -k "output_guardrail_exception_raises_from_run_loop_task_before_stream_consumption"`
- `uv run pytest tests/test_guardrails.py tests/test_agent_runner_streamed.py -k "guardrail"`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3280

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass