### PR TITLE
fix: allow structured results in tool-end hooks

### DIFF
--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -87,7 +87,7 @@ class RunHooksBase(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         agent: TAgent,
         tool: Tool,
-        result: str,
+        result: Any,
     ) -> None:
         """Called immediately after a local tool is invoked.
 
@@ -161,7 +161,7 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         agent: TAgent,
         tool: Tool,
-        result: str,
+        result: Any,
     ) -> None:
         """Called immediately after a local tool is invoked.
 

--- a/tests/test_agent_hooks.py
+++ b/tests/test_agent_hooks.py
@@ -67,7 +67,7 @@ class AgentHooksForTests(AgentHooks):
         context: RunContextWrapper[TContext],
         agent: Agent[TContext],
         tool: Tool,
-        result: str,
+        result: Any,
     ) -> None:
         self.events["on_tool_end"] += 1
         if isinstance(context, ToolContext):

--- a/tests/test_agent_llm_hooks.py
+++ b/tests/test_agent_llm_hooks.py
@@ -47,7 +47,7 @@ class AgentHooksForTests(AgentHooks):
         context: RunContextWrapper[TContext],
         agent: Agent[TContext],
         tool: Tool,
-        result: str,
+        result: Any,
     ) -> None:
         self.events["on_tool_end"] += 1
 

--- a/tests/test_computer_action.py
+++ b/tests/test_computer_action.py
@@ -510,7 +510,7 @@ class LoggingRunHooks(RunHooks[Any]):
         self.started.append((agent, tool))
 
     async def on_tool_end(
-        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: str
+        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: Any
     ) -> None:
         self.ended.append((agent, tool, result))
 
@@ -529,7 +529,7 @@ class LoggingAgentHooks(AgentHooks[Any]):
         self.started.append((agent, tool))
 
     async def on_tool_end(
-        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: str
+        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: Any
     ) -> None:
         self.ended.append((agent, tool, result))
 

--- a/tests/test_global_hooks.py
+++ b/tests/test_global_hooks.py
@@ -65,7 +65,7 @@ class RunHooksForTests(RunHooks):
         context: RunContextWrapper[TContext],
         agent: Agent[TContext],
         tool: Tool,
-        result: str,
+        result: Any,
     ) -> None:
         self.events["on_tool_end"] += 1
         if isinstance(context, ToolContext):

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -10,7 +10,7 @@ from agents.lifecycle import AgentHooks, RunHooks
 from agents.models.interface import Model
 from agents.run import Runner
 from agents.run_context import AgentHookContext, RunContextWrapper, TContext
-from agents.tool import Tool
+from agents.tool import Tool, function_tool
 from agents.tool_context import ToolContext
 from tests.test_agent_llm_hooks import AgentHooksForTests
 
@@ -60,7 +60,7 @@ class RunHooksForTests(RunHooks):
         context: RunContextWrapper[TContext],
         agent: Agent[TContext],
         tool: Tool,
-        result: str,
+        result: Any,
     ) -> None:
         self.events["on_tool_end"] += 1
         if isinstance(context, ToolContext):
@@ -386,3 +386,53 @@ async def test_streamed_run_hooks_count_tool_and_handoff_invocations():
     assert hooks.events["on_agent_start"] == 2
     assert hooks.events["on_agent_end"] == 1
     assert len(hooks.tool_context_ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_hooks_receive_structured_tool_result():
+    class RecordingRunHooks(RunHooks):
+        def __init__(self):
+            self.result: Any = None
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            tool: Tool,
+            result: Any,
+        ) -> None:
+            self.result = result
+
+    class RecordingAgentHooks(AgentHooks):
+        def __init__(self):
+            self.result: Any = None
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            tool: Tool,
+            result: Any,
+        ) -> None:
+            self.result = result
+
+    @function_tool
+    def get_metadata() -> dict[str, Any]:
+        return {"status": "ok", "count": 1}
+
+    run_hooks = RecordingRunHooks()
+    agent_hooks = RecordingAgentHooks()
+    model = FakeModel()
+    agent = Agent(name="test", model=model, tools=[get_metadata], hooks=agent_hooks)
+
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_metadata", "{}")],
+            [get_text_message("done")],
+        ]
+    )
+
+    await Runner.run(agent, input="user_message", hooks=run_hooks)
+
+    assert run_hooks.result == {"status": "ok", "count": 1}
+    assert agent_hooks.result == {"status": "ok", "count": 1}

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -1018,7 +1018,7 @@ async def test_multiple_tool_calls_surface_hook_failure_over_sibling_cancellatio
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: Any,
         ) -> None:
             if tool.name != "ok_tool":
                 return
@@ -1117,7 +1117,7 @@ async def test_function_tool_preserves_contextvar_from_tool_body_to_post_invoke_
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: Any,
         ) -> None:
             seen_values.append(("hook", tool_state.get()))
 
@@ -1249,7 +1249,7 @@ async def test_multiple_tool_calls_do_not_run_on_tool_end_for_cancelled_tool():
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: Any,
         ) -> None:
             self.results[tool.name] = result
             if tool.name == "ok_tool":
@@ -1308,7 +1308,7 @@ async def test_multiple_tool_calls_skip_post_invoke_work_for_cancelled_sibling_t
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: Any,
         ) -> None:
             if tool.name == "waiting_tool":
                 on_tool_end_called.set()
@@ -1378,7 +1378,7 @@ async def test_execute_function_tool_calls_parent_cancellation_skips_post_invoke
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: Any,
         ) -> None:
             on_tool_end_called.set()
 
@@ -1922,7 +1922,7 @@ async def test_multiple_tool_calls_allow_successful_sibling_on_tool_end_to_finis
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: Any,
         ) -> None:
             if tool.name != "ok_tool":
                 return


### PR DESCRIPTION
## Summary
- change RunHooksBase.on_tool_end and AgentHooksBase.on_tool_end to accept structured tool results
- add regression coverage for dict-valued function tool results reaching both run-level and agent-level hooks

Fixes #3512

## To verify
- uv run pytest tests/test_run_hooks.py -q
- uv run pytest tests/test_agent_hooks.py tests/test_agent_llm_hooks.py tests/test_global_hooks.py tests/test_computer_action.py tests/test_run_step_execution.py -q
- uv run ruff check src/agents/lifecycle.py tests/test_run_hooks.py tests/test_agent_hooks.py tests/test_agent_llm_hooks.py tests/test_global_hooks.py tests/test_computer_action.py tests/test_run_step_execution.py
- uv run ruff format --check src/agents/lifecycle.py tests/test_run_hooks.py tests/test_agent_hooks.py tests/test_agent_llm_hooks.py tests/test_global_hooks.py tests/test_computer_action.py tests/test_run_step_execution.py
- uv run mypy src/agents/lifecycle.py tests/test_run_hooks.py tests/test_agent_hooks.py tests/test_agent_llm_hooks.py tests/test_global_hooks.py tests/test_computer_action.py tests/test_run_step_execution.py
- uv run pyright --project pyrightconfig.json src/agents/lifecycle.py tests/test_run_hooks.py tests/test_agent_hooks.py tests/test_agent_llm_hooks.py tests/test_global_hooks.py tests/test_computer_action.py tests/test_run_step_execution.py