### PR TITLE
Docs: add canonical contributor entrypoint and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+## Contributing
+
+Thank you for your interest in contributing to OpenAI Agents SDK.
+
+### Before opening a pull request
+
+1. Start with an issue (new or existing) so the change can be scoped early.
+2. Keep proposals focused and aligned with repository goals.
+3. Prefer small PRs that are easy to review.
+
+### Development checks
+
+Before opening a PR, run:
+
+```bash
+make format
+make lint
+make test
+```
+
+### Pull request expectations
+
+- Add or update tests for behavior changes.
+- Update docs for user-facing changes.
+- Link the related issue in your PR description.
+- Use the PR template checklist.
+
+### Docs-first contributions
+
+Docs and examples contributions are valuable and welcome. Useful contributions include:
+
+- clarifying setup and migration paths
+- improving examples for common adoption paths
+- documenting edge cases discovered during usage

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ print(result.final_output)
 
 Explore the [examples](https://github.com/openai/openai-agents-python/tree/main/examples) directory to see the SDK in action, and read our [documentation](https://openai.github.io/openai-agents-python/) for more details.
 
+## Contributing
+
+Contributions are welcome.
+
+If you want to contribute:
+
+1. Open or comment on an issue first to align on scope.
+2. Follow the contribution workflow in [CONTRIBUTING.md](./CONTRIBUTING.md).
+3. Include tests/docs updates when behavior changes.
+
+For docs-only improvements, small focused PRs are encouraged.
+
 ## Acknowledgements
 
 We'd like to acknowledge the excellent work of the open-source community, especially:


### PR DESCRIPTION
## Summary
- add a `Contributing` section in README with a clear contributor path
- add `CONTRIBUTING.md` with issue-first and docs-first workflow guidance

## Context
Implements the direction discussed in #3660.

## Notes
Docs-only change.