### PR TITLE
fix: handle None refusal in extract_last_content

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -691,7 +691,7 @@ class ItemHelpers:
             # ``extract_text`` below.
             return last_content.text or ""
         elif isinstance(last_content, ResponseOutputRefusal):
-            return last_content.refusal
+            return last_content.refusal or ""
         else:
             raise ModelBehaviorError(f"Unexpected content type: {type(last_content)}")
 


### PR DESCRIPTION
`ItemHelpers.extract_last_content` returns `last_content.refusal` directly when the last content block is a refusal. Provider gateways (e.g. LiteLLM) can surface `None` for typed `str` fields, causing a `TypeError` downstream.

PR #3394 already added `or ""` to the `.text` branch for this exact reason. The `.refusal` branch was missed.

This is the same fix attempted in PR #3428, which was incorrectly closed as a duplicate -- the PR it was supposedly a duplicate of (#3394) only covered `.text`, not `.refusal`.
