### PR TITLE
fix(session): preserve required id on hosted-tool calls in OpenAIConv…

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -561,11 +561,37 @@ def _ignore_ids_for_matching(session: Session) -> bool:
     )
 
 
+# Item types whose `id` is `Required[str]` in the OpenAI Responses API param schema and
+# must therefore be preserved when persisting via the Conversations API. Stripping the id
+# from these types causes `conversations.items.create()` to reject the request with
+# `BadRequestError: Missing required parameter: 'items[0].id'` (issue #3267).
+_HOSTED_TOOL_ITEM_TYPES_REQUIRING_ID: frozenset[str] = frozenset(
+    {
+        "file_search_call",
+        "web_search_call",
+        "computer_call",
+        "code_interpreter_call",
+        "image_generation_call",
+        "local_shell_call",
+        "local_shell_call_output",
+        "mcp_call",
+        "mcp_list_tools",
+        "mcp_approval_request",
+    }
+)
+
+
 def _sanitize_openai_conversation_item(item: TResponseInputItem) -> TResponseInputItem:
-    """Remove provider-specific fields before fingerprinting or persistence."""
+    """Remove provider-specific fields before fingerprinting or persistence.
+
+    Hosted tool call items (e.g. `file_search_call`) require their `id` for the OpenAI
+    Conversations API to accept them, so we only strip `id` from item types where the
+    schema treats it as optional.
+    """
     if isinstance(item, dict):
         clean_item = cast(dict[str, Any], strip_internal_input_item_metadata(item))
-        clean_item.pop("id", None)
+        if clean_item.get("type") not in _HOSTED_TOOL_ITEM_TYPES_REQUIRING_ID:
+            clean_item.pop("id", None)
         clean_item.pop("provider_data", None)
         return cast(TResponseInputItem, clean_item)
     return item

