### PR TITLE
fix(daytona): avoid leaking internal hydrate temp path in type error

### DIFF
--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -1133,7 +1133,10 @@ class DaytonaSandboxSession(BaseSandboxSession):
         if isinstance(payload, str):
             payload = payload.encode("utf-8")
         if not isinstance(payload, bytes | bytearray):
-            raise WorkspaceWriteTypeError(path=Path(tar_path), actual_type=type(payload).__name__)
+            raise WorkspaceWriteTypeError(
+                path=root,
+                actual_type=type(payload).__name__
+            )
 
         try:
             validate_tar_bytes(


### PR DESCRIPTION
**fix(daytona): report workspace root in hydrate_workspace type errors**

## Summary
`hydrate_workspace()` currently raises `WorkspaceWriteTypeError` with the internal temporary tar path (`/tmp/sandbox-hydrate-...`) when the input payload is not bytes-like.

That path is an implementation detail and not the user-facing target of the operation. This change reports the workspace root instead, which matches the actual hydration target and keeps error reporting aligned with the rest of the Daytona sandbox code.

## Why this change
- Avoid exposing backend temp-file details in user-facing errors.
- Make the error path correspond to the workspace being hydrated, not the internal staging archive.
- Keep the failure mode consistent with other workspace archive errors in this module, which already report the workspace root on hydration failures. 

## Scope
This is intentionally narrow:
- no functional behavior changes
- no change to tar extraction logic
- no change to upload or cleanup flow
- only the `WorkspaceWriteTypeError` path is adjusted

## Validation
- Confirmed the error now references the workspace root instead of `/tmp/sandbox-hydrate-...`
- Kept the change isolated to the type-check branch so the runtime behavior remains unchanged elsewhere. :contentReference[oaicite:1]{index=1}