### PR TITLE
fix: make tracing shutdown best-effort on process exit

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -7,8 +7,9 @@ import queue
 import random
 import threading
 import time
+from collections.abc import Callable
 from functools import cached_property
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -103,6 +104,9 @@ class BackendSpanExporter(TracingExporter):
         return self._project or os.environ.get("OPENAI_PROJECT_ID")
 
     def export(self, items: list[Trace | Span[Any]]) -> None:
+        self._export_with_deadline(items, deadline=None)
+
+    def _export_with_deadline(self, items: list[Trace | Span[Any]], deadline: float | None) -> None:
         if not items:
             return
 
@@ -143,9 +147,23 @@ class BackendSpanExporter(TracingExporter):
             attempt = 0
             delay = self.base_delay
             while True:
+                request_timeout = self._timeout_for_deadline(deadline)
+                if deadline is not None and request_timeout is None:
+                    logger.warning(
+                        "[non-fatal] Tracing: export deadline reached, giving up on this batch."
+                    )
+                    break
+
                 attempt += 1
                 try:
-                    response = self._client.post(url=self.endpoint, headers=headers, json=payload)
+                    request_kwargs: dict[str, Any] = {
+                        "url": self.endpoint,
+                        "headers": headers,
+                        "json": payload,
+                    }
+                    if request_timeout is not None:
+                        request_kwargs["timeout"] = request_timeout
+                    response = self._client.post(**request_kwargs)
 
                     # If the response is successful, break out of the loop
                     if response.status_code < 300:
@@ -178,8 +196,40 @@ class BackendSpanExporter(TracingExporter):
 
                 # Exponential backoff + jitter
                 sleep_time = delay + random.uniform(0, 0.1 * delay)  # 10% jitter
-                time.sleep(sleep_time)
+                if not self._sleep_before_retry(sleep_time, deadline):
+                    break
                 delay = min(delay * 2, self.max_delay)
+
+    def _timeout_for_deadline(self, deadline: float | None) -> httpx.Timeout | None:
+        if deadline is None:
+            return None
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+
+        connect_timeout = min(5.0, remaining)
+        return httpx.Timeout(remaining, connect=connect_timeout)
+
+    def _sleep_before_retry(self, sleep_time: float, deadline: float | None) -> bool:
+        if deadline is None:
+            time.sleep(sleep_time)
+            return True
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.warning("[non-fatal] Tracing: export deadline reached before retry, giving up.")
+            return False
+
+        if sleep_time >= remaining:
+            time.sleep(remaining)
+            logger.warning(
+                "[non-fatal] Tracing: export deadline reached during retry backoff, giving up."
+            )
+            return False
+
+        time.sleep(sleep_time)
+        return True
 
     def _should_sanitize_for_openai_tracing_api(self) -> bool:
         return self.endpoint.rstrip("/") == self._OPENAI_TRACING_INGEST_ENDPOINT.rstrip("/")
@@ -502,6 +552,7 @@ class BatchTraceProcessor(TracingProcessor):
         self._worker_thread: threading.Thread | None = None
         self._thread_start_lock = threading.Lock()
         self._export_lock = threading.Lock()
+        self._shutdown_deadline: float | None = None
 
     def _ensure_thread_started(self) -> None:
         # Fast path without holding the lock
@@ -547,13 +598,19 @@ class BatchTraceProcessor(TracingProcessor):
         Called when the application stops. We signal our thread to stop, then join it.
         """
         self._shutdown_event.set()
+        deadline = None if timeout is None else time.monotonic() + timeout
+        self._shutdown_deadline = deadline
 
         # Only join if we ever started the background thread; otherwise flush synchronously.
         if self._worker_thread and self._worker_thread.is_alive():
             self._worker_thread.join(timeout=timeout)
+            if self._worker_thread.is_alive():
+                logger.warning(
+                    "[non-fatal] Tracing: shutdown timeout reached; dropping queued traces."
+                )
         else:
             # No background thread: process any remaining items synchronously.
-            self._export_batches(force=True)
+            self._export_batches(force=True, deadline=deadline)
 
     def force_flush(self):
         """
