### PR TITLE
fix(realtime): finalize assistant message status on output_item.done

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -1102,9 +1102,16 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                     elif part.get("type") in ("text", "output_text"):
                         converted_content.append({"type": "text", "text": part.get("text")})
                 status = item.get("status")
-                if status not in ("in_progress", "completed", "incomplete"):
-                    is_done = event.get("type") == "response.output_item.done"
-                    status = "completed" if is_done else "in_progress"
+                is_done = event.get("type") == "response.output_item.done"
+                if is_done:
+                    # A "response.output_item.done" event is authoritative: the item
+                    # is finalized, so surface "completed" unless the server explicitly
+                    # reported a genuine interruption. Some server payloads still carry
+                    # "in_progress" on the done event, which would otherwise leave the
+                    # history item stuck as unfinished.
+                    status = "incomplete" if status == "incomplete" else "completed"
+                elif status not in ("in_progress", "completed", "incomplete"):
+                    status = "in_progress"
                 # Explicitly type the adapter for mypy
                 type_adapter: TypeAdapter[RealtimeMessageItem] = TypeAdapter(RealtimeMessageItem)
                 message_item: RealtimeMessageItem = type_adapter.validate_python(

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -671,6 +671,83 @@ class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
         assert types.count("item_updated") >= 2
 
     @pytest.mark.asyncio
+    async def test_output_item_done_finalizes_status_to_completed(self, model):
+        """A response.output_item.done event finalizes the assistant status.
+
+        Regression test for #1434: some server payloads still carry
+        `status="in_progress"` on the done event, which previously left the
+        emitted history item stuck as unfinished.
+        """
+        listener = AsyncMock()
+        model.add_listener(listener)
+
+        def _last_item_status() -> str | None:
+            item_updated_calls = [
+                call
+                for call in listener.on_event.call_args_list
+                if call[0][0].type == "item_updated"
+            ]
+            return item_updated_calls[-1][0][0].item.status
+
+        # Server reports the item as still in_progress on the done event.
+        await model._handle_ws_event(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "id": "m1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "done"}],
+                    "status": "in_progress",
+                },
+            }
+        )
+        assert _last_item_status() == "completed"
+
+        # Server omits status on done -> still completed.
+        await model._handle_ws_event(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "id": "m2",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "done"}],
+                },
+            }
+        )
+        assert _last_item_status() == "completed"
+
+        # A genuine interruption reported by the server is preserved.
+        await model._handle_ws_event(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "id": "m3",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "partial"}],
+                    "status": "incomplete",
+                },
+            }
+        )
+        assert _last_item_status() == "incomplete"
+
+        # An added (not done) event stays in_progress.
+        await model._handle_ws_event(
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "id": "m4",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "typing"}],
+                },
+            }
+        )
+        assert _last_item_status() == "in_progress"
+
+    @pytest.mark.asyncio
     async def test_text_mode_output_item_content(self, model):
         """output_text content is properly handled in message items."""
         listener = AsyncMock()


### PR DESCRIPTION
### Summary

Fixes #1434. In `history_updated` events emitted by a `RealtimeSession`, an **assistant** message could stay `status: "in_progress"` even after the turn finished and the transcript was fully populated, leaving consumers unable to tell a completed turn from an in-flight one.

Root cause is in `OpenAIRealtimeWebSocketModel._handle_ws_event`. The `status` field on a conversation item is server-controlled and optional — the OpenAI SDK type documents it as *"has no effect on the conversation."* The previous guard only derived `"completed"` when the server's status was **missing/unknown**:

```python
status = item.get("status")
if status not in ("in_progress", "completed", "incomplete"):
    is_done = event.get("type") == "response.output_item.done"
    status = "completed" if is_done else "in_progress"
```

When a `response.output_item.done` payload still carried `status="in_progress"`, that value was treated as valid and kept, so the finalized item stayed `in_progress`. The history merge (`RealtimeSession._get_new_history`) faithfully propagates the incoming status, so the stale value surfaced in `history_updated`.

### Change

Treat a `response.output_item.done` event as authoritative: surface `"completed"` unless the server explicitly reported `"incomplete"` (so genuine interruptions are preserved). The `response.output_item.added` (non-done) path is unchanged.

### Test plan

- Added `test_output_item_done_finalizes_status_to_completed`, covering: done + server `in_progress` → `completed`; done + no status → `completed`; done + `incomplete` → `incomplete` (interruption preserved); added → `in_progress`.
- `make format`, `make lint`, `make typecheck` (mypy + pyright), and the full `make tests` pass locally (realtime suite: 302 passed; full suite: 4881 passed, 1 skipped).

### Issue number

Closes #1434

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass