### PR TITLE
fix(litellm): surface content-filter refusals instead of an empty turn

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -296,6 +296,27 @@ class LitellmModel(Model):
                 "output_tokens_details": usage.output_tokens_details.model_dump(),
             }
 
+            # Surface content-filter refusals explicitly. Some providers (e.g.
+            # Anthropic on Amazon Bedrock) signal a safety block only via
+            # ``finish_reason == "content_filter"`` with an empty message and no
+            # ``refusal`` field. Without this, ``message`` converts to zero
+            # output items and the caller sees an indistinguishable "empty turn",
+            # which drives agent loops into fruitless retries. Synthesize a
+            # refusal so downstream handling (ResponseOutputRefusal) fires.
+            if (
+                message is not None
+                and first_choice is not None
+                and getattr(first_choice, "finish_reason", None) == "content_filter"
+                and not message.content
+                and not getattr(message, "tool_calls", None)
+            ):
+                provider_specific_fields = getattr(message, "provider_specific_fields", None) or {}
+                if not provider_specific_fields.get("refusal"):
+                    provider_specific_fields["refusal"] = (
+                        "Response withheld by the provider's content filter."
+                    )
+                    message.provider_specific_fields = provider_specific_fields
+
             # Build provider_data for provider specific fields
             provider_data: dict[str, Any] = {"model": self.model}
             if message is not None and hasattr(response, "id"):

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -504,6 +504,11 @@ class ChatCmplStreamHandler:
         state = StreamingState()
         output_layout = _StreamOutputLayout()
         sequence_number = SequenceNumber()
+        # Some providers (e.g. Anthropic on Amazon Bedrock via LiteLLM) signal a
+        # safety block only through finish_reason == "content_filter" with an
+        # empty delta and no refusal field. Track it so we can synthesize an
+        # explicit refusal after the stream if nothing else was emitted.
+        saw_content_filter = False
         async for chunk in stream:
             if not state.started:
                 state.started = True
@@ -543,6 +548,9 @@ class ChatCmplStreamHandler:
             choice = next((choice for choice in chunk.choices if choice.index == 0), None)
             if choice is None:
                 continue
+
+            if choice.finish_reason == "content_filter":
+                saw_content_filter = True
 
             if not choice.delta:
                 continue
@@ -938,6 +946,66 @@ class ChatCmplStreamHandler:
                             type="response.function_call_arguments.delta",
                             sequence_number=sequence_number.get_and_increment(),
                         )
+
+        # Content-filter refusal with no emitted output: synthesize a refusal so
+        # the completed response carries a ResponseOutputRefusal rather than an
+        # empty turn. Only when nothing else was produced (text / refusal / tool
+        # calls) — a content_filter that still emitted content is left as-is.
+        if (
+            saw_content_filter
+            and not (
+                state.text_content_index_and_output and state.text_content_index_and_output[1].text
+            )
+            and state.refusal_content_index_and_output is None
+            and not state.function_calls
+        ):
+            # A content-filtered turn on Bedrock often opens an empty text part
+            # (a "" content delta) before terminating, so gate on the accumulated
+            # text being empty rather than on the part being absent. Reuse that
+            # empty text part's index for the refusal and drop the empty part so
+            # the completed message carries only the refusal.
+            refusal_index = 0
+            if state.reasoning_content_index_and_output:
+                refusal_index += 1
+            if state.text_content_index_and_output:
+                refusal_index = state.text_content_index_and_output[0]
+                state.text_content_index_and_output = None
+            refusal_message = "Response withheld by the provider's content filter."
+            state.refusal_content_index_and_output = (
+                refusal_index,
+                ResponseOutputRefusal(refusal=refusal_message, type="refusal"),
+            )
+            assistant_item = ResponseOutputMessage(
+                id=FAKE_RESPONSES_ID,
+                content=[],
+                role="assistant",
+                type="message",
+                status="in_progress",
+            )
+            if state.provider_data:
+                assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+            yield ResponseOutputItemAddedEvent(
+                item=assistant_item,
+                output_index=output_layout.assistant_message_output_index(state),
+                type="response.output_item.added",
+                sequence_number=sequence_number.get_and_increment(),
+            )
+            yield ResponseContentPartAddedEvent(
+                content_index=refusal_index,
+                item_id=FAKE_RESPONSES_ID,
+                output_index=output_layout.assistant_message_output_index(state),
+                part=ResponseOutputRefusal(refusal="", type="refusal"),
+                type="response.content_part.added",
+                sequence_number=sequence_number.get_and_increment(),
+            )
+            yield ResponseRefusalDeltaEvent(
+                content_index=refusal_index,
+                delta=refusal_message,
+                item_id=FAKE_RESPONSES_ID,
+                output_index=output_layout.assistant_message_output_index(state),
+                type="response.refusal.delta",
+                sequence_number=sequence_number.get_and_increment(),
+            )
 
         for event in cls._finish_reasoning_item(state, sequence_number):
             yield event

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -972,15 +972,20 @@ class ChatCmplStreamHandler:
             # (which would produce an incoherent event sequence).
             empty_text_part = state.text_content_index_and_output
             if empty_text_part is not None:
