### PR TITLE
docs: index sandbox extension runners and tutorials in examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -111,6 +111,9 @@ Check out a variety of sample implementations of the SDK in the examples section
     -   Sandbox-backed handoffs (`examples/sandbox/handoffs.py`)
     -   Sandbox memory and snapshot resume (`examples/sandbox/memory.py`)
     -   Sandbox agents exposed as tools (`examples/sandbox/sandbox_agents_as_tools.py`)
+    -   Third-party sandbox provider runners for Daytona (`examples/sandbox/extensions/daytona/daytona_runner.py`), E2B (`examples/sandbox/extensions/e2b_runner.py`), Modal (`examples/sandbox/extensions/modal_runner.py`), Vercel (`examples/sandbox/extensions/vercel_runner.py`), Cloudflare (`examples/sandbox/extensions/cloudflare_runner.py`), Blaxel (`examples/sandbox/extensions/blaxel_runner.py`), and Runloop (`examples/sandbox/extensions/runloop/runner.py`)
+    -   Durable Temporal sandbox workflows (`examples/sandbox/extensions/temporal/temporal_sandbox_agent.py`)
+    -   Tutorials: dataroom Q&A (`examples/sandbox/tutorials/dataroom_qa/main.py`), structured financial metric extraction from a 10-K dataroom (`examples/sandbox/tutorials/dataroom_metric_extract/main.py`), repository code review with generated findings (`examples/sandbox/tutorials/repo_code_review/main.py`), sandbox resume with workspace build instructions (`examples/sandbox/tutorials/sandbox_resume/main.py`), and vision-based website cloning from a screenshot (`examples/sandbox/tutorials/vision_website_clone/main.py`)
 
 - **[tools](https://github.com/openai/openai-agents-python/tree/main/examples/tools):** Learn how to implement OAI hosted tools and experimental Codex tooling such as:
 


### PR DESCRIPTION
### Summary

The `sandbox` section of the examples index (`docs/examples.md`) was missing a large number of examples that already exist under `examples/sandbox/`, so readers browsing the documentation had no way to discover them. This adds index entries for:

- The third-party sandbox **provider runners** under `examples/sandbox/extensions/` — Daytona, E2B, Modal, Vercel, Cloudflare, Blaxel, and Runloop.
- **Durable Temporal** sandbox workflows.
- The **tutorials** suite under `examples/sandbox/tutorials/` — dataroom Q&A, structured financial metric extraction, repository code review, sandbox resume, and vision-based website cloning.

Descriptions are drawn from each example's module docstring. There are no source or behavior changes.

### Test plan

Docs-only change (markdown additions to an existing section of the examples index). Per `AGENTS.md`, docs-only changes are exempt from the `$code-change-verification` stack.

- Verified that every one of the 13 newly referenced example paths resolves to an existing file in the repository.
- No changes to `mkdocs.yml` navigation or generated reference files; the edit only appends list items to the existing `sandbox` section.

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant — N/A (docs-only)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` — N/A (docs-only, exempt per `AGENTS.md`)
- [x] I've confirmed all verification steps pass (all referenced example paths verified to exist)
- [ ] If using Codex, I've run `/review` before submitting this PR — N/A