### PR TITLE
docs(realtime): fix RealtimeRunner context docstring

### DIFF
--- a/src/agents/realtime/runner.py
+++ b/src/agents/realtime/runner.py
@@ -38,7 +38,6 @@ class RealtimeRunner:
 
         Args:
             starting_agent: The agent to start the session with.
-            context: The context to use for the session.
             model: The model to use. If not provided, will use a default OpenAI realtime model.
             config: Override parameters to use for the entire run.
         """
@@ -50,6 +49,10 @@ class RealtimeRunner:
         self, *, context: TContext | None = None, model_config: RealtimeModelConfig | None = None
     ) -> RealtimeSession:
         """Start and returns a realtime session.
+
+        Args:
+            context: The context to use for the session.
+            model_config: Override parameters to use for this session's model.
 
         Returns:
             RealtimeSession: A session object that allows bidirectional communication with the


### PR DESCRIPTION


`RealtimeRunner.__init__` documented a `context` parameter in its `Args:` block,
but the constructor has no such parameter. Its real parameters are
`starting_agent`, `model`, and `config`. The `context` parameter actually belongs
to `RealtimeRunner.run()`, where it was moved in the `[8/n] Make realtime more
like the rest of agents sdk` change, but its `Args:` entry was left behind on the
constructor and `run()` was never given one.

This misleads users of the realtime API into thinking they can pass `context` to
the `RealtimeRunner(...)` constructor.

This change:

- Removes the stale `context:` line from `RealtimeRunner.__init__`'s `Args:` block
  so it documents only the parameters the constructor actually accepts.
- Adds an `Args:` block to `RealtimeRunner.run()` documenting its real parameters,
  `context` and `model_config`, matching how the sibling `RealtimeSession`
  documents the same values.

Docs-only; no runtime, API, or behavior change.

### Test plan

No executable behavior changes (docstring-only), so no new tests are warranted.
Verified the docstrings now match the real signatures by introspection, and ran
the standard checks on the changed file:

- `RealtimeRunner.__init__` documented `Args` names now equal its real parameters:
  `['starting_agent', 'model', 'config']`.
- `RealtimeRunner.run` documented `Args` names now equal its real parameters:
  `['context', 'model_config']`.
- `uv run ruff format --check src/agents/realtime/runner.py` -> already formatted.
- `uv run ruff check src/agents/realtime/runner.py` -> All checks passed!
- `uv run mypy src/agents/realtime/runner.py` -> Success: no issues found.

Per `AGENTS.md`, docs-only changes may skip `$code-change-verification`.

### Issue number

N/A (no existing tracker issue).

### Checks

- [ ] I've added new tests, if relevant  (N/A: docstring-only, no behavior change)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`  (N/A per
  AGENTS.md docs-only exemption; ran ruff format/check + mypy on the changed file)
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR  (N/A)

---

## The diff

```diff
diff --git a/src/agents/realtime/runner.py b/src/agents/realtime/runner.py
index e51a094..a6ec189 100644
--- a/src/agents/realtime/runner.py
+++ b/src/agents/realtime/runner.py
@@ -38,7 +38,6 @@ class RealtimeRunner:
 
         Args:
             starting_agent: The agent to start the session with.
-            context: The context to use for the session.
             model: The model to use. If not provided, will use a default OpenAI realtime model.
             config: Override parameters to use for the entire run.
         """
@@ -51,6 +50,10 @@ class RealtimeRunner:
     ) -> RealtimeSession:
         """Start and returns a realtime session.
 
+        Args:
+            context: The context to use for the session.
+            model_config: Override parameters to use for this session's model.
+
         Returns:
             RealtimeSession: A session object that allows bidirectional communication with the
             realtime model.
```
