### PR TITLE
examples(mcp): add TWZRD Agent Intel trust verification example

### DIFF
--- a/examples/mcp/twzrd_trust_verification/README.md
+++ b/examples/mcp/twzrd_trust_verification/README.md
@@ -1,0 +1,43 @@
+# TWZRD Agent Intel - Streamable HTTP Remote MCP Example
+
+This example shows how to use [TWZRD Agent Intel](https://intel.twzrd.xyz) — a zero-install remote MCP server — with the OpenAI Agents SDK to verify the trustworthiness of Solana agent wallets.
+
+## What it does
+
+1. Connects to `https://intel.twzrd.xyz/mcp` via `MCPServerStreamableHttp`
+2. Creates an agent with trust verification instructions
+3. Calls `score_agent` to get the trust score for a Solana wallet
+4. Optionally runs a `preflight_check` before recommending a transaction
+
+## Setup
+
+```bash
+pip install openai-agents
+export OPENAI_API_KEY=sk-...
+```
+
+No TWZRD API key needed — trust scoring is free.
+
+## Run
+
+```bash
+python examples/mcp/twzrd_trust_verification/main.py
+```
+
+## TWZRD MCP Config
+
+```json
+{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
+```
+
+## Available Tools
+
+| Tool | Description | Cost |
+|------|-------------|------|
+| `score_agent(wallet)` | Trust score (0-100) + reputation | Free |
+| `resolve_agent(wallet)` | Agent identity resolution | Free |
+| `preflight_check(wallet)` | Pre-transaction safety check | Free |
+| `verify_trust_receipt(receipt)` | Verify x402 receipt | Free |
+| `get_trust_receipt(wallet)` | Full trust receipt | x402 |
+
+PyPI: `pip install twzrd-agent-intel`

--- a/examples/mcp/twzrd_trust_verification/main.py
+++ b/examples/mcp/twzrd_trust_verification/main.py
@@ -1,0 +1,59 @@
+import asyncio
+
+from agents import Agent, Runner, gen_trace_id, trace
+from agents.mcp import MCPServerStreamableHttp
+
+
+async def main():
+    """
+    TWZRD Agent Intel trust verification example using the OpenAI Agents SDK.
+
+    TWZRD Agent Intel (https://intel.twzrd.xyz) is a zero-install remote MCP server
+    that provides trust scoring and x402 payment verification for AI agents on Solana.
+
+    Available tools (free):
+      - score_agent(wallet): Returns trust score (0-100) and reputation data
+      - resolve_agent(wallet): Agent identity resolution
+      - preflight_check(wallet): Pre-transaction safety check
+      - verify_trust_receipt(receipt): Verify x402 payment receipts
+
+    MCP config: {"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
+    """
+    async with MCPServerStreamableHttp(
+        name="TWZRD Agent Intel",
+        params={
+            "url": "https://intel.twzrd.xyz/mcp",
+            # Allow time for Solana RPC queries
+            "timeout": 15,
+            "sse_read_timeout": 60,
+        },
+        max_retry_attempts=2,
+        retry_backoff_seconds_base=2.0,
+        client_session_timeout_seconds=15,
+    ) as server:
+        agent = Agent(
+            name="TrustVerificationAgent",
+            instructions=(
+                "You are a trust verification agent for the agentic economy. "
+                "Use the TWZRD Agent Intel tools to verify the trustworthiness of Solana agent wallets. "
+                "When checking trust: score >= 70 is high trust, 40-70 is medium, < 40 is low trust. "
+                "Always run a preflight check before recommending a transaction with an unknown agent."
+            ),
+            mcp_servers=[server],
+        )
+
+        trace_id = gen_trace_id()
+        with trace(workflow_name="TWZRD Trust Verification", trace_id=trace_id):
+            print(f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n")
+
+            # Example: score a known Solana agent wallet
+            result = await Runner.run(
+                agent,
+                "Check the trust score for Solana wallet D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi "
+                "and tell me if it's safe to transact with this agent.",
+            )
+            print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds a Streamable HTTP remote MCP example using [TWZRD Agent Intel](https://intel.twzrd.xyz) — a zero-install remote MCP server for trust scoring and x402 payment verification of AI agents on Solana.

**Files:**
- `examples/mcp/twzrd_trust_verification/main.py`
- `examples/mcp/twzrd_trust_verification/README.md`

## What it demonstrates

Uses `MCPServerStreamableHttp` (same pattern as `streamable_http_remote_example`) to connect to `https://intel.twzrd.xyz/mcp` and create an agent that can:

1. Score Solana agent wallets (0-100 trust score + reputation data)
2. Run preflight checks before recommending transactions
3. Verify x402 payment receipts from agent-to-agent transactions

## Why this fits here

The `examples/mcp/streamable_http_remote_example` uses `MCPServerStreamableHttp` for DeepWiki. TWZRD is another production remote MCP server demonstrating the same transport for a different domain — agent trust infrastructure, relevant for the emerging agentic economy where agents need to evaluate counterparty trustworthiness.

## Running it

```bash
pip install openai-agents
export OPENAI_API_KEY=sk-...
python examples/mcp/twzrd_trust_verification/main.py
```

No TWZRD API key needed (free tier). No local server setup required.

## TWZRD Agent Intel

- Endpoint: `https://intel.twzrd.xyz/mcp` (Streamable HTTP)
- PyPI: `pip install twzrd-agent-intel`