### PR TITLE
Widen RunHooks.on_tool_end result type to Any

### DIFF
--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -87,9 +87,14 @@ class RunHooksBase(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         agent: TAgent,
         tool: Tool,
-        result: str,
+        result: Any,
     ) -> None:
         """Called immediately after a local tool is invoked.
+
+        ``result`` is the raw value the tool returned (after any output guardrails). It can be
+        a string, a Pydantic model, a dict, or any other JSON-serialisable value depending on
+        the tool — function tools that return structured output will surface that here without
+        being stringified first.
 
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
@@ -161,9 +166,14 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         agent: TAgent,
         tool: Tool,
-        result: str,
+        result: Any,
     ) -> None:
         """Called immediately after a local tool is invoked.
+
+        ``result`` is the raw value the tool returned (after any output guardrails). It can be
+        a string, a Pydantic model, a dict, or any other JSON-serialisable value depending on
+        the tool — function tools that return structured output will surface that here without
+        being stringified first.
 
         For function-tool invocations, ``context`` is typically a ``ToolContext`` instance,
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -386,3 +386,42 @@ async def test_streamed_run_hooks_count_tool_and_handoff_invocations():
     assert hooks.events["on_agent_start"] == 2
     assert hooks.events["on_agent_end"] == 1
     assert len(hooks.tool_context_ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_on_tool_end_receives_structured_dict_result():
+    # Regression for #3512: tools that return a dict (or any non-string structured
+    # value) used to hit `on_tool_end(... result: str)`'s narrow annotation and
+    # blow up at runtime once strict type checking was involved. The hook should
+    # see the raw payload the tool returned.
+    from agents.tool import function_tool
+
+    captured: dict[str, Any] = {}
+
+    @function_tool
+    def lookup_user(user_id: str) -> dict[str, Any]:
+        return {"id": user_id, "name": "Sam", "active": True}
+
+    class CapturingHooks(RunHooks):
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[TContext],
+            agent: Agent[TContext],
+            tool: Tool,
+            result: Any,
+        ) -> None:
+            captured["result"] = result
+
+    model = FakeModel()
+    agent = Agent(name="test", model=model, tools=[lookup_user])
+
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("lookup_user", json.dumps({"user_id": "u-1"}))],
+            [get_text_message("done")],
+        ]
+    )
+
+    await Runner.run(agent, input="who is u-1", hooks=CapturingHooks())
+
+    assert captured["result"] == {"id": "u-1", "name": "Sam", "active": True}


### PR DESCRIPTION
Closes #3512.

## Summary

Tools can return any JSON-serialisable value — strings, Pydantic models, dicts, lists. The runtime forwards whatever the tool returned (after output guardrails) straight into \`hooks.on_tool_end\`:

\`\`\`python
# src/agents/run_internal/tool_execution.py
final_result = await _execute_tool_output_guardrails(...)  # -> Any
self.hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result)
\`\`\`

But \`RunHooksBase.on_tool_end\` and \`AgentHooksBase.on_tool_end\` declared \`result: str\`. With strict type checking that triggers:

\`\`\`
TypeError: Argument 'result' has incorrect type (expected str, got dict)
\`\`\`

The fix is to align the hook signature with what the runtime actually passes — widen \`result\` to \`Any\` and document what the parameter contains.

## What changed

- \`src/agents/lifecycle.py\` — \`RunHooksBase.on_tool_end\` and \`AgentHooksBase.on_tool_end\` now take \`result: Any\`, with a docstring note that this is the raw post-guardrail value the tool returned.
- \`tests/test_run_hooks.py\` — new \`test_on_tool_end_receives_structured_dict_result\` regression that runs a \`function_tool\` returning \`dict[str, Any]\` and asserts the hook sees the raw dict.

No call sites changed shape — they were already passing through the raw value.

## Compatibility

Backward-compatible widening. Existing overrides that typed the parameter \`str\` keep working because \`str\` is a subtype of \`Any\`; the only behavioural change is that strict runtime type checks now accept the dict/list/Pydantic-model values the runtime was already passing in.

## Verification

\`\`\`
$ uv run pytest tests/test_run_hooks.py tests/test_global_hooks.py tests/test_agent_llm_hooks.py -q
21 passed in 0.18s

$ uv run ruff check src/agents/lifecycle.py tests/test_run_hooks.py
All checks passed!

$ uv run pyright src/agents/lifecycle.py tests/test_run_hooks.py
0 errors, 0 warnings, 0 informations
\`\`\`