### PR TITLE
fix: match pending nested agent-as-tool runs by call_id on resume

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1648,6 +1648,26 @@ def _build_handoffs_map(current_agent: Agent[Any]) -> dict[str, Handoff[Any, Age
     return handoffs_map
 
 
+def _serialized_tool_call_signature(tool_call_data: Mapping[str, Any]) -> tuple[Any, ...]:
+    """Rebuild the ephemeral cache's tool-call signature from serialized tool-call data.
+
+    The signature must mirror the field order used by the agent-tool-state cache
+    (``call_id``, ``name``, ``arguments``, ``type``, ``id``, ``status``) so a serialized
+    entry can be bound to the deserialized run that carries the same call.
+    """
+    call_id = tool_call_data.get("call_id")
+    if call_id is None:
+        call_id = tool_call_data.get("callId")
+    return (
+        call_id,
+        tool_call_data.get("name"),
+        tool_call_data.get("arguments"),
+        tool_call_data.get("type"),
+        tool_call_data.get("id"),
+        tool_call_data.get("status"),
+    )
+
+
 async def _restore_pending_nested_agent_tool_runs(
     *,
     current_agent: Agent[Any],
@@ -1663,15 +1683,52 @@ async def _restore_pending_nested_agent_tool_runs(
 
     from .agent_tool_state import drop_agent_tool_run_result, record_agent_tool_run_result
 
-    # Match serialized entries to deserialized runs by call_id rather than by
-    # position: deserialization drops entries whose tool no longer resolves (or
-    # whose tool call fails to parse), so a positional zip would bind a pending
-    # nested run to the wrong tool call whenever an earlier entry was dropped.
-    runs_by_call_id: dict[str, Any] = {}
+    # Match serialized entries to deserialized runs by the full tool-call signature the
+    # ephemeral cache keys on, not just call_id. Deserialization drops entries whose tool no
+    # longer resolves (or whose tool call fails to parse), so a positional zip would bind a
+    # pending nested run to the wrong tool call whenever an earlier entry was dropped. Keying
+    # only on call_id has the opposite failure: two surviving agent-as-tool calls can share a
+    # call_id but differ in arguments, and collapsing them would record a pending nested run
+    # against the first tool call, so the intended call loses its interruption on resume.
+    # Prefer the exact signature and fall back to a per-call_id FIFO queue for drop tolerance.
+    runs_by_signature: dict[tuple[Any, ...], deque[Any]] = {}
+    runs_by_call_id: dict[str, deque[Any]] = {}
     for function_run in function_runs:
         run_tool_call = getattr(function_run, "tool_call", None)
         if isinstance(run_tool_call, ResponseFunctionToolCall):
-            runs_by_call_id.setdefault(run_tool_call.call_id, function_run)
+            signature = (
+                run_tool_call.call_id,
+                run_tool_call.name,
+                run_tool_call.arguments,
+                run_tool_call.type,
+                run_tool_call.id,
+                run_tool_call.status,
+            )
+            runs_by_signature.setdefault(signature, deque()).append(function_run)
+            runs_by_call_id.setdefault(run_tool_call.call_id, deque()).append(function_run)
+
+    consumed_run_ids: set[int] = set()
+
+    def _take_matching_run(tool_call_data: Any, call_id: str | None) -> Any:
+        # Pop the next unconsumed run from a queue, keeping the signature and call_id queues
+        # consistent by skipping runs already claimed via the other queue.
+        def _pop(queue: deque[Any] | None) -> Any:
+            while queue:
+                candidate = queue.popleft()
+                if id(candidate) not in consumed_run_ids:
+                    consumed_run_ids.add(id(candidate))
+                    return candidate
+            return None
+
+        signature = (
+            _serialized_tool_call_signature(tool_call_data)
+            if isinstance(tool_call_data, Mapping)
+            else None
+        )
+        run = _pop(runs_by_signature.get(signature)) if signature is not None else None
+        if run is None and call_id is not None:
+            run = _pop(runs_by_call_id.get(call_id))
+        return run
 
     for entry in function_entries:
         if not isinstance(entry, Mapping):
@@ -1686,7 +1743,7 @@ async def _restore_pending_nested_agent_tool_runs(
             raw_call_id = tool_call_data.get("call_id") or tool_call_data.get("callId")
             if isinstance(raw_call_id, str):
                 call_id = raw_call_id
-        function_run = runs_by_call_id.get(call_id) if call_id else None
+        function_run = _take_matching_run(tool_call_data, call_id)
         if function_run is None:
             continue
         tool_call = function_run.tool_call

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1663,16 +1663,33 @@ async def _restore_pending_nested_agent_tool_runs(
 
     from .agent_tool_state import drop_agent_tool_run_result, record_agent_tool_run_result
 
-    for entry, function_run in zip(function_entries, function_runs, strict=False):
+    # Match serialized entries to deserialized runs by call_id rather than by
+    # position: deserialization drops entries whose tool no longer resolves (or
+    # whose tool call fails to parse), so a positional zip would bind a pending
+    # nested run to the wrong tool call whenever an earlier entry was dropped.
+    runs_by_call_id: dict[str, Any] = {}
+    for function_run in function_runs:
+        run_tool_call = getattr(function_run, "tool_call", None)
+        if isinstance(run_tool_call, ResponseFunctionToolCall):
+            runs_by_call_id.setdefault(run_tool_call.call_id, function_run)
+
+    for entry in function_entries:
         if not isinstance(entry, Mapping):
             continue
         nested_state_data = entry.get("agent_run_state")
         if not isinstance(nested_state_data, Mapping):
             continue
 
-        tool_call = getattr(function_run, "tool_call", None)
-        if not isinstance(tool_call, ResponseFunctionToolCall):
+        tool_call_data = entry.get("tool_call")
+        call_id = None
+        if isinstance(tool_call_data, Mapping):
+            raw_call_id = tool_call_data.get("call_id") or tool_call_data.get("callId")
+            if isinstance(raw_call_id, str):
+                call_id = raw_call_id
+        function_run = runs_by_call_id.get(call_id) if call_id else None
+        if function_run is None:
             continue
+        tool_call = function_run.tool_call
 
         try:
             nested_state = await _build_run_state_from_json(

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -4041,6 +4041,82 @@ class TestRunStateSerializationEdgeCases:
         assert len(result.functions) == 1
         assert result.functions[0].function_tool is billing_namespace[0]
 
+    async def test_restore_pending_nested_run_when_earlier_entry_dropped(self):
+        """Pending nested agent-as-tool state binds to its own call_id even when
+        an earlier serialized function entry is dropped during deserialization
+        (e.g. because its tool is no longer on the agent)."""
+        from agents.agent_tool_state import peek_agent_tool_run_result
+
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="TestAgent")
+
+        async def tool_func(context: ToolContext[Any], arguments: str) -> str:
+            return "result"
+
+        nested_tool = FunctionTool(
+            on_invoke_tool=tool_func,
+            name="nested_agent_tool",
+            description="Nested agent as tool",
+            params_json_schema={"type": "object", "properties": {}},
+        )
+        agent.tools = [nested_tool]
+
+        # A real nested run state carrying a pending approval interruption.
+        raw_item = ResponseFunctionToolCall(
+            type="function_call",
+            name="inner_tool",
+            call_id="inner_call",
+            status="completed",
+            arguments="{}",
+        )
+        approval_item = ToolApprovalItem(agent=agent, raw_item=raw_item)
+        nested_state = make_state_with_interruptions(agent, [approval_item], original_input="x")
+
+        processed_response_data = {
+            "new_items": [],
+            "handoffs": [],
+            "functions": [
+                {
+                    # Dropped by _deserialize_actions: tool not on the agent.
+                    "tool_call": {
+                        "type": "function_call",
+                        "name": "removed_tool",
+                        "call_id": "call_removed",
+                        "status": "completed",
+                        "arguments": "{}",
+                    },
+                    "tool": {"name": "removed_tool"},
+                },
+                {
+                    "tool_call": {
+                        "type": "function_call",
+                        "name": "nested_agent_tool",
+                        "call_id": "call_nested",
+                        "status": "completed",
+                        "arguments": "{}",
+                    },
+                    "tool": {"name": "nested_agent_tool"},
+                    "agent_run_state": nested_state.to_json(),
+                },
+            ],
+            "computer_actions": [],
+            "local_shell_actions": [],
+            "mcp_approval_requests": [],
+            "tools_used": [],
+            "interruptions": [],
+        }
+
+        result = await _deserialize_processed_response(
+            processed_response_data, agent, context, {"TestAgent": agent}
+        )
+
+        assert len(result.functions) == 1
+        restored_tool_call = result.functions[0].tool_call
+        assert restored_tool_call.call_id == "call_nested"
+        pending = peek_agent_tool_run_result(restored_tool_call)
+        assert pending is not None
+        assert pending.interruptions
+
     async def test_deserialize_processed_response_rejects_qualified_name_collision(self):
         """Reject dotted top-level names that collide with namespace-wrapped functions."""
         context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -4200,9 +4200,9 @@ class TestRunStateSerializationEdgeCases:
             pending = peek_agent_tool_run_result(restored_tool_call)
             assert pending is not None
             assert pending.interruptions
-            inner_names_by_arguments[restored_tool_call.arguments] = pending.interruptions[
-                0
-            ].raw_item.name
+            interruption_raw_item = pending.interruptions[0].raw_item
+            assert isinstance(interruption_raw_item, ResponseFunctionToolCall)
+            inner_names_by_arguments[restored_tool_call.arguments] = interruption_raw_item.name
 
         assert inner_names_by_arguments == {
             '{"which": "a"}': "inner_a",

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -4117,6 +4117,98 @@ class TestRunStateSerializationEdgeCases:
         assert pending is not None
         assert pending.interruptions
 
+    async def test_restore_pending_nested_runs_disambiguates_duplicate_call_ids(self):
+        """Two surviving agent-as-tool calls that share a call_id but differ in arguments
+        each keep their own pending nested interruption on resume, instead of both
+        collapsing onto the first tool call."""
+        from agents.agent_tool_state import peek_agent_tool_run_result
+
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="TestAgent")
+
+        async def tool_func(context: ToolContext[Any], arguments: str) -> str:
+            return "result"
+
+        nested_tool = FunctionTool(
+            on_invoke_tool=tool_func,
+            name="nested_agent_tool",
+            description="Nested agent as tool",
+            params_json_schema={"type": "object", "properties": {}},
+        )
+        agent.tools = [nested_tool]
+
+        def make_pending_state_json(inner_name: str) -> Any:
+            raw_item = ResponseFunctionToolCall(
+                type="function_call",
+                name=inner_name,
+                call_id=f"{inner_name}_call",
+                status="completed",
+                arguments="{}",
+            )
+            approval_item = ToolApprovalItem(agent=agent, raw_item=raw_item)
+            state = make_state_with_interruptions(agent, [approval_item], original_input="x")
+            return state.to_json()
+
+        # Both outer calls share call_id "call_dup" but carry distinct arguments and
+        # distinct nested pending interruptions.
+        processed_response_data = {
+            "new_items": [],
+            "handoffs": [],
+            "functions": [
+                {
+                    "tool_call": {
+                        "type": "function_call",
+                        "name": "nested_agent_tool",
+                        "call_id": "call_dup",
+                        "status": "completed",
+                        "arguments": '{"which": "a"}',
+                    },
+                    "tool": {"name": "nested_agent_tool"},
+                    "agent_run_state": make_pending_state_json("inner_a"),
+                },
+                {
+                    "tool_call": {
+                        "type": "function_call",
+                        "name": "nested_agent_tool",
+                        "call_id": "call_dup",
+                        "status": "completed",
+                        "arguments": '{"which": "b"}',
+                    },
+                    "tool": {"name": "nested_agent_tool"},
+                    "agent_run_state": make_pending_state_json("inner_b"),
+                },
+            ],
+            "computer_actions": [],
+            "local_shell_actions": [],
+            "mcp_approval_requests": [],
+            "tools_used": [],
+            "interruptions": [],
+        }
+
+        result = await _deserialize_processed_response(
+            processed_response_data, agent, context, {"TestAgent": agent}
+        )
+
+        assert len(result.functions) == 2
+
+        # Each restored tool call must keep the nested interruption that belongs to its own
+        # arguments, proving the pending state did not collapse onto the first call.
+        inner_names_by_arguments: dict[str, str] = {}
+        for function_run in result.functions:
+            restored_tool_call = function_run.tool_call
+            assert restored_tool_call.call_id == "call_dup"
+            pending = peek_agent_tool_run_result(restored_tool_call)
+            assert pending is not None
+            assert pending.interruptions
+            inner_names_by_arguments[restored_tool_call.arguments] = pending.interruptions[
+                0
+            ].raw_item.name
+
+        assert inner_names_by_arguments == {
+            '{"which": "a"}': "inner_a",
+            '{"which": "b"}': "inner_b",
+        }
+
     async def test_deserialize_processed_response_rejects_qualified_name_collision(self):
         """Reject dotted top-level names that collide with namespace-wrapped functions."""
         context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})


### PR DESCRIPTION
## Bug

`_restore_pending_nested_agent_tool_runs` pairs the **unfiltered** serialized entries (`processed_response_data["functions"]`) against the **filtered** deserialized runs with a positional `zip(..., strict=False)`. `_deserialize_actions` drops an entry when its tool no longer resolves (`if not tool: continue`) or its tool call fails to parse, so a single dropped entry shifts every later pairing.

Trigger: resume a paused run where a function whose tool the resuming agent no longer exposes precedes an agent-as-tool call that carries `agent_run_state` with a pending nested interruption. The pending state then binds to the wrong tool call, or (at the tail) is silently lost, so the nested approval never re-surfaces.

## Fix

Build a `{tool_call.call_id: run}` lookup from the deserialized runs and match each serialized entry by its `tool_call.call_id` instead of by position. Behavior for the aligned case is unchanged.

## Tests

Added `test_restore_pending_nested_run_when_earlier_entry_dropped`: a serialized `functions` list whose first entry references a removed tool, followed by an agent-as-tool entry with a real `agent_run_state` (built via the existing HITL helpers) carrying a pending approval. It fails on the old positional zip (the pending nested run is lost) and passes with this change. This restore path previously had no test coverage.

`pytest tests/test_run_state.py tests/test_agent_as_tool.py tests/test_agent_tool_state.py`: 247 passed. `ruff check`, `ruff format --check`, and `mypy` on the touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)