### PR TITLE
Send logprobs=True when top_logprobs is set on Chat Completions

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -554,6 +554,15 @@ class OpenAIChatCompletionsModel(Model):
             "extra_body": model_settings.extra_body,
             "metadata": self._non_null_or_omit(model_settings.metadata),
         }
+        # The Chat Completions API requires logprobs=True whenever top_logprobs is set.
+        # Skip the key when the caller already supplies logprobs via extra_args, so that
+        # extra_args={"logprobs": ...} keeps passing through and setting both top_logprobs
+        # and extra_args["logprobs"] (a pre-existing workaround) does not collide with the
+        # duplicate-key check below.
+        if model_settings.top_logprobs is not None and "logprobs" not in (
+            model_settings.extra_args or {}
+        ):
+            create_kwargs["logprobs"] = True
         duplicate_extra_arg_keys = sorted(
             set(create_kwargs).intersection(model_settings.extra_args or {})
         )

--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -1,7 +1,14 @@
 import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
-from agents import ModelSettings, ModelTracing, OpenAIResponsesModel
+from agents import (
+    ModelSettings,
+    ModelTracing,
+    OpenAIChatCompletionsModel,
+    OpenAIResponsesModel,
+)
 
 
 class DummyResponses:
@@ -48,3 +55,109 @@ async def test_top_logprobs_param_passed():
     )
     assert client.responses.kwargs["top_logprobs"] == 2
     assert "message.output_text.logprobs" in client.responses.kwargs["include"]
+
+
+class DummyChatCompletions:
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+        return ChatCompletion(
+            id="dummy",
+            created=0,
+            model="gpt-4",
+            object="chat.completion",
+            choices=[
+                Choice(
+                    index=0,
+                    finish_reason="stop",
+                    message=ChatCompletionMessage(role="assistant", content="hi"),
+                )
+            ],
+            usage=None,
+        )
+
+
+class DummyChatClient:
+    def __init__(self):
+        self.chat = type("_Chat", (), {"completions": DummyChatCompletions()})()
+        self.base_url = "https://api.openai.com/v1"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_chat_completions_top_logprobs_sets_logprobs_flag():
+    client = DummyChatClient()
+    model = OpenAIChatCompletionsModel(model="gpt-4", openai_client=client)  # type: ignore
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(top_logprobs=2),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+    kwargs = client.chat.completions.kwargs
+    # The Chat Completions API rejects top_logprobs unless logprobs is set to True.
+    assert kwargs["top_logprobs"] == 2
+    assert kwargs["logprobs"] is True
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_chat_completions_omits_logprobs_when_top_logprobs_unset():
+    client = DummyChatClient()
+    model = OpenAIChatCompletionsModel(model="gpt-4", openai_client=client)  # type: ignore
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+    assert "logprobs" not in client.chat.completions.kwargs
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_chat_completions_extra_args_logprobs_passthrough():
+    client = DummyChatClient()
+    model = OpenAIChatCompletionsModel(model="gpt-4", openai_client=client)  # type: ignore
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(extra_args={"logprobs": True}),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+    # With top_logprobs unset, a user can still request plain logprobs via extra_args;
+    # the SDK must not reserve the key and collide with it.
+    assert client.chat.completions.kwargs["logprobs"] is True
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_chat_completions_top_logprobs_with_extra_args_logprobs_does_not_collide():
+    client = DummyChatClient()
+    model = OpenAIChatCompletionsModel(model="gpt-4", openai_client=client)  # type: ignore
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(top_logprobs=2, extra_args={"logprobs": True}),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+    # Setting both top_logprobs and extra_args["logprobs"] was already a working workaround;
+    # the SDK must defer to the caller's logprobs rather than adding a duplicate that collides.
+    kwargs = client.chat.completions.kwargs
+    assert kwargs["top_logprobs"] == 2
+    assert kwargs["logprobs"] is True


### PR DESCRIPTION
## What

The Chat Completions request builder forwards `top_logprobs` from `ModelSettings` but never sets `logprobs`:

```python
"top_logprobs": self._non_null_or_omit(model_settings.top_logprobs),
# there is no "logprobs" key anywhere in create_kwargs
```

The OpenAI Chat Completions API requires `logprobs=true` whenever `top_logprobs` is set, and rejects the request otherwise:

```
400 - 'top_logprobs' requires 'logprobs' to be set to true
```

So any run using `ModelSettings(top_logprobs=...)` with a Chat Completions model fails — even though the code clearly intends logprobs to work (it reads `first_choice.logprobs` from the response and the stream handler emits logprobs events).

The Responses path is unaffected because it enables logprobs via `include` (`message.output_text.logprobs`); this only hit the Chat Completions provider.

## Fix

Set `logprobs=True` whenever `top_logprobs` is provided, and omit it otherwise so ordinary calls are unchanged.

## Tests

Adds two tests to `tests/test_logprobs.py` that capture the outgoing Chat Completions request kwargs:
- `ModelSettings(top_logprobs=2)` → request has `logprobs is True` and `top_logprobs == 2`
- no `top_logprobs` → `logprobs` is omitted

Both fail on the current code (the request has no `logprobs` key) and pass with the fix. `ruff check`, `ruff format`, and `mypy` are clean; the model test suite passes.
