### PR TITLE
fix: use non-None value for output in FunctionSpanData

### DIFF
--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -161,7 +161,7 @@ class FunctionSpanData(SpanData):
             "type": self.type,
             "name": self.name,
             "input": self.input,
-            "output": str(self.output) if self.output else None,
+            "output": str(self.output) if self.output is not None else None,
             "mcp_data": self.mcp_data,
         }
 


### PR DESCRIPTION
The `export()` method used a truthiness check to serialize the tool output:

```python
# before
"output": str(self.output) if self.output else None,
```

Any falsy return value (`0`, `False`, `""`, `[]`, `{}`) was silently dropped and shown as `null` in the traces dashboard. A function tool returning `0` (counter, difference) or `False` (predicate) would appear to have returned nothing.

```python
# after
"output": str(self.output) if self.output is not None else None,
```