### PR TITLE
feat: add on_tool_call_sealed hook for eager tool dispatch

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -376,6 +376,13 @@ class ToolCallItem(RunItemBase[Any]):
             return self.raw_item.get("call_id") or self.raw_item.get("id")
         return getattr(self.raw_item, "call_id", None) or getattr(self.raw_item, "id", None)
 
+    @property
+    def arguments(self) -> str | None:
+        """Return the sealed arguments of the tool call, if available."""
+        if isinstance(self.raw_item, dict):
+            return self.raw_item.get("arguments")
+        return getattr(self.raw_item, "arguments", None)
+
 
 ToolCallOutputTypes: TypeAlias = (
     FunctionCallOutput

--- a/src/agents/lifecycle.py
+++ b/src/agents/lifecycle.py
@@ -3,7 +3,7 @@ from typing import Any, Generic
 from typing_extensions import TypeVar
 
 from .agent import Agent, AgentBase
-from .items import ModelResponse, TResponseInputItem
+from .items import ModelResponse, ToolCallItem, TResponseInputItem
 from .run_context import AgentHookContext, RunContextWrapper, TContext
 from .tool import Tool
 
@@ -102,6 +102,24 @@ class RunHooksBase(Generic[TContext, TAgent]):
         """
         pass
 
+    async def on_tool_call_sealed(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: TAgent,
+        tool_call: ToolCallItem,
+    ) -> None:
+        """Called during streaming when a tool call's arguments are sealed and ready.
+
+        This hook fires when the LLM has finished producing a tool call during streaming, before
+        the full response is complete and before the tool is invoked. It carries the sealed
+        ``ToolCallItem`` with ``call_id``, ``tool_name``, and ``arguments``.
+
+        The default runner does not act on this hook — it is provided so that consumers can
+        implement eager dispatch or early tool preparation without changing the SDK's execution
+        flow. For callers that do nothing with this hook, existing behavior is unchanged.
+        """
+        pass
+
 
 class AgentHooksBase(Generic[TContext, TAgent]):
     """A class that receives callbacks on various lifecycle events for a specific agent. You can
@@ -177,6 +195,24 @@ class AgentHooksBase(Generic[TContext, TAgent]):
         Simple tool outputs are typically ``str`` values. Function tools may also return
         structured tool output objects or any value the SDK can stringify before sending it to
         the model.
+        """
+        pass
+
+    async def on_tool_call_sealed(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: TAgent,
+        tool_call: ToolCallItem,
+    ) -> None:
+        """Called during streaming when a tool call's arguments are sealed and ready.
+
+        This hook fires when the LLM has finished producing a tool call during streaming, before
+        the full response is complete and before the tool is invoked. It carries the sealed
+        ``ToolCallItem`` with ``call_id``, ``tool_name``, and ``arguments``.
+
+        The default runner does not act on this hook — it is provided so that consumers can
+        implement eager dispatch or early tool preparation without changing the SDK's execution
+        flow. For callers that do nothing with this hook, existing behavior is unchanged.
         """
         pass
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1612,6 +1612,16 @@ async def run_single_turn_streamed(
                     streamed_result._event_queue.put_nowait(
                         RunItemStreamEvent(item=tool_item, name="tool_called")
                     )
+                    await asyncio.gather(
+                        (
+                            public_agent.hooks.on_tool_call_sealed(
+                                context_wrapper, public_agent, tool_item
+                            )
+                            if public_agent.hooks
+                            else _coro.noop_coroutine()
+                        ),
+                        hooks.on_tool_call_sealed(context_wrapper, public_agent, tool_item),
+                    )
 
             elif isinstance(output_item, ResponseReasoningItem):
                 reasoning_id: str | None = getattr(output_item, "id", None)

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -186,6 +186,7 @@ async def test_streamed_run_hooks_tool_call_sealed():
     assert hooks.events["on_tool_call_sealed"] == 1
     assert hooks.sealed_tool_calls[0].tool_name == "f"
     assert hooks.sealed_tool_calls[0].call_id is not None
+    assert hooks.sealed_tool_calls[0].arguments == '{"key": "val"}'
 
 
 @pytest.mark.asyncio
@@ -216,8 +217,10 @@ async def test_streamed_run_hooks_tool_call_sealed_multiple():
     assert len(hooks.sealed_tool_calls) == 2
     assert hooks.sealed_tool_calls[0].tool_name == "get_weather"
     assert hooks.sealed_tool_calls[0].call_id == "call_1"
+    assert hooks.sealed_tool_calls[0].arguments == '{"city": "Dallas"}'
     assert hooks.sealed_tool_calls[1].tool_name == "get_time"
     assert hooks.sealed_tool_calls[1].call_id == "call_2"
+    assert hooks.sealed_tool_calls[1].arguments == '{"timezone": "CST"}'
 
 
 # test_async_run_hooks_with_agent_hooks_with_llm

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -27,12 +27,12 @@ class RunHooksForTests(RunHooks):
     def __init__(self):
         self.events: dict[str, int] = defaultdict(int)
         self.tool_context_ids: list[str] = []
-        self.last_sealed_tool_call: ToolCallItem | None = None
+        self.sealed_tool_calls: list[ToolCallItem] = []
 
     def reset(self):
         self.events.clear()
         self.tool_context_ids.clear()
-        self.last_sealed_tool_call = None
+        self.sealed_tool_calls.clear()
 
     async def on_agent_start(
         self, context: AgentHookContext[TContext], agent: Agent[TContext]
@@ -75,7 +75,7 @@ class RunHooksForTests(RunHooks):
         tool_call: ToolCallItem,
     ) -> None:
         self.events["on_tool_call_sealed"] += 1
-        self.last_sealed_tool_call = tool_call
+        self.sealed_tool_calls.append(tool_call)
 
     async def on_llm_start(
         self,
@@ -184,9 +184,40 @@ async def test_streamed_run_hooks_tool_call_sealed():
         pass
 
     assert hooks.events["on_tool_call_sealed"] == 1
-    assert hooks.last_sealed_tool_call is not None
-    assert hooks.last_sealed_tool_call.tool_name == "f"
-    assert hooks.last_sealed_tool_call.call_id is not None
+    assert hooks.sealed_tool_calls[0].tool_name == "f"
+    assert hooks.sealed_tool_calls[0].call_id is not None
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_hooks_tool_call_sealed_multiple():
+    """Verify that on_tool_call_sealed fires once per sealed tool call in a multi-tool turn."""
+    hooks = RunHooksForTests()
+    model = FakeModel()
+    agent = Agent(
+        name="A",
+        model=model,
+        tools=[
+            get_function_tool("get_weather", "weather data"),
+            get_function_tool("get_time", "current time"),
+        ],
+        handoffs=[],
+    )
+    # Simulate a streaming response with two tool calls in the same turn
+    model.set_next_output([
+        get_function_tool_call("get_weather", '{"city": "Dallas"}', call_id="call_1"),
+        get_function_tool_call("get_time", '{"timezone": "CST"}', call_id="call_2"),
+    ])
+    stream = Runner.run_streamed(agent, input="hello", hooks=hooks)
+
+    async for _event in stream.stream_events():
+        pass
+
+    assert hooks.events["on_tool_call_sealed"] == 2
+    assert len(hooks.sealed_tool_calls) == 2
+    assert hooks.sealed_tool_calls[0].tool_name == "get_weather"
+    assert hooks.sealed_tool_calls[0].call_id == "call_1"
+    assert hooks.sealed_tool_calls[1].tool_name == "get_time"
+    assert hooks.sealed_tool_calls[1].call_id == "call_2"
 
 
 # test_async_run_hooks_with_agent_hooks_with_llm

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 import pytest
 
 from agents.agent import Agent
-from agents.items import ItemHelpers, ModelResponse, TResponseInputItem
+from agents.items import ItemHelpers, ModelResponse, ToolCallItem, TResponseInputItem
 from agents.lifecycle import AgentHooks, RunHooks
 from agents.models.interface import Model
 from agents.run import Runner
@@ -27,10 +27,12 @@ class RunHooksForTests(RunHooks):
     def __init__(self):
         self.events: dict[str, int] = defaultdict(int)
         self.tool_context_ids: list[str] = []
+        self.last_sealed_tool_call: ToolCallItem | None = None
 
     def reset(self):
         self.events.clear()
         self.tool_context_ids.clear()
+        self.last_sealed_tool_call = None
 
     async def on_agent_start(
         self, context: AgentHookContext[TContext], agent: Agent[TContext]
@@ -65,6 +67,15 @@ class RunHooksForTests(RunHooks):
         self.events["on_tool_end"] += 1
         if isinstance(context, ToolContext):
             self.tool_context_ids.append(context.tool_call_id)
+
+    async def on_tool_call_sealed(
+        self,
+        context: RunContextWrapper[TContext],
+        agent: Agent[TContext],
+        tool_call: ToolCallItem,
+    ) -> None:
+        self.events["on_tool_call_sealed"] += 1
+        self.last_sealed_tool_call = tool_call
 
     async def on_llm_start(
         self,
@@ -152,6 +163,30 @@ async def test_streamed_run_hooks_with_llm():
         "on_llm_end": 1,
         "on_agent_end": 1,
     }
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_hooks_tool_call_sealed():
+    """Verify that on_tool_call_sealed fires during streaming when a tool call is sealed."""
+    hooks = RunHooksForTests()
+    model = FakeModel()
+    agent = Agent(
+        name="A",
+        model=model,
+        tools=[get_function_tool("f", "res")],
+        handoffs=[],
+    )
+    # Simulate a streaming response with a tool call
+    model.set_next_output([get_function_tool_call("f", '{"key": "val"}')])
+    stream = Runner.run_streamed(agent, input="hello", hooks=hooks)
+
+    async for _event in stream.stream_events():
+        pass
+
+    assert hooks.events["on_tool_call_sealed"] == 1
+    assert hooks.last_sealed_tool_call is not None
+    assert hooks.last_sealed_tool_call.tool_name == "f"
+    assert hooks.last_sealed_tool_call.call_id is not None
 
 
 # test_async_run_hooks_with_agent_hooks_with_llm


### PR DESCRIPTION
## Summary

Adds a new lifecycle hook `on_tool_call_sealed` to both `RunHooksBase` and `AgentHooksBase` that fires during streaming when a tool call's arguments are sealed and ready, before the full response is complete and before the tool is invoked.

This provides a hook point for consumers to implement early tool preparation or eager dispatch without changing the SDK's execution flow. The default runner does not act on this hook — callers that do nothing with it see unchanged behavior.

Refs #3404

## Changes

1. **src/agents/lifecycle.py**: Added `on_tool_call_sealed` method to `RunHooksBase` and `AgentHooksBase`
2. **src/agents/run_internal/run_loop.py**: Wired the hook into `run_single_turn_streamed` at the point where `ToolCallItem` is created from a `ResponseOutputItemDoneEvent`
3. **tests/test_run_hooks.py**: Added `test_streamed_run_hooks_tool_call_sealed` test that verifies the hook fires with the correct tool name and call_id during streaming

## Test plan

- `make format` — passed
- `make lint` — passed
- `make tests` — all 44 relevant tests pass
- New test `test_streamed_run_hooks_tool_call_sealed` passes

Closes #3404