### PR TITLE
docs(voice): add missing docstrings to VoiceWorkflowHelper, SingleAgentWorkflowCallbacks, and SingleAgentVoiceWorkflow.run()

### DIFF
--- a/src/agents/voice/workflow.py
+++ b/src/agents/voice/workflow.py
@@ -42,6 +42,8 @@ class VoiceWorkflowBase(abc.ABC):
 
 
 class VoiceWorkflowHelper:
+    """Utility helpers for extracting output from a streaming voice workflow run."""
+
     @classmethod
     async def stream_text_from(cls, result: RunResultStreaming) -> AsyncIterator[str]:
         """Wraps a `RunResultStreaming` object and yields text events from the stream."""
@@ -54,6 +56,8 @@ class VoiceWorkflowHelper:
 
 
 class SingleAgentWorkflowCallbacks:
+    """Callbacks that are invoked at key points in a `SingleAgentVoiceWorkflow` run."""
+
     def on_run(self, workflow: SingleAgentVoiceWorkflow, transcription: str) -> None:
         """Called when the workflow is run."""
         pass
@@ -78,6 +82,18 @@ class SingleAgentVoiceWorkflow(VoiceWorkflowBase):
         self._callbacks = callbacks
 
     async def run(self, transcription: str) -> AsyncIterator[str]:
+        """Run the workflow for a single transcription turn.
+
+        Appends the transcription to the input history, streams the agent's text
+        response token by token, then updates the history with the completed
+        output so the next turn has full context.
+
+        Args:
+            transcription: The user's speech, already converted to text.
+
+        Yields:
+            Text chunks from the agent's streamed response.
+        """
         if self._callbacks:
             self._callbacks.on_run(self, transcription)
 


### PR DESCRIPTION
### Summary

Three public symbols in `src/agents/voice/workflow.py` were missing docstrings:

- `VoiceWorkflowHelper` — class-level docstring added summarizing its role as a utility for extracting streamed text output
- `SingleAgentWorkflowCallbacks` — class-level docstring added explaining when callbacks fire
- `SingleAgentVoiceWorkflow.run()` — full method docstring added with Args and Yields sections, describing the turn-by-turn history management and streaming behavior

`VoiceWorkflowBase` and its abstract `run()` were already documented; these three bring the rest of the module up to the same standard.

### Test plan

- All 33 voice tests pass: `uv run pytest tests/voice/ -v` — 33 passed in 0.20s
- `make format` — no changes
- `make lint` — all checks passed
- `make typecheck` — 0 errors (with `uv sync --all-extras` to include numpy)

### Issue number

N/A

### Checks

- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass

Built by Rudrendu Paul, developed with Claude Code