### PR TITLE
docs: add missing space in MCP params docstrings

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1183,7 +1183,7 @@ class MCPServerStdio(_MCPServerWithClientSession):
 
 
 class MCPServerSseParams(TypedDict):
-    """Mirrors the params in`mcp.client.sse.sse_client`."""
+    """Mirrors the params in `mcp.client.sse.sse_client`."""
 
     url: str
     """The URL of the server."""
@@ -1309,7 +1309,7 @@ class MCPServerSse(_MCPServerWithClientSession):
 
 
 class MCPServerStreamableHttpParams(TypedDict):
-    """Mirrors the params in`mcp.client.streamable_http.streamablehttp_client`."""
+    """Mirrors the params in `mcp.client.streamable_http.streamablehttp_client`."""
 
     url: str
     """The URL of the server."""


### PR DESCRIPTION
### Summary

The class docstrings for `MCPServerSseParams` and `MCPServerStreamableHttpParams` are missing a space before the backtick:

```python
# before
"""Mirrors the params in`mcp.client.sse.sse_client`."""
"""Mirrors the params in`mcp.client.streamable_http.streamablehttp_client`."""

# after
"""Mirrors the params in `mcp.client.sse.sse_client`."""
"""Mirrors the params in `mcp.client.streamable_http.streamablehttp_client`."""
```

Without the space the inline code reference does not render as intended in generated docs. Two-line, docs-only change.

### Checks

- `ruff check src/agents/mcp/server.py` — passes
- `ruff format --check src/agents/mcp/server.py` — already formatted
