### PR TITLE
docs: add sandbox examples to examples index

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -104,13 +104,13 @@ Check out a variety of sample implementations of the SDK in the examples section
 
 - **[research_bot](https://github.com/openai/openai-agents-python/tree/main/examples/research_bot):** Simple deep research clone that demonstrates complex multi-agent research workflows.
 
-- **[sandbox](https://github.com/openai/openai-agents-python/tree/main/examples/sandbox):** Examples for running agents with isolated workspaces, including:
+- **[sandbox](https://github.com/openai/openai-agents-python/tree/main/examples/sandbox):** Examples for running agents in isolated workspaces, including:
 
     -   Basic sandbox agent setup (`examples/sandbox/basic.py`)
+    -   Unix-local and Docker sandbox lifecycle examples
     -   Sandbox-backed handoffs (`examples/sandbox/handoffs.py`)
     -   Sandbox memory and snapshot resume (`examples/sandbox/memory.py`)
     -   Sandbox agents exposed as tools (`examples/sandbox/sandbox_agents_as_tools.py`)
-    -   Guided sandbox tutorials (`examples/sandbox/tutorials`)
 
 - **[tools](https://github.com/openai/openai-agents-python/tree/main/examples/tools):** Learn how to implement OAI hosted tools and experimental Codex tooling such as:
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -104,6 +104,14 @@ Check out a variety of sample implementations of the SDK in the examples section
 
 - **[research_bot](https://github.com/openai/openai-agents-python/tree/main/examples/research_bot):** Simple deep research clone that demonstrates complex multi-agent research workflows.
 
+- **[sandbox](https://github.com/openai/openai-agents-python/tree/main/examples/sandbox):** Examples for running agents with isolated workspaces, including:
+
+    -   Basic sandbox agent setup (`examples/sandbox/basic.py`)
+    -   Sandbox-backed handoffs (`examples/sandbox/handoffs.py`)
+    -   Sandbox memory and snapshot resume (`examples/sandbox/memory.py`)
+    -   Sandbox agents exposed as tools (`examples/sandbox/sandbox_agents_as_tools.py`)
+    -   Guided sandbox tutorials (`examples/sandbox/tutorials`)
+
 - **[tools](https://github.com/openai/openai-agents-python/tree/main/examples/tools):** Learn how to implement OAI hosted tools and experimental Codex tooling such as:
 
     -   Web search and web search with filters


### PR DESCRIPTION
﻿Summary:
- Add the sandbox examples category to the examples documentation index.
- Link to the main sandbox examples README and representative sandbox example files.
- Include sandbox tutorials in the examples overview.

Why:
- The repository has a populated `examples/sandbox` directory, but the examples index did not list it.
- This makes sandbox agent examples easier to discover from the docs.

Validation:
- [x] `git diff --check`
- [x] Verified each linked `examples/sandbox` path exists locally.
- [ ] `uv run mkdocs build --strict --site-dir <temp>` did not pass because the current docs tree emits existing strict-mode warnings unrelated to this change.

Notes for reviewers:
- Docs-only change; no runtime code, dependency, or lockfile changes.
