### PR TITLE
fix(models): redact verbose model-data debug logging

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -458,7 +458,7 @@ class OpenAIChatCompletionsModel(Model):
                 len(converted_tools),
                 stream,
                 tool_choice,
-                response_format,
+                response_format_summary,
             )
 
         reasoning_effort = model_settings.reasoning.effort if model_settings.reasoning else None

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -449,6 +449,9 @@ class OpenAIChatCompletionsModel(Model):
         if _debug.DONT_LOG_MODEL_DATA:
             logger.debug("Calling LLM")
         else:
+            response_format_summary = (
+                type(response_format).__name__ if response_format is not None else "None"
+            )
             logger.debug(
                 "Calling LLM: messages=%d tools=%d stream=%s tool_choice=%s response_format=%s",
                 len(converted_messages),

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -449,22 +449,13 @@ class OpenAIChatCompletionsModel(Model):
         if _debug.DONT_LOG_MODEL_DATA:
             logger.debug("Calling LLM")
         else:
-            messages_json = json.dumps(
-                converted_messages,
-                indent=2,
-                ensure_ascii=False,
-            )
-            tools_json = json.dumps(
-                converted_tools,
-                indent=2,
-                ensure_ascii=False,
-            )
             logger.debug(
-                f"{messages_json}\n"
-                f"Tools:\n{tools_json}\n"
-                f"Stream: {stream}\n"
-                f"Tool choice: {tool_choice}\n"
-                f"Response format: {response_format}\n"
+                "Calling LLM: messages=%d tools=%d stream=%s tool_choice=%s response_format=%s",
+                len(converted_messages),
+                len(converted_tools),
+                stream,
+                tool_choice,
+                response_format,
             )
 
         reasoning_effort = model_settings.reasoning.effort if model_settings.reasoning else None


### PR DESCRIPTION
- This change reduces the amount of sensitive request/response content written to debug logs in OpenAIChatCompletionsModel.

- When model-data logging is enabled, the adapter currently serializes and logs full converted messages, tools, stream metadata, tool choice, and response format. That creates unnecessary exposure of prompts, tool definitions, and other user-provided content in logs.

- Replace the payload dump with a compact metadata-only log line that preserves debugging value while reducing privacy, IP, and incident-response risk.

- No runtime request/response behavior changes.