### PR TITLE
fix(visualization): keep fillcolor on handoff nodes by merging style attributes

### DIFF
--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -97,7 +97,7 @@ def get_all_nodes(
             name = _escape_label(handoff.agent_name)
             parts.append(
                 f'"{name}" [label="{name}", '
-                f"shape=box, style=filled, style=rounded, "
+                f'shape=box, style="filled,rounded", '
                 f"fillcolor=lightyellow, width=1.5, height=0.8];"
             )
         if isinstance(handoff, Agent):
@@ -105,7 +105,7 @@ def get_all_nodes(
                 name = _escape_label(handoff.name)
                 parts.append(
                     f'"{name}" [label="{name}", '
-                    f"shape=box, style=filled, style=rounded, "
+                    f'shape=box, style="filled,rounded", '
                     f"fillcolor=lightyellow, width=1.5, height=0.8];"
                 )
             parts.append(get_all_nodes(handoff, agent, visited))

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -64,7 +64,7 @@ def test_get_main_graph(mock_agent):
         "fillcolor=lightgreen, width=0.5, height=0.3];" in result
     )
     assert (
-        '"Handoff1" [label="Handoff1", shape=box, style=filled, style=rounded, '
+        '"Handoff1" [label="Handoff1", shape=box, style="filled,rounded", '
         "fillcolor=lightyellow, width=1.5, height=0.8];" in result
     )
     _assert_mcp_nodes(result)
@@ -93,7 +93,7 @@ def test_get_all_nodes(mock_agent):
         "fillcolor=lightgreen, width=0.5, height=0.3];" in result
     )
     assert (
-        '"Handoff1" [label="Handoff1", shape=box, style=filled, style=rounded, '
+        '"Handoff1" [label="Handoff1", shape=box, style="filled,rounded", '
         "fillcolor=lightyellow, width=1.5, height=0.8];" in result
     )
     _assert_mcp_nodes(result)
@@ -139,7 +139,7 @@ def test_draw_graph(mock_agent):
         "fillcolor=lightgreen, width=0.5, height=0.3];" in graph.source
     )
     assert (
-        '"Handoff1" [label="Handoff1", shape=box, style=filled, style=rounded, '
+        '"Handoff1" [label="Handoff1", shape=box, style="filled,rounded", '
         "fillcolor=lightyellow, width=1.5, height=0.8];" in graph.source
     )
     _assert_mcp_nodes(graph.source)
@@ -270,7 +270,7 @@ def test_draw_graph_with_real_handoff_object():
     assert '"ParentAgent"' in graph.source
     # Node uses agent_name from the Handoff object
     assert (
-        '"ChildAgent" [label="ChildAgent", shape=box, style=filled, style=rounded, '
+        '"ChildAgent" [label="ChildAgent", shape=box, style="filled,rounded", '
         "fillcolor=lightyellow, width=1.5, height=0.8];" in graph.source
     )
     # Edge points from parent to handoff agent_name


### PR DESCRIPTION
### Summary

Handoff and sub-agent nodes in the agent visualization are meant to render as filled `lightyellow` boxes (matching the root agent node), but they currently render as empty/unfilled boxes.

The node attribute list sets `style` twice: `style=filled, style=rounded`. In the DOT language a repeated attribute takes the **last** value, so `style` resolves to `rounded` only and `filled` is dropped. Because `fillcolor` only takes effect when `filled` is present in `style`, the `fillcolor=lightyellow` was silently ignored.

This merges the two into a single valid value, `style="filled,rounded"`, so the nodes are both filled and rounded as intended. Applies to both the `Handoff` and `Agent` handoff branches in `get_all_nodes`.

### Test plan

Verified against the actual Graphviz renderer (`dot`) by rendering a node both ways to SVG and inspecting the node polygon fill:

- Before (`style=filled, style=rounded`) -> `fill="none"` (unfilled)
- After (`style="filled,rounded"`) -> `fill="lightyellow"` (filled, as intended)

Updated the existing `tests/test_visualization.py` expectations (which asserted the old DOT string) to match the corrected output. Ran the standard checks:

- `uv run ruff format --check` — pass
- `uv run ruff check` — pass
- `uv run mypy src/agents/extensions/visualization.py` — pass
- `uv run pytest tests/test_visualization.py` — 10 passed

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant (updated existing visualization assertions to cover the corrected output)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (ran the equivalent stack manually: ruff format/check, mypy, pytest — see test plan)
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR — N/A