### PR TITLE
feat: add ValkeySession provider for session memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ encrypt = ["cryptography>=45.0, <46"]
 redis = ["redis>=7"]
 dapr = ["dapr>=1.16.0", "grpcio>=1.60.0"]
 mongodb = ["pymongo>=4.14"]
+valkey = ["valkey-glide>=2.1"]
 docker = ["docker>=6.1"]
 blaxel = ["blaxel>=0.2.50", "aiohttp>=3.12,<4"]
 daytona = ["daytona>=0.155.0"]
@@ -92,6 +93,7 @@ dev = [
   "testcontainers==4.12.0",       # pinned to 4.12.0 because 4.13.0 has a warning bug in wait_for_logs, see https://github.com/testcontainers/testcontainers-python/issues/874
   "pyright==1.1.408",
   "pymongo>=4.14",
+  "valkey-glide>=2.1",
 ]
 
 [tool.uv.workspace]
@@ -162,6 +164,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["vercel", "vercel.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["glide", "glide.*"]
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/src/agents/extensions/memory/__init__.py
+++ b/src/agents/extensions/memory/__init__.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from .mongodb_session import MongoDBSession
     from .redis_session import RedisSession
     from .sqlalchemy_session import SQLAlchemySession
+    from .valkey_session import ValkeySession
 
 __all__: list[str] = [
     "AdvancedSQLiteSession",
@@ -36,6 +37,7 @@ __all__: list[str] = [
     "MongoDBSession",
     "RedisSession",
     "SQLAlchemySession",
+    "ValkeySession",
 ]
 
 _LAZY_EXPORTS: dict[str, tuple[str, tuple[str, str] | None]] = {
@@ -48,6 +50,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, tuple[str, str] | None]] = {
     "DAPR_CONSISTENCY_EVENTUAL": (".dapr_session", ("dapr", "dapr")),
     "DAPR_CONSISTENCY_STRONG": (".dapr_session", ("dapr", "dapr")),
     "MongoDBSession": (".mongodb_session", ("mongodb", "mongodb")),
+    "ValkeySession": (".valkey_session", ("valkey-glide", "valkey")),
 }
 
 

--- a/src/agents/extensions/memory/valkey_session.py
+++ b/src/agents/extensions/memory/valkey_session.py
@@ -1,0 +1,335 @@
+"""Valkey-powered Session backend.
+
+Valkey is the Linux Foundation's open-source, BSD-licensed, high-performance
+key-value store, forked from Redis 7.2.5. It is wire-compatible with Redis.
+
+Usage::
+
+    from agents.extensions.memory import ValkeySession
+
+    # Create from Valkey URL (async – GlideClient.create is async)
+    session = await ValkeySession.from_url(
+        session_id="user-123",
+        url="valkey://localhost:6379/0",
+    )
+
+    # Or pass an existing GlideClient that your application already manages
+    session = ValkeySession(
+        session_id="user-123",
+        glide_client=my_glide_client,
+    )
+
+    await Runner.run(agent, "Hello", session=session)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+from ._optional_imports import raise_optional_dependency_error
+
+try:
+    from glide import (
+        Batch,
+        GlideClient,
+        GlideClientConfiguration,
+        NodeAddress,
+        ServerCredentials,
+    )
+except ImportError as e:
+    raise_optional_dependency_error(
+        "ValkeySession",
+        dependency_name="valkey-glide",
+        extra_name="valkey",
+        cause=e,
+    )
+
+from ...items import TResponseInputItem
+from ...memory.session import SessionABC
+from ...memory.session_settings import SessionSettings, resolve_session_limit
+
+
+class ValkeySession(SessionABC):
+    """Valkey implementation of [`Session`][agents.memory.session.Session].
+
+    Uses the [valkey-glide](https://github.com/valkey-io/valkey-glide) client
+    library, which is purpose-built for Valkey and will track Valkey-specific
+    features as they are released.
+    """
+
+    session_settings: SessionSettings | None = None
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        glide_client: GlideClient,
+        key_prefix: str = "agents:session",
+        ttl: int | None = None,
+        session_settings: SessionSettings | None = None,
+    ):
+        """Initializes a new ValkeySession.
+
+        Args:
+            session_id (str): Unique identifier for the conversation.
+            glide_client (GlideClient): A pre-configured Valkey GlideClient.
+            key_prefix (str, optional): Prefix for Valkey keys to avoid collisions.
+                Defaults to "agents:session".
+            ttl (int | None, optional): Time-to-live in seconds for session data.
+                If None, data persists indefinitely. Defaults to None.
+            session_settings (SessionSettings | None): Session configuration settings including
+                default limit for retrieving items. If None, uses default SessionSettings().
+        """
+        self.session_id = session_id
+        self.session_settings = session_settings or SessionSettings()
+        self._glide = glide_client
+        self._key_prefix = key_prefix
+        self._ttl = ttl
+        self._lock = asyncio.Lock()
+        self._owns_client = False  # Track if we own the GlideClient
+
+        # Valkey key patterns
+        self._session_key = f"{self._key_prefix}:{self.session_id}"
+        self._messages_key = f"{self._session_key}:messages"
+        self._counter_key = f"{self._session_key}:counter"
+
+    @classmethod
+    async def from_url(
+        cls,
+        session_id: str,
+        *,
+        url: str,
+        glide_kwargs: dict[str, Any] | None = None,
+        session_settings: SessionSettings | None = None,
+        **kwargs: Any,
+    ) -> ValkeySession:
+        """Create a session from a Valkey/Redis URL string.
+
+        Supports the following URL schemes:
+
+        * ``valkey://`` – plain-text connection to a Valkey server.
+        * ``valkeys://`` – TLS-encrypted connection to a Valkey server.
+        * ``redis://`` – plain-text connection (compatibility, connects to Valkey).
+        * ``rediss://`` – TLS-encrypted connection (compatibility).
+
+        Args:
+            session_id (str): Conversation ID.
+            url (str): Valkey/Redis URL, e.g. ``"valkey://localhost:6379/0"`` or
+                ``"valkeys://host:6380"``.
+            glide_kwargs (dict[str, Any] | None): Additional keyword arguments forwarded to
+                :class:`GlideClientConfiguration`.
+            session_settings (SessionSettings | None): Session configuration settings including
+                default limit for retrieving items. If None, uses default SessionSettings().
+            **kwargs: Additional keyword arguments forwarded to the main constructor
+                (e.g., ``key_prefix``, ``ttl``, etc.).
+
+        Returns:
+            ValkeySession: An instance of ValkeySession connected to the specified server.
+        """
+        parsed = urlparse(url)
+
+        # Determine TLS from scheme
+        use_tls = parsed.scheme in ("valkeys", "rediss")
+
+        # Get host and port
+        host = parsed.hostname or "localhost"
+        port = parsed.port or (6380 if use_tls else 6379)
+
+        # Parse database ID from path
+        database_id = None
+        if parsed.path and parsed.path not in ("", "/"):
+            db_str = parsed.path.lstrip("/")
+            try:
+                database_id = int(db_str)
+            except ValueError:
+                pass
+
+        glide_kwargs = glide_kwargs or {}
+
+        # Build configuration
+        config_kwargs: dict[str, Any] = {
+            "addresses": [NodeAddress(host, port)],
+            "use_tls": use_tls,
+        }
+
+        if database_id is not None:
+            config_kwargs["database_id"] = database_id
+
+        if parsed.username or parsed.password:
+            config_kwargs["credentials"] = ServerCredentials(
+                password=parsed.password,
+                username=parsed.username or None,
+            )
+
+        # Merge any additional glide kwargs (user overrides)
+        config_kwargs.update(glide_kwargs)
+
+        config = GlideClientConfiguration(**config_kwargs)
+        glide_client = await GlideClient.create(config)
+
+        session = cls(
+            session_id,
+            glide_client=glide_client,
+            session_settings=session_settings,
+            **kwargs,
+        )
+        session._owns_client = True  # We created the client, so we own it
+        return session
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _serialize_item(self, item: TResponseInputItem) -> bytes:
+        """Serialize an item to bytes."""
+        return json.dumps(item, separators=(",", ":")).encode("utf-8")
+
+    async def _deserialize_item(self, item: bytes) -> TResponseInputItem:
+        """Deserialize bytes to an item."""
+        return json.loads(item.decode("utf-8"))  # type: ignore[no-any-return]
+
+    async def _get_next_id(self) -> int:
+        """Get the next message ID using Valkey INCR for atomic increment."""
+        result = await self._glide.incr(self._counter_key)
+        return int(result)
+
+    async def _set_ttl_if_configured(self, *keys: str) -> None:
+        """Set TTL on keys if configured."""
+        if self._ttl is not None:
+            for key in keys:
+                await self._glide.expire(key, self._ttl)
+
+    # ------------------------------------------------------------------
+    # Session protocol implementation
+    # ------------------------------------------------------------------
+
+    async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+        """Retrieve the conversation history for this session.
+
+        Args:
+            limit: Maximum number of items to retrieve. If None, uses session_settings.limit.
+                   When specified, returns the latest N items in chronological order.
+
+        Returns:
+            List of input items representing the conversation history
+        """
+        session_limit = resolve_session_limit(limit, self.session_settings)
+
+        async with self._lock:
+            if session_limit is None:
+                # Get all messages in chronological order
+                raw_messages = await self._glide.lrange(self._messages_key, 0, -1)
+            else:
+                if session_limit <= 0:
+                    return []
+                # Get the latest N messages (Valkey list is ordered chronologically)
+                raw_messages = await self._glide.lrange(
+                    self._messages_key, -session_limit, -1
+                )
+
+            items: list[TResponseInputItem] = []
+            for raw_msg in raw_messages:
+                try:
+                    item = await self._deserialize_item(raw_msg)
+                    items.append(item)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    # Skip corrupted messages
+                    continue
+
+            return items
+
+    async def add_items(self, items: list[TResponseInputItem]) -> None:
+        """Add new items to the conversation history.
+
+        Args:
+            items: List of input items to add to the history
+        """
+        if not items:
+            return
+
+        async with self._lock:
+            now = str(int(time.time()))
+
+            # Build a non-atomic batch (pipeline) for efficiency
+            batch = Batch(is_atomic=False)
+
+            # Set session metadata, preserving created_at across subsequent writes
+            batch.hset(self._session_key, {"session_id": self.session_id})
+            batch.hsetnx(self._session_key, "created_at", now)
+
+            # Serialize and add all items to the messages list
+            serialized_items: list[bytes] = []
+            for item in items:
+                serialized = await self._serialize_item(item)
+                serialized_items.append(serialized)
+
+            if serialized_items:
+                batch.rpush(self._messages_key, serialized_items)
+
+            # Update the session timestamp
+            batch.hset(self._session_key, {"updated_at": now})
+
+            # Execute all commands in one round-trip
+            await self._glide.exec(batch, raise_on_error=False)
+
+            # Set TTL if configured
+            await self._set_ttl_if_configured(
+                self._session_key, self._messages_key, self._counter_key
+            )
+
+    async def pop_item(self) -> TResponseInputItem | None:
+        """Remove and return the most recent item from the session.
+
+        Returns:
+            The most recent item if it exists, None if the session is empty
+        """
+        async with self._lock:
+            while True:
+                raw_msg = await self._glide.rpop(self._messages_key)
+
+                if raw_msg is None:
+                    return None
+
+                try:
+                    return await self._deserialize_item(raw_msg)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    # Drop corrupted messages and keep looking for a valid item
+                    continue
+
+    async def clear_session(self) -> None:
+        """Clear all items for this session."""
+        async with self._lock:
+            # Delete all keys associated with this session
+            await self._glide.delete(
+                [
+                    self._session_key,
+                    self._messages_key,
+                    self._counter_key,
+                ]
+            )
+
+    async def close(self) -> None:
+        """Close the Valkey connection.
+
+        Only closes the connection if this session owns the GlideClient
+        (i.e., created via :meth:`from_url`). If the client was injected
+        externally, the caller is responsible for managing its lifecycle.
+        """
+        if self._owns_client:
+            await self._glide.close()
+
+    async def ping(self) -> bool:
+        """Test Valkey connectivity.
+
+        Returns:
+            True if Valkey is reachable, False otherwise.
+        """
+        try:
+            await self._glide.ping()
+            return True
+        except Exception:
+            return False

--- a/tests/extensions/memory/test_valkey_session.py
+++ b/tests/extensions/memory/test_valkey_session.py
@@ -1,0 +1,811 @@
+"""Tests for ValkeySession using testcontainers (Valkey container) or a local server.
+
+Run with::
+
+    # Requires Docker for testcontainers, or set VALKEY_URL env var
+    VALKEY_URL=valkey://localhost:6379/15 pytest tests/extensions/memory/test_valkey_session.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import time
+
+import pytest
+
+pytest.importorskip("glide")  # Skip tests if valkey-glide is not installed
+
+from agents import Agent, RunConfig, Runner, TResponseInputItem
+from agents.extensions.memory.valkey_session import ValkeySession
+from agents.memory import SessionSettings
+from tests.fake_model import FakeModel
+from tests.test_responses import get_text_message
+
+# Docker-backed integration tests should stay on the serial test path.
+pytestmark = [pytest.mark.asyncio, pytest.mark.serial]
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+
+_use_testcontainers = False
+_valkey_url_from_container: str | None = None
+
+
+def _docker_available() -> bool:
+    """Check whether Docker is available on this machine."""
+    if sys.platform == "win32":
+        return False
+    if shutil.which("docker") is None:
+        return False
+    try:
+        import docker  # type: ignore[import-untyped]
+    except ImportError:
+        return False
+    try:
+        client = docker.from_env()
+        client.ping()
+        client.close()
+        return True
+    except Exception:
+        return False
+
+
+async def _create_valkey_session(
+    session_id: str,
+    key_prefix: str = "test:",
+    ttl: int | None = None,
+    session_settings: SessionSettings | None = None,
+) -> ValkeySession:
+    """Create a ValkeySession connected to a test Valkey/Redis instance."""
+    from glide import GlideClient, GlideClientConfiguration, NodeAddress
+
+    url = os.environ.get("VALKEY_URL")
+
+    if url:
+        session = await ValkeySession.from_url(
+            session_id,
+            url=url,
+            key_prefix=key_prefix,
+            ttl=ttl,
+            session_settings=session_settings,
+        )
+    else:
+        # Fall back to localhost with default port
+        config = GlideClientConfiguration(
+            addresses=[NodeAddress("localhost", 6379)],
+        )
+        client = await GlideClient.create(config)
+        session = ValkeySession(
+            session_id=session_id,
+            glide_client=client,
+            key_prefix=key_prefix,
+            ttl=ttl,
+            session_settings=session_settings,
+        )
+        session._owns_client = True
+
+    if not await session.ping():
+        await session.close()
+        pytest.skip("Valkey/Redis server not available")
+
+    return session
+
+
+async def _create_test_session(
+    session_id: str | None = None,
+) -> ValkeySession:
+    """Create a test session with cleanup."""
+    import uuid
+
+    if session_id is None:
+        session_id = f"test_session_{uuid.uuid4().hex[:8]}"
+
+    session = await _create_valkey_session(session_id, key_prefix="test:")
+
+    # Clean up any existing data
+    await session.clear_session()
+
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def agent() -> Agent:
+    """Fixture for a basic agent with a fake model."""
+    return Agent(name="test", model=FakeModel())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_valkey_session_direct_ops():
+    """Test direct database operations of ValkeySession."""
+    session = await _create_test_session()
+
+    try:
+        # 1. Add items
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        await session.add_items(items)
+
+        # 2. Get items and verify
+        retrieved = await session.get_items()
+        assert len(retrieved) == 2
+        assert retrieved[0].get("content") == "Hello"
+        assert retrieved[1].get("content") == "Hi there!"
+
+        # 3. Pop item
+        popped = await session.pop_item()
+        assert popped is not None
+        assert popped.get("content") == "Hi there!"
+        retrieved_after_pop = await session.get_items()
+        assert len(retrieved_after_pop) == 1
+        assert retrieved_after_pop[0].get("content") == "Hello"
+
+        # 4. Clear session
+        await session.clear_session()
+        retrieved_after_clear = await session.get_items()
+        assert len(retrieved_after_clear) == 0
+
+    finally:
+        await session.close()
+
+
+async def test_runner_integration(agent: Agent):
+    """Test that ValkeySession works correctly with the agent Runner."""
+    session = await _create_test_session()
+
+    try:
+        # First turn
+        assert isinstance(agent.model, FakeModel)
+        agent.model.set_next_output([get_text_message("San Francisco")])
+        result1 = await Runner.run(
+            agent,
+            "What city is the Golden Gate Bridge in?",
+            session=session,
+        )
+        assert result1.final_output == "San Francisco"
+
+        # Second turn
+        agent.model.set_next_output([get_text_message("California")])
+        result2 = await Runner.run(agent, "What state is it in?", session=session)
+        assert result2.final_output == "California"
+
+        # Verify history was passed to the model on the second turn
+        last_input = agent.model.last_turn_args["input"]
+        assert len(last_input) > 1
+        assert any("Golden Gate Bridge" in str(item.get("content", "")) for item in last_input)
+
+    finally:
+        await session.close()
+
+
+async def test_session_isolation():
+    """Test that different session IDs result in isolated conversation histories."""
+    session1 = await _create_valkey_session("session_1")
+    session2 = await _create_valkey_session("session_2")
+
+    try:
+        agent = Agent(name="test", model=FakeModel())
+
+        await session1.clear_session()
+        await session2.clear_session()
+
+        # Interact with session 1
+        assert isinstance(agent.model, FakeModel)
+        agent.model.set_next_output([get_text_message("I like cats.")])
+        await Runner.run(agent, "I like cats.", session=session1)
+
+        # Interact with session 2
+        agent.model.set_next_output([get_text_message("I like dogs.")])
+        await Runner.run(agent, "I like dogs.", session=session2)
+
+        # Go back to session 1
+        agent.model.set_next_output([get_text_message("You said you like cats.")])
+        result = await Runner.run(agent, "What animal did I say I like?", session=session1)
+        assert "cats" in result.final_output.lower()
+        assert "dogs" not in result.final_output.lower()
+    finally:
+        try:
+            await session1.clear_session()
+            await session2.clear_session()
+        except Exception:
+            pass
+        await session1.close()
+        await session2.close()
+
+
+async def test_get_items_with_limit():
+    """Test the limit parameter in get_items."""
+    session = await _create_test_session()
+
+    try:
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "1"},
+            {"role": "assistant", "content": "2"},
+            {"role": "user", "content": "3"},
+            {"role": "assistant", "content": "4"},
+        ]
+        await session.add_items(items)
+
+        # Get last 2 items
+        latest_2 = await session.get_items(limit=2)
+        assert len(latest_2) == 2
+        assert latest_2[0].get("content") == "3"
+        assert latest_2[1].get("content") == "4"
+
+        # Get all items
+        all_items = await session.get_items()
+        assert len(all_items) == 4
+
+        # Get more than available
+        more_than_all = await session.get_items(limit=10)
+        assert len(more_than_all) == 4
+
+        # Get 0 items
+        zero_items = await session.get_items(limit=0)
+        assert len(zero_items) == 0
+
+    finally:
+        await session.close()
+
+
+async def test_pop_from_empty_session():
+    """Test that pop_item returns None on an empty session."""
+    session = await _create_valkey_session("empty_session")
+    try:
+        await session.clear_session()
+        popped = await session.pop_item()
+        assert popped is None
+    finally:
+        await session.close()
+
+
+async def test_add_empty_items_list():
+    """Test that adding an empty list of items is a no-op."""
+    session = await _create_test_session()
+
+    try:
+        initial_items = await session.get_items()
+        assert len(initial_items) == 0
+
+        await session.add_items([])
+
+        items_after_add = await session.get_items()
+        assert len(items_after_add) == 0
+
+    finally:
+        await session.close()
+
+
+async def test_unicode_content():
+    """Test that session correctly stores and retrieves unicode/non-ASCII content."""
+    session = await _create_test_session()
+
+    try:
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "こんにちは"},
+            {"role": "assistant", "content": "😊👍"},
+            {"role": "user", "content": "Привет"},
+        ]
+        await session.add_items(items)
+
+        retrieved = await session.get_items()
+        assert retrieved[0].get("content") == "こんにちは"
+        assert retrieved[1].get("content") == "😊👍"
+        assert retrieved[2].get("content") == "Привет"
+
+    finally:
+        await session.close()
+
+
+async def test_special_characters_and_json_safety():
+    """Test that session safely stores and retrieves items with special characters."""
+    session = await _create_test_session()
+
+    try:
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "O'Reilly"},
+            {"role": "assistant", "content": '{"nested": "json"}'},
+            {"role": "user", "content": 'Quote: "Hello world"'},
+            {"role": "assistant", "content": "Line1\nLine2\tTabbed"},
+            {"role": "user", "content": "Normal message"},
+        ]
+        await session.add_items(items)
+
+        retrieved = await session.get_items()
+        assert len(retrieved) == len(items)
+        assert retrieved[0].get("content") == "O'Reilly"
+        assert retrieved[1].get("content") == '{"nested": "json"}'
+        assert retrieved[2].get("content") == 'Quote: "Hello world"'
+        assert retrieved[3].get("content") == "Line1\nLine2\tTabbed"
+        assert retrieved[4].get("content") == "Normal message"
+
+    finally:
+        await session.close()
+
+
+async def test_data_integrity_with_problematic_strings():
+    """Test that session preserves data integrity with strings that could break parsers."""
+    session = await _create_test_session()
+
+    try:
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "O'Reilly"},
+            {"role": "assistant", "content": "DROP TABLE sessions;"},
+            {"role": "user", "content": '"SELECT * FROM users WHERE name = "admin";"'},
+            {"role": "assistant", "content": "Robert'); DROP TABLE students;--"},
+            {"role": "user", "content": '{"malicious": "json"}'},
+            {"role": "assistant", "content": "\\n\\t\\r Special escapes"},
+            {"role": "user", "content": "Normal message"},
+        ]
+        await session.add_items(items)
+
+        retrieved = await session.get_items()
+        assert len(retrieved) == len(items)
+        assert retrieved[0].get("content") == "O'Reilly"
+        assert retrieved[1].get("content") == "DROP TABLE sessions;"
+        assert retrieved[2].get("content") == '"SELECT * FROM users WHERE name = "admin";"'
+        assert retrieved[3].get("content") == "Robert'); DROP TABLE students;--"
+        assert retrieved[4].get("content") == '{"malicious": "json"}'
+        assert retrieved[5].get("content") == "\\n\\t\\r Special escapes"
+        assert retrieved[6].get("content") == "Normal message"
+
+    finally:
+        await session.close()
+
+
+async def test_concurrent_access():
+    """Test concurrent access to the same session to verify data integrity."""
+    import asyncio
+
+    session = await _create_test_session("concurrent_test")
+
+    try:
+        async def add_messages(start_idx: int, count: int):
+            items: list[TResponseInputItem] = [
+                {"role": "user", "content": f"Message {start_idx + i}"} for i in range(count)
+            ]
+            await session.add_items(items)
+
+        tasks = [
+            add_messages(0, 5),
+            add_messages(5, 5),
+            add_messages(10, 5),
+        ]
+
+        await asyncio.gather(*tasks)
+
+        retrieved = await session.get_items()
+        assert len(retrieved) == 15
+
+        contents = [item.get("content") for item in retrieved]
+        expected_messages = [f"Message {i}" for i in range(15)]
+
+        for expected in expected_messages:
+            assert expected in contents
+
+    finally:
+        await session.close()
+
+
+async def test_valkey_connectivity():
+    """Test Valkey connectivity methods."""
+    session = await _create_valkey_session("connectivity_test")
+    try:
+        is_connected = await session.ping()
+        assert is_connected is True
+    finally:
+        await session.close()
+
+
+async def test_ttl_functionality():
+    """Test TTL (time-to-live) functionality."""
+    session = await _create_valkey_session("ttl_test", ttl=1)
+
+    try:
+        await session.clear_session()
+
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": "This should expire"},
+        ]
+        await session.add_items(items)
+
+        retrieved = await session.get_items()
+        assert len(retrieved) == 1
+
+    finally:
+        try:
+            await session.clear_session()
+        except Exception:
+            pass
+        await session.close()
+
+
+async def test_from_url_constructor():
+    """Test the from_url constructor method."""
+    url = os.environ.get("VALKEY_URL", "valkey://localhost:6379/15")
+
+    session = await ValkeySession.from_url("url_test", url=url)
+    try:
+        if not await session.ping():
+            pytest.skip("Valkey/Redis server not available")
+
+        assert session.session_id == "url_test"
+        assert session._owns_client is True
+        assert await session.ping() is True
+    finally:
+        await session.close()
+
+
+async def test_from_url_valkey_scheme():
+    """Test that valkey:// URL scheme works."""
+    url = os.environ.get("VALKEY_URL")
+
+    if not url:
+        url = "valkey://localhost:6379/15"
+
+    session = await ValkeySession.from_url("valkey_scheme_test", url=url)
+    try:
+        if not await session.ping():
+            pytest.skip("Valkey server not available")
+
+        items: list[TResponseInputItem] = [{"role": "user", "content": "valkey scheme test"}]
+        await session.add_items(items)
+
+        retrieved = await session.get_items()
+        assert len(retrieved) == 1
+        assert retrieved[0].get("content") == "valkey scheme test"
+    finally:
+        await session.close()
+
+
+async def test_key_prefix_isolation():
+    """Test that different key prefixes isolate sessions."""
+    session1 = await _create_valkey_session("same_id", key_prefix="app1")
+    session2 = await _create_valkey_session("same_id", key_prefix="app2")
+
+    try:
+        await session1.clear_session()
+        await session2.clear_session()
+
+        await session1.add_items([{"role": "user", "content": "app1 message"}])
+        await session2.add_items([{"role": "user", "content": "app2 message"}])
+
+        items1 = await session1.get_items()
+        items2 = await session2.get_items()
+
+        assert len(items1) == 1
+        assert len(items2) == 1
+        assert items1[0].get("content") == "app1 message"
+        assert items2[0].get("content") == "app2 message"
+
+    finally:
+        try:
+            await session1.clear_session()
+            await session2.clear_session()
+        except Exception:
+            pass
+        await session1.close()
+        await session2.close()
+
+
+async def test_external_client_not_closed():
+    """Test that external GlideClient is not closed when session.close() is called."""
+    from glide import GlideClient, GlideClientConfiguration, NodeAddress
+
+    shared_config = GlideClientConfiguration(
+        addresses=[NodeAddress("localhost", 6379)],
+    )
+    shared_client = await GlideClient.create(shared_config)
+
+    try:
+        if not await shared_client.ping():
+            await shared_client.close()
+            pytest.skip("Valkey/Redis server not available")
+
+        session = ValkeySession(
+            session_id="external_client_test",
+            glide_client=shared_client,
+            key_prefix="test:",
+        )
+
+        try:
+            await session.add_items([{"role": "user", "content": "test message"}])
+            items = await session.get_items()
+            assert len(items) == 1
+
+            assert await shared_client.ping() is not None
+
+            await session.close()
+
+            # Shared client should still be usable after session.close()
+            assert await shared_client.ping() is not None
+
+            await shared_client.set("test_key", "test_value")
+            value = await shared_client.get("test_key")
+            assert value == b"test_value"
+
+        finally:
+            await session.clear_session()
+
+    finally:
+        try:
+            await shared_client.close()
+        except Exception:
+            pass
+
+
+async def test_internal_client_ownership():
+    """Test that clients created via from_url are properly managed."""
+    url = os.environ.get("VALKEY_URL", "valkey://localhost:6379/15")
+
+    session = await ValkeySession.from_url("internal_client_test", url=url)
+
+    try:
+        if not await session.ping():
+            pytest.skip("Valkey/Redis server not available")
+
+        await session.add_items([{"role": "user", "content": "test message"}])
+        items = await session.get_items()
+        assert len(items) == 1
+
+        assert hasattr(session, "_owns_client")
+        assert session._owns_client is True
+
+    finally:
+        await session.close()
+
+
+async def test_get_next_id_method():
+    """Test the _get_next_id atomic counter functionality."""
+    session = await _create_test_session("counter_test")
+
+    try:
+        await session.clear_session()
+
+        id1 = await session._get_next_id()
+        id2 = await session._get_next_id()
+        id3 = await session._get_next_id()
+
+        assert id1 == 1
+        assert id2 == 2
+        assert id3 == 3
+
+        # Counter persists across session instances with same session_id
+        from glide import GlideClient, GlideClientConfiguration, NodeAddress
+
+        config = GlideClientConfiguration(
+            addresses=[NodeAddress("localhost", 6379)],
+        )
+        client2 = await GlideClient.create(config)
+        session2 = ValkeySession(
+            session_id="counter_test",
+            glide_client=client2,
+            key_prefix="test:",
+        )
+        session2._owns_client = True
+
+        try:
+            id4 = await session2._get_next_id()
+            assert id4 == 4
+        finally:
+            await session2.close()
+
+    finally:
+        await session.close()
+
+
+async def test_add_items_preserves_created_at_metadata():
+    """`created_at` must be set once and not overwritten by subsequent add_items calls."""
+    session = await _create_test_session("created_at_test")
+
+    try:
+        await session.clear_session()
+        await session.add_items([{"role": "user", "content": "first"}])
+        first_meta = await session._glide.hgetall(session._session_key)
+        first_created = first_meta.get(b"created_at")
+        assert first_created is not None
+
+        # Force a clock advance
+        time.sleep(1.1)
+
+        await session.add_items([{"role": "user", "content": "second"}])
+        second_meta = await session._glide.hgetall(session._session_key)
+        second_created = second_meta.get(b"created_at")
+        second_updated = second_meta.get(b"updated_at")
+
+        assert second_created == first_created, "created_at must remain stable"
+        assert second_updated != first_created, "updated_at must advance on writes"
+    finally:
+        await session.close()
+
+
+async def test_ping_connection_failure():
+    """Test ping method when connection fails."""
+    session = await _create_test_session("ping_failure_test")
+
+    try:
+        assert await session.ping() is True
+
+        # Fake a failure by trying to ping a closed client
+        await session._glide.close()
+        assert await session.ping() is False
+
+    except Exception:
+        # If closing the client causes issues, skip the negative test
+        pass
+    finally:
+        # Prevent double-close
+        session._owns_client = False
+        await session.close()
+
+
+async def test_close_method_coverage():
+    """Test complete coverage of close() method behavior."""
+    from glide import GlideClient, GlideClientConfiguration, NodeAddress
+
+    # Test 1: External client (should NOT be closed)
+    external_config = GlideClientConfiguration(
+        addresses=[NodeAddress("localhost", 6379)],
+    )
+    external_client = await GlideClient.create(external_config)
+    try:
+        if not await external_client.ping():
+            await external_client.close()
+            pytest.skip("Valkey/Redis server not available")
+
+        session1 = ValkeySession(
+            session_id="close_test_1",
+            glide_client=external_client,
+            key_prefix="test:",
+        )
+
+        assert session1._owns_client is False
+        await session1.close()
+
+        # External client should still be usable
+        assert await external_client.ping() is not None
+
+    finally:
+        try:
+            await external_client.close()
+        except Exception:
+            pass
+
+
+async def test_session_settings_default():
+    """Test that session_settings defaults to empty SessionSettings."""
+    session = await _create_test_session()
+
+    try:
+        assert isinstance(session.session_settings, SessionSettings)
+        assert session.session_settings.limit is None
+    finally:
+        await session.close()
+
+
+async def test_session_settings_constructor():
+    """Test passing session_settings via constructor."""
+    session = await _create_valkey_session(
+        "settings_test",
+        session_settings=SessionSettings(limit=5),
+    )
+
+    try:
+        assert session.session_settings is not None
+        assert session.session_settings.limit == 5
+    finally:
+        await session.close()
+
+
+async def test_session_settings_from_url():
+    """Test passing session_settings via from_url."""
+    url = os.environ.get("VALKEY_URL", "valkey://localhost:6379/15")
+
+    session = await ValkeySession.from_url(
+        "from_url_settings_test",
+        url=url,
+        session_settings=SessionSettings(limit=10),
+    )
+
+    try:
+        if not await session.ping():
+            pytest.skip("Valkey/Redis server not available")
+        assert session.session_settings is not None
+        assert session.session_settings.limit == 10
+    finally:
+        await session.close()
+
+
+async def test_get_items_uses_session_settings_limit():
+    """Test that get_items uses session_settings.limit as default."""
+    session = await _create_valkey_session(
+        "uses_settings_limit_test",
+        session_settings=SessionSettings(limit=3),
+    )
+
+    try:
+        await session.clear_session()
+
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": f"Message {i}"} for i in range(5)
+        ]
+        await session.add_items(items)
+
+        retrieved = await session.get_items()
+        assert len(retrieved) == 3
+        assert retrieved[0].get("content") == "Message 2"
+        assert retrieved[1].get("content") == "Message 3"
+        assert retrieved[2].get("content") == "Message 4"
+    finally:
+        await session.close()
+
+
+async def test_get_items_explicit_limit_overrides_session_settings():
+    """Test that explicit limit parameter overrides session_settings."""
+    session = await _create_valkey_session(
+        "explicit_override_test",
+        session_settings=SessionSettings(limit=5),
+    )
+
+    try:
+        await session.clear_session()
+
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": f"Message {i}"} for i in range(10)
+        ]
+        await session.add_items(items)
+
+        retrieved = await session.get_items(limit=2)
+        assert len(retrieved) == 2
+        assert retrieved[0].get("content") == "Message 8"
+        assert retrieved[1].get("content") == "Message 9"
+    finally:
+        await session.close()
+
+
+async def test_runner_with_session_settings_override():
+    """Test that RunConfig can override session's default settings."""
+    session = await _create_valkey_session(
+        "runner_override_test",
+        session_settings=SessionSettings(limit=100),
+    )
+
+    try:
+        await session.clear_session()
+
+        items: list[TResponseInputItem] = [
+            {"role": "user", "content": f"Turn {i}"} for i in range(10)
+        ]
+        await session.add_items(items)
+
+        model = FakeModel()
+        agent = Agent(name="test", model=model)
+        model.set_next_output([get_text_message("Got it")])
+
+        await Runner.run(
+            agent,
+            "New question",
+            session=session,
+            run_config=RunConfig(
+                session_settings=SessionSettings(limit=2)
+            ),
+        )
+
+        last_input = model.last_turn_args["input"]
+        history_items = [item for item in last_input if item.get("content") != "New question"]
+        assert len(history_items) == 2
+    finally:
+        await session.close()


### PR DESCRIPTION
Adds a `ValkeySession` session provider that uses the [valkey-glide](https://github.com/valkey-io/valkey-glide) client library.

Valkey is the Linux Foundation's open-source, BSD-licensed, high-performance key-value store, forked from Redis 7.2.5. It is wire-compatible with Redis, but organizations using Valkey deserve a first-class session provider that uses the dedicated Valkey-GLIDE client, which is optimized for Valkey and will diverge from redis-py as Valkey adds its own features.

## Changes

- **New file**: `src/agents/extensions/memory/valkey_session.py` — `ValkeySession` class implementing the `Session` protocol
- **Updated**: `src/agents/extensions/memory/__init__.py` — lazy-import registration with optional `valkey` extra
- **Updated**: `pyproject.toml` — `valkey = ["valkey-glide>=2.1"]` optional dependency + dev dependency + mypy override
- **New file**: `tests/extensions/memory/test_valkey_session.py` — comprehensive test suite (27 tests covering direct ops, runner integration, isolation, limits, unicode, concurrency, TTL, key prefix isolation, client ownership, counter, metadata, settings, and more)

## API

### Direct construction with an existing client
```python
from agents.extensions.memory import ValkeySession
from glide import GlideClient, GlideClientConfiguration, NodeAddress

config = GlideClientConfiguration(addresses=[NodeAddress("localhost", 6379)])
glide_client = await GlideClient.create(config)

session = ValkeySession(session_id="user-123", glide_client=glide_client)
```

### URL-based construction
```python
session = await ValkeySession.from_url(
    session_id="user-123",
    url="valkey://localhost:6379/0",
)
```

Supported URL schemes: `valkey://`, `valkeys://`, `redis://`, `rediss://`

## Testing

Tests require a running Valkey/Redis instance (set via `VALKEY_URL` env var, defaults to `valkey://localhost:6379/15`).

Run with:
```
pytest tests/extensions/memory/test_valkey_session.py -v
```

Closes #3017
