### PR TITLE
docs: document sandbox archive limits after #3278 release

### DIFF
--- a/docs/sandbox/guide.md
+++ b/docs/sandbox/guide.md
@@ -481,6 +481,8 @@ These options only matter when the runner is creating a fresh sandbox session:
 
 `concurrency_limits` controls how much sandbox materialization work can run in parallel. Use `SandboxConcurrencyLimits(manifest_entries=..., local_dir_files=...)` when large manifests or local directory copies need tighter resource control. Set either value to `None` to disable that specific limit.
 
+`archive_limits` controls SDK-side resource checks for archive extraction. Use `SandboxArchiveLimits(max_input_bytes=..., max_extracted_bytes=..., max_members=...)` when archives need tighter resource control. Set `archive_limits=None` to keep the default behavior with no SDK archive resource limits, or set an individual value to `None` to disable that specific limit.
+
 A few implications are worth keeping in mind:
 
 - Fresh sessions: `manifest=` and `snapshot=` only apply when the runner is creating a fresh sandbox session.

--- a/docs/sandbox/guide.md
+++ b/docs/sandbox/guide.md
@@ -481,7 +481,7 @@ These options only matter when the runner is creating a fresh sandbox session:
 
 `concurrency_limits` controls how much sandbox materialization work can run in parallel. Use `SandboxConcurrencyLimits(manifest_entries=..., local_dir_files=...)` when large manifests or local directory copies need tighter resource control. Set either value to `None` to disable that specific limit.
 
-`archive_limits` controls SDK-side resource checks for archive extraction. Use `SandboxArchiveLimits(max_input_bytes=..., max_extracted_bytes=..., max_members=...)` when archives need tighter resource control. Set `archive_limits=None` to keep the default behavior with no SDK archive resource limits, or set an individual value to `None` to disable that specific limit.
+`archive_limits` controls SDK-side resource checks for archive extraction. Set `archive_limits=SandboxArchiveLimits()` to enable the SDK default thresholds, or pass explicit values such as `SandboxArchiveLimits(max_input_bytes=..., max_extracted_bytes=..., max_members=...)` when archives need tighter resource control. Leave `archive_limits=None` to keep the default behavior with no SDK archive resource limits, or set an individual field to `None` to disable only that limit.
 
 A few implications are worth keeping in mind:
 


### PR DESCRIPTION
### Summary
- Add post-release sandbox guide coverage for `archive_limits`.
- This is a docs follow-up for #3278 and should stay draft/blocked until the SDK release.

### Test plan
- `make build-docs`

### Issue number
Follow-up to #3274 / #3278. Blocked until the SDK release containing #3278.

### Checks
- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [ ] I've made sure tests pass
