### PR TITLE
fix: expose original FunctionTool callable

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -389,6 +389,14 @@ class FunctionTool:
     _emit_tool_origin: bool = field(default=True, kw_only=True, repr=False)
     """Whether runtime item generation should emit tool origin metadata for this tool."""
 
+    _func: ToolFunction[...] | None = field(default=None, kw_only=True, repr=False)
+    """Original callable when this tool was created from @function_tool."""
+
+    @property
+    def func(self) -> ToolFunction[...] | None:
+        """Return the original callable for tools created with @function_tool."""
+        return self._func
+
     @property
     def qualified_name(self) -> str:
         """Return the public qualified name used to identify this function tool."""
@@ -514,6 +522,7 @@ def _build_wrapped_function_tool(
     sync_invoker: bool = False,
     mcp_title: str | None = None,
     tool_origin: ToolOrigin | None = None,
+    original_function: ToolFunction[...] | None = None,
 ) -> FunctionTool:
     """Create a FunctionTool with copied-tool-aware failure handling bound in one place."""
     on_invoke_tool = _with_context_function_tool_failure_error_handler(
@@ -540,6 +549,7 @@ def _build_wrapped_function_tool(
             defer_loading=defer_loading,
             _mcp_title=mcp_title,
             _tool_origin=tool_origin,
+            _func=original_function,
         ),
         failure_error_function,
     )
@@ -1905,6 +1915,7 @@ def function_tool(
             timeout_error_function=timeout_error_function,
             defer_loading=defer_loading,
             sync_invoker=is_sync_function_tool,
+            original_function=the_func,
         )
         return function_tool
 

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -155,6 +155,26 @@ async def test_simple_function():
         )
 
 
+def test_function_tool_exposes_original_function_without_wrapping() -> None:
+    tool = function_tool(simple_function)
+
+    assert tool.func is simple_function
+    assert not callable(tool)
+    assert copy.copy(tool).func is simple_function
+    assert dataclasses.replace(tool, name="renamed").func is simple_function
+
+
+def test_manual_function_tool_has_no_original_function() -> None:
+    tool = FunctionTool(
+        name="manual",
+        description="manual tool",
+        params_json_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        on_invoke_tool=lambda _ctx, _input: asyncio.sleep(0),
+    )
+
+    assert tool.func is None
+
+
 @pytest.mark.asyncio
 async def test_sync_function_runs_via_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = {"to_thread": 0, "func": 0}


### PR DESCRIPTION
### Summary

Adds a stable `FunctionTool.func` property for tools created with `@function_tool`.

The original callable was previously only reachable through private closure-walking on the generated invoker. This stores it on the tool as internal `_func` metadata and exposes it through a read-only property, so downstream SDKs and tests can introspect the wrapped function without depending on closure internals.

This intentionally does not make `FunctionTool` callable and does not use `functools.update_wrapper`. PR #2146 showed that wrapper metadata can interact badly with pytest collection for tool functions whose names start with `test_`; this version keeps the runtime shape unchanged except for the new property.

### Test plan

- `python -m py_compile src\agents\tool.py tests\test_function_tool.py`
- `python -m ruff check src\agents\tool.py tests\test_function_tool.py`
- `python -m ruff format --check src\agents\tool.py tests\test_function_tool.py`
- `$env:PYTHONPATH='src'; python -m pytest tests\test_function_tool.py -q`
- `$env:PYTHONPATH='src'; python -c "from agents import function_tool; add=lambda a,b=1:a+b; tool=function_tool(add); assert tool.func is add; assert not callable(tool); print('ok')"`

### Issue number

Closes #3381

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
