### PR TITLE
feat(lifecycle): pass ToolContext to on_tool_start/end for all tool types

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -255,14 +255,14 @@ There are two hook scopes:
 The callback context also changes depending on the event:
 
 -   Agent start/end hooks receive [`AgentHookContext`][agents.run_context.AgentHookContext], which wraps your original context and carries the shared run usage state.
--   LLM, tool, and handoff hooks receive [`RunContextWrapper`][agents.run_context.RunContextWrapper].
+-   Tool start/end hooks receive [`ToolContext`][agents.tool_context.ToolContext], a subclass of `RunContextWrapper` that adds tool-call metadata such as `tool_call_id`, `tool_name`, and `tool_arguments`.
+-   LLM and handoff hooks receive [`RunContextWrapper`][agents.run_context.RunContextWrapper].
 
 Typical hook timing:
 
 -   `on_agent_start` / `on_agent_end`: when a specific agent begins or finishes producing a final output.
 -   `on_llm_start` / `on_llm_end`: immediately around each model call.
--   `on_tool_start` / `on_tool_end`: around each local tool invocation.
-    For function tools, the hook `context` is typically a `ToolContext`, so you can inspect tool-call metadata such as `tool_call_id`.
+-   `on_tool_start` / `on_tool_end`: around each local tool invocation. The hook `context` is a `ToolContext`, so you can inspect `tool_call_id` to correlate the start and end of the same call when tools run in parallel.
 -   `on_handoff`: when control moves from one agent to another.
 
 Use `RunHooks` when you want a single observer for the whole workflow, and `AgentHooks` when one agent needs custom side effects.

--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -6,6 +6,7 @@ from .agent import Agent, AgentBase
 from .items import ModelResponse, TResponseInputItem
 from .run_context import AgentHookContext, RunContextWrapper, TContext
 from .tool import Tool
+from .tool_context import ToolContext
 
 TAgent = TypeVar("TAgent", bound=AgentBase, default=AgentBase)
 
@@ -69,32 +70,32 @@ class RunHooksBase(Generic[TContext, TAgent]):
 
     async def on_tool_start(
         self,
-        context: RunContextWrapper[TContext],
+        context: ToolContext[TContext],
         agent: TAgent,
         tool: Tool,
     ) -> None:
         """Called immediately before a local tool is invoked.
 
-        For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
-        which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
-        and ``tool_arguments``. Other local tool families may provide a plain
-        ``RunContextWrapper`` instead.
+        ``context`` is always a ``ToolContext`` instance, which exposes tool-call-specific
+        metadata such as ``tool_call_id``, ``tool_name``, and ``tool_arguments``. The
+        ``tool_call_id`` lets hooks correlate ``on_tool_start`` with the matching
+        ``on_tool_end`` even when tools execute in parallel.
         """
         pass
 
     async def on_tool_end(
         self,
-        context: RunContextWrapper[TContext],
+        context: ToolContext[TContext],
         agent: TAgent,
         tool: Tool,
         result: str,
     ) -> None:
         """Called immediately after a local tool is invoked.
 
-        For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
-        which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
-        and ``tool_arguments``. Other local tool families may provide a plain
-        ``RunContextWrapper`` instead.
+        ``context`` is always a ``ToolContext`` instance, which exposes tool-call-specific
+        metadata such as ``tool_call_id``, ``tool_name``, and ``tool_arguments``. The
+        ``tool_call_id`` lets hooks correlate ``on_tool_start`` with the matching
+        ``on_tool_end`` even when tools execute in parallel.
         """
         pass
 
