### PR TITLE
fix: #3315 align generic dict output schemas

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -169,15 +169,15 @@ class AgentOutputSchema(AgentOutputSchemaBase):
 
 
 def _is_subclass_of_base_model_or_dict(t: Any) -> bool:
+    # If it's a generic alias, 'origin' will be the actual type, e.g. 'list'
+    origin = get_origin(t)
+    if origin is not None:
+        return isinstance(origin, type) and issubclass(origin, BaseModel | dict)
+
     if not isinstance(t, type):
         return False
 
-    # If it's a generic alias, 'origin' will be the actual type, e.g. 'list'
-    origin = get_origin(t)
-
-    allowed_types = (BaseModel, dict)
-    # If it's a generic alias e.g. list[str], then we should check the origin type i.e. list
-    return issubclass(origin or t, allowed_types)
+    return issubclass(t, BaseModel | dict)
 
 
 def _type_to_str(t: type[Any]) -> str:

--- a/tests/test_output_tool.py
+++ b/tests/test_output_tool.py
@@ -77,6 +77,23 @@ def test_structured_output_list():
     assert validated == ["foo", "bar"]
 
 
+def test_structured_output_generic_dict_is_not_wrapped():
+    output_schema = AgentOutputSchema(output_type=dict[str, int], strict_json_schema=False)
+    assert output_schema.output_type == dict[str, int]
+    assert not output_schema._is_wrapped, "Generic dict output should not be wrapped"
+    assert "response" not in output_schema.json_schema().get("properties", {})
+
+    validated = output_schema.validate_json(json.dumps({"foo": 1}))
+    assert validated == {"foo": 1}
+
+
+def test_structured_output_generic_dict_rejects_wrapper_shape():
+    output_schema = AgentOutputSchema(output_type=dict[str, int], strict_json_schema=False)
+
+    with pytest.raises(ModelBehaviorError):
+        output_schema.validate_json(json.dumps({"response": {"foo": 1}}))
+
+
 def test_bad_json_raises_error(mocker):
     agent = Agent(name="test", output_type=Foo)
     output_schema = get_output_schema(agent)


### PR DESCRIPTION
### Summary

- Detect generic dict output types by checking their origin before rejecting non-`type` objects.
- Keep `dict[str, int]` unwrapped like bare `dict` when generating and validating non-strict structured output schemas.
- Add regression coverage for direct generic dict validation and wrapper-shape rejection.

### Test plan

- `uv run pytest tests/test_output_tool.py -k generic_dict`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3315

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
