### PR TITLE
fix: guard None refusal in ItemHelpers.extract_last_content

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -691,7 +691,11 @@ class ItemHelpers:
             # ``extract_text`` below.
             return last_content.text or ""
         elif isinstance(last_content, ResponseOutputRefusal):
-            return last_content.refusal
+            # ``last_content.refusal`` is typed as ``str`` per the Responses API schema,
+            # but provider gateways (e.g. LiteLLM) have been observed surfacing ``None``
+            # for typed-str fields (same rationale as the ``ResponseOutputText.text``
+            # guard above).
+            return last_content.refusal or ""
         else:
             raise ModelBehaviorError(f"Unexpected content type: {type(last_content)}")
 

--- a/tests/utils/test_pretty_print_and_items.py
+++ b/tests/utils/test_pretty_print_and_items.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from openai.types.responses import ResponseOutputMessage, ResponseOutputRefusal, ResponseOutputText
 
 from agents import Agent
 from agents.exceptions import RunErrorDetails
@@ -60,6 +60,32 @@ def test_extract_last_content_returns_empty_string_for_none_text():
 def test_extract_last_content_returns_text_normally():
     msg = _make_output_message("hello")
     assert ItemHelpers.extract_last_content(msg) == "hello"
+
+
+def _make_refusal_message(refusal: str | None) -> ResponseOutputMessage:
+    return ResponseOutputMessage.model_construct(
+        id="msg_refusal",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputRefusal.model_construct(type="refusal", refusal=refusal)],
+    )
+
+
+def test_extract_last_content_returns_empty_string_for_none_refusal():
+    """extract_last_content is declared ``-> str`` and must not return None even if
+    the underlying ResponseOutputRefusal.refusal is None.  The same provider
+    gateways (e.g. LiteLLM) that surface ``None`` for ResponseOutputText.text
+    can also surface ``None`` for ResponseOutputRefusal.refusal; the ``or ""``
+    guard must be applied consistently to both branches."""
+    msg = _make_refusal_message(None)
+    result = ItemHelpers.extract_last_content(msg)
+    assert isinstance(result, str)
+    assert result == ""
+
+
+def test_extract_last_content_returns_refusal_normally():
+    msg = _make_refusal_message("I cannot do that")
+    assert ItemHelpers.extract_last_content(msg) == "I cannot do that"
 
 
 def _make_run_error_details(n_input: int = 0, n_output: int = 0) -> RunErrorDetails:


### PR DESCRIPTION
### Summary

PR #3394 added an `or \"\"` guard for `ResponseOutputText.text` in `extract_last_content` but left the `ResponseOutputRefusal` branch unguarded:

```python
# Fixed by #3394 ✓
if isinstance(last_content, ResponseOutputText):
    return last_content.text or ""

# Still unguarded before this PR ✗
elif isinstance(last_content, ResponseOutputRefusal):
    return last_content.refusal        # can be None in practice
```

`ResponseOutputRefusal.refusal` is typed as `str` per the Responses API schema, but the same provider gateways (e.g. LiteLLM) and `model_construct` paths during streaming that surface `None` for `.text` can also surface `None` for `.refusal`. Without the guard, callers that rely on the `-> str` return type of `extract_last_content` receive `None` and may crash downstream.

The fix adds the same `or ""` coercion to the refusal branch, matching the precedent from #3394 for text and `extract_refusal` (which already uses `content_item.refusal or ""` at items.py:739).

### Test plan

Added two regression tests in `tests/utils/test_pretty_print_and_items.py` mirroring the structure of the tests added in #3394:

- `test_extract_last_content_returns_empty_string_for_none_refusal` — verifies the method returns `""` (not `None`) when `ResponseOutputRefusal.refusal` is `None`
- `test_extract_last_content_returns_refusal_normally` — verifies unaffected happy-path behaviour

```
uv run pytest tests/utils/test_pretty_print_and_items.py tests/test_items_helpers.py -v
# 43 passed
```

```
make lint  # All checks passed
make typecheck  # Success: no issues found
```

### Issue number

Discovered while auditing for the same guard-None pattern that #3394 and #3375 fixed.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no doc changes needed)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass