### PR TITLE
fix(sessions): drop empty reasoning items from OpenAIConversationsSession persistence

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -333,6 +333,14 @@ async def save_result_to_session(
             serialized_to_save_counts[serialized] -= 1
             saved_run_items_count += 1
 
+    # Drop items the Conversations API cannot accept (counted above so the
+    # persisted-item counter advances correctly on the next retry/call).
+    if is_openai_conversation_session:
+        items_to_save = [
+            item for item in items_to_save
+            if not _is_unpersistable_for_openai_conversation(item)
+        ]
+
     if len(items_to_save) == 0:
         if run_state:
             run_state._current_turn_persisted_item_count = already_persisted + saved_run_items_count
@@ -569,6 +577,19 @@ def _sanitize_openai_conversation_item(item: TResponseInputItem) -> TResponseInp
         clean_item.pop("provider_data", None)
         return cast(TResponseInputItem, clean_item)
     return item
+
+
+def _is_unpersistable_for_openai_conversation(item: TResponseInputItem) -> bool:
+    """Return True for items the OpenAI Conversations API cannot accept.
+
+    The Conversations API rejects reasoning items with an empty summary list.
+    Callers should drop these items before calling ``session.add_items`` while
+    still counting them in the persisted-item counter so the retry logic
+    advances past them correctly.
+    """
+    if not isinstance(item, dict):
+        return False
+    return item.get("type") == "reasoning" and item.get("summary") == []
 
 
 def _sanitize_openai_conversation_history_items_for_model_input(

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2797,6 +2797,105 @@ async def test_save_result_to_session_omits_reasoning_ids_when_policy_is_omit() 
 
 
 @pytest.mark.asyncio
+async def test_save_result_to_session_drops_empty_reasoning_from_openai_conversations() -> None:
+    """OpenAIConversationsSession must not receive reasoning items with summary=[]."""
+
+    class DummyOpenAIConversationsSession(OpenAIConversationsSession):
+        def __init__(self) -> None:
+            self.saved_items: list[TResponseInputItem] = []
+
+        async def _get_session_id(self) -> str:
+            return "conv_test"
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            self.saved_items.extend(items)
+
+        async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+            return []
+
+        async def pop_item(self) -> TResponseInputItem | None:
+            return None
+
+        async def clear_session(self) -> None:
+            return None
+
+    session = DummyOpenAIConversationsSession()
+    agent = Agent(name="agent", model=FakeModel())
+    run_state: RunState[Any] = RunState(
+        context=RunContextWrapper(context={}),
+        original_input="input",
+        starting_agent=agent,
+        max_turns=1,
+    )
+
+    empty_reasoning = ReasoningItem(
+        agent=agent,
+        raw_item=ResponseReasoningItem(type="reasoning", id="rs_empty", summary=[]),
+    )
+
+    saved_count = await save_result_to_session(
+        session,
+        [],
+        cast(list[RunItem], [empty_reasoning]),
+        run_state,
+    )
+
+    # The item is counted (so the retry counter advances) but not sent to add_items.
+    assert saved_count == 1
+    assert run_state._current_turn_persisted_item_count == 1
+    assert len(session.saved_items) == 0
+
+
+@pytest.mark.asyncio
+async def test_save_result_to_session_keeps_nonempty_reasoning_in_openai_conversations() -> None:
+    """Non-empty reasoning items must still be persisted to OpenAIConversationsSession."""
+
+    class DummyOpenAIConversationsSession(OpenAIConversationsSession):
+        def __init__(self) -> None:
+            self.saved_items: list[TResponseInputItem] = []
+
+        async def _get_session_id(self) -> str:
+            return "conv_test"
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            self.saved_items.extend(items)
+
+        async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+            return []
+
+        async def pop_item(self) -> TResponseInputItem | None:
+            return None
+
+        async def clear_session(self) -> None:
+            return None
+
+    session = DummyOpenAIConversationsSession()
+    agent = Agent(name="agent", model=FakeModel())
+
+    nonempty_reasoning = ReasoningItem(
+        agent=agent,
+        raw_item=ResponseReasoningItem(
+            type="reasoning",
+            id="rs_full",
+            summary=[Summary(type="summary_text", text="I thought about it")],
+        ),
+    )
+
+    saved_count = await save_result_to_session(
+        session,
+        [],
+        cast(list[RunItem], [nonempty_reasoning]),
+        None,
+    )
+
+    assert saved_count == 1
+    assert len(session.saved_items) == 1
+    saved = cast(dict[str, Any], session.saved_items[0])
+    assert saved.get("type") == "reasoning"
+    assert saved.get("summary") != []
+
+
+@pytest.mark.asyncio
 async def test_save_result_to_session_keeps_tool_call_payload_api_safe() -> None:
     session = SimpleListSession()
     agent = Agent(name="agent", model=FakeModel())


### PR DESCRIPTION
### Summary

When using `OpenAIConversationsSession` with a reasoning-enabled model (e.g. `gpt-5.4-mini` with `reasoning: low`), the SDK can produce reasoning run items whose `summary` list is empty. The session persistence path converted these to `{"type":"reasoning","summary":[]}` and attempted to save them via `conversations.items.create(...)`, which the Conversations API rejects with `Invalid item`.

This PR fixes that by:

- Adding `_is_unpersistable_for_openai_conversation()` — a targeted predicate that returns `True` for `{"type":"reasoning","summary":[]}` items.
- In `save_result_to_session`, filtering such items from the `add_items` payload **after** the persisted-item counter is updated. The counter still advances past empty reasoning items so the retry/streaming deduplication logic works correctly; we just stop sending them to the API.

Non-empty reasoning items (with at least one summary entry) are unaffected and continue to be persisted normally.

```
=== LOCAL_TEST_PASSED ===
```

### Test plan

Two new `pytest` tests added to `tests/test_agent_runner.py`:

- `test_save_result_to_session_drops_empty_reasoning_from_openai_conversations` — verifies that an empty reasoning item is **not** sent to `add_items` but **is** counted in `saved_run_items_count` and `_current_turn_persisted_item_count`.
- `test_save_result_to_session_keeps_nonempty_reasoning_in_openai_conversations` — regression guard confirming that reasoning items with a non-empty summary still reach `add_items`.

```
uv run ruff check src/agents/run_internal/session_persistence.py tests/test_agent_runner.py
uv run pytest tests/test_agent_runner.py -k "session" -v
uv run pytest tests/memory/ -v
```

All 45 session tests and 119 memory tests pass.

### Issue number

Closes #3268

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
