### PR TITLE
fix(realtime): make session cleanup deterministic

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -82,6 +82,7 @@ class _RealtimeSessionClosedSentinel:
 
 
 _REALTIME_SESSION_CLOSED_SENTINEL = _RealtimeSessionClosedSentinel()
+_BACKGROUND_TASK_CANCEL_GRACE_SECONDS = 1.0
 
 
 def _serialize_tool_output(output: Any) -> str:
@@ -192,7 +193,9 @@ class RealtimeSession(RealtimeModelListener):
             asyncio.Queue()
         )
         self._event_iterator_waiters = 0
+        self._closing = False
         self._closed = False
+        self._cleanup_task: asyncio.Task[None] | None = None
         self._stored_exception: BaseException | None = None
         self._pending_tool_calls: dict[str, _PendingToolCall] = {}
         self._active_tool_call_ids: set[str] = set()
@@ -272,7 +275,7 @@ class RealtimeSession(RealtimeModelListener):
             # Check if there's a stored exception to raise
             if self._stored_exception is not None:
                 # Clean up resources before raising
-                await self._cleanup()
+                await self.close()
                 raise self._stored_exception
 
             self._event_iterator_waiters += 1
@@ -286,7 +289,27 @@ class RealtimeSession(RealtimeModelListener):
 
     async def close(self) -> None:
         """Close the session."""
-        await self._cleanup()
+        if self._closed:
+            self._wake_event_iterators()
+            return
+
+        cleanup_task = self._cleanup_task
+        current_task = asyncio.current_task()
+        if cleanup_task is not None and (
+            current_task in self._guardrail_tasks or current_task in self._tool_call_tasks
+        ):
+            # Cleanup is already waiting for this tracked task, so waiting here would form a cycle.
+            raise asyncio.CancelledError
+
+        if cleanup_task is None:
+            cleanup_task = asyncio.create_task(
+                self._cleanup(),
+                name="agents-realtime-session-cleanup",
+            )
+            self._cleanup_task = cleanup_task
+            cleanup_task.add_done_callback(self._on_cleanup_task_done)
+
+        await asyncio.shield(cleanup_task)
 
     async def send_message(self, message: RealtimeUserInput) -> None:
         """Send a message to the model."""
@@ -316,7 +339,11 @@ class RealtimeSession(RealtimeModelListener):
         )
 
     async def on_event(self, event: RealtimeModelEvent) -> None:
-        await self._put_event(RealtimeRawModelEvent(data=event, info=self._event_info))
+        if self._closing or self._closed:
+            return
+
+        if not await self._put_event(RealtimeRawModelEvent(data=event, info=self._event_info)):
+            return
 
         if event.type == "error":
             await self._put_event(RealtimeError(info=self._event_info, error=event.error))
@@ -495,9 +522,12 @@ class RealtimeSession(RealtimeModelListener):
         else:
             assert_never(event)
 
-    async def _put_event(self, event: RealtimeSessionEvent) -> None:
+    async def _put_event(self, event: RealtimeSessionEvent) -> bool:
         """Put an event into the queue."""
+        if self._closing or self._closed:
+            return False
         await self._event_queue.put(event)
+        return True
 
     async def _function_needs_approval(
         self, function_tool: FunctionTool, tool_call: RealtimeModelToolCallEvent
@@ -564,6 +594,8 @@ class RealtimeSession(RealtimeModelListener):
         )
 
         needs_approval = await self._function_needs_approval(function_tool, tool_call)
+        if self._closing or self._closed:
+            return None
         if not needs_approval:
             return True
 
@@ -584,6 +616,8 @@ class RealtimeSession(RealtimeModelListener):
                 tool_call=tool_call,
                 agent=agent,
             )
+            if self._closing or self._closed:
+                return None
             if rejected_message is not None:
                 return self._build_realtime_tool_output(
                     tool=function_tool,
@@ -591,6 +625,9 @@ class RealtimeSession(RealtimeModelListener):
                     agent=agent,
                     output=rejected_message,
                 )
+
+        if self._closing or self._closed:
+            return None
 
         self._pending_tool_calls[tool_call.call_id] = _PendingToolCall(
             tool_call=tool_call,
@@ -699,17 +736,27 @@ class RealtimeSession(RealtimeModelListener):
         )
 
     async def _send_tool_output_completion(self, pending_output: _PendingToolOutput) -> None:
