### PR TITLE
fix: #3333 use qualified keys for realtime tool approvals

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -468,13 +468,27 @@ class RealtimeSession(RealtimeModelListener):
         self, tool: FunctionTool, tool_call: RealtimeModelToolCallEvent, agent: RealtimeAgent
     ) -> ToolApprovalItem:
         """Create a ToolApprovalItem for approval tracking."""
+        tool_lookup_key = get_function_tool_lookup_key_for_tool(tool)
+        tool_namespace = (
+            tool_lookup_key[1]
+            if tool_lookup_key is not None and tool_lookup_key[0] == "namespaced"
+            else None
+        )
         raw_item = {
             "type": "function_call",
             "name": tool.name,
             "call_id": tool_call.call_id,
             "arguments": tool_call.arguments,
         }
-        return ToolApprovalItem(agent=cast(Any, agent), raw_item=raw_item, tool_name=tool.name)
+        if tool_namespace is not None:
+            raw_item["namespace"] = tool_namespace
+        return ToolApprovalItem(
+            agent=cast(Any, agent),
+            raw_item=raw_item,
+            tool_name=tool.name,
+            tool_namespace=tool_namespace,
+            tool_lookup_key=tool_lookup_key,
+        )
 
     async def _maybe_request_tool_approval(
         self,
@@ -490,8 +504,11 @@ class RealtimeSession(RealtimeModelListener):
         if not needs_approval:
             return True
 
-        approval_status = self._context_wrapper.is_tool_approved(
-            function_tool.name, tool_call.call_id
+        approval_status = self._context_wrapper.get_approval_status(
+            function_tool.name,
+            tool_call.call_id,
+            existing_pending=approval_item,
+            tool_lookup_key=get_function_tool_lookup_key_for_tool(function_tool),
         )
         if approval_status is True:
             return True

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1376,6 +1376,48 @@ class TestToolCallExecution:
         assert any(isinstance(ev, RealtimeToolEnd) for ev in events)
 
     @pytest.mark.asyncio
+    async def test_always_approve_namespaced_tool_call_uses_qualified_key(
+        self, mock_model, mock_agent
+    ):
+        """Always approval should be scoped to the qualified tool key."""
+
+        async def invoke_tool(_ctx: ToolContext[Any], _arguments: str) -> str:
+            return "account"
+
+        namespaced_tool = FunctionTool(
+            name="lookup_account",
+            description="Look up account",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=invoke_tool,
+            needs_approval=True,
+            _tool_namespace="crm",
+        )
+        mock_agent.get_all_tools.return_value = [namespaced_tool]
+
+        session = RealtimeSession(
+            mock_model,
+            mock_agent,
+            None,
+            run_config={"async_tool_calls": False},
+        )
+
+        first_call = RealtimeModelToolCallEvent(
+            name="lookup_account", call_id="call_first", arguments="{}"
+        )
+        second_call = RealtimeModelToolCallEvent(
+            name="lookup_account", call_id="call_second", arguments="{}"
+        )
+
+        await session._handle_tool_call(first_call)
+        await session.approve_tool_call(first_call.call_id, always=True)
+        await session._handle_tool_call(second_call)
+
+        assert "crm.lookup_account" in session._context_wrapper._approvals
+        assert "lookup_account" not in session._context_wrapper._approvals
+        assert session._pending_tool_calls == {}
+        assert len(mock_model.sent_tool_outputs) == 2
+
+    @pytest.mark.asyncio
     async def test_reject_pending_tool_call_sends_rejection_output(
         self, mock_model, mock_agent, mock_function_tool
     ):
@@ -1488,6 +1530,44 @@ class TestToolCallExecution:
             isinstance(ev, RealtimeToolEnd) and ev.output == "explicit rejection message"
             for ev in events
         )
+
+    @pytest.mark.asyncio
+    async def test_reject_namespaced_tool_call_prefers_explicit_message(
+        self, mock_model, mock_agent
+    ):
+        """Rejecting a namespaced tool should resolve messages by qualified key."""
+
+        async def invoke_tool(_ctx: ToolContext[Any], _arguments: str) -> str:
+            return "account"
+
+        namespaced_tool = FunctionTool(
+            name="lookup_account",
+            description="Look up account",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=invoke_tool,
+            needs_approval=True,
+            _tool_namespace="crm",
+        )
+        mock_agent.get_all_tools.return_value = [namespaced_tool]
+
+        session = RealtimeSession(mock_model, mock_agent, None)
+
+        tool_call_event = RealtimeModelToolCallEvent(
+            name="lookup_account", call_id="call_reject_namespaced", arguments="{}"
+        )
+
+        await session._handle_tool_call(tool_call_event)
+        await session.reject_tool_call(
+            tool_call_event.call_id,
+            always=True,
+            rejection_message="explicit crm rejection",
+        )
+
+        _sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
+        assert sent_output == "explicit crm rejection"
+        assert start_response is True
+        assert "crm.lookup_account" in session._context_wrapper._approvals
+        assert "lookup_account" not in session._context_wrapper._approvals
 
     @pytest.mark.asyncio
     async def test_function_tool_exception_handling(


### PR DESCRIPTION
### Summary

- Build Realtime tool approval items with the qualified tool lookup key and namespace metadata.
- Resolve Realtime approval status through the shared approval-state lookup so namespaced tools use the same qualified key for always approve/reject behavior and rejection messages.
- Add regression coverage for namespaced Realtime tool approval and rejection.

### Test plan

- `uv run pytest tests/realtime/test_session.py::TestToolCallExecution::test_always_approve_namespaced_tool_call_uses_qualified_key tests/realtime/test_session.py::TestToolCallExecution::test_reject_namespaced_tool_call_prefers_explicit_message`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3333

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
