### PR TITLE
fix: avoid mutating FunctionTool params_json_schema

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -401,7 +401,9 @@ class FunctionTool:
         if callable(bind_to_function_tool):
             self.on_invoke_tool = bind_to_function_tool(self)
         if self.strict_json_schema:
-            self.params_json_schema = ensure_strict_json_schema(self.params_json_schema)
+            self.params_json_schema = ensure_strict_json_schema(
+                copy.deepcopy(self.params_json_schema)
+            )
         _validate_function_tool_timeout_config(self)
 
     def __copy__(self) -> FunctionTool:

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -732,6 +732,27 @@ async def test_copied_function_tool_invalid_input_uses_current_name(copy_style: 
         )
 
 
+def test_function_tool_does_not_mutate_params_json_schema() -> None:
+    async def noop(ctx: ToolContext[Any], input: str) -> str:
+        return ""
+
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    schema_snapshot = copy.deepcopy(schema)
+
+    tool = FunctionTool(
+        name="t",
+        description="d",
+        params_json_schema=schema,
+        on_invoke_tool=noop,
+        strict_json_schema=True,
+    )
+
+    assert schema == schema_snapshot
+    assert tool.params_json_schema is not schema
+    assert tool.params_json_schema["additionalProperties"] is False
+    assert tool.params_json_schema["required"] == ["x"]
+
+
 @pytest.mark.asyncio
 async def test_default_failure_error_function_survives_deepcopy() -> None:
     def boom() -> None:


### PR DESCRIPTION
### Summary

Mirror the MCP fix in #3134 for the `FunctionTool` path. `ensure_strict_json_schema` is [documented as mutating](https://github.com/openai/openai-agents-python/blob/main/src/agents/strict_schema.py#L20) its input dict, but `FunctionTool.__post_init__` currently passes `self.params_json_schema` directly. When users construct `FunctionTool(...)` with a schema dict they own (e.g. reused across instances), strict-mode side effects like `additionalProperties: false` and `required: [...]` get baked into the caller's dict.

The decorator-based `function_tool(...)` path is unaffected because `function_schema()` produces a fresh dict per call. The direct `FunctionTool(...)` constructor is documented and exported from `agents.__init__`, so callers who use it directly are exposed.

```python
>>> shared = {"type": "object", "properties": {"x": {"type": "string"}}}
>>> ft = FunctionTool(name="t", description="d", params_json_schema=shared,
...                   on_invoke_tool=noop, strict_json_schema=True)
>>> shared
{'type': 'object', 'properties': {'x': {'type': 'string'}},
 'additionalProperties': False, 'required': ['x']}
```

Wrap the schema in `copy.deepcopy()` before passing to `ensure_strict_json_schema`, matching the MCP precedent at \`src/agents/mcp/util.py:286\`.

### Test plan

- New regression test \`test_function_tool_does_not_mutate_params_json_schema\` (mirrors \`tests/mcp/test_mcp_util.py::test_to_function_tool_does_not_mutate_mcp_input_schema\`).
- \`uv run pytest tests/test_function_tool.py tests/mcp/test_mcp_util.py\` — 112 passed.
- \`uv run ruff check src/agents/tool.py tests/test_function_tool.py\` — All checks passed.

### Issue number

N/A — found while auditing for the same mutation-aliasing pattern that #3134 fixed.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no doc changes needed)
- [x] I've run \`make lint\` and \`make format\`
- [x] I've made sure tests pass