### PR TITLE
fix(realtime): await cancelled background tasks during session cleanup

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -1298,7 +1298,10 @@ class RealtimeSession(RealtimeModelListener):
                 task.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-        self._guardrail_tasks.clear()
+        # Only discard the tasks we snapshotted. Tasks enqueued while awaiting
+        # above stay tracked so the caller can drain them too.
+        for task in tasks:
+            self._guardrail_tasks.discard(task)
 
     def _enqueue_tool_call_task(
         self,
@@ -1374,7 +1377,10 @@ class RealtimeSession(RealtimeModelListener):
                 task.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-        self._tool_call_tasks.clear()
+        # Only discard the tasks we snapshotted. Tasks enqueued while awaiting
+        # above stay tracked so the caller can drain them too.
+        for task in tasks:
+            self._tool_call_tasks.discard(task)
 
     def _wake_event_iterators(self) -> None:
         for _ in range(self._event_iterator_waiters):
@@ -1386,12 +1392,16 @@ class RealtimeSession(RealtimeModelListener):
             self._wake_event_iterators()
             return
 
-        # Cancel and cleanup guardrail tasks
-        await self._cleanup_guardrail_tasks()
-        await self._cleanup_tool_call_tasks()
-
-        # Remove ourselves as a listener
+        # Remove ourselves as a listener before awaiting below. Otherwise an
+        # in-flight on_event could enqueue new guardrail/tool-call tasks while we
+        # await cancellation, and those tasks could keep running after cleanup.
         self._model.remove_listener(self)
+
+        # Cancel and await guardrail/tool-call tasks. Awaiting yields control, so
+        # a suspended on_event may still enqueue a task; drain until none remain.
+        while self._guardrail_tasks or self._tool_call_tasks:
+            await self._cleanup_guardrail_tasks()
+            await self._cleanup_tool_call_tasks()
 
         # Close the model connection
         await self._model.close()

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -1291,10 +1291,13 @@ class RealtimeSession(RealtimeModelListener):
                     )
                 )
 
-    def _cleanup_guardrail_tasks(self) -> None:
-        for task in self._guardrail_tasks:
+    async def _cleanup_guardrail_tasks(self) -> None:
+        tasks = list(self._guardrail_tasks)
+        for task in tasks:
             if not task.done():
                 task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
         self._guardrail_tasks.clear()
 
     def _enqueue_tool_call_task(
@@ -1364,10 +1367,13 @@ class RealtimeSession(RealtimeModelListener):
             )
         )
 
-    def _cleanup_tool_call_tasks(self) -> None:
-        for task in self._tool_call_tasks:
+    async def _cleanup_tool_call_tasks(self) -> None:
+        tasks = list(self._tool_call_tasks)
+        for task in tasks:
             if not task.done():
                 task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
         self._tool_call_tasks.clear()
 
     def _wake_event_iterators(self) -> None:
@@ -1381,8 +1387,8 @@ class RealtimeSession(RealtimeModelListener):
             return
 
         # Cancel and cleanup guardrail tasks
-        self._cleanup_guardrail_tasks()
-        self._cleanup_tool_call_tasks()
+        await self._cleanup_guardrail_tasks()
+        await self._cleanup_tool_call_tasks()
 
         # Remove ourselves as a listener
         self._model.remove_listener(self)

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -398,6 +398,50 @@ async def test_cleanup_is_idempotent_with_completed_tasks():
 
 
 @pytest.mark.asyncio
+async def test_cleanup_drains_tasks_enqueued_during_cleanup():
+    """`_cleanup` should drain tasks enqueued while it is awaiting cancellation.
+
+    Awaiting a cancelled task yields control, so a suspended handler could enqueue
+    a new background task after its set was already processed. Cleanup must keep
+    draining until no tracked tasks remain.
+    """
+    session = RealtimeSession(_DummyModel(), RealtimeAgent(name="agent"), None)
+
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    second_finished = asyncio.Event()
+
+    async def second_task() -> None:
+        second_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            second_finished.set()
+
+    async def first_task() -> None:
+        first_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            # Simulate a suspended handler enqueueing a new task mid-cleanup,
+            # after the guardrail set has already been processed this iteration.
+            new_task = asyncio.create_task(second_task())
+            session._guardrail_tasks.add(new_task)
+            await second_started.wait()
+
+    first = asyncio.create_task(first_task())
+    session._tool_call_tasks.add(first)
+    await first_started.wait()
+
+    await session._cleanup()
+
+    assert first.done()
+    assert second_finished.is_set()
+    assert len(session._guardrail_tasks) == 0
+    assert len(session._tool_call_tasks) == 0
+
+
+@pytest.mark.asyncio
 async def test_get_handoffs_async_is_enabled(monkeypatch):
     # Agent includes both a direct Handoff and a RealtimeAgent (auto-converted)
     target = RealtimeAgent(name="target")

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -331,6 +331,73 @@ async def test_on_guardrail_task_done_emits_error_event():
 
 
 @pytest.mark.asyncio
