### PR TITLE
fix: raise a clear error when on_invoke_tool gets a non-ToolContext

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -552,6 +552,17 @@ class _FailureHandlingFunctionToolInvoker:
         return bound_invoker
 
     async def __call__(self, ctx: ToolContext[Any], input: str) -> Any:
+        # Validate the context up front. A non-context value (most commonly None) would
+        # otherwise blow up deep in the invocation with a cryptic AttributeError, so fail
+        # fast here with an actionable message before any tool logic runs. The base
+        # RunContextWrapper is accepted because agent-as-tool invokers run with one; the
+        # message points to ToolContext since that is what function tools need.
+        if not isinstance(ctx, RunContextWrapper):
+            raise TypeError(
+                f"on_invoke_tool requires a ToolContext, got {type(ctx).__name__}. "
+                "Construct one with ToolContext(context=..., tool_name=..., "
+                "tool_call_id=..., tool_arguments=...) or invoke the tool through Runner."
+            )
         try:
             return await self._invoke_tool_impl(ctx, input)
         except Exception as e:

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -156,6 +156,27 @@ async def test_simple_function():
 
 
 @pytest.mark.asyncio
+async def test_on_invoke_tool_rejects_non_tool_context():
+    tool = function_tool(simple_function)
+
+    # A non-ToolContext (most commonly None) should fail fast with a clear TypeError
+    # instead of a cryptic AttributeError raised deep inside the invocation path.
+    with pytest.raises(TypeError, match="on_invoke_tool requires a ToolContext, got NoneType"):
+        await tool.on_invoke_tool(cast(Any, None), '{"a": 1, "b": 2}')
+
+    # The error message names the offending type to help developers spot the mistake.
+    with pytest.raises(TypeError, match="got int"):
+        await tool.on_invoke_tool(cast(Any, 123), '{"a": 1, "b": 2}')
+
+    # A valid ToolContext is unaffected by the guard.
+    result = await tool.on_invoke_tool(
+        ToolContext(None, tool_name=tool.name, tool_call_id="1", tool_arguments='{"a": 1, "b": 2}'),
+        '{"a": 1, "b": 2}',
+    )
+    assert result == 3
+
+
+@pytest.mark.asyncio
 async def test_sync_function_runs_via_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = {"to_thread": 0, "func": 0}
 


### PR DESCRIPTION
### Summary

Calling a function tool's `on_invoke_tool(ctx, input_json)` with a `ctx` that is not a
run context (most commonly `None`) currently fails far from the cause with a cryptic
error. This is easy to hit when unit-testing a `@function_tool` directly without going
through `Runner`.

**Minimal reproduction (on `main`):**

```python
from agents import function_tool
import asyncio

@function_tool
def add(a: int, b: int) -> int:
    "Add two numbers."
    return a + b

asyncio.run(add.on_invoke_tool(None, '{"a": 1, "b": 2}'))
```

**Before** — a chained `AttributeError` that points nowhere near the real mistake:

```
File ".../agents/tool.py", line 1979, in _on_invoke_tool_impl
    tool_name = ctx.tool_name
AttributeError: 'NoneType' object has no attribute 'tool_name'

During handling of the above exception, another exception occurred:
...
File ".../agents/tool.py", line 1543, in _on_handled_error
    context.run_config is None or context.run_config.trace_include_sensitive_data
AttributeError: 'NoneType' object has no attribute 'run_config'
```

The first deref of `ctx.tool_name` raises, the wrapper's failure handler then dereferences
the same bad `ctx` again (`context.run_config`), and the *second* `AttributeError` is what
actually propagates — so the surfaced message is even further from the cause.

**After** — fail fast with one clear, actionable error:

```
TypeError: on_invoke_tool requires a ToolContext, got NoneType. Construct one with
ToolContext(context=..., tool_name=..., tool_call_id=..., tool_arguments=...) or invoke
the tool through Runner.
```

### Root cause

`_on_invoke_tool_impl` reads `ctx.tool_name` with no validation. When `ctx` is not a real
context this raises `AttributeError`, and the wrapper's failure-handling path
(`_on_handled_error`) then dereferences `ctx.run_config` on the same bad value, masking the
original cause behind a second exception.

### Fix

Validate the context once, at the top of the shared invocation boundary
(`_FailureHandlingFunctionToolInvoker.__call__`, i.e. the public `on_invoke_tool`), before
the `try` block, and raise a precise `TypeError`. The happy path is untouched (one
`isinstance` check) and the error propagates cleanly instead of being routed through the
failure formatter.

### Notes / decisions for maintainers

- **Where to validate — wrapper vs. impl.** I placed the guard in the wrapper rather than
  inside `_on_invoke_tool_impl`. The wrapper catches every exception from the impl and
  routes it through `maybe_invoke_function_tool_failure_error_function`; for a default
  function tool that converts the error into a model-facing string (and, with a bad `ctx`,
  crashes again in `_on_handled_error`). Raising before the `try` is the only place the
  clear error reliably propagates.
- **Accepted type — `RunContextWrapper`, not strictly `ToolContext`.** The same wrapper is
  used by `agent.as_tool()`, whose invoker legitimately runs with a base
  `RunContextWrapper` (see `_run_agent_impl`, which guards with `isinstance(context,
  ToolContext)`). Requiring `ToolContext` here would break that path (and the existing
  `test_agent_as_tool_preserves_scope_for_nested_run_context_wrapper`). The check therefore
  accepts the base `RunContextWrapper`, which still rejects `None`/garbage, while the
  message points to `ToolContext` since that is what function-tool authors actually need.
- **Error type — `TypeError`.** Chosen because passing the wrong type to a callable is the
  canonical `TypeError` case and is the most natural thing for developers unit-testing
  their tools to expect. The SDK's `UserError` was the alternative (there is precedent at
  `tool_namespace()`); happy to switch to `UserError` if maintainers prefer consistency.
- **Scope.** This PR is the fail-fast fix only. A public test helper to synthesize a
  minimal `ToolContext` (so developers don't hand-build internal context) seems useful but
  is a feature, not a fix — I left it out and can open a separate issue/PR if there's
  interest.

### Test plan

- Added `tests/test_function_tool.py::test_on_invoke_tool_rejects_non_tool_context`,
  asserting the clear `TypeError` for `None` and another non-context type, and that a valid
  `ToolContext` still works.
- `make format` — no changes; `make lint` — passed.
- `make typecheck` — pyright clean; mypy reports only a pre-existing, unrelated error in
  `tests/test_run_step_execution.py` (`asyncio.eager_task_factory` under Python 3.11),
  present on `main` and untouched here.
- `make tests` — full suite green (parallel + serial).

### Issue number

No existing issue found for this specific failure (searched issues/PRs for
`on_invoke_tool tool_name`, `ToolContext None`, etc.).

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation (no user-facing behavior change for valid inputs)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
