### PR TITLE
fix: #3348 propagate add_items structure metadata failure

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -153,6 +153,9 @@ class AdvancedSQLiteSession(SQLiteSession):
                     except Exception as cleanup_error:
                         conn.rollback()
                         self._logger.error(f"Failed to cleanup orphaned messages: {cleanup_error}")
+                    raise RuntimeError(
+                        f"Failed to persist structure metadata for session {self.session_id}"
+                    ) from e
 
         await asyncio.to_thread(_add_items_sync)
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sqlite3
 import tempfile
 from pathlib import Path
 from typing import Any, cast
@@ -1394,6 +1395,34 @@ async def test_concurrent_add_items_preserves_message_structure_for_file_db():
         assert len(rows) == len(expected_contents)
 
         session.close()
+
+
+async def test_add_items_raises_on_structure_metadata_failure(monkeypatch):
+    """Verify that add_items raises when structure metadata insertion fails.
+
+    Regression test for #3348: add_items() previously swallowed the exception
+    and reported success even when structure metadata could not be persisted.
+    """
+    session = AdvancedSQLiteSession(session_id="metadata_fail", create_tables=True)
+
+    # Force _insert_structure_metadata to raise.
+    def _raise(*args, **kwargs):
+        raise sqlite3.OperationalError("simulated metadata failure")
+
+    monkeypatch.setattr(session, "_insert_structure_metadata", _raise)
+
+    with pytest.raises(RuntimeError, match="Failed to persist structure metadata"):
+        await session.add_items([{"role": "user", "content": "hello"}])
+
+    # The orphaned message should have been cleaned up.
+    with session._locked_connection() as conn:
+        remaining = conn.execute(
+            f"SELECT COUNT(*) FROM {session.messages_table} WHERE session_id = ?",
+            (session.session_id,),
+        ).fetchone()[0]
+
+    assert remaining == 0
+    session.close()
 
 
 async def test_output_tokens_details_persisted_when_input_details_missing():


### PR DESCRIPTION
### Summary

`add_items()` wraps `_insert_structure_metadata()` in a `try/except` that rolls back, logs, and runs orphan cleanup — but then returns normally, so callers can't tell a partial failure from a success.

This adds a single `raise RuntimeError(...) from e` after the existing cleanup block, so the failure surfaces to the caller while preserving the original exception via `from e`. The existing rollback, logging, and cleanup behaviour is untouched.

| Scenario | Before (main) | After (this PR) |
|----------|---------------|-----------------|
| `_insert_structure_metadata()` raises | Exception swallowed; `add_items()` returns normally | `RuntimeError` raised with original exception chained via `from e` |
| Caller observability | Cannot distinguish partial failure from success | Failure surfaces to the caller |
| Rollback / logging / orphan cleanup | Performed | Performed (unchanged) |
| Successful path | Returns normally | Returns normally (unchanged) |

### Test plan

Adds `test_add_items_raises_on_structure_metadata_failure`, which forces `_insert_structure_metadata` to raise, then asserts `add_items()` raises `RuntimeError` and that the orphaned message was still cleaned up.

```console
$ uv run pytest tests/extensions/memory/test_advanced_sqlite_session.py::test_add_items_raises_on_structure_metadata_failure -v
tests/extensions/memory/test_advanced_sqlite_session.py::test_add_items_raises_on_structure_metadata_failure PASSED [100%]
1 passed in 0.18s
```

### Issue number

Closes #3348.

> Note: this is one half of #3498, split into a single-issue PR as suggested for easier review. The other half (#3346) is in #3526.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
