### PR TITLE
fix(memory): return [] for non-positive limit in all SQLite-based sessions

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -172,6 +172,12 @@ class AdvancedSQLiteSession(SQLiteSession):
         """
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        if session_limit is not None and session_limit <= 0:
+            # Mirror the Redis/MongoDB/Dapr backends: a non-positive limit means
+            # "no items". Without this, LIMIT -1 returns the whole branch on
+            # SQLite (LIMIT -1 == no limit).
+            return []
+
         if branch_id is None:
             branch_id = self._current_branch_id
 

--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -119,6 +119,12 @@ class AsyncSQLiteSession(SessionABC):
 
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        if session_limit is not None and session_limit <= 0:
+            # Mirror the Redis/MongoDB/Dapr backends: a non-positive limit means
+            # "no items". Without this, LIMIT -1 returns the whole history on
+            # SQLite (LIMIT -1 == no limit).
+            return []
+
         async with self._locked_connection() as conn:
             if session_limit is None:
                 cursor = await conn.execute(

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -288,6 +288,12 @@ class SQLAlchemySession(SessionABC):
 
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        if session_limit is not None and session_limit <= 0:
+            # Mirror the Redis/MongoDB/Dapr backends: a non-positive limit means
+            # "no items". Without this, .limit(-1) returns the whole history on
+            # SQLite (LIMIT -1 == no limit) and raises on PostgreSQL/MySQL.
+            return []
+
         async with self._session_factory() as sess:
             if session_limit is None:
                 stmt = (

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -211,6 +211,12 @@ class SQLiteSession(SessionABC):
         """
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        if session_limit is not None and session_limit <= 0:
+            # Mirror the Redis/MongoDB/Dapr backends: a non-positive limit means
+            # "no items". Without this, LIMIT -1 returns the whole history on
+            # SQLite (LIMIT -1 == no limit).
+            return []
+
         def _get_items_sync():
             with self._locked_connection() as conn:
                 if session_limit is None:

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -101,6 +101,28 @@ async def test_advanced_session_basic_functionality(agent: Agent):
     session.close()
 
 
