### PR TITLE
Docs: clarify when to use a guardrail vs. tool approval

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -60,6 +60,8 @@ Tool guardrails wrap **function tools** and let you validate or block tool calls
 - If a function tool requires approval, input tool guardrails normally run after approval and immediately before execution. Set [`RunConfig.tool_execution`][agents.run.RunConfig.tool_execution] to [`ToolExecutionConfig(pre_approval_tool_input_guardrails=True)`][agents.run.ToolExecutionConfig] when you want those input checks to run before the pending approval interruption is emitted. Calls that pass this pre-approval check are still checked again after approval before the tool executes.
 - Tool guardrails apply only to function tools created with [`function_tool`][agents.tool.function_tool]. Handoffs run through the SDK's handoff pipeline rather than the normal function-tool pipeline, so tool guardrails do not apply to the handoff call itself. Hosted tools (`WebSearchTool`, `FileSearchTool`, `HostedMCPTool`, `CodeInterpreterTool`, `ImageGenerationTool`) and built-in execution tools (`ComputerTool`, `ShellTool`, `ApplyPatchTool`, `LocalShellTool`) also do not use this guardrail pipeline, and [`Agent.as_tool()`][agents.agent.Agent.as_tool] does not currently expose tool-guardrail options directly.
 
+Tool guardrails check the *content* of a tool call and decide automatically. If you instead need a human or an external system to sign off before a consequential tool runs, use tool approval (`needs_approval`), which pauses the run rather than checking content. For guidance on choosing between the two, see [Guardrails vs. tool approval — which gate when](human_in_the_loop.md#guardrails-vs-tool-approval-which-gate-when).
+
 See the code snippet below for details.
 
 ## Tripwires

--- a/docs/human_in_the_loop.md
+++ b/docs/human_in_the_loop.md
@@ -8,6 +8,51 @@ With `Agent.as_tool()`, approvals can happen at two different layers: the agent 
 
 This page focuses on the manual approval flow via `interruptions`. If your app can decide in code, some tool types also support programmatic approval callbacks so the run can continue without pausing.
 
+## Guardrails vs. tool approval — which gate when
+
+[Guardrails](guardrails.md) and tool approval are both interception points, and they are complementary rather than interchangeable. A common question is which one to reach for:
+
+| | Guardrails (input/output and tool guardrails) | Tool approval (`needs_approval`) |
+|---|---|---|
+| **What it checks** | The *content* of input, output, or tool arguments/results | Whether a *specific tool call* is allowed to run |
+| **Granularity** | Per run input/output, or per function-tool invocation | Per tool call (the rule sees the parsed arguments and the call ID) |
+| **On trigger** | A tripwire raises a `{Input,Output}GuardrailTripwireTriggered` exception and **halts the run** (tool guardrails can instead skip or replace the call) | The run **pauses**; the call surfaces in `RunResult.interruptions` as a [`ToolApprovalItem`][agents.items.ToolApprovalItem] |
+| **Who decides** | A fast model or your own code, inline and automatically | A human or an external system, out of band |
+| **How it resumes** | Not applicable for a tripwire — the run has stopped | `state.approve(item)` / `state.reject(item)`, then resume with `Runner.run(agent, state)` |
+| **Default** | None until you attach a guardrail | `needs_approval=False` — approval is **off** until you opt a tool in |
+
+Rules of thumb:
+
+-   Use a **guardrail** to automatically reject disallowed *content* — jailbreak attempts, off-topic requests, secrets in tool arguments, sensitive data in tool output.
+-   Use **`needs_approval`** to require sign-off before a consequential *action* — sending an email, issuing a refund, deleting records, running a shell command.
+
+A request can pass every content guardrail and still call a tool like `send_email` or `delete_records`; deciding whether that *call* is permitted is what tool approval is for. The two can be combined on the same tool — see [Tool guardrails](guardrails.md#tool-guardrails) for the ordering when both apply.
+
+!!! Note
+
+    `needs_approval` defaults to `False`, so approval is opt-in per tool rather than deny-by-default. Gate each consequential tool explicitly:
+
+    ```python
+    from agents import function_tool
+
+
+    @function_tool(needs_approval=True)
+    async def delete_records(table: str) -> str:
+        return f"Deleted records in {table}"
+    ```
+
+    For a dynamic policy, pass an async callable. It receives the run context, the parsed tool arguments, and the tool call ID, and returns whether approval is required:
+
+    ```python
+    async def needs_review(_ctx, params, _call_id) -> bool:
+        return params.get("amount", 0) > 100  # require approval over $100
+
+
+    @function_tool(needs_approval=needs_review)
+    async def issue_refund(amount: int) -> str:
+        return f"Refunded ${amount}"
+    ```
+
 ## Marking tools that need approval
 
 Set `needs_approval` to `True` to always require approval or provide an async function that decides per call. The callable receives the run context, parsed tool parameters, and the tool call ID.

--- a/docs/human_in_the_loop.md
+++ b/docs/human_in_the_loop.md
@@ -16,7 +16,7 @@ This page focuses on the manual approval flow via `interruptions`. If your app c
 |---|---|---|
 | **What it checks** | The *content* of input, output, or tool arguments/results | Whether a *specific tool call* is allowed to run |
 | **Granularity** | Per run input/output, or per function-tool invocation | Per tool call (the rule sees the parsed arguments and the call ID) |
-| **On trigger** | A tripwire raises a `{Input,Output}GuardrailTripwireTriggered` exception and **halts the run** (tool guardrails can instead skip or replace the call) | The run **pauses**; the call surfaces in `RunResult.interruptions` as a [`ToolApprovalItem`][agents.items.ToolApprovalItem] |
+| **On trigger** | Agent input/output guardrails raise `{Input,Output}GuardrailTripwireTriggered` and **halt the run**. A tool guardrail can `reject_content` (skip/replace the call and continue) or `raise_exception` → `ToolGuardrailTripwireTriggered` (**halt**) | The run **pauses**; the call surfaces in `RunResult.interruptions` as a [`ToolApprovalItem`][agents.items.ToolApprovalItem] |
 | **Who decides** | A fast model or your own code, inline and automatically | A human or an external system, out of band |
 | **How it resumes** | Not applicable for a tripwire — the run has stopped | `state.approve(item)` / `state.reject(item)`, then resume with `Runner.run(agent, state)` |
 | **Default** | None until you attach a guardrail | `needs_approval=False` — approval is **off** until you opt a tool in |


### PR DESCRIPTION
﻿### What
Adds a "Guardrails vs. tool approval — which gate when" section to
`docs/human_in_the_loop.md`, plus a one-line cross-reference from the
"Tool guardrails" section of `docs/guardrails.md`.

### Why
The SDK ships two distinct interception points — input/output/tool **guardrails**
(content checks that can tripwire-halt a run, or skip/replace a tool call) and
per-tool **`needs_approval`** (pauses a specific tool call into
`RunResult.interruptions` for an out-of-band decision) — and even documents their
*ordering*, but never says *which one to reach for*. Users repeatedly conflate the
two (e.g. #2868). This adds a decision table, rules of thumb, and the safety note
that `needs_approval` defaults to `False` (opt-in, not deny-by-default), with an
explicit gating recipe and the dynamic `(ctx, params, call_id) -> bool` callable form.

### Scope
Docs-only, additive, no new dependency. Folded into the existing in-nav
`human_in_the_loop.md` rather than a new page, to avoid touching the i18n
(ja/ko/zh) nav blocks. Happy to split into a standalone page if preferred — the
section lifts out cleanly.

### Verification
- `mkdocs build` succeeds; built with and without this change — both emit an
  identical set of pre-existing warnings (zero new warnings), and the new anchor
  and cross-reference resolve in the generated HTML.
- All API symbols in the snippets were checked against `openai-agents` 0.17.7:
  `function_tool(needs_approval=...)` (default `False`), the async
  `(ctx, params, call_id) -> bool` callable, `RunResult.interruptions`,
  `RunResult.to_state()`, `RunState.approve(item)`, `RunState.reject(item, ...)`,
  and `Runner.run(agent, state)`.