@@ -576,14 +633,20 @@ class BatchTraceProcessor(TracingProcessor):
                 time.sleep(0.2)
 
         # Final drain after shutdown
-        self._export_batches(force=True)
+        self._export_batches(force=True, deadline=self._shutdown_deadline)
 
-    def _export_batches(self, force: bool = False):
+    def _export_batches(self, force: bool = False, deadline: float | None = None):
         """Drains the queue and exports in batches. If force=True, export everything.
         Otherwise, export up to `max_batch_size` repeatedly until the queue is completely empty.
         """
         with self._export_lock:
             while True:
+                if deadline is not None and time.monotonic() >= deadline:
+                    logger.warning(
+                        "[non-fatal] Tracing: export deadline reached; dropping queued traces."
+                    )
+                    break
+
                 items_to_export: list[Span[Any] | Trace] = []
 
                 # Gather a batch of spans up to max_batch_size
@@ -604,7 +667,15 @@ class BatchTraceProcessor(TracingProcessor):
                 # cannot kill the background worker thread and silently strand all
                 # subsequent spans in the queue.
                 try:
-                    self._exporter.export(items_to_export)
+                    export_with_deadline = getattr(self._exporter, "_export_with_deadline", None)
+                    if deadline is not None and callable(export_with_deadline):
+                        export_fn = cast(
+                            Callable[[list[Trace | Span[Any]], float | None], None],
+                            export_with_deadline,
+                        )
+                        export_fn(items_to_export, deadline)
+                    else:
+                        self._exporter.export(items_to_export)
                 except Exception as exc:
                     logger.error(
                         "[non-fatal] Tracing: exporter raised %s; dropping batch of %d items",

--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import Any
+from inspect import Parameter, signature
+from typing import Any, cast
 
 from ..logger import logger
 from .config import TracingConfig
@@ -39,6 +41,24 @@ def _safe_debug(message: str) -> None:
     except Exception:
         # Avoid noisy shutdown errors when the underlying stream is already closed.
         return
+
+
+def _remaining_timeout(deadline: float | None) -> float | None:
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.monotonic())
+
+
+def _supports_shutdown_timeout(processor: TracingProcessor) -> bool:
+    try:
+        parameters = signature(processor.shutdown).parameters
+    except (TypeError, ValueError):
+        return False
+
+    for parameter in parameters.values():
+        if parameter.kind == Parameter.VAR_KEYWORD:
+            return True
+    return "timeout" in parameters
 
 
 def _is_noop_id(value: str | None) -> bool:
@@ -119,14 +139,24 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
             except Exception as e:
                 logger.error(f"Error in trace processor {processor} during on_span_end: {e}")
 
-    def shutdown(self) -> None:
+    def shutdown(self, timeout: float | None = None) -> None:
         """
         Called when the application stops.
         """
+        deadline = None if timeout is None else time.monotonic() + timeout
         for processor in self._processors:
             _safe_debug(f"Shutting down trace processor {processor}")
             try:
-                processor.shutdown()
+                processor_timeout = _remaining_timeout(deadline)
+                if processor_timeout is not None and processor_timeout <= 0:
+                    logger.warning(
+                        "[non-fatal] Tracing: shutdown timeout reached before processor cleanup."
+                    )
+                    return
+                if processor_timeout is not None and _supports_shutdown_timeout(processor):
+                    cast(Any, processor.shutdown)(timeout=processor_timeout)
+                else:
+                    processor.shutdown()
             except Exception as e:
                 logger.error(f"Error shutting down trace processor {processor}: {e}")
 
@@ -405,13 +435,13 @@ class DefaultTraceProvider(TraceProvider):
         except Exception as e:
             logger.error(f"Error flushing trace provider: {e}")
 
