### PR TITLE
fix: guard None refusal in ItemHelpers.extract_last_content

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -691,7 +691,12 @@ class ItemHelpers:
             # ``extract_text`` below.
             return last_content.text or ""
         elif isinstance(last_content, ResponseOutputRefusal):
-            return last_content.refusal
+            # ``last_content.refusal`` is typed as ``str`` per the Responses API
+            # schema, but provider gateways and ``model_construct`` paths during
+            # streaming have been observed surfacing ``None``. Coerce so callers
+            # relying on the ``-> str`` return type don't see a ``None``. Same
+            # rationale as the text branch above.
+            return last_content.refusal or ""
         else:
             raise ModelBehaviorError(f"Unexpected content type: {type(last_content)}")
 

--- a/tests/utils/test_pretty_print_and_items.py
+++ b/tests/utils/test_pretty_print_and_items.py
@@ -62,6 +62,33 @@ def test_extract_last_content_returns_text_normally():
     assert ItemHelpers.extract_last_content(msg) == "hello"
 
 
+def _make_refusal_message(refusal: str | None) -> ResponseOutputMessage:
+    from openai.types.responses import ResponseOutputRefusal
+
+    return ResponseOutputMessage.model_construct(
+        id="msg_1",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputRefusal.model_construct(type="refusal", refusal=refusal)],
+    )
+
+
+def test_extract_last_content_returns_empty_string_for_none_refusal():
+    """extract_last_content is declared `-> str` and must not return None even if
+    the underlying ResponseOutputRefusal.refusal is None (observed via provider
+    gateways and ``model_construct`` paths, matching the text branch fix in
+    items.py:687-691)."""
+    msg = _make_refusal_message(None)
+    result = ItemHelpers.extract_last_content(msg)
+    assert isinstance(result, str)
+    assert result == ""
+
+
+def test_extract_last_content_returns_refusal_normally():
+    msg = _make_refusal_message("I cannot do that")
+    assert ItemHelpers.extract_last_content(msg) == "I cannot do that"
+
+
 def _make_run_error_details(n_input: int = 0, n_output: int = 0) -> RunErrorDetails:
     return RunErrorDetails(
         input="hi",


### PR DESCRIPTION
### Summary

Follow-up to #3394 (just merged) that fixed the text branch of \`extract_last_content\` against \`None\` from \`model_construct\` / provider gateway paths.

The refusal branch at \`src/agents/items.py:693-694\` has the same \`-> str\` return type contract and the same Pydantic-typed \`str\` source field (\`ResponseOutputRefusal.refusal\`), so it can violate the contract in the same way:

\`\`\`python
>>> from openai.types.responses import ResponseOutputMessage, ResponseOutputRefusal
>>> from agents.items import ItemHelpers
>>> refusal_part = ResponseOutputRefusal.model_construct(refusal=None, type="refusal")
>>> msg = ResponseOutputMessage.model_construct(
...     id="m", role="assistant", status="completed",
...     type="message", content=[refusal_part])
>>> ItemHelpers.extract_last_content(msg)
None        # but the function is typed `-> str`
\`\`\`

Apply the same \`or ""\` coercion and rationale comment that the text branch now has (items.py:687-691).

### Scope (apologies for the noise on #3394)

Same scope as the merged version of #3394 — only the \`-> str\` branches get the coercion. \`extract_last_text\` (declared \`-> str | None\`) is intentionally left alone because:

- \`None\` is already a legal return per its signature.
- Coalescing \`\"\"\` → \`None\` would silently change semantics for callers that distinguish empty text from missing text.

This PR is the equivalent fix on the refusal branch that I missed in #3394's first scope.

### Test plan

- New \`test_extract_last_content_returns_empty_string_for_none_refusal\` — verifies the type contract holds for \`refusal=None\`.
- New \`test_extract_last_content_returns_refusal_normally\` — verifies regular refusal text still passes through unchanged.
- \`uv run pytest tests/utils/test_pretty_print_and_items.py tests/test_items_helpers.py\` — 43 passed.
- \`uv run ruff check\` on the touched files — All checks passed.

### Issue number

N/A — direct follow-up to merged #3394.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no doc changes needed)
- [x] I've run \`make lint\` and \`make format\`
- [x] I've made sure tests pass