### PR TITLE
fix: export ToolContext, MCPToolChoice, and RequestUsage from agents

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -81,7 +81,7 @@ from .memory import (
     SessionSettings,
     is_openai_responses_compaction_aware_session,
 )
-from .model_settings import ModelSettings
+from .model_settings import MCPToolChoice, ModelSettings
 from .models.interface import Model, ModelProvider, ModelTracing
 from .models.multi_provider import MultiProvider
 from .models.openai_agent_registration import OpenAIAgentRegistrationConfig
@@ -187,6 +187,7 @@ from .tool import (
     resolve_computer,
     tool_namespace,
 )
+from .tool_context import ToolContext
 from .tool_guardrails import (
     ToolGuardrailFunctionOutput,
     ToolInputGuardrail,
@@ -242,7 +243,7 @@ from .tracing import (
     transcription_span,
     turn_span,
 )
-from .usage import Usage
+from .usage import RequestUsage, Usage
 from .version import __version__
 
 if TYPE_CHECKING:
@@ -348,6 +349,7 @@ __all__ = [
     "ModelProvider",
     "ModelTracing",
     "ModelSettings",
+    "MCPToolChoice",
     "ModelRetryAdvice",
     "ModelRetryAdviceRequest",
     "ModelRetryBackoffSettings",
@@ -436,6 +438,7 @@ __all__ = [
     "AgentHookContext",
     "RunContextWrapper",
     "TContext",
+    "ToolContext",
     "RunErrorDetails",
     "RunErrorData",
     "RunErrorHandler",
@@ -511,6 +514,7 @@ __all__ = [
     "tool_namespace",
     "resolve_computer",
     "dispose_resolved_computers",
+    "RequestUsage",
     "Usage",
     "add_trace_processor",
     "agent_span",

--- a/tests/test_public_type_exports.py
+++ b/tests/test_public_type_exports.py
@@ -1,0 +1,42 @@
+"""Verify that user-facing helper types are re-exported from the top-level agents package."""
+
+import agents
+from agents import (
+    model_settings as model_settings_module,
+    tool_context as tool_context_module,
+    usage as usage_module,
+)
+
+
+def test_tool_context_is_exported_at_top_level() -> None:
+    # ToolContext is the documented context type for function tools and lifecycle hooks,
+    # so it must be importable from `agents` like RunContextWrapper.
+    from agents import ToolContext
+
+    assert ToolContext is tool_context_module.ToolContext
+    assert "ToolContext" in agents.__all__
+
+
+def test_mcp_tool_choice_is_exported_at_top_level() -> None:
+    # MCPToolChoice is the value users assign to ModelSettings.tool_choice to force a
+    # specific hosted MCP tool, so it must be importable alongside ModelSettings.
+    from agents import MCPToolChoice
+
+    assert MCPToolChoice is model_settings_module.MCPToolChoice
+    assert "MCPToolChoice" in agents.__all__
+
+
+def test_request_usage_is_exported_at_top_level() -> None:
+    # RequestUsage is the element type of Usage.request_usage_entries, so users need it
+    # importable from `agents` to annotate per-request usage data.
+    from agents import RequestUsage
+
+    assert RequestUsage is usage_module.RequestUsage
+    assert "RequestUsage" in agents.__all__
+
+
+def test_exported_names_resolve_to_attributes() -> None:
+    # Every name listed in agents.__all__ should resolve via getattr so that
+    # `from agents import <name>` works for the package's whole public surface.
+    for name in agents.__all__:
+        assert hasattr(agents, name), f"agents.{name} is in __all__ but not importable"


### PR DESCRIPTION
### Summary

`ToolContext`, `MCPToolChoice`, and `RequestUsage` are user-facing types that currently require submodule imports. `ToolContext` is the documented context type for function tools (`docs/context.md` — even the repo's own examples import it from `agents.tool_context`), `MCPToolChoice` is the `ModelSettings.tool_choice` value for forcing a specific hosted MCP tool, and `RequestUsage` is the element type of `Usage.request_usage_entries`. This re-exports them from the top-level `agents` package, following the same pattern as #3489 and #3490. Existing submodule import paths keep working, so no docs changes are needed.

### Test plan

- Added `tests/test_public_type_exports.py`: `test_tool_context_is_exported_at_top_level`, `test_mcp_tool_choice_is_exported_at_top_level`, `test_request_usage_is_exported_at_top_level`, and `test_exported_names_resolve_to_attributes` (asserts every name in `agents.__all__` resolves via `getattr`).
- `make format`, `make lint`, and pyright pass; mypy reports only pre-existing errors also present on clean `main`.
- Full test suite run locally; the new tests pass and the only failures are pre-existing on clean `main` (local environment-related, unrelated to this change).

### Issue number

None — follow-up to the export gaps addressed in #3489/#3490.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
