### PR TITLE
fix: missing reserved_tool_names argument in non-prefixed tool path

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -276,6 +276,7 @@ class MCPUtil:
                 run_context,
                 agent,
                 failure_error_function=failure_error_function,
+                reserved_tool_names=reserved_tool_names,
             )
             server_tool_names = {tool.name for tool in server_tools}
             duplicate_tool_names = sorted(server_tool_names & tool_names)


### PR DESCRIPTION
In MCPUtil.get_all_function_tools(), the reserved_tool_names parameter was correctly forwarded when include_server_in_tool_names was set to True, but was silently dropped in the fallback loop that processes servers without name prefixing.

This omission allowed MCP tools to be registered with names that could conflict with internal SDK reserved names. The conflict would bypass the intended reservation check, potentially causing ambiguous tool routing or unexpected behavior when agents invoke tools that share names with protected SDK functions.

The fix adds the reserved_tool_names argument to the get_function_tools() call in the non-prefixed execution branch. This restores consistent name reservation logic across both code paths and ensures that SDK-reserved identifiers are always protected during tool discovery.

The change is fully backward compatible, introduces no new dependencies, and does not alter any public API signatures. All existing unit tests pass without modification.