### PR TITLE
test: add coverage for empty tool descriptions

### DIFF
--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -1063,3 +1063,103 @@ def test_function_tool_timeout_error_function_must_be_callable() -> None:
             on_invoke_tool=_noop_on_invoke_tool,
             timeout_error_function=cast(Any, "not-callable"),
         )
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        None,
+        "",
+        "   ",
+        "\t",
+        "\n",
+        "  \n  ",
+        "\t\t\t",
+    ],
+)
+def test_function_tool_handles_empty_descriptions(description: str | None) -> None:
+    """Test that function_tool handles None, empty, or whitespace-only descriptions."""
+
+    def sample_tool() -> str:
+        return "result"
+
+    # Test that descriptions are preserved as provided (including whitespace)
+    tool = function_tool(sample_tool, description_override=description)
+    # None becomes empty string, others are preserved
+    expected = "" if description is None else description
+    assert tool.description == expected
+
+
+def test_function_tool_with_docstring_and_override() -> None:
+    """Test how description_override interacts with docstring."""
+
+    def documented_tool() -> str:
+        """This tool has documentation."""
+        return "result"
+
+    # With docstring and empty override, falls back to docstring (empty string is falsy)
+    tool = function_tool(documented_tool, description_override="")
+    assert tool.description == "This tool has documentation."
+
+    # With docstring and None override, should use docstring (no override)
+    tool = function_tool(documented_tool, description_override=None)
+    assert tool.description == "This tool has documentation."
+
+    # With docstring and whitespace override, should use whitespace (explicit override)
+    tool = function_tool(documented_tool, description_override="   ")
+    assert tool.description == "   "
+
+    # With docstring and valid override, should use override
+    tool = function_tool(documented_tool, description_override="Custom description")
+    assert tool.description == "Custom description"
+
+
+def test_function_tool_with_no_docstring_and_no_override() -> None:
+    """Test that function_tool defaults to empty string when no description source."""
+
+    def undocumented_tool() -> str:
+        return "result"
+
+    tool = function_tool(undocumented_tool)
+    assert tool.description == ""
+
+
+def test_function_tool_explicit_description_validation() -> None:
+    """Test direct FunctionTool creation with various descriptions."""
+
+    # Should accept empty description
+    tool = FunctionTool(
+        name="test",
+        description="",
+        params_json_schema={},
+        on_invoke_tool=_noop_on_invoke_tool,
+    )
+    assert tool.description == ""
+
+    # Should accept whitespace description
+    tool = FunctionTool(
+        name="test",
+        description="   ",
+        params_json_schema={},
+        on_invoke_tool=_noop_on_invoke_tool,
+    )
+    assert tool.description == "   "
+
+
+@pytest.mark.parametrize(
+    "description,expected",
+    [
+        ("Valid description", "Valid description"),
+        ("Multi\nline\ndescription", "Multi\nline\ndescription"),
+        ("Description with trailing space ", "Description with trailing space "),
+        ("\tTabbed description", "\tTabbed description"),
+    ],
+)
+def test_function_tool_preserves_valid_descriptions(description: str, expected: str) -> None:
+    """Test that valid descriptions are preserved exactly."""
+
+    def sample_tool() -> str:
+        return "result"
+
+    tool = function_tool(sample_tool, description_override=description)
+    assert tool.description == expected

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -442,3 +442,55 @@ async def test_handoff_is_enabled_filtering_integration():
     agent_names = {h.agent_name for h in filtered_handoffs}
     assert agent_names == {"agent_1", "agent_3"}
     assert "agent_2" not in agent_names
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        None,
+        "",
+        "   ",
+        "\t",
+        "\n",
+        "  \n  ",
+    ],
+)
+def test_handoff_handles_empty_tool_descriptions(description: str | None) -> None:
+    """Test that handoff handles None, empty, or whitespace-only tool descriptions."""
+    agent = Agent(name="test_agent")
+
+    # Handoff should handle empty descriptions gracefully
+    h = handoff(agent, tool_description_override=description)
+
+    # Should use default description if None or empty (falsy)
+    if not description:
+        assert h.tool_description == Handoff.default_tool_description(agent)
+    else:
+        # Non-empty strings (including whitespace) are preserved
+        assert h.tool_description == description
+
+
+def test_handoff_preserves_custom_tool_descriptions() -> None:
+    """Test that handoff preserves custom tool descriptions."""
+    agent = Agent(name="test_agent")
+
+    custom_descriptions = [
+        "Custom handoff description",
+        "Multi\nline\ndescription",
+        "Description with trailing space ",
+        "\tTabbed description",
+    ]
+
+    for desc in custom_descriptions:
+        h = handoff(agent, tool_description_override=desc)
+        assert h.tool_description == desc
+
+
+def test_handoff_default_tool_description_format() -> None:
+    """Test the format of default handoff tool descriptions."""
+    agent = Agent(name="test_agent")
+    h = handoff(agent)
+
+    # Default description should mention the agent name
+    assert "test_agent" in h.tool_description
+    assert h.tool_description == Handoff.default_tool_description(agent)


### PR DESCRIPTION
Adds comprehensive test coverage for edge cases around tool descriptions, including None, empty string, and whitespace-only values.

The tests verify current behavior:
- FunctionTool preserves whitespace descriptions exactly
- Empty string doesn't override docstring (falsy value)
- Handoff falls back to default for falsy descriptions
- Both accept and preserve whitespace-only descriptions

No functionality changes, only test additions to improve coverage.