### PR TITLE
docs: mark Agent.instructions as optional

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -28,7 +28,7 @@ The most common properties of an agent are:
 | Property | Required | Description |
 | --- | --- | --- |
 | `name` | yes | Human-readable agent name. |
-| `instructions` | yes | System prompt or dynamic instructions callback. See [Dynamic instructions](#dynamic-instructions). |
+| `instructions` | no | System prompt or dynamic instructions callback. Strongly recommended. See [Dynamic instructions](#dynamic-instructions). |
 | `prompt` | no | OpenAI Responses API prompt configuration. Accepts a static prompt object or a function. See [Prompt templates](#prompt-templates). |
 | `handoff_description` | no | Short description exposed when this agent is offered as a handoff target. |
 | `handoffs` | no | Delegate the conversation to specialist agents. See [handoffs](handoffs.md). |


### PR DESCRIPTION
### Summary

The Agent properties table in \`docs/agents.md\` currently marks \`instructions\` as required (\`yes\`), but:

- \`Agent.instructions\` has \`= None\` as its default in \`src/agents/agent.py:283-290\`.
- The class docstring on \`Agent\` itself says "We strongly recommend passing \`instructions\`" — wording that signals optional-but-recommended.
- \`Agent(name="x")\` succeeds at runtime without an \`instructions\` argument; many tests rely on this.

Update the table row to mark \`instructions\` as not required, while keeping a "Strongly recommended" hint to preserve the existing guidance.

### Test plan

Docs-only change. Manually verified:

\`\`\`
$ uv run python -c "from agents import Agent; a = Agent(name='x'); print(a.instructions)"
None
\`\`\`

### Issue number

N/A — found during a docstring/docs accuracy audit.

### Checks

- [x] I've added new tests (if relevant) — docs only
- [x] I've added/updated the relevant documentation
- [x] I've run \`make lint\` and \`make format\` — no code touched
- [x] I've made sure tests pass — no code touched