+        if self._closing or self._closed:
+            return
+
         call_id = pending_output.tool_call.call_id
         self._pending_tool_outputs[call_id] = pending_output
         try:
             await self._send_pending_tool_output(pending_output)
         except Exception as exc:
+            if self._closing or self._closed:
+                self._pending_tool_outputs.pop(call_id, None)
+                return
             raise _PendingToolOutputSendError(call_id, exc) from exc
         self._pending_tool_outputs.pop(call_id, None)
 
     async def _send_pending_tool_output(self, pending_output: _PendingToolOutput) -> None:
+        if self._closing or self._closed:
+            return
         if pending_output.session_update is not None:
             await self._model.send_event(pending_output.session_update)
+        if self._closing or self._closed:
+            return
         await self._model.send_event(
             RealtimeModelSendToolOutput(
                 tool_call=pending_output.tool_call,
@@ -717,6 +764,8 @@ class RealtimeSession(RealtimeModelListener):
                 start_response=pending_output.start_response,
             )
         )
+        if self._closing or self._closed:
+            return
         if pending_output.tool_end_event is not None:
             await self._put_event(pending_output.tool_end_event)
 
@@ -765,6 +814,9 @@ class RealtimeSession(RealtimeModelListener):
 
     async def approve_tool_call(self, call_id: str, *, always: bool = False) -> None:
         """Approve a pending tool call and resume execution."""
+        if self._closing or self._closed:
+            return
+
         pending = self._pending_tool_calls.pop(call_id, None)
         if pending is None:
             return
@@ -804,6 +856,9 @@ class RealtimeSession(RealtimeModelListener):
         rejection_message: str | None = None,
     ) -> None:
         """Reject a pending tool call and notify the model."""
+        if self._closing or self._closed:
+            return
+
         pending = self._pending_tool_calls.pop(call_id, None)
         if pending is None:
             return
@@ -854,6 +909,8 @@ class RealtimeSession(RealtimeModelListener):
 
             snapshot = await self._resolve_dispatch_snapshot(agent, dispatch_snapshot)
             snapshot = await self._filter_enabled_dispatch_snapshot(snapshot)
+            if self._closing or self._closed:
+                return
             tools = snapshot.tools
             handoffs = snapshot.handoffs
             validate_realtime_tool_names(tools, handoffs)
@@ -868,6 +925,8 @@ class RealtimeSession(RealtimeModelListener):
                     agent=agent,
                     dispatch_snapshot=snapshot,
                 )
+                if self._closing or self._closed:
+                    return
                 if isinstance(approval_status, _PendingToolOutput):
                     await self._send_tool_output_completion(approval_status)
                     mark_completed = True
@@ -884,6 +943,8 @@ class RealtimeSession(RealtimeModelListener):
                     tool_call=event,
                     agent=agent,
                 )
+                if self._closing or self._closed:
+                    return
                 if rejected_message is not None:
                     await self._send_tool_output_completion(
                         self._build_realtime_tool_output(
@@ -904,6 +965,8 @@ class RealtimeSession(RealtimeModelListener):
                         arguments=event.arguments,
                     )
                 )
+                if self._closing or self._closed:
+                    return
 
                 tool_context = ToolContext(
                     context=self._context_wrapper.context,
@@ -918,6 +981,8 @@ class RealtimeSession(RealtimeModelListener):
                     context=tool_context,
                     arguments=event.arguments,
                 )
