### PR TITLE
fix: #3286 send realtime output for unknown tool calls

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -723,10 +723,18 @@ class RealtimeSession(RealtimeModelListener):
                 )
             )
         else:
+            error_message = f"Tool {event.name} not found"
+            await self._model.send_event(
+                RealtimeModelSendToolOutput(
+                    tool_call=event,
+                    output=error_message,
+                    start_response=True,
+                )
+            )
             await self._put_event(
                 RealtimeError(
                     info=self._event_info,
-                    error={"message": f"Tool {event.name} not found"},
+                    error={"message": error_message},
                 )
             )
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1264,7 +1264,7 @@ class TestToolCallExecution:
 
     @pytest.mark.asyncio
     async def test_unknown_tool_handling(self, mock_model, mock_agent, mock_function_tool):
-        """Test that unknown tools emit a RealtimeError event"""
+        """Test that unknown tools complete the model call and emit a RealtimeError event"""
         # Set up agent to return different tool than what's called
         mock_function_tool.name = "known_tool"
         mock_agent.get_all_tools.return_value = [mock_function_tool]
@@ -1276,8 +1276,14 @@ class TestToolCallExecution:
             name="unknown_tool", call_id="call_unknown", arguments="{}"
         )
 
-        # Should emit a RealtimeError event for unknown tool
         await session._handle_tool_call(tool_call_event)
+
+        # Should complete the model-visible tool call with an error output
+        assert len(mock_model.sent_tool_outputs) == 1
+        sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
+        assert sent_call == tool_call_event
+        assert "Tool unknown_tool not found" in sent_output
+        assert start_response is True
 
         # Should have emitted a RealtimeError event
         assert session._event_queue.qsize() >= 1


### PR DESCRIPTION
### Summary

Send a model-visible error tool output when realtime receives a tool call whose name is not available on the current agent.

Known function tools, rejected tools, and handoffs already complete model-visible tool calls with `RealtimeModelSendToolOutput`. This change makes the unknown-tool branch do the same with `start_response=True`, while preserving the existing local `RealtimeError` event for application observers.

### Test plan

- `uv run pytest tests/realtime/test_session.py -k "unknown_tool_handling"`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3286

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
