### PR TITLE
fix: filter hosted_tool_call types in remove_all_tools handoff filter

### DIFF
--- a/src/agents/extensions/handoff_filters.py
+++ b/src/agents/extensions/handoff_filters.py
@@ -104,6 +104,7 @@ def _remove_tool_types_from_input(
         "apply_patch_call_output",
         "custom_tool_call",
         "custom_tool_call_output",
+        "hosted_tool_call",
     ]
 
     filtered_items: list[TResponseInputItem] = []

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -1130,6 +1130,7 @@ def test_removes_hosted_tool_types_from_input_history() -> None:
         "apply_patch_call_output",
         "custom_tool_call",
         "custom_tool_call_output",
+        "hosted_tool_call",
     ]
     input_items: list[TResponseInputItem] = [_get_message_input_item("Hello")]
     for t in hosted_types:


### PR DESCRIPTION
### Summary

Extends the fix in #3095 to cover one more raw input item type that the handoff filter was missing.

\`hosted_tool_call\` is a real tool-call item type recognized elsewhere in the SDK:

- \`src/agents/run_state.py:2024\` — raw item normalization treats it as a tool-call type alongside \`shell_call\`/\`apply_patch_call\`/\`local_shell_call\`.
- \`src/agents/run_internal/tool_execution.py:2368\` — \`_is_hosted_mcp_approval_request\` detects payloads serialized as \`{"type": "hosted_tool_call", "provider_data": {"type": "mcp_approval_request"}}\`.

However, \`_remove_tool_types_from_input\` in \`src/agents/extensions/handoff_filters.py\` did not include \`hosted_tool_call\` in its filter list. Raw \`hosted_tool_call\` items in \`input_history\` therefore survived \`remove_all_tools\` handoff filtering — leaking provider-level tool-call payloads (including hosted MCP approval requests in the raw \`hosted_tool_call\` form) into the downstream agent's history.

Add \`hosted_tool_call\` to the filter list and extend the parametrized list in the existing \`test_removes_hosted_tool_types_from_input_history\` regression test.

### Test plan

- \`uv run pytest tests/test_extension_filters.py -k hosted_tool\` — 1 passed (with the new entry in the list).
- \`uv run ruff check\` on the touched files — All checks passed.

### Issue number

N/A — found while auditing for the same gap that #3095 fixed for \`custom_tool_call\`.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no doc changes needed)
- [x] I've run \`make lint\` and \`make format\`
- [x] I've made sure tests pass