### PR TITLE
fix: make chat completions response-feature validation opt-in

### DIFF
--- a/src/agents/models/multi_provider.py
+++ b/src/agents/models/multi_provider.py
@@ -83,6 +83,7 @@ class MultiProvider(ModelProvider):
         openai_project: str | None = None,
         openai_use_responses: bool | None = None,
         openai_use_responses_websocket: bool | None = None,
+        openai_strict_feature_validation: bool = False,
         openai_websocket_base_url: str | None = None,
         openai_prefix_mode: MultiProviderOpenAIPrefixMode = "alias",
         unknown_prefix_mode: MultiProviderUnknownPrefixMode = "error",
@@ -106,6 +107,10 @@ class MultiProvider(ModelProvider):
             openai_use_responses: Whether to use the OpenAI responses API.
             openai_use_responses_websocket: Whether to use websocket transport for the OpenAI
                 responses API.
+            openai_strict_feature_validation: Whether OpenAI Chat Completions models should raise
+                a UserError when callers pass Responses-only features such as previous_response_id,
+                conversation_id, or prompt. Defaults to False, which preserves the previous
+                ignore-and-warn behavior.
             openai_websocket_base_url: The websocket base URL to use for the OpenAI provider.
                 If not provided, the provider will use `OPENAI_WEBSOCKET_BASE_URL` when set.
             openai_prefix_mode: Controls how ``openai/...`` model strings are interpreted.
@@ -132,6 +137,7 @@ class MultiProvider(ModelProvider):
             project=openai_project,
             use_responses=openai_use_responses,
             use_responses_websocket=openai_use_responses_websocket,
+            strict_feature_validation=openai_strict_feature_validation,
             agent_registration=openai_agent_registration,
             responses_websocket_options=openai_responses_websocket_options,
         )

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -55,10 +55,14 @@ class OpenAIChatCompletionsModel(Model):
         model: str | ChatModel,
         openai_client: AsyncOpenAI,
         should_replay_reasoning_content: ShouldReplayReasoningContent | None = None,
+        strict_feature_validation: bool = False,
     ) -> None:
         self.model = model
         self._client = openai_client
         self.should_replay_reasoning_content = should_replay_reasoning_content
+        self._strict_feature_validation = strict_feature_validation
+        self._has_warned_unsupported_prompt = False
+        self._has_warned_unsupported_conversation_state = False
 
     def _non_null_or_omit(self, value: Any) -> Any:
         return value if value is not None else omit
@@ -66,15 +70,24 @@ class OpenAIChatCompletionsModel(Model):
     def _supports_default_prompt_cache_key(self) -> bool:
         return ChatCmplHelpers.is_openai(self._get_client())
 
-    def _validate_prompt_is_supported(self, prompt: ResponsePromptParam | None) -> None:
+    def _handle_unsupported_prompt(self, prompt: ResponsePromptParam | None) -> None:
         if prompt is None:
             return
 
-        raise UserError(
+        message = (
             "Reusable prompts are only supported by the Responses API. "
             "OpenAIChatCompletionsModel does not support `prompt`; use a Responses model "
             "instead."
         )
+        if self._strict_feature_validation:
+            raise UserError(message)
+
+        if not self._has_warned_unsupported_prompt:
+            logger.warning(
+                "%s Ignoring `prompt`; enable strict feature validation to raise an error instead.",
+                message,
+            )
+            self._has_warned_unsupported_prompt = True
 
     def get_retry_advice(self, request: ModelRetryAdviceRequest) -> ModelRetryAdvice | None:
         return get_openai_retry_advice(request)
@@ -126,11 +139,11 @@ class OpenAIChatCompletionsModel(Model):
         conversation_id: str | None = None,
         prompt: ResponsePromptParam | None = None,
     ) -> ModelResponse:
