### PR TITLE
docs: add TokenLab model provider example

### DIFF
--- a/examples/model_providers/README.md
+++ b/examples/model_providers/README.md
@@ -22,3 +22,11 @@ Direct-model examples let you override the target model:
 uv run examples/model_providers/any_llm_provider.py --model openrouter/openai/gpt-5.4-mini
 uv run examples/model_providers/litellm_provider.py --model openrouter/openai/gpt-5.4-mini
 ```
+
+You can also point the SDK at an OpenAI-compatible provider directly. For example,
+TokenLab exposes an OpenAI-compatible `/v1` API:
+
+```bash
+export TOKENLAB_API_KEY="..."
+uv run examples/model_providers/tokenlab_chat_completions.py
+```

--- a/examples/model_providers/tokenlab_chat_completions.py
+++ b/examples/model_providers/tokenlab_chat_completions.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+from openai import AsyncOpenAI
+
+from agents import Agent, OpenAIChatCompletionsModel, Runner, set_tracing_disabled
+
+TOKENLAB_API_KEY = os.getenv("TOKENLAB_API_KEY")
+TOKENLAB_BASE_URL = os.getenv("TOKENLAB_BASE_URL", "https://api.tokenlab.sh/v1")
+TOKENLAB_MODEL = os.getenv("TOKENLAB_MODEL", "gpt-5.4-mini")
+
+if not TOKENLAB_API_KEY:
+    raise ValueError("Please set TOKENLAB_API_KEY.")
+
+
+client = AsyncOpenAI(base_url=TOKENLAB_BASE_URL, api_key=TOKENLAB_API_KEY)
+
+# Disable OpenAI tracing when running only with a TokenLab API key.
+set_tracing_disabled(disabled=True)
+
+
+async def main():
+    agent = Agent(
+        name="Assistant",
+        instructions="You are concise and practical.",
+        model=OpenAIChatCompletionsModel(model=TOKENLAB_MODEL, openai_client=client),
+    )
+
+    result = await Runner.run(agent, "Explain why custom model providers are useful.")
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a TokenLab example under `examples/model_providers`
- show how to use `AsyncOpenAI(base_url=...)` with `OpenAIChatCompletionsModel`
- update the model provider examples README with the TokenLab run command

## Validation
- `git diff --check`
- `python3 -m py_compile examples/model_providers/tokenlab_chat_completions.py`
- `uv run ruff check examples/model_providers/tokenlab_chat_completions.py`

Note: I initially passed the Markdown README to Ruff as well, which reported expected Markdown-as-Python syntax errors; the targeted Python check above passes.

TokenLab docs: https://docs.tokenlab.sh/
