### PR TITLE
fix: reject nested non-string custom data keys

### DIFF
--- a/src/agents/util/_custom_data.py
+++ b/src/agents/util/_custom_data.py
@@ -15,6 +15,17 @@ CustomDataExtractor = Callable[
 ]
 
 
+def _ensure_mapping_keys_are_strings(value: Any) -> None:
+    if isinstance(value, Mapping):
+        if not all(isinstance(key, str) for key in value):
+            raise UserError("custom_data_extractor must return a mapping with string keys.")
+        for item in value.values():
+            _ensure_mapping_keys_are_strings(item)
+    elif isinstance(value, list | tuple):
+        for item in value:
+            _ensure_mapping_keys_are_strings(item)
+
+
 def normalize_custom_data(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
     """Return a JSON-compatible copy of custom tool-output data."""
     if value is None:
@@ -23,10 +34,9 @@ def normalize_custom_data(value: Mapping[str, Any] | None) -> dict[str, Any] | N
         raise UserError("custom_data_extractor must return a mapping or None.")
     if not value:
         return None
-    if not all(isinstance(key, str) for key in value):
-        raise UserError("custom_data_extractor must return a mapping with string keys.")
 
     copied = copy.deepcopy(dict(value))
+    _ensure_mapping_keys_are_strings(copied)
     try:
         return cast(dict[str, Any], json.loads(json.dumps(copied, allow_nan=False)))
     except (TypeError, ValueError) as exc:

--- a/tests/test_tool_custom_data.py
+++ b/tests/test_tool_custom_data.py
@@ -116,6 +116,28 @@ async def test_function_tool_custom_data_rejects_non_finite_floats(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("bad_data", [{"nested": {1: "one"}}, {"items": [{1: "one"}]}])
+async def test_function_tool_custom_data_rejects_nested_non_string_keys(
+    bad_data: dict[str, Any],
+) -> None:
+    @function_tool(custom_data_extractor=lambda _ctx: bad_data)
+    def get_data() -> str:
+        return "tool_result"
+
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [[get_text_message("call tool"), get_function_tool_call("get_data", "{}")]]
+    )
+    agent = Agent(name="test", model=model, tools=[get_data])
+
+    with pytest.raises(
+        UserError,
+        match="custom_data_extractor must return a mapping with string keys",
+    ):
+        await Runner.run(agent, input="user")
+
+
+@pytest.mark.asyncio
 async def test_mcp_custom_data_extractor_maps_result_meta_to_tool_output_item() -> None:
     def extract_custom_data(ctx: Any) -> dict[str, Any]:
         return {"mcp_response_meta": dict(ctx.result_meta or {})}


### PR DESCRIPTION
### Summary

Tighten `custom_data_extractor` validation so nested mappings also require string keys.

PR #3657 made custom data use strict JSON-compatible serialization by rejecting non-finite floats. However, nested mappings with non-string keys were still accepted because `json.dumps()` silently coerces those keys to strings during the validation round trip. For example, `{"nested": {1: "one"}}` became `{"nested": {"1": "one"}}` instead of being rejected.

This change recursively validates mapping keys before serialization so custom data is either preserved as provided or rejected with the existing string-key validation error.

### Test plan

- `make format`
- `make lint`
- `uv run pytest tests/test_tool_custom_data.py -q`
- `make typecheck`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u GRPC_PROXY_EXP -u grpc_proxy make tests`

### Issue number

Follow-up to #3657 / #3486

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
