### PR TITLE
test: improve coverage for stream and sandbox edge cases

### DIFF
--- a/tests/extensions/experiemental/codex/test_codex_exec_thread.py
+++ b/tests/extensions/experiemental/codex/test_codex_exec_thread.py
@@ -200,6 +200,11 @@ def test_coerce_thread_options_rejects_unknown_fields() -> None:
         coerce_thread_options({"unknown": "value"})
 
 
+def test_coerce_thread_options_rejects_non_mapping() -> None:
+    with pytest.raises(UserError, match="ThreadOptions must be a ThreadOptions or a mapping"):
+        coerce_thread_options(cast(Any, ["model", "gpt"]))
+
+
 def test_codex_start_and_resume_thread() -> None:
     codex = Codex(CodexOptions(codex_path_override="/bin/codex"))
     thread = codex.start_thread({"model": "gpt"})
@@ -717,3 +722,36 @@ async def test_thread_run_streamed_idle_timeout_sets_signal(
             pass
 
     assert signal.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_thread_run_streamed_idle_timeout_creates_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events = [
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 1, "cached_input_tokens": 0, "output_tokens": 1},
+        }
+    ]
+    fake_exec = FakeExec(events, delay=0.2)
+    thread = Thread(
+        exec_client=cast(CodexExec, fake_exec),
+        options=CodexOptions(),
+        thread_options=ThreadOptions(),
+    )
+
+    def fake_create_output_schema_file(schema: dict[str, Any] | None) -> OutputSchemaFile:
+        return OutputSchemaFile(schema_path=None, cleanup=lambda: None)
+
+    monkeypatch.setattr(thread_module, "create_output_schema_file", fake_create_output_schema_file)
+
+    with pytest.raises(RuntimeError, match="Codex stream idle for"):
+        async for _ in thread._run_streamed_internal(
+            "hello", TurnOptions(idle_timeout_seconds=0.01)
+        ):
+            pass
+
+    assert fake_exec.last_args is not None
+    assert fake_exec.last_args.signal is not None
+    assert fake_exec.last_args.signal.is_set() is True

--- a/tests/models/test_agent_registration.py
+++ b/tests/models/test_agent_registration.py
@@ -12,6 +12,7 @@ from agents.models.multi_provider import MultiProvider
 from agents.models.openai_agent_registration import (
     OPENAI_HARNESS_ID_TRACE_METADATA_KEY,
     resolve_openai_agent_registration_config,
+    resolve_openai_harness_id_for_model_provider,
 )
 from agents.models.openai_provider import OpenAIProvider
 from agents.run_internal.agent_runner_helpers import resolve_trace_settings
@@ -88,6 +89,13 @@ def test_agent_registration_provider_constructor_config() -> None:
     assert openai_provider.agent_registration.harness_id == "provider-harness"
     assert multi_provider.openai_provider.agent_registration is not None
     assert multi_provider.openai_provider.agent_registration.harness_id == "provider-harness"
+
+
+def test_harness_id_resolves_private_agent_registration() -> None:
+    class Provider:
+        _agent_registration = OpenAIAgentRegistrationConfig(harness_id="private-harness")
+
+    assert resolve_openai_harness_id_for_model_provider(Provider()) == "private-harness"
 
 
 def test_harness_id_is_added_to_trace_metadata() -> None:

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -17,6 +17,7 @@ from agents.models._retry_runtime import (
 )
 from agents.retry import (
     ModelRetryAdvice,
+    ModelRetryAdviceRequest,
     ModelRetryBackoffSettings,
     ModelRetryNormalizedError,
     ModelRetrySettings,
@@ -106,6 +107,18 @@ def _status_error_without_code(status_code: int, body_code: str = "server_error"
         response=response,
         body={"error": {"code": body_code, "message": body_code}},
     )
+
+
+def test_get_openai_retry_advice_returns_none_for_non_retryable_status() -> None:
+    advice = get_openai_retry_advice(
+        ModelRetryAdviceRequest(
+            error=_status_error(400, code="invalid_request_error"),
+            attempt=1,
+            stream=False,
+        )
+    )
+
+    assert advice is None
 
 
 class _AcloseTrackingStream:

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -913,6 +913,16 @@ def test_store_param():
     )
 
 
+def test_clean_gemini_tool_call_id_removes_thought_suffix() -> None:
+    assert (
+        ChatCmplHelpers.clean_gemini_tool_call_id(
+            "call_123__thought__signature",
+            model="gemini-2.5-pro",
+        )
+        == "call_123"
+    )
+
+
 def test_get_retry_advice_uses_openai_headers() -> None:
     request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
     response = httpx.Response(

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -29,12 +29,21 @@ from openai.types.responses import (
     ResponseOutputMessage,
     ResponseOutputRefusal,
     ResponseOutputText,
+    ResponseReasoningItem,
 )
 
 from agents import Agent, Runner, function_tool
 from agents.exceptions import ModelBehaviorError, UserError
 from agents.model_settings import ModelSettings
-from agents.models.chatcmpl_stream_handler import ChatCmplStreamHandler
+from agents.models.chatcmpl_stream_handler import (
+    ChatCmplStreamHandler,
+    Part,
+    SequenceNumber,
+    StreamingState,
+    _BufferedToolCall,
+    _merge_buffered_metadata,
+    _StreamOutputLayout,
+)
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
@@ -58,6 +67,36 @@ def _empty_response() -> Response:
         tools=[],
         parallel_tool_calls=False,
     )
+
+
+async def _completion_stream(
+    *chunks: ChatCompletionChunk,
+) -> AsyncIterator[ChatCompletionChunk]:
+    for chunk in chunks:
+        yield chunk
+
+
+async def _collect_handler_events(
+    *chunks: ChatCompletionChunk,
+    model: str | None = None,
+) -> list[Any]:
+    return [
+        event
+        async for event in ChatCmplStreamHandler.handle_stream(
+            _empty_response(), cast(Any, _completion_stream(*chunks)), model=model
+        )
+    ]
+
+
+async def _collect_buffered_tool_call_chunks(
+    *chunks: ChatCompletionChunk,
+) -> list[ChatCompletionChunk]:
+    return [
+        chunk
+        async for chunk in ChatCmplStreamHandler.buffer_tool_call_stream(
+            _completion_stream(*chunks)
+        )
+    ]
 
 
 @pytest.mark.allow_call_model_methods
@@ -294,6 +333,415 @@ async def test_stream_handler_rejects_nonzero_choice_index_in_strict_mode() -> N
             _empty_response(), cast(Any, fake_stream()), strict_feature_validation=True
         ):
             pass
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_merges_provider_metadata() -> None:
+    tool_call_delta1 = ChoiceDeltaToolCall(
+        index=0,
+        id="tool-id",
+        function=ChoiceDeltaToolCallFunction(name="my_func", arguments='{"a":'),
+        type="function",
+    )
+    tool_call_delta1_any = cast(Any, tool_call_delta1)
+    tool_call_delta1_any.provider_specific_fields = {
+        "nested": {"keep": "provider", "stable": {"value": 1}},
+        "replace": "old",
+    }
+    tool_call_delta1_any.extra_content = {
+        "google": {"thought_signature": "sig-1", "stable": {"value": "kept"}}
+    }
+    tool_call_delta2 = ChoiceDeltaToolCall(
+        index=0,
+        id=None,
+        function=ChoiceDeltaToolCallFunction(name=None, arguments="1}"),
+        type="function",
+    )
+    tool_call_delta2_any = cast(Any, tool_call_delta2)
+    tool_call_delta2_any.provider_specific_fields = {
+        "nested": {"stable": {}, "new": "provider"},
+        "replace": "new",
+    }
+    tool_call_delta2_any.extra_content = {"google": {"stable": {}, "new": "extra"}}
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[tool_call_delta1]))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[tool_call_delta2]))],
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(chunk1, chunk2)
+
+    assert len(buffered_chunks) == 1
+    buffered_delta = buffered_chunks[0].choices[0].delta
+    assert buffered_delta.tool_calls
+    buffered_tool_call = buffered_delta.tool_calls[0]
+    assert buffered_tool_call.function
+    assert buffered_tool_call.function.arguments == '{"a":1}'
+    assert cast(Any, buffered_tool_call).provider_specific_fields == {
+        "nested": {"keep": "provider", "stable": {"value": 1}, "new": "provider"},
+        "replace": "new",
+    }
+    assert cast(Any, buffered_tool_call).extra_content == {
+        "google": {"thought_signature": "sig-1", "stable": {"value": "kept"}, "new": "extra"}
+    }
+
+
+def test_stream_handler_internal_part_stores_text_and_type() -> None:
+    part = Part(text="hello", type="output_text")
+
+    assert part.text == "hello"
+    assert part.type == "output_text"
+
+
+def test_merge_buffered_metadata_keeps_existing_scalar_when_empty_dict_arrives() -> None:
+    merged = _merge_buffered_metadata(
+        {"stable": "keep-me"},
+        {"stable": {}, "new": {}},
+    )
+
+    assert merged == {"stable": "keep-me", "new": {}}
+
+
+def test_stream_output_layout_rejects_unknown_function_call_index() -> None:
+    layout = _StreamOutputLayout()
+
+    with pytest.raises(KeyError, match="Function call index 9 has not been tracked"):
+        layout.function_call_output_index(StreamingState(), 9)
+
+
+@pytest.mark.parametrize(
+    ("buffered_call", "message"),
+    [
+        (
+            _BufferedToolCall(index=0, name="my_func"),
+            "without a tool call id",
+        ),
+        (
+            _BufferedToolCall(index=0, call_id="tool-id"),
+            "without a function name",
+        ),
+    ],
+)
+def test_buffered_tool_call_delta_requires_id_and_name(
+    buffered_call: _BufferedToolCall,
+    message: str,
+) -> None:
+    with pytest.raises(ModelBehaviorError, match=message):
+        ChatCmplStreamHandler._buffered_tool_call_delta(buffered_call)
+
+
+def test_function_call_item_omits_provider_data_when_absent() -> None:
+    function_call = ResponseFunctionToolCall(
+        id="fake-id",
+        call_id="call-id",
+        arguments="",
+        name="my_func",
+        type="function_call",
+    )
+
+    item = ChatCmplStreamHandler._function_call_item(
+        StreamingState(),
+        function_call,
+        arguments="{}",
+    )
+
+    assert item.arguments == "{}"
+    assert "provider_data" not in item.model_dump()
+
+
+def test_finish_reasoning_summary_part_clears_invalid_active_index() -> None:
+    reasoning_item = ResponseReasoningItem(id="fake-id", summary=[], type="reasoning")
+    state = StreamingState(
+        reasoning_content_index_and_output=(0, reasoning_item),
+        active_reasoning_summary_index=0,
+    )
+
+    events = list(ChatCmplStreamHandler._finish_reasoning_summary_part(state, SequenceNumber()))
+
+    assert events == []
+    assert state.active_reasoning_summary_index is None
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_preserves_empty_choice_chunks() -> None:
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[],
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(chunk)
+
+    assert buffered_chunks == [chunk]
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_keeps_passthrough_index_passthrough() -> None:
+    custom_tool_call_delta = ChoiceDeltaToolCall.model_construct(
+        index=0,
+        id="custom-id",
+        type="custom",
+    )
+    function_tool_call_delta = ChoiceDeltaToolCall(
+        index=0,
+        id="function-id",
+        function=ChoiceDeltaToolCallFunction(name="my_func", arguments="{}"),
+        type="function",
+    )
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[custom_tool_call_delta]))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[function_tool_call_delta]))],
+    )
+
+    buffered_chunks = await _collect_buffered_tool_call_chunks(chunk1, chunk2)
+
+    assert len(buffered_chunks) == 2
+    assert buffered_chunks[0].choices[0].delta.tool_calls == [custom_tool_call_delta]
+    assert buffered_chunks[1].choices[0].delta.tool_calls == [function_tool_call_delta]
+
+
+@pytest.mark.parametrize(
+    ("delta", "expected"),
+    [
+        (None, False),
+        (ChoiceDelta(), False),
+        (ChoiceDelta(content="text"), True),
+        (ChoiceDelta.model_construct(refusal="blocked"), True),
+        (ChoiceDelta.model_construct(reasoning_content="summary"), True),
+        (ChoiceDelta.model_construct(reasoning="scratchpad"), True),
+        (ChoiceDelta.model_construct(thinking_blocks=[{"thinking": "hidden"}]), True),
+    ],
+)
+def test_stream_handler_detects_passthrough_delta_shapes(
+    delta: ChoiceDelta | None,
+    expected: bool,
+) -> None:
+    assert ChatCmplStreamHandler._delta_has_passthrough_output(delta) is expected
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_ignores_choice_without_delta() -> None:
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice.model_construct(index=0, delta=None)],
+    )
+
+    events = await _collect_handler_events(chunk)
+
+    assert [event.type for event in events] == ["response.created", "response.completed"]
+    completed_event = events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    assert completed_event.response.output == []
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_converts_third_party_reasoning_text() -> None:
+    reasoning_delta1 = ChoiceDelta.model_construct(reasoning="think ")
+    reasoning_delta2 = ChoiceDelta.model_construct(reasoning="hard")
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=reasoning_delta1)],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=reasoning_delta2)],
+        ),
+    ]
+
+    events = await _collect_handler_events(*chunks, model="third-party")
+
+    reasoning_delta_events = [
+        event for event in events if event.type == "response.reasoning_text.delta"
+    ]
+    assert [event.delta for event in reasoning_delta_events] == ["think ", "hard"]
+
+    reasoning_done_event = next(
+        event
+        for event in events
+        if event.type == "response.output_item.done"
+        and isinstance(event.item, ResponseReasoningItem)
+    )
+    reasoning_done_item = cast(ResponseReasoningItem, reasoning_done_event.item)
+    assert reasoning_done_item.content
+    assert cast(Any, reasoning_done_item.content[0]).text == "think hard"
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    completed_reasoning_item = completed_event.response.output[0]
+    assert isinstance(completed_reasoning_item, ResponseReasoningItem)
+    assert completed_reasoning_item.content
+    assert cast(Any, completed_reasoning_item.content[0]).text == "think hard"
+    assert completed_reasoning_item.model_dump().get("provider_data") == {
+        "model": "third-party",
+        "response_id": "chunk-id",
+    }
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_preserves_thinking_blocks_with_reasoning_summary() -> None:
+    delta = ChoiceDelta.model_construct(
+        reasoning_content="summary",
+        thinking_blocks=[
+            {"thinking": "hidden one ", "signature": "sig-1"},
+            {"thinking": "hidden two", "signature": "sig-2"},
+        ],
+    )
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=delta)],
+    )
+
+    events = await _collect_handler_events(chunk)
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    reasoning_item = completed_event.response.output[0]
+    assert isinstance(reasoning_item, ResponseReasoningItem)
+    assert reasoning_item.summary[0].text == "summary"
+    assert reasoning_item.content
+    assert cast(Any, reasoning_item.content[0]).text == "hidden one hidden two"
+    assert reasoning_item.encrypted_content == "sig-2"
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_adds_third_party_reasoning_text_to_summary_item() -> None:
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(index=0, delta=ChoiceDelta.model_construct(reasoning_content="summary"))
+            ],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta.model_construct(reasoning="details"))],
+        ),
+    ]
+
+    events = await _collect_handler_events(*chunks)
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    reasoning_item = completed_event.response.output[0]
+    assert isinstance(reasoning_item, ResponseReasoningItem)
+    assert reasoning_item.summary[0].text == "summary"
+    assert reasoning_item.content
+    assert cast(Any, reasoning_item.content[0]).text == "details"
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_orders_refusal_after_reasoning_and_text() -> None:
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(index=0, delta=ChoiceDelta.model_construct(reasoning_content="summary"))
+            ],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(content="partial"))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta.model_construct(refusal="blocked"))],
+        ),
+    ]
+
+    events = await _collect_handler_events(*chunks)
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    assistant_item = completed_event.response.output[1]
+    assert isinstance(assistant_item, ResponseOutputMessage)
+    assert isinstance(assistant_item.content[0], ResponseOutputText)
+    assert isinstance(assistant_item.content[1], ResponseOutputRefusal)
+    assert assistant_item.content[0].text == "partial"
+    assert assistant_item.content[1].refusal == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_places_text_after_existing_refusal_part() -> None:
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta.model_construct(refusal="blocked"))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(content="partial"))],
+        ),
+    ]
+
+    events = await _collect_handler_events(*chunks)
+
+    text_part_added = next(
+        event
+        for event in events
+        if event.type == "response.content_part.added"
+        and isinstance(event.part, ResponseOutputText)
+    )
+    assert text_part_added.content_index == 1
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    assistant_item = completed_event.response.output[0]
+    assert isinstance(assistant_item, ResponseOutputMessage)
+    assert isinstance(assistant_item.content[0], ResponseOutputText)
+    assert isinstance(assistant_item.content[1], ResponseOutputRefusal)
+    assert assistant_item.content[0].text == "partial"
+    assert assistant_item.content[1].refusal == "blocked"
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/realtime/test_audio_formats_unit.py
+++ b/tests/realtime/test_audio_formats_unit.py
@@ -29,6 +29,10 @@ def test_to_realtime_audio_format_none():
 
 
 def test_to_realtime_audio_format_from_mapping():
