### PR TITLE
Add example: agent wallet pattern for authorized paid API calls

### DIFF
--- a/examples/agent_wallet/README.md
+++ b/examples/agent_wallet/README.md
@@ -1,0 +1,52 @@
+# Agent Wallet Example
+
+Demonstrates the **agent wallet pattern**: an agent that can make paid API calls, but only after proving it has the right authorization from its operator.
+
+## The Pattern
+
+When AI agents make financial API calls (paying for data, compute, or services), three questions arise:
+
+1. **Which agent** is making this call?
+2. **Does it have permission** to spend money?
+3. **Who authorized it**, and when does that authorization expire?
+
+This example shows one way to answer all three before the agent spends anything.
+
+## How It Works
+
+```
+Operator (human)
+    |
+    |-- issues credential --> Agent
+    |                          |
+    |                          |-- prove identity --> Verifier
+    |                          |                        |
+    |                          |<-- authorized ---------|
+    |                          |
+    |                          |-- pay + call ---------> Paid API
+```
+
+1. The operator issues a scoped, time-limited credential to the agent
+2. Before calling a paid API, the agent proves it holds a valid credential
+3. The verifier checks identity, permissions, and expiry
+4. Only authorized agents can proceed to the paid endpoint
+
+## Run It
+
+```bash
+uv run python examples/agent_wallet/main.py
+```
+
+The example runs against a mock paid API server (no real payments). It demonstrates:
+- An authorized agent that successfully pays for data
+- An unauthorized agent that gets blocked before spending
+
+## Files
+
+- `main.py` -- OpenAI agent with wallet authorization
+- `wallet.py` -- Pluggable identity verifier and wallet abstractions
+- `mock_server.py` -- Mock paid API server for self-contained demo
+
+## Extending
+
+The `IdentityVerifier` interface in `wallet.py` is pluggable. The example uses a structural verifier (checks credential format). For production, implement the interface with your identity system of choice (DID, JWT, ZKP, etc.).