+async def test_advanced_get_items_non_positive_limit_returns_empty():
+    """A non-positive limit returns no items, matching Redis/MongoDB/Dapr.
+    Previously limit<=0 reached SQL LIMIT, which returns the whole branch on
+    SQLite (LIMIT -1 == no limit)."""
+    session = AdvancedSQLiteSession(session_id="advanced_nonpositive", create_tables=True)
+
+    await session.add_items(
+        [
+            {"role": "user", "content": "1"},
+            {"role": "assistant", "content": "2"},
+        ]
+    )
+
+    assert await session.get_items(limit=0) == []
+    assert await session.get_items(limit=-1) == []
+    # Sanity: a positive limit and the no-limit path still work.
+    assert len(await session.get_items(limit=1)) == 1
+    assert len(await session.get_items()) == 2
+
+    session.close()
+
+
 async def test_advanced_session_respects_custom_table_names():
     """AdvancedSQLiteSession should consistently use configured table names."""
     session = AdvancedSQLiteSession(

--- a/tests/extensions/memory/test_async_sqlite_session.py
+++ b/tests/extensions/memory/test_async_sqlite_session.py
@@ -57,6 +57,30 @@ async def test_async_sqlite_session_basic_flow():
         await session.close()
 
 
+async def test_async_sqlite_get_items_non_positive_limit_returns_empty():
+    """A non-positive limit returns no items, matching Redis/MongoDB/Dapr.
+    Previously limit<=0 reached SQL LIMIT, which returns the whole history on
+    SQLite (LIMIT -1 == no limit)."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "async_nonpositive.db"
+        session = AsyncSQLiteSession("async_nonpositive", db_path)
+
+        await session.add_items(
+            [
+                {"role": "user", "content": "1"},
+                {"role": "assistant", "content": "2"},
+            ]
+        )
+
+        assert await session.get_items(limit=0) == []
+        assert await session.get_items(limit=-1) == []
+        # Sanity: a positive limit and the no-limit path still work.
+        assert len(await session.get_items(limit=1)) == 1
+        assert len(await session.get_items()) == 2
+
+        await session.close()
+
+
 async def test_async_sqlite_session_pop_item():
     """Test AsyncSQLiteSession pop_item behavior."""
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/extensions/memory/test_sqlalchemy_session.py
+++ b/tests/extensions/memory/test_sqlalchemy_session.py
@@ -184,6 +184,26 @@ async def test_get_items_with_limit(agent: Agent):
     assert len(more_than_all) == 4
 
 
+async def test_get_items_with_non_positive_limit_returns_empty():
+    """A non-positive limit returns no items, matching the Redis/MongoDB/Dapr
+    backends. Previously limit<=0 reached SQL LIMIT, which returns the whole
+    history on SQLite (LIMIT -1 == no limit) and errors on PostgreSQL/MySQL."""
+    session = SQLAlchemySession.from_url("nonpositive_limit_test", url=DB_URL, create_tables=True)
+
+    await session.add_items(
+        [
+            {"role": "user", "content": "1"},
+            {"role": "assistant", "content": "2"},
+        ]
+    )
+
+    assert await session.get_items(limit=0) == []
+    assert await session.get_items(limit=-1) == []
+    # Sanity: a positive limit and the no-limit path still work.
+    assert len(await session.get_items(limit=1)) == 1
+    assert len(await session.get_items()) == 2
+
+
 async def test_pop_from_empty_session():
     """Test that pop_item returns None on an empty session."""
     session = SQLAlchemySession.from_url("empty_session", url=DB_URL, create_tables=True)

--- a/tests/memory/test_session_limit.py
+++ b/tests/memory/test_session_limit.py
@@ -174,3 +174,28 @@ async def test_session_limit_larger_than_history(runner_method):
         assert last_input[2].get("content") == "Message 2"
 
         session.close()
+
+
+@pytest.mark.asyncio
+async def test_session_limit_negative_returns_empty():
+    """A negative session_limit returns no items, like limit=0 and the
+    Redis/MongoDB/Dapr backends. Without the guard, SQLite ``LIMIT -1`` means
+    "no limit" and returns the entire history."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_limit_negative.db"
+        session = SQLiteSession("limit_negative_test", db_path)
+
+        await session.add_items(
+            [
+                {"role": "user", "content": "1"},
+                {"role": "assistant", "content": "2"},
+            ]
+        )
+
+        assert await session.get_items(limit=-1) == []
+        assert await session.get_items(limit=0) == []
+        # Sanity: a positive limit and the no-limit path still work.
+        assert len(await session.get_items(limit=1)) == 1
+        assert len(await session.get_items()) == 2
+
+        session.close()


### PR DESCRIPTION
## Summary

The Redis, MongoDB, and Dapr session backends short-circuit `get_items()` to return `[]` when the resolved limit is `<= 0`. The **SQLite-based** sessions did not — the core `SQLiteSession` plus the `AsyncSQLiteSession`, `AdvancedSQLiteSession`, and `SQLAlchemySession` backends passed the value straight to SQL `LIMIT`:

- on **SQLite**, `LIMIT -1` means "no limit", so a negative limit returned the **entire** history;
- on **PostgreSQL/MySQL**, a negative `LIMIT` raises.

`resolve_session_limit()` performs no validation, so a user-supplied `get_items(limit=-1)` (or `SessionSettings(limit=-1)`) reaches the backend unchanged. (`limit == 0` already worked via `LIMIT 0`; the bug is negative limits.)

## Fix

Guard for a non-positive resolved limit and return `[]` in all four SQLite-based sessions, matching `RedisSession`, `MongoDBSession`, and `DaprSession`.

## Test

Added a regression test for each (core `SQLiteSession`, `AsyncSQLiteSession`, `AdvancedSQLiteSession`, `SQLAlchemySession`).

Verified red→green: each fails on `main` (`get_items(limit=-1)` returns the full history on SQLite) and passes with the fix. `ruff check` / `ruff format --check` clean.
