### PR TITLE
feat(sandbox): add disabled_tools to hide capability tools by name

### DIFF
--- a/docs/sandbox/guide.md
+++ b/docs/sandbox/guide.md
@@ -143,6 +143,7 @@ These are the sandbox-specific options on top of the usual `Agent` fields:
 | `base_instructions` | Advanced escape hatch that replaces the SDK sandbox prompt. |
 | `capabilities` | Sandbox-native tools and behavior that should travel with this agent. |
 | `run_as` | User identity for model-facing sandbox tools such as shell commands, file reads, and patches. |
+| `disabled_tools` | Names of capability-contributed tools to hide from the model, even when their capability stays enabled. |
 
 </div>
 
@@ -214,6 +215,14 @@ For skills, choose the source based on how you want them materialized:
 If your skills already live on disk under something like `.agents/skills/<name>/SKILL.md`, point `LocalDir(...)` at that source root and still use `Skills(...)` to expose them. Keep the default `skills_path=".agents"` unless you have an existing workspace contract that depends on a different in-sandbox layout.
 
 Prefer built-in capabilities when they fit. Write a custom capability only when you need a sandbox-specific tool or instruction surface that the built-ins do not cover.
+
+### `disabled_tools`
+
+`disabled_tools` is a set of tool names to hide from the model while keeping the capability that provides them enabled. Use it when a capability is mostly useful but one of its tools is not, for example keeping `Filesystem` for `apply_patch` while hiding `view_image`, or keeping `Shell` while hiding `write_stdin`.
+
+It is a coarser, name-based switch than per-capability `configure_tools`: `configure_tools` customizes or replaces a tool, while `disabled_tools` removes it. The two compose, so you can customize one tool and drop another in the same agent. Filtering happens once, after capability tools are gathered, so it applies to every capability uniformly and works for non-function tools such as `apply_patch`. Names that do not match any contributed tool are ignored, and tools attached directly to `tools` are not affected.
+
+To drop a whole capability instead of an individual tool, leave it out of `capabilities` rather than listing all its tool names here.
 
 ## Concepts
 

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -2967,6 +2967,10 @@ def _agent_identity_signature(agent: Agent[Any]) -> str:
             for capability in capabilities
         )
 
+    disabled_tools = getattr(agent, "disabled_tools", None)
+    if disabled_tools:
+        signature["disabled_tools"] = sorted(str(name) for name in disabled_tools)
+
     return _stable_identity_text(signature)
 
 

