### PR TITLE
fix: apply empty-content guard to empty-string chat tool outputs

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -754,19 +754,19 @@ class Converter:
                             for c in all_output_content
                             if c.get("type") == "text"
                         ]
-                        if not tool_result_content:
-                            message = (
-                                "Chat Completions tool outputs cannot be empty or contain only "
-                                "non-text content unless preserve_tool_output_all_content=True."
-                            )
-                            if strict_feature_validation:
-                                raise UserError(message)
-                            logger.warning(
-                                "%s Replacing the tool output with a placeholder; enable strict "
-                                "feature validation to raise an error instead.",
-                                message,
-                            )
-                            tool_result_content = _OMITTED_TOOL_OUTPUT_PLACEHOLDER
+                    if not tool_result_content:
+                        message = (
+                            "Chat Completions tool outputs cannot be empty or contain only "
+                            "non-text content unless preserve_tool_output_all_content=True."
+                        )
+                        if strict_feature_validation:
+                            raise UserError(message)
+                        logger.warning(
+                            "%s Replacing the tool output with a placeholder; enable strict "
+                            "feature validation to raise an error instead.",
+                            message,
+                        )
+                        tool_result_content = _OMITTED_TOOL_OUTPUT_PLACEHOLDER
                 msg: ChatCompletionToolMessageParam = {
                     "role": "tool",
                     "tool_call_id": func_output["call_id"],

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -433,6 +433,39 @@ def test_items_to_messages_with_empty_function_output_raises_in_strict_mode():
         Converter.items_to_messages([func_output_item], strict_feature_validation=True)
 
 
+def test_items_to_messages_with_empty_string_function_output_uses_placeholder_by_default(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Default conversion should not send an empty-string tool message."""
+    func_output_item: FunctionCallOutput = {
+        "type": "function_call_output",
+        "call_id": "somecall",
+        "output": "",
+    }
+
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        messages = Converter.items_to_messages([func_output_item])
+
+    assert len(messages) == 1
+    tool_msg = messages[0]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == func_output_item["call_id"]
+    assert tool_msg["content"] == "[tool output omitted]"
+    assert "Replacing the tool output with a placeholder" in caplog.text
+
+
+def test_items_to_messages_with_empty_string_function_output_raises_in_strict_mode():
+    """Strict validation should fail explicitly instead of sending empty-string output."""
+    func_output_item: FunctionCallOutput = {
+        "type": "function_call_output",
+        "call_id": "somecall",
+        "output": "",
+    }
+
+    with pytest.raises(UserError, match="cannot be empty or contain only non-text content"):
+        Converter.items_to_messages([func_output_item], strict_feature_validation=True)
+
+
 def test_items_to_messages_with_mixed_function_output_keeps_text_by_default(
     caplog: pytest.LogCaptureFixture,
 ):


### PR DESCRIPTION
### Summary

Extends the fix in #3312 (\`fix: avoid empty chat tool outputs\`) to one case the original guard missed.

#3312 added an empty-content guard that swaps the tool message body with \`_OMITTED_TOOL_OUTPUT_PLACEHOLDER\` when the converted content is empty. The guard was placed inside the \`else\` branch of \`isinstance(all_output_content, str)\` at \`chatcmpl_converter.py:749-769\`, so it only triggered when the output was a non-text-only list. When the output is the empty string \`""\`, \`extract_all_content("")\` returns \`""\` (the string branch), \`tool_result_content\` is set to \`""\` without ever reaching the guard, and the Chat Completions message ends up with \`"content": ""\` — exactly the broken shape #3310/#3312 aimed to prevent.

Repro on current \`main\` (before this PR):

\`\`\`python
>>> from agents.models.chatcmpl_converter import Converter
>>> items = [
...     {"type": "function_call", "id": "fc_1", "call_id": "c1",
...      "name": "get_status", "arguments": "{}"},
...     {"type": "function_call_output", "call_id": "c1", "output": ""},
... ]
>>> [m for m in Converter.items_to_messages(items) if m.get("role") == "tool"]
[{'role': 'tool', 'tool_call_id': 'c1', 'content': ''}]
# Chat Completions API rejects: messages.X.content must be non-empty
\`\`\`

Lift the guard above the \`if/else\` so both branches go through it. \`not tool_result_content\` is truthy for both \`""\` and \`[]\`, so the single check covers both empty shapes.

### Test plan

- New \`test_items_to_messages_with_empty_string_function_output_uses_placeholder_by_default\` — verifies the default-mode placeholder + warning for \`output=""\`.
- New \`test_items_to_messages_with_empty_string_function_output_raises_in_strict_mode\` — verifies strict-mode UserError.
- \`uv run pytest tests/models/test_openai_chatcompletions_converter.py -k empty\` — 4 passed (both pre-existing empty-list tests + the two new empty-string tests).
- \`uv run ruff check\` on the touched files — All checks passed.

### Issue number

N/A — found while auditing for the same fix pattern that #3312 applied to empty lists.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no doc changes needed)
- [x] I've run \`make lint\` and \`make format\`
- [x] I've made sure tests pass