### PR TITLE
docs: clarify placeholders in MCP integration example

### DIFF
--- a/docs/sandbox/guide.md
+++ b/docs/sandbox/guide.md
@@ -810,6 +810,7 @@ Keep the sandbox workspace while still using ordinary tools on the same agent:
 from agents.sandbox import SandboxAgent
 from agents.sandbox.capabilities import Shell
 
+# Assumes `get_discount_approval_path` and an MCP `server` are defined elsewhere.
 agent = SandboxAgent(
     name="Workspace reviewer",
     instructions="Inspect the workspace and call host tools when needed.",


### PR DESCRIPTION
- Add context to the "Combine with local tools and MCP" example to clarify that the referenced tool and MCP server objects are assumed to be defined elsewhere.

This helps readers understand that the snippet is illustrative and avoids confusion when copying the example into a standalone script.