-                refusal_index = empty_text_part[0]
+                # Close the stale empty text part and give the refusal a DISTINCT
+                # index (not the text part's), so a consumer replaying events by
+                # (item_id, content_index) never sees two different part types at
+                # the same slot. The empty text part is dropped from the final
+                # message, so only the refusal remains in response.completed.
                 yield ResponseContentPartDoneEvent(
-                    content_index=refusal_index,
+                    content_index=empty_text_part[0],
                     item_id=FAKE_RESPONSES_ID,
                     output_index=output_layout.assistant_message_output_index(state),
                     part=empty_text_part[1],
                     type="response.content_part.done",
                     sequence_number=sequence_number.get_and_increment(),
                 )
+                refusal_index = empty_text_part[0] + 1
                 state.text_content_index_and_output = None
             refusal_message = "Response withheld by the provider's content filter."
             state.refusal_content_index_and_output = (

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -961,35 +961,50 @@ class ChatCmplStreamHandler:
         ):
             # A content-filtered turn on Bedrock often opens an empty text part
             # (a "" content delta) before terminating, so gate on the accumulated
-            # text being empty rather than on the part being absent. Reuse that
-            # empty text part's index for the refusal and drop the empty part so
-            # the completed message carries only the refusal.
+            # text being empty rather than on the part being absent.
             refusal_index = 0
             if state.reasoning_content_index_and_output:
                 refusal_index += 1
-            if state.text_content_index_and_output:
-                refusal_index = state.text_content_index_and_output[0]
+            # If an empty text part was already opened, the assistant message +
+            # that content part have already been announced on the stream. Close
+            # the stale text part and reuse its index for the refusal, rather than
+            # re-announcing the message and leaving the text part unterminated
+            # (which would produce an incoherent event sequence).
+            empty_text_part = state.text_content_index_and_output
+            if empty_text_part is not None:
+                refusal_index = empty_text_part[0]
+                yield ResponseContentPartDoneEvent(
+                    content_index=refusal_index,
+                    item_id=FAKE_RESPONSES_ID,
+                    output_index=output_layout.assistant_message_output_index(state),
+                    part=empty_text_part[1],
+                    type="response.content_part.done",
+                    sequence_number=sequence_number.get_and_increment(),
+                )
                 state.text_content_index_and_output = None
             refusal_message = "Response withheld by the provider's content filter."
             state.refusal_content_index_and_output = (
                 refusal_index,
                 ResponseOutputRefusal(refusal=refusal_message, type="refusal"),
             )