--- a/src/agents/sandbox/runtime_agent_preparation.py
+++ b/src/agents/sandbox/runtime_agent_preparation.py
@@ -81,9 +81,8 @@ def prepare_sandbox_agent(
 
     capability_tools = [tool for capability in capabilities for tool in capability.tools()]
     if agent.disabled_tools:
-        # Filter by tool name at the single point where every capability's contributed tools are
-        # gathered into one list. Comparing by `.name` works uniformly across tool types, including
-        # custom tools such as `apply_patch` that the runtime tool-enablement check skips.
+        # Filter by name here, where every tool type is uniform: `is_enabled` only applies to
+        # FunctionTool, so custom tools like `apply_patch` can only be dropped by name.
         capability_tools = [
             tool for tool in capability_tools if tool.name not in agent.disabled_tools
         ]

--- a/src/agents/sandbox/runtime_agent_preparation.py
+++ b/src/agents/sandbox/runtime_agent_preparation.py
@@ -80,6 +80,13 @@ def prepare_sandbox_agent(
             raise UserError(f"{type(capability).__name__} requires missing capabilities: {missing}")
 
     capability_tools = [tool for capability in capabilities for tool in capability.tools()]
+    if agent.disabled_tools:
+        # Filter by tool name at the single point where every capability's contributed tools are
+        # gathered into one list. Comparing by `.name` works uniformly across tool types, including
+        # custom tools such as `apply_patch` that the runtime tool-enablement check skips.
+        capability_tools = [
+            tool for tool in capability_tools if tool.name not in agent.disabled_tools
+        ]
     model_settings = agent.model_settings
     extra_args = dict(model_settings.extra_args or {})
     resolved_model_name = resolve_sandbox_model_name(

--- a/src/agents/sandbox/sandbox_agent.py
+++ b/src/agents/sandbox/sandbox_agent.py
@@ -38,15 +38,7 @@ class SandboxAgent(Agent[TContext]):
     """User identity used for model-facing sandbox tools such as shell, file reads, and patches."""
 
     disabled_tools: set[str] = field(default_factory=set)
-    """Names of tools to hide from the model.
-
-    Any tool whose ``name`` matches an entry in this set is removed from the merged tool list
-    during run preparation, regardless of which capability contributed it. Filtering happens at
-    a single point after each capability's ``configure_tools`` callback runs, so the two
-    mechanisms compose: ``configure_tools`` customizes a tool, ``disabled_tools`` removes it by
-    name. Names that do not match any contributed tool are ignored. Only capability-contributed
-    tools are filtered; tools attached directly to ``tools`` are left untouched.
-    """
+    """Names of capability-contributed tools to hide from the model during run preparation."""
 
     _sandbox_concurrency_guard: object | None = field(default=None, init=False, repr=False)
 
@@ -66,5 +58,3 @@ class SandboxAgent(Agent[TContext]):
                 f"SandboxAgent run_as must be a string, User, or None, "
                 f"got {type(self.run_as).__name__}"
             )
-        if not isinstance(self.disabled_tools, set):
-            self.disabled_tools = set(self.disabled_tools)

--- a/src/agents/sandbox/sandbox_agent.py
+++ b/src/agents/sandbox/sandbox_agent.py
@@ -37,6 +37,17 @@ class SandboxAgent(Agent[TContext]):
     run_as: User | str | None = None
     """User identity used for model-facing sandbox tools such as shell, file reads, and patches."""
 
+    disabled_tools: set[str] = field(default_factory=set)
+    """Names of tools to hide from the model.
+
+    Any tool whose ``name`` matches an entry in this set is removed from the merged tool list
+    during run preparation, regardless of which capability contributed it. Filtering happens at
+    a single point after each capability's ``configure_tools`` callback runs, so the two
+    mechanisms compose: ``configure_tools`` customizes a tool, ``disabled_tools`` removes it by
+    name. Names that do not match any contributed tool are ignored. Only capability-contributed
+    tools are filtered; tools attached directly to ``tools`` are left untouched.
+    """
+
     _sandbox_concurrency_guard: object | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -55,3 +66,5 @@ class SandboxAgent(Agent[TContext]):
                 f"SandboxAgent run_as must be a string, User, or None, "
                 f"got {type(self.run_as).__name__}"
             )
+        if not isinstance(self.disabled_tools, set):
+            self.disabled_tools = set(self.disabled_tools)

--- a/src/agents/sandbox/sandbox_agent.py
+++ b/src/agents/sandbox/sandbox_agent.py
@@ -38,7 +38,12 @@ class SandboxAgent(Agent[TContext]):
     """User identity used for model-facing sandbox tools such as shell, file reads, and patches."""
 
     disabled_tools: set[str] = field(default_factory=set)
-    """Names of capability-contributed tools to hide from the model during run preparation."""
+    """Names of capability-contributed tools to hide from the model during run preparation.
+
+    This removes the tool's schema. Instruction text that names the tool (the default sandbox
+    prompt or a capability's instructions) is not rewritten, so prefer disabling tools the base
+    instructions do not reference, or override ``base_instructions`` accordingly.
+    """
 
     _sandbox_concurrency_guard: object | None = field(default=None, init=False, repr=False)
 

--- a/tests/sandbox/test_runtime_agent_preparation.py
+++ b/tests/sandbox/test_runtime_agent_preparation.py
@@ -17,17 +17,25 @@ from agents.sandbox.entries import BaseEntry, File
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.sandbox_agent import SandboxAgent
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
+from agents.tool import CustomTool, FunctionTool
 
 
 class _Capability:
-    def __init__(self, fragment: str | None, *, type: str = "test") -> None:
+    def __init__(
+        self,
+        fragment: str | None,
+        *,
+        type: str = "test",
+        tools: list[object] | None = None,
+    ) -> None:
         self.type = type
         self.fragment = fragment
         self.manifests: list[Manifest] = []
         self.sampling_params_calls: list[dict[str, object]] = []
+        self._tools = tools or []
 
     def tools(self) -> list[object]:
-        return []
+        return list(self._tools)
 
     def sampling_params(self, sampling_params: dict[str, object]) -> dict[str, object]:
         self.sampling_params_calls.append(dict(sampling_params))
@@ -249,3 +257,171 @@ def test_prepare_sandbox_agent_validates_required_capabilities() -> None:
     )
 
     assert prepared.name == "sandbox"
