### PR TITLE
fix: #3306 track MongoDB metadata timestamps

### DIFF
--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import json
 import threading
 import weakref
+from datetime import datetime, timezone
 from typing import Any
 
 try:
@@ -294,13 +295,16 @@ class MongoDBSession(SessionABC):
 
         await self._ensure_indexes()
 
+        now = datetime.now(timezone.utc)
+
         # Atomically reserve a block of sequence numbers for this batch.
         # $inc returns the new value, so subtract len(items) to get the first
         # number in the block.
         result = await self._sessions.find_one_and_update(
             {"session_id": self.session_id},
             {
-                "$setOnInsert": {"session_id": self.session_id},
+                "$setOnInsert": {"session_id": self.session_id, "created_at": now},
+                "$set": {"updated_at": now},
                 "$inc": {"_seq": len(items)},
             },
             upsert=True,

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import sys
 import types
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
 
@@ -127,10 +128,13 @@ class FakeAsyncCollection:
                 # Apply $inc fields.
                 for field, delta in update.get("$inc", {}).items():
                     doc[field] = doc.get(field, 0) + delta
+                for field, value in update.get("$set", {}).items():
+                    doc[field] = value
                 return dict(doc) if return_document else None
         if upsert:
             new_doc: dict[str, Any] = {"_id": FakeObjectId()}
             new_doc.update(update.get("$setOnInsert", {}))
+            new_doc.update(update.get("$set", {}))
             for field, delta in update.get("$inc", {}).items():
                 new_doc[field] = new_doc.get(field, 0) + delta
             self._docs[id(new_doc["_id"])] = new_doc
@@ -343,6 +347,26 @@ async def test_multiple_add_calls_accumulate(session: MongoDBSession) -> None:
 
     items = await session.get_items()
     assert [i.get("content") for i in items] == ["a", "b", "c"]
+
+
+async def test_session_metadata_timestamps_are_written(session: MongoDBSession) -> None:
+    """Session metadata records creation time and last update time."""
+    created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    updated_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+    with patch("agents.extensions.memory.mongodb_session.datetime") as mocked_datetime:
+        mocked_datetime.now.side_effect = [created_at, updated_at]
+
+        await session.add_items([{"role": "user", "content": "first"}])
+        session_doc: dict[str, Any] = next(iter(session._sessions._docs.values()))
+        assert session_doc["session_id"] == session.session_id
+        assert session_doc["created_at"] == created_at
+        assert session_doc["updated_at"] == created_at
+
+        await session.add_items([{"role": "assistant", "content": "second"}])
+        assert session_doc["created_at"] == created_at
+        assert session_doc["updated_at"] == updated_at
+        assert session_doc["_seq"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

- Add `created_at` and `updated_at` fields to MongoDB session metadata documents on non-empty writes.
- Preserve `created_at` across later writes while refreshing `updated_at` and continuing to increment `_seq` atomically.
- Add fake MongoDB update support and regression coverage for first and subsequent writes.


### Test plan

- `uv run pytest tests/extensions/memory/test_mongodb_session.py -k "metadata_timestamps or add_and_get_items or multiple_add_calls_accumulate"`
- `uv run pytest tests/extensions/memory/test_mongodb_session.py`
- `uv run mypy tests/extensions/memory/test_mongodb_session.py`
- `uv run pytest tests/extensions/memory/test_mongodb_session.py -k metadata_timestamps`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3306

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
