### PR TITLE
docs: fix invalid :pyclass: Sphinx role in session docstrings

### DIFF
--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -55,7 +55,7 @@ _RETRY_MAX_DELAY_SECONDS: Final[float] = 1.0
 
 
 class DaprSession(SessionABC):
-    """Dapr State Store implementation of :pyclass:`agents.memory.session.Session`."""
+    """Dapr State Store implementation of :class:`agents.memory.session.Session`."""
 
     session_settings: SessionSettings | None = None
 

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -63,7 +63,7 @@ _DRIVER_INFO = DriverInfo(name="openai-agents", version=_VERSION)
 
 
 class MongoDBSession(SessionABC):
-    """MongoDB implementation of :pyclass:`agents.memory.session.Session`.
+    """MongoDB implementation of :class:`agents.memory.session.Session`.
 
     Conversation items are stored as individual documents in a ``messages``
     collection.  A lightweight ``sessions`` collection tracks metadata

--- a/src/agents/extensions/memory/redis_session.py
+++ b/src/agents/extensions/memory/redis_session.py
@@ -40,7 +40,7 @@ from ...memory.session_settings import SessionSettings, resolve_session_limit
 
 
 class RedisSession(SessionABC):
-    """Redis implementation of :pyclass:`agents.memory.session.Session`."""
+    """Redis implementation of :class:`agents.memory.session.Session`."""
 
     session_settings: SessionSettings | None = None
 

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -54,7 +54,7 @@ from ...memory.session_settings import SessionSettings, resolve_session_limit
 
 
 class SQLAlchemySession(SessionABC):
-    """SQLAlchemy implementation of :pyclass:`agents.memory.session.Session`."""
+    """SQLAlchemy implementation of :class:`agents.memory.session.Session`."""
 
     _table_init_locks: ClassVar[dict[tuple[str, str, str], threading.Lock]] = {}
     _table_init_locks_guard: ClassVar[threading.Lock] = threading.Lock()


### PR DESCRIPTION
### Summary

  Four session backend class docstrings use `:pyclass:`, which is not a valid                                             
  Sphinx / mkdocstrings cross-reference role. The canonical form is `:class:`                                             
  (short) or `:py:class:` (fully qualified). The sibling
  `src/agents/extensions/memory/__init__.py:5` already uses `:class:` for the
  same target, so this aligns the four backends with the existing convention.

  ### Files changed

  - `src/agents/extensions/memory/sqlalchemy_session.py`
  - `src/agents/extensions/memory/redis_session.py`
  - `src/agents/extensions/memory/dapr_session.py`
  - `src/agents/extensions/memory/mongodb_session.py`

  ### Why

  `:pyclass:` is a copy-paste typo that propagated across PRs from four
  different authors (different dates, per `git blame`) — each new session
  backend was written by copying an existing one. `grep` confirms zero uses
  of `:py:class:` anywhere in `src/`, and 1 existing use of `:class:` for the
  exact same target in the sibling `__init__.py`. So short `:class:` is the
  established convention.

  ### Risk

  None — docstring rendering only, no behavior change. `ruff check` and
  `ruff format --check` pass.

  ### Test plan

  - [x] `uv run ruff check src/agents/extensions/memory/` — clean
  - [x] `uv run ruff format --check src/agents/extensions/memory/` — clean
  - [x] Confirmed via `grep ":pyclass:" src/` that no other occurrences remain
  - [x] Confirmed sibling `__init__.py` already uses `:class:` for the same target

  ---