### PR TITLE
fix: preserve nested tool state during restoration

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -112,10 +112,12 @@ if TYPE_CHECKING:
     from .run_internal.run_steps import (
         NextStepInterruption,
         ProcessedResponse,
+        ToolRunFunction,
     )
 
 TContext = TypeVar("TContext", default=Any)
 TAgent = TypeVar("TAgent", bound="Agent[Any]", default="Agent[Any]")
+TAction = TypeVar("TAction")
 ContextOverride = Mapping[str, Any] | RunContextWrapper[Any]
 ContextSerializer = Callable[[Any], Mapping[str, Any]]
 ContextDeserializer = Callable[[Mapping[str, Any]], Any]
@@ -1543,6 +1545,14 @@ class _SerializedAgentToolRunResult:
         return self._state
 
 
+@dataclass(frozen=True)
+class _DeserializedFunctionAction:
+    """Keep a function action with its normalized nested run state, if present."""
+
+    action: ToolRunFunction
+    nested_agent_run_state_data: Mapping[str, Any] | None
+
+
 def _serialize_guardrail_results(
     results: Sequence[InputGuardrailResult | OutputGuardrailResult],
     *,
@@ -1651,26 +1661,23 @@ def _build_handoffs_map(current_agent: Agent[Any]) -> dict[str, Handoff[Any, Age
 async def _restore_pending_nested_agent_tool_runs(
     *,
     current_agent: Agent[Any],
-    function_entries: Sequence[Any],
-    function_runs: Sequence[Any],
+    function_actions: Sequence[_DeserializedFunctionAction],
     scope_id: str | None = None,
     context_deserializer: ContextDeserializer | None = None,
     strict_context: bool = False,
 ) -> None:
     """Rehydrate nested agent-as-tool run state into the ephemeral tool-call cache."""
-    if not function_entries or not function_runs:
+    if not function_actions:
         return
 
     from .agent_tool_state import drop_agent_tool_run_result, record_agent_tool_run_result
 
-    for entry, function_run in zip(function_entries, function_runs, strict=False):
-        if not isinstance(entry, Mapping):
-            continue
-        nested_state_data = entry.get("agent_run_state")
-        if not isinstance(nested_state_data, Mapping):
+    for function_action in function_actions:
+        nested_state_data = function_action.nested_agent_run_state_data
+        if nested_state_data is None:
             continue
 
-        tool_call = getattr(function_run, "tool_call", None)
+        tool_call = function_action.action.tool_call
         if not isinstance(tool_call, ResponseFunctionToolCall):
             continue
 
@@ -1760,11 +1767,11 @@ async def _deserialize_processed_response(
         tool_key: str,
         tool_map: Mapping[NamedToolLookupKey, Any],
         call_parser: Callable[[dict[str, Any]], Any],
-        action_factory: Callable[[Any, Any], Any],
+        action_factory: Callable[[Any, Any], TAction],
         name_resolver: Callable[[Mapping[str, Any]], NamedToolLookupKey | None] | None = None,
-    ) -> list[Any]:
+    ) -> list[TAction]:
         """Deserialize tool actions with shared structure."""
-        deserialized: list[Any] = []
+        deserialized: list[TAction] = []
         for entry in entries or []:
             tool_container = entry.get(tool_key, {}) if isinstance(entry, Mapping) else {}
             if name_resolver:
@@ -1812,7 +1819,9 @@ async def _deserialize_processed_response(
         except Exception:
             return data
 
-    def _deserialize_action_groups() -> dict[str, list[Any]]:
+    def _deserialize_action_groups() -> tuple[
+        dict[str, list[Any]], list[_DeserializedFunctionAction]
+    ]:
         def _resolve_handoff_tool_name(data: Mapping[str, Any]) -> NamedToolLookupKey | None:
             handoff_data = data.get("handoff", {})
             if not isinstance(handoff_data, Mapping):
@@ -1845,6 +1854,40 @@ async def _deserialize_processed_response(
                 cast(str | None, tool_data.get("namespace")),
             )
 
+        def _deserialize_function_actions() -> list[_DeserializedFunctionAction]:
+            """Deserialize function actions and normalize their optional nested run state."""
+            deserialized: list[_DeserializedFunctionAction] = []
+            for entry in processed_response_data.get("functions", []):
+                if not isinstance(entry, Mapping):
+                    continue
+                tool_name = _resolve_function_tool_name(entry)
+                function_tool = tools_map.get(tool_name) if tool_name else None
+                if function_tool is None:
+                    continue
+
+                tool_call_data_raw = entry.get("tool_call", {})
+                tool_call_data = (
+                    dict(tool_call_data_raw) if isinstance(tool_call_data_raw, Mapping) else {}
+                )
+                try:
+                    tool_call = ResponseFunctionToolCall(**tool_call_data)
+                except Exception:
+                    continue
+
+                nested_state_data = entry.get("agent_run_state")
+                deserialized.append(
+                    _DeserializedFunctionAction(
+                        action=ToolRunFunction(
+                            tool_call=tool_call,
+                            function_tool=function_tool,
+                        ),
+                        nested_agent_run_state_data=(
+                            nested_state_data if isinstance(nested_state_data, Mapping) else None
+                        ),
+                    )
+                )
+            return deserialized
+
         action_specs: list[
             tuple[
                 str,
@@ -1862,16 +1905,6 @@ async def _deserialize_processed_response(
                 lambda data: ResponseFunctionToolCall(**data),
                 lambda tool_call, handoff: ToolRunHandoff(tool_call=tool_call, handoff=handoff),
                 _resolve_handoff_tool_name,
-            ),
-            (
-                "functions",
-                "tool",
-                tools_map,
-                lambda data: ResponseFunctionToolCall(**data),
-                lambda tool_call, function_tool: ToolRunFunction(
-                    tool_call=tool_call, function_tool=function_tool
-                ),
-                _resolve_function_tool_name,
             ),
             (
                 "computer_actions",
@@ -1925,7 +1958,10 @@ async def _deserialize_processed_response(
             ),
         ]
 
-        action_groups: dict[str, list[Any]] = {}
+        function_actions = _deserialize_function_actions()
+        action_groups: dict[str, list[Any]] = {
+            "functions": [function_action.action for function_action in function_actions]
+        }
         for (
             key,
             tool_key,
@@ -1942,9 +1978,9 @@ async def _deserialize_processed_response(
                 action_factory=action_factory,
                 name_resolver=name_resolver,
             )
-        return action_groups
+        return action_groups, function_actions
 
-    action_groups = _deserialize_action_groups()
+    action_groups, function_actions = _deserialize_action_groups()
     handoffs = action_groups["handoffs"]
     functions = action_groups["functions"]
     computer_actions = action_groups["computer_actions"]
@@ -1955,8 +1991,7 @@ async def _deserialize_processed_response(
 
     await _restore_pending_nested_agent_tool_runs(
         current_agent=current_agent,
-        function_entries=processed_response_data.get("functions", []),
-        function_runs=functions,
+        function_actions=function_actions,
         scope_id=scope_id,
         context_deserializer=context_deserializer,
         strict_context=strict_context,

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, TypeVar, cast
 
 import pytest
@@ -53,6 +54,7 @@ from agents.items import (
     ToolSearchCallItem,
     ToolSearchOutputItem,
     TResponseInputItem,
+    TResponseOutputItem,
     TResponseStreamEvent,
 )
 from agents.run_context import RunContextWrapper
@@ -232,6 +234,37 @@ def make_state(
         context=context,
         original_input=original_input,
         max_turns=max_turns,
+    )
+
+
+def record_pending_nested_agent_tool_state(
+    agent: Agent[Any],
+    tool_call: ResponseFunctionToolCall,
+    *,
+    inner_call_id: str,
+) -> None:
+    """Record a serializable nested interruption for an outer function call."""
+    from agents.agent_tool_state import record_agent_tool_run_result
+
+    nested_approval = make_tool_approval_item(
+        agent,
+        call_id=inner_call_id,
+        name="inner_sensitive_tool",
+    )
+    nested_state = make_state_with_interruptions(
+        agent,
+        [nested_approval],
+        original_input=f"nested input for {inner_call_id}",
+    )
+    record_agent_tool_run_result(
+        tool_call,
+        cast(
+            Any,
+            SimpleNamespace(
+                interruptions=nested_state.get_interruptions(),
+                to_state=lambda: nested_state,
+            ),
+        ),
     )
 
 
@@ -2641,8 +2674,214 @@ class TestDeserializeHelpers:
         assert interruptions[0].agent.name == "InnerAgent"
         assert interruptions[0].raw_item.name == "sensitive_tool"  # type: ignore[union-attr]
 
+    @pytest.mark.parametrize("drop_mode", ["disabled", "removed", "malformed_call"])
+    async def test_nested_agent_tool_state_survives_when_earlier_function_is_dropped(
+        self, drop_mode: str
+    ) -> None:
+        """A dropped function must not shift a later function's nested state."""
+        from agents.agent_tool_state import (
+            drop_agent_tool_run_result,
+            peek_agent_tool_run_result,
+        )
+
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="OuterAgent")
+        earlier_tool_enabled = True
+        conditional_tool = function_tool(
+            lambda: "conditional",
+            name_override="conditional_tool",
+            is_enabled=lambda _context, _agent: earlier_tool_enabled,
+        )
+        nested_tool = function_tool(lambda: "nested", name_override="nested_agent_tool")
+        agent.tools = [conditional_tool, nested_tool]
+
+        conditional_call = make_tool_call(call_id="conditional-call", name="conditional_tool")
+        nested_call = make_tool_call(call_id="nested-call", name="nested_agent_tool")
+        state = make_state(agent, context=context)
+        state._last_processed_response = make_processed_response(
+            functions=[
+                ToolRunFunction(tool_call=conditional_call, function_tool=conditional_tool),
+                ToolRunFunction(tool_call=nested_call, function_tool=nested_tool),
+            ]
+        )
+
+        record_pending_nested_agent_tool_state(
+            agent,
+            nested_call,
+            inner_call_id="inner-call",
+        )
+
+        restored_call: ResponseFunctionToolCall | None = None
+        restored_scope_id: str | None = None
+        try:
+            state_json = state.to_json()
+            if drop_mode == "disabled":
+                earlier_tool_enabled = False
+            elif drop_mode == "removed":
+                agent.tools = [nested_tool]
+            else:
+                functions_data = state_json["last_processed_response"]["functions"]
+                functions_data[0]["tool_call"].pop("call_id")
+
+            restored = await RunState.from_json(agent, state_json)
+
+            assert restored._last_processed_response is not None
+            restored_scope_id = restored._agent_tool_state_scope_id
+            assert restored_scope_id is not None
+            assert len(restored._last_processed_response.functions) == 1
+            restored_call = restored._last_processed_response.functions[0].tool_call
+            assert restored_call.call_id == "nested-call"
+            pending_result = peek_agent_tool_run_result(restored_call, scope_id=restored_scope_id)
+            assert pending_result is not None
+            assert len(pending_result.interruptions) == 1
+            restored_approval = pending_result.interruptions[0]
+            assert isinstance(restored_approval.raw_item, ResponseFunctionToolCall)
+            assert restored_approval.raw_item.call_id == "inner-call"
+        finally:
+            drop_agent_tool_run_result(nested_call)
+            if restored_call is not None:
+                drop_agent_tool_run_result(restored_call, scope_id=restored_scope_id)
+
+    async def test_dropped_nested_agent_tool_state_is_not_moved_to_later_function(
+        self,
+    ) -> None:
+        """Nested state owned by a dropped function must not migrate to a retained function."""
+        from agents.agent_tool_state import (
+            drop_agent_tool_run_result,
+            peek_agent_tool_run_result,
+        )
+
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="OuterAgent")
+        dropped_tool = function_tool(lambda: "dropped", name_override="dropped_agent_tool")
+        retained_tool = function_tool(lambda: "retained", name_override="retained_tool")
+        agent.tools = [dropped_tool, retained_tool]
+
+        dropped_call = make_tool_call(call_id="dropped-call", name="dropped_agent_tool")
+        retained_call = make_tool_call(call_id="retained-call", name="retained_tool")
+        state = make_state(agent, context=context)
+        state._last_processed_response = make_processed_response(
+            functions=[
+                ToolRunFunction(tool_call=dropped_call, function_tool=dropped_tool),
+                ToolRunFunction(tool_call=retained_call, function_tool=retained_tool),
+            ]
+        )
+
+        record_pending_nested_agent_tool_state(
+            agent,
+            dropped_call,
+            inner_call_id="dropped-inner-call",
+        )
+
+        restored_call: ResponseFunctionToolCall | None = None
+        restored_scope_id: str | None = None
+        try:
+            state_json = state.to_json()
+            agent.tools = [retained_tool]
+
+            restored = await RunState.from_json(agent, state_json)
+
+            assert restored._last_processed_response is not None
+            restored_scope_id = restored._agent_tool_state_scope_id
+            assert restored_scope_id is not None
+            assert len(restored._last_processed_response.functions) == 1
+            restored_call = restored._last_processed_response.functions[0].tool_call
+            assert restored_call.call_id == "retained-call"
+            assert peek_agent_tool_run_result(restored_call, scope_id=restored_scope_id) is None
+        finally:
+            drop_agent_tool_run_result(dropped_call)
+            if restored_call is not None:
+                drop_agent_tool_run_result(restored_call, scope_id=restored_scope_id)
+
+    async def test_multiple_nested_agent_tool_states_survive_multiple_dropped_functions(
+        self,
+    ) -> None:
+        """Multiple retained functions keep their own nested state across different drops."""
+        from agents.agent_tool_state import (
+            drop_agent_tool_run_result,
+            peek_agent_tool_run_result,
+        )
+
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="OuterAgent")
+        earlier_tool_enabled = True
+        disabled_tool = function_tool(
+            lambda: "disabled",
+            name_override="disabled_tool",
+            is_enabled=lambda _context, _agent: earlier_tool_enabled,
+        )
+        first_nested_tool = function_tool(lambda: "first", name_override="first_agent_tool")
+        malformed_tool = function_tool(lambda: "malformed", name_override="malformed_tool")
+        second_nested_tool = function_tool(lambda: "second", name_override="second_agent_tool")
+        agent.tools = [disabled_tool, first_nested_tool, malformed_tool, second_nested_tool]
+
+        disabled_call = make_tool_call(call_id="disabled-call", name="disabled_tool")
+        first_nested_call = make_tool_call(call_id="first-call", name="first_agent_tool")
+        malformed_call = make_tool_call(call_id="malformed-call", name="malformed_tool")
+        second_nested_call = make_tool_call(call_id="second-call", name="second_agent_tool")
+        state = make_state(agent, context=context)
+        state._last_processed_response = make_processed_response(
+            functions=[
+                ToolRunFunction(tool_call=disabled_call, function_tool=disabled_tool),
+                ToolRunFunction(tool_call=first_nested_call, function_tool=first_nested_tool),
+                ToolRunFunction(tool_call=malformed_call, function_tool=malformed_tool),
+                ToolRunFunction(tool_call=second_nested_call, function_tool=second_nested_tool),
+            ]
+        )
+
+        nested_calls = [first_nested_call, second_nested_call]
+        inner_call_ids = ["first-inner-call", "second-inner-call"]
+        for nested_call, inner_call_id in zip(nested_calls, inner_call_ids, strict=True):
+            record_pending_nested_agent_tool_state(
+                agent,
+                nested_call,
+                inner_call_id=inner_call_id,
+            )
+
+        restored_calls: list[ResponseFunctionToolCall] = []
+        restored_scope_id: str | None = None
+        try:
+            state_json = state.to_json()
+            earlier_tool_enabled = False
+            functions_data = state_json["last_processed_response"]["functions"]
+            functions_data[2]["tool_call"].pop("call_id")
+
+            restored = await RunState.from_json(agent, state_json)
+
+            assert restored._last_processed_response is not None
+            restored_scope_id = restored._agent_tool_state_scope_id
+            assert restored_scope_id is not None
+            restored_calls = [
+                function.tool_call for function in restored._last_processed_response.functions
+            ]
+            assert [call.call_id for call in restored_calls] == ["first-call", "second-call"]
+            for restored_call, expected_inner_call_id in zip(
+                restored_calls, inner_call_ids, strict=True
+            ):
+                pending_result = peek_agent_tool_run_result(
+                    restored_call, scope_id=restored_scope_id
+                )
+                assert pending_result is not None
+                assert len(pending_result.interruptions) == 1
+                restored_approval = pending_result.interruptions[0]
+                assert isinstance(restored_approval.raw_item, ResponseFunctionToolCall)
+                assert restored_approval.raw_item.call_id == expected_inner_call_id
+        finally:
+            for nested_call in nested_calls:
+                drop_agent_tool_run_result(nested_call)
+            for restored_call in restored_calls:
+                drop_agent_tool_run_result(restored_call, scope_id=restored_scope_id)
+
     @pytest.mark.asyncio
-    async def test_nested_agent_tool_hitl_resume_survives_json_round_trip_after_gc(self) -> None:
+    @pytest.mark.parametrize(
+        "approve_nested_tool",
+        [True, False],
+        ids=["approve", "reject"],
+    )
+    async def test_nested_agent_tool_hitl_resume_survives_json_round_trip_after_gc(
+        self,
+        approve_nested_tool: bool,
+    ) -> None:
         """Nested agent-tool resumptions should survive RunState JSON round-trips."""
 
         def _has_function_call_output(input_data: str | list[TResponseInputItem]) -> bool:
@@ -2659,12 +2898,19 @@ class TestDeserializeHelpers:
 
         class ResumeAwareToolModel(Model):
             def __init__(
-                self, *, tool_name: str, tool_arguments: str, final_text: str, call_prefix: str
+                self,
+                *,
+                tool_name: str,
+                tool_arguments: str,
+                final_text: str,
+                call_prefix: str,
+                preceding_tool_name: str | None = None,
             ) -> None:
                 self.tool_name = tool_name
                 self.tool_arguments = tool_arguments
                 self.final_text = final_text
                 self.call_prefix = call_prefix
+                self.preceding_tool_name = preceding_tool_name
                 self.call_count = 0
 
             async def get_response(
@@ -2700,15 +2946,26 @@ class TestDeserializeHelpers:
                     )
 
                 self.call_count += 1
-                return ModelResponse(
-                    output=[
+                output: list[TResponseOutputItem] = []
+                if self.preceding_tool_name is not None:
+                    output.append(
                         ResponseFunctionToolCall(
                             type="function_call",
-                            name=self.tool_name,
-                            call_id=f"{self.call_prefix}-{id(self)}-{self.call_count}",
-                            arguments=self.tool_arguments,
+                            name=self.preceding_tool_name,
+                            call_id=f"{self.call_prefix}-preceding-{self.call_count}",
+                            arguments="{}",
                         )
-                    ],
+                    )
+                output.append(
+                    ResponseFunctionToolCall(
+                        type="function_call",
+                        name=self.tool_name,
+                        call_id=f"{self.call_prefix}-{id(self)}-{self.call_count}",
+                        arguments=self.tool_arguments,
+                    )
+                )
+                return ModelResponse(
+                    output=output,
                     usage=Usage(),
                     response_id=f"{self.call_prefix}-call-{self.call_count}",
                 )
@@ -2767,14 +3024,29 @@ class TestDeserializeHelpers:
             tool_arguments=json.dumps({"input": "hello"}),
             final_text="outer-complete",
             call_prefix="outer",
+            preceding_tool_name="conditional_outer_tool",
         )
-        outer_agent = Agent(name="OuterAgent", model=outer_model, tools=[outer_tool])
+        outer_tool_enabled = True
+        conditional_outer_tool = function_tool(
+            lambda: "conditional-complete",
+            name_override="conditional_outer_tool",
+            is_enabled=lambda _context, _agent: outer_tool_enabled,
+        )
+        outer_agent = Agent(
+            name="OuterAgent", model=outer_model, tools=[conditional_outer_tool, outer_tool]
+        )
 
         first_result = await Runner.run(outer_agent, "start")
         assert first_result.final_output is None
         assert first_result.interruptions
 
         state_json = first_result.to_state().to_json()
+        serialized_functions = state_json["last_processed_response"]["functions"]
+        assert [entry["tool_call"]["name"] for entry in serialized_functions] == [
+            "conditional_outer_tool",
+            "inner_agent_tool",
+        ]
+        outer_tool_enabled = False
         del first_result
         gc.collect()
 
@@ -2785,8 +3057,12 @@ class TestDeserializeHelpers:
         restored_interruptions_two = restored_state_two.get_interruptions()
         assert len(restored_interruptions_one) == 1
         assert len(restored_interruptions_two) == 1
-        restored_state_one.approve(restored_interruptions_one[0])
-        restored_state_two.approve(restored_interruptions_two[0])
+        if approve_nested_tool:
+            restored_state_one.approve(restored_interruptions_one[0])
+            restored_state_two.approve(restored_interruptions_two[0])
+        else:
+            restored_state_one.reject(restored_interruptions_one[0])
+            restored_state_two.reject(restored_interruptions_two[0])
 
         resumed_result_one = await Runner.run(outer_agent, restored_state_one)
         resumed_result_two = await Runner.run(outer_agent, restored_state_two)
@@ -2795,7 +3071,7 @@ class TestDeserializeHelpers:
         assert resumed_result_one.interruptions == []
         assert resumed_result_two.final_output == "outer-complete"
         assert resumed_result_two.interruptions == []
-        assert tool_calls == ["hello", "hello"]
+        assert tool_calls == (["hello", "hello"] if approve_nested_tool else [])
 
     async def test_json_decode_error_handling(self):
         """Test that invalid JSON raises appropriate error."""


### PR DESCRIPTION
This pull request fixes nested agent-tool state restoration when earlier serialized function entries are skipped because their tools are disabled, removed, or no longer parseable.

Function actions are restored through a dedicated typed intermediate carrying only their normalized nested run-state data. This removes positional coupling without retaining raw serialized entries or wrapping unrelated action types. Regression coverage includes multiple skipped and pending calls, scoped independent restorations, and both approval and rejection after JSON round-trips.