### PR TITLE
fix: avoid mutating codex output schema input

### DIFF
--- a/src/agents/extensions/experimental/codex/codex_tool.py
+++ b/src/agents/extensions/experimental/codex/codex_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import dataclasses
 import inspect
 import json
@@ -694,7 +695,7 @@ def _resolve_output_schema(
         return _build_codex_output_schema(descriptor)
 
     if isinstance(option, Mapping):
-        schema = dict(option)
+        schema = copy.deepcopy(dict(option))
         if "type" in schema and schema.get("type") != "object":
             raise UserError('Codex output schema must be a JSON object schema with type "object".')
         return ensure_strict_json_schema(schema)

--- a/tests/extensions/experiemental/codex/test_codex_tool.py
+++ b/tests/extensions/experiemental/codex/test_codex_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import dataclasses
 import importlib
 import inspect
@@ -1514,6 +1515,19 @@ def test_codex_tool_resolve_output_schema_validation_errors() -> None:
         )
     with pytest.raises(UserError, match='type "object"'):
         codex_tool_module._resolve_output_schema({"type": "string"})
+
+
+def test_codex_tool_resolve_output_schema_does_not_mutate_input() -> None:
+    nested = {"type": "object", "properties": {"y": {"type": "string"}}}
+    option = {"type": "object", "properties": {"inner": nested}}
+    option_snapshot = copy.deepcopy(option)
+
+    result = codex_tool_module._resolve_output_schema(option)
+
+    assert option == option_snapshot
+    assert nested == {"type": "object", "properties": {"y": {"type": "string"}}}
+    assert result is not None
+    assert result["properties"]["inner"] is not nested
 
 
 def test_codex_tool_resolve_output_schema_descriptor() -> None:


### PR DESCRIPTION
### Summary

Mirror the MCP fix in #3134 (and the \`FunctionTool\` fix in #3382) for the Codex \`output_schema\` path. \`_resolve_output_schema\` in \`src/agents/extensions/experimental/codex/codex_tool.py:696-700\` does \`schema = dict(option)\`, which is only a shallow copy — nested user dicts (e.g. entries in \`option["properties"]\`) are the same identity as the caller's. \`ensure_strict_json_schema\` (documented as mutating its input at \`src/agents/strict_schema.py:20\`) then mutates those nested dicts in place, leaking strict-mode side effects like \`additionalProperties: false\` and \`required: [...]\` back into the caller's stored schema.

\`\`\`python
>>> nested = {"type": "object", "properties": {"y": {"type": "string"}}}
>>> option = {"type": "object", "properties": {"inner": nested}}
>>> _resolve_output_schema(option)
>>> nested
{'type': 'object', 'properties': {'y': {'type': 'string'}},
 'additionalProperties': False, 'required': ['y']}
\`\`\`

Switch to \`copy.deepcopy(dict(option))\` so the strict conversion only mutates the local copy, matching the precedent established by #3134 in MCP and #3382 in \`FunctionTool\`.

### Test plan

- New regression test \`test_codex_tool_resolve_output_schema_does_not_mutate_input\` verifying both the top-level option dict and a nested object schema remain unmodified after \`_resolve_output_schema\` returns, and that the returned dict's nested entry is a fresh copy.
- \`uv run pytest tests/extensions/experiemental/codex/test_codex_tool.py -k resolve_output_schema\` — 3 passed.
- \`uv run ruff check\` on the touched files — All checks passed.

### Issue number

N/A — found while auditing for the same mutation-aliasing pattern that #3134 and #3382 fixed.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no doc changes needed)
- [x] I've run \`make lint\` and \`make format\`
- [x] I've made sure tests pass