### PR TITLE
fix(tracing): preserve precision of large integers in trace payloads

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -15,6 +15,7 @@ import httpx
 
 from ..logger import logger
 from .processor_interface import TracingExporter, TracingProcessor
+from .span_data import _convert_large_ints_to_strings
 from .spans import Span
 from .traces import Trace
 
@@ -265,39 +266,29 @@ class BackendSpanExporter(TracingExporter):
                     sanitized_span_data = dict(span_data)
                     did_mutate = True
                 sanitized_span_data.pop("usage", None)
-            if not did_mutate:
-                return payload_item
-            sanitized_payload_item = dict(payload_item)
-            sanitized_payload_item["span_data"] = sanitized_span_data
-            return sanitized_payload_item
-
-        usage = span_data.get("usage")
-        if not isinstance(usage, dict):
-            if not did_mutate:
-                return payload_item
-            sanitized_payload_item = dict(payload_item)
-            sanitized_payload_item["span_data"] = sanitized_span_data
-            return sanitized_payload_item
-
-        sanitized_usage = self._sanitize_generation_usage_for_openai_tracing_api(usage)
-
-        if sanitized_usage is None:
-            if not did_mutate:
-                sanitized_span_data = dict(span_data)
-                did_mutate = True
-            sanitized_span_data.pop("usage", None)
-        elif sanitized_usage != usage:
-            if not did_mutate:
-                sanitized_span_data = dict(span_data)
-                did_mutate = True
-            sanitized_span_data["usage"] = sanitized_usage
+        else:
+            usage = span_data.get("usage")
+            if isinstance(usage, dict):
+                sanitized_usage = self._sanitize_generation_usage_for_openai_tracing_api(usage)
+                if sanitized_usage is None:
+                    if not did_mutate:
+                        sanitized_span_data = dict(span_data)
+                        did_mutate = True
+                    sanitized_span_data.pop("usage", None)
+                elif sanitized_usage != usage:
+                    if not did_mutate:
+                        sanitized_span_data = dict(span_data)
+                        did_mutate = True
+                    sanitized_span_data["usage"] = sanitized_usage
 
         if not did_mutate:
-            return payload_item
+            sanitized_payload_item = payload_item
+        else:
+            sanitized_payload_item = dict(payload_item)
+            sanitized_payload_item["span_data"] = sanitized_span_data
 
-        sanitized_payload_item = dict(payload_item)
-        sanitized_payload_item["span_data"] = sanitized_span_data
-        return sanitized_payload_item
+        converted_payload_item, changed = _convert_large_ints_to_strings(sanitized_payload_item)
+        return converted_payload_item if changed else sanitized_payload_item
 
     def _value_json_size_bytes(self, value: Any) -> int:
         try:

--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -1,11 +1,52 @@
 from __future__ import annotations
 
 import abc
+import json
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from openai.types.responses import Response, ResponseInputItemParam
+
+
+# JavaScript's Number type can only safely represent integers in this range.
+_JS_SAFE_INT_MIN = -(2**53 - 1)
+_JS_SAFE_INT_MAX = 2**53 - 1
+
+
+def _convert_large_ints_to_strings(value: Any) -> tuple[Any, bool]:
+    """Recursively convert ints outside JS's safe range to strings.
+
+    Returns a tuple of (converted_value, changed). When no conversion is needed,
+    the original object is returned unchanged to preserve object identity.
+    """
+    if value is None or isinstance(value, str | float):
+        return value, False
+    if isinstance(value, bool):
+        return value, False
+    if isinstance(value, int):
+        if value < _JS_SAFE_INT_MIN or value > _JS_SAFE_INT_MAX:
+            return str(value), True
+        return value, False
+    if isinstance(value, dict):
+        converted_dict: dict[str, Any] = {}
+        changed = False
+        for key, nested_value in value.items():
+            if not isinstance(key, str):
+                continue
+            converted_value, value_changed = _convert_large_ints_to_strings(nested_value)
+            converted_dict[key] = converted_value
+            changed = changed or value_changed
+        return (converted_dict, True) if changed else (value, False)
+    if isinstance(value, list):
+        converted_list: list[Any] = []
+        changed = False
+        for nested_value in value:
+            converted_value, value_changed = _convert_large_ints_to_strings(nested_value)
+            converted_list.append(converted_value)
+            changed = changed or value_changed
+        return (converted_list, True) if changed else (value, False)
+    return value, False
 
 
 class SpanData(abc.ABC):
