### PR TITLE
fix: #3313 align multi-choice chat streams with strict validation

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -42,7 +42,9 @@ from openai.types.responses.response_reasoning_text_done_event import (
 )
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
+from ..exceptions import UserError
 from ..items import TResponseStreamEvent
+from ..logger import logger
 from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
 
@@ -70,6 +72,7 @@ class StreamingState:
     thinking_signature: str | None = None
     # Store provider data for all output items
     provider_data: dict[str, Any] = field(default_factory=dict)
+    has_warned_unsupported_choice: bool = False
 
 
 class SequenceNumber:
@@ -263,6 +266,7 @@ class ChatCmplStreamHandler:
         response: Response,
         stream: AsyncStream[ChatCompletionChunk],
         model: str | None = None,
+        strict_feature_validation: bool = False,
     ) -> AsyncIterator[TResponseStreamEvent]:
         """
         Handle a streaming chat completion response and yield response events.
@@ -291,7 +295,33 @@ class ChatCmplStreamHandler:
             if hasattr(chunk, "usage") and chunk.usage is not None:
                 usage = chunk.usage
 
-            if not chunk.choices or not chunk.choices[0].delta:
+            if not chunk.choices:
+                continue
+
+            unsupported_choice_indexes = [
+                choice.index for choice in chunk.choices if choice.index != 0
+            ]
+            if len(chunk.choices) > 1 or unsupported_choice_indexes:
+                message = (
+                    "Chat Completions streaming with multiple choices or nonzero choice indexes "
+                    "is not fully supported; only choice index 0 can be processed."
+                )
+                if strict_feature_validation:
+                    raise UserError(message)
+
+                if not state.has_warned_unsupported_choice:
+                    logger.warning(
+                        "%s Ignoring the other choices; enable strict feature validation to "
+                        "raise an error instead.",
+                        message,
+                    )
+                    state.has_warned_unsupported_choice = True
+
+            choice = next((choice for choice in chunk.choices if choice.index == 0), None)
+            if choice is None:
+                continue
+
+            if not choice.delta:
                 continue
 
             # Build provider_data for non-OpenAI Responses API endpoints format
@@ -303,8 +333,8 @@ class ChatCmplStreamHandler:
             if hasattr(chunk, "id") and chunk.id:
                 state.provider_data["response_id"] = chunk.id
 
-            delta = chunk.choices[0].delta
-            choice_logprobs = chunk.choices[0].logprobs
+            delta = choice.delta
+            choice_logprobs = choice.logprobs
 
             # Handle thinking blocks from Anthropic (for preserving signatures)
             if hasattr(delta, "thinking_blocks") and delta.thinking_blocks:

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -295,7 +295,10 @@ class OpenAIChatCompletionsModel(Model):
 
             final_response: Response | None = None
             async for chunk in ChatCmplStreamHandler.handle_stream(
-                response, stream, model=self.model
+                response,
+                stream,
+                model=self.model,
+                strict_feature_validation=self._strict_feature_validation,
             ):
                 yield chunk
 

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -31,6 +31,7 @@ from openai.types.responses import (
 
 from agents.exceptions import UserError
 from agents.model_settings import ModelSettings
+from agents.models.chatcmpl_stream_handler import ChatCmplStreamHandler
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
@@ -154,6 +155,180 @@ async def test_stream_response_yields_events_for_text_content(monkeypatch) -> No
     assert completed_resp.usage.total_tokens == 12
     assert completed_resp.usage.input_tokens_details.cached_tokens == 2
     assert completed_resp.usage.output_tokens_details.reasoning_tokens == 3
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_filters_multiple_choices_by_default(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=1, delta=ChoiceDelta(content="ignored-first"))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(index=0, delta=ChoiceDelta(content="kept")),
+                Choice(index=1, delta=ChoiceDelta(content="ignored-second")),
+            ],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=2, delta=ChoiceDelta(content="ignored-third"))],
+            usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+        ),
+    ]
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for chunk in chunks:
+            yield chunk
+
+    events = [
+        event
+        async for event in ChatCmplStreamHandler.handle_stream(
+            _empty_response(), cast(Any, fake_stream())
+        )
+    ]
+
+    text_delta_events = [event for event in events if event.type == "response.output_text.delta"]
+    assert [event.delta for event in text_delta_events] == ["kept"]
+    completed_event = next(event for event in events if event.type == "response.completed")
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assert isinstance(completed_event.response.output[0], ResponseOutputMessage)
+    text_part = completed_event.response.output[0].content[0]
+    assert isinstance(text_part, ResponseOutputText)
+    assert text_part.text == "kept"
+    assert completed_event.response.usage
+    assert completed_event.response.usage.total_tokens == 3
+
+    choice_warnings = [
+        record
+        for record in caplog.records
+        if "multiple choices or nonzero choice indexes" in record.getMessage()
+    ]
+    assert len(choice_warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_keeps_empty_choice_usage_chunks() -> None:
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[],
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield chunk
+
+    events = [
+        event
+        async for event in ChatCmplStreamHandler.handle_stream(
+            _empty_response(), cast(Any, fake_stream())
+        )
+    ]
+
+    assert [event.type for event in events] == ["response.created", "response.completed"]
+    completed_event = events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assert completed_event.response.output == []
+    assert completed_event.response.usage
+    assert completed_event.response.usage.total_tokens == 3
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_rejects_multiple_choices_in_strict_mode() -> None:
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[
+            Choice(index=0, delta=ChoiceDelta(content="first")),
+            Choice(index=1, delta=ChoiceDelta(content="second")),
+        ],
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield chunk
+
+    with pytest.raises(UserError, match="multiple choices or nonzero"):
+        async for _ in ChatCmplStreamHandler.handle_stream(
+            _empty_response(), cast(Any, fake_stream()), strict_feature_validation=True
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_rejects_nonzero_choice_index_in_strict_mode() -> None:
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=1, delta=ChoiceDelta(content="second"))],
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield chunk
+
+    with pytest.raises(UserError, match="multiple choices or nonzero"):
+        async for _ in ChatCmplStreamHandler.handle_stream(
+            _empty_response(), cast(Any, fake_stream()), strict_feature_validation=True
+        ):
+            pass
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_passes_strict_validation_to_stream_handler(monkeypatch) -> None:
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=1, delta=ChoiceDelta(content="ignored"))],
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield chunk
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return _empty_response(), fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(
+        use_responses=False,
+        strict_feature_validation=True,
+    ).get_model("gpt-4")
+
+    with pytest.raises(UserError, match="multiple choices or nonzero"):
+        async for _event in model.stream_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        ):
+            pass
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

- Align Chat Completions streaming multi-choice handling with `strict_feature_validation`.
- In strict mode, raise `UserError` when streamed chunks contain multiple choices or nonzero choice indexes.
- In the default compatibility path, process only `choice.index == 0`, ignore the other choices with a one-time warning, and keep `choices=[]` usage-only chunks valid.
- Add regression coverage for strict mode, default filtering, empty-choice usage chunks, and the model-to-handler strict flag wiring.

### Test plan

- `uv run pytest tests/models/test_openai_chatcompletions_stream.py -k "multiple_choices or nonzero_choice or empty_choice or strict_validation"`
- `uv run pytest tests/models/test_openai_chatcompletions_stream.py`
- `uv run pytest tests/models/test_litellm_chatcompletions_stream.py tests/models/test_any_llm_model.py::test_any_llm_stream_uses_chat_handler_when_responses_are_unsupported`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3313

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass