### PR TITLE
feat(models): add ModelSettings.defer_structured_output_until_done

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -79,6 +79,7 @@ _TRACEABLE_MODEL_SETTING_FIELDS = (
     "top_logprobs",
     "retry",
     "context_management",
+    "defer_structured_output_until_done",
 )
 
 
@@ -189,6 +190,18 @@ class ModelSettings:
 
     For example, use ``[{"type": "compaction", "compact_threshold": 200000}]``
     to enable server-side compaction when the rendered context crosses a token threshold.
+    """
+
+    defer_structured_output_until_done: bool | None = None
+    """Opt-in: defer structured output until the model stops calling tools.
+
+    When an agent has both tools and a non-plain ``output_type`` (structured output), enabling
+    this flag stops the runner from enforcing the ``response_format``/``output_schema`` on every
+    model call. Instead the model is allowed to call tools and produce a free-text answer first,
+    and the structured output is requested in a single extra, tool-free model call once the model
+    is done. This is for compatibility with OpenAI-compatible servers that enforce
+    ``response_format`` strictly from the first token (e.g. vLLM), which would otherwise suppress
+    tool calls. Defaults to ``None`` (disabled), in which case behavior is unchanged.
     """
 
     def resolve(self, override: ModelSettings | None) -> ModelSettings:

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -86,7 +86,7 @@ from .run_internal.run_loop import (
     get_handoffs,
     get_output_schema,
     initialize_computer_tools,
-    resolve_interrupted_turn,
+    resolve_interrupted_turn_with_deferred_structuring,
     run_final_output_hooks,
     run_input_guardrails,
     run_output_guardrails,
@@ -846,7 +846,7 @@ class AgentRunner:
                             ):
                                 raise UserError("No model response found in previous state")
 
-                            turn_result = await resolve_interrupted_turn(
+                            turn_result = await resolve_interrupted_turn_with_deferred_structuring(
                                 bindings=current_bindings,
                                 original_input=original_input,
                                 original_pre_step_items=generated_items,
@@ -857,6 +857,10 @@ class AgentRunner:
                                 run_config=run_config,
                                 server_manages_conversation=server_conversation_tracker is not None,
                                 run_state=run_state,
+                                server_conversation_tracker=server_conversation_tracker,
+                                tool_use_tracker=tool_use_tracker,
+                                session=session,
+                                prompt_cache_key_resolver=prompt_cache_key_resolver,
                             )
 
                             if run_state._last_processed_response is not None:
@@ -1281,6 +1285,7 @@ class AgentRunner:
                     last_saved_input_snapshot_for_rewind = None
                     should_run_agent_start_hooks = False
 
+                    model_responses.extend(turn_result.preceding_model_responses)
                     model_responses.append(turn_result.model_response)
                     original_input = turn_result.original_input
                     # For model input, use new_step_items (filtered on handoffs).

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -16,6 +16,7 @@ from openai.types.responses import (
     ResponseCompletedEvent,
     ResponseFunctionToolCall,
     ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
 )
 from openai.types.responses.response_output_item import McpCall, McpListTools, ResponseOutputItem
 from openai.types.responses.response_prompt_param import ResponsePromptParam
@@ -39,10 +40,11 @@ from ..exceptions import (
     RunErrorDetails,
     UserError,
 )
-from ..handoffs import Handoff
+from ..handoffs import Handoff, HandoffInputData
 from ..items import (
     HandoffCallItem,
     ItemHelpers,
+    MessageOutputItem,
     ModelResponse,
     ReasoningItem,
     RunItem,
@@ -58,6 +60,7 @@ from ..items import (
 from ..lifecycle import RunHooks
 from ..logger import logger
 from ..memory import Session
+from ..model_settings import ModelSettings
 from ..models._response_terminal import (
     response_error_event_failure_error,
     response_terminal_failure_error,
@@ -88,6 +91,7 @@ from ..usage import Usage
 from ..util import _coro, _error_tracing
 from .agent_bindings import AgentBindings, bind_public_agent
 from .agent_runner_helpers import (
+    append_model_response_if_new,
     apply_resumed_conversation_settings,
     attach_usage_to_span,
     get_unsent_tool_call_ids_for_interrupted_state,
@@ -222,6 +226,7 @@ __all__ = [
     "QueueCompleteSentinel",
     "execute_tools_and_side_effects",
     "resolve_interrupted_turn",
+    "resolve_interrupted_turn_with_deferred_structuring",
     "execute_function_tool_calls",
     "execute_local_shell_calls",
     "execute_shell_calls",
@@ -734,7 +739,7 @@ async def start_streaming(
 
                     last_model_response = run_state._model_responses[-1]
 
-                    turn_result = await resolve_interrupted_turn(
+                    turn_result = await resolve_interrupted_turn_with_deferred_structuring(
                         bindings=current_bindings,
                         original_input=run_state._original_input,
                         original_pre_step_items=run_state._generated_items,
@@ -745,6 +750,17 @@ async def start_streaming(
                         run_config=run_config,
                         server_manages_conversation=server_conversation_tracker is not None,
                         run_state=run_state,
+                        server_conversation_tracker=server_conversation_tracker,
+                        tool_use_tracker=tool_use_tracker,
+                        session=session,
+                        prompt_cache_key_resolver=prompt_cache_key_resolver,
+                    )
+
+                    # A deferred resume makes a new (structuring) model call; record it in
+                    # raw_responses. Use if-new semantics so a non-deferred resume -- whose
+                    # model_response is the already-seeded interrupted response -- isn't duplicated.
+                    append_model_response_if_new(
+                        streamed_result.raw_responses, turn_result.model_response
                     )
 
                     tool_use_tracker.record_processed_response(
@@ -1058,9 +1074,11 @@ async def start_streaming(
                     ),
                 )
 
-                streamed_result.raw_responses = streamed_result.raw_responses + [
-                    turn_result.model_response
-                ]
+                streamed_result.raw_responses = (
+                    streamed_result.raw_responses
+                    + turn_result.preceding_model_responses
+                    + [turn_result.model_response]
+                )
                 streamed_result.input = turn_result.original_input
                 if isinstance(turn_result.next_step, NextStepHandoff):
                     streamed_result._original_input = copy_input_items(turn_result.original_input)
@@ -1345,6 +1363,12 @@ async def run_single_turn_streamed(
     model_settings = get_model_settings(execution_agent, run_config)
     model_settings = maybe_reset_tool_choice(public_agent, tool_use_tracker, model_settings)
 
+    defer = _should_defer_structured_output(model_settings, output_schema, all_tools, handoffs)
+    # When deferring, suppress the schema on this streamed call so strict servers don't block tool
+    # calls and the free-text answer isn't validated as JSON; structured output is re-requested
+    # via a single non-streamed call once the model is done (see below).
+    effective_output_schema = None if defer else output_schema
+
     final_response: ModelResponse | None = None
     streamed_response_output: list[ResponseOutputItem] = []
 
@@ -1463,7 +1487,7 @@ async def run_single_turn_streamed(
             filtered.input,
             model_settings,
             all_tools,
-            output_schema,
+            effective_output_schema,
             handoffs,
             get_model_tracing_impl(
                 run_config.tracing_disabled, run_config.trace_include_sensitive_data
@@ -1649,7 +1673,7 @@ async def run_single_turn_streamed(
         original_input=streamed_result.input,
         pre_step_items=streamed_result._model_input_items,
         new_response=final_response,
-        output_schema=output_schema,
+        output_schema=effective_output_schema,
         all_tools=all_tools,
         handoffs=handoffs,
         hooks=hooks,
@@ -1660,7 +1684,34 @@ async def run_single_turn_streamed(
         server_manages_conversation=server_conversation_tracker is not None,
         event_queue=streamed_result._event_queue,
         before_side_effects=raise_if_input_guardrail_tripwire_known,
+        run_final_output_hooks_fn=_skip_final_output_hooks if defer else None,
     )
+
+    if (
+        defer
+        and output_schema is not None
+        and isinstance(single_step_result.next_step, NextStepFinalOutput)
+    ):
+        # The model finished calling tools and produced a free-text answer; make one extra
+        # non-streamed call to structure it. The tool-calling turns already streamed -- only the
+        # final structured object comes from this call.
+        single_step_result = await _run_deferred_structuring_pass(
+            bindings=bindings,
+            single_step_result=single_step_result,
+            original_input=streamed_result.input,
+            generated_items=single_step_result.generated_items,
+            system_instructions=system_prompt,
+            prompt_config=prompt_config,
+            output_schema=output_schema,
+            run_config=run_config,
+            hooks=hooks,
+            context_wrapper=context_wrapper,
+            tool_use_tracker=tool_use_tracker,
+            server_conversation_tracker=server_conversation_tracker,
+            reasoning_item_id_policy=reasoning_item_id_policy,
+            session=session,
+            prompt_cache_key_resolver=prompt_cache_key_resolver,
+        )
 
     items_to_filter = session_items_for_turn(single_step_result)
 
@@ -1703,6 +1754,255 @@ async def run_single_turn_streamed(
     filtered_result = _dc.replace(single_step_result, new_step_items=items_to_filter)
     stream_step_result_to_queue(filtered_result, streamed_result._event_queue)
     return single_step_result
+
+
+async def _skip_final_output_hooks(
+    agent: Agent[Any],
+    hooks: RunHooks[Any],
+    context_wrapper: RunContextWrapper[Any],
+    final_output: Any,
+) -> None:
+    """No-op end-of-run hooks for the intermediate turn of a deferred-structured-output run.
+
+    When structured output is deferred, the free-text turn reaches ``NextStepFinalOutput`` but is
+    not actually the end of the run -- the deferred structuring pass runs the real end hooks once
+    it produces the structured output (or, if it cannot, fires them itself with the plain-text
+    output). Without this, ``on_agent_end``/``Agent.hooks.on_end`` would fire twice per run.
+    """
+    return None
+
+
+def _should_defer_structured_output(
+    model_settings: ModelSettings,
+    output_schema: AgentOutputSchemaBase | None,
+    all_tools: list[Tool],
+    handoffs: list[Handoff],
+) -> bool:
+    """Decide whether structured output should be deferred until the model stops calling tools.
+
+    Only opt-in (``defer_structured_output_until_done``) agents with a non-plain structured
+    ``output_type`` and at least one model-side tool defer; everything else keeps today's behavior.
+    Handoffs count as model tools (they are sent as tool definitions), so a structured-output agent
+    with only handoffs is exactly the case this opt-in is meant to protect.
+    """
+    return bool(
+        model_settings.defer_structured_output_until_done
+        and output_schema is not None
+        and not output_schema.is_plain_text()
+        and (len(all_tools) > 0 or len(handoffs) > 0)
+    )
+
+
+async def _run_deferred_structuring_pass(
+    *,
+    bindings: AgentBindings[TContext],
+    single_step_result: SingleStepResult,
+    original_input: str | list[TResponseInputItem],
+    generated_items: list[RunItem],
+    system_instructions: str | None,
+    prompt_config: ResponsePromptParam | None,
+    output_schema: AgentOutputSchemaBase,
+    run_config: RunConfig,
+    hooks: RunHooks[TContext],
+    context_wrapper: RunContextWrapper[TContext],
+    tool_use_tracker: AgentToolUseTracker,
+    server_conversation_tracker: OpenAIServerConversationTracker | None,
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None,
+    session: Session | None = None,
+    prompt_cache_key_resolver: PromptCacheKeyResolver | None = None,
+) -> SingleStepResult:
+    """Make one extra tool-free model call to structure the model's free-text final answer.
+
+    Used when structured output was deferred (see ``_should_defer_structured_output``): the model
+    has finished calling tools and produced a plain-text answer, so we re-ask the model -- with no
+    tools and the real ``output_schema`` -- to emit the structured output. The call goes through the
+    normal ``get_new_response`` path, so input filtering, lifecycle hooks, retries, prompt caching
+    and usage accounting are all reused. The validated object replaces the step's final output and
+    the structuring response's items are appended to history.
+    """
+    public_agent = bindings.public_agent
+
+    # Acknowledge the free-text response that triggered deferral before building the structuring
+    # input, so server-managed conversations (previous_response_id / conversation_id) continue from
+    # it instead of re-sending the assistant message from stale state. The streamed path already
+    # tracks the terminal response before reaching here; track_server_items is idempotent.
+    if server_conversation_tracker is not None:
+        server_conversation_tracker.track_server_items(single_step_result.model_response)
+
+    # Build the same input the next turn would have used (accumulated input + this turn's items).
+    if server_conversation_tracker is not None:
+        structuring_input = server_conversation_tracker.prepare_input(
+            original_input, generated_items
+        )
+    else:
+        structuring_input = _prepare_turn_input_items(
+            original_input, generated_items, reasoning_item_id_policy
+        )
+
+    # Reuse the normal model-call path with no tools/handoffs and the real schema. get_new_response
+    # neutralizes any forcing tool_choice for the empty tool list, and handles input filtering,
+    # on_llm_start/on_llm_end, retries, prompt caching, server-input tracking and usage.
+    structuring_response = await get_new_response(
+        bindings,
+        system_instructions,
+        structuring_input,
+        output_schema,
+        [],
+        [],
+        hooks,
+        context_wrapper,
+        run_config,
+        tool_use_tracker,
+        server_conversation_tracker,
+        prompt_config,
+        session=session,
+        prompt_cache_key_resolver=prompt_cache_key_resolver,
+    )
+
+    # Wrap the structuring response's message items and capture the text to validate.
+    structured_text: str | None = None
+    structuring_items: list[RunItem] = []
+    for raw_item in structuring_response.output:
+        if isinstance(raw_item, ResponseOutputMessage):
+            structuring_items.append(MessageOutputItem(raw_item=raw_item, agent=public_agent))
+            extracted = ItemHelpers.extract_text(raw_item)
+            if extracted:
+                structured_text = extracted
+
+    if structured_text is None:
+        # The structuring call produced no text; fall back to the deferred plain-text result. End
+        # hooks were suppressed on the deferred turn, so fire them now with the plain-text output --
+        # this branch is the actual end of the run.
+        if isinstance(single_step_result.next_step, NextStepFinalOutput):
+            await run_final_output_hooks(
+                public_agent, hooks, context_wrapper, single_step_result.next_step.output
+            )
+        # The structuring model call still happened (its usage and on_llm_end already fired), so
+        # record it in raw_responses after the free-text response. Keep the free-text result as the
+        # final output; model_response becomes the structuring response (the last actual call) so
+        # the raw-response order and last_response_id stay correct.
+        single_step_result.preceding_model_responses = [
+            *single_step_result.preceding_model_responses,
+            single_step_result.model_response,
+        ]
+        single_step_result.model_response = structuring_response
+        return single_step_result
+
+    final_output = output_schema.validate_json(structured_text)
+
+    new_step_items = list(single_step_result.new_step_items) + structuring_items
+
+    structured_step_result = await execute_final_output(
+        public_agent=public_agent,
+        original_input=single_step_result.original_input,
+        new_response=structuring_response,
+        pre_step_items=single_step_result.pre_step_items,
+        new_step_items=new_step_items,
+        final_output=final_output,
+        hooks=hooks,
+        context_wrapper=context_wrapper,
+        tool_input_guardrail_results=single_step_result.tool_input_guardrail_results,
+        tool_output_guardrail_results=single_step_result.tool_output_guardrail_results,
+    )
+    # This step made two model calls -- the free-text response and the structuring response above.
+    # Carry the free-text response so the runner records both in raw_responses (in call order),
+    # keeping the raw-response count aligned with the number of model calls.
+    structured_step_result.preceding_model_responses = [
+        *single_step_result.preceding_model_responses,
+        single_step_result.model_response,
+    ]
+    return structured_step_result
+
+
+async def resolve_interrupted_turn_with_deferred_structuring(
+    *,
+    bindings: AgentBindings[TContext],
+    original_input: str | list[TResponseInputItem],
+    original_pre_step_items: list[RunItem],
+    new_response: ModelResponse,
+    processed_response: ProcessedResponse,
+    hooks: RunHooks[TContext],
+    context_wrapper: RunContextWrapper[TContext],
+    run_config: RunConfig,
+    server_manages_conversation: bool = False,
+    run_state: RunState | None = None,
+    nest_handoff_history_fn: Callable[..., HandoffInputData] | None = None,
+    server_conversation_tracker: OpenAIServerConversationTracker | None = None,
+    tool_use_tracker: AgentToolUseTracker,
+    session: Session | None = None,
+    prompt_cache_key_resolver: PromptCacheKeyResolver | None = None,
+) -> SingleStepResult:
+    """Resume an interrupted (HITL-approval) turn, applying deferred structured output if enabled.
+
+    Wraps ``resolve_interrupted_turn`` so a resumed turn that finalizes from an approved tool
+    (e.g. ``tool_use_behavior="stop_on_first_tool"``) with ``defer_structured_output_until_done``
+    still suppresses the intermediate end hooks and runs the structuring pass -- matching the
+    fresh-turn path. Non-deferred resumes are unaffected (no extra work, identical behavior).
+    """
+    execution_agent = bindings.execution_agent
+    model_settings = get_model_settings(execution_agent, run_config)
+    output_schema = get_output_schema(execution_agent)
+
+    # Only do the (slightly more expensive) tool/handoff lookups when the opt-in flag could apply.
+    defer = False
+    if (
+        model_settings.defer_structured_output_until_done
+        and output_schema is not None
+        and not output_schema.is_plain_text()
+    ):
+        all_tools = await get_all_tools(execution_agent, context_wrapper)
+        handoffs = await get_handoffs(execution_agent, context_wrapper)
+        defer = _should_defer_structured_output(model_settings, output_schema, all_tools, handoffs)
+
+    turn_result = await resolve_interrupted_turn(
+        bindings=bindings,
+        original_input=original_input,
+        original_pre_step_items=original_pre_step_items,
+        new_response=new_response,
+        processed_response=processed_response,
+        hooks=hooks,
+        context_wrapper=context_wrapper,
+        run_config=run_config,
+        server_manages_conversation=server_manages_conversation,
+        run_state=run_state,
+        nest_handoff_history_fn=nest_handoff_history_fn,
+        run_final_output_hooks_fn=_skip_final_output_hooks if defer else None,
+    )
+
+    if (
+        defer
+        and output_schema is not None
+        and isinstance(turn_result.next_step, NextStepFinalOutput)
+    ):
+        system_prompt, prompt_config = await asyncio.gather(
+            execution_agent.get_system_prompt(context_wrapper),
+            execution_agent.get_prompt(context_wrapper),
+        )
+        turn_result = await _run_deferred_structuring_pass(
+            bindings=bindings,
+            single_step_result=turn_result,
+            original_input=turn_result.original_input,
+            generated_items=turn_result.generated_items,
+            system_instructions=system_prompt,
+            prompt_config=prompt_config,
+            output_schema=output_schema,
+            run_config=run_config,
+            hooks=hooks,
+            context_wrapper=context_wrapper,
+            tool_use_tracker=tool_use_tracker,
+            server_conversation_tracker=server_conversation_tracker,
+            reasoning_item_id_policy=(
+                run_state._reasoning_item_id_policy if run_state is not None else None
+            ),
+            session=session,
+            prompt_cache_key_resolver=prompt_cache_key_resolver,
+        )
+        # On the resume path the free-text/interrupted response is already in raw_responses (the
+        # runner seeds it from RunState._model_responses), so drop the preceding response the
+        # structuring pass carried -- only the new structuring response should be appended here.
+        turn_result.preceding_model_responses = []
+
+    return turn_result
 
 
 async def run_single_turn(
@@ -1755,6 +2055,13 @@ async def run_single_turn(
 
     output_schema = get_output_schema(execution_agent)
     handoffs = await get_handoffs(execution_agent, context_wrapper)
+
+    model_settings = get_model_settings(execution_agent, run_config)
+    defer = _should_defer_structured_output(model_settings, output_schema, all_tools, handoffs)
+    # When deferring, suppress the schema on this call so strict servers don't block tool calls
+    # and so the free-text answer isn't validated as JSON; we re-request structured output below.
+    effective_output_schema = None if defer else output_schema
+
     if server_conversation_tracker is not None:
         input = server_conversation_tracker.prepare_input(original_input, generated_items)
     else:
@@ -1764,7 +2071,7 @@ async def run_single_turn(
         bindings,
         system_prompt,
         input,
-        output_schema,
+        effective_output_schema,
         all_tools,
         handoffs,
         hooks,
@@ -1778,12 +2085,12 @@ async def run_single_turn(
         prompt_cache_key_resolver=prompt_cache_key_resolver,
     )
 
-    return await get_single_step_result_from_response(
+    single_step_result = await get_single_step_result_from_response(
         bindings=bindings,
         original_input=original_input,
         pre_step_items=generated_items,
         new_response=new_response,
-        output_schema=output_schema,
+        output_schema=effective_output_schema,
         all_tools=all_tools,
         handoffs=handoffs,
         hooks=hooks,
@@ -1792,7 +2099,33 @@ async def run_single_turn(
         error_handlers=error_handlers,
         tool_use_tracker=tool_use_tracker,
         server_manages_conversation=server_conversation_tracker is not None,
+        run_final_output_hooks_fn=_skip_final_output_hooks if defer else None,
     )
+
+    if (
+        defer
+        and output_schema is not None
+        and isinstance(single_step_result.next_step, NextStepFinalOutput)
+    ):
+        single_step_result = await _run_deferred_structuring_pass(
+            bindings=bindings,
+            single_step_result=single_step_result,
+            original_input=original_input,
+            generated_items=single_step_result.generated_items,
+            system_instructions=system_prompt,
+            prompt_config=prompt_config,
+            output_schema=output_schema,
+            run_config=run_config,
+            hooks=hooks,
+            context_wrapper=context_wrapper,
+            tool_use_tracker=tool_use_tracker,
+            server_conversation_tracker=server_conversation_tracker,
+            reasoning_item_id_policy=reasoning_item_id_policy,
+            session=session,
+            prompt_cache_key_resolver=prompt_cache_key_resolver,
+        )
+
+    return single_step_result
 
 
 async def get_new_response(
@@ -1828,6 +2161,10 @@ async def get_new_response(
     model = get_model(execution_agent, run_config)
     model_settings = get_model_settings(execution_agent, run_config)
     model_settings = maybe_reset_tool_choice(public_agent, tool_use_tracker, model_settings)
+    if not all_tools and model_settings.tool_choice not in (None, "auto", "none"):
+        # A tool-free call must not force a tool choice (e.g. the deferred structuring call), or
+        # strict servers reject "required"/named tool_choice paired with an empty tool list.
+        model_settings = _dc.replace(model_settings, tool_choice="auto")
 
     if server_conversation_tracker is not None:
         server_conversation_tracker.mark_input_as_sent(filtered.input)

--- a/src/agents/run_internal/run_steps.py
+++ b/src/agents/run_internal/run_steps.py
@@ -208,6 +208,12 @@ class SingleStepResult:
     processed_response: ProcessedResponse | None = None
     """The processed model response. This is needed for resuming from interruptions."""
 
+    preceding_model_responses: list[ModelResponse] = dataclasses.field(default_factory=list)
+    """Additional model responses produced earlier in this step that precede ``model_response``.
+    Used when a single step makes more than one model call (e.g. deferred structured output makes a
+    free-text call and then a structuring call); the runner appends these to ``raw_responses``
+    before ``model_response`` so the raw-response count matches the number of model calls."""
+
     @property
     def generated_items(self) -> list[RunItem]:
         """Items generated during the agent run (i.e. everything generated after

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from typing import Any, Literal, cast
@@ -180,6 +181,10 @@ async def _maybe_finalize_from_tool_results(
     context_wrapper: RunContextWrapper[TContext],
     tool_input_guardrail_results: list[ToolInputGuardrailResult],
     tool_output_guardrail_results: list[ToolOutputGuardrailResult],
+    run_final_output_hooks_fn: Callable[
+        [Agent[Any], RunHooks[Any], RunContextWrapper[Any], Any], Awaitable[None]
+    ]
+    | None = None,
 ) -> SingleStepResult | None:
     check_tool_use = await check_for_final_output_from_tools(
         public_agent, function_results, context_wrapper
@@ -207,6 +212,7 @@ async def _maybe_finalize_from_tool_results(
         context_wrapper=context_wrapper,
         tool_input_guardrail_results=tool_input_guardrail_results,
         tool_output_guardrail_results=tool_output_guardrail_results,
+        run_final_output_hooks_fn=run_final_output_hooks_fn,
     )
 
 
@@ -639,11 +645,21 @@ async def execute_tools_and_side_effects(
     run_config: RunConfig,
     error_handlers: RunErrorHandlers[TContext] | None = None,
     server_manages_conversation: bool = False,
+    run_final_output_hooks_fn: Callable[
+        [Agent[Any], RunHooks[Any], RunContextWrapper[Any], Any], Awaitable[None]
+    ]
+    | None = None,
 ) -> SingleStepResult:
     """Run one turn of the loop, coordinating tools, approvals, guardrails, and handoffs."""
     public_agent = bindings.public_agent
 
     execute_final_output_call = execute_final_output
+    if run_final_output_hooks_fn is not None:
+        # Override the end-of-run hooks for every final-output branch in this turn (e.g. to suppress
+        # them on the intermediate turn of a deferred-structured-output run).
+        execute_final_output_call = functools.partial(
+            execute_final_output, run_final_output_hooks_fn=run_final_output_hooks_fn
+        )
     execute_handoffs_call = execute_handoffs
 
     pre_step_items = list(pre_step_items)
@@ -756,6 +772,7 @@ async def execute_tools_and_side_effects(
         context_wrapper=context_wrapper,
         tool_input_guardrail_results=tool_input_guardrail_results,
         tool_output_guardrail_results=tool_output_guardrail_results,
+        run_final_output_hooks_fn=run_final_output_hooks_fn,
     )
     if tool_final_output is not None:
         return tool_final_output
@@ -858,6 +875,10 @@ async def resolve_interrupted_turn(
     server_manages_conversation: bool = False,
     run_state: RunState | None = None,
     nest_handoff_history_fn: Callable[..., HandoffInputData] | None = None,
+    run_final_output_hooks_fn: Callable[
+        [Agent[Any], RunHooks[Any], RunContextWrapper[Any], Any], Awaitable[None]
+    ]
+    | None = None,
 ) -> SingleStepResult:
     """Continue a turn that was previously interrupted waiting for tool approval."""
     public_agent = bindings.public_agent
@@ -1533,6 +1554,7 @@ async def resolve_interrupted_turn(
         context_wrapper=context_wrapper,
         tool_input_guardrail_results=tool_input_guardrail_results,
         tool_output_guardrail_results=tool_output_guardrail_results,
+        run_final_output_hooks_fn=run_final_output_hooks_fn,
     )
     if tool_final_output is not None:
         return tool_final_output
@@ -2018,6 +2040,10 @@ async def get_single_step_result_from_response(
     server_manages_conversation: bool = False,
     event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None = None,
     before_side_effects: Callable[[], Awaitable[None]] | None = None,
+    run_final_output_hooks_fn: Callable[
+        [Agent[Any], RunHooks[Any], RunContextWrapper[Any], Any], Awaitable[None]
+    ]
+    | None = None,
 ) -> SingleStepResult:
     item_agent = bindings.public_agent
     processed_response = process_model_response(
@@ -2054,4 +2080,5 @@ async def get_single_step_result_from_response(
         run_config=run_config,
         error_handlers=error_handlers,
         server_manages_conversation=server_manages_conversation,
+        run_final_output_hooks_fn=run_final_output_hooks_fn,
     )

--- a/tests/model_settings/test_serialization.py
+++ b/tests/model_settings/test_serialization.py
@@ -76,6 +76,7 @@ def test_all_fields_serialization() -> None:
             ),
         ),
         context_management=[{"type": "compaction", "compact_threshold": 200000}],
+        defer_structured_output_until_done=True,
     )
 
     # Verify that every single field is set to a non-None value

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -15,6 +15,7 @@ from openai import APIConnectionError, BadRequestError
 from openai.types.responses import ResponseFunctionToolCall
 from openai.types.responses.response_output_text import AnnotationFileCitation, ResponseOutputText
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
+from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from agents import (
@@ -57,8 +58,14 @@ from agents.items import (
     ToolCallOutputItem,
     TResponseInputItem,
 )
-from agents.lifecycle import RunHooks
-from agents.run import AgentRunner, get_default_agent_runner, set_default_agent_runner
+from agents.lifecycle import AgentHooks, RunHooks
+from agents.run import (
+    AgentRunner,
+    CallModelData,
+    ModelInputData,
+    get_default_agent_runner,
+    set_default_agent_runner,
+)
 from agents.run_config import _default_trace_include_sensitive_data
 from agents.run_internal.agent_bindings import bind_public_agent
 from agents.run_internal.items import (
@@ -5305,3 +5312,360 @@ async def test_execute_approved_tools_timeout_can_raise_exception() -> None:
             approval_item=approval_item,
             approve=True,
         )
+
+
+class _DeferStructuredOutput(BaseModel):
+    city: str
+    temp: int
+
+
+class _RecordingFakeModel(FakeModel):
+    """FakeModel that records the ``output_schema``/``tools`` of every (non-streamed) call."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.recorded_calls: list[dict[str, Any]] = []
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: Any,
+        model_settings: Any,
+        tools: Any,
+        output_schema: Any,
+        handoffs: Any,
+        tracing: Any,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: Any | None,
+    ) -> ModelResponse:
+        self.recorded_calls.append(
+            {
+                "output_schema": output_schema,
+                "tools": list(tools),
+                "tool_choice": getattr(model_settings, "tool_choice", None),
+                "system_instructions": system_instructions,
+                "input": input,
+            }
+        )
+        return await super().get_response(
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            prompt=prompt,
+        )
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_until_done_defers_schema():
+    """With the opt-in flag, the schema is suppressed while tools run and applied in an extra
+    tool-free structuring call once the model produces a plain-text answer."""
+    model = _RecordingFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            # Turn 1: the model calls a tool.
+            [get_function_tool_call("get_weather", "{}")],
+            # Turn 2: the model produces a plain-text (non-JSON) final answer.
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            # Turn 3 (the structuring pass): the JSON matching the schema.
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = await Runner.run(agent, input="what's the weather?")
+
+    assert isinstance(result.final_output, _DeferStructuredOutput)
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+
+    # Three model calls: the tool turn, the free-text turn, and the structuring turn.
+    assert len(model.recorded_calls) == 3
+    # The schema is suppressed on the tool-call and free-text turns.
+    assert model.recorded_calls[0]["output_schema"] is None
+    assert model.recorded_calls[1]["output_schema"] is None
+    # The structuring turn uses the real schema with no tools competing for it.
+    assert model.recorded_calls[2]["output_schema"] is not None
+    assert model.recorded_calls[2]["tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_disabled_by_default_keeps_schema():
+    """With the flag off (default), behavior is unchanged: the schema is enforced on each turn
+    and no extra structuring call is made."""
+    model = _RecordingFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = await Runner.run(agent, input="what's the weather?")
+
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+    # No extra structuring call; the schema is present on every turn.
+    assert len(model.recorded_calls) == 2
+    assert model.recorded_calls[0]["output_schema"] is not None
+    assert model.recorded_calls[1]["output_schema"] is not None
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_fires_end_hooks_exactly_once():
+    """The deferred run is a single logical run: end-of-run hooks fire once, and with the final
+    structured output -- not twice (once with the intermediate plain text, once with the object)."""
+    end_outputs: list[Any] = []
+
+    class _CountingRunHooks(RunHooks[Any]):
+        async def on_agent_end(self, context, agent, output):
+            end_outputs.append(output)
+
+    agent_end_outputs: list[Any] = []
+
+    class _CountingAgentHooks(AgentHooks[Any]):
+        async def on_end(self, context, agent, output):
+            agent_end_outputs.append(output)
+
+    model = _RecordingFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+        hooks=_CountingAgentHooks(),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = await Runner.run(agent, input="what's the weather?", hooks=_CountingRunHooks())
+
+    expected = _DeferStructuredOutput(city="Oakland", temp=21)
+    assert result.final_output == expected
+    # Each end hook fires exactly once, with the structured output (not the intermediate text).
+    assert end_outputs == [expected]
+    assert agent_end_outputs == [expected]
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_neutralizes_tool_choice_on_structuring_call():
+    """The deferred structuring call is tool-free, so a forcing ``tool_choice`` (e.g. "required")
+    must not be sent with an empty tool list -- it is neutralized to "auto" for that call."""
+    model = _RecordingFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(
+            defer_structured_output_until_done=True,
+            tool_choice="required",
+        ),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = await Runner.run(agent, input="what's the weather?")
+
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+    assert len(model.recorded_calls) == 3
+    # The structuring turn carries no tools and a non-forcing tool_choice (the forcing "required"
+    # is neutralized so it can't conflict with the empty tool list).
+    assert model.recorded_calls[2]["tools"] == []
+    assert model.recorded_calls[2]["tool_choice"] in (None, "auto", "none")
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_applies_model_input_filter_to_structuring_call():
+    """RunConfig.call_model_input_filter must run for the deferred structuring call too, not just
+    the tool/free-text turns -- otherwise app-level redaction is bypassed for the final call."""
+    model = _RecordingFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    def filter_fn(data: CallModelData[Any]) -> ModelInputData:
+        return ModelInputData(input=list(data.model_data.input), instructions="FILTERED")
+
+    result = await Runner.run(
+        agent,
+        input="what's the weather?",
+        run_config=RunConfig(call_model_input_filter=filter_fn),
+    )
+
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+    assert len(model.recorded_calls) == 3
+    # Every model call -- including the structuring call -- saw the filtered instructions.
+    assert all(call["system_instructions"] == "FILTERED" for call in model.recorded_calls)
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_fires_end_hooks_once_with_stop_on_first_tool():
+    """With defer + tool_use_behavior='stop_on_first_tool', the tool-finalization path must not
+    fire end hooks for the intermediate tool output -- only the structuring pass fires them once."""
+    end_outputs: list[Any] = []
+
+    class _CountingRunHooks(RunHooks[Any]):
+        async def on_agent_end(self, context, agent, output):
+            end_outputs.append(output)
+
+    model = _RecordingFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        tool_use_behavior="stop_on_first_tool",
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = await Runner.run(agent, input="what's the weather?", hooks=_CountingRunHooks())
+
+    expected = _DeferStructuredOutput(city="Oakland", temp=21)
+    assert result.final_output == expected
+    # Exactly one end-hook call, carrying the structured output (not the intermediate tool output).
+    assert end_outputs == [expected]
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_preserves_all_raw_responses():
+    """The deferred turn makes two model calls (free-text + structuring); both must appear in
+    raw_responses so the count matches the number of model calls."""
+    model = _RecordingFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = await Runner.run(agent, input="what's the weather?")
+
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+    # Three model calls -> three raw responses (tool turn, free-text turn, structuring turn).
+    assert len(model.recorded_calls) == 3
+    assert len(result.raw_responses) == 3
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_pairs_llm_start_and_end_hooks():
+    """The deferred structuring call must emit on_llm_start like every other model call, so start
+    and end hooks stay paired -- one start and one end per model call."""
+    starts = 0
+    ends = 0
+
+    class _CountingRunHooks(RunHooks[Any]):
+        async def on_llm_start(self, context, agent, system_prompt, input_items):
+            nonlocal starts
+            starts += 1
+
+        async def on_llm_end(self, context, agent, response):
+            nonlocal ends
+            ends += 1
+
+    model = _RecordingFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = await Runner.run(agent, input="what's the weather?", hooks=_CountingRunHooks())
+
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+    # Three model calls (tool, free-text, structuring) -> three paired start/end hooks.
+    assert starts == 3
+    assert ends == 3
+
+
+@pytest.mark.asyncio
+async def test_defer_structured_output_defers_for_handoff_only_agent():
+    """A structured-output agent whose only model tools are handoffs must still defer, so the
+    schema doesn't suppress the handoff tool-call on strict servers."""
+    model = _RecordingFakeModel()
+    handoff_target = Agent(name="target", model=FakeModel())
+    agent = Agent(
+        name="test",
+        model=model,
+        handoffs=[handoff_target],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            # Turn 1: the model answers in free text (does not hand off) -> final output.
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            # Turn 2 (structuring pass): JSON matching the schema.
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = await Runner.run(agent, input="what's the weather?")
+
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+    # Deferred: schema suppressed on the free-text turn, applied only on the structuring call.
+    assert len(model.recorded_calls) == 2
+    assert model.recorded_calls[0]["output_schema"] is None
+    assert model.recorded_calls[1]["output_schema"] is not None

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -15,6 +15,7 @@ from openai.types.responses import (
     ResponseIncompleteEvent,
 )
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
+from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from agents import (
@@ -39,6 +40,7 @@ from agents import (
     retry_policies,
 )
 from agents.items import RunItem, ToolApprovalItem, TResponseInputItem
+from agents.lifecycle import AgentHooks, RunHooks
 from agents.memory.openai_conversations_session import OpenAIConversationsSession
 from agents.run import RunConfig
 from agents.run_internal import run_loop
@@ -2041,3 +2043,239 @@ async def test_streaming_hitl_server_conversation_tracker_priming():
     # Should complete successfully without message duplication
     assert result2.final_output == "Second response"
     assert len(result2.new_items) >= 1
+
+
+class _DeferStructuredOutput(BaseModel):
+    city: str
+    temp: int
+
+
+class _RecordingStreamFakeModel(FakeModel):
+    """FakeModel that records ``output_schema``/``tools`` for both streamed turns and the extra
+    non-streamed structuring call."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.recorded_calls: list[dict[str, Any]] = []
+
+    async def get_response(
+        self,
+        system_instructions: Any,
+        input: Any,
+        model_settings: Any,
+        tools: Any,
+        output_schema: Any,
+        handoffs: Any,
+        tracing: Any,
+        *,
+        previous_response_id: Any = None,
+        conversation_id: Any = None,
+        prompt: Any = None,
+    ) -> Any:
+        self.recorded_calls.append(
+            {"kind": "get_response", "output_schema": output_schema, "tools": list(tools)}
+        )
+        return await super().get_response(
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            prompt=prompt,
+        )
+
+    def stream_response(
+        self,
+        system_instructions: Any,
+        input: Any,
+        model_settings: Any,
+        tools: Any,
+        output_schema: Any,
+        handoffs: Any,
+        tracing: Any,
+        *,
+        previous_response_id: Any = None,
+        conversation_id: Any = None,
+        prompt: Any = None,
+    ) -> Any:
+        self.recorded_calls.append(
+            {"kind": "stream_response", "output_schema": output_schema, "tools": list(tools)}
+        )
+        return super().stream_response(
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            prompt=prompt,
+        )
+
+
+@pytest.mark.asyncio
+async def test_streamed_defer_structured_output_until_done_defers_schema():
+    model = _RecordingStreamFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            # Turn 1 (streamed): tool call.
+            [get_function_tool_call("get_weather", "{}")],
+            # Turn 2 (streamed): plain-text final answer (not JSON).
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            # Turn 3 (non-streamed structuring pass): JSON matching the schema.
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="what's the weather?")
+    await consume_stream(result)
+
+    assert isinstance(result.final_output, _DeferStructuredOutput)
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+
+    assert len(model.recorded_calls) == 3
+    # Both tool/free-text turns are streamed with the schema suppressed.
+    assert model.recorded_calls[0]["kind"] == "stream_response"
+    assert model.recorded_calls[0]["output_schema"] is None
+    assert model.recorded_calls[1]["kind"] == "stream_response"
+    assert model.recorded_calls[1]["output_schema"] is None
+    # The structuring pass is a non-streamed call with the real schema and no tools.
+    assert model.recorded_calls[2]["kind"] == "get_response"
+    assert model.recorded_calls[2]["output_schema"] is not None
+    assert model.recorded_calls[2]["tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_streamed_defer_structured_output_disabled_by_default_keeps_schema():
+    model = _RecordingStreamFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="what's the weather?")
+    await consume_stream(result)
+
+    assert result.final_output == _DeferStructuredOutput(city="Oakland", temp=21)
+    # No extra structuring call; every streamed turn carries the schema.
+    assert len(model.recorded_calls) == 2
+    assert all(call["kind"] == "stream_response" for call in model.recorded_calls)
+    assert model.recorded_calls[0]["output_schema"] is not None
+    assert model.recorded_calls[1]["output_schema"] is not None
+
+
+@pytest.mark.asyncio
+async def test_streamed_defer_structured_output_fires_end_hooks_exactly_once():
+    """Streamed deferred run: end-of-run hooks fire once, with the final structured output."""
+    end_outputs: list[Any] = []
+    agent_end_outputs: list[Any] = []
+
+    class _CountingRunHooks(RunHooks[Any]):
+        async def on_agent_end(self, context, agent, output):
+            end_outputs.append(output)
+
+    class _CountingAgentHooks(AgentHooks[Any]):
+        async def on_end(self, context, agent, output):
+            agent_end_outputs.append(output)
+
+    model = _RecordingStreamFakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("get_weather", return_value="sunny")],
+        output_type=_DeferStructuredOutput,
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+        hooks=_CountingAgentHooks(),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}")],
+            [get_text_message("It is sunny and warm in Oakland today.")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="what's the weather?", hooks=_CountingRunHooks())
+    await consume_stream(result)
+
+    expected = _DeferStructuredOutput(city="Oakland", temp=21)
+    assert result.final_output == expected
+    assert end_outputs == [expected]
+    assert agent_end_outputs == [expected]
+
+
+@pytest.mark.asyncio
+async def test_streamed_resumed_deferred_structured_output_with_approved_stop_on_first_tool():
+    """Streamed analogue of the non-streamed HITL+defer resume test: the resumed turn's extra
+    structuring model call must be recorded in raw_responses (regression for the streamed resume
+    path, which previously never appended it)."""
+    from pydantic import BaseModel
+
+    class _Weather(BaseModel):
+        city: str
+        temp: int
+
+    async def get_weather() -> str:
+        return "sunny"
+
+    tool = function_tool(get_weather, name_override="get_weather", needs_approval=True)
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[tool],
+        output_type=_Weather,
+        tool_use_behavior="stop_on_first_tool",
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}", call_id="call-1")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    end_outputs: list[Any] = []
+
+    class _CountingRunHooks(RunHooks[Any]):
+        async def on_agent_end(self, context, agent, output):
+            end_outputs.append(output)
+
+    hooks = _CountingRunHooks()
+
+    first = Runner.run_streamed(agent, input="what's the weather?", hooks=hooks)
+    await consume_stream(first)
+    assert first.interruptions
+    state = first.to_state()
+    state.approve(first.interruptions[0])
+
+    resumed = Runner.run_streamed(agent, state, hooks=hooks)
+    await consume_stream(resumed)
+
+    expected = _Weather(city="Oakland", temp=21)
+    assert isinstance(resumed.final_output, _Weather)
+    assert resumed.final_output == expected
+    assert end_outputs == [expected]
+    # The resumed structuring call must be recorded: interrupted tool-call response + structuring.
+    assert len(resumed.raw_responses) == 2

--- a/tests/test_run_impl_resume_paths.py
+++ b/tests/test_run_impl_resume_paths.py
@@ -5,7 +5,7 @@ import pytest
 from openai.types.responses import ResponseFunctionToolCall, ResponseOutputMessage
 
 import agents.run as run_module
-from agents import Agent, Runner, function_tool
+from agents import Agent, ModelSettings, Runner, function_tool
 from agents.agent import ToolsToFinalOutputResult
 from agents.items import (
     MessageOutputItem,
@@ -218,7 +218,11 @@ async def test_resumed_run_again_resets_persisted_count(monkeypatch) -> None:
             tool_output_guardrail_results=[],
         )
 
-    monkeypatch.setattr(run_module, "resolve_interrupted_turn", fake_resolve_interrupted_turn)
+    monkeypatch.setattr(
+        run_module,
+        "resolve_interrupted_turn_with_deferred_structuring",
+        fake_resolve_interrupted_turn,
+    )
     monkeypatch.setattr(run_module, "run_single_turn", fake_run_single_turn)
 
     runner = run_module.AgentRunner()
@@ -289,7 +293,11 @@ async def test_resumed_interruption_passes_server_managed_conversation_flag(
             tool_output_guardrail_results=[],
         )
 
-    monkeypatch.setattr(run_module, "resolve_interrupted_turn", fake_resolve_interrupted_turn)
+    monkeypatch.setattr(
+        run_module,
+        "resolve_interrupted_turn_with_deferred_structuring",
+        fake_resolve_interrupted_turn,
+    )
 
     runner = run_module.AgentRunner()
     result = await runner.run(agent, state, run_config=RunConfig())
@@ -446,3 +454,63 @@ async def test_resolve_interrupted_turn_only_uses_name_fallback_for_legacy_appro
             isinstance(item, ToolCallOutputItem) and item.output == "one"
             for item in result.new_step_items
         )
+
+
+@pytest.mark.asyncio
+async def test_resumed_deferred_structured_output_with_approved_stop_on_first_tool() -> None:
+    """Deferred structured output must still apply when a run pauses for tool approval and the
+    approved tool finalizes the turn (tool_use_behavior='stop_on_first_tool'). The resumed run must
+    return the declared structured output (not the raw tool result) and fire end hooks exactly once.
+    """
+    from pydantic import BaseModel
+
+    class _Weather(BaseModel):
+        city: str
+        temp: int
+
+    async def get_weather() -> str:
+        return "sunny"
+
+    tool = function_tool(get_weather, name_override="get_weather", needs_approval=True)
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[tool],
+        output_type=_Weather,
+        tool_use_behavior="stop_on_first_tool",
+        model_settings=ModelSettings(defer_structured_output_until_done=True),
+    )
+    # Turn 1 (first run): the model calls the approval-gated tool -> run interrupts.
+    # Resume: the approved tool finalizes the turn (stop_on_first_tool), then the deferred
+    # structuring pass makes one model call that returns the schema-valid JSON.
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("get_weather", "{}", call_id="call-1")],
+            [get_text_message(json.dumps({"city": "Oakland", "temp": 21}))],
+        ]
+    )
+
+    end_outputs: list[Any] = []
+
+    class _CountingRunHooks(RunHooks[Any]):
+        async def on_agent_end(self, context, agent, output):
+            end_outputs.append(output)
+
+    hooks = _CountingRunHooks()
+
+    first = await Runner.run(agent, input="what's the weather?", hooks=hooks)
+    assert first.interruptions
+    state = first.to_state()
+    state.approve(first.interruptions[0])
+
+    resumed = await Runner.run(agent, state, hooks=hooks)
+
+    expected = _Weather(city="Oakland", temp=21)
+    assert isinstance(resumed.final_output, _Weather)
+    assert resumed.final_output == expected
+    # End hooks fire exactly once, with the structured output (not the raw tool text).
+    assert end_outputs == [expected]
+    # raw_responses must not duplicate the interrupted response: the resumed turn adds only the
+    # new structuring response on top of the (already-recorded) interrupted tool-call response.
+    assert len(resumed.raw_responses) == 2


### PR DESCRIPTION
### Summary

When an `Agent` has both tools and a non-plain `output_type`, the runner sends the output schema as `response_format`/`text.format` on **every** model call ([`openai_responses.py#L781`](https://github.com/openai/openai-agents-python/blob/7713342bedf3f5b2909f90c0d41b0eae90f3850f/src/agents/models/openai_responses.py#L781) → [`#L857`](https://github.com/openai/openai-agents-python/blob/7713342bedf3f5b2909f90c0d41b0eae90f3850f/src/agents/models/openai_responses.py#L857)). OpenAI's hosted endpoint tolerates this (tool calls bypass `response_format`), but **strict OpenAI-compatible servers (e.g. vLLM)** enforce the guided-decoding grammar from the first token, which overrides `tool_choice` and **suppresses tool calls entirely** — the model is forced into the JSON schema on turn 1 and never calls its tools. See #3709.

This PR adds an **opt-in** `ModelSettings.defer_structured_output_until_done` (default off → existing OpenAI-hosted behavior is byte-for-byte unchanged). When enabled on an agent with both tools and a structured `output_type`, the runner:

- omits the schema while the model may still call tools (so tool calls are never suppressed), then
- once the model stops calling tools and produces a free-text answer, makes one extra **tool-free** model call that applies the schema, validating the result into `final_output`.

This decouples structured output from per-turn generation, mirroring how the Anthropic Agent SDK treats it as a run-level option returned on the final result ([`ClaudeAgentOptions.output_format`](https://github.com/anthropics/claude-agent-sdk-python/blob/40aebe38f1b42c478684099ca28bfa9b78aec877/src/claude_agent_sdk/types.py#L1944), [`ResultMessage.structured_output`](https://github.com/anthropics/claude-agent-sdk-python/blob/40aebe38f1b42c478684099ca28bfa9b78aec877/src/claude_agent_sdk/types.py#L1213)).

Notes on correctness:
- Covers both streaming and non-streaming runner paths.
- End-of-run lifecycle hooks (`on_agent_end` / `Agent.hooks.on_end`) fire **exactly once**, with the final structured output — the intermediate free-text turn does not re-fire them (and the no-structured-text fallback fires them once with the plain-text output).
- The tool-free structuring call neutralizes a forcing `tool_choice` (`"required"` or a specific function/MCP tool) to `"auto"`, so it doesn't conflict with the empty tool list on strict servers.

### Test plan

- New `FakeModel` unit tests (streamed + non-streamed) asserting: the schema is suppressed on tool turns and applied only on the structuring call; end hooks fire exactly once with the structured output; a forcing `tool_choice` is neutralized on the structuring call; and default (flag-off) behavior is unchanged.
- `make lint` ✓, `make format` ✓, `make tests` ✓ (4827 passed, 6 skipped). `make typecheck` is clean for all files changed here — the only reported error is a pre-existing `asyncio.eager_task_factory` stub issue in `tests/test_run_step_execution.py`, which this PR does not touch.
- Validated end-to-end against **vLLM serving Gemma 4 31B** in a sandbox: with a pristine provider that only sets the flag, the OpenAI-provider skill-invocation eval passes, and the container log confirms the deferred path (tools run across turns, then a single extra tool-free `/v1/responses` structuring call → schema-valid final output).

### Issue number

Closes #3709

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass (see note above re: the unrelated pre-existing `typecheck` error)
- [ ] If using Codex, I've run `/review` before submitting this PR
