### PR TITLE
fix: guard no-op tracing span IDs

### DIFF
--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -41,6 +41,20 @@ def _safe_debug(message: str) -> None:
         return
 
 
+def _is_noop_id(value: str | None) -> bool:
+    return value == "no-op"
+
+
+def _is_noop_span(span: Span[Any] | None) -> bool:
+    return isinstance(span, NoOpSpan) or (
+        span is not None and (_is_noop_id(span.span_id) or _is_noop_id(span.trace_id))
+    )
+
+
+def _is_noop_trace(trace: Trace | None) -> bool:
+    return isinstance(trace, NoOpTrace) or (trace is not None and _is_noop_id(trace.trace_id))
+
+
 class SynchronousMultiTracingProcessor(TracingProcessor):
     """
     Forwards all calls to a list of TracingProcessors, in order of registration.
@@ -325,17 +339,20 @@ class DefaultTraceProvider(TraceProvider):
         if self._disabled or disabled:
             logger.debug(f"Tracing is disabled. Not creating span {span_data}")
             return NoOpSpan(span_data)
+        if _is_noop_id(span_id):
+            logger.debug("Span id is no-op, returning NoOpSpan")
+            return NoOpSpan(span_data)
 
         if not parent:
             current_span = Scope.get_current_span()
             current_trace = Scope.get_current_trace()
             if current_trace is None:
-                logger.error(
+                _safe_debug(
                     "No active trace. Make sure to start a trace with `trace()` first "
                     "Returning NoOpSpan."
                 )
                 return NoOpSpan(span_data)
-            elif isinstance(current_trace, NoOpTrace) or isinstance(current_span, NoOpSpan):
+            elif _is_noop_trace(current_trace) or _is_noop_span(current_span):
                 logger.debug(
                     f"Parent {current_span} or {current_trace} is no-op, returning NoOpSpan"
                 )
@@ -348,7 +365,7 @@ class DefaultTraceProvider(TraceProvider):
             trace_metadata = getattr(current_trace, "metadata", None)
 
         elif isinstance(parent, Trace):
-            if isinstance(parent, NoOpTrace):
+            if _is_noop_trace(parent):
                 logger.debug(f"Parent {parent} is no-op, returning NoOpSpan")
                 return NoOpSpan(span_data)
             trace_id = parent.trace_id
@@ -357,7 +374,7 @@ class DefaultTraceProvider(TraceProvider):
             # Trace is an interface; custom implementations may omit metadata.
             trace_metadata = getattr(parent, "metadata", None)
         elif isinstance(parent, Span):
-            if isinstance(parent, NoOpSpan):
+            if _is_noop_span(parent):
                 logger.debug(f"Parent {parent} is no-op, returning NoOpSpan")
                 return NoOpSpan(span_data)
             parent_id = parent.span_id

--- a/tests/tracing/test_tracing_env_disable.py
+++ b/tests/tracing/test_tracing_env_disable.py
@@ -1,4 +1,9 @@
+import logging
+
 from agents.tracing.provider import DefaultTraceProvider
+from agents.tracing.scope import Scope
+from agents.tracing.span_data import AgentSpanData
+from agents.tracing.spans import NoOpSpan, SpanImpl
 from agents.tracing.traces import NoOpTrace, TraceImpl
 
 
@@ -54,3 +59,54 @@ def test_manual_override_env_disable(monkeypatch):
     reenabled = provider.create_trace("reenabled")
 
     assert isinstance(reenabled, TraceImpl)
+
+
+def test_missing_active_trace_logs_debug_for_noop_span(caplog):
+    Scope.set_current_trace(None)
+    Scope.set_current_span(None)
+    provider = DefaultTraceProvider()
+
+    with caplog.at_level(logging.DEBUG, logger="openai.agents"):
+        span = provider.create_span(AgentSpanData(name="missing-trace"))
+
+    assert isinstance(span, NoOpSpan)
+    assert "No active trace" in caplog.text
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+
+
+def test_noop_span_id_returns_noop_span_with_active_trace():
+    Scope.set_current_trace(None)
+    Scope.set_current_span(None)
+    provider = DefaultTraceProvider()
+    trace = provider.create_trace("active", trace_id="trace_123")
+    trace_token = Scope.set_current_trace(trace)
+    try:
+        span = provider.create_span(AgentSpanData(name="invalid"), span_id="no-op")
+    finally:
+        Scope.reset_current_trace(trace_token)
+
+    assert isinstance(span, NoOpSpan)
+
+
+def test_noop_current_span_id_does_not_become_parent_id():
+    Scope.set_current_trace(None)
+    Scope.set_current_span(None)
+    provider = DefaultTraceProvider()
+    trace = provider.create_trace("active", trace_id="trace_123")
+    invalid_parent = SpanImpl(
+        trace_id="trace_123",
+        span_id="no-op",
+        parent_id=None,
+        processor=provider._multi_processor,
+        span_data=AgentSpanData(name="invalid-parent"),
+        tracing_api_key=None,
+    )
+    trace_token = Scope.set_current_trace(trace)
+    span_token = Scope.set_current_span(invalid_parent)
+    try:
+        span = provider.create_span(AgentSpanData(name="child"))
+    finally:
+        Scope.reset_current_span(span_token)
+        Scope.reset_current_trace(trace_token)
+
+    assert isinstance(span, NoOpSpan)


### PR DESCRIPTION
This pull request fixes invalid tracing payloads caused by treating `NoOpSpan` sentinel IDs as real span IDs.

The tracing provider now returns `NoOpSpan` when asked to create or parent a span with the `"no-op"` sentinel, preventing invalid `parent_id="no-op"` values from being exported. It also lowers the missing active trace fallback log to debug level and adds regression coverage for both the no-active-trace fallback and no-op parent/span ID cases.