### PR TITLE
fix(memory): validate SQLite session table names to prevent SQL injection

### DIFF
--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -12,6 +12,7 @@ import aiosqlite
 from ...items import TResponseInputItem
 from ...memory import SessionABC
 from ...memory.session_settings import SessionSettings
+from ...memory.util import validate_sql_identifier
 
 
 class AsyncSQLiteSession(SessionABC):
@@ -42,8 +43,8 @@ class AsyncSQLiteSession(SessionABC):
         """
         self.session_id = session_id
         self.db_path = db_path
-        self.sessions_table = sessions_table
-        self.messages_table = messages_table
+        self.sessions_table = validate_sql_identifier(sessions_table, kind="table name")
+        self.messages_table = validate_sql_identifier(messages_table, kind="table name")
         self._connection: aiosqlite.Connection | None = None
         self._lock = asyncio.Lock()
         self._init_lock = asyncio.Lock()

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 from ..items import TResponseInputItem
 from .session import SessionABC
 from .session_settings import SessionSettings, resolve_session_limit
+from .util import validate_sql_identifier
 
 
 class SQLiteSession(SessionABC):
@@ -49,8 +50,8 @@ class SQLiteSession(SessionABC):
         self.session_id = session_id
         self.session_settings = session_settings or SessionSettings()
         self.db_path = db_path
-        self.sessions_table = sessions_table
-        self.messages_table = messages_table
+        self.sessions_table = validate_sql_identifier(sessions_table, kind="table name")
+        self.messages_table = validate_sql_identifier(messages_table, kind="table name")
         self._local = threading.local()
         self._connections: set[sqlite3.Connection] = set()
         self._connections_lock = threading.Lock()

--- a/src/agents/memory/util.py
+++ b/src/agents/memory/util.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 
 from ..items import TResponseInputItem
@@ -18,3 +19,24 @@ Args:
 Returns:
     A list of combined items to be used as input for the agent. Can be sync or async.
 """
+
+
+# SQLite identifiers cannot be parameterised, so any caller-supplied table name
+# is interpolated directly into SQL. Restrict accepted names to a conservative
+# identifier pattern to prevent SQL injection (CWE-89) when a downstream
+# application allows table names to be influenced by configuration or user input.
+_SAFE_SQL_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def validate_sql_identifier(name: str, *, kind: str = "identifier") -> str:
+    """Validate that ``name`` is a safe SQL identifier.
+
+    Only ASCII letters, digits and underscores are permitted, and the name must
+    not start with a digit. Raises ``ValueError`` otherwise. Returns ``name``
+    unchanged when valid so it can be used inline.
+    """
+    if not isinstance(name, str) or not _SAFE_SQL_IDENTIFIER.match(name):
+        raise ValueError(
+            f"Invalid SQL {kind} {name!r}: must match [A-Za-z_][A-Za-z0-9_]*"
+        )
+    return name


### PR DESCRIPTION
## Summary

`SQLiteSession` and `AsyncSQLiteSession` accept `sessions_table` and `messages_table` as constructor parameters, then interpolate them directly into SQL statements via f-strings throughout the class (e.g. `f"CREATE TABLE IF NOT EXISTS {self.sessions_table} ..."`). SQLite does not support parameterised identifiers, so this pattern is inherently vulnerable to SQL injection (CWE-89) if a downstream application ever derives these table names from configuration files, environment variables, or user input.

### Affected files

- `src/agents/memory/sqlite_session.py` — `SQLiteSession.__init__`
- `src/agents/extensions/memory/async_sqlite_session.py` — `AsyncSQLiteSession.__init__`

### Data flow

```
caller-supplied string  →  sessions_table / messages_table parameter
    →  self.sessions_table / self.messages_table
    →  f-string interpolation into ~15 SQL statements (CREATE TABLE, SELECT, INSERT, DELETE, etc.)
```

No sanitisation or validation exists on the path from constructor parameter to SQL execution.

## Proof of Concept

```python
import sqlite3
from agents.memory.sqlite_session import SQLiteSession

# An attacker-controlled table name can break out of the identifier context
malicious = "x(id INT); DROP TABLE agent_sessions;--"
session = SQLiteSession(session_id="test", db_path=":memory:", sessions_table=malicious)
# When the session initialises its schema, the injected SQL executes:
#   CREATE TABLE IF NOT EXISTS x(id INT); DROP TABLE agent_sessions;-- (...)
```

While the SDK's own defaults are safe hardcoded strings, this is a library — downstream developers are expected to customise table names, and the constructor parameters invite that. Defense-in-depth requires validating these inputs at the boundary.

## Fix

This PR adds a `validate_sql_identifier()` function in `src/agents/memory/util.py` that enforces a strict allowlist pattern: `^[A-Za-z_][A-Za-z0-9_]*$`. Both `SQLiteSession` and `AsyncSQLiteSession` call this validator in their constructors, raising `ValueError` for any table name containing characters outside this set.

The pattern is intentionally conservative — it rejects quoted identifiers, dots, and any special characters. This is appropriate because none of the existing SQL in these classes uses quoting around table names, and legitimate use cases only need simple alphanumeric names.

## Testing

- Verified that the default table names (`agent_sessions`, `agent_messages`) pass validation.
- Verified that malicious inputs like `x; DROP TABLE y;--` and `x" OR "1"="1` raise `ValueError`.
- Verified that the existing SDK import structure resolves correctly (`from .util import validate_sql_identifier`).

## Adversarial review

Before submitting, we considered whether this is truly exploitable given that the defaults are hardcoded safe strings. However, the parameters are public API — they exist specifically so callers can customise table names. In a multi-tenant application where table names might be derived from tenant identifiers or configuration, this becomes directly exploitable. No existing validation, ORM layer, or framework protection sits between the caller and the raw SQL interpolation. The fix is a minimal, zero-breaking-change validation that protects downstream users.