### PR TITLE
fix: complete realtime history on audio done

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -303,6 +303,12 @@ class RealtimeSession(RealtimeModelListener):
                     info=self._event_info, item_id=event.item_id, content_index=event.content_index
                 )
             )
+            new_history = self._mark_assistant_item_completed(self._history, event.item_id)
+            if new_history is not self._history:
+                self._history = new_history
+                await self._put_event(
+                    RealtimeHistoryUpdated(info=self._event_info, history=self._history)
+                )
         elif event.type == "input_audio_transcription_completed":
             prev_len = len(self._history)
             self._history = RealtimeSession._get_new_history(self._history, event)
@@ -785,6 +791,30 @@ class RealtimeSession(RealtimeModelListener):
                     error={"message": error_message},
                 )
             )
+
+    @staticmethod
+    def _mark_assistant_item_completed(
+        old_history: list[RealtimeItem],
+        item_id: str,
+    ) -> list[RealtimeItem]:
+        existing_index = next(
+            (i for i, item in enumerate(old_history) if item.item_id == item_id),
+            None,
+        )
+        if existing_index is None:
+            return old_history
+
+        existing_item = old_history[existing_index]
+        if (
+            existing_item.type != "message"
+            or existing_item.role != "assistant"
+            or existing_item.status == "completed"
+        ):
+            return old_history
+
+        new_history = old_history.copy()
+        new_history[existing_index] = existing_item.model_copy(update={"status": "completed"})
+        return new_history
 
     @classmethod
     def _get_new_history(

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -427,6 +427,35 @@ class TestEventHandling:
         assert isinstance(done_session_event, RealtimeAudioEnd)
 
     @pytest.mark.asyncio
+    async def test_audio_done_marks_assistant_history_item_completed(self, mock_model, mock_agent):
+        """Test that audio done events complete matching assistant history items."""
+        session = RealtimeSession(
+            mock_model, mock_agent, None, run_config={"async_tool_calls": False}
+        )
+        session._history = [
+            AssistantMessageItem(
+                item_id="item_1",
+                role="assistant",
+                status="in_progress",
+                content=[AssistantAudio(audio=None, transcript="Hello")],
+            )
+        ]
+
+        await session.on_event(RealtimeModelAudioDoneEvent(item_id="item_1", content_index=0))
+
+        updated_item = cast(AssistantMessageItem, session._history[0])
+        assert updated_item.status == "completed"
+
+        assert session._event_queue.qsize() == 3
+        await session._event_queue.get()  # raw event
+        audio_done_event = await session._event_queue.get()
+        assert isinstance(audio_done_event, RealtimeAudioEnd)
+        history_event = await session._event_queue.get()
+        assert isinstance(history_event, RealtimeHistoryUpdated)
+        history_item = cast(AssistantMessageItem, history_event.history[0])
+        assert history_item.status == "completed"
+
+    @pytest.mark.asyncio
     async def test_turn_events_transformation(self, mock_model, mock_agent):
         """Test that turn start/end events are properly transformed"""
         session = RealtimeSession(


### PR DESCRIPTION
### Summary

Fixes realtime assistant history status updates after audio playback finishes. When `audio_done` arrives, the session now marks the matching assistant message as `completed` and emits a `history_updated` event after the existing `audio_end` event. This keeps history consumers from seeing completed audio responses stuck at `in_progress`.

### Test plan

- `uv run pytest tests/realtime/test_session.py -q`
- `uv run ruff format --check src/agents/realtime/session.py tests/realtime/test_session.py`
- `uv run ruff check src/agents/realtime/session.py tests/realtime/test_session.py`
- `git diff --check`

### Issue number

Fixes #1434

### Checks

- [x] I have added new tests (if relevant)
- [ ] I have added/updated the relevant documentation
- [x] I have run `make lint` and `make format` or focused Ruff equivalents
- [x] I have made sure tests pass
