### PR TITLE
docs: fix OpenAI capitalization in auto-generated ref titles

### DIFF
--- a/docs/ref/memory/openai_conversations_session.md
+++ b/docs/ref/memory/openai_conversations_session.md
@@ -1,3 +1,3 @@
-# `Openai Conversations Session`
+# `OpenAI Conversations Session`
 
 ::: agents.memory.openai_conversations_session

--- a/docs/ref/memory/openai_responses_compaction_session.md
+++ b/docs/ref/memory/openai_responses_compaction_session.md
@@ -1,3 +1,3 @@
-# `Openai Responses Compaction Session`
+# `OpenAI Responses Compaction Session`
 
 ::: agents.memory.openai_responses_compaction_session

--- a/docs/ref/models/openai_agent_registration.md
+++ b/docs/ref/models/openai_agent_registration.md
@@ -1,3 +1,3 @@
-# `Openai Agent Registration`
+# `OpenAI Agent Registration`
 
 ::: agents.models.openai_agent_registration

--- a/docs/ref/models/openai_client_utils.md
+++ b/docs/ref/models/openai_client_utils.md
@@ -1,3 +1,3 @@
-# `Openai Client Utils`
+# `OpenAI Client Utils`
 
 ::: agents.models.openai_client_utils

--- a/docs/ref/realtime/openai_realtime.md
+++ b/docs/ref/realtime/openai_realtime.md
@@ -1,3 +1,3 @@
-# `Openai Realtime`
+# `OpenAI Realtime`
 
 ::: agents.realtime.openai_realtime


### PR DESCRIPTION
## Summary
- Fix `Openai` → `OpenAI` capitalization in the H1 titles of five auto-generated reference pages under `docs/ref/` (`memory/openai_conversations_session.md`, `memory/openai_responses_compaction_session.md`, `models/openai_agent_registration.md`, `models/openai_client_utils.md`, `realtime/openai_realtime.md`).
- Aligns these titles with the canonical "OpenAI" spelling already used by neighboring reference pages (e.g. `OpenAI Chat Completions model`, `OpenAI Provider`, `OpenAI Responses model`) and with the rest of the documentation.

## Validation
- `make build-docs` — passes. No new warnings introduced; the pre-existing "pages exist in the docs directory, but are not included in the nav configuration" warnings for these stub pages are unchanged.

No linked issue.