+
+
+def _function_tool(name: str) -> FunctionTool:
+    async def _invoke(_ctx: object, _input: str) -> str:
+        return "ok"
+
+    return FunctionTool(
+        name=name,
+        description=name,
+        params_json_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        on_invoke_tool=_invoke,
+    )
+
+
+def _custom_tool(name: str) -> CustomTool:
+    async def _invoke(_ctx: object, _input: str) -> str:
+        return "ok"
+
+    return CustomTool(name=name, description=name, on_invoke_tool=_invoke)
+
+
+def _prepare_with_tools(
+    tools: list[object],
+    *,
+    disabled_tools: set[str] | None = None,
+    agent_tools: list[object] | None = None,
+) -> list[str]:
+    manifest = Manifest(root="/workspace")
+    agent = SandboxAgent(
+        name="sandbox",
+        instructions="base instructions",
+        tools=cast(Any, agent_tools or []),
+        disabled_tools=disabled_tools or set(),
+    )
+    prepared = sandbox_prep.prepare_sandbox_agent(
+        agent=agent,
+        session=cast(BaseSandboxSession, _session_with_manifest(manifest)),
+        capabilities=cast(list[Capability], [_Capability(None, tools=tools)]),
+    )
+    return [cast(Any, tool).name for tool in prepared.tools]
+
+
+def test_disabled_tools_defaults_to_empty_set() -> None:
+    assert SandboxAgent(name="sandbox").disabled_tools == set()
+
+
+def test_disabled_tools_instances_do_not_share_default() -> None:
+    first = SandboxAgent(name="first")
+    second = SandboxAgent(name="second")
+    first.disabled_tools.add("exec_command")
+    assert "exec_command" not in second.disabled_tools
+
+
+def test_disabled_tools_removes_named_function_tool() -> None:
+    names = _prepare_with_tools(
+        [_function_tool("exec_command"), _function_tool("view_image")],
+        disabled_tools={"view_image"},
+    )
+    assert "exec_command" in names
+    assert "view_image" not in names
+
+
+def test_disabled_tools_removes_named_custom_tool() -> None:
+    # apply_patch is a CustomTool, which the runtime tool-enablement check skips. Filtering by
+    # name at the aggregation point is the only place it can be removed.
+    names = _prepare_with_tools(
+        [_function_tool("view_image"), _custom_tool("apply_patch")],
+        disabled_tools={"apply_patch"},
+    )
+    assert "view_image" in names
+    assert "apply_patch" not in names
+
+
+def test_disabled_tools_filters_uniformly_across_capabilities() -> None:
+    manifest = Manifest(root="/workspace")
+    shell = _Capability(None, type="shell", tools=[_function_tool("write_stdin")])
+    filesystem = _Capability(None, type="filesystem", tools=[_custom_tool("apply_patch")])
+    prepared = sandbox_prep.prepare_sandbox_agent(
+        agent=SandboxAgent(
+            name="sandbox",
+            instructions="base instructions",
+            disabled_tools={"write_stdin", "apply_patch"},
+        ),
+        session=cast(BaseSandboxSession, _session_with_manifest(manifest)),
+        capabilities=cast(list[Capability], [shell, filesystem]),
+    )
+    assert prepared.tools == []
+
+
+def test_disabled_tools_unknown_name_is_ignored() -> None:
+    names = _prepare_with_tools(
+        [_function_tool("exec_command")],
+        disabled_tools={"does_not_exist"},
+    )
+    assert names == ["exec_command"]
+
+
+def test_disabled_tools_keeps_untargeted_tools() -> None:
+    names = _prepare_with_tools(
+        [_function_tool("exec_command"), _function_tool("view_image")],
+        disabled_tools={"exec_command"},
+    )
+    assert names == ["view_image"]
+
+
+def test_disabled_tools_empty_set_passes_all_tools() -> None:
+    names = _prepare_with_tools([_function_tool("exec_command"), _custom_tool("apply_patch")])
+    assert names == ["exec_command", "apply_patch"]
+
+
+def test_disabled_tools_does_not_filter_agent_attached_tools() -> None:
+    # disabled_tools targets capability-contributed tools, not tools attached directly to the
+    # agent. An agent tool that happens to share a disabled name is left untouched.
+    names = _prepare_with_tools(
+        [_function_tool("exec_command")],
+        disabled_tools={"my_tool"},
+        agent_tools=[_function_tool("my_tool")],
+    )
+    assert "my_tool" in names
+    assert "exec_command" in names
+
+
+def test_disabled_tools_prepares_agent_without_raising() -> None:
+    prepared_names = _prepare_with_tools(
+        [_function_tool("exec_command"), _custom_tool("apply_patch")],
+        disabled_tools={"apply_patch"},
+    )
+    assert prepared_names == ["exec_command"]
+
+
+def test_disabled_tools_compose_with_configure_tools(tmp_path: Path) -> None:
+    # configure_tools runs while a capability builds its tools; disabled_tools filters afterwards.
+    # Both must compose: a customized-but-not-disabled tool keeps its customization, while a
+    # disabled tool is removed.
+    from agents.sandbox.capabilities import Filesystem, FilesystemToolSet
+    from agents.sandbox.sandboxes.unix_local import (
+        UnixLocalSandboxSession,
+        UnixLocalSandboxSessionState,
+    )
+    from agents.sandbox.snapshot import NoopSnapshot
+
+    def configure_tools(toolset: FilesystemToolSet) -> None:
+        toolset.view_image.needs_approval = True
+
+    session = UnixLocalSandboxSession(
+        state=UnixLocalSandboxSessionState(
+            manifest=Manifest(root=str(tmp_path / "workspace")),
+            snapshot=NoopSnapshot(id="00000000-0000-0000-0000-000000000000"),
+            workspace_root_owned=False,
+        )
+    )
+    capability = Filesystem(configure_tools=configure_tools)
+    capability.bind(session)
+
+    prepared = sandbox_prep.prepare_sandbox_agent(
+        agent=SandboxAgent(
+            name="sandbox",
+            instructions="base instructions",
+            disabled_tools={"apply_patch"},
+        ),
+        session=cast(BaseSandboxSession, session),
+        capabilities=cast(list[Capability], [capability]),
+    )
+
+    tools_by_name = {cast(Any, tool).name: tool for tool in prepared.tools}
+    assert "apply_patch" not in tools_by_name
+    assert "view_image" in tools_by_name
+    assert cast(Any, tools_by_name["view_image"]).needs_approval is True

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -84,6 +84,7 @@ from agents.run_state import (
 )
 from agents.sandbox import Manifest
 from agents.sandbox.capabilities.capability import Capability