-    def shutdown(self) -> None:
+    def shutdown(self, timeout: float | None = None) -> None:
         self._refresh_disabled_flag()
         if self._disabled:
             return
 
         try:
             _safe_debug("Shutting down trace provider")
-            self._multi_processor.shutdown()
+            self._multi_processor.shutdown(timeout=timeout)
         except Exception as e:
             logger.error(f"Error shutting down trace provider: {e}")

--- a/src/agents/tracing/setup.py
+++ b/src/agents/tracing/setup.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .provider import TraceProvider
 
+_DEFAULT_SHUTDOWN_TIMEOUT = 5.0
 GLOBAL_TRACE_PROVIDER: TraceProvider | None = None
 _GLOBAL_TRACE_PROVIDER_LOCK = threading.Lock()
 _SHUTDOWN_HANDLER_REGISTERED = False
@@ -15,6 +16,11 @@ _SHUTDOWN_HANDLER_REGISTERED = False
 def _shutdown_global_trace_provider() -> None:
     provider = GLOBAL_TRACE_PROVIDER
     if provider is not None:
+        from .provider import DefaultTraceProvider
+
+        if isinstance(provider, DefaultTraceProvider):
+            provider.shutdown(timeout=_DEFAULT_SHUTDOWN_TIMEOUT)
+            return
         provider.shutdown()
 
 

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -1,6 +1,11 @@
+import logging
 import os
+import subprocess
+import sys
+import textwrap
 import threading
 import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -170,6 +175,61 @@ def test_batch_trace_processor_shutdown_flushes(mocked_exporter):
         total_exported += len(batch)
 
     assert total_exported == 2, "All items in the queue should be exported upon shutdown"
+
+
+def test_batch_trace_processor_shutdown_timeout_returns_when_exporter_blocks(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    export_started = threading.Event()
+    release_export = threading.Event()
+
+    class BlockingExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            export_started.set()
+            release_export.wait(timeout=5.0)
+
+    processor = BatchTraceProcessor(
+        exporter=BlockingExporter(),
+        max_queue_size=1,
+        schedule_delay=60.0,
+        export_trigger_ratio=1.0,
+    )
+    processor.on_span_end(get_span(processor))
+
+    assert export_started.wait(timeout=2.0)
+
+    start = time.monotonic()
+    with caplog.at_level(logging.WARNING):
+        processor.shutdown(timeout=0.05)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.5
+    assert "shutdown timeout reached" in caplog.text
+
+    release_export.set()
+    if processor._worker_thread:
+        processor._worker_thread.join(timeout=2.0)
+
+
+def test_batch_trace_processor_shutdown_passes_deadline_to_exporter() -> None:
+    seen_deadlines: list[float | None] = []
+
+    class DeadlineExporter(TracingExporter):
+        def export(self, items: list[Trace | Span[Any]]) -> None:
+            raise AssertionError("shutdown should use the deadline-aware exporter path")
+
+        def _export_with_deadline(
+            self, items: list[Trace | Span[Any]], deadline: float | None
+        ) -> None:
+            seen_deadlines.append(deadline)
+
+    processor = BatchTraceProcessor(exporter=DeadlineExporter())
+    processor._queue.put_nowait(get_span(processor))
+
+    processor.shutdown(timeout=1.0)
+
+    assert len(seen_deadlines) == 1
+    assert seen_deadlines[0] is not None
 
 
 def test_batch_trace_processor_survives_exporter_exception():
@@ -415,8 +475,103 @@ def test_backend_span_exporter_5xx_retry(mock_client, patched_time_sleep):
 
     # Should retry up to max_retries times
     assert mock_client.return_value.post.call_count == 3
+    assert patched_time_sleep.call_count == 2
 
     exporter.close()
+
+
+@patch("httpx.Client")
+def test_backend_span_exporter_deadline_stops_during_5xx_retry_backoff(
+    mock_client,
+    patched_time_sleep,
+):
+    mock_response = MagicMock()
+    mock_response.status_code = 504
+    mock_client.return_value.post.return_value = mock_response
+
+    exporter = BackendSpanExporter(api_key="test_key", max_retries=3, base_delay=1.0)
+    exporter._export_with_deadline([get_span(mock_processor())], deadline=time.monotonic() + 0.01)
+
+    assert mock_client.return_value.post.call_count == 1
+    patched_time_sleep.assert_called_once()
+    assert patched_time_sleep.call_args.args[0] <= 0.1
+
+    exporter.close()
+
+
+def test_tracing_atexit_cleanup_timeout_preserves_process_exit_code_on_504() -> None:
+    request_seen = threading.Event()
+
+    class Always504Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            request_seen.set()
+            self.send_response(504)
+            self.end_headers()
+            self.wfile.write(b"gateway timeout")
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Always504Handler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    script = textwrap.dedent(
+        f"""
+        import sys
+        import time
+
+        from agents.tracing import custom_span, trace
+        from agents.tracing.processors import BackendSpanExporter, BatchTraceProcessor
+        from agents.tracing.provider import DefaultTraceProvider
+        from agents.tracing import setup as tracing_setup
+
+        tracing_setup._DEFAULT_SHUTDOWN_TIMEOUT = 0.2
+
+        exporter = BackendSpanExporter(
+            api_key="test_key",
+            endpoint="http://127.0.0.1:{server.server_port}/traces/ingest",
+            max_retries=100,
+            base_delay=10.0,
+            max_delay=10.0,
+        )
+        processor = BatchTraceProcessor(
+            exporter=exporter,
+            max_queue_size=1,
+            max_batch_size=1,
+            schedule_delay=60.0,
+            export_trigger_ratio=1.0,
+        )
+        provider = DefaultTraceProvider()
+        provider.register_processor(processor)
+        tracing_setup.set_trace_provider(provider)
+
+        with trace("probe"):
+            with custom_span("probe-span"):
+                pass
+
+        time.sleep(0.3)
+        sys.exit(7)
+        """
+    )
+
+    start = time.monotonic()
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+        elapsed = time.monotonic() - start
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert request_seen.is_set()
+    assert result.returncode == 7
+    assert elapsed < 2.8
 
 
 @patch("httpx.Client")

--- a/tests/tracing/test_setup.py
+++ b/tests/tracing/test_setup.py
@@ -20,6 +20,15 @@ class _DummyProvider:
         self.shutdown_calls += 1
 
 
+class _DefaultProviderWithTimeout(tracing_provider.DefaultTraceProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.shutdown_timeout: float | None = None
+
+    def shutdown(self, timeout: float | None = None) -> None:
+        self.shutdown_timeout = timeout
+
+
 class _BootstrapProvider:
     def __init__(self) -> None:
         self.processors: list[Any] = []
@@ -39,6 +48,17 @@ def test_shutdown_global_trace_provider_calls_shutdown(monkeypatch: pytest.Monke
     tracing_setup._shutdown_global_trace_provider()
 
     assert provider.shutdown_calls == 1
+
+
+def test_shutdown_global_trace_provider_passes_timeout_to_default_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _DefaultProviderWithTimeout()
+    monkeypatch.setattr(tracing_setup, "GLOBAL_TRACE_PROVIDER", provider)
+
+    tracing_setup._shutdown_global_trace_provider()
+
+    assert provider.shutdown_timeout == tracing_setup._DEFAULT_SHUTDOWN_TIMEOUT
 
 
 def test_set_trace_provider_registers_shutdown_once(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
This pull request fixes tracing shutdown so delayed or failing trace exports do not block process exit indefinitely or interfere with the original exit reason.

It adds a bounded default `atexit` cleanup path for the default trace provider, propagates shutdown deadlines through the default processor stack, and makes the OpenAI tracing exporter respect those deadlines during HTTP requests and retry backoff. It also adds regression coverage for blocking exporters, deadline-aware export, 504 retry behavior, and subprocess exit-code preservation during tracing cleanup.