### PR TITLE
fix(strict_schema): guard resolve_ref against missing $ref path

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -156,7 +156,13 @@ def resolve_ref(*, root: dict[str, object], ref: str) -> object:
     path = ref[2:].split("/")
     resolved = root
     for key in path:
-        value = resolved[key]
+        try:
+            value = resolved[key]
+        except KeyError:
+            raise ValueError(
+                f"Could not resolve $ref {ref!r}: key {key!r} not found. "
+                f"Make sure the referenced path exists in the schema."
+            )
         assert is_dict(value), (
             f"encountered non-dictionary entry while resolving {ref} - {resolved}"
         )

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -145,6 +145,17 @@ def test_invalid_ref_format():
         ensure_strict_json_schema(schema)
 
 
+def test_resolve_ref_raises_valueerror_for_missing_path():
+    # A $ref with sibling keys (triggers unraveling) pointing to a missing path
+    # must raise ValueError, not KeyError.
+    schema = {
+        "type": "object",
+        "properties": {"data": {"$ref": "#/$defs/SomeType", "description": "x"}},
+    }
+    with pytest.raises(ValueError, match="Could not resolve"):
+        ensure_strict_json_schema(schema)
+
+
 def test_chained_ref_with_sibling_keys_is_resolved():
     # When a $ref points to a definition that is itself just a $ref (a chained alias),
     # and the original $ref has sibling keys (like "description"), the chain must be


### PR DESCRIPTION
## What's broken

`resolve_ref` in `strict_schema.py` does a bare `resolved[key]` subscript with no `KeyError` guard. When `ensure_strict_json_schema` encounters a property with both a `$ref` and a sibling key (e.g. `description`), it unravels the ref via `resolve_ref`. If the referenced path does not exist — e.g. a hand-crafted `params_json_schema` with a `$ref` but no `$defs` section — the loop crashes with `KeyError: '$defs'` instead of a clear diagnostic. The adjacent code already raises `ValueError` for malformed `$ref` strings, but a well-formatted ref pointing to a missing path was unguarded.

## Why it happens

The `for key in path` loop in `resolve_ref` (line 158–163) subscripts `resolved[key]` directly without catching `KeyError`.

## Fix

Wrapped the subscript in a `try/except KeyError` that re-raises as `ValueError` naming the missing key and the offending `$ref`, consistent with the existing error handling pattern in the same function.

## Test

`test_resolve_ref_raises_valueerror_for_missing_path` in `tests/test_strict_schema.py` calls `ensure_strict_json_schema` with a schema that has a `$ref`+`description` property but no `$defs`, and asserts a `ValueError` is raised with the expected message.

Fixes #3551