### PR TITLE
fix: support cache-write usage across OpenAI Python versions

### DIFF
--- a/src/agents/extensions/experimental/codex/codex_tool.py
+++ b/src/agents/extensions/experimental/codex/codex_tool.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping, Mutabl
 from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias, TypeGuard
 
-from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+from openai.types.responses.response_usage import OutputTokensDetails
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from typing_extensions import NotRequired, TypedDict
 
@@ -30,7 +30,7 @@ from agents.tool import (
 )
 from agents.tool_context import ToolContext
 from agents.tracing import SpanError, custom_span
-from agents.usage import Usage as AgentsUsage
+from agents.usage import Usage as AgentsUsage, _make_input_tokens_details
 from agents.util._types import MaybeAwaitable
 
 from .codex import Codex
@@ -1010,7 +1010,7 @@ def _to_agent_usage(usage: Usage) -> AgentsUsage:
         input_tokens=usage.input_tokens,
         output_tokens=usage.output_tokens,
         total_tokens=usage.input_tokens + usage.output_tokens,
-        input_tokens_details=InputTokensDetails(cached_tokens=usage.cached_input_tokens),
+        input_tokens_details=_make_input_tokens_details(cached_tokens=usage.cached_input_tokens),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
     )
 

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -615,7 +615,7 @@ class AnyLLMModel(Model):
                     "input_tokens_details": (
                         final_response.usage.input_tokens_details.model_dump()
                         if final_response.usage.input_tokens_details
-                        else {"cached_tokens": 0}
+                        else {"cached_tokens": 0, "cache_write_tokens": 0}
                     ),
                     "output_tokens_details": (
                         final_response.usage.output_tokens_details.model_dump()

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator
 from copy import copy
 from typing import Any, Literal, cast, overload
 
-from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+from openai.types.responses.response_usage import OutputTokensDetails
 
 from agents.exceptions import ModelBehaviorError
 
@@ -56,7 +56,7 @@ from ...tool import Tool
 from ...tracing import generation_span
 from ...tracing.span_data import GenerationSpanData
 from ...tracing.spans import Span
-from ...usage import Usage
+from ...usage import Usage, _cache_write_tokens, _make_input_tokens_details
 from ...util._json import _to_dump_compatible
 
 
@@ -263,11 +263,14 @@ class LitellmModel(Model):
                         input_tokens=response_usage.prompt_tokens,
                         output_tokens=response_usage.completion_tokens,
                         total_tokens=response_usage.total_tokens,
-                        input_tokens_details=InputTokensDetails(
+                        input_tokens_details=_make_input_tokens_details(
                             cached_tokens=getattr(
                                 response_usage.prompt_tokens_details, "cached_tokens", 0
                             )
-                            or 0
+                            or 0,
+                            cache_write_tokens=_cache_write_tokens(
+                                response_usage.prompt_tokens_details
+                            ),
                         ),
                         output_tokens_details=OutputTokensDetails(
                             reasoning_tokens=getattr(
@@ -372,7 +375,7 @@ class LitellmModel(Model):
                     "input_tokens_details": (
                         final_response.usage.input_tokens_details.model_dump()
                         if final_response.usage.input_tokens_details
-                        else {"cached_tokens": 0}
+                        else {"cached_tokens": 0, "cache_write_tokens": 0}
                     ),
                     "output_tokens_details": (
                         final_response.usage.output_tokens_details.model_dump()

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -46,11 +46,12 @@ from openai.types.responses.response_reasoning_text_delta_event import (
 from openai.types.responses.response_reasoning_text_done_event import (
     ResponseReasoningTextDoneEvent,
 )
-from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+from openai.types.responses.response_usage import OutputTokensDetails
 
 from ..exceptions import ModelBehaviorError, UserError
 from ..items import TResponseStreamEvent
 from ..logger import logger
+from ..usage import _cache_write_tokens, _make_input_tokens_details
 from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
 
@@ -1073,10 +1074,11 @@ class ChatCmplStreamHandler:
                     and usage.completion_tokens_details.reasoning_tokens
                     else 0
                 ),
-                input_tokens_details=InputTokensDetails(
+                input_tokens_details=_make_input_tokens_details(
                     cached_tokens=usage.prompt_tokens_details.cached_tokens
                     if usage.prompt_tokens_details and usage.prompt_tokens_details.cached_tokens
-                    else 0
+                    else 0,
+                    cache_write_tokens=_cache_write_tokens(usage.prompt_tokens_details),
                 ),
             )
             if usage

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -376,7 +376,7 @@ class OpenAIChatCompletionsModel(Model):
                     "input_tokens_details": (
                         final_response.usage.input_tokens_details.model_dump()
                         if final_response.usage.input_tokens_details
-                        else {"cached_tokens": 0}
+                        else {"cached_tokens": 0, "cache_write_tokens": 0}
                     ),
                     "output_tokens_details": (
                         final_response.usage.output_tokens_details.model_dump()

--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, cast
 
-from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+from openai.types.responses.response_usage import OutputTokensDetails
 
 from ..agent import Agent
 from ..agent_tool_state import set_agent_tool_state_scope
@@ -24,6 +24,9 @@ from ..tracing.config import TracingConfig
 from ..tracing.traces import TraceState
 from ..usage import (
     Usage,
+    _cache_write_tokens,
+    _cached_tokens,
+    _make_input_tokens_details,
     task_usage_to_span_data,
     total_usage_to_span_metadata,
     turn_usage_to_span_data,
@@ -73,12 +76,9 @@ def snapshot_usage(usage: Usage) -> Usage:
         input_tokens=usage.input_tokens,
         output_tokens=usage.output_tokens,
         total_tokens=usage.total_tokens,
-        input_tokens_details=InputTokensDetails(
-            cached_tokens=(
-                usage.input_tokens_details.cached_tokens
-                if usage.input_tokens_details and usage.input_tokens_details.cached_tokens
-                else 0
-            )
+        input_tokens_details=_make_input_tokens_details(
+            cached_tokens=_cached_tokens(usage.input_tokens_details),
+            cache_write_tokens=_cache_write_tokens(usage.input_tokens_details),
         ),
         output_tokens_details=OutputTokensDetails(
             reasoning_tokens=(
@@ -97,11 +97,15 @@ def usage_delta(start: Usage, end: Usage) -> Usage:
         input_tokens=end.input_tokens - start.input_tokens,
         output_tokens=end.output_tokens - start.output_tokens,
         total_tokens=end.total_tokens - start.total_tokens,
-        input_tokens_details=InputTokensDetails(
+        input_tokens_details=_make_input_tokens_details(
             cached_tokens=(
                 (end.input_tokens_details.cached_tokens or 0)
                 - (start.input_tokens_details.cached_tokens or 0)
-            )
+            ),
+            cache_write_tokens=(
+                _cache_write_tokens(end.input_tokens_details)
+                - _cache_write_tokens(start.input_tokens_details)
+            ),
         ),
         output_tokens_details=OutputTokensDetails(
             reasoning_tokens=(
@@ -122,6 +126,7 @@ def attach_usage_to_span(
         if usage.input_tokens_details and usage.input_tokens_details.cached_tokens
         else 0
     )
+    cache_write_tokens = _cache_write_tokens(usage.input_tokens_details)
     reasoning_tokens = (
         usage.output_tokens_details.reasoning_tokens
         if usage.output_tokens_details and usage.output_tokens_details.reasoning_tokens
@@ -133,6 +138,7 @@ def attach_usage_to_span(
         and usage.output_tokens == 0
         and usage.total_tokens == 0
         and cached_tokens == 0
+        and cache_write_tokens == 0
         and reasoning_tokens == 0
     ):
         return

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -130,7 +130,7 @@ ContextDeserializer = Callable[[Mapping[str, Any]], Any]
 # 3. to_json() always emits CURRENT_SCHEMA_VERSION.
 # 4. Forward compatibility is intentionally fail-fast (older SDKs reject newer or unsupported
 #    versions).
-CURRENT_SCHEMA_VERSION = "1.11"
+CURRENT_SCHEMA_VERSION = "1.12"
 # Keep this mapping in chronological order. Every schema bump must add a one-line summary here.
 SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
     "1.0": "Initial RunState snapshot format for HITL pause/resume flows.",
@@ -148,6 +148,7 @@ SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
     "1.9": "Persists pending custom tool calls and tool origin metadata across resume flows.",
     "1.10": "Allows serialized RunState snapshots to disable max_turns with null.",
     "1.11": "Persists SDK-only custom data on tool output items across resume flows.",
+    "1.12": "Persists input cache-write token usage across resume flows.",
 }
 SUPPORTED_SCHEMA_VERSIONS = frozenset(SCHEMA_VERSION_SUMMARIES)
 

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -10,15 +10,51 @@ from pydantic import BeforeValidator, TypeAdapter, ValidationError
 from pydantic.dataclasses import dataclass
 
 
+def _make_input_tokens_details(
+    *,
+    cached_tokens: int | None = 0,
+    cache_write_tokens: int | None = 0,
+) -> InputTokensDetails:
+    """Build input-token details accepted by OpenAI Python 2.44 and 2.45+."""
+    return InputTokensDetails.model_validate(
+        {
+            "cached_tokens": cached_tokens or 0,
+            "cache_write_tokens": cache_write_tokens or 0,
+        }
+    )
+
+
+def _cached_tokens(details: Any | None) -> int:
+    """Read cached tokens from provider details, defaulting missing values to zero."""
+    return getattr(details, "cached_tokens", 0) or 0
+
+
+def _cache_write_tokens(details: Any | None) -> int:
+    """Read cache-write tokens across OpenAI Python versions."""
+    return getattr(details, "cache_write_tokens", 0) or 0
+
+
+def _coerce_input_token_details(raw_value: Any) -> InputTokensDetails:
+    """Deserialize input details while accepting snapshots written before cache writes."""
+    candidate = raw_value
+    if isinstance(candidate, list) and candidate:
+        candidate = candidate[0]
+    if isinstance(candidate, Mapping):
+        candidate = {
+            **candidate,
+            "cache_write_tokens": candidate.get("cache_write_tokens", 0) or 0,
+        }
+    try:
+        return TypeAdapter(InputTokensDetails).validate_python(candidate)
+    except ValidationError:
+        return _make_input_tokens_details()
+
+
 def deserialize_usage(usage_data: Mapping[str, Any]) -> Usage:
     """Rebuild a Usage object from serialized JSON data."""
     input_tokens_details_raw = usage_data.get("input_tokens_details")
     output_tokens_details_raw = usage_data.get("output_tokens_details")
-    input_details = _coerce_token_details(
-        TypeAdapter(InputTokensDetails),
-        input_tokens_details_raw or {"cached_tokens": 0},
-        InputTokensDetails(cached_tokens=0),
-    )
+    input_details = _coerce_input_token_details(input_tokens_details_raw)
     output_details = _coerce_token_details(
         TypeAdapter(OutputTokensDetails),
         output_tokens_details_raw or {"reasoning_tokens": 0},
@@ -33,11 +69,7 @@ def deserialize_usage(usage_data: Mapping[str, Any]) -> Usage:
                 input_tokens=entry.get("input_tokens", 0),
                 output_tokens=entry.get("output_tokens", 0),
                 total_tokens=entry.get("total_tokens", 0),
-                input_tokens_details=_coerce_token_details(
-                    TypeAdapter(InputTokensDetails),
-                    entry.get("input_tokens_details") or {"cached_tokens": 0},
-                    InputTokensDetails(cached_tokens=0),
-                ),
+                input_tokens_details=_coerce_input_token_details(entry.get("input_tokens_details")),
                 output_tokens_details=_coerce_token_details(
                     TypeAdapter(OutputTokensDetails),
                     entry.get("output_tokens_details") or {"reasoning_tokens": 0},
@@ -82,9 +114,12 @@ def _normalize_input_tokens_details(
 ) -> InputTokensDetails:
     """Converts None or PromptTokensDetails to InputTokensDetails."""
     if v is None:
-        return InputTokensDetails(cached_tokens=0)
+        return _make_input_tokens_details()
     if isinstance(v, PromptTokensDetails):
-        return InputTokensDetails(cached_tokens=v.cached_tokens or 0)
+        return _make_input_tokens_details(
+            cached_tokens=v.cached_tokens,
+            cache_write_tokens=_cache_write_tokens(v),
+        )
     return v
 
 
@@ -109,7 +144,7 @@ class Usage:
 
     input_tokens_details: Annotated[
         InputTokensDetails, BeforeValidator(_normalize_input_tokens_details)
-    ] = field(default_factory=lambda: InputTokensDetails(cached_tokens=0))
+    ] = field(default_factory=_make_input_tokens_details)
     """Details about the input tokens, matching responses API usage details."""
     output_tokens: int = 0
     """Total output tokens received, across all requests."""
@@ -137,15 +172,22 @@ class Usage:
 
     def __post_init__(self) -> None:
         # Some providers don't populate optional token detail fields
-        # (cached_tokens, reasoning_tokens), and the OpenAI SDK's generated
+        # (cached_tokens, cache_write_tokens, reasoning_tokens), and the OpenAI SDK's generated
         # code can bypass Pydantic validation (e.g., via model_construct),
         # allowing None values. We normalize these to 0 to prevent TypeErrors.
         input_details_none = self.input_tokens_details is None
         input_cached_none = (
             not input_details_none and self.input_tokens_details.cached_tokens is None
         )
-        if input_details_none or input_cached_none:
-            self.input_tokens_details = InputTokensDetails(cached_tokens=0)
+        input_cache_write_none = (
+            not input_details_none
+            and getattr(self.input_tokens_details, "cache_write_tokens", 0) is None
+        )
+        if input_details_none or input_cached_none or input_cache_write_none:
+            self.input_tokens_details = _make_input_tokens_details(
+                cached_tokens=_cached_tokens(self.input_tokens_details),
+                cache_write_tokens=_cache_write_tokens(self.input_tokens_details),
+            )
 
         output_details_none = self.output_tokens_details is None
         output_reasoning_none = (
@@ -168,28 +210,25 @@ class Usage:
         self.total_tokens += other.total_tokens if other.total_tokens else 0
 
         # Null guards for nested token details (other may bypass validation via model_construct)
-        other_cached = (
-            other.input_tokens_details.cached_tokens
-            if other.input_tokens_details and other.input_tokens_details.cached_tokens
-            else 0
-        )
+        other_cached = _cached_tokens(other.input_tokens_details)
+        other_cache_write = _cache_write_tokens(other.input_tokens_details)
         other_reasoning = (
             other.output_tokens_details.reasoning_tokens
             if other.output_tokens_details and other.output_tokens_details.reasoning_tokens
             else 0
         )
-        self_cached = (
-            self.input_tokens_details.cached_tokens
-            if self.input_tokens_details and self.input_tokens_details.cached_tokens
-            else 0
-        )
+        self_cached = _cached_tokens(self.input_tokens_details)
+        self_cache_write = _cache_write_tokens(self.input_tokens_details)
         self_reasoning = (
             self.output_tokens_details.reasoning_tokens
             if self.output_tokens_details and self.output_tokens_details.reasoning_tokens
             else 0
         )
 
-        self.input_tokens_details = InputTokensDetails(cached_tokens=self_cached + other_cached)
+        self.input_tokens_details = _make_input_tokens_details(
+            cached_tokens=self_cached + other_cached,
+            cache_write_tokens=self_cache_write + other_cache_write,
+        )
 
         self.output_tokens_details = OutputTokensDetails(
             reasoning_tokens=self_reasoning + other_reasoning
@@ -203,7 +242,7 @@ class Usage:
             self.request_usage_entries.extend(other.request_usage_entries)
         elif other.requests == 1 and other.total_tokens > 0:
             # Otherwise, if the other Usage represents a single request with tokens, record it.
-            input_details = other.input_tokens_details or InputTokensDetails(cached_tokens=0)
+            input_details = other.input_tokens_details or _make_input_tokens_details()
             output_details = other.output_tokens_details or OutputTokensDetails(reasoning_tokens=0)
             request_usage = RequestUsage(
                 input_tokens=other.input_tokens,
@@ -224,9 +263,19 @@ def _serialize_usage_details(details: Any, default: dict[str, int]) -> dict[str,
     return dict(default)
 
 
+def _serialize_input_tokens_details(details: Any) -> dict[str, Any]:
+    """Serialize both cache-read and cache-write counts across dependency versions."""
+    serialized = _serialize_usage_details(details, {"cached_tokens": 0})
+    serialized["cached_tokens"] = serialized.get("cached_tokens", 0) or 0
+    serialized["cache_write_tokens"] = (
+        serialized.get("cache_write_tokens", _cache_write_tokens(details)) or 0
+    )
+    return serialized
+
+
 def serialize_usage(usage: Usage) -> dict[str, Any]:
     """Serialize a Usage object into a JSON-friendly dictionary."""
-    input_details = _serialize_usage_details(usage.input_tokens_details, {"cached_tokens": 0})
+    input_details = _serialize_input_tokens_details(usage.input_tokens_details)
     output_details = _serialize_usage_details(usage.output_tokens_details, {"reasoning_tokens": 0})
 
     def _serialize_request_entry(entry: RequestUsage) -> dict[str, Any]:
@@ -234,9 +283,7 @@ def serialize_usage(usage: Usage) -> dict[str, Any]:
             "input_tokens": entry.input_tokens,
             "output_tokens": entry.output_tokens,
             "total_tokens": entry.total_tokens,
-            "input_tokens_details": _serialize_usage_details(
-                entry.input_tokens_details, {"cached_tokens": 0}
-            ),
+            "input_tokens_details": _serialize_input_tokens_details(entry.input_tokens_details),
             "output_tokens_details": _serialize_usage_details(
                 entry.output_tokens_details, {"reasoning_tokens": 0}
             ),
@@ -262,10 +309,7 @@ def model_usage_to_span_usage(usage: Usage) -> dict[str, Any]:
         "input_tokens": usage.input_tokens,
         "output_tokens": usage.output_tokens,
         "total_tokens": usage.total_tokens,
-        "input_tokens_details": _serialize_usage_details(
-            usage.input_tokens_details,
-            {"cached_tokens": 0},
-        ),
+        "input_tokens_details": _serialize_input_tokens_details(usage.input_tokens_details),
         "output_tokens_details": _serialize_usage_details(
             usage.output_tokens_details,
             {"reasoning_tokens": 0},
@@ -281,15 +325,16 @@ def total_usage_to_span_metadata(usage: Usage) -> dict[str, int]:
         "output_tokens": usage.output_tokens,
         "total_tokens": usage.total_tokens,
         "cached_input_tokens": _cached_input_tokens(usage),
+        "cache_write_input_tokens": _cache_write_input_tokens(usage),
     }
 
 
 def _cached_input_tokens(usage: Usage) -> int:
-    return (
-        usage.input_tokens_details.cached_tokens
-        if usage.input_tokens_details and usage.input_tokens_details.cached_tokens
-        else 0
-    )
+    return _cached_tokens(usage.input_tokens_details)
+
+
+def _cache_write_input_tokens(usage: Usage) -> int:
+    return _cache_write_tokens(usage.input_tokens_details)
 
 
 def turn_usage_to_span_data(usage: Usage) -> dict[str, int]:
@@ -298,6 +343,7 @@ def turn_usage_to_span_data(usage: Usage) -> dict[str, int]:
         "input_tokens": usage.input_tokens,
         "output_tokens": usage.output_tokens,
         "cached_input_tokens": _cached_input_tokens(usage),
+        "cache_write_input_tokens": _cache_write_input_tokens(usage),
     }
 
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -43,7 +43,9 @@ def usage_data() -> Usage:
         input_tokens=50,
         output_tokens=30,
         total_tokens=80,
-        input_tokens_details=InputTokensDetails(cached_tokens=10),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 10}
+        ),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
     )
 
@@ -59,7 +61,9 @@ def create_mock_run_result(usage: Usage | None = None, agent: Agent | None = Non
             input_tokens=50,
             output_tokens=30,
             total_tokens=80,
-            input_tokens_details=InputTokensDetails(cached_tokens=10),
+            input_tokens_details=InputTokensDetails.model_validate(
+                {"cache_write_tokens": 0, "cached_tokens": 10}
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
         )
 
@@ -1146,7 +1150,9 @@ async def test_usage_tracking_storage(agent: Agent, usage_data: Usage):
         input_tokens=75,
         output_tokens=45,
         total_tokens=120,
-        input_tokens_details=InputTokensDetails(cached_tokens=20),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 20}
+        ),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=15),
     )
 

--- a/tests/fake_model.py
+++ b/tests/fake_model.py
@@ -359,7 +359,9 @@ def get_response_obj(
             input_tokens=usage.input_tokens if usage else 0,
             output_tokens=usage.output_tokens if usage else 0,
             total_tokens=usage.total_tokens if usage else 0,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails.model_validate(
+                {"cache_write_tokens": 0, "cached_tokens": 0}
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -117,7 +117,9 @@ def _chat_completion(text: str) -> ChatCompletion:
             completion_tokens=5,
             prompt_tokens=7,
             total_tokens=12,
-            prompt_tokens_details=PromptTokensDetails(cached_tokens=2),
+            prompt_tokens_details=PromptTokensDetails.model_validate(
+                {"cached_tokens": 2, "cache_write_tokens": 4}
+            ),
         ),
     )
 
@@ -155,7 +157,9 @@ def _response(text: str, response_id: str = "resp_123") -> Response:
             input_tokens=11,
             output_tokens=13,
             total_tokens=24,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails.model_validate(
+                {"cache_write_tokens": 0, "cached_tokens": 0}
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )
@@ -289,6 +293,8 @@ async def test_any_llm_chat_path_is_used_when_responses_are_unsupported(monkeypa
     assert provider.chat_calls[0]["model"] == "openai/gpt-5.4-mini"
     assert response.response_id is None
     assert response.output[0].content[0].text == "Hello"
+    assert response.usage.input_tokens_details.cached_tokens == 2
+    assert getattr(response.usage.input_tokens_details, "cache_write_tokens", None) == 4
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -130,7 +130,9 @@ async def test_get_response_with_text_message(monkeypatch) -> None:
             prompt_tokens=7,
             total_tokens=12,
             # completion_tokens_details left blank to test default
-            prompt_tokens_details=PromptTokensDetails(cached_tokens=3),
+            prompt_tokens_details=PromptTokensDetails.model_validate(
+                {"cached_tokens": 3, "cache_write_tokens": 4}
+            ),
         ),
     )
 
@@ -164,6 +166,7 @@ async def test_get_response_with_text_message(monkeypatch) -> None:
     assert resp.usage.output_tokens == 5
     assert resp.usage.total_tokens == 12
     assert resp.usage.input_tokens_details.cached_tokens == 3
+    assert getattr(resp.usage.input_tokens_details, "cache_write_tokens", None) == 4
     assert resp.usage.output_tokens_details.reasoning_tokens == 0
     assert resp.response_id is None
 

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -126,7 +126,9 @@ async def test_stream_response_yields_events_for_text_content(monkeypatch) -> No
             completion_tokens=5,
             prompt_tokens=7,
             total_tokens=12,
-            prompt_tokens_details=PromptTokensDetails(cached_tokens=2),
+            prompt_tokens_details=PromptTokensDetails.model_validate(
+                {"cached_tokens": 2, "cache_write_tokens": 4}
+            ),
             completion_tokens_details=CompletionTokensDetails(reasoning_tokens=3),
         ),
     )
@@ -197,6 +199,7 @@ async def test_stream_response_yields_events_for_text_content(monkeypatch) -> No
     assert completed_resp.usage.output_tokens == 5
     assert completed_resp.usage.total_tokens == 12
     assert completed_resp.usage.input_tokens_details.cached_tokens == 2
+    assert getattr(completed_resp.usage.input_tokens_details, "cache_write_tokens", None) == 4
     assert completed_resp.usage.output_tokens_details.reasoning_tokens == 3
 
 

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -306,7 +306,7 @@ async def test_get_response_span_exports_usage():
             "input_tokens": 10,
             "output_tokens": 4,
             "total_tokens": 14,
-            "input_tokens_details": {"cached_tokens": 0},
+            "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
             "output_tokens_details": {"reasoning_tokens": 0},
         },
     }

--- a/tests/test_agent_tracing.py
+++ b/tests/test_agent_tracing.py
@@ -89,7 +89,9 @@ async def test_task_and_turn_spans_export_aggregate_usage():
             input_tokens=10,
             output_tokens=3,
             total_tokens=13,
-            input_tokens_details=InputTokensDetails(cached_tokens=2),
+            input_tokens_details=InputTokensDetails.model_validate(
+                {"cache_write_tokens": 3, "cached_tokens": 2}
+            ),
         )
     )
     agent = Agent(name="test_agent", model=model, tools=[foo_tool])
@@ -116,6 +118,7 @@ async def test_task_and_turn_spans_export_aggregate_usage():
                 "output_tokens": 6,
                 "total_tokens": 26,
                 "cached_input_tokens": 4,
+                "cache_write_input_tokens": 6,
             },
         },
     }
