### PR TITLE
fix: #3308 reject chat custom tool calls explicitly

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -227,7 +227,9 @@ class Converter:
 
                     items.append(ResponseFunctionToolCall(**func_call_kwargs))
                 elif tool_call.type == "custom":
-                    pass
+                    raise AgentsException(
+                        "Custom tool calls are not supported by the Chat Completions converter"
+                    )
 
         return items
 

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -115,6 +115,7 @@ class Converter:
         cls,
         message: ChatCompletionMessage,
         provider_data: dict[str, Any] | None = None,
+        strict_feature_validation: bool = False,
     ) -> list[TResponseOutputItem]:
         """
         Convert a ChatCompletionMessage to a list of response output items.
@@ -227,9 +228,10 @@ class Converter:
 
                     items.append(ResponseFunctionToolCall(**func_call_kwargs))
                 elif tool_call.type == "custom":
-                    raise AgentsException(
-                        "Custom tool calls are not supported by the Chat Completions converter"
-                    )
+                    if strict_feature_validation:
+                        raise UserError(
+                            "Custom tool calls are not supported by the Chat Completions converter"
+                        )
 
         return items
 

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -42,6 +42,7 @@ from openai.types.responses.response_reasoning_text_done_event import (
 )
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
+from ..exceptions import AgentsException
 from ..items import TResponseStreamEvent
 from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
@@ -555,6 +556,11 @@ class ChatCmplStreamHandler:
             # Handle tool calls with real-time streaming support
             if delta.tool_calls:
                 for tc_delta in delta.tool_calls:
+                    if getattr(tc_delta, "type", None) == "custom":
+                        raise AgentsException(
+                            "Custom tool calls are not supported by the Chat Completions converter"
+                        )
+
                     if tc_delta.index not in state.function_calls:
                         state.function_calls[tc_delta.index] = ResponseFunctionToolCall(
                             id=FAKE_RESPONSES_ID,

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -42,7 +42,7 @@ from openai.types.responses.response_reasoning_text_done_event import (
 )
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
-from ..exceptions import AgentsException
+from ..exceptions import UserError
 from ..items import TResponseStreamEvent
 from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
@@ -66,6 +66,7 @@ class StreamingState:
     function_calls: dict[int, ResponseFunctionToolCall] = field(default_factory=dict)
     # Fields for real-time function call streaming
     function_call_streaming: dict[int, bool] = field(default_factory=dict)
+    ignored_tool_call_indexes: set[int] = field(default_factory=set)
     # Store accumulated thinking text and signature for Anthropic compatibility
     thinking_text: str = ""
     thinking_signature: str | None = None
@@ -264,6 +265,7 @@ class ChatCmplStreamHandler:
         response: Response,
         stream: AsyncStream[ChatCompletionChunk],
         model: str | None = None,
+        strict_feature_validation: bool = False,
     ) -> AsyncIterator[TResponseStreamEvent]:
         """
         Handle a streaming chat completion response and yield response events.
@@ -556,10 +558,17 @@ class ChatCmplStreamHandler:
             # Handle tool calls with real-time streaming support
             if delta.tool_calls:
                 for tc_delta in delta.tool_calls:
+                    if tc_delta.index in state.ignored_tool_call_indexes:
+                        continue
+
                     if getattr(tc_delta, "type", None) == "custom":
-                        raise AgentsException(
-                            "Custom tool calls are not supported by the Chat Completions converter"
-                        )
+                        if strict_feature_validation:
+                            raise UserError(
+                                "Custom tool calls are not supported by the Chat Completions "
+                                "converter"
+                            )
+                        state.ignored_tool_call_indexes.add(tc_delta.index)
+                        continue
 
                     if tc_delta.index not in state.function_calls:
                         state.function_calls[tc_delta.index] = ResponseFunctionToolCall(

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -221,7 +221,11 @@ class OpenAIChatCompletionsModel(Model):
                 provider_data["response_id"] = response.id
 
             items = (
-                Converter.message_to_output_items(message, provider_data=provider_data)
+                Converter.message_to_output_items(
+                    message,
+                    provider_data=provider_data,
+                    strict_feature_validation=self._strict_feature_validation,
+                )
                 if message is not None
                 else []
             )
@@ -295,7 +299,10 @@ class OpenAIChatCompletionsModel(Model):
 
             final_response: Response | None = None
             async for chunk in ChatCmplStreamHandler.handle_stream(
-                response, stream, model=self.model
+                response,
+                stream,
+                model=self.model,
+                strict_feature_validation=self._strict_feature_validation,
             ):
                 yield chunk
 

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -10,6 +10,10 @@ from openai import APIConnectionError, APIStatusError, AsyncOpenAI, omit
 from openai.types.chat.chat_completion import ChatCompletion, Choice, ChoiceLogprobs
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.chat.chat_completion_message_custom_tool_call import (
+    ChatCompletionMessageCustomToolCall,
+    Custom,
+)
 from openai.types.chat.chat_completion_message_tool_call import (  # type: ignore[attr-defined]
     ChatCompletionMessageFunctionToolCall,
     Function,
@@ -473,6 +477,45 @@ async def test_get_response_with_tool_call(monkeypatch) -> None:
     assert fn_call_item.call_id == "call-id"
     assert fn_call_item.name == "do_thing"
     assert fn_call_item.arguments == "{'x':1}"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_rejects_custom_tool_call_in_strict_mode(monkeypatch) -> None:
+    tool_call = ChatCompletionMessageCustomToolCall(
+        id="tool1",
+        type="custom",
+        custom=Custom(name="raw_tool", input="payload"),
+    )
+    msg = ChatCompletionMessage(role="assistant", tool_calls=[tool_call])
+    chat = ChatCompletion(
+        id="resp-id",
+        created=0,
+        model="fake",
+        object="chat.completion",
+        choices=[Choice(index=0, finish_reason="tool_calls", message=msg)],
+        usage=None,
+    )
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return chat
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False, strict_feature_validation=True).get_model("gpt-4")
+
+    with pytest.raises(UserError, match="Custom tool calls are not supported"):
+        await model.get_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
 
 
 def test_get_client_disables_provider_managed_retries_on_runner_retry() -> None:

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -28,6 +28,10 @@ from typing import Literal, cast
 import pytest
 from openai import omit
 from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageFunctionToolCall
+from openai.types.chat.chat_completion_message_custom_tool_call import (
+    ChatCompletionMessageCustomToolCall,
+    Custom,
+)
 from openai.types.chat.chat_completion_message_tool_call import Function
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -41,7 +45,7 @@ from openai.types.responses import (
 from openai.types.responses.response_input_item_param import FunctionCallOutput
 
 from agents.agent_output import AgentOutputSchema
-from agents.exceptions import UserError
+from agents.exceptions import AgentsException, UserError
 from agents.items import TResponseInputItem
 from agents.models.chatcmpl_converter import Converter
 from agents.models.fake_id import FAKE_RESPONSES_ID
@@ -106,6 +110,19 @@ def test_message_to_output_items_with_tool_call():
     assert fn_call_item.name == tool_call.function.name
     assert fn_call_item.arguments == tool_call.function.arguments
     assert fn_call_item.type == "function_call"
+
+
+def test_message_to_output_items_with_custom_tool_call_raises():
+    """Custom tool calls should fail explicitly instead of being dropped."""
+    tool_call = ChatCompletionMessageCustomToolCall(
+        id="tool1",
+        type="custom",
+        custom=Custom(name="raw_tool", input="payload"),
+    )
+    msg = ChatCompletionMessage(role="assistant", tool_calls=[tool_call])
+
+    with pytest.raises(AgentsException, match="Custom tool calls are not supported"):
+        Converter.message_to_output_items(msg)
 
 
 def test_items_to_messages_with_string_user_content():

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -45,7 +45,7 @@ from openai.types.responses import (
 from openai.types.responses.response_input_item_param import FunctionCallOutput
 
 from agents.agent_output import AgentOutputSchema
-from agents.exceptions import AgentsException, UserError
+from agents.exceptions import UserError
 from agents.items import TResponseInputItem
 from agents.models.chatcmpl_converter import Converter
 from agents.models.fake_id import FAKE_RESPONSES_ID
@@ -112,8 +112,8 @@ def test_message_to_output_items_with_tool_call():
     assert fn_call_item.type == "function_call"
 
 
-def test_message_to_output_items_with_custom_tool_call_raises():
-    """Custom tool calls should fail explicitly instead of being dropped."""
+def test_message_to_output_items_with_custom_tool_call_keeps_default_compatibility():
+    """Custom tool calls should keep the default Chat Completions behavior."""
     tool_call = ChatCompletionMessageCustomToolCall(
         id="tool1",
         type="custom",
@@ -121,8 +121,41 @@ def test_message_to_output_items_with_custom_tool_call_raises():
     )
     msg = ChatCompletionMessage(role="assistant", tool_calls=[tool_call])
 
-    with pytest.raises(AgentsException, match="Custom tool calls are not supported"):
-        Converter.message_to_output_items(msg)
+    assert Converter.message_to_output_items(msg) == []
+
+
+def test_message_to_output_items_with_custom_tool_call_raises_in_strict_mode():
+    """Strict validation should fail explicitly instead of dropping custom tool calls."""
+    tool_call = ChatCompletionMessageCustomToolCall(
+        id="tool1",
+        type="custom",
+        custom=Custom(name="raw_tool", input="payload"),
+    )
+    msg = ChatCompletionMessage(role="assistant", tool_calls=[tool_call])
+
+    with pytest.raises(UserError, match="Custom tool calls are not supported"):
+        Converter.message_to_output_items(msg, strict_feature_validation=True)
+
+
+def test_message_to_output_items_with_mixed_custom_tool_call_raises_in_strict_mode():
+    """Strict validation should not partially hide an unsupported custom tool call."""
+    function_tool_call = ChatCompletionMessageFunctionToolCall(
+        id="function-tool",
+        type="function",
+        function=Function(name="myfn", arguments='{"x":1}'),
+    )
+    custom_tool_call = ChatCompletionMessageCustomToolCall(
+        id="custom-tool",
+        type="custom",
+        custom=Custom(name="raw_tool", input="payload"),
+    )
+    msg = ChatCompletionMessage(
+        role="assistant",
+        tool_calls=[function_tool_call, custom_tool_call],
+    )
+
+    with pytest.raises(UserError, match="Custom tool calls are not supported"):
+        Converter.message_to_output_items(msg, strict_feature_validation=True)
 
 
 def test_items_to_messages_with_string_user_content():

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -29,7 +29,7 @@ from openai.types.responses import (
     ResponseOutputText,
 )
 
-from agents.exceptions import AgentsException, UserError
+from agents.exceptions import UserError
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
@@ -596,7 +596,7 @@ async def test_stream_response_yields_events_for_tool_call(monkeypatch) -> None:
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
-async def test_stream_response_with_custom_tool_call_raises(monkeypatch) -> None:
+async def test_stream_response_with_custom_tool_call_raises_in_strict_mode(monkeypatch) -> None:
     custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
         index=0,
         id="tool-call-123",
@@ -627,9 +627,9 @@ async def test_stream_response_with_custom_tool_call_raises(monkeypatch) -> None
         return resp, fake_stream()
 
     monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
-    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    model = OpenAIProvider(use_responses=False, strict_feature_validation=True).get_model("gpt-4")
 
-    with pytest.raises(AgentsException, match="Custom tool calls are not supported"):
+    with pytest.raises(UserError, match="Custom tool calls are not supported"):
         async for _event in model.stream_response(
             system_instructions=None,
             input="",
@@ -643,6 +643,86 @@ async def test_stream_response_with_custom_tool_call_raises(monkeypatch) -> None
             prompt=None,
         ):
             pass
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_ignores_custom_tool_call_chunks_by_default(monkeypatch) -> None:
+    custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
+        index=0,
+        id="tool-call-123",
+        type="custom",
+    )
+    omitted_type_tool_call_delta = ChoiceDeltaToolCall.model_construct(
+        index=0,
+        function=ChoiceDeltaToolCallFunction(name="custom_tool", arguments="payload"),
+    )
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[custom_tool_call_delta]))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[omitted_type_tool_call_delta]))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(content="done"))],
+        ),
+    ]
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in chunks:
+            yield chunk
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return _empty_response(), fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    events = []
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        events.append(event)
+
+    function_call_events = []
+    for event in events:
+        item = getattr(event, "item", None)
+        if isinstance(item, ResponseFunctionToolCall):
+            function_call_events.append(event)
+    assert function_call_events == []
+    completed_event = events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assert all(
+        not isinstance(item, ResponseFunctionToolCall) for item in completed_event.response.output
+    )
+    assert len(completed_event.response.output) == 1
+    message = completed_event.response.output[0]
+    assert isinstance(message, ResponseOutputMessage)
+    assert len(message.content) == 1
+    assert isinstance(message.content[0], ResponseOutputText)
+    assert message.content[0].text == "done"
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -29,7 +29,7 @@ from openai.types.responses import (
     ResponseOutputText,
 )
 
