### PR TITLE
fix(items): guard None refusal in ItemHelpers.extract_last_content

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -698,7 +698,11 @@ class ItemHelpers:
             # ``extract_text`` below.
             return last_content.text or ""
         elif isinstance(last_content, ResponseOutputRefusal):
-            return last_content.refusal
+            # ``last_content.refusal`` is typed as ``str`` per the Responses API schema,
+            # but the same provider-gateway and ``model_construct`` paths noted above for
+            # ``text`` can surface ``None`` here too. Coerce so callers relying on the
+            # ``-> str`` return type don't see a ``None``.
+            return last_content.refusal or ""
         else:
             raise ModelBehaviorError(f"Unexpected content type: {type(last_content)}")
 

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -84,6 +84,19 @@ def test_extract_last_content_of_refusal_message() -> None:
     assert ItemHelpers.extract_last_content(message) == "I cannot do that"
 
 
+def test_extract_last_content_tolerates_none_refusal_content() -> None:
+    """Regression: ``last_content.refusal`` can be ``None`` when output items are
+    assembled via ``model_construct`` or surfaced through provider gateways like
+    LiteLLM, even though the schema types it as ``str``. ``extract_last_content`` is
+    typed ``-> str``, so the refusal branch must coerce ``None`` to ``""`` just as the
+    text branch does (mirrors the #3394 guard for text).
+    """
+    none_refusal = ResponseOutputRefusal.model_construct(refusal=None, type="refusal")
+    result = ItemHelpers.extract_last_content(make_message([none_refusal]))
+    assert result == ""
+    assert result is not None
+
+
 def test_extract_last_content_non_message_returns_empty() -> None:
     # Construct some other type of output item, e.g. a tool call, to verify non-message returns "".
     tool_call = ResponseFunctionToolCall(


### PR DESCRIPTION
### Summary

`ItemHelpers.extract_last_content` is typed `-> str`, and its `ResponseOutputText` branch already coerces a possibly-`None` `text` to `""` (added in #3394). The sibling `ResponseOutputRefusal` branch, however, returned `last_content.refusal` unguarded — the one remaining path in this helper that can return `None` despite the `-> str` contract.

`refusal` is typed `str` by the Responses API schema, but the same provider-gateway (e.g. LiteLLM) and `model_construct` streaming paths that surface a `None` `text` can surface a `None` `refusal`. This guards it with `or ""`, matching the text branch directly above and the sibling helpers `extract_text`, `extract_refusal`, and `text_message_output`, which all already use `or ""`.

### Test plan

- Added `test_extract_last_content_tolerates_none_refusal_content` in `tests/test_items_helpers.py`, mirroring the existing `test_extract_text_tolerates_none_text_content`: it builds a `ResponseOutputRefusal.model_construct(refusal=None, ...)` and asserts `extract_last_content` returns `""` (and not `None`).
- `uv run pytest tests/test_items_helpers.py` — 35 passed.
- `uv run ruff format` and `uv run ruff check` are clean; `uv run mypy src/agents/items.py` passes.

### Issue number

N/A — this completes the `None`-guarding introduced in #3394 (same function, `text` branch) and #3375 (`text_message_output`); the refusal branch is the lone remaining unguarded path in a helper typed `-> str`.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
