### PR TITLE
Validate tool output trimmer allowlist entries

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -85,6 +85,8 @@ class ToolOutputTrimmer:
                 trimmable_tools = self.trimmable_tools
             else:
                 trimmable_tools = frozenset(self.trimmable_tools)
+            if not all(isinstance(tool_name, str) for tool_name in trimmable_tools):
+                raise ValueError("trimmable_tools iterable must contain only strings")
             object.__setattr__(self, "trimmable_tools", trimmable_tools)
 
     def __call__(self, data: CallModelData[Any]) -> ModelInputData:

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -109,6 +109,10 @@ class TestValidation:
         with pytest.raises(ValueError, match="trimmable_tools must be a string or iterable"):
             ToolOutputTrimmer(trimmable_tools=b"search")  # type: ignore[arg-type]
 
+    def test_trimmable_tools_non_string_iterable_member_raises(self) -> None:
+        with pytest.raises(ValueError, match="trimmable_tools iterable must contain only strings"):
+            ToolOutputTrimmer(trimmable_tools=["search", 1])  # type: ignore[list-item]
+
 
 # ---------------------------------------------------------------------------
 # Boundary detection


### PR DESCRIPTION
## Summary
- Validate every `trimmable_tools` iterable member is a string
- Add a focused regression test for mixed-type allowlists

## Why
`ToolOutputTrimmer.trimmable_tools` accepts a string or iterable of strings. Passing an iterable with a non-string member currently succeeds silently and stores that value in the allowlist, making configuration mistakes harder to diagnose when tool outputs are not trimmed as expected.

This keeps valid string and iterable configurations unchanged, but fails fast for invalid mixed-type iterables.

## Validation
- `python -m pytest tests/extensions/test_tool_output_trimmer.py -q`
- `python -m ruff check src/agents/extensions/tool_output_trimmer.py tests/extensions/test_tool_output_trimmer.py`
- `python -m ruff format --check src/agents/extensions/tool_output_trimmer.py tests/extensions/test_tool_output_trimmer.py`
- `git diff --check`