### PR TITLE
fix(tools): raise clear TypeError when on_invoke_tool gets non-ToolContext

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -552,6 +552,12 @@ class _FailureHandlingFunctionToolInvoker:
         return bound_invoker
 
     async def __call__(self, ctx: ToolContext[Any], input: str) -> Any:
+        if not isinstance(ctx, RunContextWrapper):
+            raise TypeError(
+                f"on_invoke_tool requires a ToolContext, got {type(ctx).__name__}. "
+                "Construct one with ToolContext(context=..., tool_name=..., "
+                "tool_call_id=..., tool_arguments=...) or invoke the tool through Runner."
+            )
         try:
             return await self._invoke_tool_impl(ctx, input)
         except Exception as e:

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -34,6 +34,7 @@ from agents import (
 )
 from agents.tool import default_tool_error_function
 from agents.tool_context import ToolContext
+from openai.types.responses import ResponseFunctionToolCall
 
 
 def argless_function() -> str:
@@ -1063,3 +1064,35 @@ def test_function_tool_timeout_error_function_must_be_callable() -> None:
             on_invoke_tool=_noop_on_invoke_tool,
             timeout_error_function=cast(Any, "not-callable"),
         )
+
+
+async def test_on_invoke_tool_rejects_non_tool_context() -> None:
+    """Calling on_invoke_tool with a non-context value should fail fast and clearly."""
+
+    @function_tool
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    with pytest.raises(TypeError, match="on_invoke_tool requires a ToolContext"):
+        await add.on_invoke_tool(cast(Any, None), '{"a": 1, "b": 2}')
+
+    with pytest.raises(TypeError, match="on_invoke_tool requires a ToolContext"):
+        await add.on_invoke_tool(cast(Any, "not a context"), '{"a": 1, "b": 2}')
+
+    # A valid ToolContext should still work.
+    tool_call = ResponseFunctionToolCall(
+        type="function_call",
+        name="add",
+        call_id="call-add",
+        arguments='{"a": 1, "b": 2}',
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="add",
+        tool_call_id="call-add",
+        tool_arguments=tool_call.arguments,
+        tool_call=tool_call,
+    )
+    result = await add.on_invoke_tool(tool_context, tool_call.arguments)
+    assert result == 3


### PR DESCRIPTION
## Summary

Fixes #3681.

Calling a `@function_tool`'s `on_invoke_tool(ctx, input_json)` with a `ctx` that is not a run context (most commonly `None` when unit-testing a tool directly) currently fails far from the cause with a cryptic chained `AttributeError`:

```
AttributeError: 'NoneType' object has no attribute 'tool_name'
```

The wrapper's failure handler then dereferences the same bad `ctx` again (`context.run_config`), masking the original cause behind a second exception.

## What changed

Validate the context once, at the top of `_FailureHandlingFunctionToolInvoker.__call__` (the public `on_invoke_tool` entry point), before the `try` block. The check accepts `RunContextWrapper` (which covers both `ToolContext` and the base wrapper used by `agent.as_tool()`), and raises a precise `TypeError` for anything else.

The happy path is untouched (one `isinstance` check), and the error now propagates cleanly instead of being routed through the failure formatter.

## Tests

Added `tests/test_function_tool.py::test_on_invoke_tool_rejects_non_tool_context`, which asserts:

- `None` raises the clear `TypeError`.
- Another non-context type raises the clear `TypeError`.
- A valid `ToolContext` still works and returns the expected result.

## Notes

- The guard accepts `RunContextWrapper` rather than strictly `ToolContext`, because the same wrapper is used by `agent.as_tool()`, whose invoker legitimately runs with a base `RunContextWrapper`. Requiring `ToolContext` would break that path.
- No documentation changes: valid usage is unchanged, and the new error message is self-documenting.
