### PR TITLE
fix(items): empty list/tuple tool output dropped via all([]) == True

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -801,7 +801,10 @@ class ItemHelpers:
             maybe_converted_output_list = [
                 cls._maybe_get_output_as_structured_function_output(item) for item in output
             ]
-            if all(maybe_converted_output_list):
+            # An empty list/tuple has no structured items; ``all([])`` is ``True``,
+            # so guard against it to avoid emitting an empty structured-output list
+            # (which would drop the tool result) and stringify instead.
+            if maybe_converted_output_list and all(maybe_converted_output_list):
                 return [
                     cls._convert_single_tool_output_pydantic_model(item)
                     for item in maybe_converted_output_list

--- a/tests/test_tool_output_conversion.py
+++ b/tests/test_tool_output_conversion.py
@@ -370,3 +370,26 @@ def test_tool_call_output_item_mixed_list_partial_invalid_not_converted() -> Non
     # All-or-nothing: if any item is invalid, convert entire list to string
     assert isinstance(payload["output"], str)
     assert payload["output"] == "[{'type': 'text', 'text': 'hello'}, {'msg': 'foobar'}]"
+
+
+def test_tool_call_output_item_empty_list_not_converted() -> None:
+    """An empty list has no structured items, so it should stringify rather than
+    produce an empty structured-output list (which would drop the tool result)."""
+    call = _make_tool_call()
+    payload = ItemHelpers.tool_call_output_item(call, [])
+
+    assert payload["type"] == "function_call_output"
+    assert payload["call_id"] == call.call_id
+    assert isinstance(payload["output"], str)
+    assert payload["output"] == "[]"
+
+
+def test_tool_call_output_item_empty_tuple_not_converted() -> None:
+    """An empty tuple should stringify, mirroring the empty-list behavior."""
+    call = _make_tool_call()
+    payload = ItemHelpers.tool_call_output_item(call, ())
+
+    assert payload["type"] == "function_call_output"
+    assert payload["call_id"] == call.call_id
+    assert isinstance(payload["output"], str)
+    assert payload["output"] == "()"


### PR DESCRIPTION
## Problem

`ItemHelpers._convert_tool_output` (in `src/agents/items.py`, reached via the public `ItemHelpers.tool_call_output_item`) decides whether a tool's list/tuple return value is structured output or should be stringified:

```python
if isinstance(output, list | tuple):
    maybe_converted_output_list = [
        cls._maybe_get_output_as_structured_function_output(item) for item in output
    ]
    if all(maybe_converted_output_list):   # <-- all([]) is True
        return [ ... structured ... ]
    else:
        return str(output)
```

For an **empty** list or tuple, the comprehension yields `[]` and `all([]) == True`, so the empty collection wrongly takes the structured-output branch and returns an empty `ResponseFunctionCallOutputItemListParam` (`[]`). Sent to the Responses API as a `function_call_output`, an empty structured list **drops the tool result entirely** — the model sees no output for that tool call — instead of the expected stringified `"[]"` / `"()"`.

A non-empty plain list like `[1, 2, 3]` correctly stringifies to `"[1, 2, 3]"`; only the empty case misbehaves.

## Fix

```python
if maybe_converted_output_list and all(maybe_converted_output_list):
```

Empty collections now fall through to `str(output)`.

## Verification

```
before:  pytest tests/test_tool_output_conversion.py -k empty_list_not_converted or empty_tuple_not_converted
         2 failed  (isinstance([], str) is False -- output was [] not '[]')
after :  26 passed (24 existing + 2 new regression tests)
full suite green:  tests/test_items_helpers.py tests/test_tool_output_conversion.py
                   tests/test_tool_origin.py tests/test_output_tool.py  -> 86 passed
```

ruff check, ruff format --check, and mypy all pass on the changed files.

Adds `test_tool_call_output_item_empty_list_not_converted` and `..._empty_tuple_not_converted` mirroring the existing "not_converted" test style.