### PR TITLE
fix: #3288 normalize RunState guardrail payloads

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1554,11 +1554,11 @@ def _serialize_guardrail_results(
             },
             "output": {
                 "tripwireTriggered": result.output.tripwire_triggered,
-                "outputInfo": result.output.output_info,
+                "outputInfo": _ensure_json_compatible(result.output.output_info),
             },
         }
         if isinstance(result, OutputGuardrailResult):
-            entry["agentOutput"] = result.agent_output
+            entry["agentOutput"] = _ensure_json_compatible(result.agent_output)
             entry["agent"] = _serialize_agent_reference(
                 result.agent,
                 agent_identity_keys_by_id=agent_identity_keys_by_id,
@@ -1584,7 +1584,7 @@ def _serialize_tool_guardrail_results(
             {
                 "guardrail": {"type": type_label, "name": guardrail_name},
                 "output": {
-                    "outputInfo": result.output.output_info,
+                    "outputInfo": _ensure_json_compatible(result.output.output_info),
                     "behavior": result.output.behavior,
                 },
             }

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -1022,6 +1022,59 @@ class TestRunState:
         assert restored_output.agent_output == "final"
         assert restored_output.agent.name == agent.name
 
+    def test_guardrail_results_to_string_normalizes_non_json_payloads(self):
+        """Guardrail result payloads are JSON-compatible in RunState strings."""
+        context: RunContextWrapper[dict[str, Any]] = RunContextWrapper(context={})
+        agent = Agent(name="GuardrailPayloadAgent")
+        state = make_state(agent, context=context, original_input="input", max_turns=1)
+        observed_at = datetime(2026, 5, 8, 12, 0, 0)
+
+        input_guardrail = InputGuardrail(
+            guardrail_function=lambda ctx, ag, inp: GuardrailFunctionOutput(
+                output_info={"observed_at": observed_at},
+                tripwire_triggered=False,
+            ),
+            name="input_guardrail",
+        )
+        output_guardrail = OutputGuardrail(
+            guardrail_function=lambda ctx, ag, out: GuardrailFunctionOutput(
+                output_info={"observed_at": observed_at},
+                tripwire_triggered=False,
+            ),
+            name="output_guardrail",
+        )
+
+        state._input_guardrail_results = [
+            InputGuardrailResult(
+                guardrail=input_guardrail,
+                output=GuardrailFunctionOutput(
+                    output_info={"observed_at": observed_at},
+                    tripwire_triggered=False,
+                ),
+            )
+        ]
+        state._output_guardrail_results = [
+            OutputGuardrailResult(
+                guardrail=output_guardrail,
+                agent_output={"observed_at": observed_at},
+                agent=agent,
+                output=GuardrailFunctionOutput(
+                    output_info={"observed_at": observed_at},
+                    tripwire_triggered=False,
+                ),
+            )
+        ]
+
+        state_string = state.to_string()
+        serialized = json.loads(state_string)
+
+        assert serialized["input_guardrail_results"][0]["output"]["outputInfo"] == {
+            "observed_at": str(observed_at)
+        }
+        output_result = serialized["output_guardrail_results"][0]
+        assert output_result["output"]["outputInfo"] == {"observed_at": str(observed_at)}
+        assert output_result["agentOutput"] == {"observed_at": str(observed_at)}
+
     @pytest.mark.asyncio
     async def test_tool_guardrail_results_round_trip(self):
         """Tool guardrail results survive RunState round-trip."""
@@ -1076,6 +1129,57 @@ class TestRunState:
         assert restored_tool_output.guardrail.get_name() == "tool_output_guardrail"
         assert restored_tool_output.output.behavior["type"] == "allow"
         assert restored_tool_output.output.output_info == {"output": "info"}
+
+    def test_tool_guardrail_results_to_string_normalizes_non_json_output_info(self):
+        """Tool guardrail output_info is JSON-compatible in RunState strings."""
+        context: RunContextWrapper[dict[str, Any]] = RunContextWrapper(context={})
+        agent = Agent(name="ToolGuardrailPayloadAgent")
+        state = make_state(agent, context=context, original_input="input", max_turns=1)
+        observed_at = datetime(2026, 5, 8, 12, 0, 0)
+
+        tool_input_guardrail: ToolInputGuardrail[Any] = ToolInputGuardrail(
+            guardrail_function=lambda data: ToolGuardrailFunctionOutput(
+                output_info={"observed_at": observed_at},
+                behavior=AllowBehavior(type="allow"),
+            ),
+            name="tool_input_guardrail",
+        )
+        tool_output_guardrail: ToolOutputGuardrail[Any] = ToolOutputGuardrail(
+            guardrail_function=lambda data: ToolGuardrailFunctionOutput(
+                output_info={"observed_at": observed_at},
+                behavior=AllowBehavior(type="allow"),
+            ),
+            name="tool_output_guardrail",
+        )
+
+        state._tool_input_guardrail_results = [
+            ToolInputGuardrailResult(
+                guardrail=tool_input_guardrail,
+                output=ToolGuardrailFunctionOutput(
+                    output_info={"observed_at": observed_at},
+                    behavior=AllowBehavior(type="allow"),
+                ),
+            )
+        ]
+        state._tool_output_guardrail_results = [
+            ToolOutputGuardrailResult(
+                guardrail=tool_output_guardrail,
+                output=ToolGuardrailFunctionOutput(
+                    output_info={"observed_at": observed_at},
+                    behavior=AllowBehavior(type="allow"),
+                ),
+            )
+        ]
+
+        state_string = state.to_string()
+        serialized = json.loads(state_string)
+
+        assert serialized["tool_input_guardrail_results"][0]["output"]["outputInfo"] == {
+            "observed_at": str(observed_at)
+        }
+        assert serialized["tool_output_guardrail_results"][0]["output"]["outputInfo"] == {
+            "observed_at": str(observed_at)
+        }
 
     def test_reject_permanently_when_always_reject_option_is_passed(self):
         """Test that reject with always_reject=True sets permanent rejection."""


### PR DESCRIPTION
### Summary

- Normalize RunState guardrail result payloads so guardrail `outputInfo`, output guardrail `agentOutput`, and tool guardrail `outputInfo` remain JSON-compatible.
- Add regression coverage for non-JSON guardrail payloads using `datetime` values in input/output guardrails and tool input/output guardrails.

### Test plan

- `uv run pytest tests/test_run_state.py -k guardrail_results_to_string_normalizes_non_json`
- `uv run pytest tests/test_run_state.py -k guardrail_results`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3288

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation ()
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
