### PR TITLE
fix: #3515 guard shared approval state during serialization

### DIFF
--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from threading import RLock
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Any, Generic, SupportsIndex
 
 from typing_extensions import TypeVar
 
@@ -48,6 +48,9 @@ class _ApprovalRecords(dict[str, _ApprovalRecord]):
         super().__init__(*args, **kwargs)
         self.lock = RLock() if lock is None else lock
 
+    def __reduce_ex__(self, protocol: SupportsIndex) -> tuple[Any, ...]:
+        return (self.__class__, (dict(self),))
+
 
 @dataclass(eq=False)
 class RunContextWrapper(Generic[TContext]):
@@ -77,6 +80,15 @@ class RunContextWrapper(Generic[TContext]):
         else:
             self._approvals = _ApprovalRecords(self._approvals)
             self._approvals_lock = self._approvals.lock
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("_approvals_lock", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.__post_init__()
 
     @staticmethod
     def _to_str_or_none(value: Any) -> str | None:

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from threading import RLock
 from typing import TYPE_CHECKING, Any, Generic
 
 from typing_extensions import TypeVar
@@ -61,6 +62,9 @@ class RunContextWrapper(Generic[TContext]):
     _approvals: dict[str, _ApprovalRecord] = field(default_factory=dict)
     tool_input: Any | None = None
     """Structured input for the current agent tool run, when available."""
+
+    def __post_init__(self) -> None:
+        self._approvals_lock: Any = RLock()
 
     @staticmethod
     def _to_str_or_none(value: Any) -> str | None:
@@ -169,11 +173,12 @@ class RunContextWrapper(Generic[TContext]):
         return RunContextWrapper._to_str_or_none(candidate)
 
     def _get_or_create_approval_entry(self, tool_name: str) -> _ApprovalRecord:
-        approval_entry = self._approvals.get(tool_name)
-        if approval_entry is None:
-            approval_entry = _ApprovalRecord()
-            self._approvals[tool_name] = approval_entry
-        return approval_entry
+        with self._approvals_lock:
+            approval_entry = self._approvals.get(tool_name)
+            if approval_entry is None:
+                approval_entry = _ApprovalRecord()
+                self._approvals[tool_name] = approval_entry
+            return approval_entry
 
     def is_tool_approved(self, tool_name: str, call_id: str) -> bool | None:
         """Return True/False/None for the given tool call."""
@@ -181,34 +186,35 @@ class RunContextWrapper(Generic[TContext]):
 
     def _get_approval_status_for_key(self, approval_key: str, call_id: str) -> bool | None:
         """Return True/False/None for a concrete approval key and tool call."""
-        approval_entry = self._approvals.get(approval_key)
-        if not approval_entry:
+        with self._approvals_lock:
+            approval_entry = self._approvals.get(approval_key)
+            if not approval_entry:
+                return None
+
+            # Check for permanent approval/rejection
+            if approval_entry.approved is True and approval_entry.rejected is True:
+                # Approval takes precedence
+                return True
+
+            if approval_entry.approved is True:
+                return True
+
+            if approval_entry.rejected is True:
+                return False
+
+            approved_ids = (
+                set(approval_entry.approved) if isinstance(approval_entry.approved, list) else set()
+            )
+            rejected_ids = (
+                set(approval_entry.rejected) if isinstance(approval_entry.rejected, list) else set()
+            )
+
+            if call_id in approved_ids:
+                return True
+            if call_id in rejected_ids:
+                return False
+            # Per-call approvals are scoped to the exact call ID.
             return None
-
-        # Check for permanent approval/rejection
-        if approval_entry.approved is True and approval_entry.rejected is True:
-            # Approval takes precedence
-            return True
-
-        if approval_entry.approved is True:
-            return True
-
-        if approval_entry.rejected is True:
-            return False
-
-        approved_ids = (
-            set(approval_entry.approved) if isinstance(approval_entry.approved, list) else set()
-        )
-        rejected_ids = (
-            set(approval_entry.rejected) if isinstance(approval_entry.rejected, list) else set()
-        )
-
-        if call_id in approved_ids:
-            return True
-        if call_id in rejected_ids:
-            return False
-        # Per-call approvals are scoped to the exact call ID, so other calls require a new decision.
-        return None
 
     @staticmethod
     def _clear_rejection_message(record: _ApprovalRecord, call_id: str | None) -> None:
@@ -297,13 +303,14 @@ class RunContextWrapper(Generic[TContext]):
             ):
                 candidates.append(pending_tool_name)
 
