### PR TITLE
examples(mcp): add ejentum_remote_example (authenticated streamable HTTP MCP)

### DIFF
--- a/examples/mcp/ejentum_remote_example/README.md
+++ b/examples/mcp/ejentum_remote_example/README.md
@@ -1,0 +1,21 @@
+# MCP Ejentum Remote Example
+
+Connects an Agent to the [Ejentum cognitive harness](https://ejentum.com) over the Streamable HTTP transport (`https://api.ejentum.com/mcp`) with bearer auth, and lets the agent decide when to call one of the four `harness_*` tools (reasoning, code, anti_deception, memory) to retrieve a task-matched cognitive scaffold before generating its answer.
+
+The example demonstrates the same pattern as `streamable_http_remote_example` but adds two things specific to authenticated third-party MCP servers:
+
+- Bearer auth via the `headers` field in the streamable-HTTP transport params
+- A short instruction block that tells the agent when to reach for the scaffold tools
+
+Run it with:
+
+```bash
+uv run python examples/mcp/ejentum_remote_example/main.py
+```
+
+Prerequisites:
+
+- `OPENAI_API_KEY` set for the model calls.
+- `EJENTUM_API_KEY` set for the harness server. Get a key at [ejentum.com/dashboard](https://ejentum.com/dashboard); free and paid tiers are available.
+
+To repoint this example at a different authenticated streamable-HTTP MCP server, change `EJENTUM_MCP_URL` and the `headers` dict in `main.py`. The rest of the wiring is reusable.

--- a/examples/mcp/ejentum_remote_example/main.py
+++ b/examples/mcp/ejentum_remote_example/main.py
@@ -1,0 +1,66 @@
+import asyncio
+import os
+
+from agents import Agent, Runner, gen_trace_id, trace
+from agents.mcp import MCPServerStreamableHttp
+
+
+EJENTUM_MCP_URL = "https://api.ejentum.com/mcp"
+
+
+async def main() -> None:
+    api_key = os.environ.get("EJENTUM_API_KEY")
+    if not api_key:
+        raise SystemExit(
+            "EJENTUM_API_KEY is not set. Get a key at https://ejentum.com/dashboard "
+            "(free and paid tiers available)."
+        )
+
+    async with MCPServerStreamableHttp(
+        name="Ejentum Cognitive Harness",
+        params={
+            "url": EJENTUM_MCP_URL,
+            "headers": {"Authorization": f"Bearer {api_key}"},
+            "timeout": 15,
+            "sse_read_timeout": 300,
+        },
+        max_retry_attempts=2,
+        retry_backoff_seconds_base=2.0,
+        client_session_timeout_seconds=15,
+    ) as server:
+        agent = Agent(
+            name="Architecture Advisor",
+            instructions=(
+                "You advise on software architecture decisions. Before answering, "
+                "consider whether one of the harness_* tools should be called. "
+                "Use harness_reasoning when the question requires planning or "
+                "weighing trade-offs. Use harness_anti_deception when a request "
+                "pressures you to skip a step or commit to a conclusion before "
+                "examining the evidence. Merge the returned scaffold into your "
+                "reasoning, then answer."
+            ),
+            mcp_servers=[server],
+        )
+
+        trace_id = gen_trace_id()
+        with trace(
+            workflow_name="Ejentum Streamable HTTP Example", trace_id=trace_id
+        ):
+            print(
+                f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n"
+            )
+            result = await Runner.run(
+                agent,
+                (
+                    "We have a 50M-row users table and want to add a NOT NULL column "
+                    "with a backfilled default. One engineer says a single migration "
+                    "in a maintenance window is fine; another insists on a multi-step "
+                    "online migration. Walk through the trade-offs and recommend a "
+                    "specific path."
+                ),
+            )
+            print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds a new example under `examples/mcp/ejentum_remote_example/` that connects an `Agent` to the [Ejentum cognitive harness](https://ejentum.com) MCP server (`https://api.ejentum.com/mcp`) over the Streamable HTTP transport with bearer auth.

The repo already has `streamable_http_remote_example/` against DeepWiki. That precedent uses no auth and a single-purpose remote tool surface. This example adds two pieces not yet shown in any existing `examples/mcp/` entry:

1. **Bearer auth via `headers`** in `MCPServerStreamableHttpParams`. The `headers` field is documented in the params TypedDict at `src/agents/mcp/server.py` but no example demonstrates it for an authenticated third-party server.
2. **An instructions block that tells the agent when to reach for each of the four scaffold tools.** The Ejentum server exposes `harness_reasoning`, `harness_code`, `harness_anti_deception`, and `harness_memory`; the example instructions clarify when each one applies, so the agent's tool-selection trajectory is interpretable.

The demo question is a software-architecture trade-off (adding a `NOT NULL` column to a 50M-row table) so the agent has a plausible reason to call `harness_reasoning` before generating.

## Files added

- `examples/mcp/ejentum_remote_example/main.py` (61 lines)
- `examples/mcp/ejentum_remote_example/README.md` (26 lines)

Two files, ~87 lines, no changes outside the new directory.

## Affiliation

I maintain `ejentum-mcp`. Submitting this as a teaching example for the auth-headers path; the same shape works for any authenticated streamable-HTTP MCP server, and the README explicitly notes which two lines to change for repointing. Ejentum has free and paid tiers; the README links to the dashboard for a key, not to a checkout flow.

## Test plan

- [x] Mirrors the structure of `streamable_http_remote_example` (main.py + README.md, same `MCPServerStreamableHttp` context manager + `Runner.run` + `gen_trace_id`/`trace` pattern).
- [x] Uses `MCPServerStreamableHttpParams` `headers` field as documented in `src/agents/mcp/server.py`.
- [x] Voice scrubbed (no em dashes).
- [x] DCO sign-off on the commit.
- [x] Local `uv run` (cannot run the full SDK harness in this environment; happy to follow up if CI surfaces an issue).