### PR TITLE
fix: cancel in-flight model task when a parallel input guardrail errors

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1243,6 +1243,17 @@ class AgentRunner:
                                         )
                                     )
                                     raise
+                                except Exception:
+                                    # A parallel input guardrail (or the model turn) raised a
+                                    # non-tripwire error. asyncio.gather does not cancel the
+                                    # sibling awaitables when one fails, so cancel the in-flight
+                                    # model task to avoid leaking it (mirrors the tripwire
+                                    # cleanup above).
+                                    if should_cancel_parallel_model_task_on_input_guardrail_trip():
+                                        if not model_task.done():
+                                            model_task.cancel()
+                                        await asyncio.gather(model_task, return_exceptions=True)
+                                    raise
                             else:
                                 turn_result = await model_task
 

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -616,6 +616,56 @@ async def test_parallel_guardrail_trip_compat_mode_does_not_cancel_model_task():
 
 
 @pytest.mark.asyncio
+async def test_parallel_guardrail_non_tripwire_error_cancels_model_task():
+    # A parallel input guardrail that raises a non-tripwire exception must not leave the
+    # in-flight model task running. asyncio.gather does not cancel sibling awaitables when
+    # one fails, so the runner is responsible for cancelling the model task.
+    model_started = asyncio.Event()
+    model_cancelled = asyncio.Event()
+    model_finished = asyncio.Event()
+
+    class GuardrailBoom(RuntimeError):
+        pass
+
+    @input_guardrail(run_in_parallel=True)
+    async def raises_after_model_starts(
+        ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        await asyncio.wait_for(model_started.wait(), timeout=1)
+        raise GuardrailBoom("guardrail failed")
+
+    model = FakeModel()
+    original_get_response = model.get_response
+
+    async def slow_get_response(*args, **kwargs):
+        model_started.set()
+        try:
+            await asyncio.sleep(0.02)
+            return await original_get_response(*args, **kwargs)
+        except asyncio.CancelledError:
+            model_cancelled.set()
+            raise
+        finally:
+            model_finished.set()
+
+    agent = Agent(
+        name="parallel_guardrail_error_agent",
+        instructions="Reply with 'hello'",
+        input_guardrails=[raises_after_model_starts],
+        model=model,
+    )
+    model.set_next_output([get_text_message("should_not_finish")])
+
+    with patch.object(model, "get_response", side_effect=slow_get_response):
+        with pytest.raises(GuardrailBoom):
+            await Runner.run(agent, "trigger guardrail")
+
+    await asyncio.wait_for(model_finished.wait(), timeout=1)
+    assert model_started.is_set() is True
+    assert model_cancelled.is_set() is True
+
+
+@pytest.mark.asyncio
 async def test_parallel_guardrail_may_not_prevent_tool_execution_streaming():
     tool_was_executed = False
     guardrail_executed = False


### PR DESCRIPTION
### Summary

When input guardrails run in parallel with the model turn (`run_in_parallel=True`), the model turn is started with `asyncio.create_task(...)` and awaited together with the guardrails via `asyncio.gather(...)` in `AgentRunner.run` (`src/agents/run.py`).

The existing handler only catches `InputGuardrailTripwireTriggered`, in which case it cancels and drains the in-flight `model_task`:

```python
except InputGuardrailTripwireTriggered:
    if should_cancel_parallel_model_task_on_input_guardrail_trip():
        if not model_task.done():
            model_task.cancel()
        await asyncio.gather(model_task, return_exceptions=True)
    ...
    raise
```

If a parallel guardrail (or the model turn) raises **any other** exception — e.g. a bug in a user's guardrail function, a `ValueError`, a transient error — `asyncio.gather` propagates that exception but does **not** cancel the sibling awaitables, so `model_task` is left running after `run()` has already raised. That orphaned task keeps a live model request going and surfaces as `Task was destroyed but it is pending!` / `Task exception was never retrieved` warnings, plus wasted tokens/quota.

This adds a generic `except` clause that performs the **same flag-gated cancel-and-drain** of the model task as the tripwire path, so a non-tripwire guardrail error no longer leaks the in-flight model task. The behavior on the tripwire path is unchanged, and the `should_cancel_parallel_model_task_on_input_guardrail_trip()` gate (Temporal replay compatibility) is respected in both paths.

### Test plan

- Added `test_parallel_guardrail_non_tripwire_error_cancels_model_task` in `tests/test_guardrails.py`, mirroring the existing `test_parallel_guardrail_trip_cancels_model_task` but with a parallel guardrail that raises a non-tripwire `RuntimeError` after the model starts. It asserts the error propagates from `Runner.run` and that the in-flight model task was cancelled.
- Verified the test **fails on `main`** (`assert model_cancelled.is_set() is True` → `assert False is True`, i.e. the model task was orphaned) and **passes with this change**.
- `make format`, `make lint`, `make typecheck` clean; full suite passes (`4625 passed, 5 skipped`).

### Issue number

N/A (found via code review).

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (no user-facing docs affected)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass