### PR TITLE
fix: #985 Code Interpreter reasoning replay

### DIFF
--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -319,7 +319,10 @@ class RunConfig:
     reasoning_item_id_policy: ReasoningItemIdPolicy | None = None
     """Controls how reasoning items are converted to next-turn model input.
 
-    - ``None`` / ``"preserve"`` keeps reasoning item IDs as-is.
+    - ``None`` uses the SDK default. Reasoning item IDs are preserved except when runner-built
+      prior turn history contains Code Interpreter calls, where IDs are omitted to avoid invalid
+      replay.
+    - ``"preserve"`` keeps reasoning item IDs as-is.
     - ``"omit"`` strips reasoning item IDs from model input built by the runner.
     """
 

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -35,6 +35,7 @@ __all__ = [
     "REJECTION_MESSAGE",
     "TOOL_CALL_SESSION_DESCRIPTION_KEY",
     "TOOL_CALL_SESSION_TITLE_KEY",
+    "apply_reasoning_item_id_policy",
     "copy_input_items",
     "drop_orphan_function_calls",
     "ensure_input_item_format",
@@ -206,6 +207,8 @@ def normalize_input_items_for_api(items: list[TResponseInputItem]) -> list[TResp
 def prepare_model_input_items(
     caller_items: Sequence[TResponseInputItem],
     generated_items: Sequence[TResponseInputItem] = (),
+    *,
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
 ) -> list[TResponseInputItem]:
     """Normalize model input while pruning orphans only from runner-generated history."""
     normalized_caller_items = normalize_input_items_for_api(list(caller_items))
@@ -214,7 +217,11 @@ def prepare_model_input_items(
 
     normalized_generated_items = normalize_input_items_for_api(list(generated_items))
     filtered_generated_items = drop_orphan_function_calls(normalized_generated_items)
-    return normalized_caller_items + filtered_generated_items
+    safe_generated_items = apply_reasoning_item_id_policy(
+        filtered_generated_items,
+        reasoning_item_id_policy,
+    )
+    return normalized_caller_items + safe_generated_items
 
 
 def normalize_resumed_input(
@@ -307,6 +314,36 @@ def strip_internal_input_item_metadata(item: TResponseInputItem) -> TResponseInp
 
 def _should_omit_reasoning_item_ids(reasoning_item_id_policy: ReasoningItemIdPolicy | None) -> bool:
     return reasoning_item_id_policy == "omit"
+
+
+def apply_reasoning_item_id_policy(
+    items: list[TResponseInputItem],
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
+) -> list[TResponseInputItem]:
+    if reasoning_item_id_policy == "preserve":
+        return items
+    if reasoning_item_id_policy == "omit":
+        return [_without_reasoning_item_id(item) for item in items]
+    return _omit_reasoning_ids_for_code_interpreter_history(items)
+
+
+def _omit_reasoning_ids_for_code_interpreter_history(
+    items: list[TResponseInputItem],
+) -> list[TResponseInputItem]:
+    if not any(
+        isinstance(item, dict) and item.get("type") == "code_interpreter_call" for item in items
+    ):
+        return items
+
+    sanitized: list[TResponseInputItem] = []
+    for item in items:
+        if not (isinstance(item, dict) and item.get("type") == "reasoning" and "id" in item):
+            sanitized.append(item)
+            continue
+        reasoning_item = dict(item)
+        reasoning_item.pop("id", None)
+        sanitized.append(cast(TResponseInputItem, reasoning_item))
+    return sanitized
 
 
 def _without_reasoning_item_id(item: TResponseInputItem) -> TResponseInputItem:

--- a/src/agents/run_internal/oai_conversation.py
+++ b/src/agents/run_internal/oai_conversation.py
@@ -20,6 +20,7 @@ from ..logger import logger
 from ..models.fake_id import FAKE_RESPONSES_ID
 from .items import (
     ReasoningItemIdPolicy,
+    apply_reasoning_item_id_policy,
     drop_orphan_function_calls,
     fingerprint_input_item,
     normalize_input_items_for_api,
@@ -521,12 +522,16 @@ class OpenAIServerConversationTracker:
             )
         }
         filtered_generated_items = drop_orphan_function_calls(normalized_generated_items)
-        for item in filtered_generated_items:
-            prepared_source_item = normalized_generated_sources.get(id(item))
+        safe_generated_items = apply_reasoning_item_id_policy(
+            filtered_generated_items,
+            self.reasoning_item_id_policy,
+        )
+        for item, source_item in zip(safe_generated_items, filtered_generated_items, strict=False):
+            prepared_source_item = normalized_generated_sources.get(id(source_item))
             if prepared_source_item is not None:
                 self._register_prepared_item_source(item, prepared_source_item)
 
-        return prepared_initial_items + filtered_generated_items
+        return prepared_initial_items + safe_generated_items
 
     def _register_prepared_item_source(
         self, prepared_item: TResponseInputItem, source_item: TResponseInputItem | None = None

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -284,7 +284,11 @@ def _prepare_turn_input_items(
 ) -> list[TResponseInputItem]:
     caller_items = ItemHelpers.input_to_new_input_list(caller_input)
     continuation_items = run_items_to_input_items(generated_items, reasoning_item_id_policy)
-    return prepare_model_input_items(caller_items, continuation_items)
+    return prepare_model_input_items(
+        caller_items,
+        continuation_items,
+        reasoning_item_id_policy=reasoning_item_id_policy,
+    )
 
 
 def _complete_stream_interruption(

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -287,6 +287,71 @@ def test_drop_orphan_function_calls_does_not_pair_named_tool_search_with_anonymo
     assert [cast(dict[str, Any], item)["type"] for item in filtered] == ["tool_search_output"]
 
 
+def test_prepare_model_input_items_omits_reasoning_ids_with_code_interpreter_calls() -> None:
+    payload: list[Any] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_code", "summary": []}),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "code_interpreter_call",
+                "id": "ci_123",
+                "status": "completed",
+                "container_id": "cntr_123",
+                "outputs": [],
+            },
+        ),
+    ]
+
+    prepared = run_items.prepare_model_input_items([], cast(list[TResponseInputItem], payload))
+    reasoning_item = cast(dict[str, Any], prepared[0])
+
+    assert reasoning_item["type"] == "reasoning"
+    assert "id" not in reasoning_item
+    assert cast(dict[str, Any], prepared[1])["type"] == "code_interpreter_call"
+
+
+def test_prepare_model_input_items_preserves_reasoning_ids_when_configured() -> None:
+    payload: list[Any] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_code", "summary": []}),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "code_interpreter_call",
+                "id": "ci_123",
+                "status": "completed",
+                "container_id": "cntr_123",
+                "outputs": [],
+            },
+        ),
+    ]
+
+    prepared = run_items.prepare_model_input_items(
+        [],
+        cast(list[TResponseInputItem], payload),
+        reasoning_item_id_policy="preserve",
+    )
+    reasoning_item = cast(dict[str, Any], prepared[0])
+
+    assert reasoning_item["id"] == "rs_code"
+
+
+def test_prepare_model_input_items_omits_reasoning_ids_when_configured() -> None:
+    payload: list[Any] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_plain", "summary": []}),
+        cast(TResponseInputItem, {"type": "message", "role": "assistant", "content": "done"}),
+    ]
+
+    prepared = run_items.prepare_model_input_items(
+        [],
+        cast(list[TResponseInputItem], payload),
+        reasoning_item_id_policy="omit",
+    )
+    reasoning_item = cast(dict[str, Any], prepared[0])
+
+    assert reasoning_item["type"] == "reasoning"
+    assert "id" not in reasoning_item
+
+
 def test_normalize_and_ensure_input_item_format_keep_non_dict_entries() -> None:
     item = cast(TResponseInputItem, "raw-item")
     assert run_items.ensure_input_item_format(item) == item

--- a/tests/test_server_conversation_tracker.py
+++ b/tests/test_server_conversation_tracker.py
@@ -748,6 +748,63 @@ def test_prepare_input_applies_reasoning_item_id_policy_for_generated_items() ->
     ]
 
 
+def test_prepare_input_omits_reasoning_ids_with_code_interpreter_history() -> None:
+    tracker = OpenAIServerConversationTracker(conversation_id="conv7a", previous_response_id=None)
+    generated_items = [
+        DummyRunItem(
+            {
+                "type": "reasoning",
+                "id": "rs_code",
+                "content": [{"type": "input_text", "text": "reasoning trace"}],
+            },
+            type="reasoning_item",
+        ),
+        DummyRunItem(
+            {
+                "type": "code_interpreter_call",
+                "id": "ci_123",
+                "status": "completed",
+                "container_id": "cntr_123",
+                "outputs": [],
+            },
+            type="tool_call_item",
+        ),
+    ]
+
+    prepared = tracker.prepare_input(
+        original_input=[],
+        generated_items=cast(list[Any], generated_items),
+    )
+    reasoning_item = cast(dict[str, Any], prepared[0])
+
+    assert reasoning_item["type"] == "reasoning"
+    assert "id" not in reasoning_item
+    assert cast(dict[str, Any], prepared[1])["type"] == "code_interpreter_call"
+
+
+def test_prepare_input_preserves_reasoning_ids_without_code_interpreter_history() -> None:
+    tracker = OpenAIServerConversationTracker(conversation_id="conv7b", previous_response_id=None)
+    generated_items = [
+        DummyRunItem(
+            {
+                "type": "reasoning",
+                "id": "rs_plain",
+                "content": [{"type": "input_text", "text": "reasoning trace"}],
+            },
+            type="reasoning_item",
+        )
+    ]
+
+    prepared = tracker.prepare_input(
+        original_input=[],
+        generated_items=cast(list[Any], generated_items),
+    )
+    reasoning_item = cast(dict[str, Any], prepared[0])
+
+    assert reasoning_item["type"] == "reasoning"
+    assert reasoning_item["id"] == "rs_plain"
+
+
 def test_prepare_input_does_not_resend_reasoning_item_after_marking_omitted_id_as_sent() -> None:
     tracker = OpenAIServerConversationTracker(
         conversation_id="conv8",


### PR DESCRIPTION
## Summary
Fixes #985.

- Omit reasoning item IDs when runner-built prior history includes Code Interpreter calls.
- Apply the same policy to server-managed conversation replay so `conversation_id` and `previous_response_id` paths behave consistently.
- Preserve explicit `preserve` and `omit` policy behavior with focused regression coverage.

## Testing
- `python -m pytest tests/test_run_internal_items.py tests/test_server_conversation_tracker.py -q`
- `python -m ruff check src/agents/run_config.py src/agents/run_internal/items.py src/agents/run_internal/oai_conversation.py src/agents/run_internal/run_loop.py tests/test_run_internal_items.py tests/test_server_conversation_tracker.py`
- `python -m ruff format src/agents/run_config.py src/agents/run_internal/items.py src/agents/run_internal/oai_conversation.py src/agents/run_internal/run_loop.py tests/test_run_internal_items.py tests/test_server_conversation_tracker.py --check`
- `python -m mypy src/agents/run_internal/items.py src/agents/run_internal/oai_conversation.py src/agents/run_internal/run_loop.py src/agents/run_config.py --exclude site`
