### PR TITLE
feat(realtime): expose current_agent and context_wrapper on RealtimeSession

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -224,7 +224,9 @@ class RealtimeSession(RealtimeModelListener):
         This reflects the initial agent and is updated whenever the active agent changes,
         for example after a handoff or a call to `update_agent()`. Use it to read the active
         agent from code that runs outside the session's event loop, such as telemetry,
-        routing, or background timers.
+        routing, or background timers. This returns a live, unsynchronized snapshot, so a
+        background reader can observe the agent mid-handoff because it is reassigned in
+        `update_agent()` and after a handoff without any locking.
         """
         return self._current_agent
 
@@ -234,7 +236,9 @@ class RealtimeSession(RealtimeModelListener):
 
         The returned wrapper is the same object the session was constructed with and exposes
         the caller-provided context along with usage tracking. Use it to reach the run context
-        from code that runs outside the session's event loop.
+        from code that runs outside the session's event loop. This returns a live,
+        unsynchronized reference whose usage counters are mutated by the session's event loop,
+        so a background reader can observe values updated without any locking.
         """
         return self._context_wrapper
 

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -217,6 +217,27 @@ class RealtimeSession(RealtimeModelListener):
         """Access the underlying model for adding listeners or other direct interaction."""
         return self._model
 
+    @property
+    def current_agent(self) -> RealtimeAgent:
+        """Return the agent that is currently active for this session.
+
+        This reflects the initial agent and is updated whenever the active agent changes,
+        for example after a handoff or a call to `update_agent()`. Use it to read the active
+        agent from code that runs outside the session's event loop, such as telemetry,
+        routing, or background timers.
+        """
+        return self._current_agent
+
+    @property
+    def context_wrapper(self) -> RunContextWrapper[Any]:
+        """Return the run context wrapper backing this session.
+
+        The returned wrapper is the same object the session was constructed with and exposes
+        the caller-provided context along with usage tracking. Use it to reach the run context
+        from code that runs outside the session's event loop.
+        """
+        return self._context_wrapper
+
     async def __aenter__(self) -> RealtimeSession:
         """Start the session by connecting to the model. After this, you will be able to stream
         events from the model and send messages and audio to the model.

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -3651,6 +3651,38 @@ class TestUpdateAgentFunctionality:
         assert mock_model.sent_events == []
 
 
+class TestSessionAccessors:
+    """Tests for the public ``current_agent`` and ``context_wrapper`` accessors."""
+
+    @pytest.mark.asyncio
+    async def test_current_agent_reflects_initial_agent(self, mock_model):
+        agent = RealtimeAgent(name="initial", instructions="initial", tools=[], handoffs=[])
+        session = RealtimeSession(mock_model, agent, None)
+
+        assert session.current_agent is agent
+
+    @pytest.mark.asyncio
+    async def test_current_agent_updates_after_update_agent(self, mock_model):
+        first_agent = RealtimeAgent(name="first", instructions="first", tools=[], handoffs=[])
+        second_agent = RealtimeAgent(name="second", instructions="second", tools=[], handoffs=[])
+        session = RealtimeSession(mock_model, first_agent, None)
+
+        assert session.current_agent is first_agent
+
+        await session.update_agent(second_agent)
+
+        assert session.current_agent is second_agent
+
+    @pytest.mark.asyncio
+    async def test_context_wrapper_returns_backing_wrapper(self, mock_model):
+        context = object()
+        agent = RealtimeAgent(name="agent", instructions="agent", tools=[], handoffs=[])
+        session = RealtimeSession(mock_model, agent, context)
+
+        assert session.context_wrapper is session._context_wrapper
+        assert session.context_wrapper.context is context
+
+
 class TestTranscriptPreservation:
     """Tests ensuring assistant transcripts are preserved across updates."""
 


### PR DESCRIPTION
### Summary

Adds two read-only public properties to `RealtimeSession`: `current_agent` and `context_wrapper`.

`RealtimeSession` already exposes a public `update_agent()` setter and a public `model` property, but there is no public way to read which agent is currently active or to reach the run-context wrapper. Application code that runs outside the session's event loop (telemetry, per-agent metrics, routing decisions, background timers) currently has to read the private `session._current_agent` and `session._context_wrapper`, which couples user code to SDK internals.

This change makes those two reads first-class and additive:

- `RealtimeSession.current_agent -> RealtimeAgent`: the agent currently handling the session (the value set at construction and updated by `update_agent()` and by handoffs).
- `RealtimeSession.context_wrapper -> RunContextWrapper[Any]`: the run-context wrapper backing the session.

Both are read-only (no setters), typed consistently with existing internal usage, and documented as live, unsynchronized snapshots (a background reader can observe the value mid-handoff), matching the style of the existing `model` property.

### Test plan

- Added `tests/realtime/test_session.py::TestSessionAccessors` covering: `current_agent` returns the initial agent, reflects the value after `update_agent(...)`, and `context_wrapper` returns the same object the session was constructed with.
- Ran the standard verification stack from the repo root:
  - `make format` — pass
  - `make lint` — pass
  - `make typecheck` — pass (pyright + mypy)
  - `uv run pytest -k realtime` — pass (303 passed, 1 skipped)

### Issue number

N/A (small additive ergonomics improvement). Happy to link a tracking issue if preferred.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass (ran `make format`, `make lint`, `make typecheck`, and the realtime test suite)
- [ ] If using Codex, I've run `/review` before submitting this PR

### Compatibility notes

Purely additive. No new exported top-level symbols (properties on an existing class), no changes to constructor signatures or field order, and no behavior change to existing methods.
