### PR TITLE
fix: report effective Blaxel timeouts

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -608,7 +608,7 @@ class BlaxelSandboxSession(BaseSandboxSession):
                 return ExecResult(stdout=fallback_bytes, stderr=b"", exit_code=exit_code)
             return ExecResult(stdout=b"", stderr=fallback_bytes, exit_code=exit_code)
         except asyncio.TimeoutError as e:
-            raise ExecTimeoutError(command=command, timeout_s=timeout, cause=e) from e
+            raise ExecTimeoutError(command=command, timeout_s=exec_timeout, cause=e) from e
         except (ExecTimeoutError, ExecTransportError):
             raise
         except Exception as e:
@@ -616,7 +616,7 @@ class BlaxelSandboxSession(BaseSandboxSession):
             if api_error_cls is not None and isinstance(e, api_error_cls):
                 status = getattr(e, "status_code", None)
                 if status in (408, 504):
-                    raise ExecTimeoutError(command=command, timeout_s=timeout, cause=e) from e
+                    raise ExecTimeoutError(command=command, timeout_s=exec_timeout, cause=e) from e
             raise _blaxel_exec_transport_error(command=command, cause=e) from e
 
     # -- running check -------------------------------------------------------
@@ -834,7 +834,7 @@ class BlaxelSandboxSession(BaseSandboxSession):
         except asyncio.TimeoutError as e:
             if not registered:
                 await self._terminate_pty_entry(entry)
-            raise ExecTimeoutError(command=command, timeout_s=timeout, cause=e) from e
+            raise ExecTimeoutError(command=command, timeout_s=exec_timeout, cause=e) from e
         except Exception as e:
             if not registered:
                 await self._terminate_pty_entry(entry)

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -589,6 +589,22 @@ class TestBlaxelSandboxSession:
             await session._exec_internal("sleep", "100", timeout=0.01)
 
     @pytest.mark.asyncio
+    async def test_exec_timeout_reports_default_timeout(
+        self, fake_sandbox: _FakeSandboxInstance
+    ) -> None:
+        from agents.extensions.sandbox.blaxel.sandbox import BlaxelTimeouts
+
+        state = _make_state()
+        state.timeouts = BlaxelTimeouts(exec_timeout_s=1)
+        session = _make_session(fake_sandbox, state=state)
+        fake_sandbox.process.delay = 10.0
+
+        with pytest.raises(ExecTimeoutError) as exc_info:
+            await session._exec_internal("sleep", "100")
+
+        assert exc_info.value.timeout_s == 1.0
+
+    @pytest.mark.asyncio
     async def test_stop_calls_pty_terminate(self, fake_sandbox: _FakeSandboxInstance) -> None:
         session = _make_session(fake_sandbox)
         terminated = []
@@ -1655,6 +1671,36 @@ class TestPtyExec:
         with patch.object(mod, "_import_aiohttp", return_value=_SlowAiohttp()):
             with pytest.raises(ExecTimeoutError):
                 await session.pty_exec_start("echo", "hello", timeout=0.01)
+
+    @pytest.mark.asyncio
+    async def test_pty_exec_start_timeout_reports_default_timeout(
+        self, fake_sandbox: _FakeSandboxInstance
+    ) -> None:
+        from agents.extensions.sandbox.blaxel import sandbox as mod
+        from agents.extensions.sandbox.blaxel.sandbox import BlaxelTimeouts
+
+        state = _make_state()
+        state.timeouts = BlaxelTimeouts(exec_timeout_s=1)
+        session = _make_session(fake_sandbox, state=state)
+
+        class _SlowAiohttp:
+            WSMsgType = _FakeAiohttp.WSMsgType
+
+            def ClientSession(self) -> Any:
+                class _SlowSession:
+                    async def ws_connect(self, url: str) -> None:
+                        await asyncio.sleep(100)
+
+                    async def close(self) -> None:
+                        pass
+
+                return _SlowSession()
+
+        with patch.object(mod, "_import_aiohttp", return_value=_SlowAiohttp()):
+            with pytest.raises(ExecTimeoutError) as exc_info:
+                await session.pty_exec_start("echo", "hello")
+
+        assert exc_info.value.timeout_s == 1.0
 
     @pytest.mark.asyncio
     async def test_pty_exec_start_connection_error(


### PR DESCRIPTION
## Summary
- report the resolved Blaxel exec timeout in `ExecTimeoutError` instead of the original `timeout` argument
- apply the same fix to normal exec, provider 408/504 timeout wrapping, and PTY startup timeout handling
- add regression coverage for default-timeout exec and PTY paths

## Issue Number
Fixes #3639

## How to Test
- `python -m py_compile src\agents\extensions\sandbox\blaxel\sandbox.py tests\extensions\sandbox\test_blaxel.py`
- `$env:PYTHONPATH='src'; python -m pytest tests\extensions\sandbox\test_blaxel.py -q -k "timeout_reports_default_timeout or test_exec_timeout or test_pty_exec_start_timeout"`
- `$env:PYTHONPATH='src'; python -m pytest tests\extensions\sandbox\test_blaxel.py -q`
- `python -m ruff check src\agents\extensions\sandbox\blaxel\sandbox.py tests\extensions\sandbox\test_blaxel.py`
- `python -m ruff format --check src\agents\extensions\sandbox\blaxel\sandbox.py tests\extensions\sandbox\test_blaxel.py`
- `git diff --check`
