### PR TITLE
feat: read _meta from MCP tool call responses

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -403,6 +403,10 @@ class ToolCallOutputItem(RunItemBase[Any]):
     tool_origin: ToolOrigin | None = None
     """Optional metadata describing the source of a function-tool-backed item."""
 
+    mcp_meta: dict[str, Any] | None = None
+    """Optional metadata from the ``_meta`` field of an MCP tool call response, when the
+    tool was invoked through an MCP server."""
+
     @property
     def call_id(self) -> str | None:
         """Return the call identifier from the raw item, if available."""

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -703,4 +703,10 @@ class MCPUtil:
                     f"Current span is not a FunctionSpanData, skipping tool output: {current_span}"
                 )
 
+        # Expose ``_meta`` from the MCP response so callers can access it via
+        # ``ToolCallOutputItem.mcp_meta``.
+        response_meta = getattr(result, "_meta", None)
+        if response_meta and isinstance(response_meta, dict) and isinstance(context, ToolContext):
+            context._mcp_response_meta = copy.deepcopy(response_meta)
+
         return tool_output

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -184,6 +184,7 @@ class _FunctionToolTaskState:
     order: int
     invoke_task: asyncio.Task[Any] | None = None
     in_post_invoke_phase: bool = False
+    mcp_response_meta: dict[str, Any] | None = None
 
 
 def _background_cleanup_task_exception_message(exc: BaseException) -> str | None:
@@ -1784,6 +1785,12 @@ class _FunctionToolBatchExecutor:
 
         task_state.in_post_invoke_phase = True
 
+        # Capture MCP response meta from the tool context so it can be attached
+        # to the ToolCallOutputItem downstream.
+        mcp_meta = getattr(tool_context, "_mcp_response_meta", None)
+        if mcp_meta is not None:
+            task_state.mcp_response_meta = mcp_meta
+
         final_result = await _execute_tool_output_guardrails(
             func_tool=func_tool,
             tool_context=tool_context,
@@ -1875,6 +1882,15 @@ class _FunctionToolBatchExecutor:
 
     def _build_function_tool_results(self) -> list[FunctionToolResult]:
         function_tool_results: list[FunctionToolResult] = []
+
+        # Build a lookup from tool_run id to MCP response _meta (set by
+        # invoke_mcp_tool on the ToolContext, then copied to the task state).
+        mcp_meta_by_tool_run: dict[int, dict[str, Any] | None] = {
+            id(state.tool_run): state.mcp_response_meta
+            for state in self.task_states.values()
+            if state.mcp_response_meta is not None
+        }
+
         for tool_run in self.tool_runs:
             result = self.results_by_tool_run[id(tool_run)]
             if isinstance(result, FunctionToolResult):
@@ -1898,6 +1914,7 @@ class _FunctionToolBatchExecutor:
                     raw_item=ItemHelpers.tool_call_output_item(tool_run.tool_call, result),
                     agent=self.public_agent,
                     tool_origin=get_function_tool_origin(tool_run.function_tool),
+                    mcp_meta=mcp_meta_by_tool_run.get(id(tool_run)),
                 )
             else:
                 # Skip tool output until nested interruptions are resolved.

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -57,6 +57,10 @@ class ToolContext(RunContextWrapper[TContext]):
     run_config: RunConfig | None = None
     """The active run config for this tool call, when available."""
 
+    _mcp_response_meta: dict[str, Any] | None = None
+    """Internal: stores ``_meta`` from the MCP ``CallToolResult`` after an MCP tool
+    invocation.  Consumers should read ``ToolCallOutputItem.mcp_meta`` instead."""
+
     def __init__(
         self,
         context: TContext,


### PR DESCRIPTION
## Summary

Extracts and exposes the `_meta` field from MCP tool call responses via `ToolCallOutputItem.mcp_meta`.

## Background

PR #2375 enabled **sending** `_meta` in MCP tool call requests (client → server). This PR adds the complementary feature: **reading** `_meta` from MCP tool call **responses** (server → client).

The MCP protocol spec defines `CallToolResult._meta` as an optional metadata dictionary that servers can return alongside the tool result. Currently the SDK ignores this field entirely.

## Changes

- `src/agents/items.py` — Add `mcp_meta: dict[str, Any] | None` field to `ToolCallOutputItem`
- `src/agents/tool_context.py` — Add internal `_mcp_response_meta` field to `ToolContext` to transport the meta from tool invocation
- `src/agents/mcp/util.py` — Extract `result._meta` in `invoke_mcp_tool` and store it on the `ToolContext`
- `src/agents/run_internal/tool_execution.py` — Thread the meta through `_FunctionToolTaskState` to `ToolCallOutputItem` at result-build time

## Usage

After an MCP tool call, consumers can access the server-returned `_meta` via the event stream:

```python
from agents import RunResult

async for event in result.stream_events():
    if hasattr(event, 'item') and hasattr(event.item, 'mcp_meta'):
        meta = event.item.mcp_meta  # dict or None
```

## Backward Compatibility

All new fields default to `None`. Existing code that constructs `ToolCallOutputItem` without `mcp_meta` continues to work unchanged.

Closes #3477
