### PR TITLE
fix(models): accumulate streamed logprobs in place to avoid O(n^2) copies

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -746,10 +746,13 @@ class ChatCmplStreamHandler:
                 # Accumulate the text into the response part
                 state.text_content_index_and_output[1].text += delta.content
                 if output_logprobs:
-                    existing_logprobs = state.text_content_index_and_output[1].logprobs or []
-                    state.text_content_index_and_output[1].logprobs = (
-                        existing_logprobs + output_logprobs
-                    )
+                    existing_logprobs = state.text_content_index_and_output[1].logprobs
+                    if existing_logprobs is None:
+                        state.text_content_index_and_output[1].logprobs = output_logprobs
+                    else:
+                        # Extend in place to avoid rebuilding the full accumulated list on
+                        # every content delta, which would be O(n^2) over a long stream.
+                        existing_logprobs.extend(output_logprobs)
 
             # Handle refusals (model declines to answer)
             # This is always set by the OpenAI API, but not by others e.g. LiteLLM

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1108,6 +1108,82 @@ async def test_stream_response_includes_logprobs(monkeypatch) -> None:
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_stream_response_accumulates_logprobs_across_many_deltas(monkeypatch) -> None:
+    # Each content delta carries its own logprobs, and the streamed output text part must
+    # accumulate all of them in order across the whole stream.
+    tokens = ["a", "b", "c", "d", "e"]
+
+    def make_chunk(token: str) -> ChatCompletionChunk:
+        return ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[
+                Choice(
+                    index=0,
+                    delta=ChoiceDelta(content=token),
+                    logprobs=ChoiceLogprobs(
+                        content=[
+                            ChatCompletionTokenLogprob(
+                                token=token,
+                                logprob=-0.5,
+                                bytes=[1],
+                                top_logprobs=[TopLogprob(token=token, logprob=-0.5, bytes=[1])],
+                            )
+                        ]
+                    ),
+                )
+            ],
+        )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for token in tokens:
+            yield make_chunk(token)
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    output_events = []
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        output_events.append(event)
+
+    completed_event = next(event for event in output_events if event.type == "response.completed")
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    completed_resp = completed_event.response
+    assert isinstance(completed_resp.output[0], ResponseOutputMessage)
+    text_part = completed_resp.output[0].content[0]
+    assert isinstance(text_part, ResponseOutputText)
+    assert text_part.text == "".join(tokens)
+    assert text_part.logprobs is not None
+    assert [lp.token for lp in text_part.logprobs] == tokens
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_stream_response_yields_events_for_refusal_content(monkeypatch) -> None:
     """
     Validate that when the model streams a refusal string instead of normal content,


### PR DESCRIPTION
When Chat Completions streaming is used with logprobs enabled, the stream handler
rebuilt the entire accumulated output-text logprobs list on every content delta:

```python
existing_logprobs = state.text_content_index_and_output[1].logprobs or []
state.text_content_index_and_output[1].logprobs = existing_logprobs + output_logprobs
```

`list + list` allocates and copies a brand-new list of the full accumulated length
for each delta, so over an n-token stream this is O(n^2) allocation and copying
(the adjacent `... .text += delta.content` on the line above already grows in
place). The accumulator was introduced in #2134 using `+` where an in-place extend
was intended.

This extends the existing list in place instead, keeping the `None`-provider guard
so non-OpenAI providers (for example LiteLLM), which may leave `logprobs` unset,
still behave exactly as before. The accumulated contents and their order are
unchanged; only the per-delta work drops from O(n) to O(1), making the whole stream
O(n).

The converted logprobs are a fresh, unaliased `list[Logprob]` from
`ChatCmplHelpers.convert_logprobs_for_output_text`, and the response part's
`logprobs` is process-local (initialized to `[]` at part creation), so extending it
in place is safe and observably identical to the previous concatenation.

### Test plan

- Added `test_stream_response_accumulates_logprobs_across_many_deltas` in
  `tests/models/test_openai_chatcompletions_stream.py`: streams several
  logprob-bearing content deltas and asserts the final output-text part accumulates
  every token's logprob in order (guarding that the in-place refactor preserves
  ordered accumulation). This complements the existing
  `test_stream_response_includes_logprobs`.
- `make format` (no changes), `make lint`, and `make typecheck` (pyright clean) all
  pass on the change.
- `uv run pytest tests/models/` passes (all model tests, including both streaming
  logprob tests).

### Issue number

<!-- No tracking issue; self-identified performance defect. Remove this section or
     link an issue if one is filed. -->

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
