### PR TITLE
fix(sessions): preserve id for hosted tool-call items in OpenAIConversationsSession

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -565,10 +565,22 @@ def _sanitize_openai_conversation_item(item: TResponseInputItem) -> TResponseInp
     """Remove provider-specific fields before fingerprinting or persistence."""
     if isinstance(item, dict):
         clean_item = cast(dict[str, Any], strip_internal_input_item_metadata(item))
-        clean_item.pop("id", None)
+        if _should_strip_openai_conversation_item_id(clean_item):
+            clean_item.pop("id", None)
         clean_item.pop("provider_data", None)
         return cast(TResponseInputItem, clean_item)
     return item
+
+
+def _should_strip_openai_conversation_item_id(item: dict[str, Any]) -> bool:
+    """Return True when the Conversations API does not require the item's ``id`` field.
+
+    Hosted tool-call items (file_search_call, web_search_call, code_interpreter_call, etc.)
+    carry server-assigned IDs that the Conversations API requires when persisting those items.
+    Stripping the ``id`` from those shapes causes a 400 ``missing_required_parameter`` error.
+    Only strip for shapes where the API is known to tolerate a missing ``id``.
+    """
+    return item.get("role") == "user" or item.get("type") == "function_call_output"
 
 
 def _sanitize_openai_conversation_history_items_for_model_input(

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2865,6 +2865,138 @@ async def test_save_result_to_session_sanitizes_original_input_items() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        cast(
+            dict[str, Any],
+            {
+                "type": "file_search_call",
+                "id": "fs_abc123",
+                "queries": ["customer profile"],
+                "status": "completed",
+            },
+        ),
+        cast(
+            dict[str, Any],
+            {
+                "type": "web_search_call",
+                "id": "ws_abc123",
+                "action": {"type": "search", "query": "latest news"},
+                "status": "completed",
+            },
+        ),
+        cast(
+            dict[str, Any],
+            {
+                "type": "code_interpreter_call",
+                "id": "ci_abc123",
+                "status": "completed",
+                "code": "print('hello')",
+            },
+        ),
+    ],
+)
+async def test_save_result_to_session_preserves_id_for_hosted_tool_calls(
+    payload: dict[str, Any],
+) -> None:
+    """Hosted tool-call items must retain their server-assigned id when persisted to an
+    OpenAIConversationsSession; stripping it causes a 400 missing_required_parameter error."""
+
+    class DummyOpenAIConversationsSession(OpenAIConversationsSession):
+        def __init__(self) -> None:
+            self.saved_items: list[TResponseInputItem] = []
+
+        async def _get_session_id(self) -> str:
+            return "conv_test"
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            self.saved_items.extend(items)
+
+        async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+            return []
+
+        async def pop_item(self) -> TResponseInputItem | None:
+            return None
+
+        async def clear_session(self) -> None:
+            return None
+
+    session = DummyOpenAIConversationsSession()
+    agent = Agent(name="agent", model=FakeModel())
+    run_state: RunState[Any] = RunState(
+        context=RunContextWrapper(context={}),
+        original_input="input",
+        starting_agent=agent,
+        max_turns=1,
+    )
+
+    saved_count = await save_result_to_session(
+        session,
+        [],
+        cast(list[RunItem], [_DummyRunItem(payload)]),
+        run_state,
+    )
+
+    assert saved_count == 1
+    assert run_state._current_turn_persisted_item_count == 1
+    assert len(session.saved_items) == 1
+    saved = cast(dict[str, Any], session.saved_items[0])
+    assert saved.get("id") == payload["id"], (
+        f"id was stripped from {payload['type']} item; Conversations API requires it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_result_to_session_strips_id_from_user_message_in_openai_conversations() -> None:
+    """User-message items do not require id in the Conversations API; still stripped."""
+
+    class DummyOpenAIConversationsSession(OpenAIConversationsSession):
+        def __init__(self) -> None:
+            self.saved_items: list[TResponseInputItem] = []
+
+        async def _get_session_id(self) -> str:
+            return "conv_test"
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            self.saved_items.extend(items)
+
+        async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+            return []
+
+        async def pop_item(self) -> TResponseInputItem | None:
+            return None
+
+        async def clear_session(self) -> None:
+            return None
+
+    session = DummyOpenAIConversationsSession()
+    agent = Agent(name="agent", model=FakeModel())
+    run_state: RunState[Any] = RunState(
+        context=RunContextWrapper(context={}),
+        original_input="input",
+        starting_agent=agent,
+        max_turns=1,
+    )
+
+    user_msg = cast(
+        dict[str, Any],
+        {"type": "message", "role": "user", "id": "msg_user_001", "content": "hello"},
+    )
+
+    await save_result_to_session(
+        session,
+        [cast(TResponseInputItem, user_msg)],
+        [],
+        run_state,
+    )
+
+    assert len(session.saved_items) == 1
+    saved = cast(dict[str, Any], session.saved_items[0])
+    assert "id" not in saved
+
+
+@pytest.mark.asyncio
 async def test_prepare_input_with_session_strips_internal_tool_call_metadata() -> None:
     tool_call = cast(
         TResponseInputItem,


### PR DESCRIPTION
### Summary

`_sanitize_openai_conversation_item` unconditionally called `clean_item.pop("id", None)` for every item before persistence. For hosted tool-call items produced by the OpenAI API (such as `file_search_call`, `web_search_call`, `code_interpreter_call`) the Conversations API requires the server-assigned `id` field when persisting via `conversations.items.create`; stripping it causes a `400 Missing required parameter: 'items[0].id'` error. This surfaced in production whenever an agent used a hosted tool (e.g. file search) together with `OpenAIConversationsSession`.

The fix introduces `_should_strip_openai_conversation_item_id` — a targeted predicate returning `True` only for shapes where stripping `id` is safe (user messages and `function_call_output` items). All other item types, including hosted tool calls, retain their server-assigned `id`. Fingerprinting behaviour is unchanged because `fingerprint_input_item` already applies `ignore_ids_for_matching=True` independently of the sanitisation path.

### Test plan

Two new `pytest` tests in `tests/test_agent_runner.py`:

- `test_save_result_to_session_preserves_id_for_hosted_tool_calls` — parametrised over `file_search_call`, `web_search_call`, and `code_interpreter_call`; verifies that the server-assigned `id` is present in the payload passed to `session.add_items`.
- `test_save_result_to_session_strips_id_from_user_message_in_openai_conversations` — regression guard confirming user-message items continue to have their `id` stripped.

## Local verification

```
$ uv run ruff check src/agents/run_internal/session_persistence.py tests/test_agent_runner.py
All checks passed!

$ uv run pytest tests/test_agent_runner.py -k "session" -v 2>&1 | tail -6
tests/test_agent_runner.py::test_save_result_to_session_preserves_id_for_hosted_tool_calls[payload0] PASSED
tests/test_agent_runner.py::test_save_result_to_session_preserves_id_for_hosted_tool_calls[payload1] PASSED
tests/test_agent_runner.py::test_save_result_to_session_preserves_id_for_hosted_tool_calls[payload2] PASSED
tests/test_agent_runner.py::test_save_result_to_session_strips_id_from_user_message_in_openai_conversations PASSED
====================== 47 passed, 101 deselected in 1.43s ======================

$ uv run pytest tests/memory/ -v 2>&1 | tail -3
============================= 121 passed in 4.85s ==============================

=== LOCAL_TEST_PASSED ===
```

### Issue number

Fixes #3267

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
