### PR TITLE
chore: improve automated example coverage and local service handling

### DIFF
--- a/.agents/skills/examples-auto-run/SKILL.md
+++ b/.agents/skills/examples-auto-run/SKILL.md
@@ -8,6 +8,8 @@ description: Run python examples in auto mode with logging, rerun helpers, and b
 ## What it does
 
 - Runs `uv run examples/run_examples.py` with:
+  - Optional dependency extras enabled by default:
+    `litellm`, `any-llm`, `sqlalchemy`, `redis`, `blaxel`, `modal`, `runloop`, and `temporal`.
   - `EXAMPLES_INTERACTIVE_MODE=auto` (auto-input/auto-approve).
   - Per-example logs under `.tmp/examples-start-logs/`.
   - Main summary log path passed via `--main-log` (also under `.tmp/examples-start-logs/`).
@@ -44,6 +46,16 @@ description: Run python examples in auto mode with logging, rerun helpers, and b
 .agents/skills/examples-auto-run/scripts/run.sh rerun
 ```
 
+## Codex execution environment
+
+- When Codex invokes `start` or `rerun`, run the command outside the Codex sandbox by default
+  (`sandbox_permissions=require_escalated`). Many examples start nested sandboxes, browsers, npm
+  helpers, or cloud/local service processes; running from inside the Codex sandbox can produce
+  environment-only failures such as `sandbox-exec: sandbox_apply: Operation not permitted`,
+  Playwright cache permission errors, or npm cache permission errors.
+- Use sandboxed execution only when the user explicitly asks for it or when running a narrow dry-run
+  / log inspection command that does not execute examples.
+
 ## Defaults (overridable via env)
 
 - `EXAMPLES_INTERACTIVE_MODE=auto`
@@ -51,6 +63,7 @@ description: Run python examples in auto mode with logging, rerun helpers, and b
 - `EXAMPLES_INCLUDE_SERVER=0`
 - `EXAMPLES_INCLUDE_AUDIO=0`
 - `EXAMPLES_INCLUDE_EXTERNAL=0`
+- `EXAMPLES_UV_EXTRAS="litellm any-llm sqlalchemy redis blaxel modal runloop temporal"` (set to an empty string to disable extras)
 - Auto-approvals in auto mode: `APPLY_PATCH_AUTO_APPROVE=1`, `SHELL_AUTO_APPROVE=1`, `AUTO_APPROVE_MCP=1`
 
 ## Log locations
@@ -62,7 +75,7 @@ description: Run python examples in auto mode with logging, rerun helpers, and b
 
 ## Notes
 
-- The runner delegates to `uv run examples/run_examples.py`, which already writes per-example logs and supports `--collect`, `--rerun-file`, and `--print-auto-skip`.
+- The runner delegates to `uv run --extra ... examples/run_examples.py`, which already writes per-example logs and supports `--collect`, `--rerun-file`, and `--print-auto-skip`.
 - `start` uses `--write-rerun` so failures are captured automatically.
 - If `.tmp/examples-rerun.txt` exists and is non-empty, invoking the skill with no args runs `rerun` by default.
 

--- a/.agents/skills/examples-auto-run/scripts/run.sh
+++ b/.agents/skills/examples-auto-run/scripts/run.sh
@@ -5,6 +5,23 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 PID_FILE="$ROOT/.tmp/examples-auto-run.pid"
 LOG_DIR="$ROOT/.tmp/examples-start-logs"
 RERUN_FILE="$ROOT/.tmp/examples-rerun.txt"
+DEFAULT_UV_EXTRAS="litellm any-llm sqlalchemy redis blaxel modal runloop temporal"
+
+build_uv_prefix() {
+  UV_RUN=(uv run)
+  local extras_value
+  if [[ -n "${EXAMPLES_UV_EXTRAS+x}" ]]; then
+    extras_value="$EXAMPLES_UV_EXTRAS"
+  else
+    extras_value="$DEFAULT_UV_EXTRAS"
+  fi
+
+  local extra
+  for extra in $extras_value; do
+    UV_RUN+=(--extra "$extra")
+  done
+  export EXAMPLES_UV_EXTRAS="$extras_value"
+}
 
 ensure_dirs() {
   mkdir -p "$LOG_DIR" "$ROOT/.tmp"
@@ -28,8 +45,9 @@ cmd_start() {
   main_log="$LOG_DIR/main_${ts}.log"
   stdout_log="$LOG_DIR/stdout_${ts}.log"
 
+  build_uv_prefix
   local run_cmd=(
-    uv run examples/run_examples.py
+    "${UV_RUN[@]}" examples/run_examples.py
     --auto-mode
     --write-rerun
     --main-log "$main_log"
@@ -152,7 +170,8 @@ collect_rerun() {
     exit 1
   fi
   cd "$ROOT"
-  uv run examples/run_examples.py --collect "$log_file" --output "$RERUN_FILE"
+  build_uv_prefix
+  "${UV_RUN[@]}" examples/run_examples.py --collect "$log_file" --output "$RERUN_FILE"
 }
 
 cmd_rerun() {
@@ -171,8 +190,9 @@ cmd_rerun() {
   export APPLY_PATCH_AUTO_APPROVE="${APPLY_PATCH_AUTO_APPROVE:-1}"
   export SHELL_AUTO_APPROVE="${SHELL_AUTO_APPROVE:-1}"
   export AUTO_APPROVE_MCP="${AUTO_APPROVE_MCP:-1}"
+  build_uv_prefix
   set +e
-  uv run examples/run_examples.py --auto-mode --rerun-file "$file" --write-rerun --main-log "$main_log" --logs-dir "$LOG_DIR" 2>&1 | tee "$stdout_log"
+  "${UV_RUN[@]}" examples/run_examples.py --auto-mode --rerun-file "$file" --write-rerun --main-log "$main_log" --logs-dir "$LOG_DIR" 2>&1 | tee "$stdout_log"
   local run_status=${PIPESTATUS[0]}
   set -e
   return "$run_status"
@@ -194,6 +214,7 @@ Commands:
 Environment overrides:
   EXAMPLES_INTERACTIVE_MODE (default auto)
   EXAMPLES_INCLUDE_SERVER/INTERACTIVE/AUDIO/EXTERNAL (defaults: 0/1/0/0)
+  EXAMPLES_UV_EXTRAS (default: litellm any-llm sqlalchemy redis blaxel modal runloop; set empty to disable)
   APPLY_PATCH_AUTO_APPROVE, SHELL_AUTO_APPROVE, AUTO_APPROVE_MCP (default 1 in auto mode)
 EOF
 }

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,10 @@ cython_debug/
 # Ruff stuff:
 .ruff_cache/
 
+# Example runtime state
+examples/sandbox/extensions/daytona/usaspending_text2sql/.audit_log.jsonl
+examples/sandbox/extensions/daytona/usaspending_text2sql/.session_state.json
+
 # PyPI configuration file
 .pypirc
 .aider*

--- a/examples/financial_research_agent/agents/verifier_agent.py
+++ b/examples/financial_research_agent/agents/verifier_agent.py
@@ -6,8 +6,10 @@ from agents import Agent
 # This can be used to flag potential gaps or obvious mistakes.
 VERIFIER_PROMPT = (
     "You are a meticulous auditor. You have been handed a financial analysis report. "
-    "Your job is to verify the report is internally consistent, clearly sourced, and makes "
-    "no unsupported claims. Point out any issues or uncertainties."
+    "Your job is to verify the report is internally consistent, appropriately caveated, and "
+    "does not rely on obviously unreleased or impossible facts. You are not performing a full "
+    "citation audit because the demo passes synthesized search summaries, not source documents. "
+    "Point out any issues or uncertainties."
 )
 
 

--- a/examples/financial_research_agent/main.py
+++ b/examples/financial_research_agent/main.py
@@ -12,7 +12,8 @@ from .manager import FinancialResearchManager
 async def main() -> None:
     query = input_with_fallback(
         "Enter a financial research query: ",
-        "Write up an analysis of Apple Inc.'s most recent quarter.",
+        "Write a short analysis of Apple's long-term revenue drivers and key risks. "
+        "Avoid making claims about unreleased quarterly results.",
     )
     mgr = FinancialResearchManager()
     await mgr.run(query)

--- a/examples/mcp/manager_example/README.md
+++ b/examples/mcp/manager_example/README.md
@@ -35,6 +35,17 @@ uv run python examples/mcp/manager_example/app.py
 
 The app listens at `http://127.0.0.1:9001`.
 
