### PR TITLE
fix(realtime): use monotonic playback timing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ select = [
   "I",  # isort
   "B",  # flake8-bugbear
   "C4", # flake8-comprehensions
+  "DTZ005", # datetime.now() without a timezone
   "UP", # pyupgrade
 ]
 isort = { combine-as-imports = true, known-first-party = ["agents"] }
@@ -127,7 +128,7 @@ isort = { combine-as-imports = true, known-first-party = ["agents"] }
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"examples/**/*.py" = ["E501"]
+"examples/**/*.py" = ["DTZ005", "E501"]
 
 [tool.mypy]
 strict = true

--- a/src/agents/realtime/_default_tracker.py
+++ b/src/agents/realtime/_default_tracker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
-from datetime import datetime
 
 from ._util import calculate_audio_length_ms
 from .config import RealtimeAudioFormat
@@ -9,7 +9,7 @@ from .config import RealtimeAudioFormat
 
 @dataclass
 class ModelAudioState:
-    initial_received_time: datetime
+    initial_received_time: float
     audio_length_ms: float
 
 
@@ -35,7 +35,7 @@ class ModelAudioTracker:
 
         self._last_audio_item = new_key
         if new_key not in self._states:
-            self._states[new_key] = ModelAudioState(datetime.now(), ms)
+            self._states[new_key] = ModelAudioState(time.monotonic(), ms)
         else:
             self._states[new_key].audio_length_ms += ms
 

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -6,9 +6,9 @@ import inspect
 import json
 import math
 import os
+import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Annotated, Any, Literal, TypeAlias, cast
 
 import pydantic
@@ -890,9 +890,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
             item_id, item_content_index = last_audio_item_id
             audio_state = self._audio_state_tracker.get_state(item_id, item_content_index)
             if audio_state:
-                elapsed_ms = (
-                    datetime.now() - audio_state.initial_received_time
-                ).total_seconds() * 1000
+                elapsed_ms = (time.monotonic() - audio_state.initial_received_time) * 1000
                 return {
                     "current_item_id": item_id,
                     "current_item_content_index": item_content_index,

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from datetime import datetime, timedelta
+import time
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -815,7 +815,7 @@ class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
         model._audio_state_tracker.on_audio_delta("i1", 0, b"a" * 48_000)
         state = model._audio_state_tracker.get_state("i1", 0)
         assert state is not None
-        state.initial_received_time = datetime.now() - timedelta(seconds=5)
+        state.initial_received_time = time.monotonic() - 5
 
         monkeypatch.setattr(
             model,
@@ -846,7 +846,7 @@ class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
         model._audio_state_tracker.on_audio_delta("i1", 0, b"a" * 48_000)
         state = model._audio_state_tracker.get_state("i1", 0)
         assert state is not None
-        state.initial_received_time = datetime.now() - timedelta(seconds=5)
+        state.initial_received_time = time.monotonic() - 5
         model._ongoing_response = True
 
         monkeypatch.setattr(

--- a/tests/realtime/test_playback_tracker.py
+++ b/tests/realtime/test_playback_tracker.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -134,6 +134,19 @@ class TestPlaybackTracker:
         # Should accumulate: 8 bytes -> 4 samples -> (4 / 24000) * 1000 ≈ 0.167ms
         expected_length = (8 / (24_000 * 2)) * 1000
         assert state.audio_length_ms == pytest.approx(expected_length, rel=0, abs=1e-6)
+
+    def test_default_playback_timing_uses_monotonic_clock(self, model):
+        model._audio_state_tracker.set_audio_format("pcm16")
+
+        with patch("agents.realtime._default_tracker.time.monotonic", return_value=42.0):
+            model._audio_state_tracker.on_audio_delta("item_1", 0, b"test")
+
+        with patch("agents.realtime.openai_realtime.time.monotonic", return_value=42.25):
+            state = model._get_playback_state()
+
+        assert state["current_item_id"] == "item_1"
+        assert state["current_item_content_index"] == 0
+        assert state["elapsed_ms"] == pytest.approx(250.0)
 
     def test_state_cleanup_on_interruption(self):
         """Test both trackers properly reset state on interruption."""


### PR DESCRIPTION
This pull request fixes Realtime audio playback tracking by measuring elapsed playback time with a monotonic clock.

The default playback tracker uses this elapsed time when constructing `conversation.item.truncate` events, so system clock adjustments can no longer distort the interruption boundary. It also enables Ruff `DTZ005` for SDK code and adds regression coverage for the monotonic elapsed-time calculation.
