### PR TITLE
fix: apply hardened http client default to MCP SSE transport

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1297,8 +1297,9 @@ class MCPServerSse(_MCPServerWithClientSession):
         }
         if "auth" in self.params:
             kwargs["auth"] = self.params["auth"]
-        if "httpx_client_factory" in self.params:
-            kwargs["httpx_client_factory"] = self.params["httpx_client_factory"]
+        kwargs["httpx_client_factory"] = (
+            self.params.get("httpx_client_factory") or _create_default_streamable_http_client
+        )
         return sse_client(**kwargs)
 
     @property

--- a/tests/mcp/test_mcp_auth_params.py
+++ b/tests/mcp/test_mcp_auth_params.py
@@ -16,7 +16,7 @@ class TestMCPServerSseAuthAndFactory:
 
     @pytest.mark.asyncio
     async def test_sse_default_no_auth_no_factory(self):
-        """SSE create_streams passes only the four base params when no extras are set."""
+        """SSE create_streams falls back to the hardened default httpx_client_factory."""
         with patch("agents.mcp.server.sse_client") as mock_client:
             mock_client.return_value = MagicMock()
             server = MCPServerSse(params={"url": "http://localhost:8000/sse"})
@@ -26,11 +26,12 @@ class TestMCPServerSseAuthAndFactory:
                 headers=None,
                 timeout=5,
                 sse_read_timeout=300,
+                httpx_client_factory=_create_default_streamable_http_client,
             )
 
     @pytest.mark.asyncio
     async def test_sse_with_auth(self):
-        """SSE create_streams forwards the auth parameter when provided."""
+        """SSE create_streams forwards auth and still applies the hardened default factory."""
         auth = httpx.BasicAuth(username="user", password="pass")
         with patch("agents.mcp.server.sse_client") as mock_client:
             mock_client.return_value = MagicMock()
@@ -42,6 +43,7 @@ class TestMCPServerSseAuthAndFactory:
                 timeout=5,
                 sse_read_timeout=300,
                 auth=auth,
+                httpx_client_factory=_create_default_streamable_http_client,
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Mirror the redirect-hardening pattern from #3451 to the SSE transport.

`MCPServerStreamableHttp.create_streams` (`server.py:1444-1446`) always applies `_create_default_streamable_http_client`, which sets `follow_redirects=False`. `MCPServerSse.create_streams` (`server.py:1300-1301`) only forwarded the factory when the user supplied one, so the default path fell through to MCP SDK's `create_mcp_http_client`, which has `follow_redirects=True`.

This PR aligns the two transports so the default SSE client picks up the same hardening as StreamableHTTP.

## Test plan
- Updated `tests/mcp/test_mcp_auth_params.py::test_sse_default_no_auth_no_factory` and `test_sse_with_auth` to assert the default factory is now always forwarded.
- Existing SSE tests with user-provided factory (`test_sse_with_httpx_client_factory`, `test_sse_with_auth_and_factory`) continue to pass unchanged.
- `uv run pytest tests/mcp/` — 209 passed.
- `uv run ruff check` / `ruff format --check` — clean.