### PR TITLE
fix(realtime): send tool output on tool failure

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -611,7 +611,7 @@ class RealtimeSession(RealtimeModelListener):
             error=formatter_error,
         )
         if output is None:
-            output = default_tool_error_function(tool_context, formatter_error)
+            return
 
         await self._send_tool_output_completion(
             _PendingToolOutput(
@@ -834,7 +834,7 @@ class RealtimeSession(RealtimeModelListener):
                         context=tool_context,
                         arguments=event.arguments,
                     )
-                except BaseException as exc:
+                except Exception as exc:
                     await self._send_failed_function_tool_output(
                         event,
                         tool=func_tool,
@@ -873,7 +873,7 @@ class RealtimeSession(RealtimeModelListener):
                 # Execute the handoff to get the new agent
                 try:
                     result = await handoff.on_invoke_handoff(self._context_wrapper, event.arguments)
-                except BaseException as exc:
+                except Exception as exc:
                     await self._send_failed_handoff_output(
                         event,
                         error=exc,

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -603,7 +603,7 @@ class RealtimeSession(RealtimeModelListener):
         agent: RealtimeAgent,
         tool_context: ToolContext[Any],
         error: BaseException,
-    ) -> None:
+    ) -> bool:
         formatter_error = error if isinstance(error, Exception) else Exception(str(error))
         output = await maybe_invoke_function_tool_failure_error_function(
             function_tool=tool,
@@ -611,7 +611,7 @@ class RealtimeSession(RealtimeModelListener):
             error=formatter_error,
         )
         if output is None:
-            return
+            return False
 
         await self._send_tool_output_completion(
             _PendingToolOutput(
@@ -627,6 +627,7 @@ class RealtimeSession(RealtimeModelListener):
                 ),
             )
         )
+        return True
 
     async def _send_failed_handoff_output(
         self,
@@ -634,7 +635,7 @@ class RealtimeSession(RealtimeModelListener):
         *,
         error: BaseException,
         tool_context: ToolContext[Any],
-    ) -> None:
+    ) -> bool:
         formatter_error = error if isinstance(error, Exception) else Exception(str(error))
         await self._send_tool_output_completion(
             _PendingToolOutput(
@@ -643,6 +644,7 @@ class RealtimeSession(RealtimeModelListener):
                 start_response=True,
             )
         )
+        return True
 
     async def _send_tool_output_completion(self, pending_output: _PendingToolOutput) -> None:
         call_id = pending_output.tool_call.call_id
@@ -835,7 +837,7 @@ class RealtimeSession(RealtimeModelListener):
                         arguments=event.arguments,
                     )
                 except Exception as exc:
