### PR TITLE
fix: allow empty GitRepo subpaths as repository root

### DIFF
--- a/src/agents/sandbox/entries/artifacts.py
+++ b/src/agents/sandbox/entries/artifacts.py
@@ -820,9 +820,12 @@ class GitRepo(BaseEntry):
             return None
 
         subpath = self.subpath
+        if subpath == "":
+            return None
+
         posix_subpath = PurePosixPath(subpath)
         windows_subpath = PureWindowsPath(subpath)
-        if subpath == "" or posix_subpath.as_posix() == ".":
+        if posix_subpath.as_posix() == ".":
             raise GitSubpathError(repo=self.repo, subpath=subpath, reason="empty")
         if posix_subpath.is_absolute():
             raise GitSubpathError(repo=self.repo, subpath=subpath, reason="absolute")

--- a/tests/sandbox/test_entries.py
+++ b/tests/sandbox/test_entries.py
@@ -918,7 +918,6 @@ async def test_git_repo_uses_fetch_checkout_path_for_commit_refs() -> None:
 @pytest.mark.parametrize(
     ("subpath", "reason"),
     [
-        ("", "empty"),
         (".", "empty"),
         ("/docs", "absolute"),
         ("../outside", "parent_traversal"),
@@ -940,6 +939,20 @@ async def test_git_repo_rejects_invalid_subpath_before_copy(
     assert excinfo.value.context["reason"] == reason
     assert excinfo.value.context["subpath"] == subpath
     assert session.exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_git_repo_empty_subpath_copies_repo_root() -> None:
+    session = _RecordingSession()
+    repo = GitRepo(repo="openai/example", ref="main", subpath="")
+
+    await repo.apply(session, Path("/workspace/repo"), Path("/ignored"))
+
+    copy_call = next(call for call in session.exec_calls if call[:1] == ("cp",))
+    assert copy_call[3].startswith("/tmp/sandbox-git-")
+    assert copy_call[3].endswith("/.")
+    assert not copy_call[3].endswith("//.")
+    assert copy_call[4].replace("\\", "/") == "/workspace/repo/"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes `GitRepo.subpath` handling so an empty string is treated the same as an omitted subpath and copies the repository root.

The sandbox GitRepo hardening correctly rejects unsafe or ambiguous subpaths before clone/copy, including parent traversal, absolute paths, Windows-style paths, and `"."`. However, generated manifests from forms, JSON config, or environment-derived inputs may serialize an omitted optional `subpath` as `""`. Treating that empty string as invalid creates avoidable compatibility risk without improving the traversal protection, because repository root is already valid when `subpath=None`.

This change preserves the safety checks for path traversal and non-POSIX subpaths while normalizing `subpath=""` to the root-copy behavior. Tests cover the new empty-string root behavior and keep `"."` rejected as an invalid explicit subpath.