+                if self._closing or self._closed:
+                    return
 
                 await self._send_tool_output_completion(
                     _PendingToolOutput(
@@ -947,6 +1012,8 @@ class RealtimeSession(RealtimeModelListener):
 
                 # Execute the handoff to get the new agent
                 result = await handoff.on_invoke_handoff(self._context_wrapper, event.arguments)
+                if self._closing or self._closed:
+                    return
                 if not isinstance(result, RealtimeAgent):
                     raise UserError(
                         f"Handoff {handoff.tool_name} returned invalid result: {type(result)}"
@@ -960,6 +1027,8 @@ class RealtimeSession(RealtimeModelListener):
                     starting_settings=None,
                     agent=result,
                 )
+                if self._closing or self._closed:
+                    return
                 updated_snapshot = self._dispatch_snapshot_from_settings(result, updated_settings)
 
                 # Update current agent
@@ -1008,6 +1077,8 @@ class RealtimeSession(RealtimeModelListener):
             self._finish_tool_call(event.call_id, mark_completed=mark_completed)
 
     def _begin_tool_call(self, call_id: str, *, from_pending_approval: bool) -> bool:
+        if self._closing or self._closed:
+            return False
         if call_id in self._active_tool_call_ids or call_id in self._completed_tool_call_ids:
             return False
         if not from_pending_approval and call_id in self._pending_tool_calls:
@@ -1017,7 +1088,7 @@ class RealtimeSession(RealtimeModelListener):
 
     def _finish_tool_call(self, call_id: str, *, mark_completed: bool) -> None:
         self._active_tool_call_ids.discard(call_id)
-        if mark_completed:
+        if mark_completed and not self._closing and not self._closed:
             self._completed_tool_call_ids.add(call_id)
 
     @classmethod
@@ -1194,6 +1265,9 @@ class RealtimeSession(RealtimeModelListener):
 
     async def _run_output_guardrails(self, text: str, response_id: str) -> bool:
         """Run output guardrails on the given text. Returns True if any guardrail was triggered."""
+        if self._closing or self._closed:
+            return False
+
         combined_guardrails = self._current_agent.output_guardrails + self._run_config.get(
             "output_guardrails", []
         )
@@ -1219,6 +1293,8 @@ class RealtimeSession(RealtimeModelListener):
                     cast(Agent[Any], self._current_agent),
                     text,
                 )
+                if self._closing or self._closed:
+                    return False
                 if result.output.tripwire_triggered:
                     triggered_results.append(result)
             except Exception as exc:
@@ -1233,25 +1309,30 @@ class RealtimeSession(RealtimeModelListener):
 
         if triggered_results:
             # Double-check: bail if already interrupted for this response
-            if response_id in self._interrupted_response_ids:
+            if response_id in self._interrupted_response_ids or self._closing or self._closed:
                 return False
 
             # Mark as interrupted immediately (before any awaits) to minimize race window
             self._interrupted_response_ids.add(response_id)
 
             # Emit guardrail tripped event
-            await self._put_event(
+            if not await self._put_event(
                 RealtimeGuardrailTripped(
                     guardrail_results=triggered_results,
                     message=text,
                     info=self._event_info,
                 )
-            )
+            ):
+                return False
 
             # Interrupt the model
+            if self._closing or self._closed:
+                return False
             await self._model.send_event(RealtimeModelSendInterrupt(force_response_cancel=True))
 
             # Send guardrail triggered message
+            if self._closing or self._closed:
+                return False
             guardrail_names = [result.guardrail.get_name() for result in triggered_results]
             await self._model.send_event(
                 RealtimeModelSendUserInput(
@@ -1265,6 +1346,8 @@ class RealtimeSession(RealtimeModelListener):
 
     def _enqueue_guardrail_task(self, text: str, response_id: str) -> None:
         # Runs the guardrails in a separate task to avoid blocking the main loop
+        if self._closing or self._closed:
+            return
 
         task = asyncio.create_task(self._run_output_guardrails(text, response_id))
         self._guardrail_tasks.add(task)
@@ -1276,6 +1359,10 @@ class RealtimeSession(RealtimeModelListener):
         """Handle completion of a guardrail task."""
         # Remove from tracking set
         self._guardrail_tasks.discard(task)
+
+        if self._closing or self._closed:
+            self._consume_task_result(task)
+            return
 
         # Check for exceptions and propagate as events
         if not task.cancelled():
@@ -1291,12 +1378,6 @@ class RealtimeSession(RealtimeModelListener):
                     )
                 )
 
-    def _cleanup_guardrail_tasks(self) -> None:
-        for task in self._guardrail_tasks:
-            if not task.done():
-                task.cancel()
-        self._guardrail_tasks.clear()
-
     def _enqueue_tool_call_task(
         self,
         event: RealtimeModelToolCallEvent,
@@ -1307,6 +1388,11 @@ class RealtimeSession(RealtimeModelListener):
         call_id_reserved: bool = False,
     ) -> None:
         """Run tool calls in the background to avoid blocking realtime transport."""
+        if self._closing or self._closed:
+            if call_id_reserved:
+                self._finish_tool_call(event.call_id, mark_completed=False)
+            return
+
         handle_kwargs: dict[str, Any] = {"agent_snapshot": agent_snapshot}
         if dispatch_snapshot is not None:
             handle_kwargs["dispatch_snapshot"] = dispatch_snapshot
@@ -1321,6 +1407,10 @@ class RealtimeSession(RealtimeModelListener):
 
     def _on_tool_call_task_done(self, task: asyncio.Task[Any]) -> None:
         self._tool_call_tasks.discard(task)
+
+        if self._closing or self._closed:
+            self._consume_task_result(task)
+            return
 
         if task.cancelled():
             return
@@ -1364,11 +1454,40 @@ class RealtimeSession(RealtimeModelListener):
             )
         )
 
-    def _cleanup_tool_call_tasks(self) -> None:
-        for task in self._tool_call_tasks:
+    @staticmethod
+    def _consume_task_result(task: asyncio.Task[Any]) -> None:
+        if not task.cancelled():
+            task.exception()
+
+    def _on_cleanup_task_done(self, task: asyncio.Task[None]) -> None:
+        if self._cleanup_task is task:
+            self._cleanup_task = None
+        self._consume_task_result(task)
+
+    async def _cancel_background_tasks(self) -> None:
+        tracked_tasks = self._guardrail_tasks | self._tool_call_tasks
+        if not tracked_tasks:
+            return
+
+        for task in tracked_tasks:
             if not task.done():
                 task.cancel()
-        self._tool_call_tasks.clear()
+
+        done, pending = await asyncio.wait(
+            tracked_tasks,
+            timeout=_BACKGROUND_TASK_CANCEL_GRACE_SECONDS,
+        )
+
+        self._guardrail_tasks.difference_update(done)
+        self._tool_call_tasks.difference_update(done)
+        for task in done:
+            self._consume_task_result(task)
+
+        if pending:
+            logger.warning(
+                "Realtime session cleanup timed out with %d background task(s) still stopping.",
+                len(pending),
+            )
 
     def _wake_event_iterators(self) -> None:
         for _ in range(self._event_iterator_waiters):
@@ -1380,12 +1499,13 @@ class RealtimeSession(RealtimeModelListener):
             self._wake_event_iterators()
             return
 
-        # Cancel and cleanup guardrail tasks
-        self._cleanup_guardrail_tasks()
-        self._cleanup_tool_call_tasks()
+        self._closing = True
 
-        # Remove ourselves as a listener
+        # Stop new model events before cleanup yields control.
         self._model.remove_listener(self)
+
+        # Account for session-owned background work before closing its transport.
+        await self._cancel_background_tasks()
 
         # Close the model connection
         await self._model.close()
@@ -1393,6 +1513,8 @@ class RealtimeSession(RealtimeModelListener):
         # Clear pending approval tracking
         self._pending_tool_calls.clear()
         self._pending_tool_outputs.clear()
+        self._active_tool_call_ids.clear()
+        self._completed_tool_call_ids.clear()
 
         # Mark as closed
         self._closed = True

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -344,6 +344,8 @@ class RealtimeSession(RealtimeModelListener):
 
         if not await self._put_event(RealtimeRawModelEvent(data=event, info=self._event_info)):
             return
+        if self._closing or self._closed:
+            return
 
         if event.type == "error":
             await self._put_event(RealtimeError(info=self._event_info, error=event.error))

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -302,6 +302,7 @@ class RealtimeSession(RealtimeModelListener):
             raise asyncio.CancelledError
 
         if cleanup_task is None:
