### PR TITLE
fix: reject relative sandbox workspace roots

### DIFF
--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -114,6 +114,8 @@ class WorkspacePathPolicy:
     ) -> None:
         self._root = Path(root)
         self._sandbox_root = coerce_posix_path(root)
+        if not self._root.is_absolute() and not self._sandbox_root.is_absolute():
+            raise ValueError("sandbox workspace root must be absolute")
         self._root_is_existing_host_path = self._path_exists(self._root)
         self._extra_path_grants = extra_path_grants
 

--- a/tests/sandbox/test_workspace_paths.py
+++ b/tests/sandbox/test_workspace_paths.py
@@ -34,6 +34,11 @@ def _policy(root: Path | str = "/workspace") -> WorkspacePathPolicy:
     return WorkspacePathPolicy(root=root)
 
 
+def test_workspace_path_policy_rejects_relative_root() -> None:
+    with pytest.raises(ValueError, match="sandbox workspace root must be absolute"):
+        WorkspacePathPolicy(root="workspace")
+
+
 def _assert_workspace_path_case(
     *,
     method: PathPolicyMethod,


### PR DESCRIPTION
## Summary

- Reject relative sandbox workspace roots when constructing `WorkspacePathPolicy`.
- Add a regression test that prevents returning relative sandbox paths from a relative root.

## Why

`WorkspacePathPolicy` methods are documented and used as absolute sandbox path helpers. With `root="workspace"`, `normalize_path("file.py")` can produce `workspace/file.py` instead of an absolute sandbox path, weakening the invariant that sandbox paths are rooted under an absolute workspace.

## Testing

- `uv run pytest tests/sandbox/test_workspace_paths.py`
- `uv run ruff check src/agents/sandbox tests/sandbox`
- `uv run pyright`
