### PR TITLE
fix(function_schema): raise UserError for Pydantic-reserved parameter names

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -318,7 +318,19 @@ def function_schema(
     #   field_name -> (type_annotation, default_value_or_Field(...))
     fields: dict[str, Any] = {}
 
+    # Pydantic's create_model() treats certain names as model-level configuration
+    # keys rather than fields (e.g. 'model_config', 'model_fields').  Passing
+    # a FieldInfo for those names causes a TypeError deep inside Pydantic, so
+    # we reject them early with a clear message.
+    _PYDANTIC_RESERVED_NAMES = {"model_config", "model_fields", "model_computed_fields"}
+
     for name, param in filtered_params:
+        if name in _PYDANTIC_RESERVED_NAMES:
+            raise UserError(
+                f"Function '{func.__name__}' has a parameter named '{name}', which is reserved "
+                f"by Pydantic and cannot be used as a tool parameter name. "
+                f"Please rename the parameter."
+            )
         ann = type_hints.get(name, param.annotation)
         default = param.default
 

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -885,3 +885,13 @@ def test_function_with_annotated_field_multiple_constraints():
 
     with pytest.raises(ValidationError):  # zero factor
         fs.params_pydantic_model(**{"score": 50, "factor": 0.0})
+
+
+def test_pydantic_reserved_param_name_raises_user_error():
+    """Parameters named 'model_config' (or other Pydantic reserved names) must raise UserError."""
+
+    def func_with_reserved(model_config: str) -> str:
+        return model_config
+
+    with pytest.raises(UserError, match="reserved by Pydantic"):
+        function_schema(func_with_reserved)


### PR DESCRIPTION
## What's broken

Calling `function_schema()` (or `@function_tool`) on a function with a parameter named `model_config` crashes with a `TypeError: 'FieldInfo' object is not iterable` deep inside Pydantic. The same applies to `model_fields` and `model_computed_fields`. The error gives no indication of what went wrong or how to fix it.

## Why it happens

Pydantic's `create_model()` treats `model_config` as a model-level configuration key rather than a field. When `function_schema.py` passes a `FieldInfo` for that name, `ConfigWrapper.for_model()` calls `.update()` on the `FieldInfo` object expecting a dict, which crashes.

## Fix

Added a small set `_PYDANTIC_RESERVED_NAMES = {"model_config", "model_fields", "model_computed_fields"}` and a guard at the start of the field-building loop in `function_schema()`. If a parameter name matches, a `UserError` is raised immediately with a clear message explaining the conflict and asking the user to rename the parameter. Change is 12 lines in one file.

## Test

Added `test_pydantic_reserved_param_name_raises_user_error` to `tests/test_function_schema.py`. It defines a function with a `model_config: str` parameter and asserts that `function_schema()` raises `UserError` with a message matching "reserved by Pydantic".

Fixes #3547