### PR TITLE
fix: enforce the documented strict JSON-compatible contract for #3486

### DIFF
--- a/src/agents/util/_custom_data.py
+++ b/src/agents/util/_custom_data.py
@@ -28,7 +28,7 @@ def normalize_custom_data(value: Mapping[str, Any] | None) -> dict[str, Any] | N
 
     copied = copy.deepcopy(dict(value))
     try:
-        return cast(dict[str, Any], json.loads(json.dumps(copied)))
+        return cast(dict[str, Any], json.loads(json.dumps(copied, allow_nan=False)))
     except (TypeError, ValueError) as exc:
         raise UserError("custom_data_extractor must return JSON-compatible data.") from exc
 

--- a/tests/test_tool_custom_data.py
+++ b/tests/test_tool_custom_data.py
@@ -97,6 +97,25 @@ async def test_function_tool_custom_data_rejects_non_json_compatible_data() -> N
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+async def test_function_tool_custom_data_rejects_non_finite_floats(
+    bad_value: float,
+) -> None:
+    @function_tool(custom_data_extractor=lambda _ctx: {"score": bad_value})
+    def get_data() -> str:
+        return "tool_result"
+
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [[get_text_message("call tool"), get_function_tool_call("get_data", "{}")]]
+    )
+    agent = Agent(name="test", model=model, tools=[get_data])
+
+    with pytest.raises(UserError, match="custom_data_extractor must return JSON-compatible data"):
+        await Runner.run(agent, input="user")
+
+
+@pytest.mark.asyncio
 async def test_mcp_custom_data_extractor_maps_result_meta_to_tool_output_item() -> None:
     def extract_custom_data(ctx: Any) -> dict[str, Any]:
         return {"mcp_response_meta": dict(ctx.result_meta or {})}


### PR DESCRIPTION
### Summary

This PR tightens `custom_data_extractor` validation by rejecting non-finite float values such as `NaN`, `Infinity`, and `-Infinity`.

PR #3486 added SDK-only `custom_data` support for tool output items and validates extractor output by round-tripping through `json.dumps()` / `json.loads()`. However, Python’s `json.dumps()` allows non-finite floats by default, even though those values are not strict JSON-compatible.

This change passes `allow_nan=False` so non-finite floats raise `ValueError` and are handled consistently with other non-JSON-compatible custom data.

### Test plan

Added a regression test covering:

* `float("nan")`
* `float("inf")`
* `float("-inf")`

Ran:

```bash
uv run pytest tests/test_tool_custom_data.py -k non_finite
```
