### PR TITLE
strict_schema: recurse into prefixItems entries for tuple schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -79,6 +79,15 @@ def _ensure_strict_json_schema(
     if is_dict(items):
         json_schema["items"] = _ensure_strict_json_schema(items, path=(*path, "items"), root=root)
 
+    # tuple arrays (Pydantic v2 / JSON Schema draft 2020-12)
+    # { 'type': 'array', 'prefixItems': [{...}, {...}] }
+    prefix_items = json_schema.get("prefixItems")
+    if is_list(prefix_items):
+        json_schema["prefixItems"] = [
+            _ensure_strict_json_schema(entry, path=(*path, "prefixItems", str(i)), root=root)
+            for i, entry in enumerate(prefix_items)
+        ]
+
     # unions
     any_of = json_schema.get("anyOf")
     if is_list(any_of):


### PR DESCRIPTION
### Summary

`_ensure_strict_json_schema` in `strict_schema.py` handles `"items"` for homogeneous
arrays but has no branch for `"prefixItems"` — the key Pydantic v2 emits for
fixed-length tuple types (e.g. `tuple[int, MyModel]`) per JSON Schema draft 2020-12.

As a result, any nested object schema inside a tuple position is never visited, so:
- `"additionalProperties": false` is never added to nested objects → OpenAI rejects
  the tool definition under strict mode at runtime.
- `"default": null` is not stripped from inner schemas.
- `anyOf`/`oneOf` inside tuple positions are not normalized.

The fix adds a parallel block immediately after the existing `items` block that
iterates over `prefixItems` entries and applies `_ensure_strict_json_schema`
recursively to each one, mirroring the existing handling for `anyOf`, `oneOf`,
and `allOf`.

### Test plan

- Confirmed the bug by tracing `_ensure_strict_json_schema` — `"prefixItems"` is
  absent from the function entirely before this change.
- The existing `tests/test_strict_schema.py` suite covers the surrounding logic;
  a new test case for a `prefixItems` schema (e.g. a nested object inside a tuple
  position) should be added to confirm `additionalProperties: false` is propagated
  correctly.

### Issue number

<!-- For example: "Closes #1234" -->

### Checks

- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [ ] I've made sure tests pass