### PR TITLE
fix: reject non-default OpenAI base URL ports

### DIFF
--- a/src/agents/models/openai_client_utils.py
+++ b/src/agents/models/openai_client_utils.py
@@ -7,8 +7,17 @@ from openai import AsyncOpenAI
 
 def is_official_openai_base_url(base_url: object, *, websocket: bool = False) -> bool:
     parsed = urlsplit(str(base_url))
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+
     expected_scheme = "wss" if websocket else "https"
-    return parsed.scheme == expected_scheme and parsed.hostname == "api.openai.com"
+    return (
+        parsed.scheme == expected_scheme
+        and parsed.hostname == "api.openai.com"
+        and port in (None, 443)
+    )
 
 
 def is_official_openai_client(client: AsyncOpenAI) -> bool:

--- a/tests/models/test_openai_client_utils.py
+++ b/tests/models/test_openai_client_utils.py
@@ -13,6 +13,7 @@ from agents.models.openai_client_utils import (
     [
         "https://api.openai.com",
         "https://api.openai.com/v1/",
+        "https://api.openai.com:443/v1/",
     ],
 )
 def test_official_openai_base_url_matches_exact_host(base_url: str) -> None:
@@ -24,6 +25,9 @@ def test_official_openai_base_url_matches_exact_host(base_url: str) -> None:
     [
         "https://api.openai.com.evil/v1/",
         "https://api.openai.com.proxy.local/v1/",
+        "https://api.openai.com:444/v1/",
+        "https://api.openai.com:99999/v1/",
+        "https://api.openai.com:abc/v1/",
         "http://api.openai.com/v1/",
         "https://custom.example.test/v1/",
     ],
@@ -34,9 +38,13 @@ def test_official_openai_base_url_rejects_non_openai_hosts(base_url: str) -> Non
 
 def test_official_openai_websocket_base_url_matches_exact_host() -> None:
     assert is_official_openai_base_url("wss://api.openai.com/v1/", websocket=True) is True
+    assert is_official_openai_base_url("wss://api.openai.com:443/v1/", websocket=True) is True
     assert (
         is_official_openai_base_url("wss://api.openai.com.proxy.local/v1/", websocket=True) is False
     )
+    assert is_official_openai_base_url("wss://api.openai.com:444/v1/", websocket=True) is False
+    assert is_official_openai_base_url("wss://api.openai.com:99999/v1/", websocket=True) is False
+    assert is_official_openai_base_url("wss://api.openai.com:abc/v1/", websocket=True) is False
 
 
 def test_official_openai_client_rejects_client_without_base_url() -> None:


### PR DESCRIPTION
## Summary

- require official OpenAI base URLs to use no explicit port or the default TLS port `443`
- fail closed for malformed or out-of-range ports instead of raising from `urlsplit(...).port`
- add HTTPS and WSS regression coverage for `:443`, non-default `:444`, out-of-range `:99999`, and non-numeric `:abc`

## Validation

- `uv run pytest tests/models/test_openai_client_utils.py -q` -> 12 passed
- `uv run mypy src/agents/models/openai_client_utils.py tests/models/test_openai_client_utils.py` -> passed
- `uv run pyright src/agents/models/openai_client_utils.py tests/models/test_openai_client_utils.py` -> passed
- `make format` -> passed during worker validation
- `make lint` -> passed during worker validation
- `git diff --check` -> passed

Full `code-change-verification` was attempted during worker validation, but the repository-wide typecheck/tests did not finish in this local environment after roughly 55 minutes. The focused helper tests and type checks above passed.