### PR TITLE
Validate prompt configs before model dispatch

### DIFF
--- a/src/agents/prompts.py
+++ b/src/agents/prompts.py
@@ -48,8 +48,20 @@ DynamicPromptFunction = Callable[[GenerateDynamicPromptData], MaybeAwaitable[Pro
 """A function that dynamically generates a prompt."""
 
 
-def _coerce_prompt_dict(prompt: Prompt | dict[object, object]) -> Prompt:
-    """Convert a runtime-validated prompt dict into the Prompt TypedDict view."""
+def _validate_prompt_dict(prompt: Prompt | dict[object, object]) -> Prompt:
+    """Validate and convert a prompt dict into the Prompt TypedDict view."""
+    prompt_id = prompt.get("id")
+    if not isinstance(prompt_id, str) or not prompt_id:
+        raise UserError("Prompt config must include a non-empty string 'id'")
+
+    version = prompt.get("version")
+    if version is not None and not isinstance(version, str):
+        raise UserError("Prompt config 'version' must be a string when provided")
+
+    variables = prompt.get("variables")
+    if variables is not None and not isinstance(variables, dict):
+        raise UserError("Prompt config 'variables' must be a dict when provided")
+
     return cast(Prompt, prompt)
 
 
@@ -65,7 +77,7 @@ class PromptUtil:
 
         resolved_prompt: Prompt
         if isinstance(prompt, dict):
-            resolved_prompt = _coerce_prompt_dict(prompt)
+            resolved_prompt = PromptUtil.validate_prompt_config(prompt)
         else:
             func_result = prompt(GenerateDynamicPromptData(context=context, agent=agent))
             if inspect.isawaitable(func_result):
@@ -74,9 +86,14 @@ class PromptUtil:
                 resolved_prompt = func_result
             if not isinstance(resolved_prompt, dict):
                 raise UserError("Dynamic prompt function must return a Prompt")
+            resolved_prompt = PromptUtil.validate_prompt_config(resolved_prompt)
 
         return {
             "id": resolved_prompt["id"],
             "version": resolved_prompt.get("version"),
             "variables": resolved_prompt.get("variables"),
         }
+
+    @staticmethod
+    def validate_prompt_config(prompt: Prompt | dict[object, object]) -> Prompt:
+        return _validate_prompt_dict(prompt)

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -85,7 +85,7 @@ from typing_extensions import NotRequired, TypedDict, assert_never
 from websockets.asyncio.client import ClientConnection
 
 from agents.handoffs import Handoff
-from agents.prompts import Prompt
+from agents.prompts import Prompt, PromptUtil
 from agents.realtime._default_tracker import ModelAudioTracker
 from agents.realtime.audio_formats import to_realtime_audio_format
 from agents.tool import (
@@ -404,7 +404,7 @@ async def _build_model_settings_from_agent(
     updated_settings = base_settings.copy()
 
     if agent.prompt is not None:
-        updated_settings["prompt"] = agent.prompt
+        updated_settings["prompt"] = PromptUtil.validate_prompt_config(agent.prompt)
 
     instructions, tools, handoffs = await asyncio.gather(
         agent.get_system_prompt(context_wrapper),

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -20,6 +20,7 @@ from ..exceptions import UserError
 from ..handoffs import Handoff
 from ..items import ToolApprovalItem
 from ..logger import logger
+from ..prompts import PromptUtil
 from ..run_config import ToolErrorFormatterArgs
 from ..run_context import RunContextWrapper, TContext
 from ..tool import DEFAULT_APPROVAL_REJECTION_MESSAGE, FunctionTool, invoke_function_tool
@@ -1131,7 +1132,7 @@ class RealtimeSession(RealtimeModelListener):
         updated_settings = self._base_model_settings.copy()
 
         if agent.prompt is not None:
-            updated_settings["prompt"] = agent.prompt
+            updated_settings["prompt"] = PromptUtil.validate_prompt_config(agent.prompt)
 
         instructions, tools, handoffs = await asyncio.gather(
             agent.get_system_prompt(self._context_wrapper),

--- a/tests/realtime/test_realtime_model_settings.py
+++ b/tests/realtime/test_realtime_model_settings.py
@@ -8,6 +8,7 @@ from openai.types.realtime.realtime_session_create_request import (
 )
 from openai.types.realtime.session_update_event import SessionUpdateEvent
 
+from agents.exceptions import UserError
 from agents.handoffs import Handoff
 from agents.realtime.agent import RealtimeAgent
 from agents.realtime.config import RealtimeRunConfig, RealtimeSessionModelSettings
@@ -71,6 +72,20 @@ async def test_build_model_settings_from_agent_merges_agent_fields(monkeypatch: 
     assert merged["model_name"] == "gpt-realtime-2"
     assert merged["tracing"] is None
     assert base_settings == {"model_name": "gpt-realtime-2"}
+
+
+@pytest.mark.asyncio
+async def test_build_model_settings_from_agent_validates_prompt_config():
+    agent = RealtimeAgent(name="root", prompt={"id": 123})  # type: ignore[arg-type]
+
+    with pytest.raises(UserError, match="id"):
+        await _build_model_settings_from_agent(
+            agent=agent,
+            context_wrapper=RunContextWrapper(None),
+            base_settings={},
+            starting_settings=None,
+            run_config=None,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from openai import omit
 
-from agents import Agent, Prompt, RunConfig, RunContextWrapper, Runner
+from agents import Agent, Prompt, RunConfig, RunContextWrapper, Runner, UserError
 from agents.models.interface import Model, ModelProvider
 from agents.models.openai_responses import OpenAIResponsesModel
 
@@ -81,6 +83,44 @@ async def test_dynamic_prompt_is_resolved_correctly():
     resolved = await agent.get_prompt(context_wrapper)
 
     assert resolved == {"id": "dyn_prompt", "version": "2", "variables": None}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("prompt", "match"),
+    [
+        ({}, "id"),
+        ({"id": ""}, "id"),
+        ({"id": 123}, "id"),
+        ({"id": "pmpt_123", "version": 1}, "version"),
+        ({"id": "pmpt_123", "variables": []}, "variables"),
+    ],
+)
+async def test_static_prompt_validation_rejects_invalid_config(prompt: dict[str, Any], match: str):
+    agent = Agent(name="test", prompt=prompt)  # type: ignore[arg-type]
+
+    with pytest.raises(UserError, match=match):
+        await agent.get_prompt(RunContextWrapper(context=None))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("prompt", "match"),
+    [
+        ({}, "id"),
+        ({"id": 123}, "id"),
+        ({"id": "pmpt_123", "version": 1}, "version"),
+        ({"id": "pmpt_123", "variables": []}, "variables"),
+    ],
+)
+async def test_dynamic_prompt_validation_rejects_invalid_config(prompt: dict[str, Any], match: str):
+    def dynamic_prompt_fn(_data):
+        return prompt
+
+    agent = Agent(name="test", prompt=dynamic_prompt_fn)
+
+    with pytest.raises(UserError, match=match):
+        await agent.get_prompt(RunContextWrapper(context=None))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- validate static and dynamic prompt configs before converting them to model input
- reject missing/non-string prompt ids and invalid version/variables fields with UserError
- apply the same validation when realtime agents merge prompt configs into session model settings

## Tests
- uv run pytest tests/test_agent_prompt.py tests/realtime/test_realtime_model_settings.py -q
- uv run ruff format --check src/agents/prompts.py src/agents/realtime/openai_realtime.py src/agents/realtime/session.py tests/test_agent_prompt.py tests/realtime/test_realtime_model_settings.py
- uv run ruff check src/agents/prompts.py src/agents/realtime/openai_realtime.py src/agents/realtime/session.py tests/test_agent_prompt.py tests/realtime/test_realtime_model_settings.py
- uv run pyright --project pyrightconfig.json src/agents/prompts.py src/agents/realtime/openai_realtime.py src/agents/realtime/session.py tests/test_agent_prompt.py tests/realtime/test_realtime_model_settings.py