+## Run the smoke test
+
+To verify the MCP manager and app integration without calling a model:
+
+```
+uv run python -m examples.mcp.manager_example.smoke_test
+```
+
+The smoke test starts the local MCP server on a temporary port, points both app
+MCP server settings at that server, and checks `/health`, `/tools`, and `/add`.
+
 ## Toggle MCP manager usage
 
 By default, the app uses `MCPServerManager`. To disable it:

--- a/examples/mcp/manager_example/smoke_test.py
+++ b/examples/mcp/manager_example/smoke_test.py
@@ -1,0 +1,144 @@
+"""Smoke test for the MCP manager example app.
+
+This script starts the sibling Streamable HTTP MCP server on a temporary local
+port, loads the app with matching environment variables, and verifies the
+manager-backed endpoints without calling a model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import socket
+import subprocess
+import sys
+import time
+from typing import Any, cast
+
+import httpx
+
+HOST = "127.0.0.1"
+PORT_WAIT_SECONDS = 10.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((HOST, 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_port(process: subprocess.Popen[str], port: int) -> None:
+    deadline = time.monotonic() + PORT_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            output, _ = process.communicate(timeout=1)
+            raise RuntimeError(f"MCP server exited before it was ready:\n{output}")
+        try:
+            with socket.create_connection((HOST, port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError(f"MCP server did not listen on {HOST}:{port}.")
+
+
+def _stop_process(process: subprocess.Popen[str]) -> str:
+    if process.poll() is not None:
+        output, _ = process.communicate(timeout=1)
+        return output
+
+    process.terminate()
+    try:
+        output, _ = process.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        output, _ = process.communicate(timeout=5)
+    return output
+
+
+def _start_mcp_server(port: int) -> subprocess.Popen[str]:
+    env = {
+        **os.environ,
+        "STREAMABLE_HTTP_HOST": HOST,
+        "STREAMABLE_HTTP_PORT": str(port),
+    }
+    return subprocess.Popen(
+        [sys.executable, "-u", "-m", "examples.mcp.manager_example.mcp_server"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _load_app_module(mcp_port: int) -> Any:
+    mcp_server_url = f"http://{HOST}:{mcp_port}/mcp"
+    os.environ["MCP_SERVER_URL"] = mcp_server_url
+    # Point both configured MCP servers at the same temporary server so this
+    # smoke test stays on the clean app integration path.
+    os.environ["INACTIVE_MCP_SERVER_URL"] = mcp_server_url
+    os.environ["USE_MCP_MANAGER"] = "1"
+
+    module_name = "examples.mcp.manager_example.app"
+    if module_name in sys.modules:
+        module = importlib.reload(sys.modules[module_name])
+    else:
+        module = importlib.import_module(module_name)
+    return cast(Any, module)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+async def _exercise_app(mcp_port: int) -> None:
+    app_module = _load_app_module(mcp_port)
+    app = app_module.app
+    expected_server_url = f"http://{HOST}:{mcp_port}/mcp"
+
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            health_response = await client.get("/health")
+            health_response.raise_for_status()
+            health = health_response.json()
+            _require(
+                any(expected_server_url in name for name in health["connected_servers"]),
+                f"Expected connected MCP server in health response: {health}",
+            )
+            _require(
+                health["failed_servers"] == [],
+                f"Expected no failed MCP servers in health response: {health}",
+            )
+
+            tools_response = await client.get("/tools")
+            tools_response.raise_for_status()
+            tools = tools_response.json()["tools"]
+            _require({"add", "echo"} <= set(tools), f"Expected add and echo tools: {tools}")
+
+            add_response = await client.post("/add", json={"a": 2, "b": 3})
+            add_response.raise_for_status()
+            add_result = add_response.json()["result"]
+            texts = [
+                item.get("text")
+                for item in add_result.get("content", [])
+                if item.get("type") == "text"
+            ]
+            _require("5" in texts, f"Expected add tool result to include 5: {add_result}")
+
+
+async def main() -> None:
+    mcp_port = _free_port()
+    process = _start_mcp_server(mcp_port)
+    try:
+        _wait_for_port(process, mcp_port)
+        await _exercise_app(mcp_port)
+    finally:
+        _stop_process(process)
+
+    print("MCP manager example smoke test completed successfully.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/mcp/sse_remote_example/main.py
+++ b/examples/mcp/sse_remote_example/main.py
@@ -1,25 +1,99 @@
 import asyncio
+import os
+import shutil
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, cast
 
 from agents import Agent, Runner, gen_trace_id, trace
 from agents.mcp import MCPServerSse
+from agents.model_settings import ModelSettings
+
+SSE_HOST = os.getenv("SSE_HOST", "127.0.0.1")
+REMOTE_SSE_URL = os.getenv("MCP_SSE_REMOTE_URL")
 
 
-async def main():
+def _choose_port() -> int:
+    env_port = os.getenv("SSE_PORT")
+    if env_port:
+        return int(env_port)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((SSE_HOST, 0))
+        address = cast(tuple[str, int], sock.getsockname())
+        return address[1]
+
+
+@contextmanager
+def local_sse_server() -> Iterator[str]:
+    if not shutil.which("uv"):
+        raise RuntimeError(
+            "uv is not installed. Please install it: "
+            "https://docs.astral.sh/uv/getting-started/installation/"
+        )
+
+    sse_port = _choose_port()
+    sse_url = f"http://{SSE_HOST}:{sse_port}/sse"
+    server_file = Path(__file__).resolve().parents[1] / "sse_example" / "server.py"
+
+    print(f"Starting local SSE server at {sse_url} ...", flush=True)
+    env = os.environ.copy()
+    env.setdefault("SSE_HOST", SSE_HOST)
+    env["SSE_PORT"] = str(sse_port)
+    process: subprocess.Popen[Any] | None = None
+
+    try:
+        process = subprocess.Popen(["uv", "run", str(server_file)], env=env)
+        time.sleep(3)
+        yield sse_url
+    finally:
+        if process is not None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
+
+async def run(url: str, name: str) -> None:
     async with MCPServerSse(
-        name="GitMCP SSE Server",
-        params={"url": "https://gitmcp.io/openai/codex"},
+        name=name,
+        params={
+            "url": url,
+            "timeout": 5,
+            "sse_read_timeout": 30,
+        },
     ) as server:
         agent = Agent(
             name="SSE Assistant",
-            instructions="Use the available MCP tools to help the user.",
+            instructions="Use the available MCP tools to answer the user.",
             mcp_servers=[server],
+            model_settings=ModelSettings(tool_choice="required"),
         )
 
         trace_id = gen_trace_id()
         with trace(workflow_name="SSE MCP Server Example", trace_id=trace_id):
             print(f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n")
-            result = await Runner.run(agent, "Please help me with the available tools.")
+            result = await Runner.run(agent, "Use the MCP add tool to add 7 and 22.")
             print(result.final_output)
+
+
+async def main() -> None:
+    if REMOTE_SSE_URL:
+        print(f"Connecting to remote SSE server at {REMOTE_SSE_URL} ...", flush=True)
+        await run(REMOTE_SSE_URL, "Remote SSE Server")
+        return
+
+    print(
+        "MCP_SSE_REMOTE_URL is not set; using the bundled local SSE server for this demo.",
+        flush=True,
+    )
+    with local_sse_server() as url:
+        await run(url, "Local SSE Server")
 
 
 if __name__ == "__main__":

--- a/examples/memory/redis_session_example.py
+++ b/examples/memory/redis_session_example.py
@@ -9,9 +9,12 @@ In production, you may want to preserve existing conversation history.
 """
 
 import asyncio