--- a/tests/memory/test_session_persistence_sanitize.py
+++ b/tests/memory/test_session_persistence_sanitize.py
@@ -1,0 +1,109 @@
+"""Regression tests for `_sanitize_openai_conversation_item` (issue #3267).
+
+`OpenAIConversationsSession` persists items via `conversations.items.create()`. The
+OpenAI Responses API param schema marks `id` as `Required[str]` for hosted-tool call
+item types (e.g. `file_search_call`, `web_search_call`, `mcp_call`, ...). The sanitizer
+must therefore preserve `id` for those types while still stripping it for items where
+`id` is optional (e.g. `function_call`, plain `message`).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from agents.items import TResponseInputItem
+from agents.run_internal.session_persistence import (
+    _HOSTED_TOOL_ITEM_TYPES_REQUIRING_ID,
+    _sanitize_openai_conversation_item,
+)
+
+
+def _sanitize(item: dict[str, Any]) -> dict[str, Any]:
+    return cast(dict[str, Any], _sanitize_openai_conversation_item(cast(TResponseInputItem, item)))
+
+
+@pytest.mark.parametrize("item_type", sorted(_HOSTED_TOOL_ITEM_TYPES_REQUIRING_ID))
+def test_hosted_tool_call_item_preserves_id(item_type: str) -> None:
+    item = {"type": item_type, "id": f"{item_type}_abc123", "status": "completed"}
+
+    sanitized = _sanitize(item)
+
+    assert sanitized["id"] == f"{item_type}_abc123", (
+        f"sanitizer must preserve `id` for {item_type!r} or "
+        f"conversations.items.create() rejects with HTTP 400 (issue #3267)"
+    )
+    assert sanitized["type"] == item_type
+
+
+def test_file_search_call_full_payload_preserves_id() -> None:
+    item = {
+        "type": "file_search_call",
+        "id": "fs_call_abc",
+        "queries": ["latest q3 revenue"],
+        "status": "completed",
+        "results": [{"file_id": "file_1", "filename": "q3.pdf", "score": 0.9, "text": "..."}],
+    }
+
+    sanitized = _sanitize(item)
+
+    assert sanitized["id"] == "fs_call_abc"
+    assert sanitized["queries"] == ["latest q3 revenue"]
+    assert sanitized["status"] == "completed"
+
+
+def test_function_call_item_still_strips_id() -> None:
+    # `id` is optional for function_call in the OpenAI param schema, and the existing
+    # behaviour relies on stripping it before persistence to avoid stale-id replay.
+    item = {
+        "type": "function_call",
+        "id": "fc_abc",
+        "call_id": "call_abc",
+        "name": "get_weather",
+        "arguments": "{}",
+    }
+
+    sanitized = _sanitize(item)
+
+    assert "id" not in sanitized
+    assert sanitized["call_id"] == "call_abc"
+    assert sanitized["type"] == "function_call"
+
+
+def test_plain_message_still_strips_id() -> None:
+    item = {
+        "type": "message",
+        "id": "msg_abc",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "hi"}],
+    }
+
+    sanitized = _sanitize(item)
+
+    assert "id" not in sanitized
+    assert sanitized["role"] == "assistant"
+
+
+def test_provider_data_always_stripped() -> None:
+    item = {
+        "type": "file_search_call",
+        "id": "fs_keep",
+        "status": "completed",
+        "provider_data": {"model": "gpt-4o"},
+    }
+
+    sanitized = _sanitize(item)
+
+    assert "provider_data" not in sanitized
+    assert sanitized["id"] == "fs_keep"
+
+
+def test_non_dict_item_passthrough() -> None:
+    # The sanitizer is permissive: pydantic models / non-dicts pass through untouched.
+    class _Dummy:
+        pass
+
+    obj = _Dummy()
+    result: Any = _sanitize_openai_conversation_item(cast(TResponseInputItem, obj))
+    assert result is obj


### PR DESCRIPTION
## Summary

  Fixes #3267. `OpenAIConversationsSession` currently fails to persist runs that produce hosted tool calls (e.g.
  `file_search_call`) with:

  BadRequestError: Error code: 400 - Missing required parameter: 'items[0].id'

  Root cause: `_sanitize_openai_conversation_item` in `src/agents/run_internal/session_persistence.py` unconditionally
  popped `id` from every persisted item. The OpenAI Responses API param schema marks `id` as `Required[str]` for hosted
  tool call types, so the API rejects items where it has been stripped.

  This PR makes the sanitizer item-type-aware: `id` is preserved for the item types whose schema requires it, and still
  stripped for types where the schema treats it as optional (`function_call`, `custom_tool_call`, plain `message`, etc.).

  ## Producer trace (SDK-internal)

  1. Model emits `ResponseFileSearchToolCall(id="fs_call_…", type="file_search_call", …)`.
  2. `run_internal/run_loop.py` wraps it: `ToolCallItem(raw_item=…)` — `id` preserved on `raw_item`.
  3. `items.py:to_input_item()` returns `raw_item.model_dump(exclude_unset=True)` → dict with `id`.
  4. `session_persistence.save_result_to_session` collects it into `items_to_save`.
  5. `session_persistence.py:320` calls `_sanitize_openai_conversation_item` → pops `id`.
  6. Sanitized item is handed to `OpenAIConversationsSession.add_items` → `conversations.items.create()` → API 400.

  ## Item types affected (`id: Required[str]` per OpenAI Responses param schema)

  `file_search_call`, `web_search_call`, `computer_call`, `code_interpreter_call`, `image_generation_call`,
  `local_shell_call`, `local_shell_call_output`, `mcp_call`, `mcp_list_tools`, `mcp_approval_request`.

  Item types where `id` remains optional and is still stripped: `function_call`, `custom_tool_call`,
  `function_call_output`, `shell_call`, `apply_patch_call`, plain `message`.

  ## Why dedup / fingerprinting still works

  `_sanitize_openai_conversation_item` is also used to build fingerprints. Fingerprinting goes through
  `fingerprint_input_item(item, ignore_ids_for_matching=True)` for `OpenAIConversationsSession`, which independently drops
   `id` before hashing — so preserving `id` on the persisted dict does not change the fingerprint, and cross-run dedup
  behavior is preserved.

  ## Test plan

  - [x] New regression test `tests/memory/test_session_persistence_sanitize.py` (15 cases) covering: every
  hosted-tool-call type retains `id`; `function_call` and plain `message` still have `id` stripped; `provider_data` always
   stripped; full `file_search_call` payload roundtrip; non-dict passthrough.
  - [x] `uv run pytest tests/memory/` — 136/136 pass.
  - [x] `uv run ruff check ...` — clean.
  - [x] `uv run ruff format --check ...` — clean.
  - [x] `uv run mypy ...` — clean.
