### PR TITLE
fix: route HttpProxySink timeouts through spool fallback

### DIFF
--- a/src/agents/sandbox/session/sinks.py
+++ b/src/agents/sandbox/session/sinks.py
@@ -317,7 +317,11 @@ class HttpProxySink(EventSink):
         try:
             with urlopen(req, timeout=self.timeout_s) as resp:
                 _ = resp.read(1)  # ensure request completes
-        except (HTTPError, URLError) as e:
+        except (HTTPError, URLError, TimeoutError, OSError) as e:
+            # `urlopen` wraps most network failures in `URLError`, but socket-level
+            # timeouts (e.g. during connect) can surface as bare `TimeoutError`, and
+            # other low-level failures as `OSError`. Treat all of these as delivery
+            # failures so the configured spool fallback is exercised consistently.
             if spool_line is not None and self.spool_path is not None:
                 try:
                     self.spool_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/sandbox/test_session_sinks.py
+++ b/tests/sandbox/test_session_sinks.py
@@ -21,6 +21,7 @@ from agents.sandbox.session import (
     CallbackSink,
     ChainedSink,
     EventPayloadPolicy,
+    HttpProxySink,
     Instrumentation,
     JsonlOutboxSink,
     SandboxSession,
@@ -122,6 +123,44 @@ async def test_jsonl_outbox_sink_appends_one_line_per_event(tmp_path: Path) -> N
     assert len(lines) == 2
     assert json.loads(lines[0])["phase"] == "start"
     assert json.loads(lines[1])["phase"] == "finish"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [TimeoutError("timed out"), OSError("connection reset")],
+)
+@pytest.mark.asyncio
+async def test_http_proxy_sink_writes_spool_on_timeout_or_oserror(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exc: BaseException,
+) -> None:
+    spool_path = tmp_path / "spool.jsonl"
+    sink = HttpProxySink(
+        "http://127.0.0.1:9/events",
+        timeout_s=0.001,
+        spool_path=spool_path,
+    )
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise exc
+
+    monkeypatch.setattr("agents.sandbox.session.sinks.urlopen", _raise)
+
+    event = SandboxSessionStartEvent(
+        session_id=uuid.uuid4(),
+        seq=1,
+        op="write",
+        span_id="span_write",
+    )
+
+    with pytest.raises(RuntimeError, match="http proxy sink POST failed"):
+        await sink.handle(event)
+
+    assert spool_path.exists()
+    lines = spool_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["seq"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`HttpProxySink._post()` only caught `HTTPError` and `URLError`, so a `TimeoutError` (for example a socket-level connect timeout, or any other low-level `OSError` such as `ConnectionRefusedError`) bypassed the configured `spool_path` fallback and surfaced the raw exception to callers instead of the sink's `RuntimeError` wrapper.

This change catches `TimeoutError` and `OSError` alongside the existing URL errors so the spool write and the sink's `RuntimeError` wrapper are exercised consistently for every delivery failure, restoring the configured fallback behavior. A short comment documents why the wider exception list is intentional.

### Test plan

- Added a parametrized regression test (`tests/sandbox/test_session_sinks.py::test_http_proxy_sink_writes_spool_on_timeout_or_oserror`) that patches `urllib.request.urlopen` in the sinks module to raise `TimeoutError` and `OSError` in turn, asserts the sink raises `RuntimeError` with the expected message, and asserts the spool file contains the serialized event line.
- Ran `uv run pytest tests/sandbox/test_session_sinks.py -v -k test_http_proxy_sink_writes_spool_on_timeout_or_oserror` (both parametrized cases pass).
- Ran `uv run pytest tests/sandbox/ -q` — 806 passed, 19 skipped (no regressions).
- Ran `make format` and `uv run ruff check`/`uv run mypy`/`uv run pyright` against the changed files — all clean.

### Issue number

Closes #3641

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass

Made with [Cursor](https://cursor.com)