+import os
 
 from agents import Agent, Runner
 from agents.extensions.memory import RedisSession
+
+DEFAULT_REDIS_URL = "redis://localhost:6379/0"
 
 
 async def main():
@@ -22,8 +25,9 @@ async def main():
     )
 
     print("=== Redis Session Example ===")
-    print("This example requires Redis to be running on localhost:6379")
-    print("Start Redis with: redis-server")
+    redis_url = os.environ.get("REDIS_URL", DEFAULT_REDIS_URL)
+    print(f"This example uses Redis at {redis_url}")
+    print("Set REDIS_URL to use a different Redis server.")
     print()
 
     # Create a Redis session instance
@@ -31,7 +35,7 @@ async def main():
     try:
         session = RedisSession.from_url(
             session_id,
-            url="redis://localhost:6379/0",  # Use database 0
+            url=redis_url,
         )
 
         # Test Redis connectivity
@@ -99,7 +103,7 @@ async def main():
         print("\n=== Session Isolation Demo ===")
         new_session = RedisSession.from_url(
             "different_conversation_456",
-            url="redis://localhost:6379/0",
+            url=redis_url,
         )
 
         print("Creating a new session with different ID...")
@@ -125,7 +129,7 @@ async def main():
         print("\n=== TTL Demo ===")
         ttl_session = RedisSession.from_url(
             "ttl_demo_session",
-            url="redis://localhost:6379/0",
+            url=redis_url,
             ttl=3600,  # 1 hour TTL
         )
 
@@ -143,7 +147,7 @@ async def main():
 
     except Exception as e:
         print(f"Error: {e}")
-        print("Make sure Redis is running on localhost:6379")
+        print(f"Make sure Redis is running and reachable at {redis_url}")
 
 
 async def demonstrate_advanced_features():
@@ -153,7 +157,7 @@ async def demonstrate_advanced_features():
     # Custom key prefix for multi-tenancy
     tenant_session = RedisSession.from_url(
         "user_123",
-        url="redis://localhost:6379/0",
+        url=os.environ.get("REDIS_URL", DEFAULT_REDIS_URL),
         key_prefix="tenant_abc:sessions",  # Custom prefix for isolation
     )
 

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -17,13 +17,18 @@ import functools
 import os
 import re
 import shlex
+import shutil
+import socket
 import subprocess
 import sys
+import tempfile
 import threading
-from collections.abc import Iterable, Sequence
+import time
+from collections.abc import Iterable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 EXAMPLES_DIR = ROOT_DIR / "examples"
@@ -32,6 +37,10 @@ MAIN_PATTERN = re.compile(r"__name__\s*==\s*['\"]__main__['\"]")
 LOG_DIR_DEFAULT = ROOT_DIR / ".tmp" / "examples-start-logs"
 RERUN_FILE_DEFAULT = ROOT_DIR / ".tmp" / "examples-rerun.txt"
 DEFAULT_MAIN_LOG = LOG_DIR_DEFAULT / f"main_{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}.log"