--- a/examples/agent_wallet/main.py
+++ b/examples/agent_wallet/main.py
@@ -41,29 +41,38 @@ readonly_credential = Credential(
 
 
 # ---------------------------------------------------------------------------
-# Define tools that call the paid API
+# Tool factory — credential is bound via closure, NOT passed by the model
 # ---------------------------------------------------------------------------
 
-@function_tool
-def get_market_data(symbol: str, credential: str) -> str:
-    """Get market data for a cryptocurrency symbol.
+def make_market_data_tool(credential: str):
+    """Create a market data tool with a credential bound in the closure.
 
-    This is a paid API call that requires agent authorization.
-    The credential proves the agent has permission to spend on data access.
-
-    Args:
-        symbol: Cryptocurrency symbol (BTC, ETH, SOL).
-        credential: Agent's authorization credential.
+    The credential is supplied by trusted application code at agent setup
+    time, not by the model at runtime. This prevents the model from
+    fabricating or escalating credentials.
     """
-    result = call_paid_api(credential=credential, symbol=symbol)
-    if result.get("error"):
-        return f"Error: {result['message']}"
-    data = result["data"]
-    return (
-        f"{result['symbol']}: ${data['price']:,.2f} "
-        f"({data['change_24h']:+.1f}% 24h) "
-        f"[authorized as {result['authorized_agent']}]"
-    )
+
+    @function_tool
+    def get_market_data(symbol: str) -> str:
+        """Get market data for a cryptocurrency symbol.
+
+        This is a paid API call. Authorization is handled automatically
+        via the agent's bound credential.
+
+        Args:
+            symbol: Cryptocurrency symbol (BTC, ETH, SOL).
+        """
+        result = call_paid_api(credential=credential, symbol=symbol)
+        if result.get("error"):
+            return f"Error: {result['message']}"
+        data = result["data"]
+        return (
+            f"{result['symbol']}: ${data['price']:,.2f} "
+            f"({data['change_24h']:+.1f}% 24h) "
+            f"[authorized as {result['authorized_agent']}]"
+        )
+
+    return get_market_data
 
 
 # ---------------------------------------------------------------------------
@@ -81,11 +90,9 @@ async def run():
         name="ResearchAgent",
         instructions=(
             "You are a market research agent. Use the get_market_data tool "
-            "to look up cryptocurrency prices. Always pass the credential "
-            "provided in context.\n\n"
-            f"Your credential: {authorized_credential}"
+            "to look up cryptocurrency prices."
         ),
-        tools=[get_market_data],
+        tools=[make_market_data_tool(authorized_credential)],
     )
 
     result = await Runner.run(
@@ -103,11 +110,10 @@ async def run():
     unauthorized_agent = Agent(
         name="MonitorAgent",
         instructions=(
-            "You are a monitoring agent. Try to use get_market_data to check "
-            "BTC price. Pass the credential provided in context.\n\n"
-            f"Your credential: {readonly_credential}"
+            "You are a monitoring agent. Use get_market_data to check "
+            "the BTC price."
         ),
-        tools=[get_market_data],
+        tools=[make_market_data_tool(readonly_credential)],
     )
 
     result = await Runner.run(

--- a/examples/agent_wallet/main.py
+++ b/examples/agent_wallet/main.py
@@ -7,8 +7,12 @@ Run: uv run python examples/agent_wallet/main.py
 """
 
 import asyncio
+import os
 import sys
 import time
+
+# Ensure sibling modules are importable when run from repo root
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from agents import Agent, Runner, function_tool, gen_trace_id, trace
 from mock_server import call_paid_api
@@ -114,5 +118,7 @@ async def run():
 
 
 if __name__ == "__main__":
-    with trace("Agent Wallet Example", trace_id=gen_trace_id()):
+    trace_id = gen_trace_id()
+    print(f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n")
+    with trace("Agent Wallet Example", trace_id=trace_id):
         asyncio.run(run())

--- a/examples/agent_wallet/main.py
+++ b/examples/agent_wallet/main.py
@@ -1,0 +1,118 @@
+"""Agent Wallet Example — authorized agent payments with OpenAI Agents SDK.
+
+Demonstrates the agent wallet pattern: an agent proves it has the right
+authorization from its operator before making paid API calls.
+
+Run: uv run python examples/agent_wallet/main.py
+"""
+
+import asyncio
+import sys
+import time
+
+from agents import Agent, Runner, function_tool, gen_trace_id, trace
+from mock_server import call_paid_api
+from wallet import Credential
+
+
+# ---------------------------------------------------------------------------
+# Create credentials for two agents with different permissions
+# ---------------------------------------------------------------------------
+
+# Agent 1: authorized for paid data access
+authorized_credential = Credential(
+    agent_id="research-agent-001",
+    operator_id="operator-acme-corp",
+    permissions={"read_data", "financial_small"},
+    expiry=time.time() + 3600,  # 1 hour
+).to_json()
+
+# Agent 2: read-only, NOT authorized for financial operations
+readonly_credential = Credential(
+    agent_id="monitor-agent-002",
+    operator_id="operator-acme-corp",
+    permissions={"read_data"},
+    expiry=time.time() + 3600,
+).to_json()
+
+
+# ---------------------------------------------------------------------------
+# Define tools that call the paid API
+# ---------------------------------------------------------------------------
+
+@function_tool
+def get_market_data(symbol: str, credential: str) -> str:
+    """Get market data for a cryptocurrency symbol.
+
+    This is a paid API call that requires agent authorization.
+    The credential proves the agent has permission to spend on data access.
+
+    Args:
+        symbol: Cryptocurrency symbol (BTC, ETH, SOL).
+        credential: Agent's authorization credential.
+    """
+    result = call_paid_api(credential=credential, symbol=symbol)
+    if result.get("error"):
+        return f"Error: {result['message']}"
+    data = result["data"]
+    return (
+        f"{result['symbol']}: ${data['price']:,.2f} "
+        f"({data['change_24h']:+.1f}% 24h) "
+        f"[authorized as {result['authorized_agent']}]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run two scenarios
+# ---------------------------------------------------------------------------
+
+async def run():
+    # Scenario 1: Authorized agent
+    print("=" * 60)
+    print("Scenario 1: Authorized agent (research-agent-001)")
+    print("  Permissions: read_data, financial_small")
+    print("=" * 60)
+
+    authorized_agent = Agent(
+        name="ResearchAgent",
+        instructions=(
+            "You are a market research agent. Use the get_market_data tool "
+            "to look up cryptocurrency prices. Always pass the credential "
+            "provided in context.\n\n"
+            f"Your credential: {authorized_credential}"
+        ),
+        tools=[get_market_data],
+    )
+
+    result = await Runner.run(
+        starting_agent=authorized_agent,
+        input="Get the current price of BTC and ETH.",
+    )
+    print(f"\nResult: {result.final_output}\n")
+
+    # Scenario 2: Unauthorized agent (lacks financial_small)
+    print("=" * 60)
+    print("Scenario 2: Unauthorized agent (monitor-agent-002)")
+    print("  Permissions: read_data only (no financial_small)")
+    print("=" * 60)
+
+    unauthorized_agent = Agent(
+        name="MonitorAgent",
+        instructions=(
+            "You are a monitoring agent. Try to use get_market_data to check "
+            "BTC price. Pass the credential provided in context.\n\n"
+            f"Your credential: {readonly_credential}"
+        ),
+        tools=[get_market_data],
+    )
+
+    result = await Runner.run(
+        starting_agent=unauthorized_agent,
+        input="Get the current BTC price.",
+    )
+    print(f"\nResult: {result.final_output}\n")
+
+
+if __name__ == "__main__":
+    with trace("Agent Wallet Example", trace_id=gen_trace_id()):
+        asyncio.run(run())

--- a/examples/agent_wallet/mock_server.py
+++ b/examples/agent_wallet/mock_server.py
@@ -1,0 +1,59 @@
+"""Mock paid API server for the agent wallet example.
+
+Simulates a paid data API that requires agent authorization before serving.
+No real payments or network calls -- everything runs locally.
+"""
+
+from __future__ import annotations
+
+from wallet import VerificationResult, authorize_agent
+
+# Mock data that the "paid API" serves
+_MARKET_DATA = {
+    "BTC": {"price": 68420.50, "change_24h": 2.3},
+    "ETH": {"price": 3850.25, "change_24h": -0.8},
+    "SOL": {"price": 142.80, "change_24h": 5.1},
+}
+
+
+def call_paid_api(
+    credential: str,
+    symbol: str,
+) -> dict:
+    """Simulate a paid API call with authorization check.
+
+    Args:
+        credential: The agent's credential for authorization.
+        symbol: The market data symbol to look up.
+
+    Returns:
+        API response dict with data or error.
+    """
+    # Step 1: Verify authorization
+    result = authorize_agent(
+        credential=credential,
+        required_permissions={"read_data", "financial_small"},
+    )
+
+    if not result.authorized:
+        return {
+            "error": "unauthorized",
+            "message": f"Agent '{result.agent_id}' denied: {result.reason}",
+            "status": 401,
+        }
+
+    # Step 2: Serve the data (agent is authorized)
+    data = _MARKET_DATA.get(symbol.upper())
+    if not data:
+        return {
+            "error": "not_found",
+            "message": f"No data for symbol '{symbol}'",
+            "status": 404,
+        }
+
+    return {
+        "status": 200,
+        "symbol": symbol.upper(),
+        "data": data,
+        "authorized_agent": result.agent_id,
+    }

--- a/examples/agent_wallet/wallet.py
+++ b/examples/agent_wallet/wallet.py
@@ -1,0 +1,138 @@
+"""Pluggable identity verification and wallet abstractions for agent payments.
+
+This module defines the interfaces for agent authorization before financial
+API calls. The verifier is pluggable -- swap in any identity system (DID,
+JWT, ZKP, API keys) by implementing IdentityVerifier.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Credential:
+    """An operator-issued credential granting an agent specific permissions."""
+
+    agent_id: str
+    operator_id: str
+    permissions: set[str]
+    expiry: float
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "agent_id": self.agent_id,
+            "operator_id": self.operator_id,
+            "permissions": sorted(self.permissions),
+            "expiry": self.expiry,
+            **self.metadata,
+        })
+
+    @classmethod
+    def from_json(cls, raw: str) -> "Credential":
+        data = json.loads(raw)
+        return cls(
+            agent_id=data["agent_id"],
+            operator_id=data["operator_id"],
+            permissions=set(data.get("permissions", [])),
+            expiry=data.get("expiry", 0),
+            metadata={
+                k: v
+                for k, v in data.items()
+                if k not in ("agent_id", "operator_id", "permissions", "expiry")
+            },
+        )
+
+
+@dataclass
+class VerificationResult:
+    """Result of a credential verification check."""
+
+    authorized: bool
+    agent_id: str = ""
+    permissions: set[str] = field(default_factory=set)
+    reason: str = ""
+
+
+class IdentityVerifier(ABC):
+    """Interface for agent identity verification.
+
+    Implement this to plug in any identity system: DID, JWT, ZKP, API keys, etc.
+    """
+
+    @abstractmethod
+    def verify(self, credential: str) -> VerificationResult:
+        """Verify a credential and return the result."""
+
+
+class StructuralVerifier(IdentityVerifier):
+    """Development verifier that checks credential structure only.
+
+    NOT for production -- use a real verifier for deployed systems.
+    """
+
+    def verify(self, credential: str) -> VerificationResult:
+        try:
+            cred = Credential.from_json(credential)
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            return VerificationResult(
+                authorized=False, reason=f"invalid credential: {e}"
+            )
+
+        if cred.expiry and cred.expiry < time.time():
+            return VerificationResult(
+                authorized=False,
+                agent_id=cred.agent_id,
+                reason="credential expired",
+            )
+
+        if not cred.permissions:
+            return VerificationResult(
+                authorized=False,
+                agent_id=cred.agent_id,
+                reason="no permissions granted",
+            )
+
+        return VerificationResult(
+            authorized=True,
+            agent_id=cred.agent_id,
+            permissions=cred.permissions,
+        )
+
+
+def authorize_agent(
+    credential: str,
+    required_permissions: set[str],
+    verifier: IdentityVerifier | None = None,
+) -> VerificationResult:
+    """Check if an agent is authorized to perform an action.
+
+    Args:
+        credential: The agent's credential string.
+        required_permissions: Permissions needed for this action.
+        verifier: Verifier to use. Defaults to StructuralVerifier.
+
+    Returns:
+        VerificationResult indicating whether the agent is authorized.
+    """
+    v = verifier or StructuralVerifier()
+    result = v.verify(credential)
+
+    if not result.authorized:
+        return result
+
+    missing = required_permissions - result.permissions
+    if missing:
+        return VerificationResult(
+            authorized=False,
+            agent_id=result.agent_id,
+            permissions=result.permissions,
+            reason=f"missing permissions: {sorted(missing)}",
+        )
+
+    return result

--- a/examples/agent_wallet/wallet.py
+++ b/examples/agent_wallet/wallet.py
@@ -84,7 +84,14 @@ class StructuralVerifier(IdentityVerifier):
                 authorized=False, reason=f"invalid credential: {e}"
             )
 
-        if cred.expiry and cred.expiry < time.time():
+        if not cred.expiry or cred.expiry <= 0:
+            return VerificationResult(
+                authorized=False,
+                agent_id=cred.agent_id,
+                reason="credential missing required expiry",
+            )
+
+        if cred.expiry < time.time():
             return VerificationResult(
                 authorized=False,
                 agent_id=cred.agent_id,


### PR DESCRIPTION
## Summary

Adds an example demonstrating the **agent wallet pattern**: an agent proves it has the right authorization from its operator before making paid API calls.

**The pattern:** Before an agent spends money on an API call, it must prove:
- Which agent is making the call
- That it has permission to make financial requests
- Who authorized it, and when that authorization expires

**What the example shows:**
- Scenario 1: An authorized agent (read_data + financial_small) successfully gets market data
- Scenario 2: A read-only agent gets blocked before spending

**Files added:**
- `examples/agent_wallet/main.py` -- two-scenario demo using the Agents SDK
- `examples/agent_wallet/wallet.py` -- pluggable `IdentityVerifier` interface + structural verifier
- `examples/agent_wallet/mock_server.py` -- mock paid API (no real payments)
- `examples/agent_wallet/README.md` -- pattern explanation + usage

Self-contained, no external dependencies beyond the agents SDK.

## Test plan

- [ ] `uv run python examples/agent_wallet/main.py` runs both scenarios
- [ ] Authorized agent returns market data
- [ ] Unauthorized agent gets blocked with clear error message