### PR TITLE
docs: align FunctionTool context example

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -401,7 +401,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from agents import RunContextWrapper, FunctionTool
+from agents import FunctionTool, ToolContext
 
 
 
@@ -414,7 +414,7 @@ class FunctionArgs(BaseModel):
     age: int
 
 
-async def run_function(ctx: RunContextWrapper[Any], args: str) -> str:
+async def run_function(ctx: ToolContext[Any], args: str) -> str:
     parsed = FunctionArgs.model_validate_json(args)
     return do_some_work(data=f"{parsed.username} is {parsed.age} years old")
 


### PR DESCRIPTION
## What
- Update the custom `FunctionTool` example to type `on_invoke_tool` with `ToolContext`.
- Keep the snippet aligned with the surrounding text and the `FunctionTool.on_invoke_tool` API.

## Why
The section already says `on_invoke_tool` receives a `ToolContext`, but the example still imported and annotated `RunContextWrapper`, which can be confusing when copying the snippet.

## Test
- `git diff --check`
- Python text check for the updated docs snippet