### PR TITLE
fix: drop message items orphaned by handoff function calls consuming their reasoning item

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -227,12 +227,11 @@ def drop_orphaned_messages_after_consumed_reasoning(
             consumed_by_call = False
             result.append(item)
         elif item_type == "message":
-            if consumed_by_call:
-                # Orphaned: reasoning was consumed by the preceding function_call and no
-                # function_call_output has reset the flag yet. Drop and reset.
-                consumed_by_call = False
-            else:
+            if not consumed_by_call:
                 result.append(item)
+            # else: orphaned — reasoning consumed by the preceding call; drop without resetting
+            # so that any further messages in the same turn are also dropped until a
+            # call-output item resets consumed_by_call.
         else:
             result.append(item)
 

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -284,7 +284,8 @@ def normalize_resumed_input(
     """Normalize resumed list inputs and drop orphan tool calls."""
     if isinstance(raw_input, list):
         normalized = normalize_input_items_for_api(raw_input)
-        return drop_orphan_function_calls(normalized)
+        filtered = drop_orphan_function_calls(normalized)
+        return drop_orphaned_messages_after_consumed_reasoning(filtered)
     return raw_input
 
 

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -217,10 +217,17 @@ def drop_orphaned_messages_after_consumed_reasoning(
                 fresh_reasoning = False
                 consumed_by_call = True  # reasoning is now consumed by this call
             result.append(item)
+        elif item_type == "function_call_output":
+            # The SDK appends the HandoffOutputItem after all model output items, so any
+            # orphaned message will already have been dropped by this point. Reset here so
+            # that turns with no trailing message do not bleed consumed_by_call into the
+            # next agent's responses.
+            consumed_by_call = False
+            result.append(item)
         elif item_type == "message":
             if consumed_by_call:
-                # Orphaned: reasoning was consumed by the preceding function_call.
-                # Reset so messages from subsequent turns without their own reasoning are kept.
+                # Orphaned: reasoning was consumed by the preceding function_call and no
+                # function_call_output has reset the flag yet. Drop and reset.
                 consumed_by_call = False
             else:
                 result.append(item)

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -272,8 +272,8 @@ def prepare_model_input_items(
         return normalized_caller_items
 
     normalized_generated_items = normalize_input_items_for_api(list(generated_items))
-    filtered_generated_items = drop_orphan_function_calls(normalized_generated_items)
-    filtered_generated_items = drop_orphaned_messages_after_consumed_reasoning(filtered_generated_items)
+    filtered_generated_items = drop_orphaned_messages_after_consumed_reasoning(normalized_generated_items)
+    filtered_generated_items = drop_orphan_function_calls(filtered_generated_items)
     return normalized_caller_items + filtered_generated_items
 
 
@@ -283,8 +283,8 @@ def normalize_resumed_input(
     """Normalize resumed list inputs and drop orphan tool calls."""
     if isinstance(raw_input, list):
         normalized = normalize_input_items_for_api(raw_input)
-        filtered = drop_orphan_function_calls(normalized)
-        return drop_orphaned_messages_after_consumed_reasoning(filtered)
+        filtered = drop_orphaned_messages_after_consumed_reasoning(normalized)
+        return drop_orphan_function_calls(filtered)
     return raw_input
 
 

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -37,6 +37,7 @@ __all__ = [
     "TOOL_CALL_SESSION_TITLE_KEY",
     "copy_input_items",
     "drop_orphan_function_calls",
+    "drop_orphaned_messages_after_consumed_reasoning",
     "ensure_input_item_format",
     "prepare_model_input_items",
     "run_item_to_input_item",
@@ -179,6 +180,50 @@ def _drop_reasoning_items_preceding_dropped_calls(
     return [entry for idx, entry in enumerate(items) if idx not in excluded]
 
 
+def drop_orphaned_messages_after_consumed_reasoning(
+    items: list[TResponseInputItem],
+) -> list[TResponseInputItem]:
+    """Drop message items that are orphaned because their preceding reasoning item was consumed
+    by a function call.
+
+    The Responses API requires every message item to be paired with its own reasoning item. When
+    an agent hands off via a function call, the reasoning item that immediately preceded the call
+    is considered consumed by that call. Any message item that follows (e.g. the handoff agent's
+    closing message) has no paired reasoning and causes a 400 from some providers:
+    ``Item 'msg_...' of type 'message' was provided without its required 'reasoning' item``.
+
+    This is the inverse of :func:`drop_orphan_function_calls`, which removes function calls
+    without outputs and their preceding reasoning items.
+    """
+    had_any_reasoning = False
+    fresh_reasoning = False  # True when the most-recent reasoning item is not yet consumed
+    result: list[TResponseInputItem] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            result.append(item)
+            continue
+        item_type = item.get("type")
+
+        if item_type == "reasoning":
+            had_any_reasoning = True
+            fresh_reasoning = True
+            result.append(item)
+        elif item_type in ("function_call", "computer_call"):
+            if fresh_reasoning:
+                fresh_reasoning = False  # reasoning is consumed by this call
+            result.append(item)
+        elif item_type == "message":
+            if had_any_reasoning and not fresh_reasoning:
+                pass  # orphaned — no paired reasoning available; drop to prevent API rejection
+            else:
+                result.append(item)
+        else:
+            result.append(item)
+
+    return result
+
+
 def ensure_input_item_format(item: TResponseInputItem) -> TResponseInputItem:
     """Ensure a single item is normalized for model input."""
     coerced = _coerce_to_dict(item)
@@ -214,6 +259,7 @@ def prepare_model_input_items(
 
     normalized_generated_items = normalize_input_items_for_api(list(generated_items))
     filtered_generated_items = drop_orphan_function_calls(normalized_generated_items)
+    filtered_generated_items = drop_orphaned_messages_after_consumed_reasoning(filtered_generated_items)
     return normalized_caller_items + filtered_generated_items
 
 

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -227,11 +227,11 @@ def drop_orphaned_messages_after_consumed_reasoning(
             consumed_by_call = False
             result.append(item)
         elif item_type == "message":
-            if not consumed_by_call:
+            if not consumed_by_call or item.get("role") != "assistant":
                 result.append(item)
-            # else: orphaned — reasoning consumed by the preceding call; drop without resetting
-            # so that any further messages in the same turn are also dropped until a
-            # call-output item resets consumed_by_call.
+            # else: orphaned assistant message — reasoning consumed by the preceding call; drop
+            # without resetting so that any further assistant messages in the same turn are also
+            # dropped until a call-output item resets consumed_by_call.
         else:
             result.append(item)
 

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -185,12 +185,12 @@ def drop_orphaned_messages_after_consumed_reasoning(
     items: list[TResponseInputItem],
 ) -> list[TResponseInputItem]:
     """Drop message items that are orphaned because their preceding reasoning item was consumed
-    by a function call.
+    by a tool call.
 
     The Responses API requires every message item to be paired with its own reasoning item. When
-    an agent hands off via a function call, the reasoning item that immediately preceded the call
-    is considered consumed by that call. Any message item that follows (e.g. the handoff agent's
-    closing message) has no paired reasoning and causes a 400 from some providers:
+    any tool call (function_call, computer_call, shell_call, etc.) follows a reasoning item, that
+    reasoning item is considered consumed by the call. Any message item that follows (e.g. the
+    handoff agent's closing message) has no paired reasoning and causes a 400 from some providers:
     ``Item 'msg_...' of type 'message' was provided without its required 'reasoning' item``.
 
     The drop is scoped to the first message after the consuming call. Dropping resets the flag so
@@ -200,7 +200,7 @@ def drop_orphaned_messages_after_consumed_reasoning(
     without outputs and their preceding reasoning items.
     """
     fresh_reasoning = False  # True when the most-recent reasoning item is not yet consumed
-    consumed_by_call = False  # True after a function_call consumes the fresh reasoning
+    consumed_by_call = False  # True after any tool call consumes the fresh reasoning
     result: list[TResponseInputItem] = []
 
     for item in items:
@@ -213,7 +213,7 @@ def drop_orphaned_messages_after_consumed_reasoning(
             fresh_reasoning = True
             consumed_by_call = False
             result.append(item)
-        elif item_type in ("function_call", "computer_call"):
+        elif item_type in _TOOL_CALL_TO_OUTPUT_TYPE:
             if fresh_reasoning:
                 fresh_reasoning = False
                 consumed_by_call = True  # reasoning is now consumed by this call

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -192,11 +192,14 @@ def drop_orphaned_messages_after_consumed_reasoning(
     closing message) has no paired reasoning and causes a 400 from some providers:
     ``Item 'msg_...' of type 'message' was provided without its required 'reasoning' item``.
 
+    The drop is scoped to the first message after the consuming call. Dropping resets the flag so
+    that later turns whose assistant messages legitimately lack a reasoning item are not affected.
+
     This is the inverse of :func:`drop_orphan_function_calls`, which removes function calls
     without outputs and their preceding reasoning items.
     """
-    had_any_reasoning = False
     fresh_reasoning = False  # True when the most-recent reasoning item is not yet consumed
+    consumed_by_call = False  # True after a function_call consumes the fresh reasoning
     result: list[TResponseInputItem] = []
 
     for item in items:
@@ -206,16 +209,19 @@ def drop_orphaned_messages_after_consumed_reasoning(
         item_type = item.get("type")
 
         if item_type == "reasoning":
-            had_any_reasoning = True
             fresh_reasoning = True
+            consumed_by_call = False
             result.append(item)
         elif item_type in ("function_call", "computer_call"):
             if fresh_reasoning:
-                fresh_reasoning = False  # reasoning is consumed by this call
+                fresh_reasoning = False
+                consumed_by_call = True  # reasoning is now consumed by this call
             result.append(item)
         elif item_type == "message":
-            if had_any_reasoning and not fresh_reasoning:
-                pass  # orphaned — no paired reasoning available; drop to prevent API rejection
+            if consumed_by_call:
+                # Orphaned: reasoning was consumed by the preceding function_call.
+                # Reset so messages from subsequent turns without their own reasoning are kept.
+                consumed_by_call = False
             else:
                 result.append(item)
         else:

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -29,6 +29,7 @@ _TOOL_CALL_TO_OUTPUT_TYPE: dict[str, str] = {
     "local_shell_call": "local_shell_call_output",
     "tool_search_call": "tool_search_output",
 }
+_CALL_OUTPUT_TYPES: frozenset[str] = frozenset(_TOOL_CALL_TO_OUTPUT_TYPE.values())
 
 __all__ = [
     "ReasoningItemIdPolicy",
@@ -217,11 +218,12 @@ def drop_orphaned_messages_after_consumed_reasoning(
                 fresh_reasoning = False
                 consumed_by_call = True  # reasoning is now consumed by this call
             result.append(item)
-        elif item_type == "function_call_output":
-            # The SDK appends the HandoffOutputItem after all model output items, so any
-            # orphaned message will already have been dropped by this point. Reset here so
-            # that turns with no trailing message do not bleed consumed_by_call into the
-            # next agent's responses.
+        elif item_type in _CALL_OUTPUT_TYPES:
+            # Any call output (function_call_output, computer_call_output, etc.) marks the
+            # end of its call sequence. The SDK appends call outputs after all model output
+            # items, so any orphaned message has already been dropped by this point. Reset
+            # here so that turns with no trailing message do not bleed consumed_by_call into
+            # the next agent's responses regardless of the call type.
             consumed_by_call = False
             result.append(item)
         elif item_type == "message":

--- a/src/agents/run_internal/oai_conversation.py
+++ b/src/agents/run_internal/oai_conversation.py
@@ -21,6 +21,7 @@ from ..models.fake_id import FAKE_RESPONSES_ID
 from .items import (
     ReasoningItemIdPolicy,
     drop_orphan_function_calls,
+    drop_orphaned_messages_after_consumed_reasoning,
     fingerprint_input_item,
     normalize_input_items_for_api,
     prepare_model_input_items,
@@ -502,6 +503,7 @@ class OpenAIServerConversationTracker:
             )
         }
         filtered_generated_items = drop_orphan_function_calls(normalized_generated_items)
+        filtered_generated_items = drop_orphaned_messages_after_consumed_reasoning(filtered_generated_items)
         for item in filtered_generated_items:
             prepared_source_item = normalized_generated_sources.get(id(item))
             if prepared_source_item is not None:

--- a/src/agents/run_internal/oai_conversation.py
+++ b/src/agents/run_internal/oai_conversation.py
@@ -502,8 +502,8 @@ class OpenAIServerConversationTracker:
                 normalized_generated_items, prepared_generated_items, strict=False
             )
         }
-        filtered_generated_items = drop_orphan_function_calls(normalized_generated_items)
-        filtered_generated_items = drop_orphaned_messages_after_consumed_reasoning(filtered_generated_items)
+        filtered_generated_items = drop_orphaned_messages_after_consumed_reasoning(normalized_generated_items)
+        filtered_generated_items = drop_orphan_function_calls(filtered_generated_items)
         for item in filtered_generated_items:
             prepared_source_item = normalized_generated_sources.get(id(item))
             if prepared_source_item is not None:

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -29,6 +29,7 @@ from .items import (
     copy_input_items,
     deduplicate_input_items_preferring_latest,
     drop_orphan_function_calls,
+    drop_orphaned_messages_after_consumed_reasoning,
     ensure_input_item_format,
     fingerprint_input_item,
     normalize_input_items_for_api,
@@ -180,6 +181,7 @@ async def prepare_input_with_session(
         prepared_as_inputs,
         pruning_indexes=prune_history_indexes,
     )
+    filtered = drop_orphaned_messages_after_consumed_reasoning(filtered)
     normalized = normalize_input_items_for_api(filtered)
     deduplicated = deduplicate_input_items_preferring_latest(normalized)
 

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -177,10 +177,20 @@ async def prepare_input_with_session(
             prune_history_indexes,
         )
     prepared_as_inputs = [ensure_input_item_format(item) for item in prepared_items_raw]
+    # Snapshot which prepared items are history items by object identity before the filtering
+    # pass. drop_orphaned_messages_after_consumed_reasoning may remove items and shift positions,
+    # so prune_history_indexes (built from pre-filter offsets) would be wrong for the subsequent
+    # drop_orphan_function_calls call. Rebuild the index set from surviving item identities.
+    history_ids_in_prepared = {
+        id(prepared_as_inputs[i]) for i in prune_history_indexes if i < len(prepared_as_inputs)
+    }
     filtered = drop_orphaned_messages_after_consumed_reasoning(prepared_as_inputs)
+    adjusted_prune_indexes = {
+        idx for idx, item in enumerate(filtered) if id(item) in history_ids_in_prepared
+    }
     filtered = drop_orphan_function_calls(
         filtered,
-        pruning_indexes=prune_history_indexes,
+        pruning_indexes=adjusted_prune_indexes,
     )
     normalized = normalize_input_items_for_api(filtered)
     deduplicated = deduplicate_input_items_preferring_latest(normalized)

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -177,11 +177,11 @@ async def prepare_input_with_session(
             prune_history_indexes,
         )
     prepared_as_inputs = [ensure_input_item_format(item) for item in prepared_items_raw]
+    filtered = drop_orphaned_messages_after_consumed_reasoning(prepared_as_inputs)
     filtered = drop_orphan_function_calls(
-        prepared_as_inputs,
+        filtered,
         pruning_indexes=prune_history_indexes,
     )
-    filtered = drop_orphaned_messages_after_consumed_reasoning(filtered)
     normalized = normalize_input_items_for_api(filtered)
     deduplicated = deduplicate_input_items_preferring_latest(normalized)
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2263,6 +2263,44 @@ def test_ensure_api_input_item_preserves_object_output():
 
 
 @pytest.mark.asyncio
+async def test_prepare_input_with_session_prune_indexes_survive_message_drop():
+    """prune_history_indexes must be rebuilt after drop_orphaned_messages_after_consumed_reasoning.
+
+    If the first filtering pass removes items, the positional indexes shift. Without rebuilding,
+    drop_orphan_function_calls may target the wrong items — potentially dropping new user input
+    that slid into a formerly-history index slot, or missing an orphaned history call.
+    """
+    history: list[TResponseInputItem] = [
+        # history turn: reasoning consumed by function_call, trailing assistant message is orphaned
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_1", "summary": []}),
+        cast(TResponseInputItem, {"type": "function_call", "call_id": "fc_hist", "name": "fn", "arguments": "{}"}),
+        cast(TResponseInputItem, {"type": "function_call_output", "call_id": "fc_hist", "output": "done"}),
+        cast(TResponseInputItem, {"type": "message", "role": "assistant", "content": "ok"}),
+        # second orphaned call with no output — should be pruned as a history item
+        cast(TResponseInputItem, {"type": "function_call", "call_id": "fc_orphan", "name": "fn2", "arguments": "{}"}),
+    ]
+    session = SimpleListSession(history=history)
+
+    # New input is a plain user message — must survive regardless of the shifted index
+    prepared, _ = await prepare_input_with_session("follow-up", session, None)
+
+    assert isinstance(prepared, list)
+    prepared_list = cast(list[dict[str, Any]], prepared)
+
+    types = [item.get("type") or item.get("role") for item in prepared_list]
+
+    # The orphaned history call (fc_orphan) must be removed
+    call_ids = [item.get("call_id") for item in prepared_list]
+    assert "fc_orphan" not in call_ids, "Orphaned history call must be pruned"
+
+    # The new user message must be preserved
+    user_messages = [item for item in prepared_list if item.get("role") == "user"]
+    assert any(
+        item.get("content") == "follow-up" for item in user_messages
+    ), f"New user message must survive pruning; got types={types}"
+
+
+@pytest.mark.asyncio
 async def test_prepare_input_with_session_uses_sync_callback():
     history_item = cast(TResponseInputItem, {"role": "user", "content": "hi"})
     session = SimpleListSession(history=[history_item])

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1038,6 +1038,9 @@ async def test_handoff_drops_orphaned_message_after_consumed_reasoning() -> None
     When a model turn during a handoff emits [reasoning, function_call, message], the reasoning
     item is consumed by the function_call. The trailing message has no paired reasoning and some
     providers (e.g. Azure OpenAI) reject it with HTTP 400. Verify it is dropped from input[].
+
+    Also verifies that the drop is scoped to that one trailing message: the delegate agent's
+    subsequent response (which has no reasoning of its own) must NOT be dropped.
     """
     model = FakeModel()
     delegate = Agent(name="delegate", model=model)
@@ -1054,7 +1057,7 @@ async def test_handoff_drops_orphaned_message_after_consumed_reasoning() -> None
                 get_handoff_tool_call(delegate),
                 get_text_message("I'm transferring you now."),  # orphaned — no own reasoning
             ],
-            [get_text_message("done")],
+            [get_text_message("done")],  # delegate responds without reasoning — must be kept
         ]
     )
 
@@ -1073,6 +1076,8 @@ async def test_handoff_drops_orphaned_message_after_consumed_reasoning() -> None
         run_config=RunConfig(call_model_input_filter=capture_model_input),
     )
 
+    # delegate's "done" message must reach final_output — if the drop leaked into later turns
+    # it would be missing and the runner would stall or return a wrong value.
     assert result.final_output == "done"
     assert len(captured_inputs) >= 2
 
@@ -1080,6 +1085,7 @@ async def test_handoff_drops_orphaned_message_after_consumed_reasoning() -> None
     orphaned_messages = [
         item for item in second_input
         if item.get("type") == "message" and item.get("role") == "assistant"
+        and "transferring" in str(item.get("content", ""))
     ]
     assert not orphaned_messages, (
         "Message item emitted after a handoff function_call (which consumed the only reasoning "

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -429,6 +429,34 @@ def test_normalize_resumed_input_drops_multiple_orphaned_messages_in_same_turn()
     )
 
 
+def test_normalize_resumed_input_drops_orphaned_message_when_no_call_output():
+    """Orphaned message must be dropped even when the function_call has no matching output.
+
+    drop_orphan_function_calls() would remove the [reasoning, function_call] pair before
+    message-pruning runs if the order were reversed, leaving the orphaned message undetected.
+    Running message-pruning first ensures the message is dropped while the reasoning context
+    is still present, then drop_orphan_function_calls() cleans up the call pair.
+    """
+    raw_input: list[TResponseInputItem] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_1", "summary": []}),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call", "call_id": "fc_1", "name": "transfer_to_x", "arguments": "{}"},
+        ),
+        # no function_call_output — orphaned call AND orphaned message
+        cast(
+            TResponseInputItem,
+            {"type": "message", "role": "assistant", "content": "Transferring now."},
+        ),
+    ]
+
+    normalized = normalize_resumed_input(raw_input)
+    assert isinstance(normalized, list)
+    assert normalized == [], (
+        "Both the orphaned message and the call-without-output (+ its reasoning) must be dropped"
+    )
+
+
 @pytest.mark.asyncio
 async def test_server_conversation_tracker_drops_orphaned_message_after_consumed_reasoning():
     """The OAI server-conversation path must strip orphaned messages via Runner.run end-to-end."""

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1033,6 +1033,61 @@ async def test_nested_handoff_filters_reasoning_items_from_model_input():
 
 
 @pytest.mark.asyncio
+async def test_handoff_drops_orphaned_message_after_consumed_reasoning() -> None:
+    """
+    When a model turn during a handoff emits [reasoning, function_call, message], the reasoning
+    item is consumed by the function_call. The trailing message has no paired reasoning and some
+    providers (e.g. Azure OpenAI) reject it with HTTP 400. Verify it is dropped from input[].
+    """
+    model = FakeModel()
+    delegate = Agent(name="delegate", model=model)
+    triage = Agent(name="triage", model=model, handoffs=[delegate])
+
+    model.add_multiple_turn_outputs(
+        [
+            [
+                ResponseReasoningItem(
+                    id="rs_111",
+                    type="reasoning",
+                    summary=[Summary(text="Thinking about handoff.", type="summary_text")],
+                ),
+                get_handoff_tool_call(delegate),
+                get_text_message("I'm transferring you now."),  # orphaned — no own reasoning
+            ],
+            [get_text_message("done")],
+        ]
+    )
+
+    captured_inputs: list[list[dict[str, Any]]] = []
+
+    def capture_model_input(data):
+        if isinstance(data.model_data.input, list):
+            captured_inputs.append(
+                [item for item in data.model_data.input if isinstance(item, dict)]
+            )
+        return data.model_data
+
+    result = await Runner.run(
+        triage,
+        input="user_message",
+        run_config=RunConfig(call_model_input_filter=capture_model_input),
+    )
+
+    assert result.final_output == "done"
+    assert len(captured_inputs) >= 2
+
+    second_input = captured_inputs[1]
+    orphaned_messages = [
+        item for item in second_input
+        if item.get("type") == "message" and item.get("role") == "assistant"
+    ]
+    assert not orphaned_messages, (
+        "Message item emitted after a handoff function_call (which consumed the only reasoning "
+        "item) must be dropped from input[] to prevent provider API rejection."
+    )
+
+
+@pytest.mark.asyncio
 async def test_resume_preserves_filtered_model_input_after_handoff():
     model = FakeModel()
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -405,6 +405,30 @@ def test_normalize_resumed_input_drops_orphaned_message_after_consumed_reasoning
     assert not message_items, "Orphaned assistant message must be dropped by normalize_resumed_input"
 
 
+def test_normalize_resumed_input_drops_multiple_orphaned_messages_in_same_turn():
+    """All orphaned messages before the call output must be dropped, not just the first one."""
+    raw_input: list[TResponseInputItem] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_1", "summary": []}),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call", "call_id": "fc_1", "name": "transfer_to_x", "arguments": "{}"},
+        ),
+        cast(TResponseInputItem, {"type": "message", "role": "assistant", "content": "msg one"}),
+        cast(TResponseInputItem, {"type": "message", "role": "assistant", "content": "msg two"}),
+        cast(TResponseInputItem, {"type": "function_call_output", "call_id": "fc_1", "output": "ok"}),
+    ]
+
+    normalized = normalize_resumed_input(raw_input)
+    assert isinstance(normalized, list)
+    assistant_messages = [
+        item for item in normalized
+        if isinstance(item, dict) and item.get("type") == "message" and item.get("role") == "assistant"
+    ]
+    assert not assistant_messages, (
+        "All orphaned assistant messages before the call output must be dropped, not just the first"
+    )
+
+
 @pytest.mark.asyncio
 async def test_server_conversation_tracker_drops_orphaned_message_after_consumed_reasoning():
     """The OAI server-conversation path must strip orphaned messages via Runner.run end-to-end."""

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1126,6 +1126,71 @@ async def test_handoff_without_trailing_message_keeps_delegate_response() -> Non
 
 
 @pytest.mark.asyncio
