### PR TITLE
docs: fix docstring typo in stdio params env description

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1072,7 +1072,7 @@ class MCPServerStdioParams(TypedDict):
     `['server.js', '--port', '8080']`."""
 
     env: NotRequired[dict[str, str]]
-    """The environment variables to set for the server. ."""
+    """The environment variables to set for the server."""
 
     cwd: NotRequired[str | Path]
     """The working directory to use when spawning the process."""


### PR DESCRIPTION
### Summary
Fix a small docstring typo in MCPServerStdioParams.env. Documentation-only change.

### Why
Small documentation cleanup. Safe, no behavior change.