### PR TITLE
fix(sandbox): use consistent model for memory phase one and phase two

### DIFF
--- a/src/agents/sandbox/config.py
+++ b/src/agents/sandbox/config.py
@@ -49,7 +49,7 @@ class MemoryGenerateConfig:
     )
     """Model settings used for phase-1 single-rollout extraction."""
 
-    phase_two_model: str | Model = "gpt-5.5"
+    phase_two_model: str | Model = "gpt-5.4-mini"
     """Model used for phase-2 memory consolidation."""
 
     phase_two_model_settings: ModelSettings | None = field(

--- a/tests/sandbox/test_memory.py
+++ b/tests/sandbox/test_memory.py
@@ -627,6 +627,13 @@ def test_memory_layout_config_defaults_match_codex_names() -> None:
     assert config.sessions_dir == "sessions"
 
 
+def test_memory_generate_config_phase_models_default_to_same_model() -> None:
+    config = MemoryGenerateConfig()
+
+    assert config.phase_one_model == "gpt-5.4-mini"
+    assert config.phase_two_model == "gpt-5.4-mini"
+
+
 def test_memory_generate_config_accepts_renamed_limit_field() -> None:
     config = MemoryGenerateConfig(max_raw_memories_for_consolidation=123)
 


### PR DESCRIPTION
The memory generation system uses two phases: phase one extracts raw memories from individual rollouts, and phase two consolidates them. Previously, phase one defaulted to model-5.4-mini while phase two hardcoded model-5.5, causing inconsistent model usage during memory generation that was visible in traces and could confuse users who set a custom model in example scripts.

Changed the default for `MemoryGenerateConfig.phase_two_model` in `/work/repo/src/agents/sandbox/config.py` from "model-5.5" to "model-5.4-mini" to match `phase_one_model`. Both phases now use the same default model, ensuring consistent behavior and eliminating unexpected model switches during memory consolidation.

Added a regression test in `/work/repo/tests/sandbox/test_memory.py` to verify both phase models use the same default value.

Fixes #3703