### PR TITLE
add image search support in agents sdk

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -2022,9 +2022,16 @@ class Converter:
             }
             if tool.external_web_access is not None:
                 web_search_tool["external_web_access"] = tool.external_web_access
+            if tool.search_content_types is not None:
+                web_search_tool["search_content_types"] = list(tool.search_content_types)
+            web_search_include: ResponseIncludable | None = (
+                "web_search_call.results"
+                if tool.search_content_types is not None and "image" in tool.search_content_types
+                else None
+            )
             return (
                 _require_responses_tool_param(web_search_tool),
-                None,
+                web_search_include,
             )
         elif isinstance(tool, FileSearchTool):
             file_search_tool_param: FileSearchToolParam = {

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -8,7 +8,7 @@ import inspect
 import json
 import math
 import weakref
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from types import UnionType
@@ -705,6 +705,9 @@ class WebSearchTool:
     When omitted, the API default is used. Set to `False` to request cached or
     indexed-only behavior where supported.
     """
+
+    search_content_types: Sequence[Literal["text", "image"]] | None = None
+    """The content types to include in the search results. Omitting this uses the API default."""
 
     @property
     def name(self):

--- a/tests/models/test_openai_responses_converter.py
+++ b/tests/models/test_openai_responses_converter.py
@@ -438,6 +438,7 @@ def test_convert_tools_basic_types_and_includes():
     assert web_params.get("user_location") == web_tool.user_location
     assert web_params.get("search_context_size") == web_tool.search_context_size
     assert "external_web_access" not in web_params
+    assert "search_content_types" not in web_params
     # Verify computer tool uses the GA built-in tool payload.
     comp_params = next(ct for ct in converted.tools if ct["type"] == "computer")
     assert comp_params == {"type": "computer"}
@@ -464,6 +465,40 @@ def test_convert_tools_includes_explicit_false_external_web_access() -> None:
             "user_location": None,
             "search_context_size": "medium",
             "external_web_access": False,
+        }
+    ]
+
+
+def test_convert_tools_forwards_web_search_content_types() -> None:
+    web_tool = WebSearchTool(search_content_types=["text", "image"])
+
+    converted = Converter.convert_tools([web_tool], handoffs=[], model="gpt-5.4")
+
+    assert converted.includes == ["web_search_call.results"]
+    assert converted.tools == [
+        {
+            "type": "web_search",
+            "filters": None,
+            "user_location": None,
+            "search_context_size": "medium",
+            "search_content_types": ["text", "image"],
+        }
+    ]
+
+
+def test_convert_tools_includes_results_for_image_only_web_search() -> None:
+    web_tool = WebSearchTool(search_content_types=["image"])
+
+    converted = Converter.convert_tools([web_tool], handoffs=[], model="gpt-5.4")
+
+    assert converted.includes == ["web_search_call.results"]
+    assert converted.tools == [
+        {
+            "type": "web_search",
+            "filters": None,
+            "user_location": None,
+            "search_context_size": "medium",
+            "search_content_types": ["image"],
         }
     ]
 


### PR DESCRIPTION
This pull request adds Agent SDK support for Responses API image search through the existing `WebSearchTool`.

## Summary
- Add optional `search_content_types` to `WebSearchTool` while preserving existing default payloads.
- Forward `search_content_types` to Responses API tool payloads.
- Automatically include `web_search_call.results` whenever image results are requested.
- Add converter tests for omitted, mixed text/image, and image-only content types.

## Test plan
- Converter tests pass for the changed OpenAI Responses conversion path, including mixed text/image and image-only search content types.
- Ruff lint and formatting checks pass for the touched files.
- Pyright passes for the touched files.

Full repo verification was attempted with `.agents/skills/code-change-verification/scripts/run.sh`; it passed formatting and linting, then failed on missing optional extras/imports in the temporary clone environment (Runloop, voice/numpy, litellm, SQLAlchemy), not on this converter change.