### PR TITLE
fix: #3346 clean up orphaned messages in delete_branch

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -788,12 +788,18 @@ class AdvancedSQLiteSession(SQLiteSession):
 
                     conn.commit()
 
-                    return usage_deleted, structure_deleted
+                    # Clean up messages that are no longer referenced by any branch.
+                    orphaned_deleted = self._cleanup_orphaned_messages_sync(conn)
+                    if orphaned_deleted:
+                        conn.commit()
 
-        usage_deleted, structure_deleted = await asyncio.to_thread(_delete_sync)
+                    return usage_deleted, structure_deleted, orphaned_deleted
+
+        usage_deleted, structure_deleted, orphaned_deleted = await asyncio.to_thread(_delete_sync)
 
         self._logger.info(
-            f"Deleted branch '{branch_id}': {structure_deleted} message entries, {usage_deleted} usage entries"  # noqa: E501
+            f"Deleted branch '{branch_id}': {structure_deleted} structure entries, "
+            f"{usage_deleted} usage entries, {orphaned_deleted} orphaned messages removed"
         )
 
     async def list_branches(self) -> list[dict[str, Any]]:

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1396,6 +1396,44 @@ async def test_concurrent_add_items_preserves_message_structure_for_file_db():
         session.close()
 
 
+async def test_delete_branch_cleans_up_orphaned_messages():
+    """Verify that delete_branch removes messages only referenced by the deleted branch.
+
+    Regression test for #3346: delete_branch() previously left branch-only
+    messages in the messages table after removing their structure metadata.
+    """
+    session = AdvancedSQLiteSession(session_id="orphan_cleanup", create_tables=True)
+
+    # Add items to main branch.
+    await session.add_items([{"role": "user", "content": "Shared message"}])
+
+    # Create a branch from turn 1 and add a branch-only message.
+    await session.create_branch_from_turn(1, "feature_branch")
+    await session.add_items([{"role": "user", "content": "Branch-only message"}])
+
+    # Record total message count before deletion.
+    with session._locked_connection() as conn:
+        total_before = conn.execute(
+            f"SELECT COUNT(*) FROM {session.messages_table} WHERE session_id = ?",
+            (session.session_id,),
+        ).fetchone()[0]
+
+    assert total_before == 2  # shared + branch-only
+
+    # Delete the feature branch.
+    await session.delete_branch("feature_branch", force=True)
+
+    # The branch-only message should now be removed from messages table.
+    with session._locked_connection() as conn:
+        total_after = conn.execute(
+            f"SELECT COUNT(*) FROM {session.messages_table} WHERE session_id = ?",
+            (session.session_id,),
+        ).fetchone()[0]
+
+    assert total_after == 1  # only the shared message remains
+    session.close()
+
+
 async def test_output_tokens_details_persisted_when_input_details_missing():
     """Regression: output_tokens_details must persist even if input_tokens_details is None.
 


### PR DESCRIPTION
### Summary

`delete_branch()` removes the branch's `message_structure` rows but never cleans up the underlying messages, so messages that were only referenced by the deleted branch stay in the messages table indefinitely.

The session already has a well-factored `_cleanup_orphaned_messages_sync()` helper (the same one `add_items()` relies on for its failure path), so this fix simply calls it after the structure rows are deleted — no new deletion logic, just the missing call site. The log line now also reports how many orphaned messages were removed.

| Scenario | Before (main) | After (this PR) |
|----------|---------------|-----------------|
| `delete_branch("feature")` with branch-only messages | `message_structure` rows deleted, but the messages stay in `messages_table` forever | Orphaned messages removed via the existing `_cleanup_orphaned_messages_sync()` helper |
| Shared messages (referenced by another branch) | Retained | Retained (unchanged) |
| Log output | `Deleted branch 'feature': N message entries, M usage entries` | `Deleted branch 'feature': N structure entries, M usage entries, K orphaned messages removed` |
| New deletion logic introduced | — | None — reuses existing helper |

### Test plan

Adds `test_delete_branch_cleans_up_orphaned_messages`, a regression test that creates a branch-only message, deletes the branch, and asserts the orphaned message is gone while the shared message remains.

```console
$ uv run pytest tests/extensions/memory/test_advanced_sqlite_session.py::test_delete_branch_cleans_up_orphaned_messages -v
tests/extensions/memory/test_advanced_sqlite_session.py::test_delete_branch_cleans_up_orphaned_messages PASSED [100%]
1 passed in 0.26s
```

### Issue number

Closes #3346.

> Note: this is one half of #3498, split into a single-issue PR as suggested for easier review. The other half (#3348) is in #3527.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
