### PR TITLE
fix: add missing entries to span __slots__

### DIFF
--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -321,6 +321,7 @@ class TranscriptionSpanData(SpanData):
 
     __slots__ = (
         "input",
+        "input_format",
         "output",
         "model",
         "model_config",
@@ -363,7 +364,7 @@ class SpeechSpanData(SpanData):
     Includes input, output, model, model configuration, and first content timestamp.
     """
 
-    __slots__ = ("input", "output", "model", "model_config", "first_content_at")
+    __slots__ = ("input", "output", "output_format", "model", "model_config", "first_content_at")
 
     def __init__(
         self,


### PR DESCRIPTION
## Problem

`TranscriptionSpanData` and `SpeechSpanData` both set and read instance attributes that are absent from their `__slots__` declarations:

- `TranscriptionSpanData`: sets `self.input_format` (line 338), reads it in `export()` (line 352) — not in `__slots__` (line 322–327)
- `SpeechSpanData`: sets `self.output_format` (line 379), reads it in `export()` (line 394) — not in `__slots__` (line 366)

Because `SpanData` (the base class) doesn't define `__slots__`, instances have a `__dict__` fallback, so the code works today — but:

1. The `__slots__` declarations are incomplete and misleading
2. If `SpanData` ever gains `__slots__ = ()`, both attributes become un-settable and `__init__` raises `AttributeError` immediately
3. Any reflection-based code (e.g. `vars(span)`, serializers walking `__slots__`) sees an inconsistent picture

## Fix

Add the two missing entries — one line each:

```python
# TranscriptionSpanData
__slots__ = ("input", "input_format", "output", "model", "model_config")

# SpeechSpanData  
__slots__ = ("input", "output", "output_format", "model", "model_config", "first_content_at")
```