### PR TITLE
fix(sessions): handle list content in AdvancedSQLiteSession browsing helpers

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -17,6 +17,20 @@ from ...memory import SQLiteSession
 from ...memory.session_settings import SessionSettings, resolve_session_limit
 
 
+def _content_preview(content: Any, max_length: int | None = None) -> str:
+    """Return a string preview of a stored user-message ``content``.
+
+    User-message ``content`` may be a plain string or a list of structured parts
+    (for example multimodal ``input_text``/``input_image`` items). Both shapes are
+    coerced to a string so callers always receive the documented preview type, then
+    truncated to ``max_length`` characters when a limit is provided.
+    """
+    text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+    if max_length is not None and len(text) > max_length:
+        return text[:max_length] + "..."
+    return text
+
+
 class AdvancedSQLiteSession(SQLiteSession):
     """Enhanced SQLite session with conversation branching and usage analytics."""
 
@@ -956,9 +970,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                             turns.append(
                                 {
                                     "turn": turn_num,
-                                    "content": (
-                                        content[:100] + "..." if len(content) > 100 else content
-                                    ),
+                                    "content": _content_preview(content, 100),
                                     "full_content": content,
                                     "timestamp": created_at,
                                     "can_branch": True,
@@ -1014,7 +1026,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                             matches.append(
                                 {
                                     "turn": turn_num,
-                                    "content": content,
+                                    "content": _content_preview(content),
                                     "full_content": content,
                                     "timestamp": created_at,
                                     "can_branch": True,

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -856,6 +856,58 @@ async def test_find_turns_by_content():
     session.close()
 
 
+async def test_get_conversation_turns_with_list_content():
+    """List (multimodal) content is previewed as a string instead of crashing or leaking a list."""
+    session_id = "conversation_turns_list_content_test"
+    session = AdvancedSQLiteSession(session_id=session_id, create_tables=True)
+
+    # A short list content must be previewed as a string, not returned as the raw list.
+    short_items: list[TResponseInputItem] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+    ]
+    await session.add_items(short_items)
+
+    # A long list content must not raise when the preview is built.
+    long_items: list[TResponseInputItem] = [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": str(i)} for i in range(101)],
+        },
+    ]
+    await session.add_items(long_items)
+
+    turns = await session.get_conversation_turns()
+    assert len(turns) == 2
+
+    # 'content' is the documented truncated preview string, while 'full_content' keeps the list.
+    assert isinstance(turns[0]["content"], str)
+    assert isinstance(turns[0]["full_content"], list)
+
+    assert isinstance(turns[1]["content"], str)
+    assert turns[1]["content"].endswith("...")
+    assert isinstance(turns[1]["full_content"], list)
+
+    session.close()
+
+
+async def test_find_turns_by_content_with_list_content():
+    """find_turns_by_content returns a string preview for list (multimodal) content."""
+    session_id = "find_turns_list_content_test"
+    session = AdvancedSQLiteSession(session_id=session_id, create_tables=True)
+
+    items: list[TResponseInputItem] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "hello world"}]},
+    ]
+    await session.add_items(items)
+
+    matches = await session.find_turns_by_content("hello")
+    assert len(matches) == 1
+    assert isinstance(matches[0]["content"], str)
+    assert isinstance(matches[0]["full_content"], list)
+
+    session.close()
+
+
 async def test_create_branch_from_content():
     """Test create_branch_from_content functionality."""
     session_id = "branch_from_content_test"


### PR DESCRIPTION

<!-- PR-BODY-START -->

`AdvancedSQLiteSession.get_conversation_turns()` and `find_turns_by_content()`
assumed a stored user-message `content` is always a `str`. That holds for
plain-text turns, but a valid user message can also carry a list of structured
parts (for example multimodal `input_text`/`input_image` items), and the session
stores each item verbatim via `json.dumps`, so `json.loads(...).get("content")`
hands these helpers a `list`.

That leads to two problems in `get_conversation_turns()`, whose docstring promises
`'content': User message content (truncated)`:

- When the list has more than 100 parts, `content[:100] + "..."` evaluates
  `list + str` and raises `TypeError: can only concatenate list (not "str") to
  list`. The surrounding `except (json.JSONDecodeError, AttributeError)` does not
  catch `TypeError`, so the exception propagates out of `asyncio.to_thread` and
  aborts the whole call.
- When the list has 100 or fewer parts, the `len(content) > 100` check is `False`,
  so the raw list is returned in the `content` field, which contradicts the
  documented truncated-preview string.

`find_turns_by_content()` shares the same string-only assumption and returns the
raw list in `content` too.

The fix adds a small module-level `_content_preview` helper that coerces non-string
content to a JSON string (`json.dumps(content, ensure_ascii=False)`) before applying
the existing truncation. `get_conversation_turns()` uses it with a 100-character
limit and `find_turns_by_content()` uses it without a limit, so each keeps its prior
behavior for string content exactly while now returning the documented preview
string for list content. `full_content` still keeps the original value in both
helpers. This mirrors the defensive handling the sibling `_validate_turn` already
does for its own preview slice.

### Test plan

Added two regression tests in
`tests/extensions/memory/test_advanced_sqlite_session.py` (the existing suite only
exercised plain-string content):

- `test_get_conversation_turns_with_list_content` adds a short list-content turn and
  a 101-part list-content turn, then asserts `get_conversation_turns()` returns
  without raising, that `content` is a `str` for both, that the long one is
  truncated with a trailing `...`, and that `full_content` keeps the list.
- `test_find_turns_by_content_with_list_content` asserts a list-content match returns
  a `str` preview in `content` while `full_content` keeps the list.

Verified red -> green: reverting only the source change makes
`test_get_conversation_turns_with_list_content` fail with the `TypeError` and
`test_find_turns_by_content_with_list_content` fail because `content` is a `list`;
with the fix both pass. Also confirmed the string path is unchanged with an
equivalence check across empty, short, length-100, length-101, longer, and unicode
inputs.

Local checks:

- `uv run pytest tests/extensions/memory/test_advanced_sqlite_session.py` -> 45
  passed.
- `uv run pytest tests/extensions/memory/` -> 216 passed, 5 skipped
  (external-service integrations).
- `make format` (no changes), `make lint` clean, `pyright` on the changed module: 0
  errors.

### Issue number

<!-- No tracker issue; self-identified defect. Remove this note before opening. -->
N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
<!-- PR-BODY-END -->
