### PR TITLE
fix: guard non-positive session limit in AdvancedSQLiteSession.get_items

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -172,6 +172,9 @@ class AdvancedSQLiteSession(SQLiteSession):
         """
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        if session_limit is not None and session_limit <= 0:
+            return []
+
         if branch_id is None:
             branch_id = self._current_branch_id
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1288,6 +1288,12 @@ async def test_get_items_explicit_limit_overrides_session_settings():
     assert retrieved[0].get("content") == "Message 8"
     assert retrieved[1].get("content") == "Message 9"
 
+    # Non-positive limits must return [] for parity with MongoDB/Redis/AsyncSQLite.
+    # SQLite treats LIMIT -1 as "no limit", so without an explicit guard a negative
+    # limit would incorrectly return all rows instead of an empty list.
+    assert await session.get_items(limit=0) == []
+    assert await session.get_items(limit=-1) == []
+
     session.close()
 
 


### PR DESCRIPTION
### Summary

`AdvancedSQLiteSession.get_items()` was the only SQLite-backed session implementation missing the non-positive limit guard that all other backends enforce.

**Root cause**

Five backends already short-circuit with `return []` when `session_limit <= 0`:
- `MongoDBSession` — `if session_limit is not None and session_limit <= 0: return []`
- `RedisSession` — `if session_limit <= 0: return []`
- `DaprSession` — `if session_limit <= 0: return []`
- `AsyncSQLiteSession` — fixed in #3413
- `SQLAlchemySession` — fixed in #3413

`AdvancedSQLiteSession` passed the resolved limit directly to `LIMIT ?` without this guard. SQLite interprets `LIMIT -1` as "no limit" ([SQLite docs](https://www.sqlite.org/lang_select.html)), so `get_items(limit=-1)` silently returned the full conversation history instead of `[]`.

**Fix**

Add the same early-return guard before the SQL branch:

```python
if session_limit is not None and session_limit <= 0:
    return []
```

### Test plan

Extended the existing `test_get_items_explicit_limit_overrides_session_settings` test with:
```python
assert await session.get_items(limit=0) == []
assert await session.get_items(limit=-1) == []
```

These pin the correct behaviour (empty list for any non-positive limit) and would have caught the LIMIT -1 bug.

### Issue number

Companion to #3413 (same root cause, different file).

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass