### PR TITLE
fix(realtime): enqueue callback errors synchronously

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -532,6 +532,13 @@ class RealtimeSession(RealtimeModelListener):
         await self._event_queue.put(event)
         return True
 
+    def _put_event_nowait(self, event: RealtimeSessionEvent) -> bool:
+        """Put an event into the unbounded queue from a synchronous callback."""
+        if self._closing or self._closed:
+            return False
+        self._event_queue.put_nowait(event)
+        return True
+
     async def _function_needs_approval(
         self, function_tool: FunctionTool, tool_call: RealtimeModelToolCallEvent
     ) -> bool:
@@ -1372,12 +1379,10 @@ class RealtimeSession(RealtimeModelListener):
             exception = task.exception()
             if exception:
                 # Create an exception event instead of raising
-                asyncio.create_task(
-                    self._put_event(
-                        RealtimeError(
-                            info=self._event_info,
-                            error={"message": f"Guardrail task failed: {str(exception)}"},
-                        )
+                self._put_event_nowait(
+                    RealtimeError(
+                        info=self._event_info,
+                        error={"message": f"Guardrail task failed: {str(exception)}"},
                     )
                 )
 
@@ -1428,17 +1433,14 @@ class RealtimeSession(RealtimeModelListener):
                 exception.call_id,
                 exc_info=exception,
             )
-            asyncio.create_task(
-                self._put_event(
-                    RealtimeError(
-                        info=self._event_info,
-                        error={
-                            "message": (
-                                "Tool output send failed; cached output will be retried: "
-                                f"{exception}"
-                            )
-                        },
-                    )
+            self._put_event_nowait(
+                RealtimeError(
+                    info=self._event_info,
+                    error={
+                        "message": (
+                            f"Tool output send failed; cached output will be retried: {exception}"
+                        )
+                    },
                 )
             )
             return
@@ -1448,12 +1450,10 @@ class RealtimeSession(RealtimeModelListener):
         if self._stored_exception is None:
             self._stored_exception = exception
 
-        asyncio.create_task(
-            self._put_event(
-                RealtimeError(
-                    info=self._event_info,
-                    error={"message": f"Tool call task failed: {exception}"},
-                )
+        self._put_event_nowait(
+            RealtimeError(
+                info=self._event_info,
+                error={"message": f"Tool call task failed: {exception}"},
             )
         )
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -60,7 +60,12 @@ from agents.realtime.model_inputs import (
     RealtimeModelSendToolOutput,
     RealtimeModelSendUserInput,
 )
-from agents.realtime.session import REJECTION_MESSAGE, RealtimeSession, _serialize_tool_output
+from agents.realtime.session import (
+    REJECTION_MESSAGE,
+    RealtimeSession,
+    _PendingToolOutputSendError,
+    _serialize_tool_output,
+)
 from agents.run_context import RunContextWrapper
 from agents.tool import FunctionTool, function_tool, tool_namespace
 from agents.tool_context import ToolContext
@@ -660,12 +665,51 @@ async def test_on_guardrail_task_done_emits_error_event():
 
     session._on_guardrail_task_done(task)
 
-    # Allow event task to enqueue
-    await asyncio.sleep(0.01)
-
-    # Should have a RealtimeError queued
-    err = await session._event_queue.get()
+    err = session._event_queue.get_nowait()
     assert isinstance(err, RealtimeError)
+
+
+@pytest.mark.parametrize("state_name", ["_closing", "_closed"])
+def test_put_event_nowait_skips_events_during_cleanup(state_name: str):
+    session = RealtimeSession(_DummyModel(), RealtimeAgent(name="agent"), None)
+    setattr(session, state_name, True)
+
+    enqueued = session._put_event_nowait(
+        RealtimeError(info=session._event_info, error={"message": "late error"})
+    )
+
+    assert not enqueued
+    assert session._event_queue.empty()
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_message"),
+    [
+        (RuntimeError("tool failed"), "Tool call task failed: tool failed"),
+        (
+            _PendingToolOutputSendError("call-1", RuntimeError("send failed")),
+            "Tool output send failed; cached output will be retried: send failed",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_on_tool_call_task_done_emits_error_event_immediately(
+    exception: Exception,
+    expected_message: str,
+):
+    session = RealtimeSession(_DummyModel(), RealtimeAgent(name="agent"), None)
+
+    async def failing_task() -> None:
+        raise exception
+
+    task = asyncio.create_task(failing_task())
+    await asyncio.gather(task, return_exceptions=True)
+
+    session._on_tool_call_task_done(task)
+
+    err = session._event_queue.get_nowait()
+    assert isinstance(err, RealtimeError)
+    assert err.error["message"] == expected_message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes Realtime task completion callbacks by enqueueing `RealtimeError` events directly into the session's unbounded queue instead of spawning untracked asyncio tasks.

The synchronous path preserves the existing closing and closed state checks, prevents late errors from being queued during cleanup, and makes guardrail, tool-output retry, and tool-call failure events immediately observable.