### PR TITLE
Fix output schema names for Literal types

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -180,13 +180,15 @@ def _is_subclass_of_base_model_or_dict(t: Any) -> bool:
     return issubclass(t, BaseModel | dict)
 
 
-def _type_to_str(t: type[Any]) -> str:
+def _type_to_str(t: Any) -> str:
     origin = get_origin(t)
     args = get_args(t)
 
     if origin is None:
         # It's a simple type like `str`, `int`, etc.
-        return t.__name__
+        if hasattr(t, "__name__"):
+            return t.__name__
+        return repr(t)
     elif args:
         args_str = ", ".join(_type_to_str(arg) for arg in args)
         return f"{origin.__name__}[{args_str}]"

--- a/tests/test_output_tool.py
+++ b/tests/test_output_tool.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Literal, cast
 
 import pytest
 from pydantic import BaseModel
@@ -75,6 +75,18 @@ def test_structured_output_list():
     json_str = json.dumps({_WRAPPER_DICT_KEY: ["foo", "bar"]})
     validated = output_schema.validate_json(json_str)
     assert validated == ["foo", "bar"]
+
+
+def test_structured_output_literal_name():
+    output_schema = AgentOutputSchema(cast(type[Any], Literal["ok"]))
+
+    assert output_schema.name() == "Literal['ok']"
+
+
+def test_structured_output_nested_literal_name():
+    output_schema = AgentOutputSchema(cast(type[Any], list[Literal["ok", "done"]]))
+
+    assert output_schema.name() == "list[Literal['ok', 'done']]"
 
 
 def test_structured_output_generic_dict_is_not_wrapped():


### PR DESCRIPTION
Fixes #3357.

## Summary

- Make `AgentOutputSchema.name()` handle typing arguments that are literal values rather than Python types.
- Preserve existing formatting for normal types and generics.
- Add regression coverage for top-level `Literal["ok"]` and nested `list[Literal["ok", "done"]]` output types.

## Verification

- `uv run pytest tests/test_output_tool.py -q`
- `uv run ruff check src/agents/agent_output.py tests/test_output_tool.py`
- `uv run ruff format --check src/agents/agent_output.py tests/test_output_tool.py`
- `git diff --check`