### PR TITLE
docs: tweak in usage doc

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,7 +63,7 @@ second = await Runner.run(agent, "Can you elaborate?", session=session)
 print(second.context_wrapper.usage.total_tokens)  # Usage for second run
 ```
 
-Note that while sessions preserve conversation context between runs, the usage metrics returned by each `Runner.run()` call represent only that particular execution. In sessions, previous messages may be re-fed as input to each run, which affects the input token count in consequent turns.
+Note that while sessions preserve conversation context between runs, the usage metrics returned by each `Runner.run()` call represent only that particular execution. In sessions, previous messages may be re-fed as input to each run, which affects the input token count in subsequent turns.
 
 ## Using usage in hooks
 


### PR DESCRIPTION
- Replace "consequent turns" with "subsequent turns" in the session usage notes for standard technical accuracy.