### PR TITLE
fix(sandbox): own Docker deferred cleanup tasks

### DIFF
--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -482,7 +482,8 @@ class DockerSandboxSession(BaseSandboxSession):
     async def _after_stop(self) -> None:
         await self._wait_for_cleanup_tasks()
 
-    async def _after_shutdown(self) -> None:
+    async def _before_shutdown(self) -> None:
+        await super()._before_shutdown()
         await self._wait_for_cleanup_tasks()
 
     def _mark_workspace_root_ready_from_probe(self) -> None:

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -230,6 +230,7 @@ class DockerSandboxSession(BaseSandboxSession):
     _pty_lock: asyncio.Lock
     _pty_processes: dict[int, _DockerPtyProcessEntry]
     _reserved_pty_process_ids: set[int]
+    _cleanup_tasks: set[asyncio.Task[None]]
 
     state: DockerSandboxSessionState
     _ARCHIVE_STAGING_DIR: Path = posix_path_as_path(
@@ -251,6 +252,7 @@ class DockerSandboxSession(BaseSandboxSession):
         self._pty_lock = asyncio.Lock()
         self._pty_processes = {}
         self._reserved_pty_process_ids = set()
+        self._cleanup_tasks = set()
 
     @classmethod
     def from_state(
@@ -475,6 +477,12 @@ class DockerSandboxSession(BaseSandboxSession):
     async def _after_start(self) -> None:
         self._workspace_root_ready = True
         self._resume_workspace_probe_pending = False
+
+    async def _after_stop(self) -> None:
+        await self._wait_for_cleanup_tasks()
+
+    async def _after_shutdown(self) -> None:
+        await self._wait_for_cleanup_tasks()
 
     def _mark_workspace_root_ready_from_probe(self) -> None:
         super()._mark_workspace_root_ready_from_probe()
@@ -1394,7 +1402,13 @@ class DockerSandboxSession(BaseSandboxSession):
 
     def _schedule_rm_best_effort(self, path: Path) -> None:
         loop = asyncio.get_running_loop()
-        loop.create_task(self._rm_best_effort(path))
+        task = loop.create_task(self._rm_best_effort(path))
+        self._cleanup_tasks.add(task)
+        task.add_done_callback(self._cleanup_tasks.discard)
+
+    async def _wait_for_cleanup_tasks(self) -> None:
+        while cleanup_tasks := tuple(self._cleanup_tasks):
+            await asyncio.gather(*cleanup_tasks, return_exceptions=True)
 
     def _workspace_archive_stream(
         self,

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -89,6 +89,7 @@ logger = logging.getLogger(__name__)
 # Non-seekable payloads are spooled to measure their length; keep small ones in
 # RAM and spill larger ones to a temp file so a big upload can't OOM the process.
 _STREAM_SPOOL_MAX_SIZE = 16 * 1024 * 1024
+_DEFERRED_CLEANUP_TIMEOUT_S = 30.0
 
 
 def _measure_stream(stream: io.IOBase) -> tuple[int, io.IOBase, io.IOBase | None]:
@@ -1407,8 +1408,19 @@ class DockerSandboxSession(BaseSandboxSession):
         task.add_done_callback(self._cleanup_tasks.discard)
 
     async def _wait_for_cleanup_tasks(self) -> None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _DEFERRED_CLEANUP_TIMEOUT_S
         while cleanup_tasks := tuple(self._cleanup_tasks):
-            await asyncio.gather(*cleanup_tasks, return_exceptions=True)
+            remaining_s = deadline - loop.time()
+            if remaining_s <= 0:
+                break
+            done, pending = await asyncio.wait(cleanup_tasks, timeout=remaining_s)
+            self._cleanup_tasks.difference_update(done)
+            if pending:
+                break
+
+        for task in tuple(self._cleanup_tasks):
+            task.cancel()
 
     def _workspace_archive_stream(
         self,

--- a/tests/sandbox/test_docker.py
+++ b/tests/sandbox/test_docker.py
@@ -677,9 +677,10 @@ async def test_docker_persist_workspace_defers_stage_cleanup_until_archive_close
     assert session.stage_cleanup_calls == []
 
     _ = archive.read()
-    await asyncio.sleep(0)
+    await session._wait_for_cleanup_tasks()
 
     assert session.stage_cleanup_calls == [session.last_staging_parent]
+    assert session._cleanup_tasks == set()
 
 
 def test_docker_start_exec_socket_closes_underlying_http_response() -> None:

--- a/tests/sandbox/test_docker.py
+++ b/tests/sandbox/test_docker.py
@@ -684,6 +684,47 @@ async def test_docker_persist_workspace_defers_stage_cleanup_until_archive_close
 
 
 @pytest.mark.asyncio
+async def test_docker_shutdown_drains_deferred_cleanup_before_backend_stop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host_root = tmp_path / "container"
+    host_root.mkdir()
+    session = _CleanupTrackingDockerSession(
+        host_root=host_root,
+        manifest=Manifest(root="/workspace"),
+    )
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    events: list[str] = []
+
+    async def blocked_cleanup(_path: Path) -> None:
+        cleanup_started.set()
+        await release_cleanup.wait()
+        events.append("cleanup")
+
+    async def shutdown_backend() -> None:
+        events.append("shutdown")
+
+    monkeypatch.setattr(session, "_rm_best_effort", blocked_cleanup)
+    monkeypatch.setattr(session, "_shutdown_backend", shutdown_backend)
+
+    session._schedule_rm_best_effort(Path("/tmp/stage"))
+    await cleanup_started.wait()
+
+    shutdown_task = asyncio.create_task(session.shutdown())
+    await asyncio.sleep(0)
+
+    assert events == []
+
+    release_cleanup.set()
+    await shutdown_task
+
+    assert events == ["cleanup", "shutdown"]
+    assert session._cleanup_tasks == set()
+
+
+@pytest.mark.asyncio
 async def test_docker_after_stop_bounds_deferred_cleanup_wait(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/sandbox/test_docker.py
+++ b/tests/sandbox/test_docker.py
@@ -683,6 +683,49 @@ async def test_docker_persist_workspace_defers_stage_cleanup_until_archive_close
     assert session._cleanup_tasks == set()
 
 
+@pytest.mark.asyncio
+async def test_docker_after_stop_bounds_deferred_cleanup_wait(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host_root = tmp_path / "container"
+    host_root.mkdir()
+    session = _CleanupTrackingDockerSession(
+        host_root=host_root,
+        manifest=Manifest(root="/workspace"),
+    )
+    cleanup_started = asyncio.Event()
+    cleanup_cancelled = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def stalled_cleanup(_path: Path) -> None:
+        cleanup_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_cancelled.set()
+            await release_cleanup.wait()
+
+    monkeypatch.setattr(docker_sandbox, "_DEFERRED_CLEANUP_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(session, "_rm_best_effort", stalled_cleanup)
+
+    session._schedule_rm_best_effort(Path("/tmp/stage"))
+    cleanup_task = next(iter(session._cleanup_tasks))
+    await cleanup_started.wait()
+
+    await asyncio.wait_for(session._after_stop(), timeout=0.5)
+    await asyncio.wait_for(cleanup_cancelled.wait(), timeout=0.5)
+
+    assert cleanup_task in session._cleanup_tasks
+    assert not cleanup_task.done()
+
+    release_cleanup.set()
+    await cleanup_task
+    await asyncio.sleep(0)
+
+    assert session._cleanup_tasks == set()
+
+
 def test_docker_start_exec_socket_closes_underlying_http_response() -> None:
     api = _SocketStartAPI()
 


### PR DESCRIPTION
This pull request fixes unowned Docker workspace cleanup tasks created when persisted archive streams are closed.

The Docker sandbox session now retains deferred cleanup tasks, removes them after completion, and waits for outstanding cleanup during stop and shutdown. The regression test now deterministically drains cleanup tasks and verifies that no owned tasks remain.