-        self._validate_no_server_managed_conversation_state(
+        self._handle_unsupported_server_managed_conversation_state(
             previous_response_id=previous_response_id,
             conversation_id=conversation_id,
         )
-        self._validate_prompt_is_supported(prompt)
+        self._handle_unsupported_prompt(prompt)
 
         with generation_span(
             model=str(self.model),
@@ -147,7 +160,7 @@ class OpenAIChatCompletionsModel(Model):
                 span_generation,
                 tracing,
                 stream=False,
-                prompt=prompt,
+                prompt=None,
             )
 
             if not response.choices:
@@ -256,11 +269,11 @@ class OpenAIChatCompletionsModel(Model):
         """
         Yields a partial message as it is generated, as well as the usage information.
         """
-        self._validate_no_server_managed_conversation_state(
+        self._handle_unsupported_server_managed_conversation_state(
             previous_response_id=previous_response_id,
             conversation_id=conversation_id,
         )
-        self._validate_prompt_is_supported(prompt)
+        self._handle_unsupported_prompt(prompt)
 
         with generation_span(
             model=str(self.model),
@@ -277,7 +290,7 @@ class OpenAIChatCompletionsModel(Model):
                 span_generation,
                 tracing,
                 stream=True,
-                prompt=prompt,
+                prompt=None,
             )
 
             final_response: Response | None = None
@@ -310,7 +323,7 @@ class OpenAIChatCompletionsModel(Model):
                     ),
                 }
 
