### PR TITLE
fix: #3357 output schema names for Literal types

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -180,15 +180,16 @@ def _is_subclass_of_base_model_or_dict(t: Any) -> bool:
     return issubclass(t, BaseModel | dict)
 
 
-def _type_to_str(t: type[Any]) -> str:
+def _type_to_str(t: Any) -> str:
     origin = get_origin(t)
     args = get_args(t)
 
     if origin is None:
         # It's a simple type like `str`, `int`, etc.
-        return t.__name__
+        return getattr(t, "__name__", repr(t))
     elif args:
         args_str = ", ".join(_type_to_str(arg) for arg in args)
-        return f"{origin.__name__}[{args_str}]"
+        origin_name = getattr(origin, "__name__", str(origin))
+        return f"{origin_name}[{args_str}]"
     else:
         return str(t)

--- a/tests/test_output_tool.py
+++ b/tests/test_output_tool.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Literal, cast
 
 import pytest
 from pydantic import BaseModel
@@ -75,6 +75,18 @@ def test_structured_output_list():
     json_str = json.dumps({_WRAPPER_DICT_KEY: ["foo", "bar"]})
     validated = output_schema.validate_json(json_str)
     assert validated == ["foo", "bar"]
+
+
+def test_structured_output_literal_name_handles_literal_values():
+    output_schema = AgentOutputSchema(output_type=cast(type[Any], Literal["ok"]))
+
+    assert output_schema.name() == "Literal['ok']"
+
+
+def test_structured_output_nested_literal_name_handles_literal_values():
+    output_schema = AgentOutputSchema(output_type=list[Literal["ok", "done"]])
+
+    assert output_schema.name() == "list[Literal['ok', 'done']]"
 
 
 def test_structured_output_generic_dict_is_not_wrapped():


### PR DESCRIPTION
### Summary

Fix `AgentOutputSchema.name()` so typing arguments without `__name__`, such as `Literal` values, are formatted instead of raising.

This keeps valid structured output types like `Literal["ok"]` and `list[Literal["ok", "done"]]` usable when the runner records the output type name for tracing.

### Test plan

- `uv run pytest tests/test_output_tool.py -q`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

The focused output tool test passes on this branch directly. The full shell verification script was run in a local validation checkout where this branch was temporarily combined with the pending tracing shutdown fix, so the tracing atexit cleanup test would not time out.

### Issue number

Closes #3357

### Checks

- [x] I've added new tests (if relevant)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