-        for candidate in candidates:
-            approval_entry = self._approvals.get(candidate)
-            if not approval_entry:
-                continue
-            message = self._get_rejection_message_for_key(approval_entry, call_id)
-            if message is not None:
-                return message
+        with self._approvals_lock:
+            for candidate in candidates:
+                approval_entry = self._approvals.get(candidate)
+                if not approval_entry:
+                    continue
+                message = self._get_rejection_message_for_key(approval_entry, call_id)
+                if message is not None:
+                    return message
         return None
 
     def _apply_approval_decision(
@@ -320,37 +327,38 @@ class RunContextWrapper(Generic[TContext]):
         call_id = self._resolve_call_id(approval_item)
         decision_keys = (exact_approval_key,) if always or call_id is None else approval_keys
 
-        for approval_key in decision_keys:
-            approval_entry = self._get_or_create_approval_entry(approval_key)
-            if always or call_id is None:
-                approval_entry.approved = approve
-                approval_entry.rejected = [] if approve else True
-                if not approve:
-                    approval_entry.approved = False
-                    if rejection_message is not None and call_id is not None:
-                        approval_entry.rejection_messages[call_id] = rejection_message
-                    elif call_id is not None:
-                        self._clear_rejection_message(approval_entry, call_id)
-                    approval_entry.sticky_rejection_message = rejection_message
-                else:
-                    approval_entry.rejection_messages.clear()
-                    approval_entry.sticky_rejection_message = None
-                continue
+        with self._approvals_lock:
+            for approval_key in decision_keys:
+                approval_entry = self._get_or_create_approval_entry(approval_key)
+                if always or call_id is None:
+                    approval_entry.approved = approve
+                    approval_entry.rejected = [] if approve else True
+                    if not approve:
+                        approval_entry.approved = False
+                        if rejection_message is not None and call_id is not None:
+                            approval_entry.rejection_messages[call_id] = rejection_message
+                        elif call_id is not None:
+                            self._clear_rejection_message(approval_entry, call_id)
+                        approval_entry.sticky_rejection_message = rejection_message
+                    else:
+                        approval_entry.rejection_messages.clear()
+                        approval_entry.sticky_rejection_message = None
+                    continue
 
-            opposite = approval_entry.rejected if approve else approval_entry.approved
-            if isinstance(opposite, list) and call_id in opposite:
-                opposite.remove(call_id)
+                opposite = approval_entry.rejected if approve else approval_entry.approved
+                if isinstance(opposite, list) and call_id in opposite:
+                    opposite.remove(call_id)
 
-            target = approval_entry.approved if approve else approval_entry.rejected
-            if isinstance(target, list) and call_id not in target:
-                target.append(call_id)
-            if approve:
-                self._clear_rejection_message(approval_entry, call_id)
-            elif call_id is not None:
-                if rejection_message is not None:
-                    approval_entry.rejection_messages[call_id] = rejection_message
-                else:
+                target = approval_entry.approved if approve else approval_entry.rejected
+                if isinstance(target, list) and call_id not in target:
+                    target.append(call_id)
+                if approve:
                     self._clear_rejection_message(approval_entry, call_id)
+                elif call_id is not None:
+                    if rejection_message is not None:
+                        approval_entry.rejection_messages[call_id] = rejection_message
+                    else:
+                        self._clear_rejection_message(approval_entry, call_id)
 
     def approve_tool(self, approval_item: ToolApprovalItem, always_approve: bool = False) -> None:
         """Approve a tool call, optionally for all future calls."""
@@ -446,32 +454,56 @@ class RunContextWrapper(Generic[TContext]):
 
     def _rebuild_approvals(self, approvals: Any) -> None:
         """Restore approvals from serialized state."""
-        self._approvals = {}
-        if not isinstance(approvals, Mapping):
-            return
-        for tool_name, record_dict in approvals.items():
-            if not isinstance(tool_name, str) or not isinstance(record_dict, dict):
-                continue
-            record = _ApprovalRecord()
-            record.approved = self._restore_approval_value(record_dict.get("approved", []))
-            record.rejected = self._restore_approval_value(record_dict.get("rejected", []))
-            rejection_messages = record_dict.get("rejection_messages", {})
-            if isinstance(rejection_messages, dict):
-                record.rejection_messages = {
-                    str(call_id): message
-                    for call_id, message in rejection_messages.items()
-                    if isinstance(message, str)
-                }
-            sticky_rejection_message = record_dict.get("sticky_rejection_message")
-            if isinstance(sticky_rejection_message, str):
-                record.sticky_rejection_message = sticky_rejection_message
-            self._approvals[tool_name] = record
+        with self._approvals_lock:
+            self._approvals = {}
+            if not isinstance(approvals, Mapping):
+                return
+            for tool_name, record_dict in approvals.items():
+                if not isinstance(tool_name, str) or not isinstance(record_dict, dict):
+                    continue
+                record = _ApprovalRecord()
+                record.approved = self._restore_approval_value(record_dict.get("approved", []))
+                record.rejected = self._restore_approval_value(record_dict.get("rejected", []))
+                rejection_messages = record_dict.get("rejection_messages", {})
+                if isinstance(rejection_messages, dict):
+                    record.rejection_messages = {
+                        str(call_id): message
+                        for call_id, message in rejection_messages.items()
+                        if isinstance(message, str)
+                    }
+                sticky_rejection_message = record_dict.get("sticky_rejection_message")
+                if isinstance(sticky_rejection_message, str):
+                    record.sticky_rejection_message = sticky_rejection_message
+                self._approvals[tool_name] = record
+
+    def _approval_records_snapshot(self) -> list[tuple[str, _ApprovalRecord]]:
+        """Return a stable snapshot of the shared approval mapping."""
+        with self._approvals_lock:
+            snapshot: list[tuple[str, _ApprovalRecord]] = []
+            for tool_name, record in self._approvals.items():
+                snapshot.append(
+                    (
+                        tool_name,
+                        _ApprovalRecord(
+                            approved=record.approved
+                            if isinstance(record.approved, bool)
+                            else list(record.approved),
+                            rejected=record.rejected
+                            if isinstance(record.rejected, bool)
+                            else list(record.rejected),
+                            rejection_messages=dict(record.rejection_messages),
+                            sticky_rejection_message=record.sticky_rejection_message,
+                        ),
+                    )
+                )
+            return snapshot
 
     def _fork_with_tool_input(self, tool_input: Any) -> RunContextWrapper[TContext]:
         """Create a child context that shares approvals and usage with tool input set."""
         fork = RunContextWrapper(context=self.context)
         fork.usage = self.usage
         fork._approvals = self._approvals
+        fork._approvals_lock = self._approvals_lock
         fork.turn_input = self.turn_input
         fork.tool_input = tool_input
         return fork
@@ -481,6 +513,7 @@ class RunContextWrapper(Generic[TContext]):
         fork = RunContextWrapper(context=self.context)
         fork.usage = self.usage
         fork._approvals = self._approvals
+        fork._approvals_lock = self._approvals_lock
         fork.turn_input = self.turn_input
         return fork
 

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -41,6 +41,14 @@ class _ApprovalRecord:
     sticky_rejection_message: str | None = None
 
 
+class _ApprovalRecords(dict[str, _ApprovalRecord]):
+    """Approval records mapping that carries the lock protecting it."""
+
+    def __init__(self, *args: Any, lock: Any | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.lock = RLock() if lock is None else lock
+
+
 @dataclass(eq=False)
 class RunContextWrapper(Generic[TContext]):
     """This wraps the context object that you passed to `Runner.run()`. It also contains
@@ -64,7 +72,11 @@ class RunContextWrapper(Generic[TContext]):
     """Structured input for the current agent tool run, when available."""
 
     def __post_init__(self) -> None:
-        self._approvals_lock: Any = RLock()
+        if isinstance(self._approvals, _ApprovalRecords):
+            self._approvals_lock: Any = self._approvals.lock
+        else:
+            self._approvals = _ApprovalRecords(self._approvals)
+            self._approvals_lock = self._approvals.lock
 
     @staticmethod
     def _to_str_or_none(value: Any) -> str | None:
@@ -455,7 +467,7 @@ class RunContextWrapper(Generic[TContext]):
     def _rebuild_approvals(self, approvals: Any) -> None:
         """Restore approvals from serialized state."""
         with self._approvals_lock:
-            self._approvals = {}
+            self._approvals.clear()
             if not isinstance(approvals, Mapping):
                 return
             for tool_name, record_dict in approvals.items():

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -360,7 +360,7 @@ class RunState(Generic[TContext, TAgent]):
         if self._context is None:
             return {}
         approvals_dict: dict[str, dict[str, Any]] = {}
-        for tool_name, record in self._context._approvals.items():
+        for tool_name, record in self._context._approval_records_snapshot():
             approvals_dict[tool_name] = {
                 "approved": record.approved
                 if isinstance(record.approved, bool)

--- a/tests/test_run_context_approvals.py
+++ b/tests/test_run_context_approvals.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import copy
+import pickle
+from typing import Any
+
 from agents import Agent, RunContextWrapper
 from agents.run_context import AgentHookContext
 from agents.tool_context import ToolContext
@@ -262,3 +266,31 @@ def test_contexts_constructed_with_shared_approvals_reuse_approval_lock() -> Non
     assert tool_context._approvals_lock is context_wrapper._approvals_lock
     assert hook_context._approvals is context_wrapper._approvals
     assert hook_context._approvals_lock is context_wrapper._approvals_lock
+
+
+def test_context_approval_lock_is_recreated_after_deepcopy() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    approval_item = make_tool_approval_item(agent, call_id="call-1", name="lookup")
+
+    context_wrapper.approve_tool(approval_item)
+    copied_context = copy.deepcopy(context_wrapper)
+
+    assert copied_context.is_tool_approved("lookup", "call-1") is True
+    assert copied_context._approvals is not context_wrapper._approvals
+    copied_approvals: Any = copied_context._approvals
+    assert copied_context._approvals_lock is copied_approvals.lock
+
+
+def test_context_approval_lock_is_recreated_after_pickle_roundtrip() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    approval_item = make_tool_approval_item(agent, call_id="call-1", name="lookup")
+
+    context_wrapper.approve_tool(approval_item)
+    restored_context = pickle.loads(pickle.dumps(context_wrapper))
+
+    assert restored_context.is_tool_approved("lookup", "call-1") is True
+    assert restored_context._approvals is not context_wrapper._approvals
+    restored_approvals: Any = restored_context._approvals
+    assert restored_context._approvals_lock is restored_approvals.lock

--- a/tests/test_run_context_approvals.py
+++ b/tests/test_run_context_approvals.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from agents import Agent, RunContextWrapper
+from agents.run_context import AgentHookContext
+from agents.tool_context import ToolContext
 
 from .utils.factories import make_tool_approval_item
 
@@ -239,3 +241,24 @@ def test_forked_contexts_share_approval_lock_with_parent() -> None:
 
     assert fork._approvals is context_wrapper._approvals
     assert fork._approvals_lock is context_wrapper._approvals_lock
+
+
+def test_contexts_constructed_with_shared_approvals_reuse_approval_lock() -> None:
+    context_wrapper = RunContextWrapper(context=None)
+    tool_context = ToolContext.from_agent_context(
+        context_wrapper,
+        tool_call_id="call-1",
+        tool_name="lookup",
+        tool_arguments="{}",
+    )
+    hook_context = AgentHookContext(
+        context=context_wrapper.context,
+        usage=context_wrapper.usage,
+        _approvals=context_wrapper._approvals,
+        turn_input=context_wrapper.turn_input,
+    )
+
+    assert tool_context._approvals is context_wrapper._approvals
+    assert tool_context._approvals_lock is context_wrapper._approvals_lock
+    assert hook_context._approvals is context_wrapper._approvals
+    assert hook_context._approvals_lock is context_wrapper._approvals_lock

--- a/tests/test_run_context_approvals.py
+++ b/tests/test_run_context_approvals.py
@@ -231,3 +231,11 @@ def test_explicit_same_name_namespace_does_not_alias_to_bare_tool() -> None:
         )
         is True
     )
+
+
+def test_forked_contexts_share_approval_lock_with_parent() -> None:
+    context_wrapper = RunContextWrapper(context=None)
+    fork = context_wrapper._fork_without_tool_input()  # noqa: SLF001
+
+    assert fork._approvals is context_wrapper._approvals
+    assert fork._approvals_lock is context_wrapper._approvals_lock

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -6,6 +6,8 @@ import gc
 import io
 import json
 import logging
+import threading
+import time
 from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -1564,6 +1566,59 @@ class TestRunState:
         assert new_state._context.is_tool_approved(tool_name="tool1", call_id="cid1") is True
         assert new_state._context.is_tool_approved(tool_name="tool2", call_id="cid2") is False
         assert new_state._context.get_rejection_message("tool2", "cid2") is None
+
+    def test_serializing_approvals_blocks_concurrent_approval_mutation(self):
+        """Test that approval serialization is stable while approvals are updated."""
+
+        class SlowItemsDict(dict[str, Any]):
+            def __init__(
+                self,
+                *args: Any,
+                iteration_started: threading.Event,
+                **kwargs: Any,
+            ) -> None:
+                super().__init__(*args, **kwargs)
+                self._iteration_started = iteration_started
+
+            def items(self):
+                iterator = super().items()
+                yielded_first = False
+                for item in iterator:
+                    if not yielded_first:
+                        yielded_first = True
+                        self._iteration_started.set()
+                        time.sleep(0.01)
+                    yield item
+
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="ApprovalAgent")
+        state = make_state(agent, context=context, original_input="test")
+        for index in range(5):
+            state.approve(
+                make_tool_approval_item(agent, call_id=f"cid{index}", name=f"tool{index}")
+            )
+
+        iteration_started = threading.Event()
+        context._approvals = SlowItemsDict(  # noqa: SLF001
+            context._approvals,
+            iteration_started=iteration_started,
+        )
+
+        def approve_after_serialization_starts() -> None:
+            assert iteration_started.wait(timeout=1)
+            state.approve(make_tool_approval_item(agent, call_id="cid-new", name="tool-new"))
+
+        approval_thread = threading.Thread(
+            target=approve_after_serialization_starts,
+        )
+
+        approval_thread.start()
+        serialized = state._serialize_approvals()  # noqa: SLF001
+        approval_thread.join(timeout=1)
+
+        assert iteration_started.is_set()
+        assert "tool-new" not in serialized
+        assert context.is_tool_approved("tool-new", "cid-new") is True
 
     async def test_serializes_and_restores_rejection_messages(self):
         """Test that rejection messages are preserved through serialization."""

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -6,6 +6,7 @@ import gc
 import io
 import json
 import logging
+import pickle
 import threading
 import time
 from collections.abc import AsyncIterator, Callable, Mapping
@@ -1619,6 +1620,20 @@ class TestRunState:
         assert iteration_started.is_set()
         assert "tool-new" not in serialized
         assert context.is_tool_approved("tool-new", "cid-new") is True
+
+    def test_approval_lock_is_recreated_after_run_state_pickle_roundtrip(self):
+        """Test that pickling RunState does not serialize the approval lock."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="ApprovalAgent")
+        state = make_state(agent, context=context, original_input="test")
+        state.approve(make_tool_approval_item(agent, call_id="cid1", name="tool1"))
+
+        restored_state = pickle.loads(pickle.dumps(state))
+
+        assert restored_state._context is not None
+        assert restored_state._context.is_tool_approved("tool1", "cid1") is True
+        restored_approvals: Any = restored_state._context._approvals
+        assert restored_state._context._approvals_lock is restored_approvals.lock
 
     async def test_serializes_and_restores_rejection_messages(self):
         """Test that rejection messages are preserved through serialization."""


### PR DESCRIPTION
This pull request fixes shared approval state concurrency for #3515.

Approval state is shared across forked run contexts so approvals made while tools run can be observed by related execution paths. The shared mapping was not protected during mutation or RunState serialization, which could allow concurrent updates to invalidate iteration over the approval records. This change adds an internal shared lock for approval state, snapshots approval records under that lock before serialization, and adds regression coverage for forked context lock sharing and serialization while approval mutation is attempted concurrently.

This pull request resolves #3515.