### PR TITLE
fix: coerce ToolCallItem/ToolCallOutputItem call_id to str | None consistently

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -373,8 +373,10 @@ class ToolCallItem(RunItemBase[Any]):
     def call_id(self) -> str | None:
         """Return the call identifier from the raw item, if available."""
         if isinstance(self.raw_item, dict):
-            return self.raw_item.get("call_id") or self.raw_item.get("id")
-        return getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
+            cid = self.raw_item.get("call_id") or self.raw_item.get("id")
+        else:
+            cid = getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
+        return str(cid) if cid is not None else None
 
 
 ToolCallOutputTypes: TypeAlias = (
@@ -408,8 +410,9 @@ class ToolCallOutputItem(RunItemBase[Any]):
         """Return the call identifier from the raw item, if available."""
         if isinstance(self.raw_item, dict):
             cid = self.raw_item.get("call_id") or self.raw_item.get("id")
-            return str(cid) if cid is not None else None
-        return getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
+        else:
+            cid = getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
+        return str(cid) if cid is not None else None
 
     def to_input_item(self) -> TResponseInputItem:
         """Converts the tool output into an input item for the next model turn.

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gc
 import json
 import weakref
+from types import SimpleNamespace
 from typing import Any, cast
 
 from openai.types.responses.computer_action import Click as BatchedClick, Type as BatchedType
@@ -321,6 +322,60 @@ def test_tool_call_output_item_preserves_function_output_structure() -> None:
     assert isinstance(payload, dict)
     assert payload["type"] == "function_call_output"
     assert payload["output"] == raw_item["output"]
+
+
+def test_tool_call_item_call_id_coerces_to_str() -> None:
+    agent = Agent(name="tester")
+
+    # Dict raw item with a string call_id.
+    dict_call = ResponseFunctionToolCallParam(
+        id="f1",
+        arguments="{}",
+        call_id="c1",
+        name="func",
+        type="function_call",
+    )
+    assert ToolCallItem(agent=agent, raw_item=cast(Any, dict_call)).call_id == "c1"
+
+    # Object raw item with a non-string id falls back to a string.
+    object_call = ResponseFunctionToolCall(
+        id="f2",
+        arguments="{}",
+        call_id="c2",
+        name="func",
+        type="function_call",
+    )
+    item = ToolCallItem(agent=agent, raw_item=object_call)
+    call_id = item.call_id
+    assert call_id == "c2"
+    assert isinstance(call_id, str)
+
+
+def test_tool_call_item_call_id_missing_returns_none() -> None:
+    agent = Agent(name="tester")
+    raw_item = cast(Any, {"type": "function_call"})
+    assert ToolCallItem(agent=agent, raw_item=raw_item).call_id is None
+
+
+def test_tool_call_output_item_call_id_coerces_to_str() -> None:
+    agent = Agent(name="tester")
+
+    # Dict raw item with a string call_id.
+    dict_raw = {
+        "type": "function_call_output",
+        "call_id": "call-keep",
+        "output": "value",
+    }
+    dict_item = ToolCallOutputItem(agent=agent, raw_item=cast(Any, dict_raw), output="value")
+    assert dict_item.call_id == "call-keep"
+
+    # Object raw item whose call_id is a non-string value is coerced to str so the
+    # `str | None` return annotation is honored on both branches.
+    object_raw = cast(Any, SimpleNamespace(call_id=123))
+    object_item = ToolCallOutputItem(agent=agent, raw_item=object_raw, output="value")
+    call_id = object_item.call_id
+    assert call_id == "123"
+    assert isinstance(call_id, str)
 
 
 def test_tool_call_output_item_constructs_function_call_output_dict():


### PR DESCRIPTION
### Summary

`ToolCallItem.call_id` and `ToolCallOutputItem.call_id` returned the raw value untouched on the object branch, so a non-string `call_id`/`id` (e.g. an `int`) leaked through despite the `str | None` return annotation. This makes both properties consistently coerce to `str | None`, matching the canonical behavior of `extract_tool_call_id` in `run_internal/tool_execution.py`.

### Changes

- `ToolCallItem.call_id` and `ToolCallOutputItem.call_id` now coerce the resolved value to `str` (or `None` when absent) on both the dict and object branches.

### Test plan

- Added unit tests in `tests/test_items_helpers.py`:
  - dict and object raw items with string `call_id` return the string unchanged.
  - a non-string (`int`) `call_id` is coerced to `"123"`.
  - a missing `call_id` returns `None`.
- `make format`, `make lint`, `make typecheck`, and the full `make tests` suite pass (4615 passed, 11 skipped).
