### PR TITLE
fix: recursively extract HTTP errors from nested ExceptionGroups

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -712,13 +712,12 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         if isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
             return e
 
-        # Check if it's an ExceptionGroup containing HTTP errors
+        # Recursively check ExceptionGroups for HTTP errors
         if isinstance(e, BaseExceptionGroup):
             for exc in e.exceptions:
-                if isinstance(
-                    exc, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException
-                ):
-                    return exc
+                result = self._extract_http_error_from_exception(exc)
+                if result is not None:
+                    return result
 
         return None
 

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -1,19 +1,20 @@
+import builtins
 import sys
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
-# Handle Python version compatibility for ExceptionGroups
-if sys.version_info < (3, 11):
-    from exceptiongroup import BaseExceptionGroup
-else:
-    BaseExceptionGroup = ExceptionGroup
-
 from agents import Agent
 from agents.exceptions import UserError
 from agents.mcp.server import MCPServerStreamableHttp, _MCPServerWithClientSession
 from agents.run_context import RunContextWrapper
+
+# Handle Python version compatibility for ExceptionGroups
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+else:
+    BaseExceptionGroup = getattr(builtins, "BaseExceptionGroup")
 
 
 class CrashingClientSessionServer(_MCPServerWithClientSession):

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -1,8 +1,17 @@
+import sys
 import pytest
+import httpx
+from unittest.mock import AsyncMock, MagicMock
+
+# Handle Python version compatibility for ExceptionGroups
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+else:
+    BaseExceptionGroup = ExceptionGroup
 
 from agents import Agent
 from agents.exceptions import UserError
-from agents.mcp.server import _MCPServerWithClientSession
+from agents.mcp.server import _MCPServerWithClientSession, MCPServerStreamableHttp
 from agents.run_context import RunContextWrapper
 
 
@@ -45,3 +54,32 @@ async def test_not_calling_connect_causes_error():
 
     with pytest.raises(UserError):
         await server.call_tool("foo", {})
+
+
+@pytest.mark.asyncio
+async def test_call_tool_nested_exception_group_mapping():
+    """
+    Regression test ensuring that nested ExceptionGroups containing HTTP errors
+    are recursively extracted and mapped to a UserError in call_tool().
+    """
+    # 1. Initialize the server with mock streamable parameters
+    server = MCPServerStreamableHttp(params={"url": "http://fake-mcp-server"})
+    
+    # 2. Simulate an active connection by mocking the session object
+    server.session = MagicMock()
+    
+    # 3. Construct a nested ExceptionGroup hierarchy containing a connection error
+    http_error = httpx.ConnectError("Network unreachable")
+    inner_group = BaseExceptionGroup("inner_failures", [http_error])
+    outer_group = BaseExceptionGroup("outer_failures", [inner_group])
+    
+    # 4. Mock the internal retry handler to raise the nested exception group
+    server._call_tool_with_isolated_retry = AsyncMock(side_effect=outer_group)
+    
+    # 5. Assert that call_tool() catches the nested group, extracts the error, and raises UserError
+    with pytest.raises(UserError) as exc_info:
+        await server.call_tool(tool_name="test_tool", arguments={})
+    
+    # 6. Verify that the user-facing message is mapped correctly based on the root cause
+    assert "Connection lost" in str(exc_info.value)
+    assert exc_info.value.__cause__ is http_error

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -14,7 +14,7 @@ from agents.run_context import RunContextWrapper
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
 else:
-    BaseExceptionGroup = getattr(builtins, "BaseExceptionGroup")
+    BaseExceptionGroup = builtins.BaseExceptionGroup
 
 
 class CrashingClientSessionServer(_MCPServerWithClientSession):

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -1,7 +1,8 @@
 import sys
-import pytest
+from unittest.mock import MagicMock, patch
+
 import httpx
-from unittest.mock import AsyncMock, MagicMock
+import pytest
 
 # Handle Python version compatibility for ExceptionGroups
 if sys.version_info < (3, 11):
@@ -11,7 +12,7 @@ else:
 
 from agents import Agent
 from agents.exceptions import UserError