+REDIS_SESSION_EXAMPLE = "examples/memory/redis_session_example.py"
+DAPR_SESSION_EXAMPLE = "examples/memory/dapr_session_example.py"
+DEFAULT_REDIS_URL = "redis://localhost:6379/0"
+LOCAL_REDIS_HOSTS = {"127.0.0.1", "::1", "localhost"}
 
 COMMON_PATH_HINTS = (
     Path.home() / ".local" / "bin",
@@ -66,6 +75,7 @@ DEFAULT_AUTO_SKIP = {
     "examples/realtime/app/server.py",
     "examples/realtime/cli/demo.py",
     "examples/realtime/twilio/server.py",
+    "examples/sandbox/misc/reference_policy_mcp_server.py",
     "examples/sandbox/docker/mounts/azure_mount_read_write.py",
     "examples/sandbox/docker/mounts/gcs_mount_read_write.py",
     "examples/sandbox/docker/mounts/s3_files_mount_read_write.py",
@@ -105,7 +115,7 @@ class ExampleScript:
     @property
     def command(self) -> list[str]:
         # Run via module path so relative imports inside examples work.
-        return ["uv", "run", "python", "-m", self.module]
+        return [*build_uv_run_command(), "python", "-u", "-m", self.module]
 
 
 @dataclass
@@ -117,6 +127,23 @@ class ExampleResult:
     exit_code: int | None = None
 
 
+@dataclass
+class TemporaryRedisServer:
+    process: subprocess.Popen[bytes]
+    temp_dir: tempfile.TemporaryDirectory[str]
+    url: str
+
+    def close(self) -> None:
+        if self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+        self.temp_dir.cleanup()
+
+
 def normalize_relpath(relpath: str) -> str:
     normalized = relpath.replace("\\", "/")
     return str(PurePosixPath(normalized))
@@ -124,6 +151,17 @@ def normalize_relpath(relpath: str) -> str:
 
 def split_path_entries(path_value: str) -> list[str]:
     return [entry for entry in path_value.split(os.pathsep) if entry]
+
+
+def split_words(value: str) -> list[str]:
+    return [entry for entry in value.split() if entry]
+
+
+def build_uv_run_command() -> list[str]:
+    command = ["uv", "run"]
+    for extra in split_words(os.environ.get("EXAMPLES_UV_EXTRAS", "")):
+        command.extend(["--extra", extra])
+    return command
 
 
 def dedupe_existing_paths(paths: Iterable[str]) -> list[str]:
@@ -184,6 +222,151 @@ def build_python_path(base_path: str | None = None) -> str:
     if base_path:
         candidates.extend(split_path_entries(base_path))
     return os.pathsep.join(dedupe_existing_paths(candidates))
+
+
+def choose_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        address = sock.getsockname()
+        return int(address[1])
+
+
+def redis_url_host_port(url: str) -> tuple[str, int] | None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"redis", "rediss"}:
+        return None
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6379
+    return host, port
+
+
+def redis_url_is_local(url: str) -> bool:
+    host_port = redis_url_host_port(url)
+    if host_port is None:
+        return False
+    host, _ = host_port
+    return host in LOCAL_REDIS_HOSTS
+
+
+def redis_ping_url(url: str, timeout: float = 0.5) -> bool:
+    host_port = redis_url_host_port(url)
+    if host_port is None:
+        return False
+    host, port = host_port
+    try:
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            sock.settimeout(timeout)
+            sock.sendall(b"*1\r\n$4\r\nPING\r\n")
+            return sock.recv(16).startswith(b"+PONG")
+    except OSError:
+        return False
+
+
+def truthy_env_value(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def dapr_sidecar_available(env: Mapping[str, str], timeout: float = 0.5) -> bool:
+    endpoint = env.get("DAPR_HTTP_ENDPOINT", "http://127.0.0.1:3500")
+    parsed = urlparse(endpoint)
+    host = parsed.hostname or "127.0.0.1"
+    if parsed.port is not None:
+        port = parsed.port
+    elif parsed.scheme == "https":
+        port = 443
+    else:
+        port = 80
+
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def prerequisite_skip_reasons(
+    relpath: str,
+    *,
+    auto_mode: bool,
+    env: Mapping[str, str],
+) -> set[str]:
+    if not auto_mode:
+        return set()
+    if relpath != DAPR_SESSION_EXAMPLE:
+        return set()
+    if truthy_env_value(env.get("EXAMPLES_FORCE_DAPR")):
+        return set()
+    if dapr_sidecar_available(env):
+        return set()
+    return {"missing-dapr-sidecar"}
+
+
+def start_temporary_redis_server() -> TemporaryRedisServer | None:
+    redis_server = shutil.which("redis-server")
+    if redis_server is None:
+        return None
+
+    port = choose_loopback_port()
+    temp_dir = tempfile.TemporaryDirectory(prefix="examples-redis-")
+    url = f"redis://127.0.0.1:{port}/0"
+    process = subprocess.Popen(
+        [
+            redis_server,
+            "--bind",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--save",
+            "",
+            "--appendonly",
+            "no",
+            "--dir",
+            temp_dir.name,
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    server = TemporaryRedisServer(process=process, temp_dir=temp_dir, url=url)
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            server.close()
+            return None
+        if redis_ping_url(url, timeout=0.2):
+            return server
+        time.sleep(0.1)
+
+    server.close()
+    return None
+
+
+def prepare_redis_for_example(
+    relpath: str,
+    env: dict[str, str],
+) -> tuple[TemporaryRedisServer | None, list[str]]:
+    if relpath != REDIS_SESSION_EXAMPLE:
+        return None, []
+
+    configured_url = env.get("REDIS_URL")
+    redis_url = configured_url or DEFAULT_REDIS_URL
+    if redis_url_is_local(redis_url) and redis_ping_url(redis_url):
+        env["REDIS_URL"] = redis_url
+        return None, [f"Using existing Redis server at {redis_url}."]
+
+    if configured_url:
+        env["REDIS_URL"] = redis_url
+        return None, [f"REDIS_URL is set but not reachable before example start: {redis_url}."]
+
+    server = start_temporary_redis_server()
+    if server is None:
+        env["REDIS_URL"] = redis_url
+        return None, [
+            "redis-server was not found or did not start; running the example without managed Redis."
+        ]
+
+    env["REDIS_URL"] = server.url
+    return server, [f"Started temporary Redis server at {server.url}."]
 
 
 def parse_args() -> argparse.Namespace:
@@ -482,48 +665,72 @@ def run_examples(examples: Sequence[ExampleScript], args: argparse.Namespace) ->
             env.setdefault("SHELL_AUTO_APPROVE", "1")
             env.setdefault("AUTO_APPROVE_MCP", "1")
 
-        proc = subprocess.Popen(
-            example.command,
-            cwd=ROOT_DIR,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            env=env,
-        )
-        assert proc.stdout is not None
         force_prompt_stream = (not auto_mode) and ("interactive" in example.tags)
         buffer_output_local = buffer_output and not force_prompt_stream
         buffer_lines: list[str] = []
+        redis_server: TemporaryRedisServer | None = None
+        service_messages: list[str] = []
 
         with log_path.open("w", encoding="utf-8") as per_log:
-            if force_prompt_stream:
-                at_line_start = True
-                while True:
-                    char = proc.stdout.read(1)
-                    if char == "":
-                        break
-                    per_log.write(char)
+            redis_server, service_messages = prepare_redis_for_example(relpath, env)
+            for message in service_messages:
+                per_log.write(f"[runner] {message}\n")
+                if not buffer_output_local:
                     with output_lock:
-                        if at_line_start:
-                            sys.stdout.write(f"[{relpath}] ")
-                        sys.stdout.write(char)
-                        sys.stdout.flush()
-                    at_line_start = char == "\n"
-            else:
-                for line in proc.stdout:
-                    per_log.write(line)
-                    if buffer_output_local:
-                        buffer_lines.append(line)
-                    else:
+                        sys.stdout.write(f"[{relpath}] [runner] {message}\n")
+
+            try:
+                proc = subprocess.Popen(
+                    example.command,
+                    cwd=ROOT_DIR,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    env=env,
+                )
+                assert proc.stdout is not None
+
+                if force_prompt_stream:
+                    at_line_start = True
+                    while True:
+                        char = proc.stdout.read(1)
+                        if char == "":
+                            break
+                        per_log.write(char)
                         with output_lock:
-                            sys.stdout.write(f"[{relpath}] {line}")
-        proc.wait()
-        exit_code = proc.returncode
+                            if at_line_start:
+                                sys.stdout.write(f"[{relpath}] ")
+                            sys.stdout.write(char)
+                            sys.stdout.flush()
+                        at_line_start = char == "\n"
+                else:
+                    for line in proc.stdout:
+                        per_log.write(line)
+                        if buffer_output_local:
+                            buffer_lines.append(line)
+                        else:
+                            with output_lock:
+                                sys.stdout.write(f"[{relpath}] {line}")
+                proc.wait()
+                exit_code = proc.returncode
+            finally:
+                if redis_server is not None:
+                    redis_server.close()
+                    per_log.write(
+                        f"[runner] Stopped temporary Redis server at {redis_server.url}.\n"
+                    )
 
         if buffer_output_local and buffer_lines:
             with output_lock:
+                for message in service_messages:
+                    sys.stdout.write(f"[{relpath}] [runner] {message}\n")
                 for line in buffer_lines:
                     sys.stdout.write(f"[{relpath}] {line}")
+                if redis_server is not None:
+                    sys.stdout.write(
+                        f"[{relpath}] [runner] Stopped temporary Redis server at "
+                        f"{redis_server.url}.\n"
+                    )
 
         if exit_code == 0:
             safe_write_main(f"PASSED {relpath} exit=0 log={display_path(log_path)}")
@@ -561,6 +768,14 @@ def run_examples(examples: Sequence[ExampleScript], args: argparse.Namespace) ->
         for example in examples:
             relpath = example.relpath
             skip, reasons = should_skip(example.tags, overrides, auto_skip_set, relpath, auto_mode)
+            prerequisite_reasons = prerequisite_skip_reasons(
+                relpath,
+                auto_mode=auto_mode,
+                env=os.environ,
+            )
+            if prerequisite_reasons:
+                skip = True
+                reasons = reasons | prerequisite_reasons
             tag_label = f" [tags: {', '.join(sorted(example.tags))}]" if args.verbose else ""
 
             if skip:

--- a/examples/sandbox/extensions/daytona/usaspending_text2sql/agent.py
+++ b/examples/sandbox/extensions/daytona/usaspending_text2sql/agent.py
@@ -38,6 +38,7 @@ from agents.sandbox.session import (
     Instrumentation,
     JsonlOutboxSink,
 )
+from examples.auto_mode import input_with_fallback, is_auto_mode
 from examples.sandbox.extensions.daytona.usaspending_text2sql.sql_capability import (
     SqlCapability,
 )
@@ -92,20 +93,23 @@ DEVELOPER_INSTRUCTIONS = (
 )
 
 DB_PATH = "data/usaspending.db"
+DEFAULT_AUTO_QUESTION = "What are NASA's top 5 contractors by total obligations?"
 
 WORKSPACE_ROOT = DEFAULT_DAYTONA_WORKSPACE_ROOT
 
 
 def build_agent() -> SandboxAgent:
     """Build the agent blueprint."""
+    generate_memory = not is_auto_mode()
     manifest = Manifest(
         root=WORKSPACE_ROOT,
         entries={
             "setup_db.py": LocalFile(src=SETUP_DB_PATH),
             "schema": LocalDir(src=SCHEMA_DIR),
             "data": Dir(ephemeral=True),
-            "memory/memory_summary.md": File(content=b""),
-            "memory/phase_two_selection.json": File(content=b""),
+            "memories/MEMORY.md": File(content=b""),
+            "memories/memory_summary.md": File(content=b""),
+            "memories/phase_two_selection.json": File(content=b""),
         },
     )
 
@@ -123,13 +127,17 @@ def build_agent() -> SandboxAgent:
             Compaction(),
             Memory(
                 read=MemoryReadConfig(live_update=False),
-                generate=MemoryGenerateConfig(
-                    extra_prompt=(
-                        "Pay attention to which SQL patterns work best for the USAspending data, "
-                        "column quirks (e.g. recipient_parent_name vs recipient_name for grouping), "
-                        "and data caveats the user discovers (e.g. negative obligations, masked "
-                        "recipients)."
-                    ),
+                generate=(
+                    MemoryGenerateConfig(
+                        extra_prompt=(
+                            "Pay attention to which SQL patterns work best for the USAspending "
+                            "data, column quirks (e.g. recipient_parent_name vs recipient_name "
+                            "for grouping), and data caveats the user discovers (e.g. negative "
+                            "obligations, masked recipients)."
+                        ),
+                    )
+                    if generate_memory
+                    else None
                 ),
             ),
         ],
@@ -355,12 +363,28 @@ def _save_session_state(state: DaytonaSandboxSessionState) -> None:
     SESSION_STATE_PATH.write_text(state.model_dump_json(indent=2))
 
 
+def _require_env(name: str) -> None:
+    """Exit early with a clear message when a required environment variable is missing."""
+    if os.environ.get(name):
+        return
+    raise SystemExit(f"{name} must be set before running this example.")
+
+
+def _status(message: str) -> None:
+    """Print progress immediately so automation logs show where startup is blocked."""
+    print(message, flush=True)
+
+
 # ---------------------------------------------------------------------------
 # Main entrypoint
 # ---------------------------------------------------------------------------
 
 
 async def main() -> None:
+    _status("Starting Daytona NASA spending text-to-SQL example...")
+    _require_env("OPENAI_API_KEY")
+    _require_env("DAYTONA_API_KEY")
+
     agent = build_agent()
 
     instrumentation = Instrumentation(
@@ -369,6 +393,7 @@ async def main() -> None:
     )
     RESULTS_PORT = 8080
 
+    _status("Creating Daytona sandbox client...")
     client = DaytonaSandboxClient(instrumentation=instrumentation)
     client_options = DaytonaSandboxClientOptions(
         pause_on_exit=True,
@@ -384,20 +409,23 @@ async def main() -> None:
         if saved_state is not None:
             old_sandbox_id = saved_state.sandbox_id
             try:
+                _status(f"Resuming Daytona sandbox {old_sandbox_id}...")
                 sandbox = await client.resume(saved_state)
                 assert isinstance(sandbox.state, DaytonaSandboxSessionState)
                 if sandbox.state.sandbox_id == old_sandbox_id:
-                    print("Reconnected to existing sandbox.")
+                    _status("Reconnected to existing sandbox.")
                 else:
-                    print("Previous sandbox no longer exists. Created a new one.")
+                    _status("Previous sandbox no longer exists. Created a new one.")
             except Exception as e:
-                print(f"Could not resume previous sandbox: {e}")
+                _status(f"Could not resume previous sandbox: {e}")
                 saved_state = None
                 sandbox = None
 
         if sandbox is None:
+            _status("Creating Daytona sandbox...")
             sandbox = await client.create(manifest=agent.default_manifest, options=client_options)
 
+        _status("Starting Daytona sandbox...")
         await sandbox.start()
 
         # Persist state immediately so crashes don't orphan the sandbox.
@@ -405,7 +433,7 @@ async def main() -> None:
         _save_session_state(sandbox.state)
 
         # Build database inside sandbox (idempotent — skips if DB already exists).
-        print("Setting up database (may take a few minutes on first run)...")
+        _status("Setting up database (may take a few minutes on first run)...")
         result = await sandbox.exec("python3", "setup_db.py", timeout=1800.0)
         stdout = result.stdout.decode("utf-8", errors="replace")
         if stdout.strip():
@@ -416,6 +444,7 @@ async def main() -> None:
             sys.exit(1)
 
         # Start a file server in the sandbox so query results can be downloaded.
+        _status("Starting results file server...")
         await sandbox.exec("mkdir -p results", timeout=5.0)
         await sandbox.exec(
             f"nohup python3 -m http.server {RESULTS_PORT} --directory results > /dev/null 2>&1 &",
@@ -455,10 +484,14 @@ async def main() -> None:
 """)
 
         conversation: list[Any] = []
+        auto_mode = is_auto_mode()
 
         while True:
             try:
-                question = input("> ")
+                if auto_mode:
+                    question = input_with_fallback("> ", DEFAULT_AUTO_QUESTION)
+                else:
+                    question = input("> ")
             except (EOFError, KeyboardInterrupt):
                 print()
                 break
@@ -479,15 +512,18 @@ async def main() -> None:
                 print(f"\nError: {e}")
             print()
 
+            if auto_mode:
+                break
+
         if destroy:
             assert isinstance(sandbox.state, DaytonaSandboxSessionState)
             sandbox.state.pause_on_exit = False
             SESSION_STATE_PATH.unlink(missing_ok=True)
-            print("Deleting sandbox...")
+            _status("Deleting sandbox...")
         else:
             assert isinstance(sandbox.state, DaytonaSandboxSessionState)
             _save_session_state(sandbox.state)
-            print("Saving memory and pausing sandbox (can take a couple of minutes)...")
+            _status("Saving memory and pausing sandbox (can take a couple of minutes)...")
 
     finally:
         if sandbox is not None:

--- a/examples/sandbox/extensions/temporal/README.md
+++ b/examples/sandbox/extensions/temporal/README.md
@@ -9,6 +9,30 @@ support for multiple sandbox backends (Daytona, Docker, E2B, local unix).
 cloud backends you want to use. The local and Docker sandboxes work without
 any cloud provider API keys.
 
+## Local smoke test
+
+If you only want to confirm that Temporal workflows run locally, use the minimal
+example first:
+
+```
+export OPENAI_API_KEY="sk-..."
+# Optional: export EXAMPLES_TEMPORAL_MODEL="gpt-5.4-mini"
+# Optional: export EXAMPLES_TEMPORAL_TRACE="openai"
+uv run --extra temporal python -m examples.sandbox.extensions.temporal.local_hello_workflow
+```
+
+This starts the Temporal Python SDK test server, runs one workflow and one
+model activity, connects the workflow to a local Unix sandbox, and then shuts
+down. It does not require the Temporal CLI, an already running Temporal dev
+server, or sandbox backend credentials.
+
+The local smoke test enables OpenAI Agents tracing by default. Set
+`EXAMPLES_TEMPORAL_TRACE=none` to disable tracing, or
+`EXAMPLES_TEMPORAL_TRACE=openai_with_temporal_spans` to also ask the Temporal
+plugin to add Temporal spans. The Temporal span mode depends on Temporal plugin
+behavior and may omit regular Agents spans with some plugin versions; use the
+default `openai` mode when you want standard OpenAI trace spans.
+
 1. Install [just](https://just.systems/man/en/packages.html) and the
    [Temporal CLI](https://docs.temporal.io/cli/setup-cli#install-the-cli)
    if you don't have them already.

--- a/examples/sandbox/extensions/temporal/local_hello_workflow.py
+++ b/examples/sandbox/extensions/temporal/local_hello_workflow.py
@@ -1,0 +1,150 @@
+"""Minimal local Temporal SandboxAgent workflow example.
+
+This example is intentionally smaller than ``temporal_sandbox_agent.py``. It starts a local
+Temporal test server through the Temporal Python SDK, runs a ``SandboxAgent`` workflow against
+the local Unix sandbox backend, and then shuts everything down.
+
+It does not require the Temporal CLI, a long-running Temporal server, or cloud sandbox backend
+credentials. It does require ``OPENAI_API_KEY`` because the model call runs through the Temporal
+OpenAI Agents plugin as an activity.
+
+Usage:
+    uv run --extra temporal python -m examples.sandbox.extensions.temporal.local_hello_workflow
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.client import Client
+from temporalio.contrib.openai_agents import (
+    ModelActivityParameters,
+    OpenAIAgentsPlugin,
+    SandboxClientProvider,
+)
+from temporalio.contrib.openai_agents.workflow import temporal_sandbox_client
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner, SandboxRestrictions
+
+from agents import ModelSettings, Runner
+from agents.run import RunConfig
+from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
+from agents.sandbox.capabilities import Shell
+from agents.sandbox.entries import File
+from agents.sandbox.sandboxes import UnixLocalSandboxClient, UnixLocalSandboxClientOptions
+
+TASK_QUEUE = "local-temporal-sandbox-agent"
+WORKFLOW_ID = "local-temporal-sandbox-agent-workflow"
+DEFAULT_MODEL = "gpt-5.4-mini"
+EXPECTED_GREETING = "Temporal sandbox says hello from a local file"
+TRACE_MODE_NONE = "none"
+TRACE_MODE_OPENAI = "openai"
+TRACE_MODE_OPENAI_WITH_TEMPORAL_SPANS = "openai_with_temporal_spans"
+TRACE_MODES = {
+    TRACE_MODE_NONE,
+    TRACE_MODE_OPENAI,
+    TRACE_MODE_OPENAI_WITH_TEMPORAL_SPANS,
+}
+
+
+@workflow.defn
+class LocalSandboxAgentWorkflow:
+    @workflow.run
+    async def run(self, model: str, trace_mode: str) -> str:
+        agent = SandboxAgent(
+            name="Local Temporal Sandbox Agent",
+            model=model,
+            instructions=(
+                "Inspect the sandbox workspace with the shell tool before answering. "
+                "Report the greeting from README.md exactly."
+            ),
+            default_manifest=Manifest(
+                entries={
+                    "README.md": File(content=b"Temporal sandbox says hello from a local file.\n"),
+                }
+            ),
+            capabilities=[Shell()],
+            model_settings=ModelSettings(tool_choice="required"),
+        )
+
+        result = await Runner.run(
+            agent,
+            "Read README.md and report its greeting.",
+            run_config=RunConfig(
+                sandbox=SandboxRunConfig(
+                    client=temporal_sandbox_client("local"),
+                    options=UnixLocalSandboxClientOptions(),
+                ),
+                workflow_name="Local Temporal SandboxAgent workflow",
+                tracing_disabled=trace_mode == TRACE_MODE_NONE,
+            ),
+        )
+        return str(result.final_output)
+
+
+def _client_with_plugin(client: Client, trace_mode: str) -> Client:
+    plugin = OpenAIAgentsPlugin(
+        model_params=ModelActivityParameters(start_to_close_timeout=timedelta(seconds=120)),
+        sandbox_clients=[SandboxClientProvider("local", UnixLocalSandboxClient())],
+        add_temporal_spans=trace_mode == TRACE_MODE_OPENAI_WITH_TEMPORAL_SPANS,
+    )
+    config = client.config()
+    config["plugins"] = [*config.get("plugins", []), plugin]
+    return Client(**config)
+
+
+def _require_env(name: str) -> None:
+    if not os.environ.get(name):
+        raise SystemExit(f"{name} must be set before running this example.")
+
+
+def _trace_mode_from_env() -> str:
+    trace_mode = os.getenv("EXAMPLES_TEMPORAL_TRACE", TRACE_MODE_OPENAI).strip().lower()
+    if trace_mode not in TRACE_MODES:
+        supported = ", ".join(sorted(TRACE_MODES))
+        raise SystemExit(
+            f"EXAMPLES_TEMPORAL_TRACE must be one of: {supported}. Got {trace_mode!r}."
+        )
+    return trace_mode
+
+
+async def main() -> None:
+    _require_env("OPENAI_API_KEY")
+    model = os.getenv("EXAMPLES_TEMPORAL_MODEL", DEFAULT_MODEL)
+    trace_mode = _trace_mode_from_env()
+    print(f"Using model: {model}")
+    print(f"Using trace mode: {trace_mode}")
+    print("Starting local Temporal test server...")
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        client = _client_with_plugin(env.client, trace_mode)
+        print("Starting local Temporal worker...")
+        async with Worker(
+            client,
+            task_queue=TASK_QUEUE,
+            workflows=[LocalSandboxAgentWorkflow],
+            workflow_runner=SandboxedWorkflowRunner(
+                restrictions=SandboxRestrictions.default.with_passthrough_modules(
+                    "annotated_types",
+                    "pydantic_core",
+                ),
+            ),
+        ):
+            result = await client.execute_workflow(
+                LocalSandboxAgentWorkflow.run,
+                args=[model, trace_mode],
+                id=WORKFLOW_ID,
+                task_queue=TASK_QUEUE,
+            )
+
+    print(f"Workflow result: {result}")
+    if EXPECTED_GREETING not in result:
+        raise RuntimeError(f"Expected workflow result to contain {EXPECTED_GREETING!r}.")
+    print("Local Temporal SandboxAgent workflow completed successfully.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_daytona_usaspending_example.py
+++ b/tests/test_daytona_usaspending_example.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+from agents.sandbox.capabilities.memory import Memory
+
+
+def _load_usaspending_agent_module() -> Any:
+    try:
+        return importlib.import_module(
+            "examples.sandbox.extensions.daytona.usaspending_text2sql.agent"
+        )
+    except SystemExit as exc:
+        pytest.skip(str(exc))
+
+
+def _memory_capability(agent: Any) -> Memory:
+    memories = [capability for capability in agent.capabilities if isinstance(capability, Memory)]
+    assert len(memories) == 1
+    return memories[0]
+
+
+def test_usaspending_auto_mode_disables_memory_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXAMPLES_INTERACTIVE_MODE", "auto")
+    module = _load_usaspending_agent_module()
+
+    memory = _memory_capability(module.build_agent())
+
+    assert memory.read is not None
+    assert memory.generate is None
+
+
+def test_usaspending_prompt_mode_keeps_memory_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EXAMPLES_INTERACTIVE_MODE", raising=False)
+    module = _load_usaspending_agent_module()
+
+    memory = _memory_capability(module.build_agent())
+
+    assert memory.read is not None
+    assert memory.generate is not None

--- a/tests/test_run_examples_script.py
+++ b/tests/test_run_examples_script.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import examples.run_examples as run_examples
 
 
@@ -13,6 +15,7 @@ def test_default_auto_skip_excludes_prerequisite_bound_examples() -> None:
         "examples/sandbox/extensions/temporal/temporal_sandbox_agent.py",
         "examples/sandbox/extensions/vercel_runner.py",
         "examples/sandbox/memory_s3.py",
+        "examples/sandbox/misc/reference_policy_mcp_server.py",
         "examples/sandbox/sandbox_agent_with_remote_snapshot.py",
         "examples/sandbox/tax_prep.py",
         "examples/sandbox/tutorials/dataroom_metric_extract/evals.py",
@@ -29,3 +32,134 @@ def test_default_auto_skip_excludes_prerequisite_bound_examples() -> None:
 
 def test_default_auto_skip_keeps_computer_use_example_enabled() -> None:
     assert "examples/tools/computer_use.py" not in run_examples.DEFAULT_AUTO_SKIP
+
+
+def test_example_command_runs_python_unbuffered(monkeypatch) -> None:
+    monkeypatch.delenv("EXAMPLES_UV_EXTRAS", raising=False)
+    example = run_examples.ExampleScript(
+        run_examples.ROOT_DIR / Path("examples/basic/hello_world.py")
+    )
+
+    assert example.command == ["uv", "run", "python", "-u", "-m", "examples.basic.hello_world"]
+
+
+def test_example_command_includes_configured_uv_extras(monkeypatch) -> None:
+    monkeypatch.setenv("EXAMPLES_UV_EXTRAS", "litellm any-llm")
+    example = run_examples.ExampleScript(
+        run_examples.ROOT_DIR / Path("examples/basic/hello_world.py")
+    )
+
+    assert example.command == [
+        "uv",
+        "run",
+        "--extra",
+        "litellm",
+        "--extra",
+        "any-llm",
+        "python",
+        "-u",
+        "-m",
+        "examples.basic.hello_world",
+    ]
+
+
+def test_prepare_redis_for_example_uses_existing_local_redis(monkeypatch) -> None:
+    env: dict[str, str] = {}
+    monkeypatch.setattr(run_examples, "redis_ping_url", lambda url, timeout=0.5: True)
+
+    redis_server, messages = run_examples.prepare_redis_for_example(
+        run_examples.REDIS_SESSION_EXAMPLE,
+        env,
+    )
+
+    assert redis_server is None
+    assert env["REDIS_URL"] == run_examples.DEFAULT_REDIS_URL
+    assert messages == [f"Using existing Redis server at {run_examples.DEFAULT_REDIS_URL}."]
+
+
+def test_prepare_redis_for_example_starts_managed_redis(monkeypatch) -> None:
+    class DummyRedisServer:
+        url = "redis://127.0.0.1:12345/0"
+
+        def close(self) -> None:
+            pass
+
+    dummy_server = DummyRedisServer()
+    env: dict[str, str] = {}
+    monkeypatch.setattr(run_examples, "redis_ping_url", lambda url, timeout=0.5: False)
+    monkeypatch.setattr(run_examples, "start_temporary_redis_server", lambda: dummy_server)
+
+    redis_server, messages = run_examples.prepare_redis_for_example(
+        run_examples.REDIS_SESSION_EXAMPLE,
+        env,
+    )
+
+    assert redis_server is not None
+    assert redis_server.url == dummy_server.url
+    assert env["REDIS_URL"] == dummy_server.url
+    assert messages == [f"Started temporary Redis server at {dummy_server.url}."]
+
+
+def test_prepare_redis_for_example_respects_configured_url(monkeypatch) -> None:
+    env = {"REDIS_URL": "redis://localhost:6380/2"}
+    monkeypatch.setattr(run_examples, "redis_ping_url", lambda url, timeout=0.5: False)
+    monkeypatch.setattr(
+        run_examples,
+        "start_temporary_redis_server",
+        lambda: (_ for _ in ()).throw(AssertionError("should not start Redis")),
+    )
+
+    redis_server, messages = run_examples.prepare_redis_for_example(
+        run_examples.REDIS_SESSION_EXAMPLE,
+        env,
+    )
+
+    assert redis_server is None
+    assert env["REDIS_URL"] == "redis://localhost:6380/2"
+    assert messages == [
+        "REDIS_URL is set but not reachable before example start: redis://localhost:6380/2."
+    ]
+
+
+def test_prerequisite_skip_reasons_skip_dapr_without_sidecar(monkeypatch) -> None:
+    monkeypatch.setattr(run_examples, "dapr_sidecar_available", lambda env: False)
+
+    reasons = run_examples.prerequisite_skip_reasons(
+        run_examples.DAPR_SESSION_EXAMPLE,
+        auto_mode=True,
+        env={},
+    )
+
+    assert reasons == {"missing-dapr-sidecar"}
+
+
+def test_prerequisite_skip_reasons_allow_forced_dapr(monkeypatch) -> None:
+    monkeypatch.setattr(
+        run_examples,
+        "dapr_sidecar_available",
+        lambda env: (_ for _ in ()).throw(AssertionError("should not probe sidecar")),
+    )
+
+    reasons = run_examples.prerequisite_skip_reasons(
+        run_examples.DAPR_SESSION_EXAMPLE,
+        auto_mode=True,
+        env={"EXAMPLES_FORCE_DAPR": "1"},
+    )
+
+    assert reasons == set()
+
+
+def test_prerequisite_skip_reasons_allow_non_dapr_example(monkeypatch) -> None:
+    monkeypatch.setattr(
+        run_examples,
+        "dapr_sidecar_available",
+        lambda env: (_ for _ in ()).throw(AssertionError("should not probe sidecar")),
+    )
+
+    reasons = run_examples.prerequisite_skip_reasons(
+        run_examples.REDIS_SESSION_EXAMPLE,
+        auto_mode=True,
+        env={},
+    )
+
+    assert reasons == set()


### PR DESCRIPTION
This pull request improves the reliability and coverage of automated example validation by making examples easier to run in non-interactive Codex workflows, reducing avoidable environment-specific failures, and adding focused local smoke tests for integrations that previously required more manual setup.

The examples runner now supports default optional dependency extras, unbuffered module execution, temporary local Redis startup for the Redis memory example, prerequisite-based Dapr skipping, and clearer guidance to run example batches outside the Codex sandbox when examples need nested sandboxes or local services. This keeps full-suite example runs closer to real usage while avoiding failures caused only by missing local daemons or sandbox restrictions.

It also adds or hardens local verification paths for integration examples: the SSE MCP example can fall back to a bundled local SSE server instead of relying on a remote service, the MCP Manager FastAPI example has a separate smoke test that exercises app/server integration without complicating the app itself, and the Temporal sandbox extension now includes a minimal local SandboxAgent workflow that uses the real model API, defaults to OpenAI tracing, and allows tracing mode selection.

The Daytona USAspending text-to-SQL example is adjusted for automated runs by failing early on missing credentials, emitting clearer progress, using a deterministic auto-mode prompt, avoiding long memory generation during automation, and ignoring generated runtime state. The financial research example prompt and verifier guidance are also updated so automated runs avoid claims about unreleased quarterly results and judge the synthesized demo output appropriately. No released SDK APIs or persisted runtime schemas are changed.