+    pcm_exact_rate = to_realtime_audio_format({"type": "audio/pcm", "rate": 24000})
+    assert isinstance(pcm_exact_rate, AudioPCM)
+    assert pcm_exact_rate.rate == 24000
+
     pcm = to_realtime_audio_format({"type": "audio/pcm", "rate": 16000})
     assert isinstance(pcm, AudioPCM)
     assert pcm.type == "audio/pcm"

--- a/tests/realtime/test_realtime_handoffs.py
+++ b/tests/realtime/test_realtime_handoffs.py
@@ -248,6 +248,21 @@ def test_realtime_handoff_on_handoff_without_input_runs() -> None:
     assert called == [True]
 
 
+@pytest.mark.asyncio
+async def test_realtime_handoff_async_on_handoff_without_input_runs() -> None:
+    rt = RealtimeAgent(name="async_no_input")
+    called: list[bool] = []
+
+    async def on_handoff(ctx: RunContextWrapper[Any]) -> None:
+        called.append(True)
+
+    handoff_obj = realtime_handoff(rt, on_handoff=on_handoff)
+    result = await handoff_obj.on_invoke_handoff(RunContextWrapper(None), "")
+
+    assert result is rt
+    assert called == [True]
+
+
 class StrictInput(BaseModel):
     name: str
     age: int

