### PR TITLE
docs: add external governance gate example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -21,6 +21,7 @@ Check out a variety of sample implementations of the SDK in the examples section
     -   Human-in-the-loop with tool approval and state serialization (`examples/agent_patterns/human_in_the_loop.py`)
     -   Human-in-the-loop with streaming (`examples/agent_patterns/human_in_the_loop_stream.py`)
     -   Custom rejection messages for approval flows (`examples/agent_patterns/human_in_the_loop_custom_rejection.py`)
+    -   External governance gates before local tool execution (`examples/agent_patterns/external_governance_gate.py`)
 
 -   **[basic](https://github.com/openai/openai-agents-python/tree/main/examples/basic):**
     These examples showcase foundational capabilities of the SDK, such as

--- a/docs/human_in_the_loop.md
+++ b/docs/human_in_the_loop.md
@@ -91,6 +91,41 @@ Manual `interruptions` are the most general pattern, but they are not the only o
 
 When these callbacks return a decision, the run continues without pausing for a human response. For Realtime and voice session APIs, see the approval flow in the [Realtime guide](realtime/guide.md).
 
+## External governance gates
+
+Use the interruption flow when a person should approve a call. If an automated
+policy, audit, or compliance service must decide before execution, use
+[`RunHooks.on_tool_start`][agents.lifecycle.RunHooksBase.on_tool_start] as a
+fail-closed governance gate for local tools. For function tools, the hook
+context includes the tool call ID, tool name, and serialized tool arguments.
+
+```python
+import json
+from typing import Any, cast
+
+from agents import Agent, RunContextWrapper, RunHooks, Tool
+from agents.tool_context import ToolContext
+
+
+async def external_policy_allows(tool_name: str, arguments: dict[str, Any]) -> bool:
+    ...
+
+
+class GovernanceHooks(RunHooks):
+    async def on_tool_start(self, context: RunContextWrapper, _agent: Agent, tool: Tool) -> None:
+        tool_context = cast(ToolContext[Any], context)
+        arguments = json.loads(tool_context.tool_arguments or "{}")
+
+        allowed = await external_policy_allows(tool.name, arguments)
+        if not allowed:
+            raise PermissionError(f"External governance denied tool call: {tool.name}")
+```
+
+Keep this pattern reserved for local tools. Hosted tools run server-side and do
+not pass through `on_tool_start`; use their approval callbacks instead. Store
+policy receipts in your application or policy system if you need an audit trail,
+and avoid placing secrets in serialized run state.
+
 ## Streaming and sessions
 
 The same interruption flow works in streaming runs. After a streamed run pauses, keep consuming [`RunResultStreaming.stream_events()`][agents.result.RunResultStreaming.stream_events] until the iterator finishes, inspect [`RunResultStreaming.interruptions`][agents.result.RunResultStreaming.interruptions], resolve them, and resume with [`Runner.run_streamed(...)`][agents.run.Runner.run_streamed] if you want the resumed output to keep streaming. See [Streaming](streaming.md) for the streamed version of this pattern.

--- a/examples/agent_patterns/external_governance_gate.py
+++ b/examples/agent_patterns/external_governance_gate.py
@@ -1,0 +1,56 @@
+"""External governance gate example using run hooks.
+
+This pattern is useful when a tool call must be checked by an external policy
+service before it executes. The hook fails closed by raising if the policy
+service denies the call or cannot be reached.
+"""
+
+import asyncio
+import json
+from typing import Any, cast
+
+from agents import Agent, ModelSettings, RunContextWrapper, RunHooks, Runner, Tool, function_tool
+from agents.tool_context import ToolContext
+
+
+async def external_policy_allows(tool_name: str, arguments: dict[str, Any]) -> bool:
+    """Replace this function with a call to your policy engine."""
+    if tool_name == "refund_order" and arguments.get("amount_usd", 0) > 100:
+        return False
+    return True
+
+
+class GovernanceHooks(RunHooks):
+    async def on_tool_start(self, context: RunContextWrapper, _agent: Agent, tool: Tool) -> None:
+        tool_context = cast(ToolContext[Any], context)
+        arguments = json.loads(tool_context.tool_arguments or "{}")
+
+        allowed = await external_policy_allows(tool.name, arguments)
+        if not allowed:
+            raise PermissionError(f"External governance denied tool call: {tool.name}")
+
+
+@function_tool
+async def refund_order(order_id: str, amount_usd: float) -> str:
+    """Refund an order."""
+    return f"Refunded ${amount_usd:.2f} for order {order_id}"
+
+
+async def main() -> None:
+    agent = Agent(
+        name="Refund assistant",
+        instructions="Use the refund_order tool when the user asks for a refund.",
+        model_settings=ModelSettings(tool_choice="refund_order"),
+        tools=[refund_order],
+    )
+
+    result = await Runner.run(
+        agent,
+        "Refund order order_123 for $42",
+        hooks=GovernanceHooks(),
+    )
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add an `external_governance_gate.py` agent pattern using `RunHooks.on_tool_start`
- document when to use automated governance gates versus manual HITL interruptions
- link the new example from the examples index

## Test plan
- `uv run ruff check examples/agent_patterns/external_governance_gate.py`
- `uv run python -m py_compile examples/agent_patterns/external_governance_gate.py`
- `git diff --check`

Related: https://github.com/openai/openai-agents-python/issues/3697