### PR TITLE
fix: include auth headers in responses websocket handshake

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1377,10 +1377,15 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
 
     def _merge_websocket_headers(self, extra_headers: Mapping[str, Any]) -> dict[str, str]:
         headers: dict[str, str] = {}
-        for key, value in self._client.default_headers.items():
-            if _is_openai_omitted_value(value):
-                continue
-            headers[key] = str(value)
+        auth_headers = getattr(self._client, "auth_headers", {})
+        for source in (auth_headers, self._client.default_headers):
+            for key, value in source.items():
+                header_key = str(key)
+                for existing_key in list(headers):
+                    if existing_key.lower() == header_key.lower():
+                        del headers[existing_key]
+                if not _is_openai_omitted_value(value):
+                    headers[header_key] = str(value)
 
         for key, value in extra_headers.items():
             if isinstance(value, NotGiven):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -3206,6 +3206,45 @@ async def test_websocket_model_get_response_uses_client_default_timeout_when_ove
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_includes_client_auth_headers():
+    client = AsyncOpenAI(api_key="test-key")
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)
+
+    _frame, _ws_url, headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+        }
+    )
+
+    assert "Authorization" not in client.default_headers
+    assert headers["Authorization"] == "Bearer test-key"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_preserves_client_header_overrides():
+    client = AsyncOpenAI(
+        api_key="test-key",
+        default_headers={"authorization": "Bearer proxy-key"},
+    )
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)
+
+    _frame, _ws_url, headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+        }
+    )
+
+    assert headers["authorization"] == "Bearer proxy-key"
+    assert "Authorization" not in headers
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_websocket_model_prepare_websocket_request_omit_removes_inherited_header():
     client = DummyWSClient()
     model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]


### PR DESCRIPTION
### Summary

Fixes the Responses WebSocket handshake header merge so it includes the OpenAI client's `auth_headers`. In recent `openai` SDK versions, `Authorization` lives in `AsyncOpenAI.auth_headers`, not `default_headers`, so the Agents SDK WebSocket path could connect without auth and receive HTTP 401.

This keeps the existing precedence shape narrow:
- client auth headers are merged first
- client default headers can override them, case-insensitively
- per-request `extra_headers` still apply last and can replace or omit inherited headers

### Test plan

- `uv run pytest tests/models/test_openai_responses.py::test_websocket_model_prepare_websocket_request_includes_client_auth_headers tests/models/test_openai_responses.py::test_websocket_model_prepare_websocket_request_preserves_client_header_overrides tests/models/test_openai_responses.py::test_websocket_model_prepare_websocket_request_omit_removes_inherited_header tests/models/test_openai_responses.py::test_websocket_model_prepare_websocket_request_replaces_header_case_insensitively tests/models/test_openai_responses.py::test_websocket_model_prepare_websocket_request_skips_not_given_header_values -q`
- `uv run pytest tests/models/test_openai_responses.py tests/test_config.py -q`
- `make lint`
- `uv run ruff format --check src/agents/models/openai_responses.py tests/models/test_openai_responses.py`
- `uv run mypy src/agents/models/openai_responses.py tests/models/test_openai_responses.py --exclude site`
- `uv run python -m pyright --project pyrightconfig.json`

### Issue number

Closes #3133

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
