### PR TITLE
docs: add missing docstrings to guardrail run/get_name and ModelSettings.to_json_dict

### DIFF
--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -103,6 +103,7 @@ class InputGuardrail(Generic[TContext]):
     """
 
     def get_name(self) -> str:
+        """Return the guardrail name, falling back to the guardrail function's name."""
         if self.name:
             return self.name
 
@@ -114,6 +115,17 @@ class InputGuardrail(Generic[TContext]):
         input: str | list[TResponseInputItem],
         context: RunContextWrapper[TContext],
     ) -> InputGuardrailResult:
+        """Run the guardrail function and return the result.
+
+        Args:
+            agent: The agent being guarded.
+            input: The raw input string or message list passed to the agent.
+            context: The run context wrapper for this execution.
+
+        Returns:
+            An `InputGuardrailResult` containing this guardrail and the function's output,
+            including whether the tripwire was triggered.
+        """
         if not callable(self.guardrail_function):
             raise UserError(f"Guardrail function must be callable, got {self.guardrail_function}")
 
@@ -157,6 +169,7 @@ class OutputGuardrail(Generic[TContext]):
     """
 
     def get_name(self) -> str:
+        """Return the guardrail name, falling back to the guardrail function's name."""
         if self.name:
             return self.name
 
@@ -165,6 +178,17 @@ class OutputGuardrail(Generic[TContext]):
     async def run(
         self, context: RunContextWrapper[TContext], agent: Agent[Any], agent_output: Any
     ) -> OutputGuardrailResult:
+        """Run the guardrail function against the agent's final output and return the result.
+
+        Args:
+            context: The run context wrapper for this execution.
+            agent: The agent whose output is being checked.
+            agent_output: The final output produced by the agent.
+
+        Returns:
+            An `OutputGuardrailResult` containing this guardrail, the agent, the agent output,
+            and the function's output including whether the tripwire was triggered.
+        """
         if not callable(self.guardrail_function):
             raise UserError(f"Guardrail function must be callable, got {self.guardrail_function}")
 

--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -218,6 +218,7 @@ class ModelSettings:
         return replace(self, **changes)
 
     def to_json_dict(self) -> dict[str, Any]:
+        """Serialize model settings to a JSON-compatible dictionary."""
         return cast(dict[str, Any], TypeAdapter(ModelSettings).dump_python(self, mode="json"))
 
     def to_traceable_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
### Summary

Adds missing docstrings to four public methods that have none despite being the primary extension points users interact with when building custom guardrails.

**`InputGuardrail.get_name()`** — documents the fallback behavior (function name when `self.name` is unset).

**`InputGuardrail.run()`** — adds Args/Returns so callers know what `agent`, `input`, and `context` each represent and what the returned `InputGuardrailResult` contains.

**`OutputGuardrail.get_name()`** — same as `InputGuardrail.get_name()`.

**`OutputGuardrail.run()`** — adds Args/Returns for `context`, `agent`, and `agent_output`; documents the returned `OutputGuardrailResult`.

**`ModelSettings.to_json_dict()`** — one-line docstring for the serialization method used by external code that needs to forward settings as a plain dict (e.g., custom model adapters, logging pipelines).

### Test plan

- `make format` — 0 remaining errors
- `make lint` — all checks passed
- `make typecheck` — 0 errors in 777 source files
- `make tests` — 27 passed, 5 skipped

### Issue number

N/A

### Checks

- [x] I've made sure tests pass
- [x] I've run `make lint` and `make format`
- [x] I've added/updated the relevant documentation

Built by Rudrendu Paul, developed with Claude Code