### PR TITLE
fix: handle missing refusal content

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -691,7 +691,8 @@ class ItemHelpers:
             # ``extract_text`` below.
             return last_content.text or ""
         elif isinstance(last_content, ResponseOutputRefusal):
-            return last_content.refusal
+            # Coerce a None refusal to "" for the same reason as the text branch above.
+            return last_content.refusal or ""
         else:
             raise ModelBehaviorError(f"Unexpected content type: {type(last_content)}")
 

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -84,6 +84,16 @@ def test_extract_last_content_of_refusal_message() -> None:
     assert ItemHelpers.extract_last_content(message) == "I cannot do that"
 
 
+def test_extract_last_content_of_none_refusal_message() -> None:
+    refusal = ResponseOutputRefusal.model_construct(refusal=None, type="refusal")
+    message = make_message([refusal])
+
+    result = ItemHelpers.extract_last_content(message)
+
+    assert isinstance(result, str)
+    assert result == ""
+
+
 def test_extract_last_content_non_message_returns_empty() -> None:
     # Construct some other type of output item, e.g. a tool call, to verify non-message returns "".
     tool_call = ResponseFunctionToolCall(

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -1463,7 +1463,8 @@ async def test_execute_function_tool_calls_eager_task_factory_tracks_state_safel
     ]
     loop = asyncio.get_running_loop()
     previous_task_factory = loop.get_task_factory()
-    eager_task_factory = cast(Any, asyncio.eager_task_factory)
+    asyncio_module = cast(Any, asyncio)
+    eager_task_factory = asyncio_module.eager_task_factory
     loop.set_task_factory(eager_task_factory)
 
     try:


### PR DESCRIPTION
### Summary

Fix `ItemHelpers.extract_last_content()` so refusal content with a missing payload returns an empty string instead of `None`, preserving the helper's `str` return contract. Add regression coverage for the missing-refusal case and adjust a Python-version-specific test reference so type checking passes on Python 3.11.

### Test plan

- `PATH="/usr/bin:/bin:/usr/sbin:/sbin:/Users/ldy/.local/bin:/Users/ldy/miniforge3/bin:/opt/homebrew/bin" bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
