### PR TITLE
docs: normalize memory docstring cross-references

### DIFF
--- a/docs/ref/sandbox/entries/mounts/providers/box.md
+++ b/docs/ref/sandbox/entries/mounts/providers/box.md
@@ -1,0 +1,3 @@
+# `Box`
+
+::: agents.sandbox.entries.mounts.providers.box

--- a/docs/ref/sandbox/session/archive_ops.md
+++ b/docs/ref/sandbox/session/archive_ops.md
@@ -1,0 +1,3 @@
+# `Archive Ops`
+
+::: agents.sandbox.session.archive_ops

--- a/docs/ref/sandbox/session/manifest_ops.md
+++ b/docs/ref/sandbox/session/manifest_ops.md
@@ -1,0 +1,3 @@
+# `Manifest Ops`
+
+::: agents.sandbox.session.manifest_ops

--- a/docs/ref/sandbox/session/mount_lifecycle.md
+++ b/docs/ref/sandbox/session/mount_lifecycle.md
@@ -1,0 +1,3 @@
+# `Mount Lifecycle`
+
+::: agents.sandbox.session.mount_lifecycle

--- a/docs/ref/sandbox/session/snapshot_lifecycle.md
+++ b/docs/ref/sandbox/session/snapshot_lifecycle.md
@@ -1,0 +1,3 @@
+# `Snapshot Lifecycle`
+
+::: agents.sandbox.session.snapshot_lifecycle

--- a/docs/ref/sandbox/session/tar_workspace.md
+++ b/docs/ref/sandbox/session/tar_workspace.md
@@ -1,0 +1,3 @@
+# `Tar Workspace`
+
+::: agents.sandbox.session.tar_workspace

--- a/src/agents/extensions/memory/__init__.py
+++ b/src/agents/extensions/memory/__init__.py
@@ -2,8 +2,8 @@
 
 This package contains optional, production-grade session implementations that
 introduce extra third-party dependencies (database drivers, ORMs, etc.). They
-conform to the :class:`agents.memory.session.Session` protocol so they can be
-used as a drop-in replacement for :class:`agents.memory.session.SQLiteSession`.
+conform to the [`Session`][agents.memory.session.Session] protocol so they can be
+used as a drop-in replacement for [`SQLiteSession`][agents.memory.sqlite_session.SQLiteSession].
 """
 
 from __future__ import annotations

--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -55,7 +55,7 @@ _RETRY_MAX_DELAY_SECONDS: Final[float] = 1.0
 
 
 class DaprSession(SessionABC):
-    """Dapr State Store implementation of :pyclass:`agents.memory.session.Session`."""
+    """Dapr State Store implementation of [`Session`][agents.memory.session.Session]."""
 
     session_settings: SessionSettings | None = None
 

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -63,7 +63,7 @@ _DRIVER_INFO = DriverInfo(name="openai-agents", version=_VERSION)
 
 
 class MongoDBSession(SessionABC):
-    """MongoDB implementation of :pyclass:`agents.memory.session.Session`.
+    """MongoDB implementation of [`Session`][agents.memory.session.Session].
 
     Conversation items are stored as individual documents in a ``messages``
     collection.  A lightweight ``sessions`` collection tracks metadata
@@ -120,7 +120,7 @@ class MongoDBSession(SessionABC):
             messages_collection: Name of the collection that stores individual
                 conversation items. Defaults to ``"agent_messages"``.
             session_settings: Optional session configuration. When ``None`` a
-                default :class:`~agents.memory.session_settings.SessionSettings`
+                default [`SessionSettings`][agents.memory.session_settings.SessionSettings]
                 is used (no item limit).
         """
         self.session_id = session_id
@@ -161,14 +161,15 @@ class MongoDBSession(SessionABC):
                 ``"mongodb+srv://user:pass@cluster.example.com"``.
             database: Name of the MongoDB database to use.
             client_kwargs: Additional keyword arguments forwarded to
-                :class:`pymongo.asynchronous.mongo_client.AsyncMongoClient`.
+                `pymongo.asynchronous.mongo_client.AsyncMongoClient`.
             session_settings: Optional session configuration settings.
             **kwargs: Additional keyword arguments forwarded to the main
                 constructor (e.g. ``sessions_collection``,
                 ``messages_collection``).
 
         Returns:
-            A :class:`MongoDBSession` connected to the specified MongoDB server.
+            A [`MongoDBSession`][agents.extensions.memory.mongodb_session.MongoDBSession]
+                connected to the specified MongoDB server.
         """
         client_kwargs = client_kwargs or {}
         client_kwargs.setdefault("driver", _DRIVER_INFO)

--- a/src/agents/extensions/memory/redis_session.py
+++ b/src/agents/extensions/memory/redis_session.py
@@ -40,7 +40,7 @@ from ...memory.session_settings import SessionSettings, resolve_session_limit
 
 
 class RedisSession(SessionABC):
-    """Redis implementation of :pyclass:`agents.memory.session.Session`."""
+    """Redis implementation of [`Session`][agents.memory.session.Session]."""
 
     session_settings: SessionSettings | None = None
 

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -54,7 +54,7 @@ from ...memory.session_settings import SessionSettings, resolve_session_limit
 
 
 class SQLAlchemySession(SessionABC):
-    """SQLAlchemy implementation of :pyclass:`agents.memory.session.Session`."""
+    """SQLAlchemy implementation of [`Session`][agents.memory.session.Session]."""
 
     _table_init_locks: ClassVar[dict[tuple[str, str, str], threading.Lock]] = {}
     _table_init_locks_guard: ClassVar[threading.Lock] = threading.Lock()


### PR DESCRIPTION
This pull request updates the memory extension docstrings to use MkDocs/mkdocstrings-compatible Markdown autorefs instead of Sphinx-style roles that render literally in the generated API reference.

The change replaces invalid or ineffective `:pyclass:` / `:class:` references in the memory extension package with links such as [`Session`][agents.memory.session.Session], and leaves external PyMongo types as plain code spans. It affects only documentation text in docstrings and does not change runtime behavior or public APIs.