-from agents.mcp.server import _MCPServerWithClientSession, MCPServerStreamableHttp
+from agents.mcp.server import MCPServerStreamableHttp, _MCPServerWithClientSession
 from agents.run_context import RunContextWrapper
 
 
@@ -64,22 +65,20 @@ async def test_call_tool_nested_exception_group_mapping():
     """
     # 1. Initialize the server with mock streamable parameters
     server = MCPServerStreamableHttp(params={"url": "http://fake-mcp-server"})
-    
+
     # 2. Simulate an active connection by mocking the session object
     server.session = MagicMock()
-    
+
     # 3. Construct a nested ExceptionGroup hierarchy containing a connection error
     http_error = httpx.ConnectError("Network unreachable")
     inner_group = BaseExceptionGroup("inner_failures", [http_error])
     outer_group = BaseExceptionGroup("outer_failures", [inner_group])
-    
-    # 4. Mock the internal retry handler to raise the nested exception group
-    server._call_tool_with_isolated_retry = AsyncMock(side_effect=outer_group)
-    
-    # 5. Assert that call_tool() catches the nested group, extracts the error, and raises UserError
-    with pytest.raises(UserError) as exc_info:
-        await server.call_tool(tool_name="test_tool", arguments={})
-    
+
+    # 4 & 5. Mock the internal retry handler to raise the nested group, and assert UserError
+    with patch.object(server, "_call_tool_with_isolated_retry", side_effect=outer_group):
+        with pytest.raises(UserError) as exc_info:
+            await server.call_tool(tool_name="test_tool", arguments={})
+
     # 6. Verify that the user-facing message is mapped correctly based on the root cause
     assert "Connection lost" in str(exc_info.value)
     assert exc_info.value.__cause__ is http_error


### PR DESCRIPTION
This PR improves how the code finds HTTP-related errors inside nested exception groups, specifically when these errors surface during tool execution.

Right now, `_extract_http_error_from_exception()` only checks the first level of `BaseExceptionGroup.exceptions`. That works when the HTTP error is directly inside the group, but it fails when the error is wrapped inside another `ExceptionGroup`.

With this change, the method now checks exception groups recursively. The core behavior this fixes is real: when a nested `ExceptionGroup` reaches `MCPServerStreamableHttp.call_tool()`, the current implementation re-raises the raw group.

This change correctly catches it and maps the nested HTTP error to the intended `UserError`.

*(Note: As discussed in the PR comments, retry classification is already handled recursively elsewhere, and cleanup uses a separate one-level traversal. This fix is specifically targeted at properly surfacing nested UserErrors from the `call_tool` path).*

### Before
```python
def _extract_http_error_from_exception(self, e: BaseException) -> Exception | None:
    """Extract HTTP error from exception or ExceptionGroup."""
    if isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
        return e

    # Check if it's an ExceptionGroup containing HTTP errors
    if isinstance(e, BaseExceptionGroup):
        for exc in e.exceptions:
            if isinstance(
                exc, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException
            ):
                return exc

    return None
```

### After
```python
def _extract_http_error_from_exception(self, e: BaseException) -> Exception | None:
    """Extract HTTP error from exception or ExceptionGroup recursively."""
    if isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
        return e

    # Recursively check ExceptionGroups for HTTP errors
    if isinstance(e, BaseExceptionGroup):
        for exc in e.exceptions:
            result = self._extract_http_error_from_exception(exc)
            if result is not None:
                return result

    return None
```

## Why this matters
- It correctly maps nested HTTP errors to the intended UserError when a nested ExceptionGroup reaches MCPServerStreamableHttp.call_tool().
- It catches HTTP errors even when they are nested inside multiple exception groups.
- It makes the method more robust in real async failure cases without altering the success path.

## Testing
A regression test has been added to exercise this exact scenario through the call_tool path. The test creates a nested ExceptionGroup containing an httpx.ConnectError, verifying that the method successfully finds it and raises the correct UserError.

**Testing:** A regression test has been added to this PR to exercise this exact scenario through the `call_tool` path.