### PR TITLE
fix: log exception when output guardrail raises instead of silently ignoring

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -987,8 +987,14 @@ class RealtimeSession(RealtimeModelListener):
                 )
                 if result.output.tripwire_triggered:
                     triggered_results.append(result)
-            except Exception:
-                logger.exception("Output guardrail %r raised an exception", guardrail.get_name())
+            except Exception as exc:
+                logger.warning(
+                    "Output guardrail %r raised %s: %s; skipping it.",
+                    guardrail.get_name(),
+                    type(exc).__name__,
+                    exc,
+                )
+                logger.debug("Output guardrail failure details.", exc_info=True)
                 continue
 
         if triggered_results:

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -988,7 +988,7 @@ class RealtimeSession(RealtimeModelListener):
                 if result.output.tripwire_triggered:
                     triggered_results.append(result)
             except Exception:
-                # Continue with other guardrails if one fails
+                logger.exception("Output guardrail %r raised an exception", guardrail.get_name())
                 continue
 
         if triggered_results:


### PR DESCRIPTION
### Summary

In `RealtimeSession._run_output_guardrails()`, exceptions raised by individual
guardrails were silently swallowed with a bare `except Exception: continue`.
If a guardrail has a bug or misconfiguration, it fails invisibly with no log
output and no way to diagnose the issue.

Fix: add `logger.exception(...)` before `continue` so the error is surfaced
in logs while still allowing the remaining guardrails to run.

### Test plan

Existing realtime tests continue to pass (`make tests`). The change is a
one-line addition of a log call in an existing exception handler.

### Issue number

<!-- N/A -->

### Checks

- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass