### PR TITLE
fix(advanced-sqlite-session): re-raise structure metadata write failures (fixes #3348)

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -153,6 +153,10 @@ class AdvancedSQLiteSession(SQLiteSession):
                     except Exception as cleanup_error:
                         conn.rollback()
                         self._logger.error(f"Failed to cleanup orphaned messages: {cleanup_error}")
+                    # Re-raise so callers see the failure. Without this, add_items returns
+                    # successfully even though the message_structure rows that get_items joins
+                    # through are missing, and the new items become invisible to later reads.
+                    raise
 
         await asyncio.to_thread(_add_items_sync)
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1422,3 +1422,32 @@ async def test_output_tokens_details_persisted_when_input_details_missing():
     assert turn_usage["output_tokens_details"] == {"reasoning_tokens": 42}
     assert turn_usage["input_tokens_details"] is None
     session.close()
+
+
+async def test_add_items_propagates_structure_metadata_errors():
+    # Regression test for openai/openai-agents-python#3348.
+    # If _insert_structure_metadata raises, add_items used to log the error
+    # and return without raising, so callers could not tell that the new
+    # items were missing from later get_items() reads. Verify the error is
+    # now propagated to the caller and that the orphaned base rows are
+    # cleaned up (so the session stays internally consistent).
+    import sqlite3
+
+    class BrokenMetadataSession(AdvancedSQLiteSession):
+        def _insert_structure_metadata(
+            self, conn: sqlite3.Connection, items: list[TResponseInputItem]
+        ) -> None:
+            raise RuntimeError("simulated structure metadata write failure")
+
+    session = BrokenMetadataSession(session_id="propagation_test", create_tables=True)
+    try:
+        items: list[TResponseInputItem] = [{"role": "user", "content": "hi"}]
+        with pytest.raises(RuntimeError, match="simulated structure metadata write failure"):
+            await session.add_items(items)
+
+        # The orphan cleanup path runs in the except block, so subsequent
+        # reads see an empty session rather than rows the caller cannot reach.
+        retrieved = await session.get_items()
+        assert retrieved == []
+    finally:
+        session.close()


### PR DESCRIPTION
Fixes #3348.

## Bug

`AdvancedSQLiteSession.add_items()` writes rows to the base messages table, commits them, and only then writes `message_structure` rows. If the structure metadata write fails, the previous implementation logs the error and returns without raising:

```python
self._insert_items(conn, items)
conn.commit()  # base rows persisted here
try:
    self._insert_structure_metadata(conn, items)
    conn.commit()
except Exception as e:
    conn.rollback()
    self._logger.error(...)
    try:
        self._cleanup_orphaned_messages_sync(conn)
        ...
    except Exception as cleanup_error:
        ...
    # no `raise` -> add_items returns None as if it succeeded
```

So a caller can observe a successful `add_items()` call even though subsequent `get_items()` calls join through `message_structure` and see nothing. The session looks empty, the caller has no way to know whether to retry, and if cleanup also fails the base table keeps invisible orphan rows.

## Fix

Re-raise the original exception at the end of the outer `except`, after the orphan cleanup attempt. The cleanup path still runs first, so the on-disk state stays internally consistent (no orphaned base rows), and the caller now learns the call failed:

```python
                    except Exception as cleanup_error:
                        conn.rollback()
                        self._logger.error(...)
                    # Re-raise so callers see the failure.
                    raise
```

One-line behavioral change.

## Verification

Added `test_add_items_propagates_structure_metadata_errors` in `tests/extensions/memory/test_advanced_sqlite_session.py`. The test subclasses `AdvancedSQLiteSession` to make `_insert_structure_metadata` raise `RuntimeError`, calls `add_items()`, and asserts:

1. `add_items()` propagates the `RuntimeError` to the caller.
2. After the orphan cleanup runs, `get_items()` returns `[]` (no invisible orphan rows in the base table).

Local A/B:

```
without fix: FAILED ... Failed: DID NOT RAISE <class 'RuntimeError'>
with fix:    PASSED (37/37 tests in test_advanced_sqlite_session.py)
```

`make format`, `make lint`, and `make typecheck` on the touched files are all clean.

## Scope

4-line behavior change in `src/agents/extensions/memory/advanced_sqlite_session.py` plus 29 lines of test coverage. No public API change.