### PR TITLE
fix: honor short voice splitter chunks

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -201,7 +201,7 @@ class StreamedAudioResult:
 
         combined_sentences, self._text_buffer = self.tts_settings.text_splitter(self._text_buffer)
 
-        if len(combined_sentences) >= 20:
+        if combined_sentences:
             local_queue: asyncio.Queue[VoiceStreamEvent | None] = asyncio.Queue()
             self._ordered_tasks.append(local_queue)
             self._tasks.append(
@@ -220,6 +220,10 @@ class StreamedAudioResult:
                 )
             )
             self._text_buffer = ""
+        elif self._started_processing_turn:
+            local_queue: asyncio.Queue[VoiceStreamEvent | None] = asyncio.Queue()
+            await local_queue.put(VoiceStreamEventLifecycle(event="turn_ended"))
+            self._ordered_tasks.append(local_queue)
         self._done_processing = True
         if self._dispatcher_task is None:
             self._dispatcher_task = asyncio.create_task(self._dispatch_audio())

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 
 import numpy as np
 import numpy.typing as npt
@@ -80,6 +81,39 @@ async def test_streamed_audio_result_preserves_cross_chunk_sample_boundaries() -
             break
 
     assert audio_chunks == [np.array([1], dtype=np.int16).tobytes()]
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_sends_short_custom_splitter_chunks() -> None:
+    class RecordingTTS(FakeTTS):
+        def __init__(self) -> None:
+            super().__init__()
+            self.texts: list[str] = []
+
+        async def run(self, text: str, settings: TTSModelSettings) -> AsyncIterator[bytes]:
+            del settings
+            self.texts.append(text)
+            yield np.zeros(2, dtype=np.int16).tobytes()
+
+    def split_immediately(text: str) -> tuple[str, str]:
+        return text, ""
+
+    fake_tts = RecordingTTS()
+    result = StreamedAudioResult(
+        fake_tts,
+        TTSModelSettings(buffer_size=1, text_splitter=split_immediately),
+        VoicePipelineConfig(),
+    )
+
+    await result._add_text("ok")
+    await result._turn_done()
+    await result._done()
+
+    events, audio_chunks = await extract_events(result)
+
+    assert fake_tts.texts == ["ok"]
+    assert events == ["turn_started", "audio", "turn_ended", "session_ended"]
+    assert len(audio_chunks) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- send non-empty custom splitter chunks to TTS even when they are shorter than 20 characters
- preserve `turn_ended` when a custom splitter consumes the whole buffer before `_turn_done()`
- add a regression test for short custom chunks

Fixes #3363.

## To verify
- `uv run pytest tests\voice\test_pipeline.py -q --basetemp .tmp\pytest-voice`
- `uv run pyright src\agents\voice\result.py tests\voice\test_pipeline.py`
- `uv run ruff format --check src\agents\voice\result.py tests\voice\test_pipeline.py`
- `uv run ruff check src\agents\voice\result.py tests\voice\test_pipeline.py`
- `uv run python -m py_compile src\agents\voice\result.py tests\voice\test_pipeline.py`
- `git diff --check`
