### PR TITLE
fix(realtime): await cancelled guardrail and tool-call tasks during cleanup

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -1291,11 +1291,13 @@ class RealtimeSession(RealtimeModelListener):
                     )
                 )
 
-    def _cleanup_guardrail_tasks(self) -> None:
-        for task in self._guardrail_tasks:
-            if not task.done():
-                task.cancel()
+    async def _cleanup_guardrail_tasks(self) -> None:
+        tasks_to_cancel = [task for task in self._guardrail_tasks if not task.done()]
         self._guardrail_tasks.clear()
+        for task in tasks_to_cancel:
+            task.cancel()
+        if tasks_to_cancel:
+            await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
 
     def _enqueue_tool_call_task(
         self,
@@ -1364,11 +1366,13 @@ class RealtimeSession(RealtimeModelListener):
             )
         )
 
-    def _cleanup_tool_call_tasks(self) -> None:
-        for task in self._tool_call_tasks:
-            if not task.done():
-                task.cancel()
+    async def _cleanup_tool_call_tasks(self) -> None:
+        tasks_to_cancel = [task for task in self._tool_call_tasks if not task.done()]
         self._tool_call_tasks.clear()
+        for task in tasks_to_cancel:
+            task.cancel()
+        if tasks_to_cancel:
+            await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
 
     def _wake_event_iterators(self) -> None:
         for _ in range(self._event_iterator_waiters):
@@ -1381,8 +1385,8 @@ class RealtimeSession(RealtimeModelListener):
             return
 
         # Cancel and cleanup guardrail tasks
-        self._cleanup_guardrail_tasks()
-        self._cleanup_tool_call_tasks()
+        await self._cleanup_guardrail_tasks()
+        await self._cleanup_tool_call_tasks()
 
         # Remove ourselves as a listener
         self._model.remove_listener(self)

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -3749,3 +3749,37 @@ class TestTranscriptPreservation:
         preserved_item = cast(AssistantMessageItem, session._history[0])
         assert isinstance(preserved_item.content[0], AssistantAudio)
         assert preserved_item.content[0].transcript == "Final complete transcript"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_awaits_cancelled_guardrail_and_tool_call_tasks(mock_model, mock_agent):
+    """Cancelled background tasks must finish (finally blocks run) before cleanup returns.
+
+    Regression test for issue #3334: ``_cleanup`` cancelled pending guardrail and
+    tool-call tasks but neither awaited them nor deferred clearing the tracking sets,
+    so ``_cleanup`` could return before the tasks' ``finally`` blocks executed and
+    the sets were cleared before cancellation took effect.
+    """
+
+    async def _never_returns() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(0)
+            finished.set()
+
+    session = RealtimeSession(mock_model, mock_agent, None)
+    finished = asyncio.Event()
+
+    guardrail = asyncio.create_task(_never_returns())
+    tool_call = asyncio.create_task(_never_returns())
+    session._guardrail_tasks.add(guardrail)
+    session._tool_call_tasks.add(tool_call)
+
+    await session._cleanup()
+
+    assert guardrail.done()
+    assert tool_call.done()
+    assert finished.is_set()
+    assert session._guardrail_tasks == set()
+    assert session._tool_call_tasks == set()


### PR DESCRIPTION
## Summary

`RealtimeSession._cleanup()` cancels pending guardrail and tool-call background tasks but never awaited them, so cleanup could return before the tasks' `finally` blocks executed. The tracking sets (`_guardrail_tasks`, `_tool_call_tasks`) were also cleared *before* cancellation took effect, which could drop references to in-flight tasks.

This makes `_cleanup_guardrail_tasks` and `_cleanup_tool_call_tasks` async: they now collect the not-yet-done tasks, clear the tracking set first, cancel the tasks, and `await asyncio.gather(..., return_exceptions=True)` so each task's `finally` block runs and the cancellation is observed before `_cleanup` returns.

Fixes #3334

## Test plan

- Added `tests/realtime/test_session.py::test_cleanup_awaits_cancelled_guardrail_and_tool_call_tasks`: seeds two never-returning background tasks into the tracking sets, calls `_cleanup()`, and asserts both tasks are done, the `finished` event is set (proving the `finally` blocks ran), and the tracking sets are empty.
- Verified the test fails against the old (sync) implementation and passes with the fix.
- `uv run python -m pytest tests/realtime/test_session.py` — full suite passes (111 passed), no regressions.

Note: this repo does not require DCO sign-off, so the commit is not `-s`.