+from agents.sandbox.sandbox_agent import SandboxAgent
 from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient, UnixLocalSandboxSessionState
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.snapshot import LocalSnapshot, NoopSnapshot
@@ -491,6 +492,53 @@ class TestRunState:
         )
         assert _identity_for(first_identity_map, first_stop) == _identity_for(
             second_identity_map, second_stop
+        )
+
+    def test_build_agent_identity_map_uses_disabled_tools_for_duplicate_names(self) -> None:
+        """Duplicate-name identities should stay stable when only disabled_tools differs."""
+
+        def _identity_for(
+            identity_map: Mapping[str, Agent[Any]],
+            target: Agent[Any],
+        ) -> str:
+            return next(identity for identity, agent in identity_map.items() if agent is target)
+
+        first_patch = SandboxAgent(
+            name="sandbox",
+            instructions="Shared instructions.",
+            disabled_tools={"apply_patch"},
+        )
+        first_image = SandboxAgent(
+            name="sandbox",
+            instructions="Shared instructions.",
+            disabled_tools={"view_image"},
+        )
+        first_root = Agent(name="triage", handoffs=[first_patch, first_image])
+        first_patch.handoffs = [first_root]
+        first_image.handoffs = [first_root]
+
+        second_patch = SandboxAgent(
+            name="sandbox",
+            instructions="Shared instructions.",
+            disabled_tools={"apply_patch"},
+        )
+        second_image = SandboxAgent(
+            name="sandbox",
+            instructions="Shared instructions.",
+            disabled_tools={"view_image"},
+        )
+        second_root = Agent(name="triage", handoffs=[second_image, second_patch])
+        second_patch.handoffs = [second_root]
+        second_image.handoffs = [second_root]
+
+        first_identity_map = _build_agent_identity_map(first_root)
+        second_identity_map = _build_agent_identity_map(second_root)
+
+        assert _identity_for(first_identity_map, first_patch) == _identity_for(
+            second_identity_map, second_patch
+        )
+        assert _identity_for(first_identity_map, first_image) == _identity_for(
+            second_identity_map, second_image
         )
 
     def test_capability_identity_uses_config_but_not_bound_session(self) -> None:


### PR DESCRIPTION
### Summary

