### PR TITLE
fix(sandbox): run post-rename cleanup as the editor's bound user

### DIFF
--- a/src/agents/sandbox/apply_patch.py
+++ b/src/agents/sandbox/apply_patch.py
@@ -97,7 +97,7 @@ class WorkspaceEditor:
             moved_destination = self._session.normalize_path(moved_relative_path)
             await self._write_text(moved_destination, updated_text)
             if moved_destination != destination:
-                await self._session.rm(destination)
+                await self._session.rm(destination, user=self._user)
             moved_display_path = moved_relative_path.as_posix()
             return ApplyPatchResult(
                 output=f"Updated {display_path}\nMoved {display_path} to {moved_display_path}"

--- a/tests/sandbox/capabilities/test_apply_patch_tool.py
+++ b/tests/sandbox/capabilities/test_apply_patch_tool.py
@@ -178,6 +178,31 @@ class TestSandboxApplyPatchTool:
         assert session.rm_users == ["sandbox-user"]
 
     @pytest.mark.asyncio
+    async def test_editor_runs_move_cleanup_as_bound_user(self) -> None:
+        session = UserRecordingApplyPatchSession()
+        session.files[Path("/workspace/existing.txt")] = b"old\n"
+        tool = SandboxApplyPatchTool(session=session, user=User(name="sandbox-user"))
+
+        await cast(
+            Awaitable[ApplyPatchResult],
+            tool.editor.update_file(
+                ApplyPatchOperation(
+                    type="update_file",
+                    path="existing.txt",
+                    diff="@@\n-old\n+new\n",
+                    move_to="renamed.txt",
+                )
+            ),
+        )
+
+        # Renaming writes the new file and removes the original; both must run
+        # as the editor's bound user, not the default sandbox user.
+        assert session.write_users == ["sandbox-user"]
+        assert session.rm_users == ["sandbox-user"]
+        assert Path("/workspace/existing.txt") not in session.files
+        assert Path("/workspace/renamed.txt") in session.files
+
+    @pytest.mark.asyncio
     async def test_custom_tool_input_create_update_move_delete(self) -> None:
         session = ApplyPatchSession()
         tool = SandboxApplyPatchTool(session=session)


### PR DESCRIPTION
## Summary

In `WorkspaceEditor.apply_operation` (`src/agents/sandbox/apply_patch.py`), an `update_file` operation with `move_to` writes the renamed file as the editor's bound user but removes the *original* path with a bare `self._session.rm(destination)` — dropping the user:

```python
await self._write_text(moved_destination, updated_text)   # writes as self._user
if moved_destination != destination:
    await self._session.rm(destination)                   # ran as the DEFAULT user
```

Every other session call in this class threads `user=self._user` (`delete_file` at line 71, reads, `mkdir`, `write`). This one cleanup was the only exception, so when a `WorkspaceEditor`/`SandboxApplyPatchTool` is bound to a non-default user, the post-rename removal ran under the wrong identity — a permission error mid-operation (after the new file is already written), or a removal under the wrong privileges that leaves the original file orphaned and the rename half-applied.

## Fix

Pass `user=self._user`, matching the sibling `delete_file` path and every other session call.

## Test

Added `test_editor_runs_move_cleanup_as_bound_user`, which runs an `update_file` with `move_to` through `UserRecordingApplyPatchSession` and asserts the cleanup `rm` runs as the bound user. It **fails on the previous code** (`rm_users == [None]`) and passes with the fix.

Verified locally:
```
pytest tests/sandbox/ tests/test_apply_patch_tool.py tests/test_apply_diff.py   # 55 passed
ruff check / format                                                            # clean
```
