### PR TITLE
docs: add flight search hosted MCP example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -58,6 +58,7 @@ Check out a variety of sample implementations of the SDK in the examples section
     Examples demonstrating how to use hosted MCP (Model Context Protocol) with the OpenAI Responses API, including:
 
     -   Simple hosted MCP without approval (`examples/hosted_mcp/simple.py`)
+    -   Flight search with booking URLs (`examples/hosted_mcp/flight_search.py`)
     -   MCP connectors such as Google Calendar (`examples/hosted_mcp/connectors.py`)
     -   Human-in-the-loop with interruption-based approvals (`examples/hosted_mcp/human_in_the_loop.py`)
     -   On-approval callback for MCP tool calls (`examples/hosted_mcp/on_approval.py`)

--- a/examples/hosted_mcp/flight_search.py
+++ b/examples/hosted_mcp/flight_search.py
@@ -1,0 +1,56 @@
+import argparse
+import asyncio
+
+from agents import Agent, HostedMCPTool, ModelSettings, Runner, RunResult, RunResultStreaming
+
+"""This example demonstrates how to use the hosted MCP support in the OpenAI Responses API against
+the Ignav flight-search server (https://ignav.com/mcp), which exposes search_airports and
+search_flights tools whose itineraries include a booking_url. The server is free to use
+anonymously (rate-limited per IP), so no API key is required to run this example."""
+
+
+async def main(verbose: bool, stream: bool):
+    question = (
+        "Find a one-way flight from SFO to JFK on 2026-07-15 and include a booking URL for the "
+        "cheapest option."
+    )
+    agent = Agent(
+        name="Assistant",
+        instructions="You can use the Ignav hosted MCP server to search live flight prices.",
+        model_settings=ModelSettings(tool_choice="required"),
+        tools=[
+            HostedMCPTool(
+                tool_config={
+                    "type": "mcp",
+                    "server_label": "ignav",
+                    "server_url": "https://ignav.com/mcp",
+                    "require_approval": "never",
+                }
+            )
+        ],
+    )
+
+    run_result: RunResult | RunResultStreaming
+    if stream:
+        run_result = Runner.run_streamed(agent, question)
+        async for event in run_result.stream_events():
+            if event.type == "run_item_stream_event":
+                print(f"Got event of type {event.item.__class__.__name__}")
+        print(f"Done streaming; final result: {run_result.final_output}")
+    else:
+        run_result = await Runner.run(agent, question)
+        print(run_result.final_output)
+        # The cheapest one-way SFO -> JFK fare on 2026-07-15 is ... with this booking URL: ...
+
+    if verbose:
+        for item in run_result.new_items:
+            print(item)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", action="store_true", default=False)
+    parser.add_argument("--stream", action="store_true", default=False)
+    args = parser.parse_args()
+
+    asyncio.run(main(args.verbose, args.stream))


### PR DESCRIPTION
### Summary

Adds a small hosted-MCP example, `examples/hosted_mcp/flight_search.py`, mirroring `simple.py`. It uses `HostedMCPTool` to connect the Responses API to a third-party Streamable HTTP MCP server ([Ignav](https://ignav.com), `https://ignav.com/mcp`) that exposes `search_airports` and `search_flights` tools whose itineraries include a `booking_url`. The agent answers "Find a one-way flight from SFO to JFK on 2026-07-15 and include a booking URL for the cheapest option." The server is free to use anonymously (rate-limited per IP), so the example runs without any extra credentials. Also adds the example to the hosted_mcp listing in `docs/examples.md`.

### Test plan

- `uv run ruff format --check` and `uv run ruff check` pass (repo-wide).
- `uv run mypy examples/hosted_mcp/flight_search.py` and `uv run pyright --project pyrightconfig.json examples/hosted_mcp/flight_search.py` pass with no issues.
- Smoke-tested that the example imports and the `HostedMCPTool` agent constructs.
- Verified the MCP server live over raw JSON-RPC (`initialize`, `tools/list`, and a `search_flights` SFO->JFK call returning itineraries with a populated `booking_url`).

### Issue number

N/A

### Checks

- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass