### PR TITLE
fix: #3321 validate prompt configs

### DIFF
--- a/src/agents/prompts.py
+++ b/src/agents/prompts.py
@@ -53,6 +53,26 @@ def _coerce_prompt_dict(prompt: Prompt | dict[object, object]) -> Prompt:
     return cast(Prompt, prompt)
 
 
+def validate_prompt(prompt: object, *, source: str = "Prompt") -> Prompt:
+    """Validate a prompt config before forwarding it to a model provider."""
+    if not isinstance(prompt, dict):
+        raise UserError(f"{source} must be a Prompt")
+
+    prompt_id = prompt.get("id")
+    if not isinstance(prompt_id, str) or not prompt_id:
+        raise UserError(f"{source} must include a non-empty string 'id'")
+
+    version = prompt.get("version")
+    if version is not None and not isinstance(version, str):
+        raise UserError(f"{source} 'version' must be a string when provided")
+
+    variables = prompt.get("variables")
+    if variables is not None and not isinstance(variables, dict):
+        raise UserError(f"{source} 'variables' must be a dict when provided")
+
+    return _coerce_prompt_dict(prompt)
+
+
 class PromptUtil:
     @staticmethod
     async def to_model_input(
@@ -65,15 +85,19 @@ class PromptUtil:
 
         resolved_prompt: Prompt
         if isinstance(prompt, dict):
-            resolved_prompt = _coerce_prompt_dict(prompt)
+            resolved_prompt = validate_prompt(prompt)
         else:
+            if not callable(prompt):
+                raise UserError("Agent prompt must be a Prompt or DynamicPromptFunction")
             func_result = prompt(GenerateDynamicPromptData(context=context, agent=agent))
             if inspect.isawaitable(func_result):
                 resolved_prompt = await func_result
             else:
                 resolved_prompt = func_result
-            if not isinstance(resolved_prompt, dict):
-                raise UserError("Dynamic prompt function must return a Prompt")
+            resolved_prompt = validate_prompt(
+                resolved_prompt,
+                source="Dynamic prompt function return value",
+            )
 
         return {
             "id": resolved_prompt["id"],

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -85,7 +85,7 @@ from typing_extensions import NotRequired, TypedDict, assert_never
 from websockets.asyncio.client import ClientConnection
 
 from agents.handoffs import Handoff
-from agents.prompts import Prompt
+from agents.prompts import Prompt, validate_prompt
 from agents.realtime._default_tracker import ModelAudioTracker
 from agents.realtime.audio_formats import to_realtime_audio_format
 from agents.tool import (
@@ -403,8 +403,9 @@ async def _build_model_settings_from_agent(
 ) -> RealtimeSessionModelSettings:
     updated_settings = base_settings.copy()
 
-    if agent.prompt is not None:
-        updated_settings["prompt"] = agent.prompt
+    prompt = vars(agent).get("prompt")
+    if prompt is not None:
+        updated_settings["prompt"] = prompt
 
     instructions, tools, handoffs = await asyncio.gather(
         agent.get_system_prompt(context_wrapper),
@@ -420,6 +421,12 @@ async def _build_model_settings_from_agent(
 
     if run_config and run_config.get("tracing_disabled", False):
         updated_settings["tracing"] = None
+
+    if "prompt" in updated_settings:
+        updated_settings["prompt"] = validate_prompt(
+            updated_settings["prompt"],
+            source="Realtime session prompt",
+        )
 
     return updated_settings
 
@@ -1466,7 +1473,10 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
             session_create_request.instructions = model_settings.get("instructions")
 
         if "prompt" in model_settings:
-            _passed_prompt: Prompt = model_settings["prompt"]
+            _passed_prompt: Prompt = validate_prompt(
+                model_settings["prompt"],
+                source="Realtime session prompt",
+            )
             variables: dict[str, Any] | None = _passed_prompt.get("variables")
             session_create_request.prompt = ResponsePrompt(
                 id=_passed_prompt["id"],

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -16,6 +16,7 @@ from ..exceptions import UserError
 from ..handoffs import Handoff
 from ..items import ToolApprovalItem
 from ..logger import logger
+from ..prompts import validate_prompt
 from ..run_config import ToolErrorFormatterArgs
 from ..run_context import RunContextWrapper, TContext
 from ..tool import DEFAULT_APPROVAL_REJECTION_MESSAGE, FunctionTool, invoke_function_tool
@@ -1101,8 +1102,9 @@ class RealtimeSession(RealtimeModelListener):
         # Start with the merged base settings from run and model configuration.
         updated_settings = self._base_model_settings.copy()
 
-        if agent.prompt is not None:
-            updated_settings["prompt"] = agent.prompt
+        prompt = vars(agent).get("prompt")
+        if prompt is not None:
+            updated_settings["prompt"] = prompt
 
         instructions, tools, handoffs = await asyncio.gather(
             agent.get_system_prompt(self._context_wrapper),
@@ -1120,6 +1122,12 @@ class RealtimeSession(RealtimeModelListener):
         disable_tracing = self._run_config.get("tracing_disabled", False)
         if disable_tracing:
             updated_settings["tracing"] = None
+
+        if "prompt" in updated_settings:
+            updated_settings["prompt"] = validate_prompt(
+                updated_settings["prompt"],
+                source="Realtime session prompt",
+            )
 
         return updated_settings
 

--- a/tests/realtime/test_realtime_model_settings.py
+++ b/tests/realtime/test_realtime_model_settings.py
@@ -8,6 +8,7 @@ from openai.types.realtime.realtime_session_create_request import (
 )
 from openai.types.realtime.session_update_event import SessionUpdateEvent
 
+from agents.exceptions import UserError
 from agents.handoffs import Handoff
 from agents.realtime.agent import RealtimeAgent
 from agents.realtime.config import RealtimeRunConfig, RealtimeSessionModelSettings
@@ -74,6 +75,37 @@ async def test_build_model_settings_from_agent_merges_agent_fields(monkeypatch: 
 
 
 @pytest.mark.asyncio
+async def test_build_model_settings_from_agent_validates_prompt() -> None:
+    agent = RealtimeAgent(name="root", prompt={})  # type: ignore[arg-type]
+
+    with pytest.raises(UserError, match="Realtime session prompt must include"):
+        await _build_model_settings_from_agent(
+            agent=agent,
+            context_wrapper=RunContextWrapper(None),
+            base_settings={"model_name": "gpt-realtime-2"},
+            starting_settings=None,
+            run_config=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_model_settings_from_agent_validates_final_prompt() -> None:
+    agent = RealtimeAgent(name="root", prompt={"id": "agent-prompt"})
+    starting_settings: RealtimeSessionModelSettings = {
+        "prompt": {},  # type: ignore[typeddict-item]
+    }
+
+    with pytest.raises(UserError, match="Realtime session prompt must include"):
+        await _build_model_settings_from_agent(
+            agent=agent,
+            context_wrapper=RunContextWrapper(None),
+            base_settings={"model_name": "gpt-realtime-2"},
+            starting_settings=starting_settings,
+            run_config=None,
+        )
+
+
+@pytest.mark.asyncio
 async def test_sip_model_build_initial_session_payload(monkeypatch: pytest.MonkeyPatch):
     agent = RealtimeAgent(name="parent", prompt={"id": "prompt-99"})
     child_agent = RealtimeAgent(name="child")
@@ -131,6 +163,19 @@ async def test_sip_model_build_initial_session_payload(monkeypatch: pytest.Monke
             tool_names.add(name)
     assert ping.name in tool_names
     assert f"transfer_to_{child_agent.name}" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_sip_model_build_initial_session_payload_validates_override_prompt() -> None:
+    overrides: RealtimeSessionModelSettings = {
+        "prompt": {},  # type: ignore[typeddict-item]
+    }
+
+    with pytest.raises(UserError, match="Realtime session prompt must include"):
+        await OpenAIRealtimeSIPModel.build_initial_session_payload(
+            RealtimeAgent(name="parent"),
+            overrides=overrides,
+        )
 
 
 def test_call_id_session_update_omits_null_audio_formats() -> None:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -166,6 +166,22 @@ async def test_transcription_completed_adds_new_user_item():
     assert session._history[0].role == "user"
 
 
+@pytest.mark.asyncio
+async def test_get_updated_model_settings_from_agent_validates_final_prompt():
+    model = _DummyModel()
+    agent = RealtimeAgent(name="agent", prompt={"id": "agent-prompt"})
+    session = RealtimeSession(model, agent, None)
+    starting_settings: RealtimeSessionModelSettings = {
+        "prompt": {},  # type: ignore[typeddict-item]
+    }
+
+    with pytest.raises(UserError, match="Realtime session prompt must include"):
+        await session._get_updated_model_settings_from_agent(
+            starting_settings=starting_settings,
+            agent=agent,
+        )
+
+
 class _FakeAudio:
     # Looks like an audio part but is not an InputAudio/AssistantAudio instance
     type = "audio"

--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 from openai import omit
 
-from agents import Agent, Prompt, RunConfig, RunContextWrapper, Runner
+from agents import Agent, Prompt, RunConfig, RunContextWrapper, Runner, UserError
 from agents.models.interface import Model, ModelProvider
 from agents.models.openai_responses import OpenAIResponsesModel
 
@@ -69,6 +71,25 @@ async def test_static_prompt_is_resolved_correctly():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("prompt", "message"),
+    [
+        ({}, "non-empty string 'id'"),
+        ({"id": ""}, "non-empty string 'id'"),
+        ({"id": 123}, "non-empty string 'id'"),
+        ({"id": "pmpt_123", "version": 1}, "'version' must be a string"),
+        ({"id": "pmpt_123", "variables": []}, "'variables' must be a dict"),
+    ],
+)
+async def test_static_prompt_validation_errors(prompt: dict[str, object], message: str):
+    agent = Agent(name="test", prompt=cast(Any, prompt))
+    context_wrapper = RunContextWrapper(context=None)
+
+    with pytest.raises(UserError, match=message):
+        await agent.get_prompt(context_wrapper)
+
+
+@pytest.mark.asyncio
 async def test_dynamic_prompt_is_resolved_correctly():
     dynamic_prompt_value: Prompt = {"id": "dyn_prompt", "version": "2"}
 
@@ -81,6 +102,27 @@ async def test_dynamic_prompt_is_resolved_correctly():
     resolved = await agent.get_prompt(context_wrapper)
 
     assert resolved == {"id": "dyn_prompt", "version": "2", "variables": None}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("prompt", "message"),
+    [
+        ({}, "non-empty string 'id'"),
+        ({"id": 123}, "non-empty string 'id'"),
+        ({"id": "pmpt_123", "version": 1}, "'version' must be a string"),
+        ({"id": "pmpt_123", "variables": []}, "'variables' must be a dict"),
+    ],
+)
+async def test_dynamic_prompt_validation_errors(prompt: dict[str, object], message: str):
+    def dynamic_prompt_fn(_data):
+        return prompt
+
+    agent = Agent(name="test", prompt=dynamic_prompt_fn)
+    context_wrapper = RunContextWrapper(context=None)
+
+    with pytest.raises(UserError, match=message):
+        await agent.get_prompt(context_wrapper)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

- Validate prompt configs before forwarding them to model providers, so missing or non-string `id` values and invalid optional fields raise `UserError`.
- Apply the shared validation to static Agent prompts, dynamic prompt return values, and RealtimeAgent prompt settings while preserving existing valid prompt payloads.


### Test plan

- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3321

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
