### PR TITLE
fix: #3459 add opt-in recovery for missing function tools

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -111,6 +111,7 @@ from .run import (
     ToolErrorFormatter,
     ToolErrorFormatterArgs,
     ToolExecutionConfig,
+    ToolNotFoundBehavior,
 )
 from .run_context import AgentHookContext, RunContextWrapper, TContext
 from .run_error_handlers import (
@@ -438,6 +439,7 @@ __all__ = [
     "ToolExecutionConfig",
     "ToolErrorFormatter",
     "ToolErrorFormatterArgs",
+    "ToolNotFoundBehavior",
     "RunState",
     "RawResponsesStreamEvent",
     "RunItemStreamEvent",

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -41,6 +41,7 @@ from .run_config import (
     ToolErrorFormatter,
     ToolErrorFormatterArgs,
     ToolExecutionConfig,
+    ToolNotFoundBehavior,
 )
 from .run_context import RunContextWrapper, TContext
 from .run_error_handlers import RunErrorHandlers
@@ -140,6 +141,7 @@ __all__ = [
     "ToolExecutionConfig",
     "ToolErrorFormatter",
     "ToolErrorFormatterArgs",
+    "ToolNotFoundBehavior",
     "DEFAULT_MAX_TURNS",
     "set_default_agent_runner",
     "get_default_agent_runner",

--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -63,13 +63,14 @@ class CallModelData(Generic[TContext]):
 
 CallModelInputFilter = Callable[[CallModelData[Any]], MaybeAwaitable[ModelInputData]]
 ReasoningItemIdPolicy = Literal["preserve", "omit"]
+ToolNotFoundBehavior = Literal["raise_error", "return_error_to_model"]
 
 
 @dataclass
 class ToolErrorFormatterArgs(Generic[TContext]):
     """Data passed to ``RunConfig.tool_error_formatter`` callbacks."""
 
-    kind: Literal["approval_rejected"]
+    kind: Literal["approval_rejected", "tool_not_found"]
     """The category of tool error being formatted."""
 
     tool_type: Literal["function", "computer", "shell", "apply_patch", "custom"]
@@ -319,6 +320,14 @@ class RunConfig:
 
     tool_execution: ToolExecutionConfig | None = None
     """Optional SDK-side execution settings for local tool calls."""
+
+    tool_not_found_behavior: ToolNotFoundBehavior = "raise_error"
+    """Controls unresolved function tool calls emitted by the model.
+
+    - ``"raise_error"`` preserves the default behavior and raises ``ModelBehaviorError``.
+    - ``"return_error_to_model"`` returns a model-visible ``function_call_output`` error and lets
+      the run continue.
+    """
 
 
 class RunOptions(TypedDict, Generic[TContext]):

--- a/src/agents/run_internal/run_steps.py
+++ b/src/agents/run_internal/run_steps.py
@@ -39,6 +39,7 @@ __all__ = [
     "ToolRunLocalShellCall",
     "ToolRunShellCall",
     "ToolRunApplyPatchCall",
+    "ToolRunFunctionNotFound",
     "ProcessedResponse",
     "NextStepHandoff",
     "NextStepFinalOutput",
@@ -67,6 +68,12 @@ class ToolRunHandoff:
 class ToolRunFunction:
     tool_call: ResponseFunctionToolCall
     function_tool: FunctionTool
+
+
+@dataclass
+class ToolRunFunctionNotFound:
+    tool_call: ResponseFunctionToolCall
+    tool_name: str
 
 
 @dataclass
@@ -117,6 +124,9 @@ class ProcessedResponse:
     tools_used: list[str]  # Names of all tools used, including hosted tools
     mcp_approval_requests: list[ToolRunMCPApprovalRequest]  # Only requests with callbacks
     interruptions: list[ToolApprovalItem]  # Tool approval items awaiting user decision
+    function_tools_not_found: list[ToolRunFunctionNotFound] = dataclasses.field(
+        default_factory=list
+    )
     custom_tool_calls: list[ToolRunCustom] = dataclasses.field(default_factory=list)
 
     def has_tools_or_approvals_to_run(self) -> bool:
@@ -132,6 +142,7 @@ class ProcessedResponse:
                 self.shell_calls,
                 self.apply_patch_calls,
                 self.mcp_approval_requests,
+                self.function_tools_not_found,
             ]
         )
 

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -66,7 +66,7 @@ from ..items import (
 )
 from ..lifecycle import RunHooks
 from ..logger import logger
-from ..run_config import RunConfig
+from ..run_config import RunConfig, ToolErrorFormatterArgs
 from ..run_context import AgentHookContext, RunContextWrapper, TContext
 from ..run_error_handlers import RunErrorHandlers
 from ..run_state import RunState
@@ -116,6 +116,7 @@ from .run_steps import (
     ToolRunComputerAction,
     ToolRunCustom,
     ToolRunFunction,
+    ToolRunFunctionNotFound,
     ToolRunHandoff,
     ToolRunLocalShellCall,
     ToolRunMCPApprovalRequest,
@@ -207,6 +208,77 @@ async def _maybe_finalize_from_tool_results(
         tool_input_guardrail_results=tool_input_guardrail_results,
         tool_output_guardrail_results=tool_output_guardrail_results,
     )
+
+
+def _default_tool_not_found_message(tool_name: str) -> str:
+    return f"Tool '{tool_name}' not found."
+
+
+async def _resolve_tool_not_found_message(
+    *,
+    context_wrapper: RunContextWrapper[Any],
+    run_config: RunConfig,
+    tool_name: str,
+    call_id: str,
+) -> str:
+    default_message = _default_tool_not_found_message(tool_name)
+    formatter = run_config.tool_error_formatter
+    if formatter is None:
+        return default_message
+
+    try:
+        maybe_message = formatter(
+            ToolErrorFormatterArgs(
+                kind="tool_not_found",
+                tool_type="function",
+                tool_name=tool_name,
+                call_id=call_id,
+                default_message=default_message,
+                run_context=context_wrapper,
+            )
+        )
+        message = await maybe_message if inspect.isawaitable(maybe_message) else maybe_message
+    except Exception as exc:
+        logger.error("Tool error formatter failed for missing tool %s: %s", tool_name, exc)
+        return default_message
+
+    if message is None:
+        return default_message
+
+    if not isinstance(message, str):
+        logger.error(
+            "Tool error formatter returned non-string for missing tool %s: %s",
+            tool_name,
+            type(message).__name__,
+        )
+        return default_message
+
+    return message
+
+
+async def _build_tool_not_found_output_items(
+    *,
+    agent: Agent[Any],
+    calls: Sequence[ToolRunFunctionNotFound],
+    context_wrapper: RunContextWrapper[Any],
+    run_config: RunConfig,
+) -> list[RunItem]:
+    items: list[RunItem] = []
+    for call in calls:
+        message = await _resolve_tool_not_found_message(
+            context_wrapper=context_wrapper,
+            run_config=run_config,
+            tool_name=call.tool_name,
+            call_id=call.tool_call.call_id,
+        )
+        items.append(
+            ToolCallOutputItem(
+                output=message,
+                raw_item=ItemHelpers.tool_call_output_item(call.tool_call, message),
+                agent=agent,
+            )
+        )
+    return items
 
 
 async def run_final_output_hooks(
@@ -613,6 +685,14 @@ async def execute_tools_and_side_effects(
             shell_results=shell_results,
             apply_patch_results=apply_patch_results,
             local_shell_results=local_shell_results,
+        )
+    )
+    new_step_items.extend(
+        await _build_tool_not_found_output_items(
+            agent=public_agent,
+            calls=processed_response.function_tools_not_found,
+            context_wrapper=context_wrapper,
+            run_config=run_config,
         )
     )
 
@@ -1476,6 +1556,7 @@ def process_model_response(
     output_schema: AgentOutputSchemaBase | None,
     handoffs: list[Handoff],
     existing_items: Sequence[RunItem] | None = None,
+    run_config: RunConfig | None = None,
 ) -> ProcessedResponse:
     items: list[RunItem] = []
 
@@ -1487,6 +1568,7 @@ def process_model_response(
     shell_calls = []
     apply_patch_calls = []
     mcp_approval_requests = []
+    function_tools_not_found = []
     tools_used: list[str] = []
     handoff_map = {handoff.tool_name: handoff for handoff in handoffs}
     function_map = build_function_tool_lookup_map(
@@ -1873,6 +1955,15 @@ def process_model_response(
                         data={"tool_name": qualified_output_name or output.name},
                     )
                 )
+                if run_config is not None and (
+                    run_config.tool_not_found_behavior == "return_error_to_model"
+                ):
+                    tool_name = qualified_output_name or output.name
+                    items.append(ToolCallItem(raw_item=output, agent=agent))
+                    function_tools_not_found.append(
+                        ToolRunFunctionNotFound(tool_call=output, tool_name=tool_name)
+                    )
+                    continue
                 error = (
                     f"Tool {qualified_output_name or output.name} not found in agent {agent.name}"
                 )
@@ -1906,6 +1997,7 @@ def process_model_response(
         tools_used=tools_used,
         mcp_approval_requests=mcp_approval_requests,
         interruptions=[],
+        function_tools_not_found=function_tools_not_found,
     )
 
 
@@ -1935,6 +2027,7 @@ async def get_single_step_result_from_response(
         output_schema=output_schema,
         handoffs=handoffs,
         existing_items=pre_step_items,
+        run_config=run_config,
     )
 
     if before_side_effects is not None:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -4327,6 +4327,132 @@ async def test_dynamic_tool_addition_run() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tool_not_found_behavior_returns_error_to_model() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model, tool_use_behavior="run_llm_again")
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("missing_tool", "{}", call_id="call_missing")],
+            [get_text_message("recovered")],
+        ]
+    )
+
+    result = await Runner.run(
+        agent,
+        input="start",
+        run_config=RunConfig(tool_not_found_behavior="return_error_to_model"),
+    )
+
+    assert result.final_output == "recovered"
+    second_turn_input = model.last_turn_args["input"]
+    assert isinstance(second_turn_input, list)
+    tool_outputs = [
+        item
+        for item in second_turn_input
+        if isinstance(item, dict) and item.get("type") == "function_call_output"
+    ]
+    assert tool_outputs == [
+        {
+            "call_id": "call_missing",
+            "output": "Tool 'missing_tool' not found.",
+            "type": "function_call_output",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tool_not_found_behavior_uses_tool_error_formatter() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model, tool_use_behavior="run_llm_again")
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("missing_tool", "{}", call_id="call_missing")],
+            [get_text_message("recovered")],
+        ]
+    )
+    seen_kinds: list[str] = []
+
+    async def formatter(args: Any) -> str | None:
+        seen_kinds.append(args.kind)
+        if args.kind != "tool_not_found":
+            return None
+        return f"{args.tool_name} unavailable for {args.call_id}"
+
+    result = await Runner.run(
+        agent,
+        input="start",
+        run_config=RunConfig(
+            tool_not_found_behavior="return_error_to_model",
+            tool_error_formatter=formatter,
+        ),
+    )
+
+    assert result.final_output == "recovered"
+    assert seen_kinds == ["tool_not_found"]
+    second_turn_input = model.last_turn_args["input"]
+    assert isinstance(second_turn_input, list)
+    tool_outputs = [
+        item
+        for item in second_turn_input
+        if isinstance(item, dict) and item.get("type") == "function_call_output"
+    ]
+    assert tool_outputs == [
+        {
+            "call_id": "call_missing",
+            "output": "missing_tool unavailable for call_missing",
+            "type": "function_call_output",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tool_not_found_behavior_handles_mixed_function_tool_calls() -> None:
+    model = FakeModel()
+    calls: list[str] = []
+
+    @function_tool(name_override="known_tool")
+    async def known_tool() -> str:
+        calls.append("known_tool")
+        return "known result"
+
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[known_tool],
+        tool_use_behavior="run_llm_again",
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [
+                get_function_tool_call("missing_tool", "{}", call_id="call_missing"),
+                get_function_tool_call("known_tool", "{}", call_id="call_known"),
+            ],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = await Runner.run(
+        agent,
+        input="start",
+        run_config=RunConfig(tool_not_found_behavior="return_error_to_model"),
+    )
+
+    assert calls == ["known_tool"]
+    assert result.final_output == "done"
+    second_turn_input = model.last_turn_args["input"]
+    assert isinstance(second_turn_input, list)
+    tool_outputs = {
+        item.get("call_id"): item.get("output")
+        for item in second_turn_input
+        if isinstance(item, dict) and item.get("type") == "function_call_output"
+    }
+    assert tool_outputs == {
+        "call_known": "known result",
+        "call_missing": "Tool 'missing_tool' not found.",
+    }
+
+
+@pytest.mark.asyncio
 async def test_session_add_items_called_multiple_times_for_multi_turn_completion():
     """Test that SQLiteSession.add_items is called multiple times
     during a multi-turn agent completion.

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -139,6 +139,35 @@ async def test_simple_first_run():
 
 
 @pytest.mark.asyncio
+async def test_streamed_tool_not_found_behavior_returns_error_to_model() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model)
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("missing_tool", "{}", call_id="call_missing")],
+            [get_text_message("recovered")],
+        ]
+    )
+
+    result = Runner.run_streamed(
+        agent,
+        input="start",
+        run_config=RunConfig(tool_not_found_behavior="return_error_to_model"),
+    )
+    async for _ in result.stream_events():
+        pass
+
+    assert result.final_output == "recovered"
+    second_turn_input = model.last_turn_args["input"]
+    assert isinstance(second_turn_input, list)
+    assert {
+        item.get("call_id"): item.get("output")
+        for item in second_turn_input
+        if isinstance(item, dict) and item.get("type") == "function_call_output"
+    } == {"call_missing": "Tool 'missing_tool' not found."}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("terminal_event_type", "terminal_event_cls"),
     [

--- a/tests/test_process_model_response.py
+++ b/tests/test_process_model_response.py
@@ -23,6 +23,7 @@ from agents import (
     CustomTool,
     Handoff,
     HostedMCPTool,
+    RunConfig,
     ShellTool,
     Tool,
     function_tool,
@@ -866,3 +867,25 @@ def test_process_model_response_rejects_mismatched_function_namespace() -> None:
             output_schema=None,
             handoffs=[],
         )
+
+
+def test_process_model_response_collects_missing_function_tool_when_opted_in() -> None:
+    agent = Agent(name="test", model=FakeModel(), tools=[function_tool(lambda: "ok")])
+    missing_call = get_function_tool_call("missing_tool", "{}", call_id="call_missing")
+
+    processed = run_loop.process_model_response(
+        agent=agent,
+        all_tools=agent.tools,
+        response=_response([missing_call]),
+        output_schema=None,
+        handoffs=[],
+        run_config=RunConfig(tool_not_found_behavior="return_error_to_model"),
+    )
+
+    assert len(processed.new_items) == 1
+    assert isinstance(processed.new_items[0], ToolCallItem)
+    assert processed.functions == []
+    assert len(processed.function_tools_not_found) == 1
+    assert processed.function_tools_not_found[0].tool_call is missing_call
+    assert processed.function_tools_not_found[0].tool_name == "missing_tool"
+    assert processed.has_tools_or_approvals_to_run()

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from agents import Agent, RunConfig, Runner, ToolExecutionConfig
+from agents import Agent, RunConfig, Runner, ToolExecutionConfig, ToolNotFoundBehavior
 from agents.model_settings import ModelSettings
 from agents.models.interface import Model, ModelProvider
 
@@ -200,3 +200,16 @@ def test_tool_execution_config_is_public_from_agents_package() -> None:
 
     assert config.tool_execution is not None
     assert config.tool_execution.max_function_tool_concurrency == 2
+
+
+def test_tool_not_found_behavior_defaults_to_raise_error() -> None:
+    config = RunConfig()
+
+    assert config.tool_not_found_behavior == "raise_error"
+
+
+def test_tool_not_found_behavior_is_public_from_agents_package() -> None:
+    behavior: ToolNotFoundBehavior = "return_error_to_model"
+    config = RunConfig(tool_not_found_behavior=behavior)
+
+    assert config.tool_not_found_behavior == "return_error_to_model"

--- a/tests/test_source_compat_constructors.py
+++ b/tests/test_source_compat_constructors.py
@@ -131,6 +131,42 @@ def test_run_config_tool_execution_append_preserves_sandbox_position() -> None:
     assert config.tool_execution is tool_execution
 
 
+def test_run_config_tool_not_found_behavior_append_preserves_tool_execution_position() -> None:
+    session_settings = SessionSettings(limit=123)
+    tool_execution = ToolExecutionConfig(max_function_tool_concurrency=2)
+    config = RunConfig(
+        None,
+        MultiProvider(),
+        None,
+        None,
+        False,
+        None,
+        None,
+        None,
+        False,
+        None,
+        True,
+        "Agent workflow",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        session_settings,
+        "omit",
+        None,
+        tool_execution,
+        "return_error_to_model",
+    )
+
+    assert config.session_settings == session_settings
+    assert config.reasoning_item_id_policy == "omit"
+    assert config.sandbox is None
+    assert config.tool_execution is tool_execution
+    assert config.tool_not_found_behavior == "return_error_to_model"
+
+
 def test_model_settings_context_management_append_preserves_retry_position() -> None:
     retry = ModelRetrySettings(max_retries=1)
     settings = ModelSettings(


### PR DESCRIPTION
This pull request resolves #3459 by adding an opt-in `RunConfig.tool_not_found_behavior="return_error_to_model"` mode for unresolved function tool calls. The default remains `raise_error`, preserving the current `ModelBehaviorError` behavior unless callers explicitly opt in.

When enabled, the runner records the unresolved function call, appends a model-visible `function_call_output` error for the same `call_id`, and runs the model again so it can recover. The change also extends `tool_error_formatter` with `kind="tool_not_found"` for custom model-visible messages, exports the new behavior type, documents the option, and covers direct processing, non-streaming runs, streaming runs, mixed known/missing tool calls, formatter fallback behavior, session persistence, and public constructor compatibility.