### PR TITLE
fix: #3359 preserve local approval rejection reasons

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1091,7 +1091,12 @@ async def resolve_approval_status(
             if decision_result.get("approve") is True:
                 context_wrapper.approve_tool(approval_item)
             elif decision_result.get("approve") is False:
-                context_wrapper.reject_tool(approval_item)
+                reason = decision_result.get("reason")
+                rejection_message = reason if isinstance(reason, str) and reason else None
+                context_wrapper.reject_tool(
+                    approval_item,
+                    rejection_message=rejection_message,
+                )
         approval_status = context_wrapper.get_approval_status(
             tool_name,
             call_id,

--- a/tests/test_apply_patch_tool.py
+++ b/tests/test_apply_patch_tool.py
@@ -384,7 +384,9 @@ async def test_apply_patch_tool_on_approval_callback_auto_rejects() -> None:
 
     # Should return rejection output
     assert isinstance(result, ToolCallOutputItem)
-    assert HITL_REJECTION_MSG in result.output
+    assert result.output == "Not allowed"
+    raw_item = cast(dict[str, Any], result.raw_item)
+    assert raw_item["output"] == "Not allowed"
     assert len(editor.operations) == 0  # Should not have executed
 
 

--- a/tests/test_custom_tool.py
+++ b/tests/test_custom_tool.py
@@ -4,10 +4,11 @@ import pytest
 from openai.types.responses import ResponseCustomToolCall
 
 from agents import Agent, CustomTool, RunConfig, RunContextWrapper
-from agents.items import ToolCallOutputItem
+from agents.items import ToolApprovalItem, ToolCallOutputItem
 from agents.lifecycle import RunHooks
 from agents.run_internal.run_steps import ToolRunCustom
 from agents.run_internal.tool_actions import CustomToolAction
+from agents.tool import CustomToolOnApprovalFunctionResult
 from agents.tool_context import ToolContext
 
 
@@ -46,4 +47,48 @@ async def test_custom_tool_action_returns_custom_tool_call_output() -> None:
         "type": "custom_tool_call_output",
         "call_id": "call_custom",
         "output": "HELLO",
+    }
+
+
+@pytest.mark.asyncio
+async def test_custom_tool_on_approval_callback_auto_rejects_with_reason() -> None:
+    async def invoke(_ctx: ToolContext[Any], _raw_input: str) -> str:
+        raise AssertionError("rejected custom tool should not execute")
+
+    async def on_approval(
+        _context: RunContextWrapper[Any], _approval_item: ToolApprovalItem
+    ) -> CustomToolOnApprovalFunctionResult:
+        return {"approve": False, "reason": "Not allowed"}
+
+    tool = CustomTool(
+        name="raw_editor",
+        description="Edit raw text.",
+        on_invoke_tool=invoke,
+        format={"type": "text"},
+        needs_approval=True,
+        on_approval=on_approval,
+    )
+    agent = Agent(name="custom-agent", tools=[tool])
+    tool_call = ResponseCustomToolCall(
+        type="custom_tool_call",
+        name="raw_editor",
+        call_id="call_custom",
+        input="hello",
+    )
+
+    result = await CustomToolAction.execute(
+        agent=agent,
+        call=ToolRunCustom(tool_call=tool_call, custom_tool=tool),
+        hooks=RunHooks[Any](),
+        context_wrapper=RunContextWrapper(context=None),
+        config=RunConfig(),
+    )
+
+    assert isinstance(result, ToolCallOutputItem)
+    assert result.output == "Not allowed"
+    raw_item = cast(dict[str, Any], result.raw_item)
+    assert raw_item == {
+        "type": "custom_tool_call_output",
+        "call_id": "call_custom",
+        "output": "Not allowed",
     }

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -20,6 +20,7 @@ from agents import (
 )
 from agents.items import ToolApprovalItem, ToolCallOutputItem
 from agents.run_internal.run_loop import ShellAction, ToolRunShellCall, execute_shell_calls
+from agents.tool import ShellOnApprovalFunctionResult
 
 from .testing_processor import SPAN_PROCESSOR_TESTING
 from .utils.hitl import (
@@ -776,4 +777,37 @@ async def test_shell_tool_on_approval_callback_auto_rejects() -> None:
 
     # Should return rejection output
     assert isinstance(result, ToolCallOutputItem)
-    assert HITL_REJECTION_MSG in result.output
+    assert result.output == "Not allowed"
+    raw_item = cast(dict[str, Any], result.raw_item)
+    assert raw_item["output"][0]["stderr"] == "Not allowed"
+
+
+@pytest.mark.asyncio
+async def test_shell_tool_on_approval_empty_reason_uses_default_rejection() -> None:
+    """Test that empty rejection reasons do not suppress the default message."""
+
+    async def on_approval(
+        _context: RunContextWrapper[Any], _approval_item: ToolApprovalItem
+    ) -> ShellOnApprovalFunctionResult:
+        return {"approve": False, "reason": ""}
+
+    shell_tool = ShellTool(
+        executor=lambda request: "output",
+        needs_approval=require_approval,
+        on_approval=on_approval,
+    )
+
+    tool_run = ToolRunShellCall(tool_call=_shell_call(), shell_tool=shell_tool)
+    agent = Agent(name="shell-agent", tools=[shell_tool])
+    context_wrapper: RunContextWrapper[Any] = make_context_wrapper()
+
+    result = await ShellAction.execute(
+        agent=agent,
+        call=tool_run,
+        hooks=RunHooks[Any](),
+        context_wrapper=context_wrapper,
+        config=RunConfig(),
+    )
+
+    assert isinstance(result, ToolCallOutputItem)
+    assert result.output == HITL_REJECTION_MSG


### PR DESCRIPTION
### Summary

Preserve non-empty rejection reasons returned by local tool `on_approval` callbacks when recording an automatic rejection.

The public local approval callback result can include a `reason`, and hosted MCP approval handling already propagates rejection reasons through its own path. This change keeps shell, apply_patch, and custom local tool rejection outputs consistent with the callback decision while preserving the existing default rejection text when the reason is missing, empty, or not a string.

### Test plan

- `uv run pytest tests/test_shell_tool.py tests/test_apply_patch_tool.py tests/test_custom_tool.py -q`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

The focused local approval tests pass on this branch directly. The full shell verification script was run in a local validation checkout where this branch was temporarily combined with the pending tracing shutdown fix, so the tracing atexit cleanup test would not time out.

### Issue number

Closes #3359

### Checks

- [x] I've added new tests (if relevant)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass