### PR TITLE
docs: add Latitude to external tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -223,3 +223,4 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [HoneyHive](https://docs.honeyhive.ai/v2/integrations/openai-agents)
 -   [Asqav](https://www.asqav.com/docs/integrations#openai-agents)
 -   [Datadog](https://docs.datadoghq.com/llm_observability/instrumentation/auto_instrumentation/?tab=python#openai-agents)
+-   [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)


### PR DESCRIPTION
Adds Latitude to the list of external tracing processors in `docs/tracing.md`.

Latitude ships SDK-level instrumentation for the OpenAI Agents SDK in Python. Setup and a code sample live at https://docs.latitude.so/telemetry/frameworks/openai-agents.