### PR TITLE
fix(mcp): preserve empty structured content in tool output

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -665,7 +665,7 @@ class MCPUtil:
 
         # If structured content is requested and available, use it exclusively
         tool_output: ToolOutput
-        if server.use_structured_content and result.structuredContent:
+        if server.use_structured_content and result.structuredContent is not None:
             tool_output = json.dumps(result.structuredContent)
         else:
             tool_output_list: list[ToolOutputItem] = []


### PR DESCRIPTION
When `server.use_structured_content` is enabled, `invoke_mcp_tool()` should treat structured content as available whenever it is not `None`, even if it is an empty list or object. The current truthiness check drops valid empty JSON results and falls back to the content-based path instead. That conflicts with the code comment and documented behavior that structured content should be used exclusively when it is requested and available. 

This change updates the condition from a truthiness check to an explicit `is not None` check so that empty structured results such as `[]` and `{}` are still serialized and returned correctly. This aligns the runtime behavior with the intended MCP output handling and addresses the empty-tool-output bug reported in #1035. 

Testing:
- Add a regression test for `structuredContent=[]` with `use_structured_content=True`
- Add a regression test for `structuredContent={}` with `use_structured_content=True`
- Verify the method returns JSON text for both cases rather than falling back to `result.content`