### PR TITLE
fix: #3282 reject unsupported Chat Completions reusable prompts

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -66,6 +66,16 @@ class OpenAIChatCompletionsModel(Model):
     def _supports_default_prompt_cache_key(self) -> bool:
         return ChatCmplHelpers.is_openai(self._get_client())
 
+    def _validate_prompt_is_supported(self, prompt: ResponsePromptParam | None) -> None:
+        if prompt is None:
+            return
+
+        raise UserError(
+            "Reusable prompts are only supported by the Responses API. "
+            "OpenAIChatCompletionsModel does not support `prompt`; use a Responses model "
+            "instead."
+        )
+
     def get_retry_advice(self, request: ModelRetryAdviceRequest) -> ModelRetryAdvice | None:
         return get_openai_retry_advice(request)
 
@@ -120,6 +130,8 @@ class OpenAIChatCompletionsModel(Model):
             previous_response_id=previous_response_id,
             conversation_id=conversation_id,
         )
+        self._validate_prompt_is_supported(prompt)
+
         with generation_span(
             model=str(self.model),
             model_config=model_settings.to_json_dict() | {"base_url": str(self._client.base_url)},
@@ -248,6 +260,8 @@ class OpenAIChatCompletionsModel(Model):
             previous_response_id=previous_response_id,
             conversation_id=conversation_id,
         )
+        self._validate_prompt_is_supported(prompt)
+
         with generation_span(
             model=str(self.model),
             model_config=model_settings.to_json_dict() | {"base_url": str(self._client.base_url)},
@@ -361,6 +375,7 @@ class OpenAIChatCompletionsModel(Model):
         stream: bool = False,
         prompt: ResponsePromptParam | None = None,
     ) -> ChatCompletion | tuple[Response, AsyncStream[ChatCompletionChunk]]:
+        self._validate_prompt_is_supported(prompt)
         self._validate_official_openai_input_content_types(input)
         converted_messages = Converter.items_to_messages(
             input,

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -192,6 +192,30 @@ async def test_get_response_rejects_server_managed_conversation_state(
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_get_response_rejects_prompt(monkeypatch) -> None:
+    async def patched_fetch_response(self, *args, **kwargs):
+        raise AssertionError("_fetch_response should not run when prompt is unsupported")
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    with pytest.raises(UserError, match="Reusable prompts"):
+        await model.get_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=cast(Any, {"id": "pmpt_123"}),
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_get_response_attaches_logprobs(monkeypatch) -> None:
     msg = ChatCompletionMessage(role="assistant", content="Hi!")
     choice = Choice(

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+from typing import Any, cast
 
 import pytest
 from openai.types.chat.chat_completion_chunk import (
@@ -177,6 +178,31 @@ async def test_stream_response_rejects_server_managed_conversation_state(
 
     assert expected_param in str(exc_info.value)
     assert called is False
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_rejects_prompt(monkeypatch) -> None:
+    async def patched_fetch_response(self, *args, **kwargs):
+        raise AssertionError("_fetch_response should not run when prompt is unsupported")
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    with pytest.raises(UserError, match="Reusable prompts"):
+        async for _ in model.stream_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=cast(Any, {"id": "pmpt_123"}),
+        ):
+            pass
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

Make `OpenAIChatCompletionsModel` reject reusable `prompt` values with a clear `UserError` instead of accepting and dropping them before `chat.completions.create()`.

This keeps the existing `prompt=None` path unchanged and covers both non-streaming and streaming Chat Completions calls. I also checked the adjacent Responses model path, which already sends `prompt`, and the related server-managed state issue #3275 / PR #3279, which is a separate unsupported-parameter case.

### Test plan

- `uv run pytest tests/models/test_openai_chatcompletions.py tests/models/test_openai_chatcompletions_stream.py -k "rejects_prompt"`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3282

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
