### PR TITLE
docs: warn about pop_item assumptions in correction example

### DIFF
--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -192,6 +192,8 @@ result = await Runner.run(
 print(f"Agent: {result.final_output}")
 ```
 
+> **Note:** This example assumes the previous turn produced exactly two items: the user prompt and the assistant response. If your agent uses tools, a single turn may add additional items to session history, so you may need to inspect the stored items before popping them.
+
 ## Built-in session implementations
 
 The SDK provides several session implementations for different use cases:


### PR DESCRIPTION
- Add a note explaining that the correction example assumes a simple two-item turn.

- This helps readers avoid applying the pattern blindly when tool calls or other extra items are present in the session history.