-    def _validate_no_server_managed_conversation_state(
+    def _handle_unsupported_server_managed_conversation_state(
         self,
         *,
         previous_response_id: str | None,
@@ -325,12 +338,22 @@ class OpenAIChatCompletionsModel(Model):
             return
 
         unsupported_params = ", ".join(unsupported)
-        raise UserError(
+        message = (
             "OpenAIChatCompletionsModel does not support server-managed conversation state "
             f"({unsupported_params}). Chat Completions requires callers to pass the full "
             "conversation history; use a Responses API model for previous_response_id or a "
             "conversation-capable model for conversation_id."
         )
+        if self._strict_feature_validation:
+            raise UserError(message)
+
+        if not self._has_warned_unsupported_conversation_state:
+            logger.warning(
+                "%s Ignoring unsupported server-managed conversation state; enable strict feature "
+                "validation to raise an error instead.",
+                message,
+            )
+            self._has_warned_unsupported_conversation_state = True
 
     @overload
     async def _fetch_response(
@@ -375,7 +398,7 @@ class OpenAIChatCompletionsModel(Model):
         stream: bool = False,
         prompt: ResponsePromptParam | None = None,
     ) -> ChatCompletion | tuple[Response, AsyncStream[ChatCompletionChunk]]:
-        self._validate_prompt_is_supported(prompt)
+        self._handle_unsupported_prompt(prompt)
         self._validate_official_openai_input_content_types(input)
         converted_messages = Converter.items_to_messages(
             input,

--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -52,6 +52,7 @@ class OpenAIProvider(ModelProvider):
         project: str | None = None,
         use_responses: bool | None = None,
         use_responses_websocket: bool | None = None,
+        strict_feature_validation: bool = False,
         agent_registration: OpenAIAgentRegistrationConfig | None = None,
         responses_websocket_options: OpenAIResponsesWebSocketOptions | None = None,
     ) -> None:
@@ -71,6 +72,10 @@ class OpenAIProvider(ModelProvider):
             use_responses: Whether to use the OpenAI responses API.
             use_responses_websocket: Whether to use websocket transport for the OpenAI responses
                 API.
+            strict_feature_validation: Whether Chat Completions models should raise a UserError
+                when callers pass Responses-only features such as previous_response_id,
+                conversation_id, or prompt. Defaults to False, which preserves the previous
+                ignore-and-warn behavior.
             agent_registration: Optional agent registration configuration.
             responses_websocket_options: Optional low-level websocket keepalive options for the
                 OpenAI Responses websocket transport.
@@ -102,6 +107,7 @@ class OpenAIProvider(ModelProvider):
             self._responses_transport = _openai_shared.get_default_openai_responses_transport()
         # Backward-compatibility shim for internal tests/diagnostics that inspect the legacy flag.
         self._use_responses_websocket = self._responses_transport == "websocket"
+        self._strict_feature_validation = strict_feature_validation
         self._responses_websocket_options = responses_websocket_options
 
         # Reuse websocket model wrappers so websocket transport can keep a persistent connection
@@ -220,7 +226,11 @@ class OpenAIProvider(ModelProvider):
         model: Model
 
         if not self._use_responses:
-            return OpenAIChatCompletionsModel(model=resolved_model_name, openai_client=client)
+            return OpenAIChatCompletionsModel(
+                model=resolved_model_name,
+                openai_client=client,
+                strict_feature_validation=self._strict_feature_validation,
+            )
 
         if use_websocket_transport:
             model = OpenAIResponsesWSModel(

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -45,6 +46,22 @@ from agents.exceptions import UserError
 from agents.models._retry_runtime import provider_managed_retries_disabled
 from agents.models.chatcmpl_helpers import HEADERS_OVERRIDE, ChatCmplHelpers
 from agents.models.fake_id import FAKE_RESPONSES_ID
+
+
+def _minimal_chat_completion(content: str = "ok") -> ChatCompletion:
+    return ChatCompletion(
+        id="resp-id",
+        created=0,
+        model="fake",
+        object="chat.completion",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(role="assistant", content=content),
+            )
+        ],
+    )
 
 
 async def _run_chat_completions_model_with_custom_base_url(
@@ -156,7 +173,86 @@ async def test_get_response_with_text_message(monkeypatch) -> None:
         (None, "conv_123", "conversation_id"),
     ],
 )
-async def test_get_response_rejects_server_managed_conversation_state(
+async def test_get_response_warns_and_ignores_server_managed_conversation_state_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    previous_response_id: str | None,
+    conversation_id: str | None,
+    expected_param: str,
+) -> None:
+    called = False
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        nonlocal called
+        called = True
+        return _minimal_chat_completion()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    await model.get_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=previous_response_id,
+        conversation_id=conversation_id,
+        prompt=None,
+    )
+
+    assert expected_param in caplog.text
+    assert "Ignoring unsupported server-managed conversation state" in caplog.text
+    assert called is True
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_warns_and_ignores_prompt_by_default(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    captured_prompt: Any = None
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        nonlocal captured_prompt
+        captured_prompt = kwargs.get("prompt")
+        return _minimal_chat_completion()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    await model.get_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=cast(Any, {"id": "pmpt_123"}),
+    )
+
+    assert "Reusable prompts are only supported by the Responses API" in caplog.text
+    assert "Ignoring `prompt`" in caplog.text
+    assert captured_prompt is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("previous_response_id", "conversation_id", "expected_param"),
+    [
+        ("resp_123", None, "previous_response_id"),
+        (None, "conv_123", "conversation_id"),
+    ],
+)
+async def test_get_response_rejects_server_managed_conversation_state_in_strict_mode(
     monkeypatch: pytest.MonkeyPatch,
     previous_response_id: str | None,
     conversation_id: str | None,
@@ -170,7 +266,10 @@ async def test_get_response_rejects_server_managed_conversation_state(
         raise AssertionError("_fetch_response should not be called")
 
     monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
-    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    model = OpenAIProvider(
+        use_responses=False,
+        strict_feature_validation=True,
+    ).get_model("gpt-4")
 
     with pytest.raises(UserError, match="server-managed conversation state") as exc_info:
         await model.get_response(
@@ -192,12 +291,15 @@ async def test_get_response_rejects_server_managed_conversation_state(
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
-async def test_get_response_rejects_prompt(monkeypatch) -> None:
+async def test_get_response_rejects_prompt_in_strict_mode(monkeypatch) -> None:
     async def patched_fetch_response(self, *args, **kwargs):
         raise AssertionError("_fetch_response should not run when prompt is unsupported")
 
     monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
-    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    model = OpenAIProvider(
+        use_responses=False,
+        strict_feature_validation=True,
+    ).get_model("gpt-4")
 
     with pytest.raises(UserError, match="Reusable prompts"):
         await model.get_response(

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -33,6 +34,25 @@ from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
+
+
+async def _empty_chat_completion_stream() -> AsyncIterator[ChatCompletionChunk]:
+    chunks: list[ChatCompletionChunk] = []
+    for chunk in chunks:
+        yield chunk
+
+
+def _empty_response() -> Response:
+    return Response(
+        id="resp-id",
+        created_at=0,
+        model="fake-model",
+        object="response",
+        output=[],
+        tool_choice="none",
+        tools=[],
+        parallel_tool_calls=False,
+    )
 
 
 @pytest.mark.allow_call_model_methods
@@ -145,7 +165,88 @@ async def test_stream_response_yields_events_for_text_content(monkeypatch) -> No
         (None, "conv_123", "conversation_id"),
     ],
 )
-async def test_stream_response_rejects_server_managed_conversation_state(
+async def test_stream_response_warns_and_ignores_server_managed_conversation_state_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    previous_response_id: str | None,
+    conversation_id: str | None,
+    expected_param: str,
+) -> None:
+    called = False
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        nonlocal called
+        called = True
+        return _empty_response(), _empty_chat_completion_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    async for _event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=previous_response_id,
+        conversation_id=conversation_id,
+        prompt=None,
+    ):
+        pass
+
+    assert expected_param in caplog.text
+    assert "Ignoring unsupported server-managed conversation state" in caplog.text
+    assert called is True
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_warns_and_ignores_prompt_by_default(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    captured_prompt: Any = None
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        nonlocal captured_prompt
+        captured_prompt = kwargs.get("prompt")
+        return _empty_response(), _empty_chat_completion_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    async for _ in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=cast(Any, {"id": "pmpt_123"}),
+    ):
+        pass
+
+    assert "Reusable prompts are only supported by the Responses API" in caplog.text
+    assert "Ignoring `prompt`" in caplog.text
+    assert captured_prompt is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("previous_response_id", "conversation_id", "expected_param"),
+    [
+        ("resp_123", None, "previous_response_id"),
+        (None, "conv_123", "conversation_id"),
+    ],
+)
+async def test_stream_response_rejects_server_managed_conversation_state_in_strict_mode(
     monkeypatch: pytest.MonkeyPatch,
     previous_response_id: str | None,
     conversation_id: str | None,
@@ -159,7 +260,10 @@ async def test_stream_response_rejects_server_managed_conversation_state(
         raise AssertionError("_fetch_response should not be called")
 
     monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
-    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    model = OpenAIProvider(
+        use_responses=False,
+        strict_feature_validation=True,
+    ).get_model("gpt-4")
 
     with pytest.raises(UserError, match="server-managed conversation state") as exc_info:
         async for _event in model.stream_response(
@@ -182,12 +286,15 @@ async def test_stream_response_rejects_server_managed_conversation_state(
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
-async def test_stream_response_rejects_prompt(monkeypatch) -> None:
+async def test_stream_response_rejects_prompt_in_strict_mode(monkeypatch) -> None:
     async def patched_fetch_response(self, *args, **kwargs):
         raise AssertionError("_fetch_response should not run when prompt is unsupported")
 
     monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
-    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    model = OpenAIProvider(
+        use_responses=False,
+        strict_feature_validation=True,
+    ).get_model("gpt-4")
 
     with pytest.raises(UserError, match="Reusable prompts"):
         async for _ in model.stream_response(


### PR DESCRIPTION
This pull request updates Chat Completions handling for Responses-only options so existing integrations keep working by default while still allowing strict validation when desired.

The v0.17.1 release review flagged a compatibility risk: users who pass `previous_response_id`, `conversation_id`, or reusable `prompt` through `OpenAIChatCompletionsModel` would start receiving `UserError` instead of the previous no-op behavior. This change makes that failure mode opt-in with `strict_feature_validation=True`.

By default, Chat Completions now warns once per model instance and ignores those unsupported values. Strict mode still raises `UserError`, making it useful for tests, CI, and new integrations that want to catch Responses-only configuration mistakes early. The option is exposed through `OpenAIChatCompletionsModel`, `OpenAIProvider`, and `MultiProvider`, with coverage for both non-streaming and streaming calls.
