### PR TITLE
docs(repl): fix redundancy, formatting, and grammar in utility

### DIFF
--- a/docs/repl.md
+++ b/docs/repl.md
@@ -2,7 +2,6 @@
 
 The SDK provides `run_demo_loop` for quick, interactive testing of an agent's behavior directly in your terminal.
 
-
 ```python
 import asyncio
 from agents import Agent, run_demo_loop
@@ -15,6 +14,6 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-`run_demo_loop` prompts for user input in a loop, keeping the conversation history between turns. By default, it streams model output as it is produced. When you run the example above, run_demo_loop starts an interactive chat session. It continuously asks for your input, remembers the entire conversation history between turns (so your agent knows what's been discussed) and automatically streams the agent's responses to you in real-time as they are generated.
+When you run the example above, `run_demo_loop` starts an interactive chat session. It continuously prompts for your input and retains the full conversation history between turns so your agent knows what has been discussed. By default, it also streams the agent's responses to you in real time as they are generated.
 
 To end this chat session, simply type `quit` or `exit` (and press Enter) or use the `Ctrl-D` keyboard shortcut.


### PR DESCRIPTION
- Merge repetitive sentences about run_demo_loop behavior into a single cohesive paragraph
- Add missing backticks around `run_demo_loop` for consistent inline code formatting
- Change "real-time" to "real time" per standard grammar rules (unhyphenated after preposition)