### PR TITLE
fix: reject failed and incomplete Responses statuses in non-streaming path

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -360,6 +360,13 @@ class AnyLLMModel(Model):
                 prompt=prompt,
             )
 
+            status = getattr(response, "status", None)
+            if status in {"failed", "incomplete"}:
+                raise response_terminal_failure_error(
+                    f"response.{status}",
+                    response if isinstance(response, Response) else None,
+                )
+
             if _debug.DONT_LOG_MODEL_DATA:
                 logger.debug("LLM responded")
             else:

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -472,6 +472,13 @@ class OpenAIResponsesModel(Model):
                     prompt=prompt,
                 )
 
+                status = getattr(response, "status", None)
+                if status in {"failed", "incomplete"}:
+                    raise response_terminal_failure_error(
+                        f"response.{status}",
+                        response if isinstance(response, Response) else None,
+                    )
+
                 if _debug.DONT_LOG_MODEL_DATA:
                     logger.debug("LLM responded")
                 else:

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -625,6 +625,35 @@ async def test_any_llm_responses_stream_rejects_error_event(monkeypatch) -> None
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["failed", "incomplete"])
+async def test_any_llm_responses_path_rejects_failed_or_incomplete_status(
+    monkeypatch,
+    status: str,
+) -> None:
+    response = _response("partial", response_id="resp-terminal")
+    response.status = status  # type: ignore[assignment]
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=response)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    AnyLLMModel = module.AnyLLMModel
+
+    model = AnyLLMModel(model="openai/gpt-5.4-mini")
+    with pytest.raises(ModelBehaviorError, match=f"response.{status}"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_any_llm_responses_path_passes_transport_kwargs_via_private_provider_api(
     monkeypatch,
 ) -> None:

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -312,6 +312,34 @@ async def test_get_response_span_exports_usage():
     }
 
 
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["failed", "incomplete"])
+async def test_get_response_rejects_failed_or_incomplete_response_status(status: str) -> None:
+    class DummyResponses:
+        async def create(self, **kwargs: Any) -> Any:
+            response = get_response_obj([], response_id="resp-terminal")
+            response.status = status  # type: ignore[assignment]
+            return response
+
+    class DummyResponsesClient:
+        def __init__(self) -> None:
+            self.responses = DummyResponses()
+
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=DummyResponsesClient())  # type: ignore[arg-type]
+
+    with pytest.raises(ModelBehaviorError, match=f"response.{status}"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+
+
 def test_get_client_disables_provider_managed_retries_on_runner_retry() -> None:
     class DummyResponsesClient:
         def __init__(self) -> None:


### PR DESCRIPTION
### Summary

Mirror the streaming-side fix in #3107 (\`fix: reject failed responses stream terminals\`) for the non-streaming \`get_response\` paths.

Streaming responses are guarded today: when the streaming code sees a \`response.failed\` or \`response.incomplete\` terminal event, it raises \`response_terminal_failure_error\` (defined in \`src/agents/models/_response_terminal.py\`). The non-streaming HTTP paths in \`OpenAIResponsesModel.get_response\` (\`src/agents/models/openai_responses.py:462-525\`) and \`AnyLLMModel._get_response_via_responses\` (\`src/agents/extensions/models/any_llm_model.py:335-397\`) previously did not inspect \`response.status\` at all and would silently return a \`ModelResponse\` built from the partial/empty \`response.output\`.

That violates parity with the streaming guard: identical underlying failures (provider backend error, content-filter \`incomplete\`, \`max_output_tokens\` hit) crash one path and silently succeed on the other. Users who pick streaming vs non-streaming dynamically would observe inconsistent agent-run results.

Check \`response.status in {"failed", "incomplete"}\` right after the non-streaming fetch returns and raise the same \`response_terminal_failure_error\` helper used by the streaming path.

### Test plan

- New parametrized test \`test_get_response_rejects_failed_or_incomplete_response_status\` in \`tests/models/test_openai_responses.py\` — covers \`status="failed"\` and \`status="incomplete"\` for the OpenAI Responses model.
- New parametrized test \`test_any_llm_responses_path_rejects_failed_or_incomplete_status\` in \`tests/models/test_any_llm_model.py\` — same coverage for the \`any_llm\` Responses path.
- \`uv run pytest tests/models/test_openai_responses.py tests/models/test_any_llm_model.py\` — 131 passed, 4 skipped (skipped tests are environment-dependent, unrelated to this change).
- \`uv run ruff check\` on the touched files — All checks passed.

### Issue number

N/A — found while auditing for the same fix-pattern that #3107 applied to streaming.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no doc changes needed)
- [x] I've run \`make lint\` and \`make format\`
- [x] I've made sure tests pass