-from agents.exceptions import UserError
+from agents.exceptions import AgentsException, UserError
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
@@ -592,6 +592,57 @@ async def test_stream_response_yields_events_for_tool_call(monkeypatch) -> None:
     assert isinstance(final_fn, ResponseFunctionToolCall)
     assert final_fn.name == "my_func"
     assert final_fn.arguments == "arg1arg2"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_with_custom_tool_call_raises(monkeypatch) -> None:
+    custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
+        index=0,
+        id="tool-call-123",
+        type="custom",
+    )
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[custom_tool_call_delta]))],
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield chunk
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    with pytest.raises(AgentsException, match="Custom tool calls are not supported"):
+        async for _event in model.stream_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        ):
+            pass
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

- Gate Chat Completions `custom` tool-call rejection behind `strict_feature_validation` so the default behavior stays compatible.
- Raise `UserError` for unsupported `custom` tool calls in both non-streaming and streaming Chat Completions strict mode.
- Track ignored streamed custom tool-call indexes so later chunks without `type` do not become malformed function-call items.
- Add regression coverage for default compatibility, strict-mode rejection, mixed function/custom calls, and streamed custom chunks.

### Test plan

- `uv run pytest tests/models/test_openai_chatcompletions_converter.py -k custom_tool_call`
- `uv run pytest tests/models/test_openai_chatcompletions_converter.py -k "custom_tool_call or mixed_custom"`
- `uv run pytest tests/models/test_openai_chatcompletions_stream.py -k custom_tool_call`
- `uv run pytest tests/models/test_openai_chatcompletions.py -k custom_tool_call`
- `uv run pytest tests/models/test_openai_chatcompletions_converter.py tests/models/test_openai_chatcompletions_stream.py tests/models/test_openai_chatcompletions.py`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3308

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass