### PR TITLE
fix: #3330 handle string tool trimmer allowlists

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
@@ -56,8 +57,8 @@ class ToolOutputTrimmer:
             trimming. Defaults to 500.
         preview_chars: How many characters of the original output to preserve as a
             preview when trimming. Defaults to 200.
-        trimmable_tools: Optional set of tool names whose outputs can be trimmed. For
-            namespaced tools, both bare names and qualified ``namespace.name`` entries are
+        trimmable_tools: Optional tool name or set of tool names whose outputs can be trimmed.
+            For namespaced tools, both bare names and qualified ``namespace.name`` entries are
             supported. If ``None``, all tool outputs are eligible for trimming. Defaults
             to ``None``.
     """
@@ -65,7 +66,7 @@ class ToolOutputTrimmer:
     recent_turns: int = 2
     max_output_chars: int = 500
     preview_chars: int = 200
-    trimmable_tools: frozenset[str] | None = field(default=None)
+    trimmable_tools: str | Iterable[str] | None = field(default=None)
 
     def __post_init__(self) -> None:
         if self.recent_turns < 1:
@@ -74,9 +75,17 @@ class ToolOutputTrimmer:
             raise ValueError(f"max_output_chars must be >= 1, got {self.max_output_chars}")
         if self.preview_chars < 0:
             raise ValueError(f"preview_chars must be >= 0, got {self.preview_chars}")
-        # Coerce any iterable to frozenset for immutability
-        if self.trimmable_tools is not None and not isinstance(self.trimmable_tools, frozenset):
-            object.__setattr__(self, "trimmable_tools", frozenset(self.trimmable_tools))
+        # Coerce configured tool names to frozenset for immutability.
+        if self.trimmable_tools is not None:
+            if isinstance(self.trimmable_tools, str):
+                trimmable_tools = frozenset({self.trimmable_tools})
+            elif isinstance(self.trimmable_tools, bytes):
+                raise ValueError("trimmable_tools must be a string or iterable of strings")
+            elif isinstance(self.trimmable_tools, frozenset):
+                trimmable_tools = self.trimmable_tools
+            else:
+                trimmable_tools = frozenset(self.trimmable_tools)
+            object.__setattr__(self, "trimmable_tools", trimmable_tools)
 
     def __call__(self, data: CallModelData[Any]) -> ModelInputData:
         """Filter callback invoked before each model call.
@@ -113,8 +122,9 @@ class ToolOutputTrimmer:
                     ("tool_search",) if item_type == "tool_search_output" else (),
                 )
 
-                if self.trimmable_tools is not None and not any(
-                    candidate in self.trimmable_tools for candidate in tool_names
+                trimmable_tools = cast(frozenset[str] | None, self.trimmable_tools)
+                if trimmable_tools is not None and not any(
+                    candidate in trimmable_tools for candidate in tool_names
                 ):
                     new_items.append(item)
                     continue

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -68,10 +68,15 @@ class TestDefaults:
         assert trimmer.trimmable_tools == frozenset({"a", "b"})
 
     def test_trimmable_tools_from_list(self) -> None:
-        trimmer = ToolOutputTrimmer(trimmable_tools=["search", "run_code"])  # type: ignore[arg-type]
+        trimmer = ToolOutputTrimmer(trimmable_tools=["search", "run_code"])
         assert isinstance(trimmer.trimmable_tools, frozenset)
         assert "search" in trimmer.trimmable_tools
         assert "run_code" in trimmer.trimmable_tools
+
+    def test_trimmable_tools_from_string(self) -> None:
+        trimmer = ToolOutputTrimmer(trimmable_tools="search")
+        assert isinstance(trimmer.trimmable_tools, frozenset)
+        assert trimmer.trimmable_tools == frozenset({"search"})
 
 
 # ---------------------------------------------------------------------------
@@ -99,6 +104,10 @@ class TestValidation:
     def test_preview_chars_zero_allowed(self) -> None:
         trimmer = ToolOutputTrimmer(preview_chars=0)
         assert trimmer.preview_chars == 0
+
+    def test_trimmable_tools_bytes_raises(self) -> None:
+        with pytest.raises(ValueError, match="trimmable_tools must be a string or iterable"):
+            ToolOutputTrimmer(trimmable_tools=b"search")  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +240,26 @@ class TestTrimming:
         # search output trimmed
         assert "[Trimmed:" in _output(result, 2)
         # resolve_entity output preserved
+        assert _output(result, 4) == large
+
+    def test_string_trimmable_tools_allowlist_matches_single_tool_name(self) -> None:
+        """A string trimmable_tools value should match one tool name, not characters."""
+        large = "x" * 1000
+        items = [
+            _user("q1"),
+            _func_call("c1", "search"),
+            _func_output("c1", large),
+            _func_call("c2", "s"),
+            _func_output("c2", large),
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+        trimmer = ToolOutputTrimmer(trimmable_tools="search")
+        result = trimmer(_make_data(items))
+        assert "[Trimmed:" in _output(result, 2)
         assert _output(result, 4) == large
 
     def test_respects_qualified_tool_names_allowlist(self) -> None:


### PR DESCRIPTION
### Summary

- Treat a string `ToolOutputTrimmer.trimmable_tools` value as one tool name instead of iterating it into characters.
- Keep list, set, and `frozenset` allowlists normalized to `frozenset`, and reject `bytes` so byte strings do not become integer allowlists.
- Add regression coverage for single-string allowlists matching the intended tool name without matching single-character tool names.

### Test plan

- `uv run pytest tests/extensions/test_tool_output_trimmer.py -k "trimmable_tools or allowlist"`
- `uv run mypy src/agents/extensions/tool_output_trimmer.py tests/extensions/test_tool_output_trimmer.py`
- `uv run pytest tests/extensions/test_tool_output_trimmer.py`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3330

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
