### PR TITLE
fix: normalize leading question marks in exposed port queries

### DIFF
--- a/src/agents/sandbox/types.py
+++ b/src/agents/sandbox/types.py
@@ -181,5 +181,8 @@ class ExposedPortEndpoint:
             base = f"{prefix}://{host}:{self.port}/"
 
         if self.query:
-            return f"{base}?{self.query}"
+            query = self.query[1:] if self.query.startswith("?") else self.query
+            if query:
+                return f"{base}?{query}"
+
         return base

--- a/tests/sandbox/test_exposed_ports.py
+++ b/tests/sandbox/test_exposed_ports.py
@@ -28,6 +28,18 @@ def test_exposed_port_endpoint_with_query() -> None:
     assert endpoint.url_for("ws") == "wss://preview.example.com/?bl_preview_token=abc123"
 
 
+def test_exposed_port_endpoint_accepts_leading_question_mark_query() -> None:
+    endpoint = ExposedPortEndpoint(
+        host="preview.example.com",
+        port=443,
+        tls=True,
+        query="?bl_preview_token=abc123",
+    )
+
+    assert endpoint.url_for("http") == "https://preview.example.com/?bl_preview_token=abc123"
+    assert endpoint.url_for("ws") == "wss://preview.example.com/?bl_preview_token=abc123"
+
+
 def test_exposed_port_endpoint_empty_query() -> None:
     endpoint = ExposedPortEndpoint(host="127.0.0.1", port=8080, tls=False, query="")
     assert endpoint.url_for("http") == "http://127.0.0.1:8080/"


### PR DESCRIPTION
## Summary

- Normalize `ExposedPortEndpoint.query` when it already starts with `?`.
- Preserve existing behavior for plain query strings and empty query strings.
- Add a regression test for providers that pass a URL query component with the leading delimiter included.

## Why

`url_for()` currently always formats `?{self.query}`. That works when `query="token=..."`, but produces `??token=...` when a provider passes the query in URL-component form (`query="?token=..."`). Normalizing this in one place makes provider implementations less fragile.

## Testing

- `uv run pytest tests/sandbox/test_exposed_ports.py`
- `uv run ruff check src/agents/sandbox tests/sandbox`
- `uv run pyright`