@@ -143,32 +144,32 @@ class AgentHooksBase(Generic[TContext, TAgent]):
 
     async def on_tool_start(
         self,
-        context: RunContextWrapper[TContext],
+        context: ToolContext[TContext],
         agent: TAgent,
         tool: Tool,
     ) -> None:
         """Called immediately before a local tool is invoked.
 
-        For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
-        which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
-        and ``tool_arguments``. Other local tool families may provide a plain
-        ``RunContextWrapper`` instead.
+        ``context`` is always a ``ToolContext`` instance, which exposes tool-call-specific
+        metadata such as ``tool_call_id``, ``tool_name``, and ``tool_arguments``. The
+        ``tool_call_id`` lets hooks correlate ``on_tool_start`` with the matching
+        ``on_tool_end`` even when tools execute in parallel.
         """
         pass
 
     async def on_tool_end(
         self,
-        context: RunContextWrapper[TContext],
+        context: ToolContext[TContext],
         agent: TAgent,
         tool: Tool,
         result: str,
     ) -> None:
         """Called immediately after a local tool is invoked.
 
-        For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
-        which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
-        and ``tool_arguments``. Other local tool families may provide a plain
-        ``RunContextWrapper`` instead.
+        ``context`` is always a ``ToolContext`` instance, which exposes tool-call-specific
+        metadata such as ``tool_call_id``, ``tool_name``, and ``tool_arguments``. The
+        ``tool_call_id`` lets hooks correlate ``on_tool_start`` with the matching
+        ``on_tool_end`` even when tools execute in parallel.
         """
         pass
 

--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -110,6 +110,19 @@ class ComputerAction:
         """Run a computer action, capturing a screenshot and notifying hooks."""
         trace_tool_name = get_tool_trace_name_for_tool(action.computer_tool) or cls.TRACE_TOOL_NAME
 
+        # Build a ToolContext so lifecycle hooks can attribute parallel tool calls via
+        # ``tool_call_id``. Computer tools encode their arguments in structured action
+        # fields rather than a JSON string, so serialize the actions for visibility.
+        tool_arguments = _serialize_trace_payload(cls._get_trace_input_payload(action.tool_call))
+        tool_context = ToolContext.from_agent_context(
+            context_wrapper,
+            action.tool_call.call_id,
+            tool_name=action.computer_tool.name,
+            tool_arguments=tool_arguments,
+            agent=agent,
+            run_config=config,
+        )
+
         async def _run_action(span: Any | None) -> RunItem:
             if span and config.trace_include_sensitive_data:
                 span.span_data.input = _serialize_trace_payload(
@@ -121,9 +134,9 @@ class ComputerAction:
             )
             agent_hooks = agent.hooks
             await asyncio.gather(
-                hooks.on_tool_start(context_wrapper, agent, action.computer_tool),
+                hooks.on_tool_start(tool_context, agent, action.computer_tool),
                 (
-                    agent_hooks.on_tool_start(context_wrapper, agent, action.computer_tool)
+                    agent_hooks.on_tool_start(tool_context, agent, action.computer_tool)
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -151,9 +164,9 @@ class ComputerAction:
                 raise
 
             await asyncio.gather(
-                hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output),
+                hooks.on_tool_end(tool_context, agent, action.computer_tool, output),
                 (
-                    agent_hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output)
+                    agent_hooks.on_tool_end(tool_context, agent, action.computer_tool, output)
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -374,10 +387,22 @@ class LocalShellAction:
     ) -> RunItem:
         """Run a local shell tool call and wrap the result as a ToolCallOutputItem."""
         agent_hooks = agent.hooks
+        # Build a ToolContext so lifecycle hooks can attribute parallel tool calls via
+        # ``tool_call_id``. Local shell calls carry structured action fields, so we
+        # serialize the action payload for ``tool_arguments`` visibility.
+        tool_arguments = _serialize_trace_payload(call.tool_call.action)
+        tool_context = ToolContext.from_agent_context(
+            context_wrapper,
+            call.tool_call.call_id,
+            tool_name=call.local_shell_tool.name,
+            tool_arguments=tool_arguments,
+            agent=agent,
+            run_config=config,
+        )
         await asyncio.gather(
-            hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool),
+            hooks.on_tool_start(tool_context, agent, call.local_shell_tool),
             (
-                agent_hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool)
+                agent_hooks.on_tool_start(tool_context, agent, call.local_shell_tool)
                 if agent_hooks
                 else _coro.noop_coroutine()
             ),
@@ -391,9 +416,9 @@ class LocalShellAction:
         result = await output if inspect.isawaitable(output) else output
 
         await asyncio.gather(
-            hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result),
+            hooks.on_tool_end(tool_context, agent, call.local_shell_tool, result),
             (
-                agent_hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result)
+                agent_hooks.on_tool_end(tool_context, agent, call.local_shell_tool, result)
                 if agent_hooks
                 else _coro.noop_coroutine()
             ),
@@ -428,6 +453,18 @@ class ShellAction:
         shell_call = coerce_shell_call(call.tool_call)
         shell_tool = call.shell_tool
         agent_hooks = agent.hooks
+        # Build a ToolContext so lifecycle hooks can attribute parallel tool calls via
+        # ``tool_call_id``. Shell calls carry a structured action payload, so serialize
+        # it for ``tool_arguments`` visibility.
+        tool_arguments = _serialize_trace_payload(dataclasses.asdict(shell_call.action))
+        tool_context = ToolContext.from_agent_context(
+            context_wrapper,
+            shell_call.call_id,
+            tool_name=shell_tool.name,
+            tool_arguments=tool_arguments,
+            agent=agent,
+            run_config=config,
+        )
 
         async def _run_call(span: Any | None) -> RunItem:
             if span and config.trace_include_sensitive_data:
@@ -467,9 +504,9 @@ class ShellAction:
                     return approval_item
 
             await asyncio.gather(
-                hooks.on_tool_start(context_wrapper, agent, shell_tool),
+                hooks.on_tool_start(tool_context, agent, shell_tool),
                 (
-                    agent_hooks.on_tool_start(context_wrapper, agent, shell_tool)
+                    agent_hooks.on_tool_start(tool_context, agent, shell_tool)
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -541,9 +578,9 @@ class ShellAction:
                 logger.error("Shell executor failed: %s", exc, exc_info=True)
 
             await asyncio.gather(
-                hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text),
+                hooks.on_tool_end(tool_context, agent, call.shell_tool, output_text),
                 (
-                    agent_hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text)
+                    agent_hooks.on_tool_end(tool_context, agent, call.shell_tool, output_text)
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -747,6 +784,27 @@ class ApplyPatchAction:
             context_wrapper=context_wrapper,
         )
         call_id = extract_apply_patch_call_id(call.tool_call)
+        # Build a ToolContext so lifecycle hooks can attribute parallel tool calls via
+        # ``tool_call_id``. Apply patch operations carry structured fields, so serialize
+        # the operation list for ``tool_arguments`` visibility.
+        tool_arguments = _serialize_trace_payload(
+            [
+                {
+                    "type": operation.type,
+                    "path": operation.path,
+                    "diff": operation.diff,
+                }
+                for operation in operations
+            ]
+        )
+        tool_context = ToolContext.from_agent_context(
+            context_wrapper,
+            call_id,
+            tool_name=apply_patch_tool.name,
+            tool_arguments=tool_arguments,
+            agent=agent,
+            run_config=config,
+        )
 
         async def _run_call(span: Any | None) -> RunItem:
             if span and config.trace_include_sensitive_data:
@@ -798,9 +856,9 @@ class ApplyPatchAction:
                     return approval_item
 
             await asyncio.gather(
-                hooks.on_tool_start(context_wrapper, agent, apply_patch_tool),
+                hooks.on_tool_start(tool_context, agent, apply_patch_tool),
                 (
-                    agent_hooks.on_tool_start(context_wrapper, agent, apply_patch_tool)
+                    agent_hooks.on_tool_start(tool_context, agent, apply_patch_tool)
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),
@@ -854,9 +912,9 @@ class ApplyPatchAction:
                 logger.error("Apply patch editor failed: %s", exc, exc_info=True)
 
             await asyncio.gather(
-                hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text),
+                hooks.on_tool_end(tool_context, agent, apply_patch_tool, output_text),
                 (
-                    agent_hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text)
+                    agent_hooks.on_tool_end(tool_context, agent, apply_patch_tool, output_text)
                     if agent_hooks
                     else _coro.noop_coroutine()
                 ),

--- a/tests/test_apply_patch_tool.py
+++ b/tests/test_apply_patch_tool.py
@@ -438,3 +438,49 @@ async def test_apply_patch_failed_status_not_overwritten_by_later_completed_op()
     assert raw_item["status"] == "failed"
     assert "Failed a.md" in result.output
     assert "Created b.md" in result.output
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_action_exposes_tool_call_id_on_lifecycle_hooks() -> None:
+    """Apply patch lifecycle hooks must receive a ToolContext with tool_call_id set."""
+    from agents.tool_context import ToolContext
+
+    captured: dict[str, list[Any]] = {"start": [], "end": []}
+
+    class CapturingHooks(RunHooks[Any]):
+        async def on_tool_start(
+            self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
+        ) -> None:
+            captured["start"].append(context)
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            tool: Any,
+            result: str,
+        ) -> None:
+            captured["end"].append(context)
+
+    editor = RecordingEditor()
+    tool = ApplyPatchTool(editor=editor)
+    agent, context_wrapper, tool_run = build_apply_patch_call(
+        tool,
+        "call_apply_ctx",
+        {"type": "update_file", "path": "tasks.md", "diff": "-a\n+b\n"},
+    )
+
+    await ApplyPatchAction.execute(
+        agent=agent,
+        call=tool_run,
+        hooks=CapturingHooks(),
+        context_wrapper=context_wrapper,
+        config=RunConfig(),
+    )
+
+    assert len(captured["start"]) == 1
+    assert len(captured["end"]) == 1
+    for context in (captured["start"][0], captured["end"][0]):
+        assert isinstance(context, ToolContext)
+        assert context.tool_call_id == "call_apply_ctx"
+        assert context.tool_name == tool.name

--- a/tests/test_computer_action.py
+++ b/tests/test_computer_action.py
@@ -503,16 +503,20 @@ class LoggingRunHooks(RunHooks[Any]):
         super().__init__()
         self.started: list[tuple[Agent[Any], Any]] = []
         self.ended: list[tuple[Agent[Any], Any, str]] = []
+        self.start_contexts: list[Any] = []
+        self.end_contexts: list[Any] = []
 
     async def on_tool_start(
         self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
     ) -> None:
         self.started.append((agent, tool))
+        self.start_contexts.append(context)
 
     async def on_tool_end(
         self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: str
     ) -> None:
         self.ended.append((agent, tool, result))
+        self.end_contexts.append(context)
 
 
 class LoggingAgentHooks(AgentHooks[Any]):
@@ -522,16 +526,20 @@ class LoggingAgentHooks(AgentHooks[Any]):
         super().__init__()
         self.started: list[tuple[Agent[Any], Any]] = []
         self.ended: list[tuple[Agent[Any], Any, str]] = []
+        self.start_contexts: list[Any] = []
+        self.end_contexts: list[Any] = []
 
     async def on_tool_start(
         self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
     ) -> None:
         self.started.append((agent, tool))
+        self.start_contexts.append(context)
 
     async def on_tool_end(
         self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: str
     ) -> None:
         self.ended.append((agent, tool, result))
+        self.end_contexts.append(context)
 
 
 @pytest.mark.asyncio
@@ -591,6 +599,50 @@ async def test_execute_invokes_hooks_and_returns_tool_call_output() -> None:
     assert raw["output"]["type"] == "computer_screenshot"
     assert "image_url" in raw["output"]
     assert raw["output"]["image_url"].endswith("xyz")
