### PR TITLE
fix(models): ensure parallel_tool_calls is always a bool

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -543,7 +543,7 @@ class OpenAIChatCompletionsModel(Model):
             top_p=model_settings.top_p,
             temperature=model_settings.temperature,
             tools=[],
-            parallel_tool_calls=parallel_tool_calls or False,
+            parallel_tool_calls=parallel_tool_calls if isinstance(parallel_tool_calls, bool) else False,
             reasoning=model_settings.reasoning,
         )
         return response, ret


### PR DESCRIPTION
- This change prevents a non-boolean value from being passed into the synthetic Responses object created for Chat Completions compatibility.

- The current fallback uses `parallel_tool_calls or False`, which can forward `omit` instead of a real boolean when the setting is unset. That creates a validation risk and makes the compatibility path less robust.

- Use an explicit boolean guard so the field is always normalized to a valid bool before constructing the Response object.

- No intended behavior change for valid boolean inputs.