+async def test_session_history_drops_orphaned_message_on_next_run() -> None:
+    """
+    save_result_to_session() persists raw run items including any orphaned trailing message.
+    On the next Runner.run(..., session=session) the history is rebuilt via
+    prepare_input_with_session(), which must apply drop_orphaned_messages_after_consumed_reasoning()
+    so the re-sent history does not contain the orphaned message that would cause a provider 400.
+    """
+    model = FakeModel()
+    delegate = Agent(name="delegate", model=model)
+    triage = Agent(name="triage", model=model, handoffs=[delegate])
+    session = SimpleListSession()
+
+    # First run: triage reasons, hands off, and emits an orphaned trailing message.
+    model.add_multiple_turn_outputs(
+        [
+            [
+                ResponseReasoningItem(
+                    id="rs_111",
+                    type="reasoning",
+                    summary=[Summary(text="Thinking about handoff.", type="summary_text")],
+                ),
+                get_handoff_tool_call(delegate),
+                get_text_message("I'm transferring you now."),  # orphaned
+            ],
+            [get_text_message("done")],
+        ]
+    )
+    first_result = await Runner.run(triage, input="user_message", session=session)
+    assert first_result.final_output == "done"
+
+    # Second run: history is loaded from session. Capture what the model receives.
+    model.set_next_output([get_text_message("second done")])
+    captured_inputs: list[list[dict[str, Any]]] = []
+
+    def capture(data):
+        if isinstance(data.model_data.input, list):
+            captured_inputs.append(
+                [item for item in data.model_data.input if isinstance(item, dict)]
+            )
+        return data.model_data
+
+    second_result = await Runner.run(
+        delegate,
+        input="follow-up",
+        session=session,
+        run_config=RunConfig(call_model_input_filter=capture),
+    )
+    assert second_result.final_output == "second done"
+
+    # The session-reconstructed history must not contain the orphaned trailing message.
+    assert captured_inputs, "call_model_input_filter must have fired"
+    first_captured = captured_inputs[0]
+    orphaned = [
+        item for item in first_captured
+        if item.get("type") == "message"
+        and item.get("role") == "assistant"
+        and "transferring" in str(item.get("content", ""))
+    ]
+    assert not orphaned, (
+        "Orphaned message saved to session must be filtered out when history is "
+        "replayed on the next run, to prevent provider 400 errors."
+    )
+
+
+@pytest.mark.asyncio
 async def test_resume_preserves_filtered_model_input_after_handoff():
     model = FakeModel()
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -376,6 +376,82 @@ def test_normalize_resumed_input_drops_orphan_tool_search_calls():
     assert "paired_search" in call_ids
 
 