-            assistant_item = ResponseOutputMessage(
-                id=FAKE_RESPONSES_ID,
-                content=[],
-                role="assistant",
-                type="message",
-                status="in_progress",
-            )
-            if state.provider_data:
-                assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
-            yield ResponseOutputItemAddedEvent(
-                item=assistant_item,
-                output_index=output_layout.assistant_message_output_index(state),
-                type="response.output_item.added",
-                sequence_number=sequence_number.get_and_increment(),
-            )
+            # Announce the assistant message only if it wasn't already opened by a
+            # prior text part.
+            if empty_text_part is None:
+                assistant_item = ResponseOutputMessage(
+                    id=FAKE_RESPONSES_ID,
+                    content=[],
+                    role="assistant",
+                    type="message",
+                    status="in_progress",
+                )
+                if state.provider_data:
+                    assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+                yield ResponseOutputItemAddedEvent(
+                    item=assistant_item,
+                    output_index=output_layout.assistant_message_output_index(state),
+                    type="response.output_item.added",
+                    sequence_number=sequence_number.get_and_increment(),
+                )
             yield ResponseContentPartAddedEvent(
                 content_index=refusal_index,
                 item_id=FAKE_RESPONSES_ID,

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -970,12 +970,13 @@ class ChatCmplStreamHandler:
             # A content-filtered turn (e.g. Bedrock) can terminate with no
             # emitted output. Its leading empty "" content delta is suppressed
             # above so no text part opens, so we announce a fresh assistant
-            # message and place the refusal at the first content index — the same
-            # index it occupies in response.completed, keeping raw-event replay
-            # and the final response aligned.
+            # message and place the refusal at content index 0. A reasoning item
+            # is a *separate* output item (it affects the message's output_index,
+            # via assistant_message_output_index, not its content_index) and is
+            # never appended to the assistant message's content — so the refusal,
+            # the sole content part, is at content_index 0 in both the stream and
+            # response.completed regardless of any reasoning item.
             refusal_index = 0
-            if state.reasoning_content_index_and_output:
-                refusal_index += 1
             refusal_message = "Response withheld by the provider's content filter."
             state.refusal_content_index_and_output = (
                 refusal_index,

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -685,7 +685,17 @@ class ChatCmplStreamHandler:
                     yield event
 
             # Handle regular content
-            if delta.content is not None:
+            if delta.content is not None and not (
+                not state.text_content_index_and_output and delta.content == ""
+            ):
+                # An empty leading content delta ("") is dropped rather than
+                # opening a text content part: materializing an empty part would
+                # add a spurious ResponseOutputText to response.completed. Bedrock
+                # content-filter turns emit exactly this "" warm-up chunk before
+                # the terminal content_filter, so suppressing it here keeps the
+                # synthesized refusal (below) at content index 0 in both the
+                # streamed events and the completed response. Empty deltas after a
+                # text part has already opened keep their existing behavior.
                 if not state.text_content_index_and_output:
                     content_index = 0
                     if state.reasoning_content_index_and_output:
@@ -953,63 +963,39 @@ class ChatCmplStreamHandler:
         # calls) — a content_filter that still emitted content is left as-is.
         if (
             saw_content_filter
-            and not (
-                state.text_content_index_and_output and state.text_content_index_and_output[1].text
-            )
+            and state.text_content_index_and_output is None
             and state.refusal_content_index_and_output is None
             and not state.function_calls
         ):
-            # A content-filtered turn on Bedrock often opens an empty text part
-            # (a "" content delta) before terminating, so gate on the accumulated
-            # text being empty rather than on the part being absent.
+            # A content-filtered turn (e.g. Bedrock) can terminate with no
+            # emitted output. Its leading empty "" content delta is suppressed
+            # above so no text part opens, so we announce a fresh assistant
+            # message and place the refusal at the first content index — the same
+            # index it occupies in response.completed, keeping raw-event replay
+            # and the final response aligned.
             refusal_index = 0
             if state.reasoning_content_index_and_output:
                 refusal_index += 1
-            # If an empty text part was already opened, the assistant message +
-            # that content part have already been announced on the stream. Close
-            # the stale text part and reuse its index for the refusal, rather than
-            # re-announcing the message and leaving the text part unterminated
-            # (which would produce an incoherent event sequence).
-            empty_text_part = state.text_content_index_and_output
-            if empty_text_part is not None:
-                # Close the stale empty text part and give the refusal a DISTINCT
-                # index (not the text part's), so a consumer replaying events by
-                # (item_id, content_index) never sees two different part types at
-                # the same slot. The empty text part is dropped from the final
-                # message, so only the refusal remains in response.completed.
-                yield ResponseContentPartDoneEvent(
-                    content_index=empty_text_part[0],
-                    item_id=FAKE_RESPONSES_ID,
-                    output_index=output_layout.assistant_message_output_index(state),
-                    part=empty_text_part[1],
-                    type="response.content_part.done",
-                    sequence_number=sequence_number.get_and_increment(),
-                )
-                refusal_index = empty_text_part[0] + 1
-                state.text_content_index_and_output = None
             refusal_message = "Response withheld by the provider's content filter."
             state.refusal_content_index_and_output = (
                 refusal_index,
                 ResponseOutputRefusal(refusal=refusal_message, type="refusal"),
             )
-            # Announce the assistant message only if it wasn't already opened by a
-            # prior text part.
-            if empty_text_part is None:
-                assistant_item = ResponseOutputMessage(
-                    id=FAKE_RESPONSES_ID,
-                    content=[],
-                    role="assistant",
-                    type="message",
-                    status="in_progress",
-                )
-                if state.provider_data:
-                    assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
-                yield ResponseOutputItemAddedEvent(
-                    item=assistant_item,
-                    output_index=output_layout.assistant_message_output_index(state),
-                    type="response.output_item.added",
-                    sequence_number=sequence_number.get_and_increment(),
-                )
+            assistant_item = ResponseOutputMessage(
+                id=FAKE_RESPONSES_ID,
+                content=[],
+                role="assistant",
+                type="message",
+                status="in_progress",
+            )
+            if state.provider_data:
+                assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+            yield ResponseOutputItemAddedEvent(
+                item=assistant_item,
+                output_index=output_layout.assistant_message_output_index(state),
+                type="response.output_item.added",
+                sequence_number=sequence_number.get_and_increment(),
+            )
             yield ResponseContentPartAddedEvent(
                 content_index=refusal_index,
                 item_id=FAKE_RESPONSES_ID,

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -417,3 +417,160 @@ async def test_stream_response_yields_real_time_function_call_arguments(monkeypa
     assert isinstance(added_event.item, ResponseFunctionToolCall)
     assert added_event.item.name == "generate_code"
     assert added_event.item.call_id == "litellm-call-456"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_synthesizes_refusal_on_content_filter(monkeypatch) -> None:
+    """A stream that terminates with finish_reason == "content_filter" and no
+    emitted content (as Anthropic-on-Bedrock does via LiteLLM) must synthesize a
+    ResponseOutputRefusal so the completed response carries an explicit refusal
+    rather than an empty assistant turn.
+
+    Mirrors the real Bedrock chunk shape: an empty-string content delta (which
+    opens a text content part) followed by a terminal content_filter chunk with
+    no content. The synthesized refusal must replace that empty text part, not
+    sit alongside it.
+    """
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(role="assistant", content=""))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="content_filter")],
+        usage=CompletionUsage(
+            completion_tokens=0,
+            prompt_tokens=7,
+            total_tokens=7,
+        ),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for c in (chunk1, chunk2):
+            yield c
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, fake_stream()
+
+    monkeypatch.setattr(LitellmModel, "_fetch_response", patched_fetch_response)
+    model = LitellmProvider().get_model("gpt-4")
+    output_events = []
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        output_events.append(event)
+
+    types = [e.type for e in output_events]
+    # Coherent refusal sequence: the message + refusal part are opened, a refusal
+    # delta is emitted, and the parts/message are closed before completion.
+    assert "response.output_item.added" in types
+    assert "response.content_part.added" in types
+    assert "response.refusal.delta" in types
+    assert types[-1] == "response.completed"
+    # done events for the refusal part + assistant message precede completion.
+    assert "response.content_part.done" in types
+    assert "response.output_item.done" in types
+
+    # The refusal delta carries a non-empty message.
+    refusal_deltas = [e for e in output_events if e.type == "response.refusal.delta"]
+    assert refusal_deltas and refusal_deltas[0].delta
+
+    # The completed response contains exactly one content part: the refusal.
+    # (The empty text part opened by the "" content delta must be dropped, not
+    # left sitting alongside the refusal.)
+    completed_resp = output_events[-1].response
+    assert isinstance(completed_resp.output[0], ResponseOutputMessage)
+    assert len(completed_resp.output[0].content) == 1
+    refusal_part = completed_resp.output[0].content[0]
+    assert isinstance(refusal_part, ResponseOutputRefusal)
+    assert refusal_part.refusal
+    # No spurious empty text delta leaked through as real content.
+    assert not any(e.type == "response.output_text.delta" and e.delta for e in output_events)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_content_filter_does_not_clobber_text(monkeypatch) -> None:
+    """A content_filter finish_reason that arrives AFTER real text was streamed
+    must not synthesize a refusal (the text stands)."""
+    chunk1 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="answer"))],
+    )
+    chunk2 = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="content_filter")],
+        usage=CompletionUsage(completion_tokens=1, prompt_tokens=7, total_tokens=8),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for c in (chunk1, chunk2):
+            yield c
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, fake_stream()
+
+    monkeypatch.setattr(LitellmModel, "_fetch_response", patched_fetch_response)
+    model = LitellmProvider().get_model("gpt-4")
+    output_events = [
+        event
+        async for event in model.stream_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+    ]
+
+    assert "response.refusal.delta" not in [e.type for e in output_events]
+    completed_resp = output_events[-1].response
+    assert isinstance(completed_resp.output[0].content[0], ResponseOutputText)
+    assert completed_resp.output[0].content[0].text == "answer"

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -493,13 +493,18 @@ async def test_stream_response_synthesizes_refusal_on_content_filter(monkeypatch
     assert "response.content_part.added" in types
     assert "response.refusal.delta" in types
     assert types[-1] == "response.completed"
-    # done events for the refusal part + assistant message precede completion.
-    assert "response.content_part.done" in types
     assert "response.output_item.done" in types
 
     # The refusal delta carries a non-empty message.
     refusal_deltas = [e for e in output_events if e.type == "response.refusal.delta"]
     assert refusal_deltas and refusal_deltas[0].delta
+
+    # Event coherence: the assistant message is announced exactly once (not
+    # re-announced by the synthesized refusal), and every content part that is
+    # opened is also closed — the empty text part opened by the "" content delta
+    # must be given a matching content_part.done, not left dangling.
+    assert types.count("response.output_item.added") == 1
+    assert types.count("response.content_part.added") == types.count("response.content_part.done")
 
     # The completed response contains exactly one content part: the refusal.
     # (The empty text part opened by the "" content delta must be dropped, not

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -15,6 +15,7 @@ from openai.types.completion_usage import (
 )
 from openai.types.responses import (
     Response,
+    ResponseCompletedEvent,
     ResponseFunctionToolCall,
     ResponseOutputMessage,
     ResponseOutputRefusal,
@@ -509,7 +510,9 @@ async def test_stream_response_synthesizes_refusal_on_content_filter(monkeypatch
     # The completed response contains exactly one content part: the refusal.
     # (The empty text part opened by the "" content delta must be dropped, not
     # left sitting alongside the refusal.)
-    completed_resp = output_events[-1].response
+    completed_event = output_events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    completed_resp = completed_event.response
     assert isinstance(completed_resp.output[0], ResponseOutputMessage)
     assert len(completed_resp.output[0].content) == 1
     refusal_part = completed_resp.output[0].content[0]
@@ -576,6 +579,9 @@ async def test_stream_response_content_filter_does_not_clobber_text(monkeypatch)
     ]
 
     assert "response.refusal.delta" not in [e.type for e in output_events]
-    completed_resp = output_events[-1].response
+    completed_event = output_events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    completed_resp = completed_event.response
+    assert isinstance(completed_resp.output[0], ResponseOutputMessage)
     assert isinstance(completed_resp.output[0].content[0], ResponseOutputText)
     assert completed_resp.output[0].content[0].text == "answer"

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -16,10 +16,13 @@ from openai.types.completion_usage import (
 from openai.types.responses import (
     Response,
     ResponseCompletedEvent,
+    ResponseContentPartAddedEvent,
     ResponseFunctionToolCall,
     ResponseOutputMessage,
     ResponseOutputRefusal,
     ResponseOutputText,
+    ResponseReasoningItem,
+    ResponseRefusalDeltaEvent,
 )
 
 from agents.extensions.models.litellm_model import LitellmModel
@@ -594,3 +597,101 @@ async def test_stream_response_content_filter_does_not_clobber_text(monkeypatch)
     assert isinstance(completed_resp.output[0], ResponseOutputMessage)
     assert isinstance(completed_resp.output[0].content[0], ResponseOutputText)
     assert completed_resp.output[0].content[0].text == "answer"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_content_filter_refusal_after_reasoning(monkeypatch) -> None:
+    """A content_filter turn preceded by reasoning must still place the
+    synthesized refusal at content_index 0 of the assistant message. Reasoning
+    is a *separate* output item (it shifts the message's output_index, not its
+    content_index), so the refusal — the sole content part — stays at
+    content_index 0 in both the stream and response.completed."""
+    reasoning_delta = ChoiceDelta(role="assistant", content=None)
+    # reasoning_content is a provider extra field the handler reads via hasattr.
+    reasoning_delta.reasoning_content = "thinking..."  # type: ignore[attr-defined]
+    chunk_reasoning = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=reasoning_delta)],
+    )
+    chunk_empty = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content=""))],
+    )
+    chunk_filter = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="content_filter")],
+        usage=CompletionUsage(completion_tokens=0, prompt_tokens=7, total_tokens=7),
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        for c in (chunk_reasoning, chunk_empty, chunk_filter):
+            yield c
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, fake_stream()
+
+    monkeypatch.setattr(LitellmModel, "_fetch_response", patched_fetch_response)
+    model = LitellmProvider().get_model("gpt-4")
+    output_events = [
+        event
+        async for event in model.stream_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+    ]
+
+    # A reasoning item was produced as a separate output item.
+    completed_event = output_events[-1]
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    completed_resp = completed_event.response
+    assert isinstance(completed_resp.output[0], ResponseReasoningItem)
+    assistant_msg = completed_resp.output[1]
+    assert isinstance(assistant_msg, ResponseOutputMessage)
+    # The refusal is the sole content part of the assistant message, at index 0.
+    assert len(assistant_msg.content) == 1
+    assert isinstance(assistant_msg.content[0], ResponseOutputRefusal)
+
+    # The assistant message's output_index is 1 (after the reasoning item), and
+    # every refusal event uses that output_index and content_index 0 — matching
+    # the refusal's position in response.completed.
+    added = [
+        e
+        for e in output_events
+        if isinstance(e, ResponseContentPartAddedEvent)
+        and isinstance(e.part, ResponseOutputRefusal)
+    ]
+    deltas = [e for e in output_events if isinstance(e, ResponseRefusalDeltaEvent)]
+    assert len(added) == 1
+    assert added[0].content_index == 0
+    assert added[0].output_index == 1
+    assert deltas and all(d.content_index == 0 and d.output_index == 1 for d in deltas)
+    # The empty "" delta still opens no text part.
+    assert "response.output_text.delta" not in [e.type for e in output_events]

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -428,10 +428,10 @@ async def test_stream_response_synthesizes_refusal_on_content_filter(monkeypatch
     ResponseOutputRefusal so the completed response carries an explicit refusal
     rather than an empty assistant turn.
 
-    Mirrors the real Bedrock chunk shape: an empty-string content delta (which
-    opens a text content part) followed by a terminal content_filter chunk with
-    no content. The synthesized refusal must replace that empty text part, not
-    sit alongside it.
+    Mirrors the real Bedrock chunk shape: an empty-string content delta followed
+    by a terminal content_filter chunk with no content. The empty "" delta must
+    not open a text content part; the synthesized refusal must be the only
+    content part, at the same index in the stream and in response.completed.
     """
     chunk1 = ChatCompletionChunk(
         id="chunk-id",
@@ -500,16 +500,19 @@ async def test_stream_response_synthesizes_refusal_on_content_filter(monkeypatch
     refusal_deltas = [e for e in output_events if e.type == "response.refusal.delta"]
     assert refusal_deltas and refusal_deltas[0].delta
 
-    # Event coherence: the assistant message is announced exactly once (not
-    # re-announced by the synthesized refusal), and every content part that is
-    # opened is also closed — the empty text part opened by the "" content delta
-    # must be given a matching content_part.done, not left dangling.
+    # Event coherence: the assistant message is announced exactly once, and every
+    # content part that is opened is also closed.
     assert types.count("response.output_item.added") == 1
     assert types.count("response.content_part.added") == types.count("response.content_part.done")
 
+    # The empty "" content delta must NOT open a text content part: no text part
+    # events and no output_text.delta are emitted at all.
+    assert "response.output_text.delta" not in types
+    added_parts = [e for e in output_events if e.type == "response.content_part.added"]
+    assert len(added_parts) == 1
+    assert isinstance(added_parts[0].part, ResponseOutputRefusal)
+
     # The completed response contains exactly one content part: the refusal.
-    # (The empty text part opened by the "" content delta must be dropped, not
-    # left sitting alongside the refusal.)
     completed_event = output_events[-1]
     assert isinstance(completed_event, ResponseCompletedEvent)
     completed_resp = completed_event.response
@@ -518,8 +521,14 @@ async def test_stream_response_synthesizes_refusal_on_content_filter(monkeypatch
     refusal_part = completed_resp.output[0].content[0]
     assert isinstance(refusal_part, ResponseOutputRefusal)
     assert refusal_part.refusal
-    # No spurious empty text delta leaked through as real content.
-    assert not any(e.type == "response.output_text.delta" and e.delta for e in output_events)
+
+    # The refusal's streamed content_index matches its position in the completed
+    # response (0), so raw-event replay and the final response stay aligned.
+    assert added_parts[0].content_index == 0
+    assert refusal_deltas[0].content_index == 0
+    done_parts = [e for e in output_events if e.type == "response.content_part.done"]
+    assert len(done_parts) == 1
+    assert done_parts[0].content_index == 0
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_litellm_content_filter.py
+++ b/tests/models/test_litellm_content_filter.py
@@ -1,0 +1,89 @@
+import litellm
+import pytest
+from litellm.types.utils import Choices, Message, ModelResponse, Usage
+from openai.types.responses import ResponseOutputMessage, ResponseOutputRefusal
+
+from agents.extensions.models.litellm_model import LitellmModel
+from agents.model_settings import ModelSettings
+from agents.models.interface import ModelTracing
+
+
+async def _get_response(monkeypatch, *, finish_reason, content):
+    """Drive get_response against a mocked litellm completion and return the items."""
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        msg = Message(role="assistant", content=content)
+        choice = Choices(index=0, finish_reason=finish_reason, message=msg)
+        return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    model = LitellmModel(model="test-model")
+    return await model.get_response(
+        system_instructions=None,
+        input=[],
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_content_filter_finish_reason_surfaces_refusal(monkeypatch):
+    """A content-filter block (empty message, finish_reason=content_filter) must
+    become an explicit ResponseOutputRefusal, not zero output items.
+
+    Some providers (e.g. Anthropic on Amazon Bedrock) signal a safety block only
+    via ``finish_reason == "content_filter"`` with an empty message and no
+    ``refusal`` field; without this the turn is indistinguishable from an empty
+    response and drives agent loops into fruitless retries.
+    """
+    resp = await _get_response(monkeypatch, finish_reason="content_filter", content="")
+
+    refusals = [
+        content
+        for item in resp.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert refusals, f"expected a refusal item, got: {resp.output}"
+    assert refusals[0].refusal  # non-empty message
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_content_filter_does_not_clobber_real_content(monkeypatch):
+    """A content_filter finish_reason that still carries text is left alone — we
+    only synthesize a refusal when the message is genuinely empty."""
+    resp = await _get_response(
+        monkeypatch, finish_reason="content_filter", content="here is the answer"
+    )
+
+    refusals = [
+        content
+        for item in resp.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert not refusals, "should not synthesize a refusal when content is present"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_normal_stop_is_unaffected(monkeypatch):
+    """A normal completion is unchanged — no spurious refusal."""
+    resp = await _get_response(monkeypatch, finish_reason="stop", content="all good")
+
+    refusals = [
+        content
+        for item in resp.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert not refusals


### PR DESCRIPTION
### Summary

Some providers — notably Anthropic on Amazon Bedrock — signal a safety block only via `finish_reason == "content_filter"` with an **empty message** and no `refusal` field. `LitellmModel.get_response` then converts that message to **zero output items**, so the caller sees an "empty turn" indistinguishable from any other model hiccup.

In an agent loop this is costly: the run can't tell a refusal from a transient empty response, so it re-prompts the same (refusing) model until it exhausts its turn budget. We hit this on Bedrock `claude-*` models where an offensive-security prompt is content-filtered — the agent burned its entire budget re-prompting a model that would never comply.

The fix: when a completion finishes with `content_filter` and carries no content and no tool calls, synthesize a `refusal` on the message so the **existing** converter path emits a `ResponseOutputRefusal` (and `Runner` raises `ModelRefusalError`) rather than silently dropping the turn. A `content_filter` response that still carries text is left untouched, and normal completions are unaffected.

**Scope:** this covers the non-streaming `get_response` path. The streaming path (`stream_response` / `ChatCmplStreamHandler`) currently surfaces refusals only when the provider sends a `refusal` *delta*; synthesizing one from a terminal `content_filter` finish_reason there is a larger change to the stream state machine, left as a follow-up.

### Test plan

- New `tests/models/test_litellm_content_filter.py` (3 cases): empty + `content_filter` → `ResponseOutputRefusal`; `content_filter` **with** text → no synthesized refusal; normal `stop` → unaffected.
- `pytest tests/models -k litellm` → **25 passed** (3 new + existing, no regressions).
- `ruff format --check`, `ruff check`, and `mypy` on the changed file all clean.

### Issue number

<!-- none filed; happy to open one if preferred -->

### Checks

- [x] I've added new tests, if relevant
- [x] I've confirmed all verification steps pass (ruff format/check, mypy, litellm tests)

Co-authored with Claude Opus 4.8.