### PR TITLE
fix: #3267 preserve required hosted tool IDs in OpenAI conversation sessions

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -561,14 +561,42 @@ def _ignore_ids_for_matching(session: Session) -> bool:
     )
 
 
+_OPENAI_CONVERSATION_ITEM_TYPES_WITH_REQUIRED_ID: frozenset[str] = frozenset(
+    {
+        "file_search_call",
+        "web_search_call",
+        "computer_call",
+        "code_interpreter_call",
+        "image_generation_call",
+        "local_shell_call",
+        "local_shell_call_output",
+        "mcp_list_tools",
+        "mcp_approval_request",
+        "mcp_call",
+        "item_reference",
+    }
+)
+
+
 def _sanitize_openai_conversation_item(item: TResponseInputItem) -> TResponseInputItem:
-    """Remove provider-specific fields before fingerprinting or persistence."""
+    """Remove provider-specific fields before fingerprinting or persistence.
+
+    Some Responses input item types require their server-assigned ``id`` when they are
+    persisted through the Conversations API. Other item IDs remain stripped so replayed
+    messages, reasoning items, and function calls do not carry stale provider IDs.
+    """
     if isinstance(item, dict):
         clean_item = cast(dict[str, Any], strip_internal_input_item_metadata(item))
-        clean_item.pop("id", None)
+        if not _openai_conversation_item_requires_id(clean_item):
+            clean_item.pop("id", None)
         clean_item.pop("provider_data", None)
         return cast(TResponseInputItem, clean_item)
     return item
+
+
+def _openai_conversation_item_requires_id(item: dict[str, Any]) -> bool:
+    """Return whether the Conversations create-item schema requires this item's top-level ID."""
+    return item.get("type") in _OPENAI_CONVERSATION_ITEM_TYPES_WITH_REQUIRED_ID
 
 
 def _sanitize_openai_conversation_history_items_for_model_input(

--- a/tests/memory/test_session_persistence_sanitize.py
+++ b/tests/memory/test_session_persistence_sanitize.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from agents.items import TResponseInputItem
+from agents.run_internal.session_persistence import _sanitize_openai_conversation_item
+
+
+def _sanitize(item: dict[str, Any]) -> dict[str, Any]:
+    return cast(dict[str, Any], _sanitize_openai_conversation_item(cast(TResponseInputItem, item)))
+
+
+@pytest.mark.parametrize(
+    "item_type",
+    [
+        "file_search_call",
+        "web_search_call",
+        "computer_call",
+        "code_interpreter_call",
+        "image_generation_call",
+        "local_shell_call",
+        "local_shell_call_output",
+        "mcp_list_tools",
+        "mcp_approval_request",
+        "mcp_call",
+        "item_reference",
+    ],
+)
+def test_sanitize_preserves_ids_required_by_openai_conversation_items(item_type: str) -> None:
+    item = {"type": item_type, "id": f"{item_type}_abc123", "status": "completed"}
+
+    sanitized = _sanitize(item)
+
+    assert sanitized["id"] == f"{item_type}_abc123"
+    assert sanitized["type"] == item_type
+
+
+def test_sanitize_preserves_file_search_call_payload_id() -> None:
+    item = {
+        "type": "file_search_call",
+        "id": "fs_call_abc",
+        "queries": ["latest q3 revenue"],
+        "status": "completed",
+        "results": [{"file_id": "file_1", "filename": "q3.pdf", "score": 0.9, "text": "..."}],
+    }
+
+    sanitized = _sanitize(item)
+
+    assert sanitized["id"] == "fs_call_abc"
+    assert sanitized["queries"] == ["latest q3 revenue"]
+    assert sanitized["status"] == "completed"
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {
+            "type": "message",
+            "id": "msg_abc",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hi"}],
+        },
+        {
+            "type": "function_call",
+            "id": "fc_abc",
+            "call_id": "call_abc",
+            "name": "get_weather",
+            "arguments": "{}",
+        },
+        {"type": "function_call_output", "id": "out_abc", "call_id": "call_abc", "output": "{}"},
+        {"type": "computer_call_output", "id": "ccout_abc", "call_id": "call_abc", "output": {}},
+        {"type": "reasoning", "id": "rs_abc", "summary": []},
+        {"type": "tool_search_call", "id": "ts_abc", "status": "completed"},
+        {"type": "shell_call", "id": "sh_abc", "call_id": "call_abc", "action": {}},
+    ],
+)
+def test_sanitize_strips_optional_or_policy_controlled_ids(item: dict[str, Any]) -> None:
+    sanitized = _sanitize(item)
+
+    assert "id" not in sanitized
+    assert sanitized["type"] == item["type"]
+
+
+def test_sanitize_always_strips_provider_data() -> None:
+    item = {
+        "type": "file_search_call",
+        "id": "fs_keep",
+        "status": "completed",
+        "provider_data": {"model": "gpt-4.1-mini"},
+    }
+
+    sanitized = _sanitize(item)
+
+    assert sanitized["id"] == "fs_keep"
+    assert "provider_data" not in sanitized
+
+
+def test_sanitize_passes_through_non_dict_items() -> None:
+    class DummyItem:
+        pass
+
+    item = DummyItem()
+
+    sanitized: Any = _sanitize_openai_conversation_item(cast(TResponseInputItem, item))
+
+    assert sanitized is item


### PR DESCRIPTION
This pull request fixes #3267 OpenAIConversationsSession persistence for hosted tool-call items whose top-level `id` is required by the Conversations API.

When a Responses run emits items such as `file_search_call`, the session persistence sanitizer previously stripped `id` before calling `conversations.items.create()`, causing the API to reject the saved turn with `Missing required parameter: 'items[0].id'`. The fix keeps IDs only for Conversations item types that require them, while continuing to strip optional or policy-controlled IDs from messages, function calls, reasoning items, and tool outputs to avoid replaying stale provider IDs.

The change also adds focused regression coverage for required-ID item types, optional-ID item types, provider data stripping, and non-dict passthrough behavior.