### PR TITLE
fix(models): don't offset streamed content_index by the reasoning item

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -679,9 +679,10 @@ class ChatCmplStreamHandler:
             # Handle regular content
             if delta.content is not None:
                 if not state.text_content_index_and_output:
+                    # content_index is the part's position within this message's content
+                    # list. The reasoning item is a separate output item (its own
+                    # output_index), so it must not shift the content index here.
                     content_index = 0
-                    if state.reasoning_content_index_and_output:
-                        content_index += 1
                     if state.refusal_content_index_and_output:
                         content_index += 1
 
@@ -755,9 +756,9 @@ class ChatCmplStreamHandler:
             # This is always set by the OpenAI API, but not by others e.g. LiteLLM
             if hasattr(delta, "refusal") and delta.refusal:
                 if not state.refusal_content_index_and_output:
+                    # The reasoning item is a separate output item, so it must not shift
+                    # this content index (see the text branch above).
                     refusal_index = 0
-                    if state.reasoning_content_index_and_output:
-                        refusal_index += 1
                     if state.text_content_index_and_output:
                         refusal_index += 1
 

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -804,6 +804,68 @@ async def test_stream_handler_places_text_after_existing_refusal_part() -> None:
     assert assistant_item.content[1].refusal == "blocked"
 
 
+@pytest.mark.asyncio
+async def test_stream_handler_content_index_excludes_reasoning_item() -> None:
+    # Reasoning is emitted as its own output item (with its own output_index), not as a
+    # content part of the assistant message. So the message's text/refusal parts must be
+    # streamed at the content_index they occupy in message.content (0 and 1), independent
+    # of any preceding reasoning item. Regression: the streamed content_index used to be
+    # bumped by the reasoning item, diverging from both the final message and the index the
+    # OpenAI Responses API emits for the same output.
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(index=0, delta=ChoiceDelta.model_construct(reasoning_content="thinking"))
+            ],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(content="answer"))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta.model_construct(refusal="blocked"))],
+        ),
+    ]
+
+    events = await _collect_handler_events(*chunks)
+
+    text_part_added = next(
+        event
+        for event in events
+        if event.type == "response.content_part.added"
+        and isinstance(event.part, ResponseOutputText)
+    )
+    refusal_part_added = next(
+        event
+        for event in events
+        if event.type == "response.content_part.added"
+        and isinstance(event.part, ResponseOutputRefusal)
+    )
+
+    # The reasoning item lives at output[0]; the assistant message at output[1].
+    completed_event = next(event for event in events if event.type == "response.completed")
+    assistant_item = completed_event.response.output[1]
+    assert isinstance(assistant_item, ResponseOutputMessage)
+    assert isinstance(assistant_item.content[0], ResponseOutputText)
+    assert isinstance(assistant_item.content[1], ResponseOutputRefusal)
+
+    # The streamed content_index must match each part's position in message.content,
+    # unaffected by the separate reasoning output item.
+    assert text_part_added.content_index == 0
+    assert refusal_part_added.content_index == 1
+
+
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 async def test_stream_response_passes_strict_validation_to_stream_handler(monkeypatch) -> None:


### PR DESCRIPTION
## Problem

The Chat Completions stream handler builds each assistant content part's `content_index` by counting the reasoning item. But reasoning is emitted as a *separate output item* (its own `output_index`, 0), not a content part of the assistant message: `_reasoning_output_count` / `assistant_message_output_index` already place the message at a later `output_index` because of it.

So when a stream contains reasoning followed by assistant text (and/or a refusal), the message's first content part is streamed with `content_index=1`, even though it lands at `message.content[0]` in the final `response.completed` message, and even though the OpenAI Responses API emits `content_index=0` for the same output. `content_index` is the part's position *within that item's* `content` array; `output_index` is what distinguishes items.

This affects reasoning models routed through the Chat Completions adapter (for example `deepseek-reasoner`, and OpenAI-compatible reasoning models) that also return visible text or a refusal in the same turn. A consumer that reconstructs the message from the raw streamed events via `message.content[event.content_index]` writes to the wrong slot (or hits an `IndexError`). The SDK's high-level `RunResult` is unaffected because it reads the final `response.completed` item; the impact is on consumers of the raw streamed events (`raw_response_event`).

## Root cause

In `chatcmpl_stream_handler.py`, the text and refusal branches both did:

```python
content_index = 0
if state.reasoning_content_index_and_output:   # reasoning is a separate output item, not a content part
    content_index += 1
if state.refusal_content_index_and_output:
    content_index += 1
```

The text/refusal cross-increment is correct (both are content parts of the same message). The reasoning increment is the bug.

## Fix

Drop the reasoning increment in both branches. The final message assembly appends parts in order and never used these `content_index` values, so only the streamed events change; the final `response.completed` message is byte-identical.

## Verification

Clean Docker container (`python:3.12-slim`, `uv sync --frozen`):

- New regression test `test_stream_handler_content_index_excludes_reasoning_item` fails on `main` (streamed `content_index=1`) and passes with the fix.
- `tests/models/test_openai_chatcompletions_stream.py` and `tests/models/test_reasoning_content.py`: 62 passed. The existing `content_index == 1` test (refusal-then-text, no reasoning) still passes, via the refusal increment.
- `ruff check`, `ruff format --check`, and `mypy` on the changed files: clean.

No public API change (parameter/field order and import paths are untouched). This corrects the streamed `content_index` value so it matches the final message and the Responses API.
