### PR TITLE
Create request usage entry when total_tokens is unset

### DIFF
--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -201,8 +201,12 @@ class Usage:
         # when synthesizing an entry from only the top-level fields).
         if other.request_usage_entries:
             self.request_usage_entries.extend(other.request_usage_entries)
-        elif other.requests == 1 and other.total_tokens > 0:
+        elif other.requests == 1 and (
+            other.total_tokens > 0 or other.input_tokens > 0 or other.output_tokens > 0
+        ):
             # Otherwise, if the other Usage represents a single request with tokens, record it.
+            # Some providers report input/output tokens but leave total_tokens at 0, so the
+            # entry is keyed off any non-zero token count to match the documented invariant.
             input_details = other.input_tokens_details or InputTokensDetails(cached_tokens=0)
             output_details = other.output_tokens_details or OutputTokensDetails(reasoning_tokens=0)
             request_usage = RequestUsage(

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -134,6 +134,32 @@ def test_usage_add_preserves_single_request():
     assert request_usage.output_tokens_details.reasoning_tokens == 20
 
 
+def test_usage_add_preserves_single_request_when_total_tokens_unset():
+    """A single request that reports input/output tokens but leaves total_tokens at 0
+    (some providers pass total_tokens through without populating it) still creates a
+    RequestUsage entry, matching the documented "non-zero tokens" invariant.
+    """
+    u1 = Usage()
+    u2 = Usage(
+        requests=1,
+        input_tokens=100,
+        input_tokens_details=InputTokensDetails(cached_tokens=10),
+        output_tokens=200,
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=20),
+        total_tokens=0,
+    )
+
+    u1.add(u2)
+
+    assert len(u1.request_usage_entries) == 1
+    request_usage = u1.request_usage_entries[0]
+    assert request_usage.input_tokens == 100
+    assert request_usage.output_tokens == 200
+    assert request_usage.total_tokens == 0
+    assert request_usage.input_tokens_details.cached_tokens == 10
+    assert request_usage.output_tokens_details.reasoning_tokens == 20
+
+
 def test_usage_add_ignores_zero_token_requests():
     """Test that zero-token requests don't create request_usage_entries."""
     u1 = Usage()


### PR DESCRIPTION
### Summary

`Usage.add()` only recorded a per-request entry in `request_usage_entries` when `total_tokens > 0`. A single request that reports `input_tokens`/`output_tokens` but leaves `total_tokens` at `0` still aggregated the top-level counters (`requests`, `input_tokens`, `output_tokens`) but created **no** `request_usage_entries` entry.

This contradicts the field's own documented invariant:

> Each call to `add()` automatically creates an entry in this list if the added usage represents a new request (i.e., **has non-zero tokens**).

A request with `input_tokens=100, total_tokens=0` has non-zero tokens, so an entry should be created. This is reachable in practice: `total_tokens` is passed through from the provider in the Chat Completions / LiteLLM adapters (e.g. `chatcmpl_stream_handler.py` builds `total_tokens=usage.total_tokens or 0`), so a provider that omits the total yields `input_tokens>0, total_tokens=0`. The result is a `request_usage_entries` list whose count and token sums disagree with the aggregate totals, making per-request cost/context-window accounting silently incomplete for that request.

The fix keys the entry off any non-zero token count (`total_tokens`, `input_tokens`, or `output_tokens`).

### Test plan

Added `test_usage_add_preserves_single_request_when_total_tokens_unset`: a single request with `input_tokens=100`, `output_tokens=200`, `total_tokens=0` now creates one `RequestUsage` entry. It fails before this change (`request_usage_entries` is empty) and passes after. The existing `test_usage_add_ignores_zero_token_requests` (all-zero request → no entry) still passes. `make format`, `make lint`, `mypy`, and the `tests/test_usage.py` suite pass locally.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
