### PR TITLE
Fix SandboxAgent text preamble termination after handoff

### DIFF
--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -70,6 +70,7 @@ from ..run_config import RunConfig, ToolErrorFormatterArgs
 from ..run_context import AgentHookContext, RunContextWrapper, TContext
 from ..run_error_handlers import RunErrorHandlers
 from ..run_state import RunState
+from ..sandbox.sandbox_agent import SandboxAgent
 from ..stream_events import StreamEvent
 from ..tool import (
     ApplyPatchTool,
@@ -207,6 +208,30 @@ async def _maybe_finalize_from_tool_results(
         context_wrapper=context_wrapper,
         tool_input_guardrail_results=tool_input_guardrail_results,
         tool_output_guardrail_results=tool_output_guardrail_results,
+    )
+
+
+def _should_continue_after_sandbox_handoff_text_response(
+    *,
+    public_agent: Agent[Any],
+    execution_agent: Agent[Any],
+    pre_step_items: list[RunItem],
+    message_items: list[MessageOutputItem],
+    refusal: str | None,
+) -> bool:
+    if not isinstance(public_agent, SandboxAgent):
+        return False
+    if not execution_agent.tools:
+        return False
+    if not message_items:
+        return False
+    if refusal:
+        return False
+    if any(item.agent is public_agent for item in pre_step_items):
+        return False
+    return any(
+        isinstance(item, HandoffOutputItem) and item.target_agent is public_agent
+        for item in pre_step_items
     )
 
 
@@ -808,6 +833,22 @@ async def execute_tools_and_side_effects(
         has_tool_activity_without_message = not message_items and bool(
             processed_response.tools_used
         )
+        if _should_continue_after_sandbox_handoff_text_response(
+            public_agent=public_agent,
+            execution_agent=bindings.execution_agent,
+            pre_step_items=pre_step_items,
+            message_items=message_items,
+            refusal=refusal,
+        ):
+            return SingleStepResult(
+                original_input=original_input,
+                model_response=new_response,
+                pre_step_items=pre_step_items,
+                new_step_items=new_step_items,
+                next_step=NextStepRunAgain(),
+                tool_input_guardrail_results=tool_input_guardrail_results,
+                tool_output_guardrail_results=tool_output_guardrail_results,
+            )
         if not has_tool_activity_without_message:
             if refusal:
                 refusal_error = ModelRefusalError(refusal)

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -20,7 +20,7 @@ from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 
 import agents.sandbox.runtime_agent_preparation as runtime_agent_preparation_module
 from agents import Agent, AgentHooks, LocalShellTool, RunHooks, Runner, function_tool
-from agents.exceptions import InputGuardrailTripwireTriggered, UserError
+from agents.exceptions import InputGuardrailTripwireTriggered, ModelRefusalError, UserError
 from agents.guardrail import GuardrailFunctionOutput, InputGuardrail, OutputGuardrail
 from agents.items import ModelResponse, ToolCallOutputItem, TResponseInputItem
 from agents.model_settings import ModelSettings
@@ -92,6 +92,8 @@ from tests.test_responses import (
     get_function_tool,
     get_function_tool_call,
     get_handoff_tool_call,
+    get_refusal_message,
+    get_text_message,
 )
 from tests.testing_processor import fetch_normalized_spans
 from tests.utils.factories import TestSessionState
@@ -1827,6 +1829,70 @@ async def test_runner_rebuilds_sandbox_resources_for_handoff_target_agent() -> N
         "Worker workspace\n\n"
         f"{runtime_agent_preparation_module._filesystem_instructions(worker_manifest)}"
     )
+
+
+@pytest.mark.asyncio
+async def test_runner_continues_after_sandbox_handoff_text_preamble() -> None:
+    triage_model = FakeModel()
+    worker_model = FakeModel()
+    session = _FakeSession(Manifest())
+    client = _FakeClient(session)
+    worker = SandboxAgent(
+        name="worker",
+        model=worker_model,
+        instructions="Worker instructions.",
+    )
+    triage = Agent(
+        name="triage",
+        model=triage_model,
+        instructions="Triage instructions.",
+        handoffs=[worker],
+    )
+    triage_model.turn_outputs = [[get_handoff_tool_call(worker)]]
+    worker_model.add_multiple_turn_outputs(
+        [
+            [get_text_message("I'll inspect the workspace now.")],
+            [get_final_output_message("done")],
+        ]
+    )
+
+    result = await Runner.run(
+        triage,
+        "route this",
+        run_config=_sandbox_run_config(client),
+    )
+
+    assert result.final_output == "done"
+    assert len(result.raw_responses) == 3
+
+
+@pytest.mark.asyncio
+async def test_runner_preserves_sandbox_handoff_refusal_handling() -> None:
+    triage_model = FakeModel()
+    worker_model = FakeModel(initial_output=[get_refusal_message("I cannot do that.")])
+    session = _FakeSession(Manifest())
+    client = _FakeClient(session)
+    worker = SandboxAgent(
+        name="worker",
+        model=worker_model,
+        instructions="Worker instructions.",
+    )
+    triage = Agent(
+        name="triage",
+        model=triage_model,
+        instructions="Triage instructions.",
+        handoffs=[worker],
+    )
+    triage_model.turn_outputs = [[get_handoff_tool_call(worker)]]
+
+    with pytest.raises(ModelRefusalError) as exc_info:
+        await Runner.run(
+            triage,
+            "route this",
+            run_config=_sandbox_run_config(client),
+        )
+
+    assert exc_info.value.refusal == "I cannot do that."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request fixes a SandboxAgent handoff case where a text-only preamble could be treated as final output before the sandbox agent had a chance to call its tools.

The change keeps normal final-output behavior intact for non-sandbox agents and sandbox agents without tools, while continuing the run when a newly handed-off SandboxAgent with available tools returns only a message on its first turn.

### Test plan

- [x] `uv run pytest -q tests/sandbox/test_runtime.py::test_runner_continues_after_sandbox_handoff_text_preamble`
- [x] `uv run pytest -q tests/sandbox/test_runtime.py`
- [x] `make format`
- [x] `make lint`
- [x] `make typecheck`
- [x] `make tests`
- [x] `bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

Closes #3756

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
