### PR TITLE
fix(runloop): declare SDK model aliases for type checkers

### DIFF
--- a/src/agents/extensions/sandbox/runloop/sandbox.py
+++ b/src/agents/extensions/sandbox/runloop/sandbox.py
@@ -22,7 +22,7 @@ import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 from urllib.parse import urlsplit
 
 from pydantic import BaseModel, Field
@@ -71,9 +71,9 @@ _RUNLOOP_SANDBOX_SNAPSHOT_MAGIC = b"RUNLOOP_SANDBOX_SNAPSHOT_V1\n"
 
 logger = logging.getLogger(__name__)
 
-RunloopAfterIdle = _RunloopSdkAfterIdle
-RunloopLaunchParameters = _RunloopSdkLaunchParameters
-RunloopUserParameters = _RunloopSdkUserParameters
+RunloopAfterIdle: TypeAlias = _RunloopSdkAfterIdle
+RunloopLaunchParameters: TypeAlias = _RunloopSdkLaunchParameters
+RunloopUserParameters: TypeAlias = _RunloopSdkUserParameters
 
 
 @dataclass(frozen=True)
@@ -1387,7 +1387,7 @@ def _runloop_launch_parameters_payload(
     launch_parameters: RunloopLaunchParameters | None,
     user_parameters: RunloopUserParameters | None,
 ) -> dict[str, object] | None:
-    payload = (
+    payload: dict[str, object] = (
         launch_parameters.to_dict(mode="json", exclude_none=True, exclude_defaults=True)
         if launch_parameters is not None
         else {}

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -1463,8 +1463,9 @@ async def test_execute_function_tool_calls_eager_task_factory_tracks_state_safel
     ]
     loop = asyncio.get_running_loop()
     previous_task_factory = loop.get_task_factory()
-    eager_task_factory = cast(Any, asyncio.eager_task_factory)
-    loop.set_task_factory(eager_task_factory)
+    eager_task_factory = getattr(asyncio, "eager_task_factory", None)
+    assert eager_task_factory is not None
+    loop.set_task_factory(cast(Any, eager_task_factory))
 
     try:
         (


### PR DESCRIPTION
### Summary

This pull request fixes the Runloop sandbox backend's exported SDK model aliases so the backend type-checks cleanly without changing runtime behavior.

The Runloop extension already exports `RunloopAfterIdle`, `RunloopLaunchParameters`, and `RunloopUserParameters` as public symbols, but `sandbox.py` defined them as plain runtime aliases and then reused them in type positions. Pyright and mypy treated those names as variables rather than type aliases and rejected the file when checked directly.

The patch makes those exports explicit `TypeAlias` declarations and adds a concrete annotation for the launch-parameter payload mapping. It also includes a small test-only typing cleanup for `asyncio.eager_task_factory` so the branch does not inherit an existing mypy failure from `main` on the repo's supported Python floor.

### Test plan

- Ran `bash .agents/skills/code-change-verification/scripts/run.sh`
- Ran `make coverage`
- Ran `uv run --python 3.12 pytest tests/test_run_step_execution.py -q -k eager_task_factory`
- Ran `env UV_PROJECT_ENVIRONMENT=.venv_310 uv run --python 3.10 pytest tests/test_run_step_execution.py -q -k eager_task_factory`

### Issue number

N/A

### Checks

- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