-                    await self._send_failed_function_tool_output(
+                    mark_completed = await self._send_failed_function_tool_output(
                         event,
                         tool=func_tool,
                         agent=agent,
@@ -874,7 +876,7 @@ class RealtimeSession(RealtimeModelListener):
                 try:
                     result = await handoff.on_invoke_handoff(self._context_wrapper, event.arguments)
                 except Exception as exc:
-                    await self._send_failed_handoff_output(
+                    mark_completed = await self._send_failed_handoff_output(
                         event,
                         error=exc,
                         tool_context=tool_context,

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -22,7 +22,13 @@ from ..items import ToolApprovalItem
 from ..logger import logger
 from ..run_config import ToolErrorFormatterArgs
 from ..run_context import RunContextWrapper, TContext
-from ..tool import DEFAULT_APPROVAL_REJECTION_MESSAGE, FunctionTool, invoke_function_tool
+from ..tool import (
+    DEFAULT_APPROVAL_REJECTION_MESSAGE,
+    FunctionTool,
+    default_tool_error_function,
+    invoke_function_tool,
+    maybe_invoke_function_tool_failure_error_function,
+)
 from ..tool_context import ToolContext
 from ..util._approvals import evaluate_needs_approval_setting
 from .agent import RealtimeAgent
@@ -589,6 +595,55 @@ class RealtimeSession(RealtimeModelListener):
             )
         )
 
+    async def _send_failed_function_tool_output(
+        self,
+        event: RealtimeModelToolCallEvent,
+        *,
+        tool: FunctionTool,
+        agent: RealtimeAgent,
+        tool_context: ToolContext[Any],
+        error: BaseException,
+    ) -> None:
+        formatter_error = error if isinstance(error, Exception) else Exception(str(error))
+        output = await maybe_invoke_function_tool_failure_error_function(
+            function_tool=tool,
+            context=tool_context,
+            error=formatter_error,
+        )
+        if output is None:
+            output = default_tool_error_function(tool_context, formatter_error)
+
+        await self._send_tool_output_completion(
+            _PendingToolOutput(
+                tool_call=event,
+                output=output,
+                start_response=True,
+                tool_end_event=RealtimeToolEnd(
+                    info=self._event_info,
+                    tool=tool,
+                    output=output,
+                    agent=agent,
+                    arguments=event.arguments,
+                ),
+            )
+        )
+
+    async def _send_failed_handoff_output(
+        self,
+        event: RealtimeModelToolCallEvent,
+        *,
+        error: BaseException,
+        tool_context: ToolContext[Any],
+    ) -> None:
+        formatter_error = error if isinstance(error, Exception) else Exception(str(error))
+        await self._send_tool_output_completion(
+            _PendingToolOutput(
+                tool_call=event,
+                output=default_tool_error_function(tool_context, formatter_error),
+                start_response=True,
+            )
+        )
+
     async def _send_tool_output_completion(self, pending_output: _PendingToolOutput) -> None:
         call_id = pending_output.tool_call.call_id
         self._pending_tool_outputs[call_id] = pending_output
@@ -773,11 +828,21 @@ class RealtimeSession(RealtimeModelListener):
                     tool_arguments=event.arguments,
                     agent=agent,
                 )
-                result = await invoke_function_tool(
-                    function_tool=func_tool,
-                    context=tool_context,
-                    arguments=event.arguments,
-                )
+                try:
+                    result = await invoke_function_tool(
+                        function_tool=func_tool,
+                        context=tool_context,
+                        arguments=event.arguments,
+                    )
+                except BaseException as exc:
+                    await self._send_failed_function_tool_output(
+                        event,
+                        tool=func_tool,
+                        agent=agent,
+                        tool_context=tool_context,
+                        error=exc,
+                    )
+                    raise
 
                 await self._send_tool_output_completion(
                     _PendingToolOutput(
@@ -806,7 +871,15 @@ class RealtimeSession(RealtimeModelListener):
                 )
 
                 # Execute the handoff to get the new agent
-                result = await handoff.on_invoke_handoff(self._context_wrapper, event.arguments)
+                try:
+                    result = await handoff.on_invoke_handoff(self._context_wrapper, event.arguments)
+                except BaseException as exc:
+                    await self._send_failed_handoff_output(
+                        event,
+                        error=exc,
+                        tool_context=tool_context,
+                    )
+                    raise
                 if not isinstance(result, RealtimeAgent):
                     raise UserError(
                         f"Handoff {handoff.tool_name} returned invalid result: {type(result)}"

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1209,13 +1209,22 @@ class TestToolCallExecution:
         with pytest.raises(ToolTimeoutError, match="timed out"):
             await session._handle_tool_call(tool_call_event)
 
-        assert len(mock_model.sent_tool_outputs) == 0
-        assert session._event_queue.qsize() == 1
+        assert len(mock_model.sent_tool_outputs) == 1
+        sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
+        assert sent_call == tool_call_event
+        assert "timed out" in sent_output.lower()
+        assert start_response is True
+        assert session._event_queue.qsize() == 2
 
         tool_start_event = await session._event_queue.get()
         assert isinstance(tool_start_event, RealtimeToolStart)
         assert tool_start_event.tool == timeout_tool
         assert tool_start_event.arguments == "{}"
+
+        tool_end_event = await session._event_queue.get()
+        assert isinstance(tool_end_event, RealtimeToolEnd)
+        assert tool_end_event.tool == timeout_tool
+        assert tool_end_event.output == sent_output
 
     @pytest.mark.asyncio
     async def test_function_tool_timeout_uses_async_error_function_result(
@@ -1296,7 +1305,11 @@ class TestToolCallExecution:
 
         assert isinstance(session._stored_exception, ToolTimeoutError)
         assert session._stored_exception.tool_name == "slow_tool"
-        assert len(mock_model.sent_tool_outputs) == 0
+        assert len(mock_model.sent_tool_outputs) == 1
+        sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
+        assert sent_call == tool_call_event
+        assert "timed out" in sent_output.lower()
+        assert start_response is True
 
         events = []
         while True:
@@ -1314,6 +1327,66 @@ class TestToolCallExecution:
         error_event = next(event for event in events if isinstance(event, RealtimeError))
         assert "Tool call task failed" in error_event.error["message"]
         assert "timed out" in error_event.error["message"]
+
+    @pytest.mark.asyncio
+    async def test_function_tool_exception_sends_model_output_before_reraising(
+        self, mock_model, mock_agent
+    ):
+        async def fail_tool(_ctx: ToolContext[Any], _arguments: str) -> str:
+            raise ValueError("tool failed")
+
+        failing_tool = FunctionTool(
+            name="failing_tool",
+            description="always fails",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=fail_tool,
+        )
+        mock_agent.get_all_tools.return_value = [failing_tool]
+
+        session = RealtimeSession(mock_model, mock_agent, None)
+        tool_call_event = RealtimeModelToolCallEvent(
+            name="failing_tool",
+            call_id="call_fail",
+            arguments="{}",
+        )
+
+        with pytest.raises(ValueError, match="tool failed"):
+            await session._handle_tool_call(tool_call_event)
+
+        assert len(mock_model.sent_tool_outputs) == 1
+        sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
+        assert sent_call == tool_call_event
+        assert "tool failed" in sent_output
+        assert start_response is True
+
+    @pytest.mark.asyncio
+    async def test_handoff_exception_sends_model_output_before_reraising(self, mock_model):
+        target = RealtimeAgent(name="target")
+
+        failing_handoff = Handoff(
+            tool_name="switch",
+            tool_description="",
+            input_json_schema={},
+            on_invoke_handoff=AsyncMock(side_effect=ValueError("handoff failed")),
+            input_filter=None,
+            agent_name=target.name,
+            is_enabled=True,
+        )
+
+        agent = RealtimeAgent(name="agent", handoffs=[failing_handoff])
+        session = RealtimeSession(mock_model, agent, None)
+        tool_call_event = RealtimeModelToolCallEvent(
+            name="switch", call_id="c_handoff", arguments="{}"
+        )
+
+        with pytest.raises(ValueError, match="handoff failed"):
+            await session._handle_tool_call(tool_call_event)
+
+        assert len(mock_model.sent_tool_outputs) == 1
+        sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
+        assert sent_call == tool_call_event
+        assert "handoff failed" in sent_output
+        assert start_response is True
 
     @pytest.mark.asyncio
     async def test_function_tool_with_multiple_tools_available(self, mock_model, mock_agent):
@@ -1868,7 +1941,7 @@ class TestToolCallExecution:
     async def test_function_tool_exception_handling(
         self, mock_model, mock_agent, mock_function_tool
     ):
-        """Test that exceptions in function tools are handled (currently they propagate)"""
+        """Known tool failures should still send a model-visible output before propagating."""
         # Set up tool to raise exception
         mock_function_tool.on_invoke_tool.side_effect = ValueError("Tool error")
         mock_agent.get_all_tools.return_value = [mock_function_tool]
@@ -1879,18 +1952,24 @@ class TestToolCallExecution:
             name="test_function", call_id="call_error", arguments="{}"
         )
 
-        # Currently exceptions propagate (no error handling implemented)
         with pytest.raises(ValueError, match="Tool error"):
             await session._handle_tool_call(tool_call_event)
 
-        # Tool start event should have been queued before the error
-        assert session._event_queue.qsize() == 1
+        assert len(mock_model.sent_tool_outputs) == 1
+        sent_call, sent_output, start_response = mock_model.sent_tool_outputs[0]
+        assert sent_call == tool_call_event
+        assert "Tool error" in sent_output
+        assert start_response is True
+
+        # Tool start/end events should still be queued around the failure.
+        assert session._event_queue.qsize() == 2
         tool_start_event = await session._event_queue.get()
         assert isinstance(tool_start_event, RealtimeToolStart)
         assert tool_start_event.arguments == "{}"
 
-        # But no tool output should have been sent and no end event queued
-        assert len(mock_model.sent_tool_outputs) == 0
+        tool_end_event = await session._event_queue.get()
+        assert isinstance(tool_end_event, RealtimeToolEnd)
+        assert tool_end_event.output == sent_output
 
     @pytest.mark.asyncio
     async def test_tool_call_with_complex_arguments(

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -1360,6 +1360,70 @@ class TestToolCallExecution:
         assert start_response is True
 
     @pytest.mark.asyncio
+    async def test_function_tool_failure_error_function_none_reraises_without_model_output(
+        self, mock_model, mock_agent
+    ):
+        async def fail_tool(_ctx: ToolContext[Any], _arguments: str) -> str:
+            raise ValueError("tool failed")
+
+        failing_tool = FunctionTool(
+            name="failing_tool",
+            description="always fails",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=fail_tool,
+            _failure_error_function=None,
+            _use_default_failure_error_function=False,
+        )
+        mock_agent.get_all_tools.return_value = [failing_tool]
+
+        session = RealtimeSession(mock_model, mock_agent, None)
+        tool_call_event = RealtimeModelToolCallEvent(
+            name="failing_tool",
+            call_id="call_fail_no_formatter",
+            arguments="{}",
+        )
+
+        with pytest.raises(ValueError, match="tool failed"):
+            await session._handle_tool_call(tool_call_event)
+
+        assert len(mock_model.sent_tool_outputs) == 0
+        assert session._event_queue.qsize() == 1
+        tool_start_event = await session._event_queue.get()
+        assert isinstance(tool_start_event, RealtimeToolStart)
+        assert tool_start_event.tool == failing_tool
+
+    @pytest.mark.asyncio
+    async def test_function_tool_cancelled_error_reraises_without_model_output(
+        self, mock_model, mock_agent
+    ):
+        async def cancel_tool(_ctx: ToolContext[Any], _arguments: str) -> str:
+            raise asyncio.CancelledError()
+
+        cancelling_tool = FunctionTool(
+            name="cancelling_tool",
+            description="cancels",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=cancel_tool,
+        )
+        mock_agent.get_all_tools.return_value = [cancelling_tool]
+
+        session = RealtimeSession(mock_model, mock_agent, None)
+        tool_call_event = RealtimeModelToolCallEvent(
+            name="cancelling_tool",
+            call_id="call_cancel",
+            arguments="{}",
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await session._handle_tool_call(tool_call_event)
+
+        assert len(mock_model.sent_tool_outputs) == 0
+        assert session._event_queue.qsize() == 1
+        tool_start_event = await session._event_queue.get()
+        assert isinstance(tool_start_event, RealtimeToolStart)
+        assert tool_start_event.tool == cancelling_tool
+
+    @pytest.mark.asyncio
     async def test_handoff_exception_sends_model_output_before_reraising(self, mock_model):
         target = RealtimeAgent(name="target")
 

--- a/tests/realtime/test_session_exceptions.py
+++ b/tests/realtime/test_session_exceptions.py
@@ -8,13 +8,17 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 import websockets.exceptions
 
+from agents import FunctionTool
+from agents.realtime import RealtimeAgent, realtime_handoff
 from agents.realtime.events import RealtimeError
 from agents.realtime.model import RealtimeModel, RealtimeModelConfig, RealtimeModelListener
 from agents.realtime.model_events import (
     RealtimeModelErrorEvent,
     RealtimeModelEvent,
     RealtimeModelExceptionEvent,
+    RealtimeModelToolCallEvent,
 )
+from agents.realtime.model_inputs import RealtimeModelSendToolOutput
 from agents.realtime.session import RealtimeSession
 
 
@@ -24,6 +28,7 @@ class FakeRealtimeModel(RealtimeModel):
     def __init__(self):
         self._listeners: list[RealtimeModelListener] = []
         self._events_to_send: list[RealtimeModelEvent] = []
+        self.sent_events: list[Any] = []
         self._is_connected = False
         self._send_task: asyncio.Task[None] | None = None
 
@@ -74,7 +79,7 @@ class FakeRealtimeModel(RealtimeModel):
 
     async def send_event(self, event: Any) -> None:
         """Fake send event."""
-        pass
+        self.sent_events.append(event)
 
     async def send_tool_output(self, tool_call: Any, output: str, start_response: bool) -> None:
         """Fake send tool output."""
@@ -300,3 +305,82 @@ class TestSessionExceptions:
         error_events = [e for e in events_received if hasattr(e, "type") and e.type == "error"]
         assert len(error_events) >= 1
         assert isinstance(error_events[0], RealtimeError)
+
+    @pytest.mark.asyncio
+    async def test_failed_function_tool_output_marks_call_completed(
+        self, fake_model: FakeRealtimeModel
+    ):
+        """A duplicate failed tool call should not re-run after output is sent."""
+        calls = 0
+
+        async def failing_tool(_ctx: Any, _arguments: str) -> str:
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("boom")
+
+        tool = FunctionTool(
+            name="failing_tool",
+            description="Fails",
+            params_json_schema={"type": "object", "properties": {}, "additionalProperties": False},
+            on_invoke_tool=failing_tool,
+            _failure_error_function=lambda _ctx, _exc: "handled failure",
+            _use_default_failure_error_function=False,
+        )
+
+        agent = RealtimeAgent(name="agent", tools=[tool])
+        session = RealtimeSession(fake_model, agent, None)
+        event = RealtimeModelToolCallEvent(
+            name="failing_tool",
+            call_id="call_failed",
+            arguments="{}",
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await session._handle_tool_call(event)
+        await session._handle_tool_call(event)
+
+        tool_outputs = [
+            event
+            for event in fake_model.sent_events
+            if isinstance(event, RealtimeModelSendToolOutput)
+        ]
+        assert calls == 1
+        assert len(tool_outputs) == 1
+        assert tool_outputs[0].output == "handled failure"
+        assert "call_failed" in session._completed_tool_call_ids
+
+    @pytest.mark.asyncio
+    async def test_failed_handoff_output_marks_call_completed(
+        self, fake_model: FakeRealtimeModel
+    ):
+        """A duplicate failed handoff call should not re-run after output is sent."""
+        calls = 0
+        target_agent = RealtimeAgent(name="target")
+
+        def on_handoff(_ctx: Any) -> None:
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("handoff boom")
+
+        handoff = realtime_handoff(target_agent, on_handoff=on_handoff)
+        agent = RealtimeAgent(name="agent", handoffs=[handoff])
+        session = RealtimeSession(fake_model, agent, None)
+        event = RealtimeModelToolCallEvent(
+            name=handoff.tool_name,
+            call_id="call_handoff_failed",
+            arguments="",
+        )
+
+        with pytest.raises(RuntimeError, match="handoff boom"):
+            await session._handle_tool_call(event)
+        await session._handle_tool_call(event)
+
+        tool_outputs = [
+            event
+            for event in fake_model.sent_events
+            if isinstance(event, RealtimeModelSendToolOutput)
+        ]
+        assert calls == 1
+        assert len(tool_outputs) == 1
+        assert "handoff boom" in tool_outputs[0].output
+        assert "call_handoff_failed" in session._completed_tool_call_ids


### PR DESCRIPTION
Fixes #3356.

## Summary
- send a model-visible tool output when a known realtime function tool fails before re-raising the original exception
- do the same for handoff invocation failures so the model is not left waiting on a sealed tool call
- update realtime session regressions to cover timeout, generic exception, and handoff failure paths

## Testing
- uv run pytest tests/realtime/test_session.py
- uv run ruff check src/agents/realtime/session.py tests/realtime/test_session.py