@@ -157,10 +198,20 @@ class FunctionSpanData(SpanData):
         return "function"
 
     def export(self) -> dict[str, Any]:
+        input_value = self.input
+        if isinstance(input_value, str):
+            try:
+                parsed_input = json.loads(input_value)
+                converted_input, changed = _convert_large_ints_to_strings(parsed_input)
+                if changed:
+                    input_value = json.dumps(converted_input, ensure_ascii=False)
+            except (ValueError, TypeError):
+                pass
+
         return {
             "type": self.type,
             "name": self.name,
-            "input": self.input,
+            "input": input_value,
             "output": str(self.output) if self.output is not None else None,
             "mcp_data": self.mcp_data,
         }

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -1299,3 +1299,56 @@ def test_truncate_string_for_json_limit_handles_escape_heavy_input():
     assert truncated.endswith(exporter._OPENAI_TRACING_STRING_TRUNCATION_SUFFIX)
     assert exporter._value_json_size_bytes(truncated) <= max_bytes
     exporter.close()
+
+
+def test_sanitize_for_openai_tracing_api_converts_large_ints_to_strings():
+    exporter = BackendSpanExporter(api_key="test_key")
+    payload = {
+        "object": "trace.span",
+        "span_data": {
+            "type": "generation",
+            "input": [
+                {
+                    "role": "user",
+                    "content": {
+                        "big_int": 10_000_000_000_000_001,
+                        "small_int": 42,
+                        "flag": True,
+                    },
+                }
+            ],
+            "output": [
+                {
+                    "role": "assistant",
+                    "content": {
+                        "big_int": -10_000_000_000_000_002,
+                        "small_int": 9007199254740991,
+                    },
+                }
+            ],
+        },
+    }
+
+    sanitized = exporter._sanitize_for_openai_tracing_api(payload)
+    assert sanitized["span_data"]["input"][0]["content"]["big_int"] == "10000000000000001"
+    assert sanitized["span_data"]["input"][0]["content"]["small_int"] == 42
+    assert sanitized["span_data"]["input"][0]["content"]["flag"] is True
+    assert sanitized["span_data"]["output"][0]["content"]["big_int"] == "-10000000000000002"
+    assert sanitized["span_data"]["output"][0]["content"]["small_int"] == 9007199254740991
+    exporter.close()
+
+
+def test_sanitize_for_openai_tracing_api_keeps_small_payload_identity():
+    exporter = BackendSpanExporter(api_key="test_key")
+    payload = {
+        "object": "trace.span",
+        "span_data": {
+            "type": "function",
+            "input": "short input",
+            "output": "short output",
+        },
+    }
+
+    sanitized = exporter._sanitize_for_openai_tracing_api(payload)
+    assert sanitized is payload
+    exporter.close()

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -528,3 +528,25 @@ def test_trace_to_json_only_includes_tracing_api_key_when_requested():
         with_key = tr.to_json(include_tracing_api_key=True)
         assert with_key is not None
         assert with_key["tracing_api_key"] == "secret-key"
+
+
+def test_function_span_data_export_converts_large_ints_in_json_input():
+    from agents.tracing.span_data import FunctionSpanData
+
+    span_data = FunctionSpanData(
+        name="add",
+        input='{"a": 10000000000000001, "b": 123456789}',
+        output="10000000123456790",
+    )
+    exported = span_data.export()
+    assert exported["input"] == '{"a": "10000000000000001", "b": 123456789}'
+    assert exported["output"] == "10000000123456790"
+
+
+def test_function_span_data_export_leaves_non_json_input_unchanged():
+    from agents.tracing.span_data import FunctionSpanData
+
+    span_data = FunctionSpanData(name="add", input="plain text: 10000000000000001", output=None)
+    exported = span_data.export()
+    assert exported["input"] == "plain text: 10000000000000001"
+    assert exported["output"] is None


### PR DESCRIPTION
Convert Python ints outside JavaScript's safe integer range (-(2**53 - 1) .. 2**53 - 1) to strings before exporting trace data to the OpenAI tracing API. This prevents the trace dashboard from truncating large integer tool arguments or model I/O.

Changes:
- Add _convert_large_ints_to_strings helper in span_data.py.
- FunctionSpanData.export() now converts large ints inside JSON input.
- BackendSpanExporter._sanitize_for_openai_tracing_api() converts large ints recursively across the whole payload.

Fixes #2094