### PR TITLE
docs: explain resuming interrupted session runs

### DIFF
--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -56,6 +56,8 @@ if result.interruptions:
     state = result.to_state()
     for interruption in result.interruptions:
         state.approve(interruption)
+
+    # Resume with the approved run state, not a new user prompt.
     result = await Runner.run(agent, state, session=session)
 ```
 


### PR DESCRIPTION
- Add a short comment to the interrupted-run example explaining that the resumed call passes the approved `state` object rather than a new user prompt.

- This makes the special-case resume flow clearer for readers who are following the snippet step by step.