### PR TITLE
fix: include sandbox provider error details

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -72,6 +72,36 @@ DEFAULT_BLAXEL_WORKSPACE_ROOT = "/workspace"
 logger = logging.getLogger(__name__)
 
 
+def _blaxel_provider_error_detail(error: BaseException) -> str | None:
+    message = str(error)
+    status = getattr(error, "status_code", None) or getattr(error, "status", None)
+    if isinstance(status, int):
+        if message:
+            return f"HTTP {status}: {message}"
+        return f"HTTP {status}"
+    if message:
+        return f"{type(error).__name__}: {message}"
+    return type(error).__name__
+
+
+def _blaxel_exec_transport_error(
+    *,
+    command: tuple[str | Path, ...],
+    cause: BaseException,
+) -> ExecTransportError:
+    detail = _blaxel_provider_error_detail(cause)
+    context: dict[str, object] = {"backend": "blaxel"}
+    if detail:
+        context["provider_error"] = detail
+    status = getattr(cause, "status_code", None) or getattr(cause, "status", None)
+    if isinstance(status, int):
+        context["http_status"] = status
+    message = "Blaxel exec failed"
+    if detail:
+        message = f"{message}: {detail}"
+    return ExecTransportError(command=command, context=context, cause=cause, message=message)
+
+
 def _import_blaxel_sdk() -> Any:
     """Lazily import SandboxInstance from the Blaxel SDK, raising a clear error if missing."""
     try:
@@ -496,7 +526,7 @@ class BlaxelSandboxSession(BaseSandboxSession):
                 status = getattr(e, "status_code", None)
                 if status in (408, 504):
                     raise ExecTimeoutError(command=command, timeout_s=timeout, cause=e) from e
-            raise ExecTransportError(command=command, cause=e) from e
+            raise _blaxel_exec_transport_error(command=command, cause=e) from e
 
     # -- running check -------------------------------------------------------
 
@@ -716,7 +746,7 @@ class BlaxelSandboxSession(BaseSandboxSession):
         except Exception as e:
             if not registered:
                 await self._terminate_pty_entry(entry)
-            raise ExecTransportError(command=command, cause=e) from e
+            raise _blaxel_exec_transport_error(command=command, cause=e) from e
 
         if pruned is not None:
             await self._terminate_pty_entry(pruned)

--- a/src/agents/extensions/sandbox/cloudflare/sandbox.py
+++ b/src/agents/extensions/sandbox/cloudflare/sandbox.py
@@ -156,6 +156,26 @@ def _cloudflare_exec_error_detail(error: ExecTransportError) -> str | None:
     return None
 
 
+def _cloudflare_transport_error(
+    *,
+    command: tuple[str, ...],
+    cause: BaseException,
+    operation: str,
+) -> ExecTransportError:
+    detail = str(cause)
+    provider_error = f"{type(cause).__name__}: {detail}" if detail else type(cause).__name__
+    return ExecTransportError(
+        command=command,
+        context={
+            "backend": "cloudflare",
+            "operation": operation,
+            "provider_error": provider_error,
+        },
+        cause=cause,
+        message=f"Cloudflare {operation} transport failed: {provider_error}",
+    )
+
+
 def _is_transient_workspace_error(exc: BaseException) -> bool:
     """Return True if *exc* is a workspace archive error caused by a transient HTTP status."""
     if not isinstance(exc, WorkspaceArchiveReadError | WorkspaceArchiveWriteError):
@@ -789,7 +809,11 @@ class CloudflareSandboxSession(BaseSandboxSession):
         except (ExecTimeoutError, ExecTransportError):
             raise
         except aiohttp.ClientError as e:
-            raise ExecTransportError(command=tuple(argv), cause=e) from e
+            raise _cloudflare_transport_error(
+                command=tuple(argv),
+                cause=e,
+                operation="exec",
+            ) from e
         except Exception as e:
             raise ExecTransportError(command=tuple(argv), cause=e) from e
 
@@ -1015,6 +1039,13 @@ class CloudflareSandboxSession(BaseSandboxSession):
         except ExecTransportError:
             await self._cleanup_unregistered_pty(entry, ws, registered)
             raise
+        except aiohttp.ClientError as e:
+            await self._cleanup_unregistered_pty(entry, ws, registered)
+            raise _cloudflare_transport_error(
+                command=tuple(str(part) for part in command),
+                cause=e,
+                operation="pty exec",
+            ) from e
         except Exception as e:
             await self._cleanup_unregistered_pty(entry, ws, registered)
             raise ExecTransportError(command=tuple(str(part) for part in command), cause=e) from e

--- a/src/agents/extensions/sandbox/cloudflare/sandbox.py
+++ b/src/agents/extensions/sandbox/cloudflare/sandbox.py
@@ -72,8 +72,88 @@ from ....sandbox.workspace_paths import coerce_posix_path, posix_path_as_path, s
 
 _DEFAULT_EXEC_TIMEOUT_S = 30.0
 _DEFAULT_REQUEST_TIMEOUT_S = 120.0
+_MAX_ERROR_BODY_CHARS = 2000
 
 logger = logging.getLogger(__name__)
+
+
+def _format_cloudflare_response_body(body: bytes | str) -> str | None:
+    if isinstance(body, bytes):
+        text = body.decode("utf-8", errors="replace")
+    else:
+        text = body
+
+    trimmed = text.strip()
+    if not trimmed:
+        return None
+
+    try:
+        payload = json.loads(trimmed)
+    except json.JSONDecodeError:
+        return _truncate_error_body(trimmed)
+
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        code = payload.get("code")
+        if isinstance(error, str) and isinstance(code, str):
+            return _truncate_error_body(f"{code}: {error}")
+        if isinstance(error, str):
+            return _truncate_error_body(error)
+
+    return _truncate_error_body(trimmed)
+
+
+def _truncate_error_body(value: str) -> str:
+    if len(value) <= _MAX_ERROR_BODY_CHARS:
+        return value
+    return value[:_MAX_ERROR_BODY_CHARS] + "... [truncated]"
+
+
+def _looks_like_sse_stream(body: bytes) -> bool:
+    text = body.decode("utf-8", errors="replace").lstrip()
+    return text.startswith(("event:", "data:", "id:", "retry:", ":"))
+
+
+async def _read_cloudflare_response_body(resp: aiohttp.ClientResponse) -> str | None:
+    try:
+        return _format_cloudflare_response_body(await resp.read())
+    except Exception as e:
+        return f"failed to read error body: {e}"
+
+
+def _cloudflare_http_error_message(operation: str, status: int, detail: str | None) -> str:
+    message = f"{operation} failed: HTTP {status}"
+    if detail:
+        message += f": {detail}"
+    return message
+
+
+def _cloudflare_error_context(
+    *,
+    status: int | None = None,
+    detail: str | None = None,
+) -> dict[str, object]:
+    context: dict[str, object] = {"backend": "cloudflare"}
+    if status is not None:
+        context["http_status"] = status
+    if detail:
+        context["provider_error"] = detail
+    return context
+
+
+def _cloudflare_exec_error_detail(error: ExecTransportError) -> str | None:
+    detail = error.context.get("provider_error")
+    if isinstance(detail, str) and detail:
+        status = error.context.get("http_status")
+        if isinstance(status, int):
+            return f"POST /exec failed: HTTP {status}: {detail}"
+        return detail
+    cause = error.__cause__
+    if cause is not None:
+        message = str(cause)
+        if message:
+            return message
+    return None
 
 
 def _is_transient_workspace_error(exc: BaseException) -> bool:
@@ -509,6 +589,21 @@ class CloudflareSandboxSession(BaseSandboxSession):
         try:
             root = self._workspace_root_path()
             await self._exec_internal("mkdir", "-p", "--", root.as_posix())
+        except ExecTransportError as e:
+            detail = _cloudflare_exec_error_detail(e)
+            message = "failed to start session"
+            if detail:
+                message = f"{message}: {detail}"
+            raise WorkspaceStartError(
+                path=self._workspace_root_path(),
+                context={
+                    "backend": "cloudflare",
+                    "reason": "prepare_workspace_exec_failed",
+                    "exec_error_context": dict(e.context),
+                },
+                cause=e,
+                message=message,
+            ) from e
         except Exception as e:
             raise WorkspaceStartError(path=self._workspace_root_path(), cause=e) from e
 
@@ -564,8 +659,14 @@ class CloudflareSandboxSession(BaseSandboxSession):
         try:
             http = self._session()
             url = self.state.worker_url.rstrip("/") + f"/v1/sandbox/{self.state.sandbox_id}"
-            async with http.delete(url):
-                pass
+            async with http.delete(url) as resp:
+                if resp.status < 400 or resp.status == 404:
+                    return
+                detail = await _read_cloudflare_response_body(resp)
+                logger.debug(
+                    "Failed to delete Cloudflare sandbox on shutdown: %s",
+                    _cloudflare_http_error_message("DELETE /sandbox", resp.status, detail),
+                )
         except Exception:
             logger.debug("Failed to delete Cloudflare sandbox on shutdown", exc_info=True)
 
@@ -603,20 +704,23 @@ class CloudflareSandboxSession(BaseSandboxSession):
             )
             async with http.post(url, json=payload, timeout=request_timeout) as resp:
                 if resp.status != 200:
-                    body: dict[str, Any] = {}
-                    try:
-                        body = await resp.json(content_type=None)
-                    except Exception:
-                        pass
-                    msg = body.get("error", f"HTTP {resp.status}")
-                    raise ExecTransportError(command=tuple(argv), cause=Exception(msg))
+                    detail = await _read_cloudflare_response_body(resp)
+                    message = _cloudflare_http_error_message("POST /exec", resp.status, detail)
+                    raise ExecTransportError(
+                        command=tuple(argv),
+                        context=_cloudflare_error_context(status=resp.status, detail=detail),
+                        cause=Exception(message),
+                        message=message,
+                    )
 
                 stdout_parts: list[bytes] = []
                 stderr_parts: list[bytes] = []
+                raw_stream = bytearray()
                 line_decoder = _SSELineDecoder()
                 sse_decoder = _SSEDecoder()
 
                 async for chunk in resp.content.iter_any():
+                    raw_stream.extend(chunk)
                     text = chunk.decode("utf-8")
                     for line in line_decoder.decode(text):
                         event = sse_decoder.decode(line)
@@ -662,9 +766,22 @@ class CloudflareSandboxSession(BaseSandboxSession):
                             cause=Exception(err_data.get("error", "unknown error")),
                         )
 
+                stream_detail = (
+                    None
+                    if not raw_stream or _looks_like_sse_stream(bytes(raw_stream))
+                    else _format_cloudflare_response_body(bytes(raw_stream))
+                )
+                message = "SSE stream ended without exit event"
+                if stream_detail:
+                    message = f"POST /exec returned non-SSE error body: {stream_detail}"
                 raise ExecTransportError(
                     command=tuple(argv),
-                    cause=Exception("SSE stream ended without exit event"),
+                    context=_cloudflare_error_context(
+                        status=resp.status,
+                        detail=stream_detail,
+                    ),
+                    cause=Exception(message),
+                    message=message,
                 )
 
         except asyncio.TimeoutError as e:
@@ -1347,18 +1464,14 @@ class CloudflareSandboxClient(BaseSandboxClient[CloudflareSandboxClientOptions])
                     url, timeout=aiohttp.ClientTimeout(total=request_timeout_s)
                 ) as resp:
                     if resp.status != 200:
-                        body: dict[str, Any] = {}
-                        try:
-                            body = await resp.json(content_type=None)
-                        except Exception:
-                            pass
+                        detail = await _read_cloudflare_response_body(resp)
                         raise ConfigurationError(
-                            message=(
-                                f"POST /sandbox failed: {body.get('error', f'HTTP {resp.status}')}"
+                            message=_cloudflare_http_error_message(
+                                "POST /sandbox", resp.status, detail
                             ),
                             error_code=ErrorCode.SANDBOX_CONFIG_INVALID,
                             op="start",
-                            context={"http_status": resp.status},
+                            context=_cloudflare_error_context(status=resp.status, detail=detail),
                         )
                     data = await resp.json()
                     sandbox_id = data.get("id")

--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -76,6 +76,36 @@ DEFAULT_DAYTONA_WORKSPACE_ROOT = "/home/daytona/workspace"
 logger = logging.getLogger(__name__)
 
 
+def _daytona_provider_error_detail(error: BaseException) -> str | None:
+    message = str(error)
+    status = getattr(error, "status_code", None) or getattr(error, "status", None)
+    if isinstance(status, int):
+        if message:
+            return f"HTTP {status}: {message}"
+        return f"HTTP {status}"
+    if message:
+        return f"{type(error).__name__}: {message}"
+    return type(error).__name__
+
+
+def _daytona_exec_transport_error(
+    *,
+    command: tuple[str | Path, ...],
+    cause: BaseException,
+) -> ExecTransportError:
+    detail = _daytona_provider_error_detail(cause)
+    context: dict[str, object] = {"backend": "daytona"}
+    if detail:
+        context["provider_error"] = detail
+    status = getattr(cause, "status_code", None) or getattr(cause, "status", None)
+    if isinstance(status, int):
+        context["http_status"] = status
+    message = "Daytona exec failed"
+    if detail:
+        message = f"{message}: {detail}"
+    return ExecTransportError(command=command, context=context, cause=cause, message=message)
+
+
 def _import_daytona_sdk() -> tuple[Any, Any, Any, Any]:
     """Lazily import Daytona SDK classes, raising a clear error if missing."""
     try:
@@ -381,17 +411,34 @@ class DaytonaSandboxSession(BaseSandboxSession):
                 timeout=self.state.timeouts.fast_op_s,
             )
         except Exception as e:
-            raise WorkspaceStartError(path=error_root, cause=e) from e
+            detail = _daytona_provider_error_detail(e)
+            message = "failed to start session"
+            if detail:
+                message = f"{message}: Daytona workspace root setup failed: {detail}"
+            raise WorkspaceStartError(
+                path=error_root,
+                context={"backend": "daytona", "reason": "workspace_root_setup_failed"},
+                cause=e,
+                message=message,
+            ) from e
 
         exit_code = int(getattr(result, "exit_code", 0) or 0)
         if exit_code != 0:
+            output = str(getattr(result, "result", "") or "")
+            message = (
+                f"failed to start session: Daytona workspace root setup exited with {exit_code}"
+            )
+            if output:
+                message = f"{message}: {output}"
             raise WorkspaceStartError(
                 path=error_root,
                 context={
+                    "backend": "daytona",
                     "reason": "workspace_root_nonzero_exit",
                     "exit_code": exit_code,
-                    "output": str(getattr(result, "result", "") or ""),
+                    "output": output,
                 },
+                message=message,
             )
 
     async def _prepare_backend_workspace(self) -> None:
@@ -490,7 +537,7 @@ class DaytonaSandboxSession(BaseSandboxSession):
         except Exception as e:
             if timeout_exc is not None and isinstance(e, timeout_exc):
                 raise ExecTimeoutError(command=command, timeout_s=timeout, cause=e) from e
