### PR TITLE
fix: suppress handoff whitespace tool-name warnings

### DIFF
--- a/src/agents/handoffs/__init__.py
+++ b/src/agents/handoffs/__init__.py
@@ -170,7 +170,10 @@ class Handoff(Generic[TContext, TAgent]):
 
     @classmethod
     def default_tool_name(cls, agent: AgentBase[Any]) -> str:
-        return _transforms.transform_string_function_style(f"transfer_to_{agent.name}")
+        return _transforms.transform_string_function_style(
+            f"transfer_to_{agent.name}",
+            warn_on_whitespace=False,
+        )
 
     @classmethod
     def default_tool_description(cls, agent: AgentBase[Any]) -> str:

--- a/src/agents/util/_transforms.py
+++ b/src/agents/util/_transforms.py
@@ -3,13 +3,15 @@ import re
 from ..logger import logger
 
 
-def transform_string_function_style(name: str) -> str:
-    transformed_name = name.replace(" ", "_")
+def transform_string_function_style(name: str, *, warn_on_whitespace: bool = True) -> str:
+    whitespace_normalized_name = re.sub(r"\s", "_", name)
 
-    transformed_name = re.sub(r"[^a-zA-Z0-9_]", "_", transformed_name)
+    transformed_name = re.sub(r"[^a-zA-Z0-9_]", "_", whitespace_normalized_name)
     final_name = transformed_name.lower()
 
-    if transformed_name != name:
+    if transformed_name != name and (
+        warn_on_whitespace or transformed_name != whitespace_normalized_name
+    ):
         logger.warning(
             f"Tool name {name!r} contains invalid characters for function calling and has been "
             f"transformed to {final_name!r}. Please use only letters, digits, and underscores "

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import logging
 from typing import Any
 
 import pytest
@@ -79,6 +80,31 @@ async def test_multiple_handoffs_setup():
 
     assert handoff_objects[0].agent_name == agent_1.name
     assert handoff_objects[1].agent_name == agent_2.name
+
+
+def test_default_handoff_tool_name_allows_whitespace_without_warning(
+    caplog: pytest.LogCaptureFixture,
+):
+    agent = Agent(name="Refund agent")
+
+    with caplog.at_level(logging.WARNING):
+        tool_name = Handoff.default_tool_name(agent)
+
+    assert tool_name == "transfer_to_refund_agent"
+    assert not caplog.records
+
+
+def test_default_handoff_tool_name_warns_for_non_whitespace_invalid_characters(
+    caplog: pytest.LogCaptureFixture,
+):
+    agent = Agent(name="Refund/agent")
+
+    with caplog.at_level(logging.WARNING):
+        tool_name = Handoff.default_tool_name(agent)
+
+    assert tool_name == "transfer_to_refund_agent"
+    assert len(caplog.records) == 1
+    assert "contains invalid characters for function calling" in caplog.records[0].message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes default handoff tool-name generation so common agent names with whitespace, such as `Refund agent`, normalize to valid function-style names without emitting an invalid-character warning.

The generated tool name remains unchanged (`transfer_to_refund_agent`), preserving existing behavior for model-visible handoff tools. Non-whitespace invalid characters still produce the existing warning, and regression coverage verifies both the whitespace-only and invalid-character cases.