### PR TITLE
fix: #3284 wake realtime event iterators on close

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -70,6 +70,13 @@ from .model_inputs import (
 REJECTION_MESSAGE = DEFAULT_APPROVAL_REJECTION_MESSAGE
 
 
+class _RealtimeSessionClosedSentinel:
+    pass
+
+
+_REALTIME_SESSION_CLOSED_SENTINEL = _RealtimeSessionClosedSentinel()
+
+
 def _serialize_tool_output(output: Any) -> str:
     """Serialize structured tool outputs to JSON when possible."""
     if isinstance(output, str):
@@ -143,7 +150,10 @@ class RealtimeSession(RealtimeModelListener):
             **(run_config_settings or {}),
             **(initial_model_settings or {}),
         }
-        self._event_queue: asyncio.Queue[RealtimeSessionEvent] = asyncio.Queue()
+        self._event_queue: asyncio.Queue[RealtimeSessionEvent | _RealtimeSessionClosedSentinel] = (
+            asyncio.Queue()
+        )
+        self._event_iterator_waiters = 0
         self._closed = False
         self._stored_exception: BaseException | None = None
         self._pending_tool_calls: dict[
@@ -206,7 +216,10 @@ class RealtimeSession(RealtimeModelListener):
 
     async def __aiter__(self) -> AsyncIterator[RealtimeSessionEvent]:
         """Iterate over events from the session."""
-        while not self._closed:
+        while True:
+            if self._closed and self._event_queue.empty():
+                return
+
             try:
                 # Check if there's a stored exception to raise
                 if self._stored_exception is not None:
@@ -214,8 +227,14 @@ class RealtimeSession(RealtimeModelListener):
                     await self._cleanup()
                     raise self._stored_exception
 
-                event = await self._event_queue.get()
-                yield event
+                self._event_iterator_waiters += 1
+                try:
+                    event = await self._event_queue.get()
+                finally:
+                    self._event_iterator_waiters -= 1
+                if event is _REALTIME_SESSION_CLOSED_SENTINEL:
+                    return
+                yield cast(RealtimeSessionEvent, event)
             except asyncio.CancelledError:
                 break
 
@@ -1039,8 +1058,16 @@ class RealtimeSession(RealtimeModelListener):
                 task.cancel()
         self._tool_call_tasks.clear()
 
+    def _wake_event_iterators(self) -> None:
+        for _ in range(self._event_iterator_waiters):
+            self._event_queue.put_nowait(_REALTIME_SESSION_CLOSED_SENTINEL)
+
     async def _cleanup(self) -> None:
         """Clean up all resources and mark session as closed."""
+        if self._closed:
+            self._wake_event_iterators()
+            return
+
         # Cancel and cleanup guardrail tasks
         self._cleanup_guardrail_tasks()
         self._cleanup_tool_call_tasks()
@@ -1056,6 +1083,7 @@ class RealtimeSession(RealtimeModelListener):
 
         # Mark as closed
         self._closed = True
+        self._wake_event_iterators()
 
     async def _get_updated_model_settings_from_agent(
         self,

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -128,6 +128,30 @@ async def test_aiter_cancel_breaks_loop_gracefully():
 
 
 @pytest.mark.asyncio
+async def test_aiter_exits_waiting_iterators_when_session_closes():
+    model = _DummyModel()
+    agent = RealtimeAgent(name="agent")
+    session = RealtimeSession(model, agent, None)
+
+    iterators = [session.__aiter__(), session.__aiter__()]
+    next_events = [asyncio.ensure_future(iterator.__anext__()) for iterator in iterators]
+    await asyncio.sleep(0.01)
+
+    await session.close()
+
+    done, pending = await asyncio.wait(set(next_events), timeout=0.1)
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+
+    assert done == set(next_events)
+    assert not pending
+    for task in next_events:
+        with pytest.raises(StopAsyncIteration):
+            task.result()
+
+
+@pytest.mark.asyncio
 async def test_transcription_completed_adds_new_user_item():
     model = _DummyModel()
     agent = RealtimeAgent(name="agent")


### PR DESCRIPTION
### Summary

Wake realtime event iterators that are blocked in `RealtimeSession.__aiter__()` when the session closes.

The fix uses a private queue sentinel so normal close does not surface as a public error event. It tracks current iterator waiters so multiple simultaneous consumers are woken, while repeated close calls without waiters do not accumulate internal sentinel items. Cancellation behavior remains unchanged.

### Test plan

- `uv run pytest tests/realtime/test_session.py -k "aiter_exits_waiting_iterators_when_session_closes"`
- `uv run pyright --project pyrightconfig.json`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3284

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
