### PR TITLE
docs: add DProvenanceKit to external tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -224,3 +224,4 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [Asqav](https://www.asqav.com/docs/integrations#openai-agents)
 -   [Datadog](https://docs.datadoghq.com/llm_observability/instrumentation/auto_instrumentation/?tab=python#openai-agents)
 -   [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
+-   [DProvenanceKit](https://github.com/Therealdk8890/DProvenanceKitPython#openai-agents-sdk)

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -224,4 +224,4 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [Asqav](https://www.asqav.com/docs/integrations#openai-agents)
 -   [Datadog](https://docs.datadoghq.com/llm_observability/instrumentation/auto_instrumentation/?tab=python#openai-agents)
 -   [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
--   [DProvenanceKit](https://github.com/Therealdk8890/DProvenanceKitPython#openai-agents-sdk)
+-   [DProvenanceKit](https://dprovenance.dev/openai-agents/)


### PR DESCRIPTION
### Summary

Adds DProvenanceKit to the list of external tracing processors in `docs/tracing.md`.

DProvenanceKit records each agent run as a queryable, diffable trace for reasoning observability and regression testing. Its `DProvenanceTracingProcessor` implements the SDK's `TracingProcessor` interface and is registered globally via `register(store)`; install with `pip install "dprovenancekit[openai-agents]"`. Repo: https://github.com/Therealdk8890/DProvenanceKitPython. PyPI: https://pypi.org/project/dprovenancekit/. Docs: https://dprovenance.dev/openai-agents/.

### Test plan

Docs-only change; per `AGENTS.md`, verification steps are skipped for `docs/` changes. Previewed the markdown to confirm the new bullet matches the formatting of the existing entries.

### Issue number

N/A
