### PR TITLE
fix: use tuple form for SpeechGroupSpanData __slots__

### DIFF
--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -405,7 +405,7 @@ class SpeechGroupSpanData(SpanData):
     Represents a Speech Group Span in the trace.
     """
 
-    __slots__ = "input"
+    __slots__ = ("input",)
 
     def __init__(
         self,


### PR DESCRIPTION
### Summary

`SpeechGroupSpanData.__slots__` is assigned a bare string `"input"` instead of a one-element tuple. Because Python treats a string as an iterable, this creates five single-character slots (`i`, `n`, `p`, `u`, `t`) rather than a single `input` slot — so the class does not get the intended `__slots__` for its actual attribute.

```python
# before
__slots__ = "input"

# after
__slots__ = ("input",)
```

Every other `SpanData` subclass in this file already uses the tuple form (e.g. `("input", "output", "usage")`), so this aligns `SpeechGroupSpanData` with the rest and ensures `self.input` is backed by a real slot.

### Checks

- `ruff check src/agents/tracing/span_data.py` — passes
- `ruff format --check src/agents/tracing/span_data.py` — already formatted
- One-line change, no behavior change other than the intended slot fix.
