### PR TITLE
fix: prevent ValueError when no eligible response-create versions exist

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -239,7 +239,7 @@ class _ResponseCreateSequencer:
                 for version in self._pending_request_versions
                 if version < next_manual_version
             }
-        return max(eligible_versions)
+        return max(eligible_versions, default=request_version)
 
     def set_ongoing_response_for_test(self, value: bool) -> None:
         self._ongoing_response = value


### PR DESCRIPTION
## Summary
Prevents a potential `ValueError` in `_ResponseCreateSequencer._auto_response_create_target_version()` when no eligible pending versions exist.

## Problem
The current implementation computes the target version using `max(eligible_versions)`. If `eligible_versions` is empty, Python raises `ValueError: max() arg is an empty sequence`, which can cause response sequencing to fail unexpectedly.

## Change
Updates the return statement to use the `default` parameter:
```python
return max(eligible_versions, default=request_version)
```

## Rationale
Using `max(..., default=...)` is idiomatic Python and cleanly handles empty iterables without adding conditional branches. `request_version` is a safe fallback that represents the currently reserved request and maintains forward progress. The change only affects the edge case where no eligible versions are found.

## Impact
- Prevents `ValueError: max() arg is an empty sequence`
- Preserves existing sequencing behavior for normal execution paths
- Improves robustness against unexpected state transitions
- Zero breaking changes to public APIs or async flow