### PR TITLE
fix(items): coerce None refusal to empty string in extract_last_content

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -698,7 +698,12 @@ class ItemHelpers:
             # ``extract_text`` below.
             return last_content.text or ""
         elif isinstance(last_content, ResponseOutputRefusal):
-            return last_content.refusal
+            # ``last_content.refusal`` is typed as ``str`` per the Responses API schema,
+            # but provider gateways (e.g. LiteLLM) and ``model_construct`` paths during
+            # streaming have been observed surfacing ``None``. Coerce so callers relying
+            # on the ``-> str`` return type don't see a ``None``. Mirrors the text branch
+            # above and ``extract_refusal``.
+            return last_content.refusal or ""
         else:
             raise ModelBehaviorError(f"Unexpected content type: {type(last_content)}")
 

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -84,6 +84,21 @@ def test_extract_last_content_of_refusal_message() -> None:
     assert ItemHelpers.extract_last_content(message) == "I cannot do that"
 
 
+def test_extract_last_content_of_refusal_message_with_null_refusal() -> None:
+    # Provider gateways (e.g. LiteLLM) and ``model_construct`` streaming paths can surface a
+    # ``None`` refusal even though the schema types it as ``str``. Since ``extract_last_content``
+    # is annotated ``-> str``, it must coerce ``None`` to "" rather than return ``None``.
+    refusal = ResponseOutputRefusal.model_construct(refusal=None, type="refusal")
+    message = ResponseOutputMessage.model_construct(
+        id="msg123",
+        content=[refusal],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+    assert ItemHelpers.extract_last_content(message) == ""
+
+
 def test_extract_last_content_non_message_returns_empty() -> None:
     # Construct some other type of output item, e.g. a tool call, to verify non-message returns "".
     tool_call = ResponseFunctionToolCall(


### PR DESCRIPTION
### Summary

`ItemHelpers.extract_last_content` is annotated `-> str`, and its text-content branch already coerces a `None` `text` to `""` — with a comment noting that provider gateways (e.g. LiteLLM) and `model_construct` streaming paths can surface `None` even though the schema types the field as `str`. The **refusal** branch had the identical exposure but returned `last_content.refusal` bare, so for a refusal message whose `refusal` is `None`, `extract_last_content` returned `None`, violating its own `-> str` contract.

This coerces the refusal branch the same way, matching both the text branch above it and the sibling `extract_refusal` (which already uses `refusal or ""`).

### Test plan

Added `test_extract_last_content_of_refusal_message_with_null_refusal`, which reproduces the `None`-refusal case via `model_construct` (the documented provider-gateway path). Change-relevant checks:

- `uv run ruff format --check src/agents/items.py tests/test_items_helpers.py` — pass
- `uv run ruff check src/agents/items.py tests/test_items_helpers.py` — pass
- `uv run mypy src/agents/items.py` — `Success: no issues found`
- `uv run pytest tests/test_items_helpers.py` — 35 passed

I also ran the full `.agents/skills/code-change-verification/scripts/run.sh`: `make format` and `make lint` pass. `make typecheck` fails only on ~22 pre-existing errors in files unrelated to this change (e.g. `tests/sandbox/test_unix_local.py` references `signal.SIGQUIT`, unavailable on Windows; plus tool-version/stub issues in `extensions/memory/redis_session.py`, `sandbox/util/tar_utils.py`, `models/openai_responses.py`, etc.). I verified there are **no** typecheck errors in the changed files (`items.py`, `test_items_helpers.py`). This is a local Windows/tool-version environment issue, not a regression from this PR, so I've left the "all steps pass" box unchecked.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant (added a null-refusal regression test)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh` (format + lint pass; typecheck blocked only by pre-existing, unrelated Windows errors — none in the changed files; see test plan)
- [ ] I've confirmed all verification steps pass (change-relevant checks pass; full stack blocked by unrelated pre-existing typecheck errors in this local environment)
- [ ] If using Codex, I've run `/review` before submitting this PR — N/A