### PR TITLE
fix(util): preserve non-dict Mapping values in _to_dump_compatible

### DIFF
--- a/src/agents/util/_json.py
+++ b/src/agents/util/_json.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any, Literal
 
 from pydantic import TypeAdapter, ValidationError
@@ -37,7 +37,7 @@ def _to_dump_compatible(obj: Any) -> Any:
 
 
 def _to_dump_compatible_internal(obj: Any) -> Any:
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
         return {k: _to_dump_compatible_internal(v) for k, v in obj.items()}
 
     if isinstance(obj, list | tuple):

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -1,4 +1,5 @@
 import json
+from types import MappingProxyType
 
 from openai.types.responses.response_output_message_param import ResponseOutputMessageParam
 from openai.types.responses.response_output_text_param import ResponseOutputTextParam
@@ -31,3 +32,12 @@ def test_to_dump_compatible():
         result
         == """[{"id": "a75654dc-7492-4d1c-bce0-89e8312fbdd7", "content": [{"type": "output_text", "text": "Hey, what's up?", "annotations": [], "logprobs": []}], "role": "assistant", "status": "completed", "type": "message"}]"""  # noqa: E501
     )
+
+
+def test_to_dump_compatible_preserves_non_dict_mapping_values():
+    # A non-dict Mapping (e.g. MappingProxyType) must be preserved as an object,
+    # recursing into its values, instead of collapsing to a list of its keys.
+    out = _to_dump_compatible({"config": MappingProxyType({"timeout": 30, "retries": 3})})
+    assert out == {"config": {"timeout": 30, "retries": 3}}
+    # A top-level mapping is preserved as an object, not flattened to its keys.
+    assert _to_dump_compatible(MappingProxyType({"a": 1, "b": 2})) == {"a": 1, "b": 2}


### PR DESCRIPTION
### Summary

`_to_dump_compatible_internal` in `src/agents/util/_json.py` only special-cased `dict`. Any other `Mapping` (for example `types.MappingProxyType`, or a custom `collections.abc.Mapping` subclass) failed the `isinstance(obj, dict)` check, fell through to the generic `Iterable` branch, and was iterated as **keys**, silently dropping every value and collapsing the mapping to a list of its keys.

On current `main`:

```python
from types import MappingProxyType
from agents.util._json import _to_dump_compatible

_to_dump_compatible({"config": MappingProxyType({"timeout": 30, "retries": 3})})
# -> {'config': ['timeout', 'retries']}   # values 30 and 3 are gone
_to_dump_compatible(MappingProxyType({"a": 1, "b": 2}))
# -> ['a', 'b']                            # collapsed to keys
```

This helper exists to produce a JSON-`dumps`-compatible deep copy that materializes lazy iterables **while preserving structure** (added in #1683). A non-dict mapping is exactly the kind of structured container it should preserve, so silently turning it into a list of keys is a bug.

The fix matches on `collections.abc.Mapping` instead of `dict`. `dict` is a `Mapping`, so the plain-dict path and the branch ordering are unchanged, and the lazy-iterator / generator materialization that #1683 added is preserved because non-Mapping iterables still reach the `Iterable` branch.

### Test plan

- Added `tests/utils/test_json.py::test_to_dump_compatible_preserves_non_dict_mapping_values`, covering a nested `MappingProxyType` and a top-level `MappingProxyType`. It fails on `main` (`{'config': ['timeout', 'retries']} != {'config': {'timeout': 30, 'retries': 3}}`) and passes with this change.
- `uv run pytest tests/utils/test_json.py tests/models/test_model_payload_iterators.py` -> 4 passed. (`test_model_payload_iterators.py` guards the #1683 lazy-iterator materialization; it stays green, confirming no regression there.)
- Full local stack per `AGENTS.md`: `make format` (0 changes), `make lint` (passed), `make typecheck` (mypy + pyright clean on the touched files), `make tests` (4786 passed / 3 skipped parallel; 27 passed / 5 skipped serial).

### Issue number

No GitHub issue. Self-identified defect with a live repro above.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
