### PR TITLE
fix(mcp): use is not None to cache empty tools list correctly

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -830,7 +830,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
         try:
             # Return from cache if caching is enabled, we have tools, and the cache is not dirty
-            if self.cache_tools_list and not self._cache_dirty and self._tools_list:
+            if self.cache_tools_list and not self._cache_dirty and self._tools_list is not None:
                 tools = self._tools_list
             else:
                 # Fetch the tools from the server


### PR DESCRIPTION
When an MCP server returns an empty tools list, `self._tools_list` is `[]` which is falsy. The cache check

```python
if self.cache_tools_list and not self._cache_dirty and self._tools_list:
```

treats an empty cached list the same as an uncached one, causing a redundant re-fetch on every subsequent `list_tools()` call even when `cache_tools_list=True` and the cache is clean.

The field is initialized to `None` (line 600) to mean "not yet fetched," so the correct guard is `is not None`.