### PR TITLE
[codex] Harden release tag workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,6 +14,7 @@ jobs:
   tag-release:
     if: >-
       github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Require release-tag PRs to come from the same repository before creating tags.
- Preserve the existing merged-PR and `release/v*` branch gates.

## Validation

- Parsed `.github/workflows/release-tag.yml` with PyYAML.