### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+For a more in-depth look at our security policy, please check out our [Coordinated Vulnerability Disclosure Policy](https://openai.com/policies/coordinated-vulnerability-disclosure-policy).
+
+To report a security issue in `openai-agents-python`, please email **disclosure@openai.com**. Our PGP key can be located [at this address](https://cdn.openai.com/security.txt).


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` matching the format used by sibling project [`openai/openai-agents-js`](https://github.com/openai/openai-agents-js/blob/main/SECURITY.md).
- Provides an explicit email contact (`disclosure@openai.com`) so the GitHub Security tab surfaces a clear reporting channel instead of "This project has not set up a SECURITY.md file yet".

## Context
The repo currently has no `SECURITY.md`, so the Security tab shows no reporting guidance. This brings the repo in line with `openai/openai-agents-js`, `openai/swarm`, and `openai/evals`.

## Test plan
- N/A (markdown only).