### PR TITLE
fix: avoid auto response for unknown realtime tools (ref: #3287)

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -776,7 +776,7 @@ class RealtimeSession(RealtimeModelListener):
                 RealtimeModelSendToolOutput(
                     tool_call=event,
                     output=error_message,
-                    start_response=True,
+                    start_response=False,
                 )
             )
             await self._put_event(

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1288,7 +1288,7 @@ class TestToolCallExecution:
 
     @pytest.mark.asyncio
     async def test_unknown_tool_handling(self, mock_model, mock_agent, mock_function_tool):
-        """Test that unknown tools complete the model call and emit a RealtimeError event"""
+        """Test that unknown tools complete the model call without starting a response."""
         # Set up agent to return different tool than what's called
         mock_function_tool.name = "known_tool"
         mock_agent.get_all_tools.return_value = [mock_function_tool]
@@ -1307,7 +1307,7 @@ class TestToolCallExecution:
         sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
         assert sent_call == tool_call_event
         assert "Tool unknown_tool not found" in sent_output
-        assert start_response is True
+        assert start_response is False
 
         # Should have emitted a RealtimeError event
         assert session._event_queue.qsize() >= 1


### PR DESCRIPTION
This pull request fixes unknown Realtime tool handling so the SDK completes the model-visible tool call with an error output without automatically triggering a follow-up model response.

Previously, the unknown-tool branch sent `RealtimeModelSendToolOutput(start_response=True)`, which caused the Realtime model backend to receive a `response.create` immediately after the error output. That made the assistant respond even when the application may want to decide whether to continue, recover tool configuration, or stop the turn. Known tools, approval rejections, and handoffs still trigger follow-up responses as before.

context: https://github.com/openai/openai-agents-python/pull/3287#issuecomment-4425289301