### PR TITLE
examples: add circuit breaker pattern for agents

### DIFF
--- a/examples/agent_patterns/README.md
+++ b/examples/agent_patterns/README.md
@@ -70,6 +70,19 @@ See [`model_behavior_error_handling.py`](./model_behavior_error_handling.py) for
 2. **Log and re-raise with enriched context** — useful in production pipelines that need structured error reporting.
 3. **Retry with a fallback agent** — hand the same task to a more reliable model when the primary one misbehaves.
 
+## Circuit breaker
+
+A circuit breaker wraps repeated agent calls and stops trying after a configurable number of consecutive failures, preventing a misbehaving model or unreachable API from running up costs indefinitely.
+
+The breaker moves through three states:
+- **CLOSED** — normal operation; failures are counted.
+- **OPEN** — too many consecutive failures; calls are rejected immediately without hitting the API.
+- **HALF_OPEN** — after a cooldown period, one probe call is let through. Success resets to CLOSED; failure stays OPEN.
+
+This is useful when running many parallel agent tasks, enforcing cost controls, or integrating with unreliable external tools.
+
+See [`circuit_breaker.py`](./circuit_breaker.py) for an example.
+
 ## Self-healing agent
 
 A more advanced pattern: when `ModelBehaviorError` is caught, the error description is appended to the conversation as a correction and the run is retried, giving the model a chance to fix its own mistake without a full restart.

--- a/examples/agent_patterns/README.md
+++ b/examples/agent_patterns/README.md
@@ -60,3 +60,20 @@ See the [`input_guardrails.py`](./input_guardrails.py) and [`output_guardrails.p
 You can pause runs for manual approval before executing sensitive tools. This is useful for operations like sending money, deleting data, or running destructive commands.
 
 See [`human_in_the_loop.py`](./human_in_the_loop.py) for the base approval flow and [`human_in_the_loop_custom_rejection.py`](./human_in_the_loop_custom_rejection.py) for run-level tool error formatting when approvals are rejected.
+
+## Handling ModelBehaviorError
+
+`ModelBehaviorError` is raised when the model does something unexpected — calling a tool that doesn't exist, returning malformed JSON, or failing schema validation. Rather than always letting the exception crash your run, you have several options.
+
+See [`model_behavior_error_handling.py`](./model_behavior_error_handling.py) for three patterns:
+1. **Return a safe fallback value** — useful for best-effort tasks.
+2. **Log and re-raise with enriched context** — useful in production pipelines that need structured error reporting.
+3. **Retry with a fallback agent** — hand the same task to a more reliable model when the primary one misbehaves.
+
+## Self-healing agent
+
+A more advanced pattern: when `ModelBehaviorError` is caught, the error description is appended to the conversation as a correction and the run is retried, giving the model a chance to fix its own mistake without a full restart.
+
+This is useful when the task is long-running, restarting from scratch is expensive, or you are using a smaller model that occasionally calls wrong tools.
+
+See [`self_healing_agent.py`](./self_healing_agent.py) for an example.

--- a/examples/agent_patterns/circuit_breaker.py
+++ b/examples/agent_patterns/circuit_breaker.py
@@ -1,0 +1,201 @@
+"""Circuit breaker pattern for agents.
+
+A circuit breaker wraps repeated agent calls and stops trying after a
+configurable number of consecutive failures.  This prevents a misbehaving
+or unreachable model from hammering the API and running up costs.
+
+States:
+- CLOSED  — normal operation; failures are counted.
+- OPEN    — too many consecutive failures; calls are rejected immediately
+            without hitting the API.
+- HALF_OPEN — after a cooldown period the circuit lets one call through as
+              a probe.  Success resets the breaker to CLOSED; failure puts
+              it back to OPEN.
+
+This pattern is useful when:
+- You are running many parallel agent tasks and want fast-fail on outages.
+- You have cost controls and cannot afford unlimited retries.
+- You are integrating with unreliable external tools or APIs.
+
+Run with:
+    python -m examples.agent_patterns.circuit_breaker
+"""
+
+import asyncio
+import time
+from enum import Enum, auto
+
+from agents import Agent, ModelBehaviorError, Runner, function_tool
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker implementation
+# ---------------------------------------------------------------------------
+
+
+class CircuitState(Enum):
+    CLOSED = auto()
+    OPEN = auto()
+    HALF_OPEN = auto()
+
+
+class CircuitBreakerOpen(Exception):
+    """Raised when a call is attempted while the circuit breaker is OPEN."""
+
+    def __init__(self, failure_count: int, cooldown_remaining: float) -> None:
+        self.failure_count = failure_count
+        self.cooldown_remaining = cooldown_remaining
+        super().__init__(
+            f"Circuit breaker is OPEN after {failure_count} consecutive failures. "
+            f"Cooldown: {cooldown_remaining:.1f}s remaining."
+        )
+
+
+class AgentCircuitBreaker:
+    """Circuit breaker that wraps ``Runner.run`` calls for a single agent.
+
+    Args:
+        agent: The agent to protect.
+        failure_threshold: Number of consecutive failures before the circuit opens.
+        cooldown_seconds: How long to wait in OPEN state before probing again.
+    """
+
+    def __init__(
+        self,
+        agent: Agent,
+        failure_threshold: int = 3,
+        cooldown_seconds: float = 10.0,
+    ) -> None:
+        self._agent = agent
+        self._failure_threshold = failure_threshold
+        self._cooldown_seconds = cooldown_seconds
+
+        self._state = CircuitState.CLOSED
+        self._consecutive_failures = 0
+        self._opened_at: float | None = None
+
+    @property
+    def state(self) -> CircuitState:
+        if self._state == CircuitState.OPEN:
+            elapsed = time.monotonic() - (self._opened_at or 0)
+            if elapsed >= self._cooldown_seconds:
+                self._state = CircuitState.HALF_OPEN
+        return self._state
+
+    def _on_success(self) -> None:
+        self._consecutive_failures = 0
+        self._opened_at = None
+        self._state = CircuitState.CLOSED
+
+    def _on_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self._failure_threshold:
+            self._state = CircuitState.OPEN
+            self._opened_at = time.monotonic()
+
+    def _cooldown_remaining(self) -> float:
+        if self._opened_at is None:
+            return 0.0
+        return max(0.0, self._cooldown_seconds - (time.monotonic() - self._opened_at))
+
+    async def run(self, task: str) -> str:
+        """Run the agent through the circuit breaker.
+
+        Args:
+            task: The user message to send to the agent.
+
+        Returns:
+            The agent's final output string.
+
+        Raises:
+            CircuitBreakerOpen: If the circuit is currently OPEN.
+            Exception: Any exception from the underlying agent run (in CLOSED
+                or HALF_OPEN state), after the failure counter is updated.
+        """
+        current_state = self.state
+
+        if current_state == CircuitState.OPEN:
+            raise CircuitBreakerOpen(
+                failure_count=self._consecutive_failures,
+                cooldown_remaining=self._cooldown_remaining(),
+            )
+
+        if current_state == CircuitState.HALF_OPEN:
+            print("[circuit] HALF_OPEN — sending probe request...")
+
+        try:
+            result = await Runner.run(self._agent, task)
+            self._on_success()
+            if current_state == CircuitState.HALF_OPEN:
+                print("[circuit] Probe succeeded — circuit CLOSED.")
+            return result.final_output
+        except Exception:
+            self._on_failure()
+            if self._state == CircuitState.OPEN:
+                print(
+                    f"[circuit] Opened after {self._consecutive_failures} consecutive failures."
+                )
+            elif current_state == CircuitState.HALF_OPEN:
+                print("[circuit] Probe failed — circuit remains OPEN.")
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Demo
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+def lookup_order(order_id: str) -> str:
+    """Look up the status of an order.
+
+    Args:
+        order_id: The order identifier.
+    """
+    statuses = {
+        "ORD-001": "Shipped — expected delivery Jun 25",
+        "ORD-002": "Processing",
+        "ORD-003": "Delivered",
+    }
+    return statuses.get(order_id, f"Order {order_id} not found.")
+
+
+support_agent = Agent(
+    name="Support Agent",
+    instructions="You are a customer support agent. Use the lookup_order tool to answer order status questions.",
+    tools=[lookup_order],
+)
+
+
+async def main() -> None:
+    breaker = AgentCircuitBreaker(
+        agent=support_agent,
+        failure_threshold=2,
+        cooldown_seconds=5.0,
+    )
+
+    tasks = [
+        "What is the status of order ORD-001?",
+        "Check order ORD-002 for me please.",
+        "Where is order ORD-003?",
+    ]
+
+    print("Running tasks through circuit breaker...\n")
+
+    for i, task in enumerate(tasks, 1):
+        print(f"Task {i}: {task}")
+        print(f"  Circuit state: {breaker.state.name}")
+        try:
+            output = await breaker.run(task)
+            print(f"  Result: {output}")
+        except CircuitBreakerOpen as exc:
+            print(f"  [BLOCKED] {exc}")
+        except ModelBehaviorError as exc:
+            print(f"  [AGENT ERROR] {exc.message}")
+        except Exception as exc:
+            print(f"  [ERROR] {exc}")
+        print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/agent_patterns/model_behavior_error_handling.py
+++ b/examples/agent_patterns/model_behavior_error_handling.py
@@ -1,0 +1,158 @@
+"""Handling ModelBehaviorError — three patterns.
+
+``ModelBehaviorError`` is raised when the model does something the SDK cannot
+handle: calling a tool that does not exist, returning malformed JSON for a
+structured output, or producing an output that fails schema validation.
+
+This file demonstrates three practical ways to deal with it, in increasing
+order of complexity.
+
+Pattern 1 — Ignore and return a fallback value.
+    Useful when the task is best-effort and a graceful default is acceptable.
+
+Pattern 2 — Log and re-raise with context.
+    Useful in production pipelines where you want structured error reporting
+    without losing the original exception.
+
+Pattern 3 — Retry with a fallback agent.
+    When the primary model misbehaves, hand the same task to a more reliable
+    (often larger) fallback model.
+
+Run with:
+    python -m examples.agent_patterns.model_behavior_error_handling
+"""
+
+import asyncio
+from dataclasses import dataclass
+
+from agents import Agent, ModelBehaviorError, Runner, function_tool
+
+
+@function_tool
+def get_stock_price(ticker: str) -> str:
+    """Return a (mocked) stock price for the given ticker symbol.
+
+    Args:
+        ticker: Stock ticker symbol, e.g. AAPL.
+    """
+    prices = {"AAPL": "$189.30", "GOOGL": "$175.20", "MSFT": "$415.50"}
+    return prices.get(ticker.upper(), f"Ticker '{ticker}' not found.")
+
+
+primary_agent = Agent(
+    name="Stock Assistant",
+    instructions=(
+        "You are a stock price assistant. Use the get_stock_price tool to answer questions. "
+        "Do not call any other tools."
+    ),
+    tools=[get_stock_price],
+)
+
+# A more conservative fallback agent using explicit instructions to reduce errors.
+fallback_agent = Agent(
+    name="Stock Assistant (fallback)",
+    instructions=(
+        "You are a stock price assistant. You have ONE tool: get_stock_price(ticker). "
+        "Call it exactly once with the ticker symbol the user mentioned. "
+        "Do not call any other tool. Do not make up data."
+    ),
+    tools=[get_stock_price],
+)
+
+
+# ---------------------------------------------------------------------------
+# Pattern 1 — Return a safe default on error
+# ---------------------------------------------------------------------------
+
+
+async def pattern_1_fallback_value(task: str) -> str:
+    """Run the agent; return a safe default string if ModelBehaviorError occurs."""
+    try:
+        result = await Runner.run(primary_agent, task)
+        return result.final_output
+    except ModelBehaviorError as exc:
+        print(f"[pattern-1] ModelBehaviorError: {exc.message}")
+        return "Sorry, I could not retrieve that information right now."
+
+
+# ---------------------------------------------------------------------------
+# Pattern 2 — Log and re-raise with enriched context
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EnrichedModelError(Exception):
+    original: ModelBehaviorError
+    task: str
+    agent_name: str
+
+    def __str__(self) -> str:
+        return (
+            f"Agent '{self.agent_name}' failed on task: {self.task!r}\n"
+            f"Reason: {self.original.message}"
+        )
+
+
+async def pattern_2_log_and_reraise(task: str) -> str:
+    """Run the agent; re-raise ModelBehaviorError with structured context."""
+    try:
+        result = await Runner.run(primary_agent, task)
+        return result.final_output
+    except ModelBehaviorError as exc:
+        raise EnrichedModelError(
+            original=exc,
+            task=task,
+            agent_name=primary_agent.name,
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Pattern 3 — Retry with a fallback agent
+# ---------------------------------------------------------------------------
+
+
+async def pattern_3_fallback_agent(task: str) -> str:
+    """Try the primary agent; fall back to a more reliable agent on error."""
+    try:
+        result = await Runner.run(primary_agent, task)
+        print("[pattern-3] Primary agent succeeded.")
+        return result.final_output
+    except ModelBehaviorError as exc:
+        print(f"[pattern-3] Primary agent failed ({exc.message}), trying fallback agent...")
+        result = await Runner.run(fallback_agent, task)
+        print("[pattern-3] Fallback agent succeeded.")
+        return result.final_output
+
+
+# ---------------------------------------------------------------------------
+# Demo
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    task = "What is the current price of AAPL stock?"
+
+    print("=" * 60)
+    print("Pattern 1 — fallback value")
+    print("=" * 60)
+    output = await pattern_1_fallback_value(task)
+    print(f"Output: {output}\n")
+
+    print("=" * 60)
+    print("Pattern 2 — log and re-raise")
+    print("=" * 60)
+    try:
+        output = await pattern_2_log_and_reraise(task)
+        print(f"Output: {output}\n")
+    except EnrichedModelError as exc:
+        print(f"Caught enriched error:\n{exc}\n")
+
+    print("=" * 60)
+    print("Pattern 3 — fallback agent")
+    print("=" * 60)
+    output = await pattern_3_fallback_agent(task)
+    print(f"Output: {output}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/agent_patterns/self_healing_agent.py
+++ b/examples/agent_patterns/self_healing_agent.py
@@ -1,0 +1,118 @@
+"""Self-healing agent pattern.
+
+When a model calls a tool that does not exist, or produces malformed JSON for
+a structured output, the SDK raises ``ModelBehaviorError``.  The default
+behaviour is to let that exception propagate and crash the run.
+
+This example shows a loop that catches ``ModelBehaviorError``, appends the
+error text to the conversation as a user-turn correction, and retries — giving
+the model a chance to fix its own mistake before giving up.
+
+The pattern is useful when:
+- You are using a smaller/cheaper model that occasionally calls wrong tools.
+- You want resilience without replacing the model or hard-coding fallbacks.
+- The task is long-running and restarting from scratch is expensive.
+
+Run with:
+    python -m examples.agent_patterns.self_healing_agent
+"""
+
+import asyncio
+
+from agents import Agent, ModelBehaviorError, Runner, function_tool
+
+MAX_SELF_HEALS = 3
+
+
+@function_tool
+def add(a: int, b: int) -> int:
+    """Return the sum of two integers.
+
+    Args:
+        a: First integer.
+        b: Second integer.
+    """
+    return a + b
+
+
+@function_tool
+def multiply(a: int, b: int) -> int:
+    """Return the product of two integers.
+
+    Args:
+        a: First integer.
+        b: Second integer.
+    """
+    return a * b
+
+
+agent = Agent(
+    name="Math Assistant",
+    instructions=(
+        "You are a math assistant. Use the available tools to answer questions. "
+        "Only call tools that exist: add, multiply."
+    ),
+    tools=[add, multiply],
+)
+
+
+async def run_with_self_healing(task: str) -> str:
+    """Run an agent task, retrying up to MAX_SELF_HEALS times on ModelBehaviorError.
+
+    On each retry the error description is appended to the conversation so the
+    model can understand what went wrong and correct itself.
+
+    Args:
+        task: The initial user message to send to the agent.
+
+    Returns:
+        The final output string from the agent.
+
+    Raises:
+        ModelBehaviorError: If the model keeps misbehaving after all retries.
+    """
+    messages: str | list = task
+    heals_remaining = MAX_SELF_HEALS
+
+    while True:
+        try:
+            result = await Runner.run(agent, messages)
+            return result.final_output
+        except ModelBehaviorError as exc:
+            if heals_remaining <= 0:
+                print(f"[self-heal] Giving up after {MAX_SELF_HEALS} attempts.")
+                raise
+
+            heals_remaining -= 1
+            print(
+                f"[self-heal] ModelBehaviorError caught "
+                f"({MAX_SELF_HEALS - heals_remaining}/{MAX_SELF_HEALS}): {exc.message}"
+            )
+
+            # Feed the error back so the model can self-correct on the next turn.
+            correction = (
+                f"Your previous response caused an error: {exc.message}\n"
+                "Please correct your approach and try again using only the tools available."
+            )
+
+            # Build a fresh input that includes the correction.
+            # We restart from the original task plus the correction note so the
+            # model has full context without the broken tool call in its history.
+            messages = f"{task}\n\n[System note: {correction}]"
+            print("[self-heal] Retrying with correction appended to input...")
+
+
+async def main() -> None:
+    task = "What is (7 + 3) multiplied by 4?"
+
+    print(f"Task: {task}")
+    print("-" * 60)
+
+    output = await run_with_self_healing(task)
+
+    print("-" * 60)
+    print(f"Answer: {output}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Adds [circuit_breaker.py](cci:7://file:///C:/Users/mdkta/OneDrive/Desktop/open_sorce_contributions/agents-repo/examples/agent_patterns/circuit_breaker.py:0:0-0:0) to [examples/agent_patterns/](cci:9://file:///C:/Users/mdkta/OneDrive/Desktop/open_sorce_contributions/agents-repo/examples/agent_patterns:0:0-0:0) — the classic circuit breaker pattern applied to agent runs.

[AgentCircuitBreaker](cci:2://file:///C:/Users/mdkta/OneDrive/Desktop/open_sorce_contributions/agents-repo/examples/agent_patterns/circuit_breaker.py:53:0-139:17) wraps [Runner.run()](cci:1://file:///C:/Users/mdkta/OneDrive/Desktop/open_sorce_contributions/agents-repo/examples/agent_patterns/circuit_breaker.py:100:4-139:17) and tracks consecutive failures. After `failure_threshold` consecutive failures it opens the circuit and rejects further calls immediately without hitting the API. After a `cooldown_seconds` period it enters `HALF_OPEN` and sends one probe — success resets to `CLOSED`, failure stays `OPEN`.

Three states: **CLOSED** (normal) → **OPEN** (fast-fail) → **HALF_OPEN** (probe) → **CLOSED**

Useful for:
- Cost control — stop spending tokens on a broken model/tool
- Fault tolerance in parallel agent pipelines  
- Agents that call unreliable external APIs

Also updates [README.md](cci:7://file:///C:/Users/mdkta/OneDrive/Desktop/open_sorce_contributions/cookbook-repo/README.md:0:0-0:0) to document the pattern.