### PR TITLE
fix(mounts): resolve rclone remote names consistently

### DIFF
--- a/src/agents/sandbox/entries/mounts/patterns.py
+++ b/src/agents/sandbox/entries/mounts/patterns.py
@@ -753,7 +753,7 @@ class RcloneMountPattern(MountPatternBase):
                 tool="rclone serve nfs",
                 context={"type": config.mount_type},
             )
-        cmd: list[str] = ["rclone", "serve", "nfs", f"{config.remote_name}:{config.remote_path}"]
+        cmd: list[str] = ["rclone", "serve", "nfs", f"{remote_name}:{config.remote_path}"]
         cmd.extend(["--addr", nfs_addr])
         cmd.extend(["--config", sandbox_path_str(config_path)])
         if config.read_only:
@@ -784,7 +784,7 @@ class RcloneMountPattern(MountPatternBase):
             cmd: list[str] = [
                 "rclone",
                 "mount",
-                f"{config.remote_name}:{config.remote_path}",
+                f"{remote_name}:{config.remote_path}",
                 sandbox_path_str(path),
             ]
             if config.read_only:
@@ -900,6 +900,11 @@ class RcloneMountPattern(MountPatternBase):
                 context={"type": rclone_config.mount_type},
             )
         session_id_str = session_id.hex
+        remote_name = self.resolve_remote_name(
+            session_id=session_id_str,
+            remote_kind=rclone_config.remote_kind,
+            mount_type=rclone_config.mount_type,
+        )
         # Keep generated rclone config under the workspace root so `session.mkdir()` /
         # `session.write()` can handle it without special-casing absolute paths.
         config_dir = posix_path_as_path(
@@ -963,6 +968,16 @@ class RcloneMountPattern(MountPatternBase):
                 "-lc",
                 f"umount {shlex.quote(sandbox_path_str(path))} >/dev/null 2>&1 || true",
                 shell=False,
+            )
+
+        session_id = getattr(session.state, "session_id", None)
+        if session_id is None:
+            remote_name = rclone_config.remote_name
+        else:
+            remote_name = self.resolve_remote_name(
+                session_id=session_id.hex,
+                remote_kind=rclone_config.remote_kind,
+                mount_type=rclone_config.mount_type,
             )
 
         await session.exec(

--- a/src/agents/sandbox/entries/mounts/patterns.py
+++ b/src/agents/sandbox/entries/mounts/patterns.py
@@ -902,17 +902,13 @@ class RcloneMountPattern(MountPatternBase):
                 context={"type": rclone_config.mount_type},
             )
         session_id_str = session_id.hex
-        remote_name = self.resolve_remote_name(
-            session_id=session_id_str,
-            remote_kind=rclone_config.remote_kind,
-            mount_type=rclone_config.mount_type,
-        )
+        remote_name = rclone_config.remote_name
         # Keep generated rclone config under the workspace root so `session.mkdir()` /
         # `session.write()` can handle it without special-casing absolute paths.
         config_dir = posix_path_as_path(
             coerce_posix_path(f".sandbox-rclone-config/{session_id_str}")
         )
-        config_path = config_dir / f"{rclone_config.remote_name}.conf"
+        config_path = config_dir / f"{remote_name}.conf"
         await session.mkdir(path, parents=True)
         await session.mkdir(config_dir, parents=True)
         session.register_persist_workspace_skip_path(config_dir)

--- a/src/agents/sandbox/entries/mounts/patterns.py
+++ b/src/agents/sandbox/entries/mounts/patterns.py
@@ -739,6 +739,7 @@ class RcloneMountPattern(MountPatternBase):
         *,
         config: RcloneMountConfig,
         config_path: Path,
+        remote_name: str,
         nfs_addr: str,
     ) -> None:
         nfs_check = await session.exec(
@@ -778,6 +779,7 @@ class RcloneMountPattern(MountPatternBase):
         path: Path,
         config: RcloneMountConfig,
         config_path: Path,
+        remote_name: str,
         nfs_addr: str | None = None,
     ) -> None:
         if self.mode == "fuse":
@@ -929,6 +931,7 @@ class RcloneMountPattern(MountPatternBase):
                 session,
                 config=rclone_config,
                 config_path=command_config_path,
+                remote_name=remote_name,
                 nfs_addr=nfs_addr,
             )
             await self._start_rclone_client(
@@ -936,6 +939,7 @@ class RcloneMountPattern(MountPatternBase):
                 path=path,
                 config=rclone_config,
                 config_path=command_config_path,
+                remote_name=remote_name,
                 nfs_addr=nfs_addr,
             )
         else:
@@ -945,6 +949,7 @@ class RcloneMountPattern(MountPatternBase):
                 path=path,
                 config=rclone_config,
                 config_path=command_config_path,
+                remote_name=remote_name,
             )
 
     async def unapply(
@@ -985,7 +990,7 @@ class RcloneMountPattern(MountPatternBase):
             "-lc",
             (
                 "pkill -f -- "
-                f"'rclone (mount|serve nfs) {rclone_config.remote_name}:' >/dev/null 2>&1 || true"
+                f"'rclone (mount|serve nfs) {remote_name}:' >/dev/null 2>&1 || true"
             ),
             shell=False,
         )


### PR DESCRIPTION
- Use `RcloneMountPattern.resolve_remote_name()` when building the per-session config path and when launching/unmounting rclone processes.

- This keeps `apply()` and `unapply()` aligned on the same remote name, preserves deterministic naming when no explicit remote_name is provided, and removes the current dead wiring around pattern-level name resolution.

- The change is intentionally limited to name resolution and does not alter mount semantics.