### PR TITLE
docs: drop nonexistent 'context' param from RealtimeRunner.__init__ docstring

### DIFF
--- a/src/agents/realtime/runner.py
+++ b/src/agents/realtime/runner.py
@@ -38,7 +38,6 @@ class RealtimeRunner:
 
         Args:
             starting_agent: The agent to start the session with.
-            context: The context to use for the session.
             model: The model to use. If not provided, will use a default OpenAI realtime model.
             config: Override parameters to use for the entire run.
         """


### PR DESCRIPTION
## Summary

`RealtimeRunner.__init__` only accepts `starting_agent`, `model`, and `config`:

```python
def __init__(
    self,
    starting_agent: RealtimeAgent,
    *,
    model: RealtimeModel | None = None,
    config: RealtimeRunConfig | None = None,
) -> None:
```

But its docstring's `Args:` block also lists `context: The context to use for the session.` — that parameter actually belongs to the separate `run()` method below it (`async def run(self, *, context=..., model_config=...)`). It's a copy-paste leftover that documents a parameter `__init__` doesn't take.

This drops the stale line so the `Args:` block matches the signature. Docstring-only; no code or behavior change.

## Test plan
No runtime impact (comment-only). Module still parses; the documented args now exactly match `__init__`'s signature.