### PR TITLE
feat: expose the wrapped callable on FunctionTool (closes #3381)

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -455,6 +455,14 @@ class FunctionTool:
     )
     """Optional callback that attaches SDK-only custom data to the tool output item."""
 
+    function: ToolFunction[...] | None = field(default=None, kw_only=True, repr=False)
+    """The original Python callable wrapped by `function_tool`, when available.
+
+    This is `None` for tools that are not backed by a plain function (for example,
+    agent-as-tool or hosted-tool wrappers). It gives code outside the Agents
+    runtime a stable hook to introspect, directly test, or re-run the underlying
+    function without going through a `ToolContext`/JSON round-trip."""
+
     _failure_error_function: ToolErrorFunction | None = field(
         default=None,
         kw_only=True,
@@ -619,6 +627,7 @@ def _build_wrapped_function_tool(
     sync_invoker: bool = False,
     mcp_title: str | None = None,
     tool_origin: ToolOrigin | None = None,
+    function: ToolFunction[...] | None = None,
 ) -> FunctionTool:
     """Create a FunctionTool with copied-tool-aware failure handling bound in one place."""
     on_invoke_tool = _with_context_function_tool_failure_error_handler(
@@ -644,6 +653,7 @@ def _build_wrapped_function_tool(
             timeout_error_function=timeout_error_function,
             defer_loading=defer_loading,
             custom_data_extractor=custom_data_extractor,
+            function=function,
             _mcp_title=mcp_title,
             _tool_origin=tool_origin,
         ),
@@ -2033,6 +2043,7 @@ def function_tool(
             timeout_error_function=timeout_error_function,
             defer_loading=defer_loading,
             custom_data_extractor=custom_data_extractor,
+            function=the_func,
             sync_invoker=is_sync_function_tool,
         )
         return function_tool

--- a/tests/test_function_tool_exposes_function.py
+++ b/tests/test_function_tool_exposes_function.py
@@ -1,0 +1,45 @@
+"""Tests for FunctionTool.function — public access to the wrapped callable (#3381)."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+from agents import FunctionTool, function_tool
+
+
+def test_sync_function_tool_exposes_underlying_function() -> None:
+    @function_tool
+    def add(x: int, y: int) -> int:
+        """Add two numbers."""
+        return x + y
+
+    assert add.function is not None
+    # The original callable is reachable and runnable without a ToolContext.
+    fn = cast(Callable[[int, int], int], add.function)
+    assert fn(2, 3) == 5
+
+
+async def test_async_function_tool_exposes_underlying_function() -> None:
+    @function_tool
+    async def slow_add(x: int, y: int) -> int:
+        """Add two numbers."""
+        return x + y
+
+    assert slow_add.function is not None
+    fn = cast(Callable[[int, int], Awaitable[int]], slow_add.function)
+    assert await fn(2, 3) == 5
+
+
+def test_function_tool_function_defaults_to_none() -> None:
+    # Tools not built from a plain function (constructed directly) expose None.
+    async def _invoke(ctx: object, input: str) -> str:
+        return "ok"
+
+    tool = FunctionTool(
+        name="manual",
+        description="",
+        params_json_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        on_invoke_tool=_invoke,
+    )
+    assert tool.function is None


### PR DESCRIPTION
### Summary

Adds a public `FunctionTool.function` attribute that holds the original Python callable wrapped by `@function_tool`.

Today the wrapped function is only reachable by walking the closure of `on_invoke_tool` (`...on_invoke_tool._invoke_tool_impl.__closure__`), which is brittle and got an extra hop in 0.16 with the failure-handling indirection. This gives code outside the Agents runtime a stable hook to introspect, directly test, or re-run a tool's body without constructing a `ToolContext` and doing a JSON encode/decode cycle.

- New field is `None` for tools not backed by a plain function (agent-as-tool, hosted-tool wrappers), so the attribute is always present and safe to check.
- Added as a keyword-only dataclass field, so it does **not** change the positional constructor order of `FunctionTool`.
- Documented via the field docstring (renders in the API reference).

This revives the approach from #2146 (which was closed only over an unrelated pytest fixture-collection regression, not the concept). Happy to rename to `func` or also wire `__wrapped__` for `inspect.unwrap()` if preferred.

### Test plan

- New `tests/test_function_tool_exposes_function.py`: sync + async tools expose a runnable `.function`; directly-constructed tools expose `None`.
- `tests/test_function_tool.py` (49 tests) still pass — no regression.
- `make format`, `make lint`, `make typecheck` (mypy + pyright) clean.

### Issue number

Closes #3381

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
