### PR TITLE
fix: keep advanced session message writes atomic

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -133,26 +133,14 @@ class AdvancedSQLiteSession(SQLiteSession):
         def _add_items_sync():
             """Synchronous helper to add items and structure metadata together."""
             with self._locked_connection() as conn:
-                # Keep both writes in one critical section so message IDs and metadata stay aligned.
-                self._insert_items(conn, items)
-                conn.commit()
                 try:
+                    # Keep both writes in one transaction so message IDs and metadata stay aligned.
+                    self._insert_items(conn, items)
                     self._insert_structure_metadata(conn, items)
                     conn.commit()
-                except Exception as e:
+                except Exception:
                     conn.rollback()
-                    self._logger.error(
-                        f"Failed to add structure metadata for session {self.session_id}: {e}"
-                    )
-                    try:
-                        deleted_count = self._cleanup_orphaned_messages_sync(conn)
-                        if deleted_count:
-                            conn.commit()
-                        else:
-                            conn.rollback()
-                    except Exception as cleanup_error:
-                        conn.rollback()
-                        self._logger.error(f"Failed to cleanup orphaned messages: {cleanup_error}")
+                    raise
 
         await asyncio.to_thread(_add_items_sync)
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sqlite3
 import tempfile
 from pathlib import Path
 from typing import Any, cast
@@ -97,6 +98,37 @@ async def test_advanced_session_basic_functionality(agent: Agent):
     assert len(retrieved) == 2
     assert retrieved[0].get("content") == "Hello"
     assert retrieved[1].get("content") == "Hi there!"
+
+    session.close()
+
+
+async def test_add_items_rolls_back_when_structure_metadata_fails():
+    class BrokenMetadataSession(AdvancedSQLiteSession):
+        def _insert_structure_metadata(
+            self,
+            conn: sqlite3.Connection,
+            items: list[TResponseInputItem],
+        ) -> None:
+            raise RuntimeError("metadata write failed")
+
+    session = BrokenMetadataSession(session_id="metadata_failure_test", create_tables=True)
+
+    with pytest.raises(RuntimeError, match="metadata write failed"):
+        await session.add_items([{"role": "user", "content": "hello"}])
+
+    with session._locked_connection() as conn:
+        message_count = conn.execute(
+            f"SELECT COUNT(*) FROM {session.messages_table} WHERE session_id = ?",
+            (session.session_id,),
+        ).fetchone()[0]
+        structure_count = conn.execute(
+            "SELECT COUNT(*) FROM message_structure WHERE session_id = ?",
+            (session.session_id,),
+        ).fetchone()[0]
+
+    assert message_count == 0
+    assert structure_count == 0
+    assert await session.get_items() == []
 
     session.close()
 


### PR DESCRIPTION
﻿## Summary
- keep AdvancedSQLiteSession message inserts and structure metadata inserts in one transaction
- roll back and surface the metadata error instead of reporting a false-success write
- add a regression test that confirms no base-table or structure rows remain after failure

Fixes #3348.

## To verify
- python -m py_compile src\agents\extensions\memory\advanced_sqlite_session.py tests\extensions\memory\test_advanced_sqlite_session.py
- uv run ruff check src\agents\extensions\memory\advanced_sqlite_session.py tests\extensions\memory\test_advanced_sqlite_session.py
- uv run --extra sqlalchemy pytest tests\extensions\memory\test_advanced_sqlite_session.py -q
- git diff --check
