### PR TITLE
fix: #3357 AgentOutputSchema.name() crash on Literal output types

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -180,15 +180,25 @@ def _is_subclass_of_base_model_or_dict(t: Any) -> bool:
     return issubclass(t, BaseModel | dict)
 
 
-def _type_to_str(t: type[Any]) -> str:
+def _type_to_str(t: Any) -> str:
     origin = get_origin(t)
     args = get_args(t)
 
     if origin is None:
-        # It's a simple type like `str`, `int`, etc.
-        return t.__name__
+        # Plain type (str, int, MyModel, ...) or a non-type value supplied as a
+        # type argument — e.g. the "ok" inside `Literal["ok"]` is a str instance,
+        # not a class, so `t.__name__` would raise. Fall back to repr() in that
+        # case so nested forms like `list[Literal["ok"]]` still format cleanly.
+        if isinstance(t, type):
+            return t.__name__
+        return repr(t)
     elif args:
         args_str = ", ".join(_type_to_str(arg) for arg in args)
-        return f"{origin.__name__}[{args_str}]"
+        # `typing.Literal`/`typing.Union`/etc. expose `_name` rather than
+        # `__name__` on some Python versions.
+        origin_name = (
+            getattr(origin, "__name__", None) or getattr(origin, "_name", None) or str(origin)
+        )
+        return f"{origin_name}[{args_str}]"
     else:
         return str(t)

--- a/tests/test_output_tool.py
+++ b/tests/test_output_tool.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Literal, cast
 
 import pytest
 from pydantic import BaseModel
@@ -92,6 +92,33 @@ def test_structured_output_generic_dict_rejects_wrapper_shape():
 
     with pytest.raises(ModelBehaviorError):
         output_schema.validate_json(json.dumps({"response": {"foo": 1}}))
+
+
+def test_structured_output_literal_name_does_not_crash():
+    # `AgentOutputSchema.name()` used to raise `AttributeError` on `Literal["ok"]`
+    # because the Literal value "ok" is a `str` instance rather than a class, and
+    # the name formatter unconditionally read `__name__`. See issue #3357.
+    schema = AgentOutputSchema(cast(type[Any], Literal["ok"]))
+    assert schema.name() == "Literal['ok']"
+
+    # Multiple Literal members format cleanly.
+    schema_multi = AgentOutputSchema(cast(type[Any], Literal["ok", "done"]))
+    assert schema_multi.name() == "Literal['ok', 'done']"
+
+    # Literal nested inside a generic still works.
+    schema_nested = AgentOutputSchema(
+        cast(type[Any], list[Literal["ok", "done"]]),
+        strict_json_schema=False,
+    )
+    assert schema_nested.name() == "list[Literal['ok', 'done']]"
+
+    # Non-string Literal values use repr() so they keep their original literal form.
+    schema_int = AgentOutputSchema(cast(type[Any], Literal[1, 2]))
+    assert schema_int.name() == "Literal[1, 2]"
+
+    # Plain and other generic types are unchanged by the fix.
+    assert AgentOutputSchema(str).name() == "str"
+    assert AgentOutputSchema(list[int]).name() == "list[int]"
 
 
 def test_bad_json_raises_error(mocker):


### PR DESCRIPTION
### Summary

`AgentOutputSchema.name()` previously crashed for any output type that contained `typing.Literal`, because `_type_to_str` recursed into each typing arg and unconditionally read `__name__`. The Literal value (e.g. the `"ok"` inside `Literal["ok"]`) is a `str` instance rather than a class, so the lookup raised `AttributeError` and broke the trace path when the run started. `schema.json_schema()` already worked, so the bug only surfaced at the very last step of agent setup.

The fix is local to `_type_to_str`:

- If the recursive arg isn't a class, fall back to `repr(t)` so literal values keep their original form (`"'ok'"`, `'1'`, etc.).
- Resolve origin names through `getattr(origin, "__name__", None) or getattr(origin, "_name", None) or str(origin)` so typing constructs that only expose `_name` (`typing.Literal`, `typing.Union`) still produce a readable label.

`_type_to_str` is now typed as `t: Any` to match the recursive call, which already passed non-type values into itself.

### Test plan

Added `test_structured_output_literal_name_does_not_crash` covering:

- `Literal["ok"]` → `"Literal['ok']"` (the exact repro from the issue)
- `Literal["ok", "done"]` → `"Literal['ok', 'done']"`
- `list[Literal["ok", "done"]]` → `"list[Literal['ok', 'done']]"`
- `Literal[1, 2]` → `"Literal[1, 2]"`
- Plain types and existing generics (`str`, `list[int]`) unchanged

```
$ make format
All checks passed!
$ make lint
All checks passed!
$ uv run mypy src/agents/agent_output.py tests/test_output_tool.py
Success: no issues found in 2 source files
$ uv run pytest tests/test_output_tool.py -v
...
tests/test_output_tool.py::test_structured_output_literal_name_does_not_crash PASSED
============================== 12 passed in 0.11s ==============================
```

### Issue number

Closes #3357.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run \`make lint\` and \`make format\`
- [x] I've made sure tests pass