### PR TITLE
fix(realtime): emit history updates for transcript deltas

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -389,6 +389,9 @@ class RealtimeSession(RealtimeModelListener):
                     content=[AssistantAudio(transcript=self._item_transcripts[item_id])],
                 ),
             )
+            await self._put_event(
+                RealtimeHistoryUpdated(info=self._event_info, history=self._history)
+            )
 
             # Check if we should run guardrails based on debounce threshold
             current_length = len(self._item_transcripts[item_id])

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -822,6 +822,45 @@ class TestEventHandling:
         assert len(history_event.history) == 1
 
     @pytest.mark.asyncio
+    async def test_transcript_delta_event_updates_history(self, mock_model, mock_agent):
+        """Test that transcript delta events update history and emit events"""
+        session = RealtimeSession(
+            mock_model, mock_agent, None, run_config={"async_tool_calls": False}
+        )
+
+        first_delta = RealtimeModelTranscriptDeltaEvent(
+            item_id="item_1", delta="hel", response_id="resp_1"
+        )
+        await session.on_event(first_delta)
+
+        assert session._event_queue.qsize() == 2
+
+        raw_event = await session._event_queue.get()
+        assert isinstance(raw_event, RealtimeRawModelEvent)
+        history_event = await session._event_queue.get()
+        assert isinstance(history_event, RealtimeHistoryUpdated)
+        assert len(history_event.history) == 1
+
+        item = cast(AssistantMessageItem, history_event.history[0])
+        content = cast(AssistantAudio, item.content[0])
+        assert item.item_id == "item_1"
+        assert content.transcript == "hel"
+
+        second_delta = RealtimeModelTranscriptDeltaEvent(
+            item_id="item_1", delta="lo", response_id="resp_1"
+        )
+        await session.on_event(second_delta)
+
+        assert session._event_queue.qsize() == 2
+        await session._event_queue.get()
+        history_event = await session._event_queue.get()
+        assert isinstance(history_event, RealtimeHistoryUpdated)
+
+        item = cast(AssistantMessageItem, history_event.history[0])
+        content = cast(AssistantAudio, item.content[0])
+        assert content.transcript == "hello"
+
+    @pytest.mark.asyncio
     async def test_item_updated_event_adds_new_item(self, mock_model, mock_agent):
         """Test that item_updated events add new items to history"""
         session = RealtimeSession(
@@ -921,15 +960,8 @@ class TestEventHandling:
 
     @pytest.mark.asyncio
     async def test_ignored_events_only_generate_raw_events(self, mock_model, mock_agent):
-        """Test that ignored events (transcript_delta, connection_status, other) only generate raw
-        events"""
+        """Test that ignored events only generate raw events"""
         session = RealtimeSession(mock_model, mock_agent, None)
-
-        # Test transcript delta (should be ignored per TODO comment)
-        transcript_event = RealtimeModelTranscriptDeltaEvent(
-            item_id="item_1", delta="hello", response_id="resp_1"
-        )
-        await session.on_event(transcript_event)
 
         # Test connection status (should be ignored)
         connection_event = RealtimeModelConnectionStatusEvent(status="connected")
@@ -939,10 +971,10 @@ class TestEventHandling:
         other_event = RealtimeModelOtherEvent(data={"custom": "data"})
         await session.on_event(other_event)
 
-        # Should only have 3 raw events (no transformed events)
-        assert session._event_queue.qsize() == 3
+        # Should only have 2 raw events (no transformed events)
+        assert session._event_queue.qsize() == 2
 
-        for _ in range(3):
+        for _ in range(2):
             event = await session._event_queue.get()
             assert isinstance(event, RealtimeRawModelEvent)
 


### PR DESCRIPTION
### Summary

Closes #2940.

Realtime transcript deltas already update session history, but high-level event consumers only received the raw model event. This emits `RealtimeHistoryUpdated` after each transcript delta so UI code can keep rendering from the session history stream without also subscribing to raw model events.

The regression test covers two deltas for the same item and verifies the emitted history contains the accumulated transcript.

### Test plan

- `uv run pytest tests\realtime\test_session.py::TestEventHandling::test_transcript_delta_event_updates_history -q`
- `uv run pytest tests\realtime\test_session.py::TestEventHandling -q`
- `uv run pytest tests\realtime\test_session.py -q`
- `uv run ruff format src\agents\realtime\session.py tests\realtime\test_session.py`
- `uv run ruff check --fix src\agents\realtime\session.py tests\realtime\test_session.py`
- `uv run ruff format --check src\agents\realtime\session.py tests\realtime\test_session.py`
- `uv run ruff check src\agents\realtime\session.py tests\realtime\test_session.py`
- `uv run mypy src\agents\realtime\session.py tests\realtime\test_session.py --exclude site`
- `uv run pyright src\agents\realtime\session.py tests\realtime\test_session.py`

### Issue number

Closes #2940

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format` equivalents with direct `uv run ruff` commands
- [x] I've made sure tests pass