--- a/tests/sandbox/capabilities/test_shell_capability.py
+++ b/tests/sandbox/capabilities/test_shell_capability.py
@@ -15,6 +15,7 @@ from agents.sandbox.capabilities.tools import (
     WriteStdinArgs,
     WriteStdinTool,
 )
+from agents.sandbox.capabilities.tools.shell_tool import _resolve_shell
 from agents.sandbox.errors import ExecTimeoutError, ExecTransportError, PtySessionNotFoundError
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.session.pty_types import PtyExecUpdate
@@ -197,6 +198,19 @@ class _PtyNoStdinShellSession(_PtyShellSession):
         raise RuntimeError("stdin is not available for this process")
 
 
+class _PtyUnexpectedStdinErrorShellSession(_PtyShellSession):
+    async def pty_write_stdin(
+        self,
+        *,
+        session_id: int,
+        chars: str,
+        yield_time_s: float | None = None,
+        max_output_tokens: int | None = None,
+    ) -> PtyExecUpdate:
+        _ = (session_id, chars, yield_time_s, max_output_tokens)
+        raise RuntimeError("unexpected stdin failure")
+
+
 class _PtyTransportFailingShellSession(_OutputShellSession):
     def __init__(
         self,
@@ -261,6 +275,9 @@ def _patch_shell_tool_clock(
 
 
 class TestShellCapability:
+    def test_resolve_shell_uses_plain_sh_when_login_is_false(self) -> None:
+        assert _resolve_shell(None, login=False) == ["sh", "-c"]
+
     def test_tools_requires_bound_session(self) -> None:
         capability = Shell()
 
@@ -860,3 +877,15 @@ class TestShellCapability:
             "stdin is not available for this process. Start the command with `tty=true` in "
             "`exec_command` before using `write_stdin`."
         )
+
+    @pytest.mark.asyncio
+    async def test_write_stdin_tool_reraises_unexpected_runtime_error(self) -> None:
+        tool = WriteStdinTool(
+            session=_PtyUnexpectedStdinErrorShellSession(Manifest(root="/workspace"))
+        )
+
+        with pytest.raises(RuntimeError, match="unexpected stdin failure"):
+            await tool.on_invoke_tool(
+                cast(ToolContext[object], None),
+                WriteStdinArgs(session_id=1337).model_dump_json(),
+            )

--- a/tests/sandbox/test_extract.py
+++ b/tests/sandbox/test_extract.py
@@ -10,7 +10,11 @@ import pytest
 
 from agents.sandbox import SandboxArchiveLimits
 from agents.sandbox.entries import GCSMount, InContainerMountStrategy, MountpointMountPattern
-from agents.sandbox.errors import InvalidManifestPathError, WorkspaceArchiveWriteError
+from agents.sandbox.errors import (
+    InvalidCompressionSchemeError,
+    InvalidManifestPathError,
+    WorkspaceArchiveWriteError,
+)
 from agents.sandbox.files import EntryKind, FileEntry
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.sandboxes.unix_local import (
@@ -18,6 +22,7 @@ from agents.sandbox.sandboxes.unix_local import (
     UnixLocalSandboxSessionState,
 )
 from agents.sandbox.session.archive_extraction import zipfile_compatible_stream
+from agents.sandbox.session.archive_ops import extract_archive
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.snapshot import NoopSnapshot
 from agents.sandbox.types import ExecResult, Permissions
@@ -216,6 +221,17 @@ def test_sandbox_archive_limits_defaults_enable_sdk_thresholds() -> None:
     assert limits.max_input_bytes == 1024 * 1024 * 1024
     assert limits.max_extracted_bytes == 4 * 1024 * 1024 * 1024
     assert limits.max_members == 100_000
+
+
+@pytest.mark.asyncio
+async def test_extract_archive_rejects_missing_compression_scheme(tmp_path: Path) -> None:
+    session = _CountingExtractSession(tmp_path / "workspace")
+
+    with pytest.raises(InvalidCompressionSchemeError) as exc_info:
+        await extract_archive(session, "bundle", io.BytesIO(b"not an archive"))
+
+    assert exc_info.value.context["path"] == "bundle"
+    assert exc_info.value.context["scheme"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/sandbox/test_memory.py
+++ b/tests/sandbox/test_memory.py
@@ -398,6 +398,28 @@ def test_render_memory_prompts_include_extra_prompt_section() -> None:
     assert "Focus on user preferences." in consolidation_prompt
 
 
+def test_render_memory_consolidation_prompt_lists_removed_rollouts() -> None:
+    selection = PhaseTwoInputSelection(
+        selected=[],
+        retained_rollout_ids=set(),
+        removed=[
+            PhaseTwoSelectionItem(
+                rollout_id="old-rollout",
+                updated_at="",
+                rollout_path="sessions/old-rollout.jsonl",
+                rollout_summary_file="memories/rollout_summaries/old.md",
+                terminal_state="completed",
+            )
+        ],
+    )
+
+    prompt = render_memory_consolidation_prompt(memory_root="memory", selection=selection)
+
+    assert "- removed from the last successful Phase 2 run: 1" in prompt
+    assert "rollout_id=old-rollout" in prompt
+    assert "updated_at=unknown" in prompt
+
+
 def test_updated_at_sort_key_places_unknown_timestamps_last() -> None:
     assert _updated_at_sort_key("updated_at: 2025-03-01T00:00:00Z\n") > _updated_at_sort_key(
         "updated_at: unknown\n"
@@ -610,6 +632,14 @@ def test_memory_capability_rejects_invalid_sessions_dir(
 def test_memory_capability_requires_read_or_generate() -> None:
     with pytest.raises(ValueError, match="Memory requires at least one of `read` or `generate`"):
         Memory(read=None, generate=None)
+
+
+@pytest.mark.asyncio
+async def test_memory_capability_instructions_requires_bound_session() -> None:
+    capability = Memory(generate=None)
+
+    with pytest.raises(ValueError, match="Memory capability is not bound to a SandboxSession"):
+        await capability.instructions(Manifest())
 
 
 def test_memory_generate_config_rejects_non_positive_recent_rollout_limit() -> None:

--- a/tests/sandbox/test_remote_mount_policy.py
+++ b/tests/sandbox/test_remote_mount_policy.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from agents.sandbox.entries import BaseEntry, DockerVolumeMountStrategy, S3Mount
+from agents.sandbox.entries import BaseEntry, Dir, DockerVolumeMountStrategy, S3Mount
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.remote_mount_policy import build_remote_mount_policy_instructions
 
@@ -55,3 +55,9 @@ def test_remote_mount_policy_handles_mixed_read_only_and_read_write_mounts() -> 
     assert "Do not edit paths marked read-only in place" in policy
     assert "including with `apply_patch`" in policy
     assert "do not write edited files back" in policy
+
+
+def test_remote_mount_policy_returns_none_without_remote_mounts() -> None:
+    policy = build_remote_mount_policy_instructions(Manifest(entries={"local": Dir()}))
+
+    assert policy is None

--- a/tests/sandbox/test_session_state_roundtrip.py
+++ b/tests/sandbox/test_session_state_roundtrip.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
-from typing import Literal
+from typing import ClassVar, Literal
 
 import pytest
 from pydantic import ValidationError
@@ -150,6 +150,13 @@ class TestSandboxSessionStateRoundTrip:
     def test_subclass_registration_skips_non_literal_or_empty_type_defaults(self) -> None:
         assert "plain-type" not in SandboxSessionState._subclass_registry
         assert "" not in SandboxSessionState._subclass_registry
+
+    def test_subclass_registration_skips_missing_type_field(self) -> None:
+        class _NoTypeFieldSessionState(SandboxSessionState):
+            type: ClassVar[str] = "no-type-field"  # type: ignore[misc]
+
+        assert "no-type-field" not in SandboxSessionState._subclass_registry
+        assert "type" not in _NoTypeFieldSessionState.model_fields
 
     @pytest.mark.parametrize(
         ("raw_ports", "expected"),

--- a/tests/sandbox/test_session_utils.py
+++ b/tests/sandbox/test_session_utils.py
@@ -13,7 +13,7 @@ from agents.sandbox.files import EntryKind, FileEntry
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.session import SandboxSessionStartEvent
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
-from agents.sandbox.session.events import SandboxSessionFinishEvent
+from agents.sandbox.session.events import SandboxSessionFinishEvent, validate_sandbox_session_event
 from agents.sandbox.session.utils import (
     _best_effort_stream_len,
     _safe_decode,
@@ -113,6 +113,21 @@ def test_event_to_json_line_is_single_line() -> None:
     line = event_to_json_line(event)
     assert line.endswith("\n")
     assert "\n" not in line[:-1]
+
+
+def test_validate_sandbox_session_event_uses_phase_discriminator() -> None:
+    event = SandboxSessionStartEvent(
+        session_id=uuid.uuid4(),
+        seq=1,
+        op="read",
+        span_id="span_read",
+    )
+
+    restored = validate_sandbox_session_event(event.model_dump(mode="json"))
+
+    assert isinstance(restored, SandboxSessionStartEvent)
+    assert restored.phase == "start"
+    assert restored.op == "read"
 
 
 def test_sandbox_session_finish_event_excludes_raw_bytes_from_json_dump() -> None:

--- a/tests/test_exception_exports.py
+++ b/tests/test_exception_exports.py
@@ -1,5 +1,9 @@
 """Verify that all public exception classes are re-exported from the top-level agents package."""
 
+from typing import Any, cast
+
+import pytest
+
 import agents
 from agents import exceptions as exceptions_module
 
@@ -28,3 +32,22 @@ def test_all_public_exception_classes_are_reexported() -> None:
     for name in public_exception_names:
         assert hasattr(agents, name), f"agents.{name} is not re-exported from agents package"
         assert name in agents.__all__, f"{name} is missing from agents.__all__"
+
+
+def test_run_error_details_str_uses_pretty_printer(monkeypatch: pytest.MonkeyPatch) -> None:
+    details = exceptions_module.RunErrorDetails(
+        input="hello",
+        new_items=[],
+        raw_responses=[],
+        last_agent=cast(Any, object()),
+        context_wrapper=cast(Any, object()),
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+    )
+    monkeypatch.setattr(
+        exceptions_module,
+        "pretty_print_run_error_details",
+        lambda value: "formatted details" if value is details else "unexpected",
+    )
+
+    assert str(details) == "formatted details"

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -22,7 +22,7 @@ from agents import (
 )
 from agents.guardrail import input_guardrail, output_guardrail
 from agents.result import RunResultStreaming
-from agents.run_internal.guardrails import run_input_guardrails_with_queue
+from agents.run_internal.guardrails import run_input_guardrails, run_input_guardrails_with_queue
 
 from .fake_model import FakeModel
 from .test_responses import get_function_tool_call, get_text_message
@@ -42,6 +42,18 @@ def get_sync_guardrail(triggers: bool, output_info: Any | None = None):
         )
 
     return sync_guardrail
+
+
+@pytest.mark.asyncio
+async def test_run_input_guardrails_returns_empty_for_no_guardrails() -> None:
+    result = await run_input_guardrails(
+        agent=Agent(name="test"),
+        guardrails=[],
+        input="test",
+        context=RunContextWrapper(context=None),
+    )
+
+    assert result == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -470,6 +470,40 @@ async def test_handoff_is_enabled_filtering_integration():
     assert "agent_2" not in agent_names
 
 
+@pytest.mark.asyncio
+async def test_handoff_is_enabled_sync_callable_false_filters_handoff():
+    target_agent = Agent(name="target")
+    main_agent = Agent(
+        name="main",
+        handoffs=[handoff(target_agent, is_enabled=lambda ctx, agent: False)],
+    )
+
+    filtered_handoffs = await get_handoffs(main_agent, RunContextWrapper(main_agent))
+
+    assert filtered_handoffs == []
+
+
+@pytest.mark.asyncio
+async def test_handoff_direct_sync_is_enabled_callable_filters_handoff():
+    async def invoke_handoff(ctx: RunContextWrapper[Any], input_json: str) -> Agent[Any]:
+        _ = (ctx, input_json)
+        return Agent(name="target")
+
+    handoff_obj = Handoff(
+        tool_name="transfer_to_target",
+        tool_description="Transfer to target.",
+        input_json_schema={},
+        on_invoke_handoff=invoke_handoff,
+        agent_name="target",
+        is_enabled=lambda ctx, agent: False,
+    )
+    main_agent = Agent(name="main", handoffs=[handoff_obj])
+
+    filtered_handoffs = await get_handoffs(main_agent, RunContextWrapper(main_agent))
+
+    assert filtered_handoffs == []
+
+
 class StrictInput(BaseModel):
     name: str
     age: int

--- a/tests/test_run_hooks.py
+++ b/tests/test_run_hooks.py
@@ -10,6 +10,7 @@ from agents.lifecycle import AgentHooks, RunHooks
 from agents.models.interface import Model
 from agents.run import Runner
 from agents.run_context import AgentHookContext, RunContextWrapper, TContext
+from agents.run_internal.run_loop import validate_run_hooks
 from agents.tool import Tool, function_tool
 from agents.tool_context import ToolContext
 from tests.test_agent_llm_hooks import AgentHooksForTests
@@ -220,6 +221,11 @@ def test_runner_run_streamed_rejects_agent_hooks():
 
     with pytest.raises(TypeError, match="Run hooks must be instances of RunHooks"):
         Runner.run_streamed(agent, input="hello", hooks=hooks)
+
+
+def test_validate_run_hooks_rejects_non_hook_objects() -> None:
+    with pytest.raises(TypeError, match="Received object"):
+        validate_run_hooks(object())
 
 
 class BoomModel(Model):

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -287,6 +287,32 @@ def test_drop_orphan_function_calls_does_not_pair_named_tool_search_with_anonymo
     assert [cast(dict[str, Any], item)["type"] for item in filtered] == ["tool_search_output"]
 
 
+def test_drop_orphan_function_calls_keeps_reasoning_chain_before_non_dropped_item() -> None:
+    payload: list[Any] = [
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_1", "summary": []}),
+        cast(TResponseInputItem, {"type": "reasoning", "id": "rs_2", "summary": []}),
+        cast(TResponseInputItem, {"type": "message", "role": "assistant", "content": []}),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "function_call",
+                "call_id": "orphan_call",
+                "name": "orphan",
+                "arguments": "{}",
+            },
+        ),
+    ]
+
+    filtered = run_items.drop_orphan_function_calls(cast(list[TResponseInputItem], payload))
+
+    assert [cast(dict[str, Any], item)["id"] for item in filtered[:2]] == ["rs_1", "rs_2"]
+    assert [cast(dict[str, Any], item)["type"] for item in filtered] == [
+        "reasoning",
+        "reasoning",
+        "message",
+    ]
+
+
 def test_normalize_and_ensure_input_item_format_keep_non_dict_entries() -> None:
     item = cast(TResponseInputItem, "raw-item")
     assert run_items.ensure_input_item_format(item) == item
@@ -325,6 +351,28 @@ def test_fingerprint_input_item_handles_edge_cases(monkeypatch: pytest.MonkeyPat
     opaque_fingerprint = run_items.fingerprint_input_item(_Opaque(), ignore_ids_for_matching=True)
     assert opaque_fingerprint is not None
     assert '"id"' not in opaque_fingerprint
+
+
+def test_fingerprint_input_item_returns_none_when_serialization_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_json_error(*_args: Any, **_kwargs: Any) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cast(Any, run_items).json, "dumps", _raise_json_error)
+
+    assert run_items.fingerprint_input_item({"type": "message", "role": "user"}) is None
+
+
+def test_strip_metadata_and_reasoning_id_helpers_keep_non_matching_items() -> None:
+    raw = cast(TResponseInputItem, "raw-item")
+    non_reasoning = cast(TResponseInputItem, {"type": "message", "id": "msg_1"})
+    reasoning_without_id = cast(TResponseInputItem, {"type": "reasoning", "summary": []})
+
+    assert run_items.strip_internal_input_item_metadata(raw) == raw
+    assert run_items._without_reasoning_item_id(raw) == raw
+    assert run_items._without_reasoning_item_id(non_reasoning) == non_reasoning
+    assert run_items._without_reasoning_item_id(reasoning_without_id) == reasoning_without_id
 
 
 def test_deduplicate_input_items_handles_fake_ids_and_approval_request_ids() -> None:

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -2934,6 +2934,14 @@ def make_processed_response(
     )
 
 
+def test_processed_response_reports_interruptions() -> None:
+    processed_response = make_processed_response(
+        interruptions=[cast(ToolApprovalItem, object())],
+    )
+
+    assert processed_response.has_interruptions() is True
+
+
 async def get_execute_result(
     agent: Agent[Any],
     response: ModelResponse,

--- a/tests/test_source_compat_constructors.py
+++ b/tests/test_source_compat_constructors.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any, cast
 
+import pytest
+
 from agents import (
     Agent,
     AgentHookContext,
@@ -172,6 +174,14 @@ def test_tool_execution_config_pre_approval_append_preserves_max_concurrency() -
 
     assert config.max_function_tool_concurrency == 2
     assert config.pre_approval_tool_input_guardrails is True
+
+
+def test_tool_execution_config_rejects_non_bool_pre_approval_guardrails() -> None:
+    with pytest.raises(
+        ValueError,
+        match="tool_execution.pre_approval_tool_input_guardrails must be a bool",
+    ):
+        ToolExecutionConfig(pre_approval_tool_input_guardrails=cast(Any, "true"))
 
 
 def test_model_settings_context_management_append_preserves_retry_position() -> None:

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -210,6 +210,7 @@ def test_stream_step_items_to_queue_emits_helper_events_and_skips_approvals(
             agent=agent,
             raw_item=_make_hosted_mcp_list_tools("test-mcp-server", "search_docs"),
         ),
+        ReasoningItem(agent=agent, raw_item=get_reasoning_item()),
         ToolApprovalItem(
             agent=agent,
             raw_item={"type": "function_call", "call_id": "call-1", "name": "tool"},
@@ -231,6 +232,7 @@ def test_stream_step_items_to_queue_emits_helper_events_and_skips_approvals(
         "mcp_approval_requested",
         "mcp_approval_response",
         "mcp_list_tools",
+        "reasoning_item_created",
     ]
     assert "Unexpected item type" in caplog.text
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -145,6 +145,20 @@ def test_draw_graph(mock_agent):
     _assert_mcp_nodes(graph.source)
 
 
+def test_draw_graph_renders_filename(monkeypatch, mock_agent):
+    render_calls: list[tuple[str, str, bool]] = []
+
+    def fake_render(self, filename: str, *, format: str, cleanup: bool):
+        render_calls.append((filename, format, cleanup))
+
+    monkeypatch.setattr(graphviz.Source, "render", fake_render)
+
+    graph = draw_graph(mock_agent, filename="agent_graph")
+
+    assert isinstance(graph, graphviz.Source)
+    assert render_calls == [("agent_graph", "png", True)]
+
+
 def _assert_mcp_nodes(source: str):
     assert (
         '"MCPServer1" [label="MCPServer1", shape=box, style=filled, '

--- a/tests/tracing/test_trace_context.py
+++ b/tests/tracing/test_trace_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from uuid import uuid4
 
 import agents.tracing.traces as trace_module
@@ -78,6 +79,24 @@ def test_create_trace_for_run_does_not_reattach_after_trace_state_reload() -> No
     created = create_trace_for_run(
         workflow_name="workflow",
         trace_id=trace_state.trace_id,
+        group_id=trace_state.group_id,
+        metadata=dict(trace_state.metadata or {}),
+        tracing=None,
+        disabled=False,
+        trace_state=trace_state,
+        reattach_resumed_trace=True,
+    )
+
+    assert isinstance(created, TraceImpl)
+    assert not isinstance(created, ReattachedTrace)
+
+
+def test_create_trace_for_run_does_not_reattach_when_trace_id_differs() -> None:
+    trace_state = _mark_trace_as_started()
+
+    created = create_trace_for_run(
+        workflow_name="workflow",
+        trace_id=_new_trace_id(),
         group_id=trace_state.group_id,
         metadata=dict(trace_state.metadata or {}),
         tracing=None,
@@ -214,6 +233,21 @@ def test_create_trace_for_run_uses_existing_current_trace() -> None:
         )
 
         assert created is None
+
+
+def test_trace_logs_warning_when_current_trace_exists(
+    caplog,
+) -> None:
+    Scope.set_current_trace(None)
+    outer_trace = trace(workflow_name="outer", trace_id=_new_trace_id())
+    assert isinstance(outer_trace, TraceImpl)
+
+    with outer_trace:
+        with caplog.at_level(logging.WARNING, logger="openai.agents"):
+            inner_trace = trace(workflow_name="inner", trace_id=_new_trace_id())
+
+    assert isinstance(inner_trace, TraceImpl)
+    assert "Trace already exists" in caplog.text
 
 
 def test_started_trace_id_cache_is_bounded(monkeypatch) -> None:


### PR DESCRIPTION
This pull request improves test coverage across Chat Completions streaming, sandbox session utilities, Codex thread options, realtime handoffs, tracing context behavior, guardrails, and small runtime helper edge cases. It also refactors the newly added stream-handler tests to share local collection helpers and removes an overly artificial monkeypatch-only coverage case in favor of clearer public-behavior coverage.

The changes are test-only and do not alter runtime behavior.