+
+
+@pytest.mark.asyncio
+async def test_execute_exposes_tool_call_id_on_lifecycle_hooks() -> None:
+    """Computer tool lifecycle hooks must receive a ToolContext with tool_call_id set."""
+    from agents.tool_context import ToolContext
+
+    computer = LoggingComputer(screenshot_return="hookimg")
+    comptool = ComputerTool(computer=computer)
+    action = ActionClick(type="click", x=4, y=5, button="left")
+    tool_call = ResponseComputerToolCall(
+        id="computer_call_42",
+        type="computer_call",
+        action=action,
+        call_id="computer_call_42",
+        pending_safety_checks=[],
+        status="completed",
+    )
+
+    tool_run = ToolRunComputerAction(tool_call=tool_call, computer_tool=comptool)
+    agent = Agent(name="ctx_id_agent", tools=[comptool])
+    agent_hooks = LoggingAgentHooks()
+    agent.hooks = agent_hooks
+    run_hooks = LoggingRunHooks()
+    context_wrapper: RunContextWrapper[Any] = RunContextWrapper(context=None)
+
+    await ComputerAction.execute(
+        agent=agent,
+        action=tool_run,
+        hooks=run_hooks,
+        context_wrapper=context_wrapper,
+        config=RunConfig(),
+    )
+
+    # Each hook should receive a ToolContext whose tool_call_id matches the tool call.
+    for context in (
+        run_hooks.start_contexts[0],
+        run_hooks.end_contexts[0],
+        agent_hooks.start_contexts[0],
+        agent_hooks.end_contexts[0],
+    ):
+        assert isinstance(context, ToolContext)
+        assert context.tool_call_id == "computer_call_42"
+        assert context.tool_name == comptool.name
 
 
 @pytest.mark.asyncio

--- a/tests/test_local_shell_tool.py
+++ b/tests/test_local_shell_tool.py
@@ -21,6 +21,7 @@ from agents import (
 )
 from agents.items import ToolCallOutputItem
 from agents.run_internal.run_loop import LocalShellAction, ToolRunLocalShellCall
+from agents.tool_context import ToolContext
 
 from .fake_model import FakeModel
 from .test_responses import get_text_message
@@ -156,3 +157,60 @@ async def test_runner_executes_local_shell_calls() -> None:
 
     assert result.final_output == "shell complete"
     assert len(result.raw_responses) == 2
+
+
+@pytest.mark.asyncio
+async def test_local_shell_action_exposes_tool_call_id_on_lifecycle_hooks() -> None:
+    """Local shell lifecycle hooks must receive a ToolContext with tool_call_id set."""
+
+    captured: dict[str, list[Any]] = {"start": [], "end": []}
+
+    class CapturingHooks(RunHooks[Any]):
+        async def on_tool_start(
+            self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
+        ) -> None:
+            captured["start"].append(context)
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            tool: Any,
+            result: str,
+        ) -> None:
+            captured["end"].append(context)
+
+    executor = RecordingLocalShellExecutor(output="ok")
+    tool = LocalShellTool(executor=executor)
+    action = LocalShellCallAction(
+        command=["bash", "-c", "true"],
+        env={},
+        type="exec",
+        timeout_ms=1000,
+        working_directory="/tmp",
+    )
+    tool_call = LocalShellCall(
+        id="lsh_id_test",
+        action=action,
+        call_id="call_local_shell_id",
+        status="completed",
+        type="local_shell_call",
+    )
+    tool_run = ToolRunLocalShellCall(tool_call=tool_call, local_shell_tool=tool)
+    agent = Agent(name="local_shell_id_agent", tools=[tool])
+    context_wrapper: RunContextWrapper[Any] = RunContextWrapper(context=None)
+
+    await LocalShellAction.execute(
+        agent=agent,
+        call=tool_run,
+        hooks=CapturingHooks(),
+        context_wrapper=context_wrapper,
+        config=RunConfig(),
+    )
+
+    assert len(captured["start"]) == 1
+    assert len(captured["end"]) == 1
+    for context in (captured["start"][0], captured["end"][0]):
+        assert isinstance(context, ToolContext)
+        assert context.tool_call_id == "call_local_shell_id"
+        assert context.tool_name == tool.name

--- a/tests/test_shell_tool.py
+++ b/tests/test_shell_tool.py
@@ -811,3 +811,46 @@ async def test_shell_tool_on_approval_empty_reason_uses_default_rejection() -> N
 
     assert isinstance(result, ToolCallOutputItem)
     assert result.output == HITL_REJECTION_MSG
+
+
+@pytest.mark.asyncio
+async def test_shell_action_exposes_tool_call_id_on_lifecycle_hooks() -> None:
+    """Shell lifecycle hooks must receive a ToolContext with tool_call_id set."""
+    from agents.tool_context import ToolContext
+
+    captured: dict[str, list[Any]] = {"start": [], "end": []}
+
+    class CapturingHooks(RunHooks[Any]):
+        async def on_tool_start(
+            self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
+        ) -> None:
+            captured["start"].append(context)
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            tool: Any,
+            result: str,
+        ) -> None:
+            captured["end"].append(context)
+
+    shell_tool = ShellTool(executor=lambda request: "ok")
+    tool_run = ToolRunShellCall(tool_call=_shell_call("call_shell_ctx"), shell_tool=shell_tool)
+    agent = Agent(name="shell-ctx-agent", tools=[shell_tool])
+    context_wrapper: RunContextWrapper[Any] = RunContextWrapper(context=None)
+
+    await ShellAction.execute(
+        agent=agent,
+        call=tool_run,
+        hooks=CapturingHooks(),
+        context_wrapper=context_wrapper,
+        config=RunConfig(),
+    )
+
+    assert len(captured["start"]) == 1
+    assert len(captured["end"]) == 1
+    for context in (captured["start"][0], captured["end"][0]):
+        assert isinstance(context, ToolContext)
+        assert context.tool_call_id == "call_shell_ctx"
+        assert context.tool_name == shell_tool.name


### PR DESCRIPTION
## Summary

Users who track timing metrics inside `on_tool_start` and `on_tool_end` cannot
correlate the start and end of the same tool call when calls execute in
parallel, because the `RunContextWrapper` they receive has no `tool_call_id`.
Function tools already pass a `ToolContext` (which exposes `tool_call_id`,
`tool_name`, and `tool_arguments`), but `ComputerTool`, `LocalShellTool`,
`ShellTool`, and `ApplyPatchTool` all passed a plain `RunContextWrapper`, so
hooks could not rely on the field being present.

This PR constructs a `ToolContext` via `ToolContext.from_agent_context(...)`
at the four remaining call sites in `run_internal/tool_actions.py`. Each site
pulls `tool_call_id` from the call's `call_id` field, sets `tool_name` from
the tool's `.name`, and serializes the structured action payload into
`tool_arguments` for visibility. The same `tool_context` is then passed to
both global `RunHooks` and per-agent `AgentHooks` for `on_tool_start` and
`on_tool_end`, mirroring the pattern already used for function tools and
custom tools.

The parameter annotation on `RunHooksBase.on_tool_start`,
`RunHooksBase.on_tool_end`, `AgentHooksBase.on_tool_start`, and
`AgentHooksBase.on_tool_end` is refined from `RunContextWrapper[TContext]` to
`ToolContext[TContext]`. Because `ToolContext` is a subclass of
`RunContextWrapper`, existing user subclasses that accept the wider type
continue to type-check; new hooks can rely on `tool_call_id`, `tool_name`,
and `tool_arguments` directly. New regression tests in
`tests/test_computer_action.py`, `tests/test_local_shell_tool.py`,
`tests/test_shell_tool.py`, and `tests/test_apply_patch_tool.py` capture
the hook context for each tool family and assert the `tool_call_id` matches
the actual call's `call_id`.

Closes #1849

## Test plan

- [x] `make format`
- [x] `make lint`
- [x] `make typecheck` (no new errors introduced in touched files)
- [x] `uv run pytest tests/test_run_hooks.py tests/test_agent_hooks.py tests/test_computer_action.py tests/test_local_shell_tool.py tests/test_apply_patch_tool.py tests/test_shell_tool.py tests/test_custom_tool.py tests/test_global_hooks.py tests/test_agent_llm_hooks.py tests/test_computer_tool_lifecycle.py tests/test_agent_runner.py tests/test_agent_runner_streamed.py tests/test_function_tool.py`