### PR TITLE
fix(sandbox): own Daytona PTY worker tasks

### DIFF
--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -943,7 +943,13 @@ class DaytonaSandboxSession(BaseSandboxSession):
             if worker_task is not None and worker_task is not asyncio.current_task():
                 if not worker_task.done():
                     worker_task.cancel()
-                await asyncio.gather(worker_task, return_exceptions=True)
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(worker_task, return_exceptions=True),
+                        timeout=self.state.timeouts.cleanup_s,
+                    )
+                except asyncio.TimeoutError:
+                    pass
 
     async def read(self, path: Path | str, *, user: str | User | None = None) -> io.IOBase:
         error_path = posix_path_as_path(coerce_posix_path(path))

--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -388,6 +388,7 @@ class _DaytonaPtySessionEntry:
     last_used: float = field(default_factory=time.monotonic)
     done: bool = False
     exit_code: int | None = None
+    worker_task: asyncio.Task[None] | None = None
 
 
 class DaytonaSandboxSession(BaseSandboxSession):
@@ -672,7 +673,7 @@ class DaytonaSandboxSession(BaseSandboxSession):
                     timeout=exec_timeout,
                 )
                 entry.pty_handle = pty_handle
-                asyncio.create_task(self._run_pty_waiter(entry))
+                entry.worker_task = asyncio.create_task(self._run_pty_waiter(entry))
                 await asyncio.wait_for(pty_handle.wait_for_connection(), timeout=exec_timeout)
                 await asyncio.wait_for(
                     pty_handle.send_input(cmd_str + "\n"),
@@ -699,7 +700,7 @@ class DaytonaSandboxSession(BaseSandboxSession):
                     timeout=exec_timeout,
                 )
                 entry.cmd_id = resp.cmd_id
-                asyncio.create_task(
+                entry.worker_task = asyncio.create_task(
                     self._run_session_reader(
                         entry,
                         daytona_session_id,
@@ -936,6 +937,13 @@ class DaytonaSandboxSession(BaseSandboxSession):
                 await self._sandbox.process.delete_session(entry.daytona_session_id)
         except Exception:
             pass
+        finally:
+            worker_task = entry.worker_task
+            entry.worker_task = None
+            if worker_task is not None and worker_task is not asyncio.current_task():
+                if not worker_task.done():
+                    worker_task.cancel()
+                await asyncio.gather(worker_task, return_exceptions=True)
 
     async def read(self, path: Path | str, *, user: str | User | None = None) -> io.IOBase:
         error_path = posix_path_as_path(coerce_posix_path(path))

--- a/tests/extensions/sandbox/test_daytona.py
+++ b/tests/extensions/sandbox/test_daytona.py
@@ -1526,6 +1526,43 @@ class TestDaytonaSandbox:
         assert entry.done is False
         assert entry.exit_code is None
 
+    @pytest.mark.asyncio
+    async def test_terminate_pty_entry_awaits_worker_finalizer(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        daytona_module = _load_daytona_module(monkeypatch)
+        sandbox = _FakeDaytonaSandbox()
+        state = daytona_module.DaytonaSandboxSessionState(
+            manifest=Manifest(root=daytona_module.DEFAULT_DAYTONA_WORKSPACE_ROOT),
+            snapshot=NoopSnapshot(id="snapshot"),
+            sandbox_id=sandbox.id,
+        )
+        session = daytona_module.DaytonaSandboxSession.from_state(state, sandbox=sandbox)
+        entry = daytona_module._DaytonaPtySessionEntry(  # noqa: SLF001
+            daytona_session_id="session-123",
+            pty_handle=object(),
+            tty=False,
+            cmd_id="cmd-123",
+        )
+        finalizer_finished = asyncio.Event()
+
+        async def worker() -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                await asyncio.sleep(0)
+                finalizer_finished.set()
+
+        entry.worker_task = asyncio.create_task(worker())
+        await asyncio.sleep(0)
+
+        await session._terminate_pty_entry(entry)  # noqa: SLF001
+
+        assert finalizer_finished.is_set()
+        assert entry.worker_task is None
+        assert sandbox.process.delete_session_calls == ["session-123"]
+
 
 # ---------------------------------------------------------------------------
 # DaytonaCloudBucketMountStrategy tests

--- a/tests/extensions/sandbox/test_daytona.py
+++ b/tests/extensions/sandbox/test_daytona.py
@@ -1563,6 +1563,59 @@ class TestDaytonaSandbox:
         assert entry.worker_task is None
         assert sandbox.process.delete_session_calls == ["session-123"]
 
+    @pytest.mark.asyncio
+    async def test_terminate_pty_entry_bounds_worker_finalizer(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        daytona_module = _load_daytona_module(monkeypatch)
+        sandbox = _FakeDaytonaSandbox()
+        state = daytona_module.DaytonaSandboxSessionState(
+            manifest=Manifest(root=daytona_module.DEFAULT_DAYTONA_WORKSPACE_ROOT),
+            snapshot=NoopSnapshot(id="snapshot"),
+            sandbox_id=sandbox.id,
+        )
+        monkeypatch.setattr(state.timeouts, "cleanup_s", 0.01)
+        session = daytona_module.DaytonaSandboxSession.from_state(state, sandbox=sandbox)
+        entry = daytona_module._DaytonaPtySessionEntry(  # noqa: SLF001
+            daytona_session_id="session-123",
+            pty_handle=object(),
+            tty=False,
+            cmd_id="cmd-123",
+        )
+        logs_started = asyncio.Event()
+        finalizer_started = asyncio.Event()
+
+        async def read_logs(*_args: object) -> None:
+            logs_started.set()
+            await asyncio.Event().wait()
+
+        async def get_command(*_args: object) -> object:
+            finalizer_started.set()
+            await asyncio.Event().wait()
+            return types.SimpleNamespace(exit_code=None)
+
+        monkeypatch.setattr(sandbox.process, "get_session_command_logs_async", read_logs)
+        monkeypatch.setattr(sandbox.process, "get_session_command", get_command)
+
+        worker_task = asyncio.create_task(
+            session._run_session_reader(  # noqa: SLF001
+                entry,
+                "session-123",
+                "cmd-123",
+                lambda _chunk: None,
+            )
+        )
+        entry.worker_task = worker_task
+        await logs_started.wait()
+
+        await asyncio.wait_for(session._terminate_pty_entry(entry), timeout=0.5)  # noqa: SLF001
+
+        assert finalizer_started.is_set()
+        assert worker_task.done()
+        assert entry.worker_task is None
+        assert sandbox.process.delete_session_calls == ["session-123"]
+
 
 # ---------------------------------------------------------------------------
 # DaytonaCloudBucketMountStrategy tests


### PR DESCRIPTION
This pull request fixes Daytona PTY session cleanup by retaining each background waiter or log-reader task on its owning PTY entry.

Termination now cancels and awaits the exact worker after provider cleanup, including its asynchronous finalizer. This prevents stop, shutdown, pruning, and partial-startup cleanup from leaving unowned Daytona worker tasks running. The change does not affect public APIs or serialized session state.