### PR TITLE
docs(tools): fix string concatenation typo in agent instructions

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -561,7 +561,7 @@ french_agent = Agent(
 orchestrator_agent = Agent(
     name="orchestrator_agent",
     instructions=(
-        "You are a translation agent. You use the tools given to you to translate."
+        "You are a translation agent. You use the tools given to you to translate. "
         "If asked for multiple translations, you call the relevant tools."
     ),
     tools=[


### PR DESCRIPTION
- Add a trailing space to the first string literal in the `orchestrator_agent` instructions tuple
- Prevent Python's implicit string concatenation from merging "translate." and "If" into "translate.If"