@@ -125,11 +128,13 @@ async def test_task_and_turn_spans_export_aggregate_usage():
             "input_tokens": 10,
             "output_tokens": 3,
             "cached_input_tokens": 2,
+            "cache_write_input_tokens": 3,
         },
         {
             "input_tokens": 10,
             "output_tokens": 3,
             "cached_input_tokens": 2,
+            "cache_write_input_tokens": 3,
         },
     ]
     assert [span["span_data"] for span in turn_spans if span] == [
@@ -144,6 +149,7 @@ async def test_task_and_turn_spans_export_aggregate_usage():
                     "input_tokens": 10,
                     "output_tokens": 3,
                     "cached_input_tokens": 2,
+                    "cache_write_input_tokens": 3,
                 },
             },
         },
@@ -158,6 +164,7 @@ async def test_task_and_turn_spans_export_aggregate_usage():
                     "input_tokens": 10,
                     "output_tokens": 3,
                     "cached_input_tokens": 2,
+                    "cache_write_input_tokens": 3,
                 },
             },
         },
@@ -168,6 +175,7 @@ async def test_task_and_turn_spans_export_aggregate_usage():
         "output_tokens": 6,
         "total_tokens": 26,
         "cached_input_tokens": 4,
+        "cache_write_input_tokens": 6,
     }
 
     assert len(agent_spans) == 1
@@ -318,8 +326,16 @@ async def test_resumed_run_task_span_usage_is_run_local_delta():
     assert resumed.final_output == "done"
     task_spans = [span.export() for span in fetch_ordered_spans() if span.span_data.type == "task"]
     assert [span["span_data"]["data"]["usage"] for span in task_spans if span] == [
-        {**_usage_metadata(requests=1, input_tokens=10, output_tokens=3), "cached_input_tokens": 0},
-        {**_usage_metadata(requests=1, input_tokens=10, output_tokens=3), "cached_input_tokens": 0},
+        {
+            **_usage_metadata(requests=1, input_tokens=10, output_tokens=3),
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+        },
+        {
+            **_usage_metadata(requests=1, input_tokens=10, output_tokens=3),
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+        },
     ]
 
 
@@ -744,8 +760,16 @@ async def test_resumed_streaming_run_task_span_usage_is_run_local_delta():
     assert resumed.final_output == "done"
     task_spans = [span.export() for span in fetch_ordered_spans() if span.span_data.type == "task"]
     assert [span["span_data"]["data"]["usage"] for span in task_spans if span] == [
-        {**_usage_metadata(requests=1, input_tokens=11, output_tokens=4), "cached_input_tokens": 0},
-        {**_usage_metadata(requests=1, input_tokens=11, output_tokens=4), "cached_input_tokens": 0},
+        {
+            **_usage_metadata(requests=1, input_tokens=11, output_tokens=4),
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+        },
+        {
+            **_usage_metadata(requests=1, input_tokens=11, output_tokens=4),
+            "cached_input_tokens": 0,
+            "cache_write_input_tokens": 0,
+        },
     ]
 
 

--- a/tests/test_extra_headers.py
+++ b/tests/test_extra_headers.py
@@ -29,7 +29,9 @@ async def test_extra_headers_passed_to_openai_responses_model():
                         "input_tokens": 0,
                         "output_tokens": 0,
                         "total_tokens": 0,
-                        "input_tokens_details": InputTokensDetails(cached_tokens=0),
+                        "input_tokens_details": InputTokensDetails.model_validate(
+                            {"cache_write_tokens": 0, "cached_tokens": 0}
+                        ),
                         "output_tokens_details": OutputTokensDetails(reasoning_tokens=0),
                     },
                 )()

--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -25,7 +25,9 @@ class DummyResponses:
                     "input_tokens": 0,
                     "output_tokens": 0,
                     "total_tokens": 0,
-                    "input_tokens_details": InputTokensDetails(cached_tokens=0),
+                    "input_tokens_details": InputTokensDetails.model_validate(
+                        {"cache_write_tokens": 0, "cached_tokens": 0}
+                    ),
                     "output_tokens_details": OutputTokensDetails(reasoning_tokens=0),
                 },
             )()

--- a/tests/test_responses_tracing.py
+++ b/tests/test_responses_tracing.py
@@ -29,7 +29,9 @@ class DummyUsage:
         self.output_tokens = output_tokens
         self.total_tokens = total_tokens
         self.input_tokens_details = (
-            input_tokens_details if input_tokens_details else InputTokensDetails(cached_tokens=0)
+            input_tokens_details
+            if input_tokens_details
+            else InputTokensDetails.model_validate({"cache_write_tokens": 0, "cached_tokens": 0})
         )
         self.output_tokens_details = (
             output_tokens_details
@@ -102,7 +104,10 @@ async def test_get_response_creates_trace(monkeypatch):
                                 "input_tokens": 1,
                                 "output_tokens": 1,
                                 "total_tokens": 2,
-                                "input_tokens_details": {"cached_tokens": 0},
+                                "input_tokens_details": {
+                                    "cached_tokens": 0,
+                                    "cache_write_tokens": 0,
+                                },
                                 "output_tokens_details": {"reasoning_tokens": 0},
                             },
                         },
@@ -162,7 +167,10 @@ async def test_non_data_tracing_doesnt_set_response_id(monkeypatch):
                                 "input_tokens": 1,
                                 "output_tokens": 1,
                                 "total_tokens": 2,
-                                "input_tokens_details": {"cached_tokens": 0},
+                                "input_tokens_details": {
+                                    "cached_tokens": 0,
+                                    "cache_write_tokens": 0,
+                                },
                                 "output_tokens_details": {"reasoning_tokens": 0},
                             }
                         },
@@ -276,7 +284,10 @@ async def test_stream_response_creates_trace(monkeypatch):
                                 "input_tokens": 0,
                                 "output_tokens": 0,
                                 "total_tokens": 0,
-                                "input_tokens_details": {"cached_tokens": 0},
+                                "input_tokens_details": {
+                                    "cached_tokens": 0,
+                                    "cache_write_tokens": 0,
+                                },
                                 "output_tokens_details": {"reasoning_tokens": 0},
                             },
                         },
@@ -414,7 +425,10 @@ async def test_stream_non_data_tracing_doesnt_set_response_id(monkeypatch):
                                 "input_tokens": 0,
                                 "output_tokens": 0,
                                 "total_tokens": 0,
-                                "input_tokens_details": {"cached_tokens": 0},
+                                "input_tokens_details": {
+                                    "cached_tokens": 0,
+                                    "cache_write_tokens": 0,
+                                },
                                 "output_tokens_details": {"reasoning_tokens": 0},
                             }
                         },

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -27,6 +27,7 @@ from openai.types.responses.response_computer_tool_call import (
     ResponseComputerToolCall,
 )
 from openai.types.responses.response_output_item import LocalShellCall, McpApprovalRequest