-            raise ExecTransportError(command=command, cause=e) from e
+            raise _daytona_exec_transport_error(command=command, cause=e) from e
         finally:
             try:
                 await asyncio.wait_for(
@@ -612,7 +659,7 @@ class DaytonaSandboxSession(BaseSandboxSession):
                     await asyncio.shield(cleanup_task)
             if timeout_exc is not None and isinstance(e, timeout_exc):
                 raise ExecTimeoutError(command=command, timeout_s=timeout, cause=e) from e
-            raise ExecTransportError(command=command, cause=e) from e
+            raise _daytona_exec_transport_error(command=command, cause=e) from e
         except BaseException:
             if not registered:
                 cleanup_task = asyncio.ensure_future(self._terminate_pty_entry(entry))

--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -102,6 +102,39 @@ logger = logging.getLogger(__name__)
 R = TypeVar("R")
 
 
+def _modal_provider_error_detail(error: BaseException) -> str | None:
+    if isinstance(error, ExecTransportError):
+        message = str(error)
+        return message or type(error).__name__
+    message = str(error)
+    status = getattr(error, "status_code", None) or getattr(error, "status", None)
+    if isinstance(status, int):
+        if message:
+            return f"HTTP {status}: {message}"
+        return f"HTTP {status}"
+    if message:
+        return f"{type(error).__name__}: {message}"
+    return type(error).__name__
+
+
+def _modal_exec_transport_error(
+    *,
+    command: tuple[str | Path, ...],
+    cause: BaseException,
+) -> ExecTransportError:
+    detail = _modal_provider_error_detail(cause)
+    context: dict[str, object] = {"backend": "modal"}
+    if detail:
+        context["provider_error"] = detail
+    status = getattr(cause, "status_code", None) or getattr(cause, "status", None)
+    if isinstance(status, int):
+        context["http_status"] = status
+    message = "Modal exec failed"
+    if detail:
+        message = f"{message}: {detail}"
+    return ExecTransportError(command=command, context=context, cause=cause, message=message)
+
+
 @asynccontextmanager
 async def _override_modal_image_builder_version(
     image_builder_version: str | None,
@@ -440,7 +473,16 @@ class ModalSandboxSession(BaseSandboxSession):
     def _wrap_start_error(self, error: Exception) -> Exception:
         if isinstance(error, WorkspaceStartError):
             return error
-        return WorkspaceStartError(path=self._workspace_root_path(), cause=error)
+        detail = _modal_provider_error_detail(error)
+        message = "failed to start session"
+        if detail:
+            message = f"{message}: {detail}"
+        return WorkspaceStartError(
+            path=self._workspace_root_path(),
+            context={"backend": "modal"},
+            cause=error,
+            message=message,
+        )
 
     async def _resolve_exposed_port(self, port: int) -> ExposedPortEndpoint:
         await self._ensure_sandbox()
@@ -665,7 +707,7 @@ class ModalSandboxSession(BaseSandboxSession):
         except ExecTimeoutError:
             raise
         except Exception as e:
-            raise ExecTransportError(command=command, cause=e) from e
+            raise _modal_exec_transport_error(command=command, cause=e) from e
 
     def supports_pty(self) -> bool:
         return True
@@ -725,7 +767,7 @@ class ModalSandboxSession(BaseSandboxSession):
         except Exception as e:
             if entry is not None and not registered:
                 await self._terminate_pty_entry(entry)
-            raise ExecTransportError(command=command, cause=e) from e
+            raise _modal_exec_transport_error(command=command, cause=e) from e
 
         if pruned_entry is not None:
             await self._terminate_pty_entry(pruned_entry)

--- a/src/agents/sandbox/errors.py
+++ b/src/agents/sandbox/errors.py
@@ -310,9 +310,10 @@ class ExecTransportError(ExecFailureError):
         command: Sequence[str | Path],
         context: Mapping[str, object] | None = None,
         cause: BaseException | None = None,
+        message: str | None = None,
     ) -> None:
         super().__init__(
-            message="exec transport error",
+            message=message or "exec transport error",
             error_code=ErrorCode.EXEC_TRANSPORT_ERROR,
             command=command,
             context=_as_context(context),
@@ -538,9 +539,10 @@ class WorkspaceStartError(SandboxRuntimeError):
         path: Path,
         context: Mapping[str, object] | None = None,
         cause: BaseException | None = None,
+        message: str | None = None,
     ) -> None:
         super().__init__(
-            message="failed to start session",
+            message=message or "failed to start session",
             error_code=ErrorCode.WORKSPACE_START_ERROR,
             op="start",
             context={"path": str(path), **_as_context(context)},

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -354,8 +354,11 @@ class TestBlaxelSandboxSession:
             raise ConnectionError("transport error")
 
         fake_sandbox.process.exec = _raise  # type: ignore[assignment]
-        with pytest.raises(ExecTransportError):
+        with pytest.raises(ExecTransportError) as exc_info:
             await session._exec_internal("echo", "hello")
+        assert str(exc_info.value) == "Blaxel exec failed: ConnectionError: transport error"
+        assert exc_info.value.context["backend"] == "blaxel"
+        assert exc_info.value.context["provider_error"] == "ConnectionError: transport error"
 
     @pytest.mark.asyncio
     async def test_mkdir(self, fake_sandbox: _FakeSandboxInstance) -> None:
@@ -3277,8 +3280,12 @@ class TestSdkExceptionMapping:
         fake_sandbox.process.exec = _raise_500  # type: ignore[assignment]
 
         with patch.object(mod, "_import_sandbox_api_error", return_value=FakeApiError):
-            with pytest.raises(ExecTransportError):
+            with pytest.raises(ExecTransportError) as exc_info:
                 await session._exec_internal("echo", "hello")
+        assert str(exc_info.value) == "Blaxel exec failed: HTTP 500: internal error"
+        assert exc_info.value.context["backend"] == "blaxel"
+        assert exc_info.value.context["http_status"] == 500
+        assert exc_info.value.context["provider_error"] == "HTTP 500: internal error"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/extensions/sandbox/test_cloudflare.py
+++ b/tests/extensions/sandbox/test_cloudflare.py
@@ -32,6 +32,7 @@ from agents.sandbox.errors import (
     WorkspaceArchiveReadError,
     WorkspaceArchiveWriteError,
     WorkspaceReadNotFoundError,
+    WorkspaceStartError,
     WorkspaceWriteTypeError,
 )
 from agents.sandbox.manifest import Environment, Manifest
@@ -627,6 +628,104 @@ async def test_cloudflare_exec_timeout_raises_exec_timeout_error() -> None:
 
     with pytest.raises(ExecTimeoutError):
         await _make_session(fake_http=_TimeoutHttp())._exec_internal("sleep", "999", timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_exec_non_200_includes_provider_error_details() -> None:
+    sess = _make_session(
+        fake_http=_FakeHttp(
+            {
+                "POST /exec": _FakeResponse(
+                    status=502,
+                    json_body={
+                        "error": "pool error: Failed to start container",
+                        "code": "pool_error",
+                    },
+                )
+            }
+        )
+    )
+
+    with pytest.raises(ExecTransportError) as exc_info:
+        await sess._exec_internal("mkdir", "-p", "--", "/workspace", timeout=5.0)
+
+    assert exc_info.value.context == {
+        "command": ("mkdir", "-p", "--", "/workspace"),
+        "command_str": "mkdir -p -- /workspace",
+        "backend": "cloudflare",
+        "http_status": 502,
+        "provider_error": "pool_error: pool error: Failed to start container",
+    }
+    assert (
+        str(exc_info.value.__cause__)
+        == "POST /exec failed: HTTP 502: pool_error: pool error: Failed to start container"
+    )
+    assert (
+        str(exc_info.value)
+        == "POST /exec failed: HTTP 502: pool_error: pool error: Failed to start container"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_exec_non_sse_json_body_includes_provider_error_details() -> None:
+    sess = _make_session(
+        fake_http=_FakeHttp(
+            {
+                "POST /exec": _FakeSSEResponse(
+                    status=200,
+                    sse_body=(
+                        b'{"error":"pool error: Failed to start container","code":"pool_error"}'
+                    ),
+                )
+            }
+        )
+    )
+
+    with pytest.raises(ExecTransportError) as exc_info:
+        await sess._exec_internal("mkdir", "-p", "--", "/workspace", timeout=5.0)
+
+    assert exc_info.value.context["http_status"] == 200
+    assert (
+        exc_info.value.context["provider_error"]
+        == "pool_error: pool error: Failed to start container"
+    )
+    assert str(exc_info.value.__cause__) == (
+        "POST /exec returned non-SSE error body: pool_error: pool error: Failed to start container"
+    )
+    assert str(exc_info.value) == (
+        "POST /exec returned non-SSE error body: pool_error: pool error: Failed to start container"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_prepare_workspace_preserves_exec_error_context() -> None:
+    sess = _make_session(
+        fake_http=_FakeHttp(
+            {
+                "POST /exec": _FakeResponse(
+                    status=502,
+                    json_body={
+                        "error": "pool error: Failed to start container",
+                        "code": "pool_error",
+                    },
+                )
+            }
+        )
+    )
+
+    with pytest.raises(WorkspaceStartError) as exc_info:
+        await sess._prepare_backend_workspace()
+
+    assert exc_info.value.context["backend"] == "cloudflare"
+    assert exc_info.value.context["reason"] == "prepare_workspace_exec_failed"
+    exec_context = exc_info.value.context["exec_error_context"]
+    assert isinstance(exec_context, dict)
+    assert exec_context["http_status"] == 502
+    assert exec_context["provider_error"] == "pool_error: pool error: Failed to start container"
+    assert str(exc_info.value) == (
+        "failed to start session: "
+        "POST /exec failed: HTTP 502: pool_error: pool error: Failed to start container"
+    )
 
 
 @pytest.mark.asyncio
@@ -1315,3 +1414,34 @@ async def test_cloudflare_shutdown_logs_on_failure(caplog: pytest.LogCaptureFixt
         await sess._shutdown_backend()
 
     assert any("Failed to delete Cloudflare sandbox" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_shutdown_logs_delete_response_details(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify that DELETE response bodies are kept when shutdown cleanup fails."""
+    import logging
+
+    sess = _make_session(
+        fake_http=_FakeHttp(
+            {
+                "DELETE /v1/sandbox/": _FakeResponse(
+                    status=502,
+                    json_body={
+                        "error": "pool error: Failed to start container",
+                        "code": "pool_error",
+                    },
+                )
+            }
+        )
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="agents.extensions.sandbox.cloudflare.sandbox"):
+        await sess._shutdown_backend()
+
+    assert any(
+        "DELETE /sandbox failed: HTTP 502: pool_error: pool error: Failed to start container"
+        in r.message
+        for r in caplog.records
+    )

--- a/tests/extensions/sandbox/test_cloudflare.py
+++ b/tests/extensions/sandbox/test_cloudflare.py
@@ -729,6 +729,24 @@ async def test_cloudflare_prepare_workspace_preserves_exec_error_context() -> No
 
 
 @pytest.mark.asyncio
+async def test_cloudflare_exec_client_error_includes_provider_context() -> None:
+    class _FailingHttp(_FakeHttp):
+        def post(self, url: str, **kwargs: Any) -> Any:
+            self._record("POST", url, **kwargs)
+            raise aiohttp.ClientError("connection reset")
+
+    with pytest.raises(ExecTransportError) as exc_info:
+        await _make_session(fake_http=_FailingHttp())._exec_internal("echo", "hello", timeout=1.0)
+
+    assert str(exc_info.value) == (
+        "Cloudflare exec transport failed: ClientError: connection reset"
+    )
+    assert exc_info.value.context["backend"] == "cloudflare"
+    assert exc_info.value.context["operation"] == "exec"
+    assert exc_info.value.context["provider_error"] == "ClientError: connection reset"
+
+
+@pytest.mark.asyncio
 async def test_cloudflare_exec_stream_without_exit_raises_transport_error() -> None:
     sess = _make_session(
         fake_http=_FakeHttp(
@@ -1296,6 +1314,12 @@ async def test_cloudflare_pty_exec_start_wraps_websocket_connect_failures() -> N
 
     assert isinstance(exc_info.value.__cause__, aiohttp.ClientError)
     assert str(exc_info.value.__cause__) == "connect failed"
+    assert str(exc_info.value) == (
+        "Cloudflare pty exec transport failed: ClientError: connect failed"
+    )
+    assert exc_info.value.context["backend"] == "cloudflare"
+    assert exc_info.value.context["operation"] == "pty exec"
+    assert exc_info.value.context["provider_error"] == "ClientError: connect failed"
 
 
 @pytest.mark.asyncio

--- a/tests/extensions/sandbox/test_daytona.py
+++ b/tests/extensions/sandbox/test_daytona.py
@@ -576,10 +576,14 @@ class TestDaytonaSandbox:
 
         assert exc_info.value.context == {
             "path": daytona_module.DEFAULT_DAYTONA_WORKSPACE_ROOT,
+            "backend": "daytona",
             "reason": "workspace_root_nonzero_exit",
             "exit_code": 2,
             "output": "mkdir failed",
         }
+        assert str(exc_info.value) == (
+            "failed to start session: Daytona workspace root setup exited with 2: mkdir failed"
+        )
         assert sandbox.process.execute_session_command_calls == []
         assert session.state.workspace_root_ready is False
 
@@ -1320,8 +1324,11 @@ class TestDaytonaSandbox:
         )
         session = daytona_module.DaytonaSandboxSession.from_state(state, sandbox=sandbox)
 
-        with pytest.raises(ExecTransportError):
+        with pytest.raises(ExecTransportError) as exc_info:
             await session.pty_exec_start("python3", shell=False, tty=True)
+        assert str(exc_info.value) == "Daytona exec failed: FileNotFoundError: missing-shell"
+        assert exc_info.value.context["backend"] == "daytona"
+        assert exc_info.value.context["provider_error"] == "FileNotFoundError: missing-shell"
 
     @pytest.mark.asyncio
     async def test_pty_start_maps_sdk_timeout_failures(

--- a/tests/extensions/sandbox/test_modal.py
+++ b/tests/extensions/sandbox/test_modal.py
@@ -3291,8 +3291,45 @@ async def test_modal_pty_start_wraps_startup_failures(
     )
     session = modal_module.ModalSandboxSession.from_state(state, sandbox=_FailingSandbox())
 
-    with pytest.raises(modal_module.ExecTransportError):
+    with pytest.raises(modal_module.ExecTransportError) as exc_info:
         await session.pty_exec_start("python3", shell=False, tty=True)
+    assert str(exc_info.value) == "Modal exec failed: FileNotFoundError: missing-shell"
+    assert exc_info.value.context["backend"] == "modal"
+    assert exc_info.value.context["provider_error"] == "FileNotFoundError: missing-shell"
+
+
+@pytest.mark.asyncio
+async def test_modal_start_wraps_exec_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+
+    class _FailingSandbox:
+        object_id = "sb-fail"
+
+        def __init__(self) -> None:
+            self.exec = _with_aio(self._exec)
+            self.poll = _with_aio(lambda: None)
+
+        def _exec(self, *command: object, **kwargs: object) -> object:
+            _ = (command, kwargs)
+            raise FileNotFoundError("missing-shell")
+
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        sandbox_id="sb-fail",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state, sandbox=_FailingSandbox())
+
+    with pytest.raises(modal_module.WorkspaceStartError) as exc_info:
+        await session.start()
+
+    assert str(exc_info.value) == (
+        "failed to start session: Modal exec failed: FileNotFoundError: missing-shell"
+    )
+    assert exc_info.value.context["backend"] == "modal"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes sandbox provider diagnostics so transport and startup failures include the provider error details that are reliably available from each backend.

It preserves existing exception types while allowing structured sandbox errors to carry clearer messages, expands Cloudflare HTTP/body diagnostics, and adds targeted Daytona, Modal, and Blaxel error summaries for exec, PTY startup, and workspace-start paths. Regression tests cover the visible messages and structured context for the updated providers.