### PR TITLE
fix(function_schema): raise UserError for Pydantic protected-namespace param names

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -404,6 +404,21 @@ def function_schema(
                 )
 
     # 3. Dynamically build a Pydantic model
+    # Pydantic raises ValueError for field names that match built-in BaseModel methods in a
+    # protected namespace (e.g. model_dump, model_validate).  Catch these early.
+    _PYDANTIC_PROTECTED_NAMES = {
+        "model_dump",
+        "model_dump_json",
+        "model_validate",
+        "model_validate_json",
+        "model_validate_strings",
+    }
+    colliding = _PYDANTIC_PROTECTED_NAMES.intersection(fields)
+    if colliding:
+        raise UserError(
+            f"Function '{func_name}' has parameter(s) {sorted(colliding)} whose name(s) conflict "
+            "with Pydantic BaseModel built-in methods. Rename the parameter(s) to avoid this."
+        )
     dynamic_model = create_model(f"{func_name}_args", __base__=BaseModel, **fields)
 
     # 4. Build JSON schema from that model

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -885,3 +885,13 @@ def test_function_with_annotated_field_multiple_constraints():
 
     with pytest.raises(ValidationError):  # zero factor
         fs.params_pydantic_model(**{"score": 50, "factor": 0.0})
+
+
+def test_pydantic_protected_namespace_param_raises_user_error():
+    # Parameters named after Pydantic's protected BaseModel methods must raise UserError,
+    # not an opaque ValueError from inside Pydantic's create_model().
+    def func_with_model_validate(model_validate: str, query: str) -> str:
+        return query
+
+    with pytest.raises(UserError, match="model_validate"):
+        function_schema(func_with_model_validate, use_docstring_info=False)


### PR DESCRIPTION
## What's broken

Calling `function_schema()` (or `@function_tool`) on a function whose parameter is named `model_dump`, `model_dump_json`, `model_validate`, `model_validate_json`, or `model_validate_strings` raises an unhandled `ValueError` deep inside Pydantic's `create_model()`. The traceback points into Pydantic internals and gives no hint that the parameter name is the problem or how to fix it.

## Why it happens

Pydantic treats field names that match built-in `BaseModel` methods as belonging to a protected namespace and raises `ValueError` inside `create_model()`. These five names are distinct from `model_config` / `model_fields` / `model_computed_fields` covered by PR #3548.

## Fix

A guard clause before `create_model()` in `function_schema.py` detects any field name in the protected set and raises a `UserError` with an actionable message listing the offending parameter names, before Pydantic ever sees them.

## Test

Added `test_pydantic_protected_namespace_param_raises_user_error` in `test_function_schema.py`, which asserts that a function with a `model_validate` parameter raises `UserError` (not `ValueError`) and that the error message names the conflicting parameter.

Fixes #3549