### PR TITLE
fix: preserve unsafe integers in OpenAI trace payloads

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -34,6 +34,7 @@ class BackendSpanExporter(TracingExporter):
     _OPENAI_TRACING_INGEST_ENDPOINT = "https://api.openai.com/v1/traces/ingest"
     _OPENAI_TRACING_MAX_FIELD_BYTES = 100_000
     _OPENAI_TRACING_STRING_TRUNCATION_SUFFIX = "... [truncated]"
+    _MAX_JAVASCRIPT_SAFE_INTEGER = 9_007_199_254_740_991
     _OPENAI_TRACING_ALLOWED_USAGE_KEYS = frozenset(
         {
             "input_tokens",
@@ -251,7 +252,7 @@ class BackendSpanExporter(TracingExporter):
         for field_name in ("input", "output"):
             if field_name not in span_data:
                 continue
-            sanitized_field = self._truncate_span_field_value(span_data[field_name])
+            sanitized_field = self._sanitize_span_field_value(span_data[field_name])
             if sanitized_field is span_data[field_name]:
                 continue
             if not did_mutate:
@@ -343,6 +344,61 @@ class BackendSpanExporter(TracingExporter):
             return self._truncated_preview(value)
 
         return self._truncate_json_value_for_limit(sanitized_value, max_bytes)
+
+    def _sanitize_span_field_value(self, value: Any) -> Any:
+        normalized_value = self._normalize_trace_numbers_for_json_viewers(value)
+        truncated_value = self._truncate_span_field_value(normalized_value)
+        if truncated_value is value:
+            return value
+        return truncated_value
+
+    def _normalize_trace_numbers_for_json_viewers(self, value: Any) -> Any:
+        """Stringify unsafe integers so browser-based trace viewers do not round them."""
+        if isinstance(value, str):
+            try:
+                parsed_value = json.loads(value)
+            except (TypeError, ValueError):
+                return value
+            normalized_value = self._normalize_trace_numbers_for_json_viewers(parsed_value)
+            if normalized_value is parsed_value:
+                return value
+            return json.dumps(normalized_value, ensure_ascii=False, separators=(",", ":"))
+
+        if isinstance(value, bool):
+            return value
+
+        if isinstance(value, int):
+            if abs(value) > self._MAX_JAVASCRIPT_SAFE_INTEGER:
+                return str(value)
+            return value
+
+        if isinstance(value, dict):
+            normalized_dict: dict[Any, Any] | None = None
+            for key, nested_value in value.items():
+                normalized_nested = self._normalize_trace_numbers_for_json_viewers(nested_value)
+                if normalized_nested is nested_value:
+                    if normalized_dict is not None:
+                        normalized_dict[key] = nested_value
+                    continue
+                if normalized_dict is None:
+                    normalized_dict = dict(value)
+                normalized_dict[key] = normalized_nested
+            return value if normalized_dict is None else normalized_dict
+
+        if isinstance(value, list):
+            normalized_list: list[Any] | None = None
+            for index, nested_value in enumerate(value):
+                normalized_nested = self._normalize_trace_numbers_for_json_viewers(nested_value)
+                if normalized_nested is nested_value:
+                    if normalized_list is not None:
+                        normalized_list.append(nested_value)
+                    continue
+                if normalized_list is None:
+                    normalized_list = value[:index]
+                normalized_list.append(normalized_nested)
+            return value if normalized_list is None else normalized_list
+
+        return value
 
     def _truncate_json_value_for_limit(self, value: Any, max_bytes: int) -> Any:
         if self._value_json_size_bytes(value) <= max_bytes:

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import subprocess
@@ -1136,6 +1137,97 @@ def test_sanitize_for_openai_tracing_api_keeps_small_input_without_mutation():
     }
 
     assert exporter._sanitize_for_openai_tracing_api(payload) is payload
+    exporter.close()
+
+
+def test_sanitize_for_openai_tracing_api_stringifies_unsafe_integers_in_json_input():
+    exporter = BackendSpanExporter(api_key="test_key")
+    unsafe_integer = BackendSpanExporter._MAX_JAVASCRIPT_SAFE_INTEGER + 1
+    payload = {
+        "object": "trace.span",
+        "span_data": {
+            "type": "function",
+            "input": json.dumps(
+                {
+                    "safe": BackendSpanExporter._MAX_JAVASCRIPT_SAFE_INTEGER,
+                    "unsafe": unsafe_integer,
+                    "nested": [unsafe_integer * -1],
+                    "flag": True,
+                }
+            ),
+        },
+    }
+
+    sanitized = exporter._sanitize_for_openai_tracing_api(payload)
+
+    assert sanitized is not payload
+    assert json.loads(sanitized["span_data"]["input"]) == {
+        "safe": BackendSpanExporter._MAX_JAVASCRIPT_SAFE_INTEGER,
+        "unsafe": str(unsafe_integer),
+        "nested": [str(unsafe_integer * -1)],
+        "flag": True,
+    }
+    assert json.loads(payload["span_data"]["input"])["unsafe"] == unsafe_integer
+    exporter.close()
+
+
+def test_sanitize_for_openai_tracing_api_stringifies_unsafe_integers_in_structured_output():
+    exporter = BackendSpanExporter(api_key="test_key")
+    unsafe_integer = BackendSpanExporter._MAX_JAVASCRIPT_SAFE_INTEGER + 1
+    payload = {
+        "object": "trace.span",
+        "span_data": {
+            "type": "function",
+            "output": {
+                "safe": BackendSpanExporter._MAX_JAVASCRIPT_SAFE_INTEGER,
+                "unsafe": unsafe_integer,
+                "nested": [{"value": unsafe_integer}],
+            },
+        },
+    }
+
+    sanitized = exporter._sanitize_for_openai_tracing_api(payload)
+
+    assert sanitized["span_data"]["output"] == {
+        "safe": BackendSpanExporter._MAX_JAVASCRIPT_SAFE_INTEGER,
+        "unsafe": str(unsafe_integer),
+        "nested": [{"value": str(unsafe_integer)}],
+    }
+    assert payload["span_data"]["output"]["unsafe"] == unsafe_integer
+    exporter.close()
+
+
+@patch("httpx.Client")
+def test_backend_span_exporter_keeps_unsafe_integers_for_custom_endpoint(mock_client):
+    class DummyItem:
+        tracing_api_key = None
+
+        def __init__(self):
+            self.unsafe_integer = BackendSpanExporter._MAX_JAVASCRIPT_SAFE_INTEGER + 1
+            self.exported_payload = {
+                "object": "trace.span",
+                "span_data": {
+                    "type": "function",
+                    "input": json.dumps({"unsafe": self.unsafe_integer}),
+                },
+            }
+
+        def export(self):
+            return self.exported_payload
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_client.return_value.post.return_value = mock_response
+
+    exporter = BackendSpanExporter(
+        api_key="test_key",
+        endpoint="https://example.com/v1/traces/ingest",
+    )
+    item = DummyItem()
+    exporter.export([cast(Any, item)])
+
+    sent_payload = mock_client.return_value.post.call_args.kwargs["json"]["data"][0]
+    assert sent_payload["span_data"]["input"] == item.exported_payload["span_data"]["input"]
     exporter.close()
 
 


### PR DESCRIPTION
### Summary

Fixes #2094 by normalizing trace `input`/`output` fields sent to the default OpenAI tracing ingest endpoint so integers outside JavaScript's safe integer range are stringified before browser-based trace viewers can round them. Runtime tool inputs and custom tracing endpoints are unchanged.

Root cause: function trace inputs can contain JSON strings or structured payloads with Python integers larger than `Number.MAX_SAFE_INTEGER`. Those values are valid JSON numbers, but browser JSON viewers can lose precision when parsing/displaying them.

Change:
- Add OpenAI-endpoint-only trace field sanitization for unsafe integers in JSON strings and structured `input`/`output` payloads.
- Preserve safe integers, booleans, original payload objects, and custom endpoint behavior.
- Keep existing trace field truncation behavior after the numeric normalization step.

### Test plan

- [x] `uv run pytest tests/test_trace_processor.py -k 'unsafe_integers or keeps_unsafe_integers or truncates_oversized_output or keeps_small_input'`
- [x] `uv run pytest tests/test_trace_processor.py -m 'not serial'`
- [x] `uv run ruff format --check src/agents/tracing/processors.py tests/test_trace_processor.py`
- [x] `uv run ruff check src/agents/tracing/processors.py tests/test_trace_processor.py`
- [x] `git diff --check`

Not run to completion:
- `uv run pytest tests/test_trace_processor.py` because existing serial test `test_tracing_atexit_cleanup_timeout_preserves_process_exit_code_on_504` timed out; rerunning that single test also timed out.
- `uv run mypy src/agents/tracing/processors.py tests/test_trace_processor.py` because it produced no output for several minutes and was stopped.

### Issue number

Fixes #2094

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [x] I've made sure tests pass

Notes: no docs were needed for this internal tracing-export normalization. I ran focused `ruff` format/lint checks on the touched files rather than full `make lint`/`make format`.