+from openai.types.responses.response_usage import InputTokensDetails
 from openai.types.responses.tool_param import Mcp
 from pydantic import BaseModel
 
@@ -1798,13 +1799,21 @@ class TestSerializationRoundTrip:
         context.usage.input_tokens = 100
         context.usage.output_tokens = 50
         context.usage.total_tokens = 150
+        context.usage.input_tokens_details = InputTokensDetails.model_validate(
+            {"cache_write_tokens": 7, "cached_tokens": 3}
+        )
 
         agent = Agent(name="UsageAgent")
         state = make_state(agent, context=context, original_input="test", max_turns=10)
 
         str_data = state.to_string()
+        serialized = json.loads(str_data)
         new_state = await RunState.from_string(agent, str_data)
 
+        assert serialized["$schemaVersion"] == "1.12"
+        assert serialized["context"]["usage"]["input_tokens_details"] == [
+            {"cached_tokens": 3, "cache_write_tokens": 7}
+        ]
         assert new_state._context is not None
         assert new_state._context.usage.requests == 5
         assert new_state._context.usage is not None
@@ -1813,6 +1822,41 @@ class TestSerializationRoundTrip:
         assert new_state._context.usage.output_tokens == 50
         assert new_state._context.usage is not None
         assert new_state._context.usage.total_tokens == 150
+        assert new_state._context.usage.input_tokens_details.cached_tokens == 3
+        assert (
+            getattr(
+                new_state._context.usage.input_tokens_details,
+                "cache_write_tokens",
+                None,
+            )
+            == 7
+        )
+
+    async def test_restores_schema_1_11_usage_without_cache_write_tokens(self):
+        """Released snapshots default the newly required OpenAI usage field to zero."""
+        agent = Agent(name="UsageAgent")
+        state: RunState[dict[str, Any]] = make_state(
+            agent,
+            context=RunContextWrapper(context={}),
+            original_input="test",
+            max_turns=10,
+        )
+        state_json = state.to_json()
+        state_json["$schemaVersion"] = "1.11"
+        state_json["context"]["usage"]["input_tokens_details"] = [{"cached_tokens": 3}]
+
+        restored = await RunState.from_json(agent, state_json)
+
+        assert restored._context is not None
+        assert restored._context.usage.input_tokens_details.cached_tokens == 3
+        assert (
+            getattr(
+                restored._context.usage.input_tokens_details,
+                "cache_write_tokens",
+                None,
+            )
+            == 0
+        )
 
     def test_serializes_generated_items(self):
         """Test that generated items are serialized and restored."""
@@ -4944,6 +4988,7 @@ class TestRunStateSerializationEdgeCases:
                 "1.8",
                 "1.9",
                 "1.10",
+                "1.11",
                 CURRENT_SCHEMA_VERSION,
             }
         )

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -5,9 +5,23 @@ from openai.types.completion_usage import CompletionTokensDetails, PromptTokensD
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 from agents import Agent, Runner
-from agents.usage import RequestUsage, Usage
+from agents.run_internal.agent_runner_helpers import snapshot_usage, usage_delta
+from agents.usage import (
+    RequestUsage,
+    Usage,
+    deserialize_usage,
+    model_usage_to_span_usage,
+    serialize_usage,
+)
 from tests.fake_model import FakeModel
 from tests.test_responses import get_text_message
+
+
+def test_usage_defaults_cache_write_tokens_to_zero() -> None:
+    usage = Usage()
+
+    assert usage.input_tokens_details.cached_tokens == 0
+    assert getattr(usage.input_tokens_details, "cache_write_tokens", None) == 0
 
 
 @pytest.mark.asyncio
@@ -23,7 +37,9 @@ async def test_runner_run_carries_request_usage_entries() -> None:
                 input_tokens=10,
                 output_tokens=5,
                 total_tokens=15,
-                input_tokens_details=InputTokensDetails(cached_tokens=0),
+                input_tokens_details=InputTokensDetails.model_validate(
+                    {"cache_write_tokens": 0, "cached_tokens": 0}
+                ),
                 output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
             )
         ],
@@ -48,7 +64,9 @@ def test_usage_add_aggregates_all_fields():
     u1 = Usage(
         requests=1,
         input_tokens=10,
-        input_tokens_details=InputTokensDetails(cached_tokens=3),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 5, "cached_tokens": 3}
+        ),
         output_tokens=20,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
         total_tokens=30,
@@ -56,7 +74,9 @@ def test_usage_add_aggregates_all_fields():
     u2 = Usage(
         requests=2,
         input_tokens=7,
-        input_tokens_details=InputTokensDetails(cached_tokens=4),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 6, "cached_tokens": 4}
+        ),
         output_tokens=8,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=6),
         total_tokens=15,
@@ -69,6 +89,7 @@ def test_usage_add_aggregates_all_fields():
     assert u1.output_tokens == 28
     assert u1.total_tokens == 45
     assert u1.input_tokens_details.cached_tokens == 7
+    assert getattr(u1.input_tokens_details, "cache_write_tokens", None) == 11
     assert u1.output_tokens_details.reasoning_tokens == 11
 
 
@@ -77,7 +98,9 @@ def test_usage_add_aggregates_with_none_values():
     u2 = Usage(
         requests=2,
         input_tokens=7,
-        input_tokens_details=InputTokensDetails(cached_tokens=4),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 4}
+        ),
         output_tokens=8,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=6),
         total_tokens=15,
@@ -99,7 +122,9 @@ def test_request_usage_creation():
         input_tokens=100,
         output_tokens=200,
         total_tokens=300,
-        input_tokens_details=InputTokensDetails(cached_tokens=10),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 10}
+        ),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=20),
     )
 
@@ -116,7 +141,9 @@ def test_usage_add_preserves_single_request():
     u2 = Usage(
         requests=1,
         input_tokens=100,
-        input_tokens_details=InputTokensDetails(cached_tokens=10),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 10}
+        ),
         output_tokens=200,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=20),
         total_tokens=300,
@@ -140,7 +167,9 @@ def test_usage_add_ignores_zero_token_requests():
     u2 = Usage(
         requests=1,
         input_tokens=0,
-        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 0}
+        ),
         output_tokens=0,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         total_tokens=0,
@@ -158,7 +187,9 @@ def test_usage_add_ignores_multi_request_usage():
     u2 = Usage(
         requests=3,  # Multiple requests
         input_tokens=100,
-        input_tokens_details=InputTokensDetails(cached_tokens=10),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 10}
+        ),
         output_tokens=200,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=20),
         total_tokens=300,
@@ -177,7 +208,9 @@ def test_usage_add_merges_existing_request_usage_entries():
     u2 = Usage(
         requests=1,
         input_tokens=100,
-        input_tokens_details=InputTokensDetails(cached_tokens=10),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 10}
+        ),
         output_tokens=200,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=20),
         total_tokens=300,
@@ -188,7 +221,9 @@ def test_usage_add_merges_existing_request_usage_entries():
     u3 = Usage(
         requests=1,
         input_tokens=50,
-        input_tokens_details=InputTokensDetails(cached_tokens=5),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 5}
+        ),
         output_tokens=75,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
         total_tokens=125,
@@ -220,7 +255,9 @@ def test_usage_add_with_pre_existing_request_usage_entries():
     u2 = Usage(
         requests=1,
         input_tokens=100,
-        input_tokens_details=InputTokensDetails(cached_tokens=10),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 10}
+        ),
         output_tokens=200,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=20),
         total_tokens=300,
@@ -231,7 +268,9 @@ def test_usage_add_with_pre_existing_request_usage_entries():
     u3 = Usage(
         requests=1,
         input_tokens=50,
-        input_tokens_details=InputTokensDetails(cached_tokens=5),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 5}
+        ),
         output_tokens=75,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=10),
         total_tokens=125,
@@ -263,7 +302,9 @@ def test_usage_add_preserves_existing_entries_when_top_level_also_set():
                 input_tokens=100,
                 output_tokens=50,
                 total_tokens=150,
-                input_tokens_details=InputTokensDetails(cached_tokens=10),
+                input_tokens_details=InputTokensDetails.model_validate(
+                    {"cache_write_tokens": 0, "cached_tokens": 10}
+                ),
                 output_tokens_details=OutputTokensDetails(reasoning_tokens=5),
             )
         ],
@@ -296,7 +337,9 @@ def test_anthropic_cost_calculation_scenario():
     req1 = Usage(
         requests=1,
         input_tokens=100_000,
-        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 0}
+        ),
         output_tokens=50_000,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         total_tokens=150_000,
@@ -307,7 +350,9 @@ def test_anthropic_cost_calculation_scenario():
     req2 = Usage(
         requests=1,
         input_tokens=150_000,
-        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 0}
+        ),
         output_tokens=75_000,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         total_tokens=225_000,
@@ -318,7 +363,9 @@ def test_anthropic_cost_calculation_scenario():
     req3 = Usage(
         requests=1,
         input_tokens=80_000,
-        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 0}
+        ),
         output_tokens=40_000,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         total_tokens=120_000,
@@ -362,8 +409,9 @@ def test_usage_normalizes_none_token_details():
     assert usage.output_tokens_details.reasoning_tokens == 0
 
     # Test fields within objects being None (__post_init__)
-    input_details = InputTokensDetails(cached_tokens=0)
+    input_details = InputTokensDetails.model_validate({"cache_write_tokens": 0, "cached_tokens": 0})
     input_details.__dict__["cached_tokens"] = None
+    input_details.__dict__["cache_write_tokens"] = None
 
     output_details = OutputTokensDetails(reasoning_tokens=0)
     output_details.__dict__["reasoning_tokens"] = None
@@ -379,6 +427,7 @@ def test_usage_normalizes_none_token_details():
 
     # __post_init__ should normalize None to 0
     assert usage.input_tokens_details.cached_tokens == 0
+    assert getattr(usage.input_tokens_details, "cache_write_tokens", None) == 0
     assert usage.output_tokens_details.reasoning_tokens == 0
 
 
@@ -387,7 +436,13 @@ def test_usage_normalizes_chat_completions_types():
     # while Usage expects InputTokensDetails and OutputTokensDetails (Responses API).
     # The BeforeValidator should convert between these types.
 
-    prompt_details = PromptTokensDetails(audio_tokens=10, cached_tokens=50)
+    prompt_details = PromptTokensDetails.model_validate(
+        {
+            "audio_tokens": 10,
+            "cached_tokens": 50,
+            "cache_write_tokens": 7,
+        }
+    )
     completion_details = CompletionTokensDetails(
         accepted_prediction_tokens=5,
         audio_tokens=10,
@@ -407,6 +462,109 @@ def test_usage_normalizes_chat_completions_types():
     # Should convert to Responses API types, extracting the relevant fields
     assert isinstance(usage.input_tokens_details, InputTokensDetails)
     assert usage.input_tokens_details.cached_tokens == 50
+    assert getattr(usage.input_tokens_details, "cache_write_tokens", None) == 7
 
     assert isinstance(usage.output_tokens_details, OutputTokensDetails)
     assert usage.output_tokens_details.reasoning_tokens == 100
+
+
+def test_usage_serialization_preserves_cache_write_tokens() -> None:
+    usage = Usage(
+        requests=1,
+        input_tokens=20,
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 7, "cached_tokens": 3}
+        ),
+        output_tokens=5,
+        total_tokens=25,
+        request_usage_entries=[
+            RequestUsage(
+                input_tokens=20,
+                output_tokens=5,
+                total_tokens=25,
+                input_tokens_details=InputTokensDetails.model_validate(
+                    {"cache_write_tokens": 7, "cached_tokens": 3}
+                ),
+                output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+            )
+        ],
+    )
+
+    serialized = serialize_usage(usage)
+    restored = deserialize_usage(serialized)
+
+    assert serialized["input_tokens_details"] == [{"cached_tokens": 3, "cache_write_tokens": 7}]
+    assert getattr(restored.input_tokens_details, "cache_write_tokens", None) == 7
+    assert (
+        getattr(
+            restored.request_usage_entries[0].input_tokens_details,
+            "cache_write_tokens",
+            None,
+        )
+        == 7
+    )
+
+
+def test_usage_deserialization_defaults_legacy_cache_write_tokens() -> None:
+    restored = deserialize_usage(
+        {
+            "requests": 1,
+            "input_tokens": 20,
+            "output_tokens": 5,
+            "total_tokens": 25,
+            "input_tokens_details": [{"cached_tokens": 3}],
+            "request_usage_entries": [
+                {
+                    "input_tokens": 20,
+                    "output_tokens": 5,
+                    "total_tokens": 25,
+                    "input_tokens_details": {"cached_tokens": 3},
+                }
+            ],
+        }
+    )
+
+    assert restored.input_tokens_details.cached_tokens == 3
+    assert getattr(restored.input_tokens_details, "cache_write_tokens", None) == 0
+    assert restored.request_usage_entries[0].input_tokens_details.cached_tokens == 3
+    assert (
+        getattr(
+            restored.request_usage_entries[0].input_tokens_details,
+            "cache_write_tokens",
+            None,
+        )
+        == 0
+    )
+
+
+def test_usage_snapshot_delta_and_span_preserve_cache_write_tokens() -> None:
+    start = Usage(
+        requests=1,
+        input_tokens=10,
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 2, "cached_tokens": 3}
+        ),
+        output_tokens=4,
+        total_tokens=14,
+    )
+    end = Usage(
+        requests=2,
+        input_tokens=30,
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 9, "cached_tokens": 8}
+        ),
+        output_tokens=10,
+        total_tokens=40,
+    )
+
+    snapshot = snapshot_usage(start)
+    delta = usage_delta(snapshot, end)
+    span_usage = model_usage_to_span_usage(delta)
+
+    assert getattr(snapshot.input_tokens_details, "cache_write_tokens", None) == 2
+    assert delta.input_tokens_details.cached_tokens == 5
+    assert getattr(delta.input_tokens_details, "cache_write_tokens", None) == 7
+    assert span_usage["input_tokens_details"] == {
+        "cached_tokens": 5,
+        "cache_write_tokens": 7,
+    }


### PR DESCRIPTION
This pull request resolves #3772 by supporting the `cache_write_tokens` usage field across OpenAI Python 2.44 and 2.45.

It constructs input-token details through a version-compatible validation path and preserves cache-write counts across provider conversion, aggregation, tracing, and RunState serialization. RunState schema 1.12 prevents older readers from silently losing the new usage data while retaining backward compatibility with existing snapshots. The supported OpenAI dependency range remains unchanged.