### PR TITLE
fix: redact invalid JSON payload in ModelBehaviorError data

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -1451,14 +1451,23 @@ def _build_handled_function_tool_error_handler(
 
 def _parse_function_tool_json_input(*, tool_name: str, input_json: str) -> dict[str, Any]:
     """Decode raw tool arguments with consistent diagnostics."""
+    json_decode_error: Exception | None = None
     try:
         parsed = json.loads(input_json) if input_json else {}
     except Exception as exc:
+        json_decode_error = exc
+
+    if json_decode_error is not None:
+        base_message = f"Invalid JSON input for tool {tool_name}"
         if _debug.DONT_LOG_TOOL_DATA:
-            logger.debug(f"Invalid JSON input for tool {tool_name}")
-        else:
-            logger.debug(f"Invalid JSON input for tool {tool_name}: {input_json}")
-        raise ModelBehaviorError(f"Invalid JSON input for tool {tool_name}: {input_json}") from exc
+            logger.debug(base_message)
+            # Raise outside the ``except`` block so the JSONDecodeError, which
+            # carries the raw payload in ``.doc``, is not attached as the
+            # ``__context__`` of the redacted ModelBehaviorError.
+            raise ModelBehaviorError(base_message)
+        detailed_message = f"{base_message}: {input_json}"
+        logger.debug(detailed_message)
+        raise ModelBehaviorError(detailed_message) from json_decode_error
 
     if not isinstance(parsed, dict):
         raise ModelBehaviorError(f"Invalid JSON input for tool {tool_name}: expected a JSON object")

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -3,6 +3,7 @@ import contextlib
 import copy
 import dataclasses
 import json
+import logging
 import time
 from collections.abc import Callable
 from typing import Any, cast
@@ -11,6 +12,7 @@ import pytest
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+import agents._debug as _debug
 import agents.tool as tool_module
 from agents import (
     Agent,
@@ -778,6 +780,68 @@ async def test_function_tool_rejects_non_object_json_input(input_json: str) -> N
             ),
             input_json,
         )
+
+
+@pytest.mark.asyncio
+async def test_function_tool_bad_json_redacts_payload_when_dont_log_tool_data(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", True)
+
+    def echo(value: str) -> str:
+        return value
+
+    tool = function_tool(echo, name_override="echo_tool", failure_error_function=None)
+    bad_json = '{"secret":"SECRET_TOKEN_123"'
+
+    with pytest.raises(ModelBehaviorError) as exc_info:
+        await tool.on_invoke_tool(
+            ToolContext(
+                None,
+                tool_name="echo_tool",
+                tool_call_id="1",
+                tool_arguments=bad_json,
+            ),
+            bad_json,
+        )
+
+    assert str(exc_info.value) == "Invalid JSON input for tool echo_tool"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+    assert "SECRET_TOKEN_123" not in str(exc_info.value)
+    assert "SECRET_TOKEN_123" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_function_tool_bad_json_includes_payload_when_tool_logging_enabled(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    def echo(value: str) -> str:
+        return value
+
+    tool = function_tool(echo, name_override="echo_tool", failure_error_function=None)
+    bad_json = '{"secret":"SECRET_TOKEN_123"'
+
+    with pytest.raises(ModelBehaviorError) as exc_info:
+        await tool.on_invoke_tool(
+            ToolContext(
+                None,
+                tool_name="echo_tool",
+                tool_call_id="1",
+                tool_arguments=bad_json,
+            ),
+            bad_json,
+        )
+
+    assert str(exc_info.value) == f"Invalid JSON input for tool echo_tool: {bad_json}"
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+    assert exc_info.value.__cause__.doc == bad_json
+    assert "SECRET_TOKEN_123" in str(exc_info.value)
+    assert "SECRET_TOKEN_123" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -46,6 +46,7 @@ from agents import (
     TResponseInputItem,
     Usage,
     UserError,
+    _debug,
     tool_namespace,
     tool_output_guardrail,
     trace,
@@ -2814,7 +2815,11 @@ async def test_multiple_final_output_leads_to_final_output_next_step():
 
 
 @pytest.mark.asyncio
-async def test_input_guardrail_runs_on_invalid_json():
+async def test_input_guardrail_runs_on_invalid_json(monkeypatch: pytest.MonkeyPatch):
+    # Opt in to payload logging so the JSON decode error chain is preserved and the
+    # default failure formatter can recover the friendly "parsing tool arguments" message.
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
     guardrail_calls: list[str] = []
 
     def guardrail(data) -> ToolGuardrailFunctionOutput:

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -16,6 +16,7 @@ from agents import (
     RunContextWrapper,
     Runner,
     TResponseInputItem,
+    _debug,
 )
 
 from .fake_model import FakeModel
@@ -133,7 +134,11 @@ async def test_multi_turn_no_handoffs():
 
 
 @pytest.mark.asyncio
-async def test_tool_call_error():
+async def test_tool_call_error(monkeypatch: pytest.MonkeyPatch):
+    # Opt in to tool payload logging so the friendly "parsing tool arguments" message,
+    # which depends on inspecting the chained JSONDecodeError, is preserved.
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
     model = FakeModel(tracing_enabled=True)
 
     agent = Agent(

--- a/tests/test_tracing_errors_streamed.py
+++ b/tests/test_tracing_errors_streamed.py
@@ -19,6 +19,7 @@ from agents import (
     RunContextWrapper,
     Runner,
     TResponseInputItem,
+    _debug,
 )
 
 from .fake_model import FakeModel
@@ -160,7 +161,11 @@ async def test_multi_turn_no_handoffs():
 
 
 @pytest.mark.asyncio
-async def test_tool_call_error():
+async def test_tool_call_error(monkeypatch: pytest.MonkeyPatch):
+    # Opt in to tool payload logging so the friendly "parsing tool arguments" message,
+    # which depends on inspecting the chained JSONDecodeError, is preserved.
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
     model = FakeModel(tracing_enabled=True)
 
     agent = Agent(


### PR DESCRIPTION
### Summary

`_parse_function_tool_json_input` in `src/agents/tool.py` raised `ModelBehaviorError(f"Invalid JSON input for tool {tool_name}: {input_json}") from exc` regardless of `OPENAI_AGENTS_DONT_LOG_TOOL_DATA`. The same handler in `MCPUtil.invoke_mcp_tool` was hardened to redact the payload and drop the chained `JSONDecodeError` (whose `.doc` attribute carries the raw input), but the function tool path still leaked the input via the exception message, `__cause__`, and `__context__`, which then surfaces in traceback display, logs, and trace propagation.

This change mirrors the MCP handler: when `DONT_LOG_TOOL_DATA` is on, raise outside the `except` block with a payload-free message and no chained exception. When logging is opted in, preserve the existing message and the chained `JSONDecodeError` so `default_tool_error_function` can still recover the friendly "parsing tool arguments" output.

### Test plan

- `uv run pytest tests/test_function_tool.py tests/test_run_step_execution.py tests/test_tracing_errors.py tests/test_tracing_errors_streamed.py tests/mcp/test_mcp_util.py` (224 passed)
- `uv run pytest tests/ --ignore=tests/realtime --ignore=tests/voice --ignore=tests/extensions/memory --ignore=tests/models --ignore=tests/extensions/sandbox` (3079 passed, 19 skipped)
- `uv run ruff check`, `uv run ruff format --check`, `uv run mypy` on the touched files

New tests cover the redaction and non-redaction paths next to the existing MCP equivalents. Three pre-existing tests that asserted the friendly "parsing tool arguments" output now opt in to payload logging via `monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)`, which is the only configuration in which the chained `JSONDecodeError` is still attached.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass