### PR TITLE
Move types-requests to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "griffelib>=2, <3",
     "typing-extensions>=4.12.2, <5",
     "requests>=2.0, <3",
-    "types-requests>=2.0, <3",
     "websockets>=15.0, <17",
     "mcp>=1.19.0, <2; python_version >= '3.10'",
 ]
@@ -77,6 +76,7 @@ dev = [
   "inline-snapshot>=0.20.7",
   "pynput",
   "types-pynput",
+  "types-requests>=2.0, <3",
   "sounddevice",
   "textual",
   "websockets",

--- a/uv.lock
+++ b/uv.lock
@@ -2440,7 +2440,6 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "requests" },
-    { name = "types-requests" },
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
@@ -2545,6 +2544,7 @@ dev = [
     { name = "testcontainers" },
     { name = "textual" },
     { name = "types-pynput" },
+    { name = "types-requests" },
     { name = "websockets" },
 ]
 
@@ -2578,7 +2578,6 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=2.0" },
     { name = "temporalio", marker = "extra == 'temporal'", specifier = "==1.26.0" },
     { name = "textual", marker = "extra == 'temporal'", specifier = ">=8.2.3,<8.3" },
-    { name = "types-requests", specifier = ">=2.0,<3" },
     { name = "typing-extensions", specifier = ">=4.12.2,<5" },
     { name = "vercel", marker = "extra == 'vercel'", specifier = ">=0.5.6,<0.6" },
     { name = "websockets", specifier = ">=15.0,<17" },
@@ -2619,6 +2618,7 @@ dev = [
     { name = "testcontainers", specifier = "==4.12.0" },
     { name = "textual" },
     { name = "types-pynput" },
+    { name = "types-requests", specifier = ">=2.0,<3" },
     { name = "websockets" },
 ]
 


### PR DESCRIPTION
### Summary

Move `types-requests` out of the published runtime dependency list and into the dev dependency group. Update `uv.lock` so `openai-agents` no longer advertises `types-requests` in `requires-dist`, while local development still installs it for type-checking.

This addresses #3507: `types-requests` is a stub package and does not affect runtime behavior. Keeping it in runtime dependencies makes regular installs pull an unnecessary package, and recent `requests` releases include inline type hints.

### Test plan

- `uv lock --check`
- `uv tree --no-dev --package openai-agents` confirmed no `types-requests` in the non-dev install tree
- `git diff --check`
- `make sync`
- `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3507

### Checks

- [ ] I've added new tests (not relevant: dependency metadata only)
- [ ] I've added/updated the relevant documentation (not relevant: dependency metadata only)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
