### PR TITLE
fix: clean up orphaned messages in delete_branch and propagate add_items metadata errors

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -153,6 +153,9 @@ class AdvancedSQLiteSession(SQLiteSession):
                     except Exception as cleanup_error:
                         conn.rollback()
                         self._logger.error(f"Failed to cleanup orphaned messages: {cleanup_error}")
+                    raise RuntimeError(
+                        f"Failed to persist structure metadata for session {self.session_id}"
+                    ) from e
 
         await asyncio.to_thread(_add_items_sync)
 
@@ -788,12 +791,18 @@ class AdvancedSQLiteSession(SQLiteSession):
 
                     conn.commit()
 
-                    return usage_deleted, structure_deleted
+                    # Clean up messages that are no longer referenced by any branch.
+                    orphaned_deleted = self._cleanup_orphaned_messages_sync(conn)
+                    if orphaned_deleted:
+                        conn.commit()
 
-        usage_deleted, structure_deleted = await asyncio.to_thread(_delete_sync)
+                    return usage_deleted, structure_deleted, orphaned_deleted
+
+        usage_deleted, structure_deleted, orphaned_deleted = await asyncio.to_thread(_delete_sync)
 
         self._logger.info(
-            f"Deleted branch '{branch_id}': {structure_deleted} message entries, {usage_deleted} usage entries"  # noqa: E501
+            f"Deleted branch '{branch_id}': {structure_deleted} structure entries, "
+            f"{usage_deleted} usage entries, {orphaned_deleted} orphaned messages removed"
         )
 
     async def list_branches(self) -> list[dict[str, Any]]:

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sqlite3
 import tempfile
 from pathlib import Path
 from typing import Any, cast
@@ -1394,6 +1395,72 @@ async def test_concurrent_add_items_preserves_message_structure_for_file_db():
         assert len(rows) == len(expected_contents)
 
         session.close()
+
+
+async def test_delete_branch_cleans_up_orphaned_messages():
+    """Verify that delete_branch removes messages only referenced by the deleted branch.
+
+    Regression test for #3346: delete_branch() previously left branch-only
+    messages in the messages table after removing their structure metadata.
+    """
+    session = AdvancedSQLiteSession(session_id="orphan_cleanup", create_tables=True)
+
+    # Add items to main branch.
+    await session.add_items([{"role": "user", "content": "Shared message"}])
+
+    # Create a branch from turn 1 and add a branch-only message.
+    await session.create_branch_from_turn(1, "feature_branch")
+    await session.add_items([{"role": "user", "content": "Branch-only message"}])
+
+    # Record total message count before deletion.
+    with session._locked_connection() as conn:
+        total_before = conn.execute(
+            f"SELECT COUNT(*) FROM {session.messages_table} WHERE session_id = ?",
+            (session.session_id,),
+        ).fetchone()[0]
+
+    assert total_before == 2  # shared + branch-only
+
+    # Delete the feature branch.
+    await session.delete_branch("feature_branch", force=True)
+
+    # The branch-only message should now be removed from messages table.
+    with session._locked_connection() as conn:
+        total_after = conn.execute(
+            f"SELECT COUNT(*) FROM {session.messages_table} WHERE session_id = ?",
+            (session.session_id,),
+        ).fetchone()[0]
+
+    assert total_after == 1  # only the shared message remains
+    session.close()
+
+
+async def test_add_items_raises_on_structure_metadata_failure(monkeypatch):
+    """Verify that add_items raises when structure metadata insertion fails.
+
+    Regression test for #3348: add_items() previously swallowed the exception
+    and reported success even when structure metadata could not be persisted.
+    """
+    session = AdvancedSQLiteSession(session_id="metadata_fail", create_tables=True)
+
+    # Force _insert_structure_metadata to raise.
+    def _raise(*args, **kwargs):
+        raise sqlite3.OperationalError("simulated metadata failure")
+
+    monkeypatch.setattr(session, "_insert_structure_metadata", _raise)
+
+    with pytest.raises(RuntimeError, match="Failed to persist structure metadata"):
+        await session.add_items([{"role": "user", "content": "hello"}])
+
+    # The orphaned message should have been cleaned up.
+    with session._locked_connection() as conn:
+        remaining = conn.execute(
+            f"SELECT COUNT(*) FROM {session.messages_table} WHERE session_id = ?",
+            (session.session_id,),
+        ).fetchone()[0]
+
+    assert remaining == 0
+    session.close()
 
 
 async def test_output_tokens_details_persisted_when_input_details_missing():


### PR DESCRIPTION
### Summary

Two correctness fixes for `AdvancedSQLiteSession`, each with a regression test.

**#3346** — `delete_branch()` removes `message_structure` rows but never cleans up the
actual messages, leaking storage indefinitely. The fix reuses the existing
`_cleanup_orphaned_messages_sync()` (which `add_items()` already calls on failure)
so there's no new deletion logic — just a missing call site.

**#3348** — `add_items()` catches `_insert_structure_metadata()` failures, runs cleanup,
but then returns normally. Callers cannot distinguish success from partial failure.
The fix adds a `raise RuntimeError(...) from e` after the existing cleanup block (3 lines).

### Approach

Both fixes reuse existing infrastructure rather than introducing new code:

| Fix | Approach | Why |
|-----|----------|-----|
| #3346 | Call `self._cleanup_orphaned_messages_sync(conn)` after structure deletion | This method already exists at L491 and uses the same `LEFT JOIN ... IS NULL` pattern — no new query logic needed |
| #3348 | Add `raise RuntimeError(...) from e` after the existing `except` cleanup block | The cleanup + logging already exists; only the re-raise was missing |

### Before / After

| Scenario | Before (main) | After (this PR) |
|----------|---------------|-----------------|
| `delete_branch("feat")` with branch-only messages | `message_structure` deleted, orphan rows stay in `messages_table` forever | Orphans removed via existing `_cleanup_orphaned_messages_sync()` |
| `add_items([...])` when metadata fails | Logs error, returns `None` — caller assumes success | Raises `RuntimeError` with cause chain; caller can handle or retry |
| Run Test | <img height="400" alt="image" src="https://github.com/user-attachments/assets/9c1aeb67-2c9f-4e45-a9ce-6674c5aacc28" /> |  <img height="400" alt="image" src="https://github.com/user-attachments/assets/c017176b-a21f-44b0-9e08-720c263ba372" /> |
| Existing test suite | 36 pass | 36 pass (zero regressions) + 2 new |


### Test plan

- All 36 pre-existing tests pass unchanged (zero regressions)
- `test_delete_branch_cleans_up_orphaned_messages`: creates branch-only messages, deletes branch, asserts `messages_table` is clean
- `test_add_items_raises_on_structure_metadata_failure`: monkeypatches metadata insertion to fail, asserts `RuntimeError` and verifies orphan cleanup ran

```
$ uv run pytest tests/extensions/memory/test_advanced_sqlite_session.py -v
...
38 passed in 0.22s
```
<img width="1241" height="191" alt="image" src="https://github.com/user-attachments/assets/20e348ce-65df-436f-9e26-d1a7ad033793" />


### Issue number

Closes #3346
Closes #3348

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass

