### PR TITLE
fix: #3363 honor short custom voice splitter chunks

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -201,7 +201,7 @@ class StreamedAudioResult:
 
         combined_sentences, self._text_buffer = self.tts_settings.text_splitter(self._text_buffer)
 
-        if len(combined_sentences) >= 20:
+        if combined_sentences:
             local_queue: asyncio.Queue[VoiceStreamEvent | None] = asyncio.Queue()
             self._ordered_tasks.append(local_queue)
             self._tasks.append(
@@ -220,6 +220,10 @@ class StreamedAudioResult:
                 )
             )
             self._text_buffer = ""
+        elif self._started_processing_turn:
+            local_queue = asyncio.Queue()
+            self._ordered_tasks.append(local_queue)
+            await local_queue.put(VoiceStreamEventLifecycle(event="turn_ended"))
         self._done_processing = True
         if self._dispatcher_task is None:
             self._dispatcher_task = asyncio.create_task(self._dispatch_audio())

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -83,6 +83,64 @@ async def test_streamed_audio_result_preserves_cross_chunk_sample_boundaries() -
 
 
 @pytest.mark.asyncio
+async def test_streamed_audio_result_synthesizes_short_custom_splitter_chunk() -> None:
+    texts: list[str] = []
+
+    class RecordingTTS(FakeTTS):
+        async def run(self, text: str, settings: TTSModelSettings):
+            texts.append(text)
+            yield np.zeros(2, dtype=np.int16).tobytes()
+
+    def split_immediately(text: str) -> tuple[str, str]:
+        return text, ""
+
+    result = StreamedAudioResult(
+        RecordingTTS(),
+        TTSModelSettings(buffer_size=1, text_splitter=split_immediately),
+        VoicePipelineConfig(),
+    )
+
+    await result._add_text("ok")
+    await result._turn_done()
+    await result._done()
+
+    events, audio_chunks = await extract_events(result)
+
+    assert texts == ["ok"]
+    assert events == ["turn_started", "audio", "turn_ended", "session_ended"]
+    assert audio_chunks == [np.zeros(2, dtype=np.int16).tobytes()]
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_ignores_empty_custom_splitter_chunk() -> None:
+    texts: list[str] = []
+
+    class RecordingTTS(FakeTTS):
+        async def run(self, text: str, settings: TTSModelSettings):
+            texts.append(text)
+            yield np.zeros(2, dtype=np.int16).tobytes()
+
+    def discard_text(_text: str) -> tuple[str, str]:
+        return "", ""
+
+    result = StreamedAudioResult(
+        RecordingTTS(),
+        TTSModelSettings(buffer_size=1, text_splitter=discard_text),
+        VoicePipelineConfig(),
+    )
+
+    await result._add_text("ok")
+    await result._turn_done()
+    await result._done()
+
+    events, audio_chunks = await extract_events(result)
+
+    assert texts == []
+    assert events == ["turn_started", "turn_ended", "session_ended"]
+    assert audio_chunks == []
+
+
+@pytest.mark.asyncio
 async def test_voicepipeline_run_single_turn() -> None:
     # Single turn. Should produce a single audio output, which is the TTS output for "out_1".
 


### PR DESCRIPTION
### Summary

Honor non-empty chunks returned by custom voice `text_splitter` functions, even when they are shorter than 20 characters.

This lets custom splitters decide when text is ready for TTS and keeps turn lifecycle events balanced when the splitter consumes all buffered text before `_turn_done()`.

### Test plan

- `uv run pytest tests/voice/test_pipeline.py -q`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

The focused voice pipeline tests pass on this branch directly. The full shell verification script was run in a local validation checkout where this branch was temporarily combined with the pending tracing shutdown fix, so the tracing atexit cleanup test would not time out.

### Issue number

Closes #3363

### Checks

- [x] I've added new tests (if relevant)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
