### PR TITLE
test(items): document refusal None invariant

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -698,6 +698,10 @@ class ItemHelpers:
             # ``extract_text`` below.
             return last_content.text or ""
         elif isinstance(last_content, ResponseOutputRefusal):
+            # Unlike output text, supported provider paths only create refusal parts after
+            # receiving refusal text. A ``None`` value requires bypassing model validation
+            # with ``model_construct``, so this intentionally does not mirror the fallback
+            # above.
             return last_content.refusal
         else:
             raise ModelBehaviorError(f"Unexpected content type: {type(last_content)}")

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -5,6 +5,7 @@ import json
 import weakref
 from typing import Any, cast
 
+import pytest
 from openai.types.responses.computer_action import Click as BatchedClick, Type as BatchedType
 from openai.types.responses.response_computer_tool_call import (
     ActionScreenshot,
@@ -32,7 +33,7 @@ from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 from openai.types.responses.response_reasoning_item_param import ResponseReasoningItemParam
 from openai.types.responses.response_tool_search_call import ResponseToolSearchCall
 from openai.types.responses.response_tool_search_output_item import ResponseToolSearchOutputItem
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from agents import (
     Agent,
@@ -82,6 +83,11 @@ def test_extract_last_content_of_refusal_message() -> None:
     message = make_message([content1, refusal])
     # Helpers should extract the refusal string when last content is a refusal.
     assert ItemHelpers.extract_last_content(message) == "I cannot do that"
+
+
+def test_none_refusal_is_rejected_before_extract_last_content() -> None:
+    with pytest.raises(ValidationError, match="refusal"):
+        ResponseOutputRefusal.model_validate({"refusal": None, "type": "refusal"})
 
 
 def test_extract_last_content_non_message_returns_empty() -> None:


### PR DESCRIPTION
This pull request documents why `ItemHelpers.extract_last_content` intentionally does not normalize `None` refusal values. Supported provider paths only create refusal parts after receiving refusal text, while normal model validation rejects `None`; a focused test preserves this distinction from output-text handling and discourages parity changes based solely on synthetic `model_construct` objects.

ref:
- https://github.com/openai/openai-agents-python/pull/3394
- https://github.com/openai/openai-agents-python/pull/3750