+async def test_cleanup_awaits_cancelled_background_tasks():
+    """`_cleanup` should cancel and await pending guardrail/tool-call tasks.
+
+    Regression test for the case where cleanup cancelled the tracked tasks but
+    cleared the tracking sets before awaiting them, so cancelled tasks could
+    outlive `_cleanup()` with their `finally` blocks not yet run.
+    """
+    session = RealtimeSession(_DummyModel(), RealtimeAgent(name="agent"), None)
+
+    guardrail_started = asyncio.Event()
+    guardrail_finished = asyncio.Event()
+    tool_started = asyncio.Event()
+    tool_finished = asyncio.Event()
+
+    async def guardrail_task() -> None:
+        guardrail_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            guardrail_finished.set()
+
+    async def tool_call_task() -> None:
+        tool_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            tool_finished.set()
+
+    guardrail = asyncio.create_task(guardrail_task())
+    tool_call = asyncio.create_task(tool_call_task())
+    session._guardrail_tasks.add(guardrail)
+    session._tool_call_tasks.add(tool_call)
+
+    await guardrail_started.wait()
+    await tool_started.wait()
+
+    await session._cleanup()
+
+    assert guardrail.done()
+    assert tool_call.done()
+    assert guardrail_finished.is_set()
+    assert tool_finished.is_set()
+    assert len(session._guardrail_tasks) == 0
+    assert len(session._tool_call_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_is_idempotent_with_completed_tasks():
+    """`_cleanup` should not raise when tracked tasks have already completed."""
+    session = RealtimeSession(_DummyModel(), RealtimeAgent(name="agent"), None)
+
+    async def done_task() -> None:
+        return None
+
+    guardrail = asyncio.create_task(done_task())
+    tool_call = asyncio.create_task(done_task())
+    await asyncio.gather(guardrail, tool_call)
+    session._guardrail_tasks.add(guardrail)
+    session._tool_call_tasks.add(tool_call)
+
+    await session._cleanup()
+
+    assert len(session._guardrail_tasks) == 0
+    assert len(session._tool_call_tasks) == 0
+
+
+@pytest.mark.asyncio
 async def test_get_handoffs_async_is_enabled(monkeypatch):
     # Agent includes both a direct Handoff and a RealtimeAgent (auto-converted)
     target = RealtimeAgent(name="target")

--- a/tests/realtime/test_session_exceptions.py
+++ b/tests/realtime/test_session_exceptions.py
@@ -249,16 +249,19 @@ class TestSessionExceptions:
 
         session = RealtimeSession(fake_model, fake_agent, None)
 
-        # Add some fake guardrail tasks
-        fake_task1 = Mock()
-        fake_task1.done.return_value = False
-        fake_task1.cancel = Mock()
+        # Add some real guardrail tasks: one still running (should be cancelled
+        # and awaited) and one already completed (should be left as-is).
+        async def _running() -> None:
+            await asyncio.Event().wait()
 
-        fake_task2 = Mock()
-        fake_task2.done.return_value = True
-        fake_task2.cancel = Mock()
+        async def _completed() -> None:
+            return None
 
-        session._guardrail_tasks = {fake_task1, fake_task2}
+        pending_task = asyncio.create_task(_running())
+        completed_task = asyncio.create_task(_completed())
+        await completed_task
+
+        session._guardrail_tasks = {pending_task, completed_task}
 
         fake_model.set_next_events([exception_event])
 
@@ -267,9 +270,10 @@ class TestSessionExceptions:
                 async for _event in session:
                     pass
 
-        # Verify guardrail tasks were properly cleaned up
-        fake_task1.cancel.assert_called_once()
-        fake_task2.cancel.assert_not_called()  # Already done
+        # Verify guardrail tasks were properly cancelled and awaited.
+        assert pending_task.cancelled()
+        assert completed_task.done()
+        assert not completed_task.cancelled()  # Already done before cleanup
         assert len(session._guardrail_tasks) == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`RealtimeSession._cleanup()` cancelled pending guardrail and tool-call background tasks but cleared the tracking sets immediately after `task.cancel()`, without awaiting the cancelled tasks. As a result `_cleanup()` could return before the tasks' `finally` blocks ran, and cancellation exceptions/callbacks could be processed after the session had already closed the model connection.

This makes the two cleanup helpers (`_cleanup_guardrail_tasks`, `_cleanup_tool_call_tasks`) `async` and awaits the cancelled tasks with `asyncio.gather(..., return_exceptions=True)` before clearing the tracking sets, matching the standard asyncio cancel-and-await cleanup pattern. Both helpers are private and only called from the async `_cleanup()`, so there is no public API impact.

### Test plan

- Added `test_cleanup_awaits_cancelled_background_tasks` (ports the issue's repro): after `_cleanup()`, both tasks are `done()`, both `finally` blocks ran, and both tracking sets are empty.
- Added `test_cleanup_is_idempotent_with_completed_tasks`: cleanup with already-completed tasks does not raise.
- Updated `test_exception_during_guardrail_processing` to use real tasks, since the previous `Mock` tasks are not awaitable by `gather`.
- Verified the issue repro script now prints `True` for `guardrail_done_after_cleanup`, `tool_done_after_cleanup`, `guardrail_finally_ran`, `tool_finally_ran` (previously all `False`).
- `make format`, `make lint`, `make typecheck`, `make tests` all pass locally.

### Issue number

Closes #3334

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass