### PR TITLE
docs: fix duplicated word in usaspending glossary example

### DIFF
--- a/examples/sandbox/extensions/daytona/usaspending_text2sql/schema/glossary.md
+++ b/examples/sandbox/extensions/daytona/usaspending_text2sql/schema/glossary.md
@@ -831,7 +831,7 @@ A prime award is an agreement that the government makes with a non-federal entit
 
 The term “prime award” can be used as a generic term to describe either  transactions or prime award summaries.
 
-**Official definition:** A Prime Award is a a federal award that is either:
+**Official definition:** A Prime Award is a federal award that is either:
 (1) Federal financial assistance that a non-Federal entity receives directly from a Federal awarding agency; or
 (2) The cost-reimbursement contract under the Federal Acquisition Regulations that a non-Federal entity receives directly from a Federal awarding agency.
 (Adapted from 2 CFR §200.38)


### PR DESCRIPTION
Tiny docs fix in the Daytona/USAspending text-to-SQL example glossary. Line 834 had a duplicated indefinite article:

> **Official definition:** A Prime Award is **a a** federal award that is either:

Fixed to:

> **Official definition:** A Prime Award is **a** federal award that is either:

Single-line markdown change. No code paths affected.