### PR TITLE
docs: fix LiteLLM API reference redirect

### DIFF
--- a/docs/ref/extensions/litellm.md
+++ b/docs/ref/extensions/litellm.md
@@ -1,9 +1,9 @@
 # `LiteLLM Models`
 
 <script>
-  window.location.replace("../third_party_adapters/");
+  window.location.replace("models/litellm_model/");
 </script>
 
-This page moved to the [Third-party adapters API reference](third_party_adapters.md).
+This page moved to the [LiteLLM model API reference](models/litellm_model.md).
 
 If you are not redirected automatically, use the link above.


### PR DESCRIPTION
## Summary

- Fix the legacy LiteLLM API reference redirect target
- Update the fallback Markdown link to point at the existing LiteLLM model API reference

## Validation
- git diff --check
- Targeted content assertion confirmed the stale third_party_adapters target is gone, models/litellm_model is present, and docs/ref/extensions/models/litellm_model.md exists