### PR TITLE
docs: capitalization fix in tracing docs

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -188,7 +188,7 @@ await Runner.run(
 ```
 
 ## Additional notes
-- View free traces at Openai Traces dashboard.
+- View free traces at OpenAI Traces dashboard.
 
 
 ## Ecosystem integrations


### PR DESCRIPTION
Correct "Openai" to "OpenAI" in the additional notes for proper brand capitalization