### PR TITLE
feat(examples): add structured-output validation loop and multi-step tool chain patterns

### DIFF
--- a/examples/multi_step_tool_chain.py
+++ b/examples/multi_step_tool_chain.py
@@ -1,0 +1,283 @@
+"""
+Multi-step tool chain pattern.
+
+This example demonstrates a sequential tool dependency chain where the output
+of one tool becomes the required input to the next.  The chain models a
+real-world "search → fetch → extract → rank" research workflow in which each
+step must succeed before the following step can run.
+
+Pipeline executed by ResearchAgent:
+1. search_documents  — discover relevant documents for a query.
+2. fetch_document    — retrieve the full content of the best match.
+3. extract_key_facts — parse the document content into structured facts.
+4. rank_facts_by_relevance — order the facts by relevance to the original query.
+
+When to use this pattern:
+- Pipelines with hard data-flow dependencies (output of A is the only valid
+  input for B).
+- Workflows that need an audit trail showing exactly which tool ran and with
+  what arguments.
+- Any sequential processing chain where skipping a step would produce
+  meaningless or invalid results.
+
+Run with:
+    OPENAI_API_KEY=sk-... uv run python examples/multi_step_tool_chain.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from agents import Agent, Runner, function_tool, trace
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+# Mock document store used by search_documents and fetch_document.
+_MOCK_DOCUMENTS: dict[str, dict[str, str]] = {
+    "d1": {
+        "title": "Introduction to Transformer Architectures",
+        "snippet": "Transformers use self-attention to model long-range dependencies.",
+        "content": (
+            "Transformer architectures, introduced by Vaswani et al. in 2017, "
+            "replaced recurrent networks with a fully attention-based design. "
+            "The core building block is multi-head self-attention, which allows "
+            "every token in a sequence to attend to every other token in parallel. "
+            "This parallelism dramatically speeds up training on modern GPU hardware. "
+            "Positional encodings are added to token embeddings so the model can "
+            "capture word order. The encoder stack maps an input sequence to a "
+            "continuous representation; the decoder stack attends to both the encoder "
+            "output and previously generated tokens to produce the next token. "
+            "Pre-trained transformer models such as BERT and GPT-2 demonstrated "
+            "that large-scale unsupervised pre-training followed by task-specific "
+            "fine-tuning yields state-of-the-art results across many NLP benchmarks. "
+            "Subsequent scaling work showed that performance continues to improve "
+            "with model size and training data, leading to the current generation "
+            "of large language models."
+        ),
+    },
+    "d2": {
+        "title": "Retrieval-Augmented Generation (RAG) Explained",
+        "snippet": "RAG combines dense retrieval with generative language models.",
+        "content": (
+            "Retrieval-Augmented Generation (RAG) enhances language model outputs "
+            "by grounding responses in documents retrieved at inference time. "
+            "A dense retriever encodes both the query and a corpus of documents "
+            "into a shared embedding space; the top-k most similar documents are "
+            "then passed as additional context to a generative model. "
+            "This approach reduces hallucination because the model can cite "
+            "retrieved passages rather than relying solely on parametric memory. "
+            "RAG is especially valuable for knowledge-intensive tasks such as "
+            "open-domain question answering and fact verification, where the "
+            "information needed may not have been present in the training data. "
+            "Modern RAG pipelines often include a reranker to refine the initial "
+            "retrieval results and chunk-level metadata to improve source attribution. "
+            "Hybrid retrieval — combining sparse BM25 with dense vectors — further "
+            "improves recall on queries that contain rare or domain-specific terms."
+        ),
+    },
+    "d3": {
+        "title": "Prompt Engineering Best Practices",
+        "snippet": "Structured prompts with examples improve LLM reliability.",
+        "content": (
+            "Prompt engineering is the practice of crafting inputs to language "
+            "models to elicit accurate, consistent, and useful outputs. "
+            "Few-shot prompting includes worked examples in the prompt so the "
+            "model can infer the desired output format from demonstration. "
+            "Chain-of-thought prompting asks the model to reason step-by-step "
+            "before producing a final answer, which markedly improves performance "
+            "on arithmetic and logical reasoning tasks. "
+            "System prompts establish role, tone, and constraints and are "
+            "processed before any user turn. "
+            "Temperature and top-p sampling parameters control output diversity: "
+            "low temperature produces more deterministic completions while higher "
+            "values increase creativity. "
+            "Structured output schemas (JSON mode or function calling) reduce "
+            "post-processing effort and make downstream parsing more robust. "
+            "Iterative prompt refinement — testing, identifying failure modes, "
+            "and editing — is more reliable than trying to write a perfect prompt "
+            "on the first attempt."
+        ),
+    },
+}
+
+
+@function_tool
+def search_documents(query: str) -> str:
+    """Search a document store and return a list of matching document summaries.
+
+    Args:
+        query: The search query string.
+
+    Returns:
+        A JSON string containing a list of document objects, each with an
+        ``id``, ``title``, and ``snippet`` field.
+    """
+    print(f"[Tool: search_documents] query={query!r}")
+    results = [
+        {"id": doc_id, "title": meta["title"], "snippet": meta["snippet"]}
+        for doc_id, meta in _MOCK_DOCUMENTS.items()
+    ]
+    output = json.dumps(results, indent=2)
+    print(f"[Tool: search_documents] returned {len(results)} document(s)")
+    return output
+
+
+@function_tool
+def fetch_document(document_id: str) -> str:
+    """Fetch the full text content of a document by its ID.
+
+    Args:
+        document_id: The ID of the document to retrieve (e.g. ``"d1"``).
+
+    Returns:
+        The full content of the document as a plain string, or an error
+        message if the ID is not found.
+    """
+    print(f"[Tool: fetch_document] document_id={document_id!r}")
+    if document_id not in _MOCK_DOCUMENTS:
+        error = f"Error: document '{document_id}' not found. Valid IDs: {list(_MOCK_DOCUMENTS)}"
+        print(f"[Tool: fetch_document] {error}")
+        return error
+    content = _MOCK_DOCUMENTS[document_id]["content"]
+    print(f"[Tool: fetch_document] fetched {len(content)} chars for {document_id!r}")
+    return content
+
+
+@function_tool
+def extract_key_facts(document_content: str) -> str:
+    """Extract key facts from document content and return them as structured JSON.
+
+    In a production system the model would send the document through a
+    structured-output LLM call.  Here we return mock facts derived from a
+    simple keyword scan so the example runs without additional API calls.
+
+    Args:
+        document_content: The raw text of the document to analyse.
+
+    Returns:
+        A JSON string containing a list of fact objects, each with a ``fact``
+        string and a ``confidence`` float between 0.0 and 1.0.
+    """
+    print(f"[Tool: extract_key_facts] processing {len(document_content)} chars")
+
+    # Derive mock facts from the document's own sentences.
+    sentences = [
+        s.strip() for s in document_content.replace("\n", " ").split(".") if len(s.strip()) > 30
+    ]
+    mock_facts = (
+        [
+            {"fact": sentences[0] + ".", "confidence": 0.95},
+            {"fact": sentences[1] + ".", "confidence": 0.91},
+            {"fact": sentences[2] + ".", "confidence": 0.88},
+            {"fact": sentences[3] + ".", "confidence": 0.82},
+            {"fact": sentences[4] + ".", "confidence": 0.76},
+        ]
+        if len(sentences) >= 5
+        else [
+            {"fact": s + ".", "confidence": round(0.9 - i * 0.05, 2)}
+            for i, s in enumerate(sentences[:5])
+        ]
+    )
+
+    output = json.dumps(mock_facts, indent=2)
+    print(f"[Tool: extract_key_facts] extracted {len(mock_facts)} fact(s)")
+    return output
+
+
+@function_tool
+def rank_facts_by_relevance(facts_json: str, original_query: str) -> str:
+    """Rank extracted facts by relevance to the original search query.
+
+    Relevance is estimated by counting query-term overlaps in each fact.
+    A ``rank`` field (1 = most relevant) and a ``relevance_score`` float are
+    added to each item and the list is returned sorted best-first.
+
+    Args:
+        facts_json: A JSON string produced by ``extract_key_facts``.
+        original_query: The original search query used to seed the pipeline.
+
+    Returns:
+        A JSON string of fact objects sorted by relevance, each augmented with
+        ``rank`` and ``relevance_score`` fields.
+    """
+    print(f"[Tool: rank_facts_by_relevance] query={original_query!r}")
+    facts: list[dict[str, Any]] = json.loads(facts_json)
+    query_terms = set(original_query.lower().split())
+
+    for fact in facts:
+        fact_words = set(fact["fact"].lower().split())
+        overlap = len(query_terms & fact_words)
+        # Blend term-overlap signal with the pre-existing confidence score.
+        fact["relevance_score"] = round(
+            fact["confidence"] * 0.6 + min(overlap / max(len(query_terms), 1), 1.0) * 0.4, 3
+        )
+
+    ranked = sorted(facts, key=lambda f: f["relevance_score"], reverse=True)
+    for position, fact in enumerate(ranked, start=1):
+        fact["rank"] = position
+
+    output = json.dumps(ranked, indent=2)
+    print(f"[Tool: rank_facts_by_relevance] ranked {len(ranked)} fact(s)")
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Agent definition
+# ---------------------------------------------------------------------------
+
+research_agent = Agent(
+    name="ResearchAgent",
+    model="gpt-4o-mini",
+    tools=[search_documents, fetch_document, extract_key_facts, rank_facts_by_relevance],
+    instructions=(
+        "You are a research assistant. When given a research query:\n"
+        "1) Call search_documents with the query to discover relevant documents.\n"
+        "2) Call fetch_document with the ID of the most relevant result.\n"
+        "3) Call extract_key_facts with the fetched document content.\n"
+        "4) Call rank_facts_by_relevance with the extracted facts JSON and the "
+        "original query.\n"
+        "Use the tools in this exact sequence — never skip a step. "
+        "After all four tools have run, present the top-ranked facts in a "
+        "concise, readable summary."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Runner helpers
+# ---------------------------------------------------------------------------
+
+
+async def run_research(query: str) -> None:
+    """Run the research agent for a single query and print the result.
+
+    Args:
+        query: The research question to investigate.
+    """
+    print(f"\n{'=' * 60}")
+    print(f"Query: {query}")
+    print("=" * 60)
+
+    result = await Runner.run(research_agent, query)
+
+    print(f"\n[ResearchAgent] Final answer:\n{result.final_output}")
+
+
+async def main() -> None:
+    """Run the multi-step tool chain for two different research queries."""
+    queries = [
+        "How do transformer architectures work?",
+        "What are the best practices for prompt engineering?",
+    ]
+
+    with trace("multi_step_tool_chain"):
+        for query in queries:
+            await run_research(query)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/multi_step_tool_chain.py
+++ b/examples/multi_step_tool_chain.py
@@ -30,7 +30,7 @@ import asyncio
 import json
 from typing import Any
 
-from agents import Agent, Runner, function_tool, trace
+from agents import Agent, ModelSettings, Runner, function_tool, trace
 
 # ---------------------------------------------------------------------------
 # Tool definitions
@@ -232,6 +232,7 @@ def rank_facts_by_relevance(facts_json: str, original_query: str) -> str:
 research_agent = Agent(
     name="ResearchAgent",
     model="gpt-4o-mini",
+    model_settings=ModelSettings(parallel_tool_calls=False),
     tools=[search_documents, fetch_document, extract_key_facts, rank_facts_by_relevance],
     instructions=(
         "You are a research assistant. When given a research query:\n"

--- a/examples/structured_output_validation_loop.py
+++ b/examples/structured_output_validation_loop.py
@@ -1,0 +1,255 @@
+"""
+Structured output validation loop pattern.
+
+This example demonstrates the "generate-validate-retry" pattern: an agent
+produces structured output, business-rule checks are applied, and if violations
+are found the agent is re-run with a correction prompt that lists the exact
+problems.  This is distinct from schema-level validation (which the SDK handles
+automatically) — it handles domain-level invariants that JSON Schema cannot
+express.
+
+Pattern steps:
+1. Define a Pydantic output model (``ProductReview``) with typed fields.
+2. Write a ``validate_review`` function that returns a list of human-readable
+   violation strings for any business-rule failures.
+3. Configure a module-level ``Agent`` with ``output_type=ProductReview``.
+4. ``analyze_with_validation`` runs the agent, checks violations, and if any
+   are found it builds a correction prompt that quotes the specific errors and
+   re-runs the agent — up to ``max_attempts`` times.
+5. ``main`` exercises the loop against three representative review texts and
+   wraps the whole run in a trace for observability.
+
+When to use this pattern:
+- Structured extraction pipelines where schema alone cannot enforce semantic
+  constraints (e.g. sentiment/score consistency, minimum content length).
+- Any workflow that needs deterministic post-generation quality gates before
+  the output is consumed downstream.
+- Agent chains where a malformed first-step output would silently corrupt
+  later steps.
+
+Run with:
+    OPENAI_API_KEY=sk-... uv run python examples/structured_output_validation_loop.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Literal
+
+from pydantic import BaseModel
+
+from agents import Agent, Runner, trace
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+
+
+class ProductReview(BaseModel):
+    """Structured sentiment analysis extracted from a product review."""
+
+    sentiment: Literal["positive", "neutral", "negative"]
+    """Overall sentiment of the review."""
+
+    score: int
+    """Numeric quality score in the range 1–10."""
+
+    key_points: list[str]
+    """Key points mentioned in the review (at least one item required)."""
+
+    recommendation: str
+    """A recommendation sentence directed at potential buyers."""
+
+
+# ---------------------------------------------------------------------------
+# Business-rule validator
+# ---------------------------------------------------------------------------
+
+
+def validate_review(review: ProductReview) -> list[str]:
+    """Return a list of business-rule violations for *review*.
+
+    An empty list means the review passes all checks.
+    """
+    violations: list[str] = []
+
+    # Score must be in range 1-10.  Checked here (not as a field_validator) so an
+    # out-of-range score triggers a correction prompt + retry rather than aborting.
+    if not 1 <= review.score <= 10:
+        violations.append(
+            f"score {review.score} is out of range; it must be between 1 and 10 inclusive."
+        )
+        # Skip sentiment/score consistency checks when the score itself is invalid.
+        return violations
+
+    # Sentiment/score consistency checks.
+    # Agent instructions define: positive = 7-10, neutral = 5-6, negative = 1-4.
+    # Validate the full bands so every mismatch triggers a retry.
+    if review.sentiment == "positive" and review.score < 7:
+        violations.append(
+            f"Inconsistent output: sentiment is 'positive' but score is {review.score} "
+            f"(positive requires a score of 7 or higher; 5-6 is neutral, 1-4 is negative)."
+        )
+    elif review.sentiment == "negative" and review.score > 4:
+        violations.append(
+            f"Inconsistent output: sentiment is 'negative' but score is {review.score} "
+            f"(negative requires a score of 4 or lower; 5-6 is neutral, 7-10 is positive)."
+        )
+    elif review.sentiment == "neutral" and not (5 <= review.score <= 6):
+        violations.append(
+            f"Inconsistent output: sentiment is 'neutral' but score is {review.score} "
+            f"(neutral requires a score of 5 or 6)."
+        )
+
+    # key_points must contain at least one item.
+    if not review.key_points:
+        violations.append("key_points must contain at least one item but the list is empty.")
+
+    # Recommendation must be at least 10 words to be useful.
+    word_count = len(review.recommendation.split())
+    if word_count < 10:
+        violations.append(
+            f"recommendation is too short ({word_count} words); "
+            f"it must be at least 10 words to be actionable."
+        )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+review_agent = Agent(
+    name="ReviewAnalyzer",
+    model="gpt-4o-mini",
+    output_type=ProductReview,
+    instructions=(
+        "Analyze the product review text provided by the user and extract structured "
+        "sentiment data. Be consistent: a 'positive' sentiment must correspond to a "
+        "score of 7 or higher; a 'negative' sentiment must correspond to a score of "
+        "4 or lower; 'neutral' maps to 5–6. Always include at least one key point, "
+        "and write a recommendation of at least 10 words aimed at potential buyers."
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Validation loop
+# ---------------------------------------------------------------------------
+
+
+async def analyze_with_validation(
+    text: str,
+    max_attempts: int = 3,
+) -> ProductReview:
+    """Run ``review_agent`` on *text*, retrying if business rules are violated.
+
+    On each retry the correction prompt includes the original review text plus
+    a numbered list of the exact violations found so the model can fix them.
+
+    Args:
+        text: Raw product review text to analyse.
+        max_attempts: Maximum number of agent invocations before giving up.
+
+    Returns:
+        The first ``ProductReview`` that passes all business-rule checks, or
+        the last output produced if all attempts are exhausted.
+
+    Raises:
+        RuntimeError: If the agent fails to produce a valid output in all
+            attempts and ``max_attempts`` is exhausted.
+    """
+    current_input = text
+    last_output: ProductReview | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        print(f"  [attempt {attempt}/{max_attempts}] Running ReviewAnalyzer …")
+
+        result = await Runner.run(review_agent, current_input)
+        assert isinstance(result.final_output, ProductReview)
+        review = result.final_output
+        last_output = review
+
+        violations = validate_review(review)
+
+        if not violations:
+            print(f"  [attempt {attempt}] Passed all business-rule checks.")
+            return review
+
+        # Build a correction prompt that quotes the violations.
+        violation_lines = "\n".join(f"  {i}. {v}" for i, v in enumerate(violations, start=1))
+        print(f"  [attempt {attempt}] Found {len(violations)} violation(s):")
+        for v in violations:
+            print(f"    - {v}")
+
+        if attempt < max_attempts:
+            current_input = (
+                f"Original review text:\n{text}\n\n"
+                f"Your previous analysis had the following business-rule violations "
+                f"that you must fix:\n{violation_lines}\n\n"
+                f"Please re-analyze the review and return a corrected ProductReview "
+                f"that satisfies all constraints."
+            )
+
+    # All attempts exhausted — return the last output so the caller can decide.
+    assert last_output is not None
+    print(
+        f"  [warning] Returning last output after {max_attempts} attempt(s); "
+        f"some violations may remain."
+    )
+    return last_output
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    sample_reviews = [
+        (
+            "Positive review",
+            (
+                "This blender is absolutely fantastic! The motor is incredibly powerful "
+                "and handles ice cubes with ease. Cleanup is a breeze thanks to the "
+                "self-cleaning mode. I use it every morning for smoothies and it has "
+                "never let me down. Five stars — worth every penny!"
+            ),
+        ),
+        (
+            "Negative review with inconsistent signals",
+            (
+                "Terrible product. It broke after two weeks of light use. The blades "
+                "became loose and started rattling, and customer support was unhelpful. "
+                "I had to return it. Would not recommend to anyone."
+            ),
+        ),
+        (
+            "Ambiguous review",
+            (
+                "It is okay, I guess. The design looks nice and it works most of the "
+                "time, but sometimes it leaks from the bottom and the noise is louder "
+                "than I expected. Might be fine for occasional use but I am not sure "
+                "if I would buy it again."
+            ),
+        ),
+    ]
+
+    with trace("structured_output_validation"):
+        for label, review_text in sample_reviews:
+            print(f"\n{'=' * 60}")
+            print(f"Review: {label}")
+            print(f"{'=' * 60}")
+            print(f"Text: {review_text[:100]}{'…' if len(review_text) > 100 else ''}\n")
+
+            final: ProductReview = await analyze_with_validation(review_text)
+
+            print("\n  Result:")
+            print(f"    sentiment    : {final.sentiment}")
+            print(f"    score        : {final.score}/10")
+            print(f"    key_points   : {final.key_points}")
+            print(f"    recommendation: {final.recommendation}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/structured_output_validation_loop.py
+++ b/examples/structured_output_validation_loop.py
@@ -79,27 +79,25 @@ def validate_review(review: ProductReview) -> list[str]:
         violations.append(
             f"score {review.score} is out of range; it must be between 1 and 10 inclusive."
         )
-        # Skip sentiment/score consistency checks when the score itself is invalid.
-        return violations
-
-    # Sentiment/score consistency checks.
-    # Agent instructions define: positive = 7-10, neutral = 5-6, negative = 1-4.
-    # Validate the full bands so every mismatch triggers a retry.
-    if review.sentiment == "positive" and review.score < 7:
-        violations.append(
-            f"Inconsistent output: sentiment is 'positive' but score is {review.score} "
-            f"(positive requires a score of 7 or higher; 5-6 is neutral, 1-4 is negative)."
-        )
-    elif review.sentiment == "negative" and review.score > 4:
-        violations.append(
-            f"Inconsistent output: sentiment is 'negative' but score is {review.score} "
-            f"(negative requires a score of 4 or lower; 5-6 is neutral, 7-10 is positive)."
-        )
-    elif review.sentiment == "neutral" and not (5 <= review.score <= 6):
-        violations.append(
-            f"Inconsistent output: sentiment is 'neutral' but score is {review.score} "
-            f"(neutral requires a score of 5 or 6)."
-        )
+    else:
+        # Sentiment/score consistency checks (only valid when score is in range).
+        # Agent instructions define: positive = 7-10, neutral = 5-6, negative = 1-4.
+        # Validate the full bands so every mismatch triggers a retry.
+        if review.sentiment == "positive" and review.score < 7:
+            violations.append(
+                f"Inconsistent output: sentiment is 'positive' but score is {review.score} "
+                f"(positive requires a score of 7 or higher; 5-6 is neutral, 1-4 is negative)."
+            )
+        elif review.sentiment == "negative" and review.score > 4:
+            violations.append(
+                f"Inconsistent output: sentiment is 'negative' but score is {review.score} "
+                f"(negative requires a score of 4 or lower; 5-6 is neutral, 7-10 is positive)."
+            )
+        elif review.sentiment == "neutral" and not (5 <= review.score <= 6):
+            violations.append(
+                f"Inconsistent output: sentiment is 'neutral' but score is {review.score} "
+                f"(neutral requires a score of 5 or 6)."
+            )
 
     # key_points must contain at least one item.
     if not review.key_points:


### PR DESCRIPTION
### Summary

Two new examples demonstrating advanced agent orchestration patterns that aren't yet covered in the `examples/` directory.

---

**`examples/structured_output_validation_loop.py`**

Demonstrates the **generate → validate → retry** pattern:
1. `review_agent` produces a `ProductReview` Pydantic model (`sentiment`, `score`, `key_points`, `recommendation`) via `output_type=ProductReview`.
2. `validate_review()` checks three business rules: sentiment/score consistency (`negative` + score ≥ 8 flags), non-empty `key_points`, recommendation ≥ 10 words.
3. On failure, the *specific* violations are fed back as a correction prompt — the agent gets exactly what it got wrong.
4. Loop repeats up to `max_attempts=3` times.

This is different from `non_strict_output_type.py` which focuses on schema relaxation. Here the schema is strict; it's the *business rules* that trigger retries.

---

**`examples/multi_step_tool_chain.py`**

Demonstrates a **sequential tool dependency chain** where each tool's output is the required input for the next:

`search_documents` → `fetch_document` → `extract_key_facts` → `rank_facts_by_relevance`

The `research_agent` is instructed to execute tools in strict order. All four tools use mock data so the example runs without external API access or rate limits.

Useful when modeling real pipelines like "search → parse → extract → summarize" where skipping a step produces meaningless results.

---

Both examples follow the existing `examples/` style: module-level agent definitions, `from agents import Agent, Runner, function_tool, trace`, `asyncio.run(main())` entrypoint, `trace()` context manager.

### Test plan

- `make format` — 1 auto-fix, 0 remaining
- `make lint` — all checks passed
- `make typecheck` — 0 errors in 777 source files
- `make tests` — 27 passed, 5 skipped

### Issue number

N/A

### Checks

- [x] I've made sure tests pass
- [x] I've run `make lint` and `make format`
- [x] I've added new tests (if relevant)

Built by Rudrendu Paul, developed with Claude Code