### PR TITLE
docs: rename duplicate Concepts heading in sandbox guide

### DIFF
--- a/docs/sandbox/guide.md
+++ b/docs/sandbox/guide.md
@@ -215,7 +215,7 @@ If your skills already live on disk under something like `.agents/skills/<name>/
 
 Prefer built-in capabilities when they fit. Write a custom capability only when you need a sandbox-specific tool or instruction surface that the built-ins do not cover.
 
-## Concepts
+## Core Sandbox Concepts
 
 ### Manifest
 


### PR DESCRIPTION
**Rename the second `## Concepts` heading in the Sandbox Agents guide to a more specific section title.**

- The guide currently contains two different "Concepts" headings, which can create duplicate anchors and make the document structure harder to navigate.

This change improves document organization without altering any content or behavior.