### PR TITLE
fix: #3512 type tool-end hook results as object

### DIFF
--- a/examples/basic/agent_lifecycle_example.py
+++ b/examples/basic/agent_lifecycle_example.py
@@ -51,7 +51,7 @@ class CustomAgentHooks(AgentHooks):
         )
 
     async def on_tool_end(
-        self, context: RunContextWrapper, agent: Agent, tool: Tool, result: str
+        self, context: RunContextWrapper, agent: Agent, tool: Tool, result: object
     ) -> None:
         self.event_counter += 1
         print(

--- a/examples/basic/lifecycle_example.py
+++ b/examples/basic/lifecycle_example.py
@@ -88,7 +88,7 @@ class ExampleHooks(RunHooks):
         )
 
     async def on_tool_end(
-        self, context: RunContextWrapper, agent: Agent, tool: Tool, result: str
+        self, context: RunContextWrapper, agent: Agent, tool: Tool, result: object
     ) -> None:
         self.event_counter += 1
         # While this type cast is not ideal,

--- a/examples/sandbox/healthcare_support/workflow.py
+++ b/examples/sandbox/healthcare_support/workflow.py
@@ -87,7 +87,7 @@ class WorkflowHooks(RunHooks[HealthcareSupportContext]):
         context: RunContextWrapper[HealthcareSupportContext],
         agent: Agent[HealthcareSupportContext],
         tool: Tool,
-        result: str,
+        result: object,
     ) -> None:
         tool_context = cast(ToolContext[HealthcareSupportContext], context)
         await context.context.emit(

--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -87,7 +87,7 @@ class RunHooksBase(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         agent: TAgent,
         tool: Tool,
-        result: str,
+        result: object,
     ) -> None:
         """Called immediately after a local tool is invoked.
 
@@ -95,6 +95,10 @@ class RunHooksBase(Generic[TContext, TAgent]):
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
         and ``tool_arguments``. Other local tool families may provide a plain
         ``RunContextWrapper`` instead.
+
+        Simple tool outputs are typically ``str`` values. Function tools may also return
+        structured tool output objects or any value the SDK can stringify before sending it to
+        the model.
         """
         pass
 
@@ -161,7 +165,7 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         context: RunContextWrapper[TContext],
         agent: TAgent,
         tool: Tool,
-        result: str,
+        result: object,
     ) -> None:
         """Called immediately after a local tool is invoked.
 
@@ -169,6 +173,10 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         which exposes tool-call-specific metadata such as ``tool_call_id``, ``tool_name``,
         and ``tool_arguments``. Other local tool families may provide a plain
         ``RunContextWrapper`` instead.
+
+        Simple tool outputs are typically ``str`` values. Function tools may also return
+        structured tool output objects or any value the SDK can stringify before sending it to
+        the model.
         """
         pass
 

--- a/tests/test_agent_hooks.py
+++ b/tests/test_agent_hooks.py
@@ -67,7 +67,7 @@ class AgentHooksForTests(AgentHooks):
         context: RunContextWrapper[TContext],
         agent: Agent[TContext],
         tool: Tool,
-        result: str,
+        result: object,
     ) -> None:
         self.events["on_tool_end"] += 1
         if isinstance(context, ToolContext):

--- a/tests/test_agent_llm_hooks.py
+++ b/tests/test_agent_llm_hooks.py
@@ -47,7 +47,7 @@ class AgentHooksForTests(AgentHooks):
         context: RunContextWrapper[TContext],
         agent: Agent[TContext],
         tool: Tool,
-        result: str,
+        result: object,
     ) -> None:
         self.events["on_tool_end"] += 1
 

--- a/tests/test_computer_action.py
+++ b/tests/test_computer_action.py
@@ -502,7 +502,7 @@ class LoggingRunHooks(RunHooks[Any]):
     def __init__(self) -> None:
         super().__init__()
         self.started: list[tuple[Agent[Any], Any]] = []
-        self.ended: list[tuple[Agent[Any], Any, str]] = []
+        self.ended: list[tuple[Agent[Any], Any, object]] = []
 
     async def on_tool_start(
         self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
@@ -510,7 +510,7 @@ class LoggingRunHooks(RunHooks[Any]):
         self.started.append((agent, tool))
 
     async def on_tool_end(
-        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: str
+        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: object
     ) -> None:
         self.ended.append((agent, tool, result))
 
@@ -521,7 +521,7 @@ class LoggingAgentHooks(AgentHooks[Any]):
     def __init__(self) -> None:
         super().__init__()
         self.started: list[tuple[Agent[Any], Any]] = []
-        self.ended: list[tuple[Agent[Any], Any, str]] = []
+        self.ended: list[tuple[Agent[Any], Any, object]] = []
 
     async def on_tool_start(
         self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
@@ -529,7 +529,7 @@ class LoggingAgentHooks(AgentHooks[Any]):
         self.started.append((agent, tool))
 
     async def on_tool_end(
-        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: str
+        self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any, result: object
     ) -> None:
         self.ended.append((agent, tool, result))
 

--- a/tests/test_global_hooks.py
+++ b/tests/test_global_hooks.py
@@ -65,7 +65,7 @@ class RunHooksForTests(RunHooks):
         context: RunContextWrapper[TContext],
         agent: Agent[TContext],
         tool: Tool,
-        result: str,
+        result: object,
     ) -> None:
         self.events["on_tool_end"] += 1
         if isinstance(context, ToolContext):

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -10,7 +10,7 @@ from agents.lifecycle import AgentHooks, RunHooks
 from agents.models.interface import Model
 from agents.run import Runner
 from agents.run_context import AgentHookContext, RunContextWrapper, TContext
-from agents.tool import Tool
+from agents.tool import Tool, function_tool
 from agents.tool_context import ToolContext
 from tests.test_agent_llm_hooks import AgentHooksForTests
 
@@ -60,7 +60,7 @@ class RunHooksForTests(RunHooks):
         context: RunContextWrapper[TContext],
         agent: Agent[TContext],
         tool: Tool,
-        result: str,
+        result: object,
     ) -> None:
         self.events["on_tool_end"] += 1
         if isinstance(context, ToolContext):
@@ -386,3 +386,55 @@ async def test_streamed_run_hooks_count_tool_and_handoff_invocations():
     assert hooks.events["on_agent_start"] == 2
     assert hooks.events["on_agent_end"] == 1
     assert len(hooks.tool_context_ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_tool_end_hooks_receive_raw_function_tool_result():
+    class RecordingRunHooks(RunHooks):
+        def __init__(self):
+            self.result: object | None = None
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            tool: Tool,
+            result: object,
+        ) -> None:
+            self.result = result
+
+    class RecordingAgentHooks(AgentHooks):
+        def __init__(self):
+            self.result: object | None = None
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            tool: Tool,
+            result: object,
+        ) -> None:
+            self.result = result
+
+    metadata_result: dict[str, object] = {"status": "ok", "count": 1}
+
+    @function_tool
+    def get_metadata() -> dict[str, object]:
+        return metadata_result
+
+    run_hooks = RecordingRunHooks()
+    agent_hooks = RecordingAgentHooks()
+    model = FakeModel()
+    agent = Agent(name="test", model=model, tools=[get_metadata], hooks=agent_hooks)
+
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_metadata", "{}")],
+            [get_text_message("done")],
+        ]
+    )
+
+    await Runner.run(agent, input="user_message", hooks=run_hooks)
+
+    assert run_hooks.result is metadata_result
+    assert agent_hooks.result is metadata_result

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -1018,7 +1018,7 @@ async def test_multiple_tool_calls_surface_hook_failure_over_sibling_cancellatio
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: object,
         ) -> None:
             if tool.name != "ok_tool":
                 return
@@ -1117,7 +1117,7 @@ async def test_function_tool_preserves_contextvar_from_tool_body_to_post_invoke_
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: object,
         ) -> None:
             seen_values.append(("hook", tool_state.get()))
 
@@ -1242,14 +1242,14 @@ async def test_multiple_tool_calls_do_not_run_on_tool_end_for_cancelled_tool():
 
     class RecordingHooks(RunHooks[Any]):
         def __init__(self):
-            self.results: dict[str, str] = {}
+            self.results: dict[str, object] = {}
 
         async def on_tool_end(
             self,
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: object,
         ) -> None:
             self.results[tool.name] = result
             if tool.name == "ok_tool":
@@ -1308,7 +1308,7 @@ async def test_multiple_tool_calls_skip_post_invoke_work_for_cancelled_sibling_t
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: object,
         ) -> None:
             if tool.name == "waiting_tool":
                 on_tool_end_called.set()
@@ -1378,7 +1378,7 @@ async def test_execute_function_tool_calls_parent_cancellation_skips_post_invoke
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: object,
         ) -> None:
             on_tool_end_called.set()
 
@@ -1922,7 +1922,7 @@ async def test_multiple_tool_calls_allow_successful_sibling_on_tool_end_to_finis
             context: RunContextWrapper[Any],
             agent: Agent[Any],
             tool,
-            result: str,
+            result: object,
         ) -> None:
             if tool.name != "ok_tool":
                 return


### PR DESCRIPTION
This pull request fixes tool-end hook result typing so run-level and agent-level hooks accept arbitrary function tool return values without weakening hook implementations with `Any`.

It updates `RunHooksBase.on_tool_end` and `AgentHooksBase.on_tool_end` to use `object`, documents that simple outputs are typically strings while function tools may return structured output objects or stringifyable values, and aligns tests and examples with the revised public hook signature.

This pull request resolves #3512.