+            self._closing = True
             cleanup_task = asyncio.create_task(
                 self._cleanup(),
                 name="agents-realtime-session-cleanup",
@@ -1500,8 +1501,6 @@ class RealtimeSession(RealtimeModelListener):
         if self._closed:
             self._wake_event_iterators()
             return
-
-        self._closing = True
 
         # Stop new model events before cleanup yields control.
         self._model.remove_listener(self)

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -319,6 +319,41 @@ async def test_cancelling_one_close_waiter_does_not_cancel_cleanup():
 
 
 @pytest.mark.asyncio
+async def test_close_sets_closing_before_cleanup_task_runs(monkeypatch):
+    model = _DummyModel()
+    session = RealtimeSession(model, RealtimeAgent(name="agent"), None)
+    release_cleanup = asyncio.Event()
+    original_cleanup = session._cleanup
+
+    async def delayed_cleanup() -> None:
+        await release_cleanup.wait()
+        await original_cleanup()
+
+    monkeypatch.setattr(session, "_cleanup", delayed_cleanup)
+    close_task = asyncio.create_task(session.close())
+    await asyncio.sleep(0)
+
+    try:
+        assert session._cleanup_task is not None
+        assert session._closing
+
+        await session.on_event(
+            RealtimeModelInputAudioTranscriptionCompletedEvent(
+                item_id="late-item",
+                transcript="late transcript",
+            )
+        )
+
+        assert session._history == []
+        assert session._event_queue.empty()
+    finally:
+        release_cleanup.set()
+        await close_task
+
+    assert session._closed
+
+
+@pytest.mark.asyncio
 async def test_tracked_task_reentering_active_cleanup_does_not_create_wait_cycle():
     class CountingCloseModel(_DummyModel):
         def __init__(self) -> None:

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -478,6 +478,40 @@ async def test_in_flight_model_event_cannot_enqueue_work_after_close(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_model_event_cannot_mutate_history_after_raw_event_enqueue_and_close(monkeypatch):
+    model = _DummyModel()
+    session = RealtimeSession(model, RealtimeAgent(name="agent"), None)
+    raw_event_enqueued = asyncio.Event()
+    release_raw_put = asyncio.Event()
+    original_put_event = session._put_event
+
+    async def blocked_put_event(event):
+        was_enqueued = await original_put_event(event)
+        if isinstance(event, RealtimeRawModelEvent):
+            raw_event_enqueued.set()
+            await release_raw_put.wait()
+        return was_enqueued
+
+    monkeypatch.setattr(session, "_put_event", blocked_put_event)
+    event_task = asyncio.create_task(
+        session.on_event(
+            RealtimeModelInputAudioTranscriptionCompletedEvent(
+                item_id="late-item",
+                transcript="late transcript",
+            )
+        )
+    )
+    await raw_event_enqueued.wait()
+
+    await session.close()
+    release_raw_put.set()
+    await event_task
+
+    assert session._closed
+    assert session._history == []
+
+
+@pytest.mark.asyncio
 async def test_transcription_completed_adds_new_user_item():
     model = _DummyModel()
     agent = RealtimeAgent(name="agent")

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -209,6 +209,275 @@ async def test_aiter_exits_waiting_iterators_when_session_closes():
 
 
 @pytest.mark.asyncio
+async def test_close_waits_for_background_finalizers_before_model_close():
+    order: list[str] = []
+
+    class OrderingModel(_DummyModel):
+        async def close(self):
+            order.append("model")
+
+    session = RealtimeSession(OrderingModel(), RealtimeAgent(name="agent"), None)
+    guardrail_started = asyncio.Event()
+    tool_started = asyncio.Event()
+
+    async def background_task(label: str, started: asyncio.Event) -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(0)
+            order.append(label)
+
+    guardrail = asyncio.create_task(background_task("guardrail", guardrail_started))
+    tool = asyncio.create_task(background_task("tool", tool_started))
+    session._guardrail_tasks.add(guardrail)
+    session._tool_call_tasks.add(tool)
+    await guardrail_started.wait()
+    await tool_started.wait()
+
+    await session.close()
+
+    assert order[-1] == "model"
+    assert set(order[:-1]) == {"guardrail", "tool"}
+    assert guardrail.done()
+    assert tool.done()
+    assert session._guardrail_tasks == set()
+    assert session._tool_call_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_close_callers_share_failure_and_retry():
+    class FailOnceModel(_DummyModel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_started = asyncio.Event()
+            self.release_close = asyncio.Event()
+            self.close_calls = 0
+
+        async def close(self):
+            self.close_calls += 1
+            self.close_started.set()
+            await self.release_close.wait()
+            if self.close_calls == 1:
+                raise RuntimeError("close failed")
+
+    model = FailOnceModel()
+    session = RealtimeSession(model, RealtimeAgent(name="agent"), None)
+
+    first = asyncio.create_task(session.close())
+    await model.close_started.wait()
+    second = asyncio.create_task(session.close())
+    await asyncio.sleep(0)
+    assert not second.done()
+
+    model.release_close.set()
+    first_result, second_result = await asyncio.gather(first, second, return_exceptions=True)
+
+    assert isinstance(first_result, RuntimeError)
+    assert second_result is first_result
+    assert model.close_calls == 1
+    assert session._closing
+    assert not session._closed
+
+    await session.close()
+
+    assert model.close_calls == 2
+    assert session._closed
+
+
+@pytest.mark.asyncio
+async def test_cancelling_one_close_waiter_does_not_cancel_cleanup():
+    class BlockingCloseModel(_DummyModel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_started = asyncio.Event()
+            self.release_close = asyncio.Event()
+            self.close_calls = 0
+
+        async def close(self):
+            self.close_calls += 1
+            self.close_started.set()
+            await self.release_close.wait()
+
+    model = BlockingCloseModel()
+    session = RealtimeSession(model, RealtimeAgent(name="agent"), None)
+
+    surviving_waiter = asyncio.create_task(session.close())
+    await model.close_started.wait()
+    cancelled_waiter = asyncio.create_task(session.close())
+    await asyncio.sleep(0)
+    assert not cancelled_waiter.done()
+    cancelled_waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled_waiter
+
+    model.release_close.set()
+    await surviving_waiter
+
+    assert model.close_calls == 1
+    assert session._closed
+
+
+@pytest.mark.asyncio
+async def test_tracked_task_reentering_active_cleanup_does_not_create_wait_cycle():
+    class CountingCloseModel(_DummyModel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_calls = 0
+
+        async def close(self):
+            self.close_calls += 1
+
+    model = CountingCloseModel()
+    session = RealtimeSession(model, RealtimeAgent(name="agent"), None)
+    task_started = asyncio.Event()
+    close_reentered = asyncio.Event()
+
+    async def close_during_cancellation() -> None:
+        task_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            close_reentered.set()
+            await session.close()
+
+    tracked = asyncio.create_task(close_during_cancellation())
+    session._tool_call_tasks.add(tracked)
+    tracked.add_done_callback(session._on_tool_call_task_done)
+    await task_started.wait()
+
+    await asyncio.wait_for(session.close(), timeout=0.5)
+
+    assert close_reentered.is_set()
+    assert tracked.cancelled()
+    assert model.close_calls == 1
+    assert session._closed
+    assert tracked not in session._tool_call_tasks
+
+
+@pytest.mark.asyncio
+async def test_tracked_task_can_start_cleanup_without_self_await():
+    class CountingCloseModel(_DummyModel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_calls = 0
+
+        async def close(self):
+            self.close_calls += 1
+
+    model = CountingCloseModel()
+    session = RealtimeSession(model, RealtimeAgent(name="agent"), None)
+    close_started = asyncio.Event()
+    tracked_finally_ran = asyncio.Event()
+
+    async def close_from_tracked_task() -> None:
+        close_started.set()
+        try:
+            await session.close()
+        finally:
+            tracked_finally_ran.set()
+
+    tracked = asyncio.create_task(close_from_tracked_task())
+    session._tool_call_tasks.add(tracked)
+    tracked.add_done_callback(session._on_tool_call_task_done)
+    await close_started.wait()
+
+    cleanup_task = session._cleanup_task
+    assert cleanup_task is not None
+    await asyncio.shield(cleanup_task)
+    result = (await asyncio.gather(tracked, return_exceptions=True))[0]
+
+    assert isinstance(result, asyncio.CancelledError)
+    assert tracked_finally_ran.is_set()
+    assert model.close_calls == 1
+    assert session._closed
+    assert tracked not in session._tool_call_tasks
+
+
+@pytest.mark.asyncio
+async def test_late_tool_completion_stays_tracked_and_cannot_send_after_close(monkeypatch):
+    monkeypatch.setattr(
+        "agents.realtime.session._BACKGROUND_TASK_CANCEL_GRACE_SECONDS",
+        0.01,
+    )
+    tool_started = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    @function_tool
+    async def cancellation_resistant_tool() -> str:
+        tool_started.set()
+        try:
+            await asyncio.Event().wait()
+            return "unreachable output"
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+            await release_tool.wait()
+            return "late output"
+
+    model = _DummyModel()
+    agent = RealtimeAgent(name="agent", tools=[cancellation_resistant_tool])
+    session = RealtimeSession(model, agent, None)
+    await session.on_event(
+        RealtimeModelToolCallEvent(
+            name=cancellation_resistant_tool.name,
+            call_id="late-call",
+            arguments="{}",
+        )
+    )
+    await tool_started.wait()
+    tracked = next(iter(session._tool_call_tasks))
+
+    await session.close()
+
+    assert cancellation_seen.is_set()
+    assert session._closed
+    assert tracked in session._tool_call_tasks
+    assert not any(isinstance(event, RealtimeModelSendToolOutput) for event in model.events)
+
+    release_tool.set()
+    await tracked
+    await asyncio.sleep(0)
+
+    assert tracked not in session._tool_call_tasks
+    assert session._stored_exception is None
+    assert not any(isinstance(event, RealtimeModelSendToolOutput) for event in model.events)
+
+
+@pytest.mark.asyncio
+async def test_in_flight_model_event_cannot_enqueue_work_after_close(monkeypatch):
+    model = _DummyModel()
+    session = RealtimeSession(model, RealtimeAgent(name="agent"), None)
+    put_started = asyncio.Event()
+    release_put = asyncio.Event()
+    original_put_event = session._put_event
+
+    async def blocked_put_event(event):
+        put_started.set()
+        await release_put.wait()
+        return await original_put_event(event)
+
+    monkeypatch.setattr(session, "_put_event", blocked_put_event)
+    event_task = asyncio.create_task(
+        session.on_event(
+            RealtimeModelToolCallEvent(
+                name="late-tool",
+                call_id="late-event",
+                arguments="{}",
+            )
+        )
+    )
+    await put_started.wait()
+
+    await session.close()
+    release_put.set()
+    await event_task
+
+    assert session._closed
+    assert session._tool_call_tasks == set()
+
+
+@pytest.mark.asyncio
 async def test_transcription_completed_adds_new_user_item():
     model = _DummyModel()
     agent = RealtimeAgent(name="agent")

--- a/tests/realtime/test_session_exceptions.py
+++ b/tests/realtime/test_session_exceptions.py
@@ -249,16 +249,17 @@ class TestSessionExceptions:
 
         session = RealtimeSession(fake_model, fake_agent, None)
 
-        # Add some fake guardrail tasks
-        fake_task1 = Mock()
-        fake_task1.done.return_value = False
-        fake_task1.cancel = Mock()
+        async def running_task() -> None:
+            await asyncio.Event().wait()
 
-        fake_task2 = Mock()
-        fake_task2.done.return_value = True
-        fake_task2.cancel = Mock()
+        async def completed_task() -> None:
+            return None
 
-        session._guardrail_tasks = {fake_task1, fake_task2}
+        pending = asyncio.create_task(running_task())
+        completed = asyncio.create_task(completed_task())
+        await asyncio.sleep(0)
+        await completed
+        session._guardrail_tasks = {pending, completed}
 
         fake_model.set_next_events([exception_event])
 
@@ -267,9 +268,10 @@ class TestSessionExceptions:
                 async for _event in session:
                     pass
 
-        # Verify guardrail tasks were properly cleaned up
-        fake_task1.cancel.assert_called_once()
-        fake_task2.cancel.assert_not_called()  # Already done
+        # Verify guardrail tasks were properly cleaned up.
+        assert pending.cancelled()
+        assert completed.done()
+        assert not completed.cancelled()
         assert len(session._guardrail_tasks) == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This pull request resolves #3334 by coordinating Realtime session cleanup through a single session-owned task.

It awaits cooperative background-task cancellation before transport shutdown, prevents late work from mutating closed-session state, protects shared cleanup from caller cancellation, and avoids a reentrant wait cycle when a tracked task calls `close()` while cleanup is already waiting for that task. Public APIs remain unchanged.