### PR TITLE
fix: preserve GitRepo root subpath aliases

### DIFF
--- a/src/agents/sandbox/entries/artifacts.py
+++ b/src/agents/sandbox/entries/artifacts.py
@@ -819,20 +819,26 @@ class GitRepo(BaseEntry):
         if self.subpath is None:
             return None
 
-        subpath = self.subpath
-        if subpath == "":
+        original_subpath = self.subpath
+        if original_subpath == "":
             return None
+
+        subpath = original_subpath.strip()
+        if not subpath:
+            raise GitSubpathError(repo=self.repo, subpath=original_subpath, reason="empty")
 
         posix_subpath = PurePosixPath(subpath)
         windows_subpath = PureWindowsPath(subpath)
         if posix_subpath.as_posix() == ".":
-            raise GitSubpathError(repo=self.repo, subpath=subpath, reason="empty")
+            return None
         if posix_subpath.is_absolute():
-            raise GitSubpathError(repo=self.repo, subpath=subpath, reason="absolute")
-        if "\\" in subpath or windows_subpath.drive:
-            raise GitSubpathError(repo=self.repo, subpath=subpath, reason="windows_path")
+            raise GitSubpathError(repo=self.repo, subpath=original_subpath, reason="absolute")
+        if "\\" in original_subpath or windows_subpath.drive:
+            raise GitSubpathError(repo=self.repo, subpath=original_subpath, reason="windows_path")
         if ".." in posix_subpath.parts:
-            raise GitSubpathError(repo=self.repo, subpath=subpath, reason="parent_traversal")
+            raise GitSubpathError(
+                repo=self.repo, subpath=original_subpath, reason="parent_traversal"
+            )
 
         return posix_subpath
 

--- a/tests/sandbox/test_entries.py
+++ b/tests/sandbox/test_entries.py
@@ -918,7 +918,7 @@ async def test_git_repo_uses_fetch_checkout_path_for_commit_refs() -> None:
 @pytest.mark.parametrize(
     ("subpath", "reason"),
     [
-        (".", "empty"),
+        ("   ", "empty"),
         ("/docs", "absolute"),
         ("../outside", "parent_traversal"),
         ("docs/../../outside", "parent_traversal"),
@@ -942,9 +942,10 @@ async def test_git_repo_rejects_invalid_subpath_before_copy(
 
 
 @pytest.mark.asyncio
-async def test_git_repo_empty_subpath_copies_repo_root() -> None:
+@pytest.mark.parametrize("subpath", ["", ".", "./", "./.", " ./ "])
+async def test_git_repo_root_subpath_alias_copies_repo_root(subpath: str) -> None:
     session = _RecordingSession()
-    repo = GitRepo(repo="openai/example", ref="main", subpath="")
+    repo = GitRepo(repo="openai/example", ref="main", subpath=subpath)
 
     await repo.apply(session, Path("/workspace/repo"), Path("/ignored"))
 


### PR DESCRIPTION
This pull request fixes GitRepo manifest subpath normalization so root aliases such as `.`, `./`, `./.`, and trimmed `./` are treated the same as an empty subpath. This aligns Python SDK behavior with the TypeScript SDK while continuing to reject whitespace-only, absolute, parent-traversing, and Windows-style subpaths.

https://github.com/openai/openai-agents-js/pull/1294