### PR TITLE
fix: guard None text in text_message_output and add output guardrail count to RunErrorDetails

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -764,7 +764,7 @@ class ItemHelpers:
         text = ""
         for item in message.raw_item.content:
             if isinstance(item, ResponseOutputText):
-                text += item.text
+                text += item.text or ""
         return text
 
     @classmethod

--- a/src/agents/util/_pretty_print.py
+++ b/src/agents/util/_pretty_print.py
@@ -45,6 +45,7 @@ def pretty_print_run_error_details(result: "RunErrorDetails") -> str:
     output += f"\n- {len(result.new_items)} new item(s)"
     output += f"\n- {len(result.raw_responses)} raw response(s)"
     output += f"\n- {len(result.input_guardrail_results)} input guardrail result(s)"
+    output += f"\n- {len(result.output_guardrail_results)} output guardrail result(s)"
     output += "\n(See `RunErrorDetails` for more details)"
 
     return output

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -83,6 +83,7 @@ RunErrorDetails:
 - 0 new item(s)
 - 0 raw response(s)
 - 0 input guardrail result(s)
+- 0 output guardrail result(s)
 (See `RunErrorDetails` for more details)\
 """)
 

--- a/tests/utils/test_pretty_print_and_items.py
+++ b/tests/utils/test_pretty_print_and_items.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+from agents import Agent
+from agents.exceptions import RunErrorDetails
+from agents.items import ItemHelpers, MessageOutputItem
+from agents.util._pretty_print import pretty_print_run_error_details
+
+
+def _make_message_item(text: str | None) -> MessageOutputItem:
+    msg = ResponseOutputMessage.model_construct(
+        id="msg_1",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText.model_construct(type="output_text", text=text, annotations=[])],
+    )
+    agent = Agent(name="test")
+    return MessageOutputItem(agent=agent, raw_item=msg)
+
+
+def test_text_message_output_returns_empty_string_for_none_text():
+    """text_message_output must not crash when a content item has text=None."""
+    item = _make_message_item(None)
+    assert ItemHelpers.text_message_output(item) == ""
+
+
+def test_text_message_output_returns_text_normally():
+    item = _make_message_item("hello")
+    assert ItemHelpers.text_message_output(item) == "hello"
+
+
+def test_text_message_outputs_handles_none_text_across_items():
+    """text_message_outputs must tolerate None text in any item."""
+    from agents.items import RunItem
+
+    items: list[RunItem] = [_make_message_item(None), _make_message_item("world")]
+    assert ItemHelpers.text_message_outputs(items) == "world"
+
+
+def _make_run_error_details(n_input: int = 0, n_output: int = 0) -> RunErrorDetails:
+    return RunErrorDetails(
+        input="hi",
+        new_items=[],
+        raw_responses=[],
+        last_agent=Agent(name="test"),
+        context_wrapper=None,  # type: ignore[arg-type]
+        input_guardrail_results=[None] * n_input,  # type: ignore[list-item]
+        output_guardrail_results=[None] * n_output,  # type: ignore[list-item]
+    )
+
+
+def test_pretty_print_run_error_details_includes_output_guardrail_count():
+    """pretty_print_run_error_details must report output_guardrail_results like its siblings."""
+    details = _make_run_error_details(n_input=1, n_output=2)
+    text = pretty_print_run_error_details(details)
+    assert "1 input guardrail result(s)" in text
+    assert "2 output guardrail result(s)" in text
+
+
+def test_pretty_print_run_error_details_zero_output_guardrails():
+    details = _make_run_error_details(n_input=0, n_output=0)
+    text = pretty_print_run_error_details(details)
+    assert "0 output guardrail result(s)" in text


### PR DESCRIPTION
### Summary

Two small, related fixes in the SDK's output-handling utilities:

**1. `ItemHelpers.text_message_output` — guard against `None` text**

`extract_text` (the sibling method in the same class) already applies an `or ""` guard with an explicit comment explaining that provider gateways (e.g. LiteLLM) and `model_construct` paths during streaming can surface `None` for `ResponseOutputText.text`. `text_message_output` had the same concatenation loop without the guard, so the same `TypeError: can only concatenate str (not "NoneType") to str` could fire through `text_message_outputs` and `agent.py`'s `text_output` path.

Fix: `text += item.text or ""`

**2. `pretty_print_run_error_details` — include output guardrail count**

`pretty_print_result` and `pretty_print_run_result_streaming` both report `input_guardrail_results` and `output_guardrail_results`. `pretty_print_run_error_details` reported only the input count, so `RunErrorDetails.__str__()` silently omitted output guardrail results — misleading when an output guardrail is the reason the run failed.

Fix: add the missing `output_guardrail_results` line.

### Test plan

New file `tests/utils/test_pretty_print_and_items.py` (5 tests):
- `test_text_message_output_returns_empty_string_for_none_text` — reproduces the `TypeError` on the old code via `model_construct`
- `test_text_message_output_returns_text_normally` — normal path still works
- `test_text_message_outputs_handles_none_text_across_items` — multi-item list with a `None` entry
- `test_pretty_print_run_error_details_includes_output_guardrail_count` — asserts both counts appear
- `test_pretty_print_run_error_details_zero_output_guardrails` — zero case

Updated inline snapshot in `tests/test_pretty_print.py::test_pretty_run_error_details`.

```
uv run pytest tests/utils/test_pretty_print_and_items.py tests/test_pretty_print.py -v
```

![tests pass](https://raw.githubusercontent.com/zhoufengen/openai-agents-python/pr-media/tests-pass.png)

Full verification stack:
- `make format` — no changes
- `make lint` — all checks passed
- `make typecheck` — mypy: no issues (767 files), pyright: 0 errors
- `make tests` (parallel + serial) — all passed

### Issue number

N/A (no existing issue; both are small, self-contained defects).

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass