### PR TITLE
fix: #3317 return fresh empty strict schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import Any, TypeGuard
 
 from openai import NOT_GIVEN
@@ -21,7 +22,7 @@ def ensure_strict_json_schema(
     that the OpenAI API expects.
     """
     if schema == {}:
-        return _EMPTY_SCHEMA
+        return copy.deepcopy(_EMPTY_SCHEMA)
     return _ensure_strict_json_schema(schema, path=(), root=schema)
 
 

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -9,6 +9,25 @@ def test_empty_schema_has_additional_properties_false():
     assert strict_schema["additionalProperties"] is False
 
 
+def test_empty_schema_returns_fresh_copy():
+    first = ensure_strict_json_schema({})
+    first["additionalProperties"] = True
+    first["properties"]["polluted"] = {"type": "string"}
+    first["required"].append("polluted")
+
+    second = ensure_strict_json_schema({})
+
+    assert second is not first
+    assert second == {
+        "additionalProperties": False,
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+    assert second["properties"] is not first["properties"]
+    assert second["required"] is not first["required"]
+
+
 def test_non_dict_schema_errors():
     with pytest.raises(TypeError):
         ensure_strict_json_schema([])  # type: ignore


### PR DESCRIPTION
### Summary

- Return a fresh deep copy for the `ensure_strict_json_schema({})` fast path so callers cannot mutate the shared `_EMPTY_SCHEMA` object.
- Add regression coverage for top-level and nested mutable fields on empty strict schemas.
- Checked adjacent PR #3199; it fixes MCP fallback isolation after failed in-place strict conversion, but it does not cover this empty-schema shared-object path. Checked similar callers in function tools, handoffs, realtime handoffs, output schemas, and MCP conversion; the fix is limited to exact empty dict input and leaves documented non-empty in-place normalization unchanged.

### Test plan

- `uv run pytest tests/test_strict_schema.py -k empty_schema`
- `uv run pytest tests/test_strict_schema.py`
- `uv run pytest tests/test_strict_schema_oneof.py`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3317

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
