### PR TITLE
fix: propagate realtime session iterator cancellation

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -269,23 +269,20 @@ class RealtimeSession(RealtimeModelListener):
             if self._closed and self._event_queue.empty():
                 return
 
-            try:
-                # Check if there's a stored exception to raise
-                if self._stored_exception is not None:
-                    # Clean up resources before raising
-                    await self._cleanup()
-                    raise self._stored_exception
+            # Check if there's a stored exception to raise
+            if self._stored_exception is not None:
+                # Clean up resources before raising
+                await self._cleanup()
+                raise self._stored_exception
 
-                self._event_iterator_waiters += 1
-                try:
-                    event = await self._event_queue.get()
-                finally:
-                    self._event_iterator_waiters -= 1
-                if event is _REALTIME_SESSION_CLOSED_SENTINEL:
-                    return
-                yield cast(RealtimeSessionEvent, event)
-            except asyncio.CancelledError:
-                break
+            self._event_iterator_waiters += 1
+            try:
+                event = await self._event_queue.get()
+            finally:
+                self._event_iterator_waiters -= 1
+            if event is _REALTIME_SESSION_CLOSED_SENTINEL:
+                return
+            yield cast(RealtimeSessionEvent, event)
 
     async def close(self) -> None:
         """Close the session."""

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -165,7 +165,7 @@ async def test_property_and_send_helpers_and_enter_alias():
 
 
 @pytest.mark.asyncio
-async def test_aiter_cancel_breaks_loop_gracefully():
+async def test_aiter_cancel_propagates_cancelled_error():
     model = _DummyModel()
     agent = RealtimeAgent(name="agent")
     session = RealtimeSession(model, agent, None)
@@ -177,8 +177,11 @@ async def test_aiter_cancel_breaks_loop_gracefully():
     consumer = asyncio.create_task(consume())
     await asyncio.sleep(0.01)
     consumer.cancel()
-    # The iterator swallows CancelledError internally and exits cleanly
-    await consumer
+
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+
+    assert session._event_iterator_waiters == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Let `RealtimeSession.__aiter__` propagate `asyncio.CancelledError` instead of treating cancellation as normal stream exhaustion.
- Keep the existing waiter bookkeeping cleanup via the inner `finally` around `_event_queue.get()`.
- Update the realtime session regression test to assert cancellation propagation.

## Why

Caller task cancellation should stay visible to parent orchestration, timeouts, and shutdown logic. Swallowing `CancelledError` makes cancellation look like graceful iteration completion.

## Tests

- `uv run pytest tests/realtime/test_session.py::test_aiter_cancel_propagates_cancelled_error`
- `uv run pytest tests/realtime/test_session.py`
- `uv run ruff check src/agents/realtime/session.py tests/realtime/test_session.py`