### PR TITLE
fix: redact realtime validation failure logs

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -96,6 +96,7 @@ from agents.tool import (
 )
 from agents.util._types import MaybeAwaitable
 
+from .. import _debug
 from ..exceptions import UserError
 from ..logger import logger
 from ..run_context import RunContextWrapper, TContext
@@ -186,6 +187,36 @@ AllRealtimeServerEvents = Annotated[
 ]
 
 ServerEventTypeAdapter: TypeAdapter[AllRealtimeServerEvents] | None = None
+
+
+def _server_event_validation_summary(error: BaseException) -> str:
+    if isinstance(error, pydantic.ValidationError):
+        return f"{error.error_count()} validation error(s)"
+
+    return error.__class__.__name__
+
+
+def _server_event_identity(event: Any) -> tuple[Any, Any]:
+    if not isinstance(event, dict):
+        return "unknown", None
+
+    return event.get("type", "unknown"), event.get("event_id")
+
+
+def _log_server_event_validation_failure(event: Any, error: BaseException) -> str:
+    event_type, event_id = _server_event_identity(event)
+
+    if _debug.DONT_LOG_MODEL_DATA:
+        logger.error(
+            "Failed to validate server event type=%s event_id=%s: %s",
+            event_type,
+            event_id,
+            _server_event_validation_summary(error),
+        )
+    else:
+        logger.error(f"Failed to validate server event: {event}", exc_info=True)
+
+    return str(event_type)
 
 
 @dataclass(frozen=True)
@@ -1100,12 +1131,11 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 validation_event
             )
         except pydantic.ValidationError as e:
-            logger.error(f"Failed to validate server event: {event}", exc_info=True)
+            _log_server_event_validation_failure(event, e)
             await self._emit_event(RealtimeModelErrorEvent(error=e))
             return
         except Exception as e:
-            event_type = event.get("type", "unknown") if isinstance(event, dict) else "unknown"
-            logger.error(f"Failed to validate server event: {event}", exc_info=True)
+            event_type = _log_server_event_validation_failure(event, e)
             exception_event = RealtimeModelExceptionEvent(
                 exception=e,
                 context=f"Failed to validate server event: {event_type}",

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -447,6 +447,36 @@ class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
         assert error_event.type == "error"
 
     @pytest.mark.asyncio
+    async def test_handle_invalid_event_schema_redacts_payload_from_logs(self, model, monkeypatch):
+        """Test that invalid event logs omit payload data when model data logging is disabled."""
+        mock_listener = AsyncMock()
+        model.add_listener(mock_listener)
+        monkeypatch.setattr(
+            "agents.realtime.openai_realtime._debug.DONT_LOG_MODEL_DATA",
+            True,
+        )
+
+        invalid_event = {
+            "type": "response.output_audio.delta",
+            "event_id": "evt_123",
+            "delta": "secret transcript",
+        }
+
+        with patch("agents.realtime.openai_realtime.logger") as mock_logger:
+            await model._handle_ws_event(invalid_event)
+
+        mock_logger.error.assert_called_once()
+        logged_call = str(mock_logger.error.call_args)
+        assert "secret transcript" not in logged_call
+        assert "response.output_audio.delta" in logged_call
+        assert "evt_123" in logged_call
+        assert mock_logger.error.call_args.kwargs.get("exc_info") is not True
+
+        assert mock_listener.on_event.call_count == 2
+        error_event = mock_listener.on_event.call_args_list[1][0][0]
+        assert error_event.type == "error"
+
+    @pytest.mark.asyncio
     async def test_custom_voice_response_events_update_response_sequencer(self, model, monkeypatch):
         """Dict-shaped custom voices should not block response.create sequencing."""
         payload_types: list[str] = []


### PR DESCRIPTION
## Summary

- Route realtime server-event validation failures through a small logging helper.
- Honor `_debug.DONT_LOG_MODEL_DATA` by logging only event type, event ID, and a validation summary when model-data logging is disabled.
- Avoid `exc_info=True` in the redacted path so validation exception text cannot leak raw event payloads.
- Add a regression test covering invalid realtime events with sensitive payload data.

## Why

Realtime server events can include transcript text, tool arguments, IDs, and other user or model data. Validation failures should not write that payload into logs when model-data logging is disabled.

## Tests

- `uv run pytest tests/realtime/test_openai_realtime.py::TestEventHandlingRobustness::test_handle_invalid_event_schema_redacts_payload_from_logs`
- `uv run pytest tests/realtime/test_openai_realtime.py`
- `uv run ruff check src/agents/realtime/openai_realtime.py tests/realtime/test_openai_realtime.py`