### PR TITLE
feat: update default realtime model to gpt-realtime-2.1

### DIFF
--- a/examples/realtime/app/server.py
+++ b/examples/realtime/app/server.py
@@ -52,7 +52,7 @@ class RealtimeWebSocketManager:
         # runner = RealtimeRunner(agent, config=runner_config)
         model_config: RealtimeModelConfig = {
             "initial_model_settings": {
-                "model_name": "gpt-realtime-2",
+                "model_name": "gpt-realtime-2.1",
                 "turn_detection": {
                     "type": "server_vad",
                     "prefix_padding_ms": 300,

--- a/examples/realtime/cli/demo.py
+++ b/examples/realtime/cli/demo.py
@@ -225,7 +225,7 @@ class NoUIDemo:
             model_config: RealtimeModelConfig = {
                 "playback_tracker": self.playback_tracker,
                 "initial_model_settings": {
-                    "model_name": "gpt-realtime-2",
+                    "model_name": "gpt-realtime-2.1",
                     "turn_detection": {
                         "type": "semantic_vad",
                         "interrupt_response": True,

--- a/examples/realtime/twilio/twilio_handler.py
+++ b/examples/realtime/twilio/twilio_handler.py
@@ -93,7 +93,7 @@ class TwilioHandler:
             model_config={
                 "api_key": api_key,
                 "initial_model_settings": {
-                    "model_name": "gpt-realtime-2",
+                    "model_name": "gpt-realtime-2.1",
                     "input_audio_format": "g711_ulaw",
                     "output_audio_format": "g711_ulaw",
                     "turn_detection": {

--- a/examples/realtime/twilio_sip/server.py
+++ b/examples/realtime/twilio_sip/server.py
@@ -69,7 +69,7 @@ async def accept_call(call_id: str) -> None:
             f"/realtime/calls/{call_id}/accept",
             body={
                 "type": "realtime",
-                "model": "gpt-realtime-2",
+                "model": "gpt-realtime-2.1",
                 "instructions": instructions_payload,
             },
             cast_to=dict,

--- a/src/agents/realtime/config.py
+++ b/src/agents/realtime/config.py
@@ -21,6 +21,8 @@ RealtimeModelName: TypeAlias = (
         "gpt-realtime",
         "gpt-realtime-1.5",
         "gpt-realtime-2",
+        "gpt-realtime-2.1",
+        "gpt-realtime-2.1-mini",
         "gpt-realtime-2025-08-28",
         "gpt-4o-realtime-preview",
         "gpt-4o-realtime-preview-2024-10-01",

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -155,7 +155,7 @@ OpenAIRealtimeAudioOutput = _rt_audio_config.RealtimeAudioConfigOutput  # type: 
 
 
 _USER_AGENT = f"Agents/Python {__version__}"
-DEFAULT_REALTIME_MODEL = "gpt-realtime-2"
+DEFAULT_REALTIME_MODEL = "gpt-realtime-2.1"
 
 DEFAULT_MODEL_SETTINGS: RealtimeSessionModelSettings = {
     "voice": "ash",

--- a/tests/realtime/test_conversion_helpers.py
+++ b/tests/realtime/test_conversion_helpers.py
@@ -33,7 +33,7 @@ class TestConversionHelperTryConvertRawMessage:
                 "type": "session.update",
                 "other_data": {
                     "session": {
-                        "model": "gpt-realtime-2",
+                        "model": "gpt-realtime-2.1",
                         "type": "realtime",
                         "modalities": ["text", "audio"],
                         "voice": "ash",

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -116,8 +116,8 @@ class TestConnectionLifecycle(TestOpenAIRealtimeWebSocketModel):
         assert model.model == "gpt-4o-realtime-preview"
 
     @pytest.mark.asyncio
-    async def test_connect_defaults_to_gpt_realtime_2(self, model, mock_websocket):
-        """Test that connect() uses gpt-realtime-2 when no model is provided."""
+    async def test_connect_defaults_to_gpt_realtime_2_1(self, model, mock_websocket):
+        """Test that connect() uses gpt-realtime-2.1 when no model is provided."""
         config = {
             "api_key": "test-api-key-123",
             "initial_model_settings": {},
@@ -140,8 +140,8 @@ class TestConnectionLifecycle(TestOpenAIRealtimeWebSocketModel):
 
                 mock_connect.assert_called_once()
                 call_args = mock_connect.call_args
-                assert call_args[0][0] == "wss://api.openai.com/v1/realtime?model=gpt-realtime-2"
-                assert model.model == "gpt-realtime-2"
+                assert call_args[0][0] == "wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1"
+                assert model.model == "gpt-realtime-2.1"
 
         assert model._websocket_task is not None
 
@@ -1672,7 +1672,7 @@ class TestSendEventAndConfig(TestOpenAIRealtimeWebSocketModel):
     def test_session_config_defaults_audio_formats_when_not_call(self, model):
         settings: dict[str, Any] = {}
         cfg = model._get_session_config(settings)
-        assert cfg.model == "gpt-realtime-2"
+        assert cfg.model == "gpt-realtime-2.1"
         assert cfg.audio is not None
         assert cfg.audio.input is not None
         assert cfg.audio.input.format is not None
@@ -1689,7 +1689,7 @@ class TestSendEventAndConfig(TestOpenAIRealtimeWebSocketModel):
         cfg = model._get_session_config(settings)
         payload = cfg.model_dump(exclude_unset=True)
 
-        assert payload["model"] == "gpt-realtime-2"
+        assert payload["model"] == "gpt-realtime-2.1"
         assert payload["parallel_tool_calls"] is False
         assert payload["reasoning"] == {"effort": "low"}
 

--- a/tests/realtime/test_realtime_model_settings.py
+++ b/tests/realtime/test_realtime_model_settings.py
@@ -68,7 +68,7 @@ async def test_build_model_settings_from_agent_merges_agent_fields(monkeypatch: 
 
     monkeypatch.setattr(agent, "get_all_tools", AsyncMock(return_value=[helper]))
     agent.handoffs = [RealtimeAgent(name="handoff-child")]
-    base_settings: RealtimeSessionModelSettings = {"model_name": "gpt-realtime-2"}
+    base_settings: RealtimeSessionModelSettings = {"model_name": "gpt-realtime-2.1"}
     starting_settings: RealtimeSessionModelSettings = {"voice": "verse"}
     run_config: RealtimeRunConfig = {"tracing_disabled": True}
 
@@ -85,9 +85,9 @@ async def test_build_model_settings_from_agent_merges_agent_fields(monkeypatch: 
     assert merged["tools"][0].name == helper.name
     assert merged["handoffs"][0].agent_name == "handoff-child"
     assert merged["voice"] == "verse"
-    assert merged["model_name"] == "gpt-realtime-2"
+    assert merged["model_name"] == "gpt-realtime-2.1"
     assert merged["tracing"] is None
-    assert base_settings == {"model_name": "gpt-realtime-2"}
+    assert base_settings == {"model_name": "gpt-realtime-2.1"}
 
 
 @pytest.mark.asyncio

--- a/tests/realtime/test_session_payload_and_formats.py
+++ b/tests/realtime/test_session_payload_and_formats.py
@@ -26,10 +26,10 @@ class _DummyModel(pydantic.BaseModel):
 
 def _session_with_output(fmt: Any | None) -> RealtimeSessionCreateRequest:
     if fmt is None:
-        return RealtimeSessionCreateRequest(type="realtime", model="gpt-realtime-2")
+        return RealtimeSessionCreateRequest(type="realtime", model="gpt-realtime-2.1")
     return RealtimeSessionCreateRequest(
         type="realtime",
-        model="gpt-realtime-2",
+        model="gpt-realtime-2.1",
         # Use dict for output to avoid importing non-exported symbols in tests
         audio=RealtimeAudioConfig(output=cast(Any, {"format": fmt})),
     )
@@ -49,7 +49,7 @@ def test_normalize_session_payload_variants() -> None:
     assert Model._normalize_session_payload(transcription_mapping) is None
 
     # Valid realtime mapping should be converted to model
-    realtime_mapping: Mapping[str, object] = {"type": "realtime", "model": "gpt-realtime-2"}
+    realtime_mapping: Mapping[str, object] = {"type": "realtime", "model": "gpt-realtime-2.1"}
     as_model = Model._normalize_session_payload(realtime_mapping)
     assert isinstance(as_model, RealtimeSessionCreateRequest)
     assert as_model.type == "realtime"

--- a/tests/realtime/test_tracing.py
+++ b/tests/realtime/test_tracing.py
@@ -103,7 +103,7 @@ class TestRealtimeTracingIntegration:
                     "session": {
                         "id": "session_456",
                         "type": "realtime",
-                        "model": "gpt-realtime-2",
+                        "model": "gpt-realtime-2.1",
                     },
                 }
 
@@ -148,7 +148,7 @@ class TestRealtimeTracingIntegration:
                     "session": {
                         "id": "session_456",
                         "type": "realtime",
-                        "model": "gpt-realtime-2",
+                        "model": "gpt-realtime-2.1",
                     },
                 }
 
@@ -174,7 +174,7 @@ class TestRealtimeTracingIntegration:
         session_created_event = {
             "type": "session.created",
             "event_id": "event_123",
-            "session": {"id": "session_456", "type": "realtime", "model": "gpt-realtime-2"},
+            "session": {"id": "session_456", "type": "realtime", "model": "gpt-realtime-2.1"},
         }
 
         with patch.object(model, "send_event") as mock_send_event:
@@ -216,7 +216,7 @@ class TestRealtimeTracingIntegration:
                     "session": {
                         "id": "session_456",
                         "type": "realtime",
-                        "model": "gpt-realtime-2",
+                        "model": "gpt-realtime-2.1",
                     },
                 }
 


### PR DESCRIPTION
This pull request updates the Python Realtime default model from gpt-realtime-2 to gpt-realtime-2.1 and adds the newly released gpt-realtime-2.1 and gpt-realtime-2.1-mini model IDs to the typed realtime model name list.