### PR TITLE
docs: clarify agent tool state options

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -583,7 +583,9 @@ async def main():
 
 ### Customizing tool-agents
 
-The `agent.as_tool` function is a convenience method to make it easy to turn an agent into a tool. It supports common runtime options such as `max_turns`, `run_config`, `hooks`, `previous_response_id`, `conversation_id`, `session`, and `needs_approval`. It also supports structured input with `parameters`, `input_builder`, and `include_input_schema`. For advanced orchestration (for example, conditional retries, fallback behavior, or chaining multiple agent calls), use `Runner.run` directly in your tool implementation:
+The `agent.as_tool` function is a convenience method to make it easy to turn an agent into a tool. It supports common runtime options such as `max_turns`, `run_config`, `hooks`, `previous_response_id`, `conversation_id`, `session`, and `needs_approval`. It also supports structured input with `parameters`, `input_builder`, and `include_input_schema`.
+
+The state options apply only to the nested agent run started by the tool call; they are not shared with the parent run's conversation state. Choose the same kind of state you would use with `Runner.run`: either client-managed `session` history, or server-managed `previous_response_id` / `conversation_id`, not both for the same nested run. For advanced orchestration (for example, conditional retries, fallback behavior, or chaining multiple agent calls), use `Runner.run` directly in your tool implementation:
 
 ```python
 @function_tool

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -585,7 +585,7 @@ async def main():
 
 The `agent.as_tool` function is a convenience method to make it easy to turn an agent into a tool. It supports common runtime options such as `max_turns`, `run_config`, `hooks`, `previous_response_id`, `conversation_id`, `session`, and `needs_approval`. It also supports structured input with `parameters`, `input_builder`, and `include_input_schema`.
 
-The state options apply only to the nested agent run started by the tool call; they are not shared with the parent run's conversation state. Choose the same kind of state you would use with `Runner.run`: either client-managed `session` history, or server-managed `previous_response_id` / `conversation_id`, not both for the same nested run. For advanced orchestration (for example, conditional retries, fallback behavior, or chaining multiple agent calls), use `Runner.run` directly in your tool implementation:
+The state options configure the nested agent run started by the tool call; the parent run's conversation state is not inherited automatically. To share client-managed history between the parent and nested runs, explicitly pass the same `session` to both. As with `Runner.run`, choose one state strategy for the nested run: a client-managed `session`, or server-managed continuation through `previous_response_id` or `conversation_id`.
 
 ```python
 @function_tool


### PR DESCRIPTION
## What
Clarify that `agent.as_tool()` state options such as `session`, `previous_response_id`, and `conversation_id` apply to the nested agent run started by the tool call.

## Why
This avoids confusion about whether nested tool-agent state is shared with the parent run, and points readers back to the same state-management choices used with `Runner.run`.

## Test
- `git diff --check`
- Checked `docs/tools.md` contains the new note and keeps the structured-input sentence.