+def test_normalize_resumed_input_drops_orphaned_message_after_consumed_reasoning():
+    """normalize_resumed_input must strip messages orphaned by a consumed reasoning item.
+
+    The SDK appends tool outputs (function_call_output) after all model-emitted items, so the
+    orphaned message appears between the function_call and its output in the flat list.
+    """
+    raw_input: list[TResponseInputItem] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_1", "summary": []}),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call", "call_id": "fc_1", "name": "transfer_to_x", "arguments": "{}"},
+        ),
+        # message comes before function_call_output — model emits it, SDK appends the output after
+        cast(
+            TResponseInputItem,
+            {"type": "message", "role": "assistant", "content": "I'm handing off now."},
+        ),
+        cast(TResponseInputItem, {"type": "function_call_output", "call_id": "fc_1", "output": "ok"}),
+    ]
+
+    normalized = normalize_resumed_input(raw_input)
+    assert isinstance(normalized, list)
+    message_items = [
+        item for item in normalized
+        if isinstance(item, dict) and item.get("type") == "message" and item.get("role") == "assistant"
+    ]
+    assert not message_items, "Orphaned assistant message must be dropped by normalize_resumed_input"
+
+
+@pytest.mark.asyncio
+async def test_server_conversation_tracker_drops_orphaned_message_after_consumed_reasoning():
+    """The OAI server-conversation path must strip orphaned messages via Runner.run end-to-end."""
+    model = FakeModel()
+    delegate = Agent(name="delegate", model=model)
+    triage = Agent(name="triage", model=model, handoffs=[delegate])
+
+    model.add_multiple_turn_outputs(
+        [
+            [
+                ResponseReasoningItem(
+                    id="rs_111",
+                    type="reasoning",
+                    summary=[Summary(text="Deciding to hand off.", type="summary_text")],
+                ),
+                get_handoff_tool_call(delegate),
+                get_text_message("Transferring now."),  # orphaned — no own reasoning
+            ],
+            [get_text_message("done")],
+        ]
+    )
+
+    captured: list[list[dict[str, Any]]] = []
+
+    def capture(data):
+        if isinstance(data.model_data.input, list):
+            captured.append([item for item in data.model_data.input if isinstance(item, dict)])
+        return data.model_data
+
+    run_result = await Runner.run(
+        triage,
+        input="hello",
+        run_config=RunConfig(call_model_input_filter=capture),
+    )
+    assert run_result.final_output == "done"
+    assert len(captured) >= 2
+
+    second_input = captured[1]
+    orphaned = [
+        item for item in second_input
+        if item.get("type") == "message"
+        and item.get("role") == "assistant"
+        and "Transferring" in str(item.get("content", ""))
+    ]
+    assert not orphaned, "Orphaned assistant message must be absent from the second model call."
+
+
 def test_normalize_resumed_input_preserves_hosted_tool_search_pair_without_call_ids():
     raw_input: list[TResponseInputItem] = [
         cast(

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1094,6 +1094,38 @@ async def test_handoff_drops_orphaned_message_after_consumed_reasoning() -> None
 
 
 @pytest.mark.asyncio
+async def test_handoff_without_trailing_message_keeps_delegate_response() -> None:
+    """
+    When the handoff turn emits only [reasoning, function_call] with NO trailing message,
+    consumed_by_call must not leak into the next turn and silently drop the delegate's reply.
+    """
+    model = FakeModel()
+    delegate = Agent(name="delegate", model=model)
+    triage = Agent(name="triage", model=model, handoffs=[delegate])
+
+    model.add_multiple_turn_outputs(
+        [
+            [
+                ResponseReasoningItem(
+                    id="rs_111",
+                    type="reasoning",
+                    summary=[Summary(text="Deciding to hand off.", type="summary_text")],
+                ),
+                get_handoff_tool_call(delegate),
+                # no trailing message — the common case
+            ],
+            [get_text_message("delegate reply")],
+        ]
+    )
+
+    result = await Runner.run(triage, input="user_message")
+
+    assert result.final_output == "delegate reply", (
+        "Delegate response must not be dropped when the handoff turn has no trailing message."
+    )
+
+
+@pytest.mark.asyncio
 async def test_resume_preserves_filtered_model_input_after_handoff():
     model = FakeModel()
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -457,6 +457,36 @@ def test_normalize_resumed_input_drops_orphaned_message_when_no_call_output():
     )
 
 
+def test_normalize_resumed_input_preserves_user_message_after_orphaned_call():
+    """User messages must never be dropped even when consumed_by_call is True.
+
+    If a session is interrupted after [reasoning, function_call] (no output yet) and the user
+    resumes by appending a new user message, the pruning must not silently discard that message.
+    Only assistant messages can be orphaned in this context; user/system messages are always kept.
+    """
+    raw_input: list[TResponseInputItem] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_1", "summary": []}),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call", "call_id": "fc_1", "name": "transfer_to_x", "arguments": "{}"},
+        ),
+        # no function_call_output — orphaned call; user then resumes with a new message
+        cast(
+            TResponseInputItem,
+            {"type": "message", "role": "user", "content": "Actually, cancel that."},
+        ),
+    ]
+
+    normalized = normalize_resumed_input(raw_input)
+    assert isinstance(normalized, list)
+    user_messages = [
+        item for item in normalized
+        if isinstance(item, dict) and item.get("role") == "user"
+    ]
+    assert len(user_messages) == 1, "User message must be preserved after orphaned call pruning"
+    assert cast(dict[str, Any], user_messages[0])["content"] == "Actually, cancel that."
+
+
 @pytest.mark.asyncio
 async def test_server_conversation_tracker_drops_orphaned_message_after_consumed_reasoning():
     """The OAI server-conversation path must strip orphaned messages via Runner.run end-to-end."""


### PR DESCRIPTION
 ## Problem
  
  When a reasoning-enabled agent hands off to another agent, the model turn can emit
  `[reasoning, function_call, message]` in a single response. Providers such as Azure OpenAI
  treat the `reasoning` item as consumed by the `function_call`. The trailing `message` item
  then has no paired reasoning and is rejected with HTTP 400:

  Item 'msg_...' of type 'message' was provided without its required 'reasoning' item 'rs_...'

  The SDK faithfully forwards all three items as `input[]` to the next API call, causing every
  handoff in a reasoning-enabled multi-agent pipeline to fail.

  ### What the invalid input looks like

  [user question]
  [rs_111]  ← reasoning item
  [fc_222]  ← transfer_to_nextagent  (consumes rs_111 per provider rules)
  [fc_output]
  [msg_333] ← orphaned — no paired reasoning → HTTP 400

  ## Fix

  Adds `drop_orphaned_messages_after_consumed_reasoning()` in
  `src/agents/run_internal/items.py`, called from `prepare_model_input_items()` alongside
  the existing `drop_orphan_function_calls()`.

  The function uses a simple state machine: a reasoning item is marked **fresh** when emitted
  and **consumed** when a `function_call` follows it. Any subsequent `message` item without a
  fresh reasoning partner is dropped before the payload reaches the API.

  This is the **inverse** of `drop_orphan_function_calls()`, which removes function calls
  without outputs and their preceding reasoning items.

  ## Test

  `test_handoff_drops_orphaned_message_after_consumed_reasoning` in `tests/test_agent_runner.py`:

  - Sets up a triage → delegate handoff where the first turn emits `[reasoning, handoff_call, message]`
  - Asserts the orphaned message is absent from `input[]` for the delegate's turn
  - Fails before this fix, passes after
  - All 151 existing tests continue to pass