### PR TITLE
docs: add session memory examples for limit, callback, and pop_item

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -73,9 +73,13 @@ Check out a variety of sample implementations of the SDK in the examples section
 - **[memory](https://github.com/openai/openai-agents-python/tree/main/examples/memory):** Examples of different memory implementations for agents, including:
 
     -   SQLite session storage
+    -   Session history limit with `SessionSettings(limit=N)` (`examples/memory/session_limit_example.py`)
+    -   Custom history merging with `session_input_callback` (`examples/memory/session_input_callback_example.py`)
+    -   Correcting the latest turn with `pop_item` (`examples/memory/session_pop_item_example.py`)
     -   Advanced SQLite session storage
     -   Redis session storage
     -   SQLAlchemy session storage
+    -   MongoDB session storage (`examples/memory/mongodb_session_example.py`)
     -   Dapr state store session storage
     -   Encrypted session storage
     -   OpenAI Conversations session storage

--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -107,6 +107,8 @@ result = await Runner.run(
 
 Use this when you need custom pruning, reordering, or selective inclusion of history without changing how the session stores items. If you need a later final pass immediately before the model call, use [`call_model_input_filter`][agents.run.RunConfig.call_model_input_filter] from the [running agents guide](../running_agents.md).
 
+See [`examples/memory/session_input_callback_example.py`](https://github.com/openai/openai-agents-python/tree/main/examples/memory/session_input_callback_example.py) for a runnable example.
+
 ## Limiting retrieved history
 
 Use [`SessionSettings`][agents.memory.SessionSettings] to control how much history is fetched before each run.
@@ -131,6 +133,8 @@ result = await Runner.run(
 ```
 
 If your session implementation exposes default session settings, `RunConfig.session_settings` overrides any non-`None` values for that run. This is useful for long conversations where you want to cap retrieval size without changing the session's default behavior.
+
+See [`examples/memory/session_limit_example.py`](https://github.com/openai/openai-agents-python/tree/main/examples/memory/session_limit_example.py) for a runnable example.
 
 ## Memory operations
 
@@ -191,6 +195,8 @@ result = await Runner.run(
 )
 print(f"Agent: {result.final_output}")
 ```
+
+See [`examples/memory/session_pop_item_example.py`](https://github.com/openai/openai-agents-python/tree/main/examples/memory/session_pop_item_example.py) for a runnable example.
 
 ## Built-in session implementations
 

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -1,0 +1,36 @@
+# Session memory examples
+
+This folder contains runnable examples for Agents SDK session memory: built-in backends, compaction, human-in-the-loop flows, and history management patterns.
+
+## Getting started
+
+- [`sqlite_session_example.py`](./sqlite_session_example.py) — Basic multi-turn conversation with `SQLiteSession`.
+- [`session_limit_example.py`](./session_limit_example.py) — Cap retrieved history with `SessionSettings(limit=N)`.
+- [`session_input_callback_example.py`](./session_input_callback_example.py) — Prune or customize history merging via `RunConfig.session_input_callback`.
+- [`session_pop_item_example.py`](./session_pop_item_example.py) — Undo the latest turn with `pop_item` before re-asking.
+
+## Built-in session backends
+
+- [`redis_session_example.py`](./redis_session_example.py) — Shared memory across workers with Redis.
+- [`sqlalchemy_session_example.py`](./sqlalchemy_session_example.py) — SQLAlchemy-backed persistence.
+- [`mongodb_session_example.py`](./mongodb_session_example.py) — MongoDB-backed sessions with a shared client.
+- [`dapr_session_example.py`](./dapr_session_example.py) — Dapr state store sessions.
+- [`encrypted_session_example.py`](./encrypted_session_example.py) — Transparent encryption wrapper.
+- [`advanced_sqlite_session_example.py`](./advanced_sqlite_session_example.py) — Branching and usage analytics.
+
+## OpenAI-managed history
+
+- [`openai_session_example.py`](./openai_session_example.py) — `OpenAIConversationsSession`.
+- [`compaction_session_example.py`](./compaction_session_example.py) — Auto-compaction with `OpenAIResponsesCompactionSession`.
+- [`compaction_session_stateless_example.py`](./compaction_session_stateless_example.py) — Compaction with `ModelSettings(store=False)`.
+
+## Custom and file-backed sessions
+
+- [`file_session.py`](./file_session.py) — Reusable `FileSession` implementation for examples.
+- [`file_hitl_example.py`](./file_hitl_example.py) — File-backed session with human-in-the-loop approvals.
+
+## Human-in-the-loop across sessions
+
+- [`memory_session_hitl_example.py`](./memory_session_hitl_example.py) — SQLite in-memory session with approvals.
+- [`openai_session_hitl_example.py`](./openai_session_hitl_example.py) — OpenAI Conversations session with approvals.
+- [`hitl_session_scenario.py`](./hitl_session_scenario.py) — Approval, rejection, and rehydration scenarios.

--- a/examples/memory/session_input_callback_example.py
+++ b/examples/memory/session_input_callback_example.py
@@ -1,0 +1,57 @@
+"""
+Example demonstrating RunConfig.session_input_callback for custom history merging.
+
+Use session_input_callback when you need to prune, reorder, or filter session history
+before each model call without changing how the session stores new turn items.
+"""
+
+import asyncio
+
+from agents import Agent, RunConfig, Runner, SQLiteSession
+
+
+def keep_recent_history(history, new_input):
+    """Keep only the last 4 history items, then append the new turn."""
+    return history[-4:] + new_input
+
+
+async def main():
+    agent = Agent(
+        name="Assistant",
+        instructions="Reply very concisely.",
+    )
+
+    session = SQLiteSession("session_input_callback_demo")
+
+    print("=== Session Input Callback Example ===")
+    print("History is pruned to the last 4 items before each model call.\n")
+
+    prompts = [
+        "Name one planet in our solar system.",
+        "Name another planet.",
+        "Name a third planet.",
+        "Name a fourth planet.",
+        "Which planet did you mention first?",
+    ]
+
+    run_config = RunConfig(session_input_callback=keep_recent_history)
+
+    for index, prompt in enumerate(prompts, start=1):
+        print(f"Turn {index}:")
+        print(f"User: {prompt}")
+        result = await Runner.run(
+            agent,
+            prompt,
+            session=session,
+            run_config=run_config,
+        )
+        print(f"Assistant: {result.final_output}\n")
+
+    all_items = await session.get_items()
+    print(f"Total items stored in session: {len(all_items)}")
+    print("The full conversation is still persisted even though older history")
+    print("may be excluded from individual model calls.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/memory/session_limit_example.py
+++ b/examples/memory/session_limit_example.py
@@ -1,0 +1,48 @@
+"""
+Example demonstrating SessionSettings(limit=N) via RunConfig.
+
+Use session_settings to cap how much history is retrieved from a session before
+each run. This is useful for long conversations where you want to bound context size.
+"""
+
+import asyncio
+
+from agents import Agent, RunConfig, Runner, SessionSettings, SQLiteSession
+
+
+async def main():
+    agent = Agent(
+        name="Assistant",
+        instructions="Reply very concisely.",
+    )
+
+    session = SQLiteSession("session_limit_demo")
+
+    print("=== Session Limit Example ===")
+    print("Only the most recent 2 history items are sent to the model each turn.\n")
+
+    prompts = [
+        "What city is the Golden Gate Bridge in?",
+        "What state is it in?",
+        "What's the population of that state?",
+        "What country is that state part of?",
+    ]
+
+    for index, prompt in enumerate(prompts, start=1):
+        print(f"Turn {index}:")
+        print(f"User: {prompt}")
+        result = await Runner.run(
+            agent,
+            prompt,
+            session=session,
+            run_config=RunConfig(session_settings=SessionSettings(limit=2)),
+        )
+        print(f"Assistant: {result.final_output}\n")
+
+    all_items = await session.get_items()
+    print(f"Total items stored in session: {len(all_items)}")
+    print("All turns are persisted, but each run only retrieves the latest 2 items.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/memory/session_pop_item_example.py
+++ b/examples/memory/session_pop_item_example.py
@@ -1,0 +1,42 @@
+"""
+Example demonstrating pop_item for correcting the most recent conversation turn.
+
+Use pop_item when a user wants to undo or replace their last message without
+starting a new session.
+"""
+
+import asyncio
+
+from agents import Agent, Runner, SQLiteSession
+
+
+async def main():
+    agent = Agent(
+        name="Assistant",
+        instructions="Reply very concisely with just the numeric answer.",
+    )
+
+    session = SQLiteSession("session_pop_item_demo")
+
+    print("=== Session pop_item Example ===\n")
+
+    print("Turn 1:")
+    print("User: What's 2 + 2?")
+    result = await Runner.run(agent, "What's 2 + 2?", session=session)
+    print(f"Assistant: {result.final_output}\n")
+
+    print("User wants to correct the question instead of adding a new turn.")
+    await session.pop_item()  # Remove the assistant reply
+    await session.pop_item()  # Remove the original user question
+
+    print("Turn 1 (corrected):")
+    print("User: What's 2 + 3?")
+    result = await Runner.run(agent, "What's 2 + 3?", session=session)
+    print(f"Assistant: {result.final_output}\n")
+
+    items = await session.get_items()
+    print(f"Session now has {len(items)} items (one corrected question and answer).")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds a small focused improvement for session memory management patterns.

## Changes

* Add runnable examples for session limit, input callback, and pop_item correction
* Add examples/memory/README.md catalog
* Cross-link new examples in docs/examples.md and docs/sessions/index.md

## Validation

* python -m ruff format - pass
* python -m ruff check - pass

## Notes

Kept intentionally small and aligned with existing project patterns.