Adds a `disabled_tools: set[str]` field to `SandboxAgent` that hides specific capability-contributed tools from the model by name.

Today, suppressing a single tool requires writing a per-capability `configure_tools` callback for each capability that contributes it, which is verbose and inconsistent across capability types. This adds one declarative, top-level switch:

```python
agent = SandboxAgent(
    name="assistant",
    disabled_tools={"view_image", "write_stdin"},
)
```

The filtering is applied at a single point in `prepare_sandbox_agent`, right after every capability's tools are gathered into one list. Comparing by `.name` there covers every tool type uniformly, which matters because the runtime tool-enablement path (`Agent.get_all_tools` → `is_enabled`) only inspects `FunctionTool` and silently skips custom tools. As a result, a tool like `apply_patch` (a `CustomTool`) cannot be hidden via `is_enabled`, but is removed correctly by name-based filtering at aggregation time.

### Why disable individual tools

A capability is all-or-nothing: adding it gives the model every tool it ships. But the unit you usually care about is the tool, not the capability, and they don't line up. A capability can bundle a tool you want with one you don't, and dropping the whole capability to remove one tool also throws away the parts you were relying on. `configure_tools` can suppress a tool, but only per-capability and at the cost of writing a callback for each one.

Common reasons to drop a specific tool while keeping its capability:

- **The tool doesn't fit the deployment.** `Filesystem` ships `view_image`, but a text-only assistant has no images in its workspace, so the tool is just extra schema and an action the model can waste a turn on.
- **The tool is interactive and the surface isn't.** `Shell` ships `write_stdin`, which only makes sense when something is at an interactive prompt. In a batch/one-shot setup there's nothing to talk to.
- **Narrower blast radius.** Keep `Shell` for read-only commands but drop the structured patch tool so the model can't edit files, even though both arrive together.
- **Leaner prompt.** Every exposed tool is schema the model reads and a branch it can take. Trimming the ones that don't apply keeps the agent focused and cuts per-turn token cost.

Practical example: a documentation assistant wants `Shell` (to grep and read files) and `apply_patch` (to propose clean edits), but not `view_image` (the docs are text) and not `write_stdin` (nothing interactive is ever running). Today the only clean lever is the capability, so you keep `Filesystem` and `Shell` whole and live with `view_image`/`write_stdin` on the menu. With `disabled_tools={"view_image", "write_stdin"}` they're gone, while both capabilities keep doing everything else.

### Behavior

- Works for any capability (shell, filesystem, skills, memory, custom) since filtering is centralized, not per-capability.
- Composes with `configure_tools`: the callback runs first to customize a tool, then `disabled_tools` removes it by name.
- Names that match no contributed tool are ignored (no error).
- Tools attached directly to `Agent.tools` are left untouched; only capability-contributed tools are filtered.
- Included in the sandbox agent identity signature (`run_state._agent_identity_signature`), so duplicate-named agents that differ only by `disabled_tools` stay distinguishable across resume flows.
- The field is appended to the end of the `SandboxAgent` dataclass to preserve public positional compatibility.

Known limitation: this removes a tool's schema but does not rewrite instruction text. The default sandbox prompt and capability instructions may still mention a disabled tool by name. The field docstring notes this; prefer disabling tools the base instructions don't reference, or override `base_instructions`. Making `Capability.instructions` tool-set-aware is a larger, signature-level change left for a follow-up.

### Test plan

Added tests to `tests/sandbox/test_runtime_agent_preparation.py` covering:
- field default (empty set) and per-instance isolation
- removing a named `FunctionTool`
- removing a named `CustomTool` (`apply_patch`), the case `is_enabled` cannot handle
- uniform filtering across multiple capabilities
- unknown names ignored without raising
- untargeted tools preserved
- empty `disabled_tools` passes everything through
- `Agent.tools` not filtered
- preparation returns a built agent without raising
- composition with a real `Filesystem` `configure_tools` callback (customization survives on a non-disabled tool while a disabled one is removed)

Added a test to `tests/test_run_state.py` covering identity-signature stability:
- two same-named `SandboxAgent`s differing only by `disabled_tools` keep stable identities under reordered handoff graphs

Verification (all green):
- `uv run pytest tests/sandbox tests/test_run_state.py` → 1030 passed, 1 skipped
- `uv run ruff format --check` and `uv run ruff check` on changed files → pass
- `uv run mypy` on changed source and test files → no issues
- `uv run mkdocs build` → succeeds (docs/sandbox/guide.md updated)

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
