### PR TITLE
feat: add hosted multi-agent beta support

### DIFF
--- a/examples/agent_patterns/README.md
+++ b/examples/agent_patterns/README.md
@@ -2,6 +2,10 @@
 
 This folder contains examples of different common patterns for agents.
 
+## Hosted multi-agent (experimental)
+
+The Responses API can coordinate server-hosted GPT-5.6 subagents while the normal SDK Runner executes developer-defined function tools locally. See [`hosted_multi_agent_beta.py`](./hosted_multi_agent_beta.py) for non-streaming and streaming examples using the experimental model module.
+
 ## Deterministic flows
 
 A common tactic is to break down a task into a series of smaller steps. Each task can be performed by an agent, and the output of one agent is used as input to the next. For example, if your task was to generate a story, you could break it down into the following steps:

--- a/examples/agent_patterns/hosted_multi_agent_beta.py
+++ b/examples/agent_patterns/hosted_multi_agent_beta.py
@@ -1,5 +1,5 @@
 # Copy/paste command (does not modify uv.lock):
-# uv run --frozen --with 'openai[realtime]==2.45.0' --exclude-newer-package 'openai=2026-07-10T00:00:00Z' -m examples.agent_patterns.hosted_multi_agent_beta --mode stream
+# uv run -m examples.agent_patterns.hosted_multi_agent_beta --mode stream
 
 import argparse
 import asyncio

--- a/examples/agent_patterns/hosted_multi_agent_beta.py
+++ b/examples/agent_patterns/hosted_multi_agent_beta.py
@@ -1,0 +1,92 @@
+# Copy/paste command (does not modify uv.lock):
+# uv run --frozen --with 'openai[realtime]==2.45.0' --exclude-newer-package 'openai=2026-07-10T00:00:00Z' -m examples.agent_patterns.hosted_multi_agent_beta --mode stream
+
+import argparse
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from agents import Agent, Runner, function_tool
+from agents.extensions.experimental.hosted_multi_agent import (
+    OpenAIHostedMultiAgentModel,
+    get_hosted_agent_metadata,
+)
+from agents.tool_context import ToolContext
+
+PROPOSALS = {
+    "alpha": {"estimated_weeks": 6, "risk": "medium"},
+    "beta": {"estimated_weeks": 8, "risk": "low"},
+}
+
+
+@function_tool
+def get_proposal(ctx: ToolContext[Any], proposal: str) -> dict[str, object]:
+    """Return deterministic details for one proposal."""
+    metadata = get_hosted_agent_metadata(ctx)
+    caller = metadata.agent_name if metadata else "unknown"
+    print(f"local tool caller={caller} call_id={ctx.tool_call_id} proposal={proposal}")
+    if proposal not in PROPOSALS:
+        raise ValueError(f"Unknown proposal: {proposal}")
+    return PROPOSALS[proposal]
+
+
+def build_agent() -> Agent[Any]:
+    return Agent(
+        name="Hosted proposal coordinator",
+        instructions=(
+            "Create two subagents. Ask one to inspect proposal alpha and the other to inspect "
+            "proposal beta. Each subagent must call get_proposal for its assigned proposal. "
+            "Wait for both results, then return one concise comparison from the root agent."
+        ),
+        model=OpenAIHostedMultiAgentModel(
+            model="gpt-5.6-sol",
+            config={"max_concurrent_subagents": 3},
+        ),
+        tools=[get_proposal],
+    )
+
+
+def log_hosted_event(event: object) -> None:
+    if getattr(event, "type", None) != "response.output_item.done":
+        return
+    item = getattr(event, "item", None)
+    item_type = item.get("type") if isinstance(item, Mapping) else getattr(item, "type", None)
+    metadata = get_hosted_agent_metadata(item)
+    is_hosted_item = item_type in {
+        "agent_message",
+        "multi_agent_call",
+        "multi_agent_call_output",
+    }
+    is_subagent_message = (
+        item_type == "message" and metadata is not None and metadata.agent_name != "/root"
+    )
+    if is_hosted_item or is_subagent_message:
+        caller = metadata.agent_name if metadata else "unknown"
+        print(f"hosted item type={item_type} agent={caller}")
+
+
+async def run_nonstreamed() -> None:
+    result = await Runner.run(build_agent(), "Compare proposal alpha and proposal beta.")
+    print(f"\nFinal response:\n{result.final_output}")
+
+
+async def run_streamed() -> None:
+    result = Runner.run_streamed(build_agent(), "Compare proposal alpha and proposal beta.")
+    async for event in result.stream_events():
+        if event.type == "raw_response_event":
+            log_hosted_event(event.data)
+    print(f"\nFinal response:\n{result.final_output}")
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("nonstream", "stream"), default="nonstream")
+    args = parser.parse_args()
+    if args.mode == "stream":
+        await run_streamed()
+    else:
+        await run_nonstreamed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "OpenAI", email = "support@openai.com" }]
 dependencies = [
-    "openai>=2.36.0,<3",
+    "openai>=2.45.0,<3",
     "pydantic>=2.12.2, <3",
     "griffelib>=2, <3",
     "typing-extensions>=4.12.2, <5",

--- a/src/agents/extensions/experimental/__init__.py
+++ b/src/agents/extensions/experimental/__init__.py
@@ -3,4 +3,5 @@
 
 __all__ = [
     "codex",
+    "hosted_multi_agent",
 ]

--- a/src/agents/extensions/experimental/hosted_multi_agent/__init__.py
+++ b/src/agents/extensions/experimental/hosted_multi_agent/__init__.py
@@ -1,0 +1,15 @@
+"""Experimental OpenAI Responses hosted multi-agent support."""
+
+from .model import (
+    HostedAgentMetadata,
+    HostedMultiAgentConfig,
+    OpenAIHostedMultiAgentModel,
+    get_hosted_agent_metadata,
+)
+
+__all__ = [
+    "HostedAgentMetadata",
+    "HostedMultiAgentConfig",
+    "OpenAIHostedMultiAgentModel",
+    "get_hosted_agent_metadata",
+]

--- a/src/agents/extensions/experimental/hosted_multi_agent/model.py
+++ b/src/agents/extensions/experimental/hosted_multi_agent/model.py
@@ -33,6 +33,7 @@ from ....models._response_terminal import (
     response_error_event_failure_error,
     response_terminal_failure_error,
 )
+from ....models._run_context import get_model_run_owner
 from ....models.openai_responses import OpenAIResponsesModel
 from ....tool import Tool
 from ....tool_context import ToolContext
@@ -104,6 +105,7 @@ class _ActiveWebSocketResponse:
     manager: Any
     connection: Any
     loop: asyncio.AbstractEventLoop
+    owner: object
     response_id: str | None = None
     response_template: object | None = None
     pending_call_ids: set[str] = field(default_factory=set)
@@ -535,6 +537,7 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
     async def _start_active_response(
         self,
         create_kwargs: dict[str, Any],
+        owner: object,
     ) -> _ActiveWebSocketResponse:
         frame, headers, query = self._prepare_websocket_request(create_kwargs)
         responses = self._get_beta_responses()
@@ -557,6 +560,7 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
             manager=manager,
             connection=connection,
             loop=asyncio.get_running_loop(),
+            owner=owner,
         )
         try:
             await connection.send(frame)
@@ -590,8 +594,10 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         self._request_lock = None
         self._request_lock_loop_ref = None
 
-    async def _cleanup_on_run_end(self) -> None:
-        await self._close_active_response()
+    async def _cleanup_on_run_end(self, owner: object) -> None:
+        active = self._active_response
+        if active is not None and active.owner is owner:
+            await self._close_active_response(active)
 
     @staticmethod
     def _matching_function_outputs(
@@ -746,12 +752,25 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         create_kwargs: dict[str, Any],
     ) -> AsyncIterator[ResponseStreamEvent]:
         reached_boundary = False
+        owner = get_model_run_owner()
+        if owner is None:
+            owner = asyncio.current_task()
+        if owner is None:
+            raise UserError("Hosted multi-agent could not identify the current model run.")
         async with self._get_request_lock():
             active = self._active_response
+            owns_active = False
             try:
                 if active is None:
-                    active = await self._start_active_response(create_kwargs)
+                    active = await self._start_active_response(create_kwargs, owner)
+                    owns_active = True
                 else:
+                    if active.owner is not owner:
+                        raise UserError(
+                            "OpenAIHostedMultiAgentModel already has a paused response owned by "
+                            "another agent run. Use a separate model instance for concurrent runs."
+                        )
+                    owns_active = True
                     if active.loop is not asyncio.get_running_loop():
                         raise UserError(
                             "An active hosted multi-agent WebSocket response cannot be resumed "
@@ -882,7 +901,7 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
                     )
                     return
             except BaseException:
-                if not reached_boundary:
+                if owns_active and not reached_boundary:
                     with contextlib.suppress(Exception):
                         await self._close_active_response(active)
                 raise

--- a/src/agents/extensions/experimental/hosted_multi_agent/model.py
+++ b/src/agents/extensions/experimental/hosted_multi_agent/model.py
@@ -9,7 +9,9 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, cast, get_args, overload
 
 from openai import AsyncOpenAI
+from openai.resources.beta.responses.responses import AsyncResponsesConnection
 from openai.types import ChatModel
+from openai.types.beta.beta_responses_client_event_param import BetaResponsesClientEventParam
 from openai.types.responses import (
     Response,
     ResponseCompletedEvent,
@@ -34,7 +36,7 @@ from ....models._response_terminal import (
     response_terminal_failure_error,
 )
 from ....models._run_context import get_model_run_owner
-from ....models.openai_responses import OpenAIResponsesModel
+from ....models.openai_responses import OpenAIResponsesModel, _is_openai_omitted_value
 from ....tool import Tool
 from ....tool_context import ToolContext
 
@@ -61,6 +63,13 @@ def _stable_response_output_types() -> frozenset[str]:
 
 
 _STABLE_RESPONSE_OUTPUT_TYPES = _stable_response_output_types()
+
+
+async def _send_websocket_event(
+    connection: AsyncResponsesConnection,
+    event: dict[str, Any],
+) -> None:
+    await connection.send(cast(BetaResponsesClientEventParam, event))
 
 
 @dataclass(frozen=True)
@@ -102,8 +111,7 @@ class _PendingInjection:
 
 @dataclass
 class _ActiveWebSocketResponse:
-    manager: Any
-    connection: Any
+    connection: AsyncResponsesConnection
     loop: asyncio.AbstractEventLoop
     owner: object
     response_id: str | None = None
@@ -455,19 +463,6 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         kwargs["betas"] = [_BETA_ID]
         return kwargs
 
-    def _get_beta_responses(self) -> Any:
-        client = self._get_client()
-        beta = getattr(client, "beta", None)
-        responses = getattr(beta, "responses", None)
-        connect = getattr(responses, "connect", None)
-        if not callable(connect):
-            raise UserError(
-                "OpenAIHostedMultiAgentModel requires an OpenAI Python beta build that "
-                "provides client.beta.responses.connect. Install openai[realtime]>=2.45.0 "
-                "before using this experimental model."
-            )
-        return responses
-
     def _get_request_lock(self) -> asyncio.Lock:
         loop = asyncio.get_running_loop()
         if (
@@ -478,10 +473,6 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
             self._request_lock = asyncio.Lock()
             self._request_lock_loop_ref = weakref.ref(loop)
         return self._request_lock
-
-    @staticmethod
-    def _is_omitted(value: object) -> bool:
-        return value.__class__.__name__ in {"NotGiven", "Omit"}
 
     def _prepare_websocket_request(
         self,
@@ -496,14 +487,14 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         kwargs.pop("betas", None)
 
         headers: dict[str, str] = {}
-        if extra_headers is not None and not self._is_omitted(extra_headers):
+        if extra_headers is not None and not _is_openai_omitted_value(extra_headers):
             if not isinstance(extra_headers, Mapping):
                 raise UserError("Hosted multi-agent WebSocket headers must be a mapping.")
             headers.update(
                 {
                     str(key): str(value)
                     for key, value in extra_headers.items()
-                    if not self._is_omitted(value)
+                    if not _is_openai_omitted_value(value)
                 }
             )
         for existing_key in list(headers):
@@ -512,23 +503,23 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         headers["OpenAI-Beta"] = _BETA_ID
 
         query: dict[str, Any] = {}
-        if extra_query is not None and not self._is_omitted(extra_query):
+        if extra_query is not None and not _is_openai_omitted_value(extra_query):
             if not isinstance(extra_query, Mapping):
                 raise UserError("Hosted multi-agent WebSocket query must be a mapping.")
             query.update(extra_query)
 
         frame: dict[str, Any] = {"type": "response.create"}
         for key, value in kwargs.items():
-            if not self._is_omitted(value):
+            if not _is_openai_omitted_value(value):
                 frame[key] = value
-        if extra_body is not None and not self._is_omitted(extra_body):
+        if extra_body is not None and not _is_openai_omitted_value(extra_body):
             if not isinstance(extra_body, Mapping):
                 raise UserError("Hosted multi-agent WebSocket extra_body must be a mapping.")
             frame.update(
                 {
                     str(key): value
                     for key, value in extra_body.items()
-                    if not self._is_omitted(value)
+                    if not _is_openai_omitted_value(value)
                 }
             )
         frame["type"] = "response.create"
@@ -540,33 +531,23 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         owner: object,
     ) -> _ActiveWebSocketResponse:
         frame, headers, query = self._prepare_websocket_request(create_kwargs)
-        responses = self._get_beta_responses()
-        manager = responses.connect(
+        manager = self._get_client().beta.responses.connect(
             extra_headers=headers,
             extra_query=query,
             max_retries=0,
         )
-        try:
-            connection = await manager.enter()
-        except Exception as exc:
-            if "openai[realtime]" in str(exc):
-                raise UserError(
-                    "OpenAIHostedMultiAgentModel requires the openai[realtime] extra. "
-                    "Install openai[realtime]>=2.45.0."
-                ) from exc
-            raise
+        connection = await manager.enter()
 
         active = _ActiveWebSocketResponse(
-            manager=manager,
             connection=connection,
             loop=asyncio.get_running_loop(),
             owner=owner,
         )
         try:
-            await connection.send(frame)
+            await _send_websocket_event(connection, frame)
         except BaseException:
             with contextlib.suppress(Exception):
-                await manager.__aexit__(None, None, None)
+                await connection.close()
             raise
         self._active_response = active
         return active
@@ -587,7 +568,7 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
             if callable(abort):
                 abort()
             return
-        await target.manager.__aexit__(None, None, None)
+        await target.connection.close()
 
     async def close(self) -> None:
         await self._close_active_response()
@@ -647,12 +628,13 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
 
         for output in outputs:
             call_id = cast(str, output["call_id"])
-            await active.connection.send(
+            await _send_websocket_event(
+                active.connection,
                 {
                     "type": "response.inject",
                     "response_id": active.response_id,
                     "input": [output],
-                }
+                },
             )
             active.sent_call_ids.add(call_id)
             active.pending_injections.append(_PendingInjection(call_id=call_id, input_item=output))
@@ -728,7 +710,7 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         continuation_kwargs = dict(create_kwargs)
         continuation_kwargs["input"] = fallback_input
         conversation = continuation_kwargs.get("conversation")
-        if conversation is not None and not self._is_omitted(conversation):
+        if conversation is not None and not _is_openai_omitted_value(conversation):
             continuation_kwargs.pop("previous_response_id", None)
         else:
             continuation_kwargs["previous_response_id"] = response_id
@@ -744,7 +726,7 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         active.fallback_input.clear()
         active.request_count += 1
         active.last_sequence_number = 0
-        await active.connection.send(frame)
+        await _send_websocket_event(active.connection, frame)
         return active
 
     async def _iter_websocket_turn(

--- a/src/agents/extensions/experimental/hosted_multi_agent/model.py
+++ b/src/agents/extensions/experimental/hosted_multi_agent/model.py
@@ -590,6 +590,9 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         self._request_lock = None
         self._request_lock_loop_ref = None
 
+    async def _cleanup_on_run_end(self) -> None:
+        await self._close_active_response()
+
     @staticmethod
     def _matching_function_outputs(
         create_kwargs: dict[str, Any],

--- a/src/agents/extensions/experimental/hosted_multi_agent/model.py
+++ b/src/agents/extensions/experimental/hosted_multi_agent/model.py
@@ -379,12 +379,24 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
     def _validate_beta_settings(
         self,
         model_settings: ModelSettings,
+        tools: list[Tool],
         handoffs: list[Handoff],
     ) -> None:
         if handoffs:
             raise UserError(
                 "OpenAI hosted multi-agent cannot be combined with SDK handoffs. "
                 "Use local function tools or agents-as-tools instead."
+            )
+
+        approval_tool_names = sorted(
+            tool.name for tool in tools if getattr(tool, "needs_approval", False) is not False
+        )
+        if approval_tool_names:
+            tool_names = ", ".join(approval_tool_names)
+            raise UserError(
+                "OpenAI hosted multi-agent does not support SDK tool approval interruptions "
+                "because an active hosted response cannot be restored from serialized RunState. "
+                f"Remove needs_approval from these tools: {tool_names}."
             )
 
         extra_args = model_settings.extra_args or {}
@@ -421,7 +433,7 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         stream: bool = False,
         prompt: ResponsePromptParam | None = None,
     ) -> dict[str, Any]:
-        self._validate_beta_settings(model_settings, handoffs)
+        self._validate_beta_settings(model_settings, tools, handoffs)
         kwargs = super()._build_response_create_kwargs(
             system_instructions=system_instructions,
             input=input,

--- a/src/agents/extensions/experimental/hosted_multi_agent/model.py
+++ b/src/agents/extensions/experimental/hosted_multi_agent/model.py
@@ -1,0 +1,951 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import weakref
+from collections import deque
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast, get_args, overload
+
+from openai import AsyncOpenAI
+from openai.types import ChatModel
+from openai.types.responses import (
+    Response,
+    ResponseCompletedEvent,
+    ResponseFailedEvent,
+    ResponseIncompleteEvent,
+    ResponseOutputItem,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseStreamEvent,
+    ResponseUsage,
+)
+from openai.types.responses.response_prompt_param import ResponsePromptParam
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+from ....agent_output import AgentOutputSchemaBase
+from ....exceptions import UserError
+from ....handoffs import Handoff
+from ....items import TResponseInputItem
+from ....model_settings import ModelSettings
+from ....models._response_terminal import (
+    response_error_event_failure_error,
+    response_terminal_failure_error,
+)
+from ....models.openai_responses import OpenAIResponsesModel
+from ....tool import Tool
+from ....tool_context import ToolContext
+
+_BETA_ID = "responses_multi_agent=v1"
+_ROOT_AGENT_NAME = "/root"
+_HOSTED_PROVIDER_ITEM_TYPES = frozenset(
+    {"agent_message", "multi_agent_call", "multi_agent_call_output"}
+)
+_FUNCTION_CALL_TYPE = "function_call"
+_FUNCTION_OUTPUT_TYPE = "function_call_output"
+_RESPONSE_OUTPUT_ADAPTER: TypeAdapter[ResponseOutputItem] = TypeAdapter(ResponseOutputItem)
+_RESPONSE_USAGE_ADAPTER: TypeAdapter[ResponseUsage] = TypeAdapter(ResponseUsage)
+
+
+def _stable_response_output_types() -> frozenset[str]:
+    annotated_args = get_args(ResponseOutputItem)
+    output_union = annotated_args[0] if annotated_args else ResponseOutputItem
+    item_types: set[str] = set()
+    for output_class in get_args(output_union):
+        type_field = getattr(output_class, "model_fields", {}).get("type")
+        annotation = getattr(type_field, "annotation", None)
+        item_types.update(value for value in get_args(annotation) if isinstance(value, str))
+    return frozenset(item_types)
+
+
+_STABLE_RESPONSE_OUTPUT_TYPES = _stable_response_output_types()
+
+
+@dataclass(frozen=True)
+class HostedMultiAgentConfig:
+    """Configuration for the Responses API hosted multi-agent beta."""
+
+    max_concurrent_subagents: int | None = None
+    """Maximum active subagents across the hosted tree, excluding the root agent."""
+
+    def __post_init__(self) -> None:
+        value = self.max_concurrent_subagents
+        if value is not None and (isinstance(value, bool) or value <= 0):
+            raise ValueError("max_concurrent_subagents must be a positive integer or None.")
+
+
+def _normalize_hosted_multi_agent_config(
+    config: HostedMultiAgentConfig | Mapping[str, Any] | None,
+) -> HostedMultiAgentConfig:
+    if config is None:
+        return HostedMultiAgentConfig()
+    if isinstance(config, HostedMultiAgentConfig):
+        return config
+    return HostedMultiAgentConfig(**config)
+
+
+@dataclass(frozen=True)
+class HostedAgentMetadata:
+    """Hosted-agent attribution attached to a beta response item."""
+
+    agent_name: str
+    phase: str | None = None
+
+
+@dataclass
+class _PendingInjection:
+    call_id: str
+    input_item: dict[str, Any]
+
+
+@dataclass
+class _ActiveWebSocketResponse:
+    manager: Any
+    connection: Any
+    loop: asyncio.AbstractEventLoop
+    response_id: str | None = None
+    response_template: object | None = None
+    pending_call_ids: set[str] = field(default_factory=set)
+    sent_call_ids: set[str] = field(default_factory=set)
+    pending_injections: deque[_PendingInjection] = field(default_factory=deque)
+    delivered_item_keys: set[tuple[str, str]] = field(default_factory=set)
+    completed_response: object | None = None
+    fallback_input: list[dict[str, Any]] = field(default_factory=list)
+    accumulated_usage: ResponseUsage | None = None
+    request_usages: list[ResponseUsage] = field(default_factory=list)
+    request_count: int = 1
+    last_sequence_number: int = 0
+
+
+def _get_field(value: object, name: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def get_hosted_agent_metadata(value: object) -> HostedAgentMetadata | None:
+    """Return hosted-agent attribution from an item or function-tool context."""
+
+    if isinstance(value, ToolContext):
+        value = value.tool_call
+    else:
+        tool_call = _get_field(value, "tool_call")
+        if tool_call is not None:
+            value = tool_call
+
+    if value is None:
+        return None
+
+    agent = _get_field(value, "agent")
+    agent_name = _get_field(agent, "agent_name") if agent is not None else None
+    if not isinstance(agent_name, str) or not agent_name:
+        return None
+
+    phase = _get_field(value, "phase")
+    return HostedAgentMetadata(
+        agent_name=agent_name,
+        phase=phase if isinstance(phase, str) else None,
+    )
+
+
+def _model_dump(value: object) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="python", exclude_unset=True, warnings=False)
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return cast(dict[str, Any], model_dump(mode="python", exclude_unset=True))
+    data = getattr(value, "__dict__", None)
+    if isinstance(data, dict):
+        return dict(data)
+    raise UserError(f"Unsupported hosted multi-agent response value: {type(value).__name__}")
+
+
+def _is_root_final_message(payload: Mapping[str, Any]) -> bool:
+    agent = payload.get("agent")
+    agent_name = _get_field(agent, "agent_name") if agent is not None else None
+    return (
+        payload.get("type") == "message"
+        and agent_name == _ROOT_AGENT_NAME
+        and payload.get("phase") == "final_answer"
+    )
+
+
+def _output_item_key(value: object) -> tuple[str, str] | None:
+    payload = _model_dump(value)
+    item_type = payload.get("type")
+    if not isinstance(item_type, str):
+        return None
+    for field_name in ("id", "call_id"):
+        identifier = payload.get(field_name)
+        if isinstance(identifier, str) and identifier:
+            return item_type, identifier
+    return None
+
+
+def _normalize_output_item(value: object) -> ResponseOutputItem | None:
+    payload = _model_dump(value)
+    item_type = payload.get("type")
+
+    if item_type in _HOSTED_PROVIDER_ITEM_TYPES:
+        return None
+    if item_type == "message" and not _is_root_final_message(payload):
+        return None
+    if not isinstance(item_type, str) or item_type not in _STABLE_RESPONSE_OUTPUT_TYPES:
+        return None
+
+    try:
+        return _RESPONSE_OUTPUT_ADAPTER.validate_python(payload)
+    except ValidationError as exc:
+        raise UserError(
+            f"Hosted multi-agent returned an invalid stable output item of type '{item_type}'."
+        ) from exc
+
+
+def _normalize_output_items(values: list[object]) -> list[ResponseOutputItem]:
+    output: list[ResponseOutputItem] = []
+    for value in values:
+        item = _normalize_output_item(value)
+        if item is not None:
+            output.append(item)
+    return output
+
+
+def _normalize_response_usage(value: object) -> ResponseUsage:
+    normalized = _RESPONSE_USAGE_ADAPTER.validate_python(value, from_attributes=True)
+    input_details = _get_field(value, "input_tokens_details")
+    cache_write_tokens = _get_field(input_details, "cache_write_tokens")
+    if not isinstance(cache_write_tokens, int):
+        return normalized
+
+    normalized_input_details = _model_dump(normalized.input_tokens_details)
+    normalized_input_details["cache_write_tokens"] = cache_write_tokens
+    return normalized.model_copy(
+        update={
+            "input_tokens_details": type(normalized.input_tokens_details).model_validate(
+                normalized_input_details
+            )
+        }
+    )
+
+
+def _merge_response_usage(
+    previous: ResponseUsage | None,
+    current: ResponseUsage,
+) -> ResponseUsage:
+    if previous is None:
+        return current
+
+    payload = current.model_dump(mode="python", exclude_unset=False, warnings=False)
+    payload["input_tokens"] = previous.input_tokens + current.input_tokens
+    payload["output_tokens"] = previous.output_tokens + current.output_tokens
+    payload["total_tokens"] = previous.total_tokens + current.total_tokens
+
+    previous_input_details = _model_dump(previous.input_tokens_details)
+    current_input_details = _model_dump(current.input_tokens_details)
+    merged_input_details = {
+        **previous_input_details,
+        **current_input_details,
+        "cached_tokens": (previous_input_details.get("cached_tokens") or 0)
+        + (current_input_details.get("cached_tokens") or 0),
+        "cache_write_tokens": (previous_input_details.get("cache_write_tokens") or 0)
+        + (current_input_details.get("cache_write_tokens") or 0),
+    }
+    payload["input_tokens_details"] = merged_input_details
+
+    previous_output_details = _model_dump(previous.output_tokens_details)
+    current_output_details = _model_dump(current.output_tokens_details)
+    payload["output_tokens_details"] = {
+        **previous_output_details,
+        **current_output_details,
+        "reasoning_tokens": (previous_output_details.get("reasoning_tokens") or 0)
+        + (current_output_details.get("reasoning_tokens") or 0),
+    }
+    merged = _RESPONSE_USAGE_ADAPTER.validate_python(payload)
+    return merged.model_copy(
+        update={
+            "input_tokens_details": type(current.input_tokens_details).model_validate(
+                merged_input_details
+            )
+        }
+    )
+
+
+def _normalize_response(
+    value: object,
+    *,
+    exclude_item_keys: set[tuple[str, str]] | None = None,
+    fallback_output: list[object] | None = None,
+    accumulated_usage: ResponseUsage | None = None,
+    request_usages: list[ResponseUsage] | None = None,
+    request_count: int = 1,
+) -> Response:
+    payload = _model_dump(value)
+    output = _get_field(value, "output")
+    if not isinstance(output, list):
+        raise UserError("Hosted multi-agent response did not contain an output list.")
+
+    if not output and fallback_output:
+        output = fallback_output
+    if exclude_item_keys:
+        output = [item for item in output if _output_item_key(item) not in exclude_item_keys]
+
+    # Preserve typed nested response fields such as usage while replacing only the output union.
+    normalized_usage = accumulated_usage
+    current_usage: ResponseUsage | None = None
+    for field_name in Response.model_fields:
+        field_value = _get_field(value, field_name)
+        if field_value is not None:
+            if field_name == "usage":
+                current_usage = _normalize_response_usage(field_value)
+                normalized_usage = _merge_response_usage(
+                    normalized_usage,
+                    current_usage,
+                )
+            else:
+                payload[field_name] = field_value
+    if normalized_usage is not None and request_count > 1:
+        individual_usages = list(request_usages or [])
+        if current_usage is not None:
+            individual_usages.append(current_usage)
+        object.__setattr__(
+            normalized_usage,
+            "_agents_sdk_request_usages",
+            individual_usages,
+        )
+        object.__setattr__(normalized_usage, "_agents_sdk_request_count", request_count)
+    payload["usage"] = normalized_usage
+    payload["output"] = _normalize_output_items(output)
+    return Response.model_construct(**payload)
+
+
+def _logical_pause_response(
+    active: _ActiveWebSocketResponse,
+    output: list[object],
+) -> Response:
+    template = active.response_template
+    if template is None or active.response_id is None:
+        raise UserError("Hosted multi-agent received a function call before response.created.")
+
+    payload = _model_dump(template)
+    for field_name in Response.model_fields:
+        field_value = _get_field(template, field_name)
+        if field_value is not None:
+            payload[field_name] = field_value
+    payload["id"] = active.response_id
+    payload["status"] = "completed"
+    payload["usage"] = None
+    payload["output"] = _normalize_output_items(output)
+    return Response.model_construct(**payload)
+
+
+def _construct_event(event_type: str, payload: dict[str, Any]) -> ResponseStreamEvent | None:
+    event_classes: dict[str, type[BaseModel]] = {
+        "response.output_item.added": ResponseOutputItemAddedEvent,
+        "response.output_item.done": ResponseOutputItemDoneEvent,
+        "response.completed": ResponseCompletedEvent,
+        "response.failed": ResponseFailedEvent,
+        "response.incomplete": ResponseIncompleteEvent,
+    }
+    event_class = event_classes.get(event_type)
+    if event_class is None:
+        return None
+    return cast(ResponseStreamEvent, event_class.model_construct(**payload))
+
+
+class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
+    """Experimental Responses model backed by OpenAI-hosted multi-agent orchestration."""
+
+    def __init__(
+        self,
+        model: str | ChatModel,
+        openai_client: AsyncOpenAI | None = None,
+        *,
+        config: HostedMultiAgentConfig | Mapping[str, Any] | None = None,
+        model_is_explicit: bool = True,
+    ) -> None:
+        super().__init__(
+            model=model,
+            openai_client=cast(AsyncOpenAI, openai_client),
+            model_is_explicit=model_is_explicit,
+        )
+        self.config = _normalize_hosted_multi_agent_config(config)
+        self._active_response: _ActiveWebSocketResponse | None = None
+        self._request_lock: asyncio.Lock | None = None
+        self._request_lock_loop_ref: weakref.ReferenceType[asyncio.AbstractEventLoop] | None = None
+
+    def _validate_beta_settings(
+        self,
+        model_settings: ModelSettings,
+        handoffs: list[Handoff],
+    ) -> None:
+        if handoffs:
+            raise UserError(
+                "OpenAI hosted multi-agent cannot be combined with SDK handoffs. "
+                "Use local function tools or agents-as-tools instead."
+            )
+
+        extra_args = model_settings.extra_args or {}
+        extra_body = (
+            model_settings.extra_body if isinstance(model_settings.extra_body, Mapping) else {}
+        )
+        for reserved_key in ("multi_agent", "betas"):
+            if reserved_key in extra_args or reserved_key in extra_body:
+                raise UserError(
+                    f"Configure '{reserved_key}' through OpenAIHostedMultiAgentModel, "
+                    "not ModelSettings."
+                )
+
+        if "max_tool_calls" in extra_args or "max_tool_calls" in extra_body:
+            raise UserError("max_tool_calls is not supported by the hosted multi-agent beta.")
+
+        if model_settings.reasoning is not None:
+            reasoning = _model_dump(model_settings.reasoning)
+            if reasoning.get("summary") is not None:
+                raise UserError(
+                    "reasoning.summary is not supported by the hosted multi-agent beta."
+                )
+
+    def _build_response_create_kwargs(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        previous_response_id: str | None = None,
+        conversation_id: str | None = None,
+        stream: bool = False,
+        prompt: ResponsePromptParam | None = None,
+    ) -> dict[str, Any]:
+        self._validate_beta_settings(model_settings, handoffs)
+        kwargs = super()._build_response_create_kwargs(
+            system_instructions=system_instructions,
+            input=input,
+            model_settings=model_settings,
+            tools=tools,
+            output_schema=output_schema,
+            handoffs=handoffs,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            stream=stream,
+            prompt=prompt,
+        )
+        multi_agent: dict[str, Any] = {"enabled": True}
+        if self.config.max_concurrent_subagents is not None:
+            multi_agent["max_concurrent_subagents"] = self.config.max_concurrent_subagents
+        kwargs["multi_agent"] = multi_agent
+        kwargs["betas"] = [_BETA_ID]
+        return kwargs
+
+    def _get_beta_responses(self) -> Any:
+        client = self._get_client()
+        beta = getattr(client, "beta", None)
+        responses = getattr(beta, "responses", None)
+        connect = getattr(responses, "connect", None)
+        if not callable(connect):
+            raise UserError(
+                "OpenAIHostedMultiAgentModel requires an OpenAI Python beta build that "
+                "provides client.beta.responses.connect. Install openai[realtime]>=2.45.0 "
+                "before using this experimental model."
+            )
+        return responses
+
+    def _get_request_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        if (
+            self._request_lock is None
+            or self._request_lock_loop_ref is None
+            or self._request_lock_loop_ref() is not loop
+        ):
+            self._request_lock = asyncio.Lock()
+            self._request_lock_loop_ref = weakref.ref(loop)
+        return self._request_lock
+
+    @staticmethod
+    def _is_omitted(value: object) -> bool:
+        return value.__class__.__name__ in {"NotGiven", "Omit"}
+
+    def _prepare_websocket_request(
+        self,
+        create_kwargs: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, str], dict[str, Any]]:
+        kwargs = dict(create_kwargs)
+        extra_headers = kwargs.pop("extra_headers", None)
+        extra_query = kwargs.pop("extra_query", None)
+        extra_body = kwargs.pop("extra_body", None)
+        kwargs.pop("timeout", None)
+        kwargs.pop("stream", None)
+        kwargs.pop("betas", None)
+
+        headers: dict[str, str] = {}
+        if extra_headers is not None and not self._is_omitted(extra_headers):
+            if not isinstance(extra_headers, Mapping):
+                raise UserError("Hosted multi-agent WebSocket headers must be a mapping.")
+            headers.update(
+                {
+                    str(key): str(value)
+                    for key, value in extra_headers.items()
+                    if not self._is_omitted(value)
+                }
+            )
+        for existing_key in list(headers):
+            if existing_key.lower() == "openai-beta":
+                del headers[existing_key]
+        headers["OpenAI-Beta"] = _BETA_ID
+
+        query: dict[str, Any] = {}
+        if extra_query is not None and not self._is_omitted(extra_query):
+            if not isinstance(extra_query, Mapping):
+                raise UserError("Hosted multi-agent WebSocket query must be a mapping.")
+            query.update(extra_query)
+
+        frame: dict[str, Any] = {"type": "response.create"}
+        for key, value in kwargs.items():
+            if not self._is_omitted(value):
+                frame[key] = value
+        if extra_body is not None and not self._is_omitted(extra_body):
+            if not isinstance(extra_body, Mapping):
+                raise UserError("Hosted multi-agent WebSocket extra_body must be a mapping.")
+            frame.update(
+                {
+                    str(key): value
+                    for key, value in extra_body.items()
+                    if not self._is_omitted(value)
+                }
+            )
+        frame["type"] = "response.create"
+        return frame, headers, query
+
+    async def _start_active_response(
+        self,
+        create_kwargs: dict[str, Any],
+    ) -> _ActiveWebSocketResponse:
+        frame, headers, query = self._prepare_websocket_request(create_kwargs)
+        responses = self._get_beta_responses()
+        manager = responses.connect(
+            extra_headers=headers,
+            extra_query=query,
+            max_retries=0,
+        )
+        try:
+            connection = await manager.enter()
+        except Exception as exc:
+            if "openai[realtime]" in str(exc):
+                raise UserError(
+                    "OpenAIHostedMultiAgentModel requires the openai[realtime] extra. "
+                    "Install openai[realtime]>=2.45.0."
+                ) from exc
+            raise
+
+        active = _ActiveWebSocketResponse(
+            manager=manager,
+            connection=connection,
+            loop=asyncio.get_running_loop(),
+        )
+        try:
+            await connection.send(frame)
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await manager.__aexit__(None, None, None)
+            raise
+        self._active_response = active
+        return active
+
+    async def _close_active_response(
+        self,
+        active: _ActiveWebSocketResponse | None = None,
+    ) -> None:
+        target = active or self._active_response
+        if target is None:
+            return
+        if self._active_response is target:
+            self._active_response = None
+        if target.loop is not asyncio.get_running_loop():
+            connection = getattr(target.connection, "_connection", target.connection)
+            transport = getattr(connection, "transport", None)
+            abort = getattr(transport, "abort", None)
+            if callable(abort):
+                abort()
+            return
+        await target.manager.__aexit__(None, None, None)
+
+    async def close(self) -> None:
+        await self._close_active_response()
+        self._request_lock = None
+        self._request_lock_loop_ref = None
+
+    @staticmethod
+    def _matching_function_outputs(
+        create_kwargs: dict[str, Any],
+        active: _ActiveWebSocketResponse,
+    ) -> list[dict[str, Any]]:
+        request_input = create_kwargs.get("input")
+        if not isinstance(request_input, list):
+            return []
+
+        outputs: list[dict[str, Any]] = []
+        for item in request_input:
+            try:
+                payload = _model_dump(item)
+            except UserError:
+                continue
+            call_id = payload.get("call_id")
+            if (
+                payload.get("type") == _FUNCTION_OUTPUT_TYPE
+                and isinstance(call_id, str)
+                and call_id in active.pending_call_ids
+                and call_id not in active.sent_call_ids
+            ):
+                outputs.append(payload)
+        return outputs
+
+    async def _inject_function_outputs(
+        self,
+        active: _ActiveWebSocketResponse,
+        create_kwargs: dict[str, Any],
+    ) -> None:
+        unsent_call_ids = active.pending_call_ids - active.sent_call_ids
+        if not unsent_call_ids:
+            return
+
+        outputs = self._matching_function_outputs(create_kwargs, active)
+        output_call_ids = {
+            cast(str, item["call_id"]) for item in outputs if isinstance(item.get("call_id"), str)
+        }
+        missing_call_ids = unsent_call_ids - output_call_ids
+        if missing_call_ids:
+            missing = ", ".join(sorted(missing_call_ids))
+            raise UserError(
+                "OpenAIHostedMultiAgentModel has an active response waiting for function "
+                f"outputs, but the next model input did not contain outputs for: {missing}."
+            )
+
+        for output in outputs:
+            call_id = cast(str, output["call_id"])
+            await active.connection.send(
+                {
+                    "type": "response.inject",
+                    "response_id": active.response_id,
+                    "input": [output],
+                }
+            )
+            active.sent_call_ids.add(call_id)
+            active.pending_injections.append(_PendingInjection(call_id=call_id, input_item=output))
+
+    @staticmethod
+    def _record_created_event(active: _ActiveWebSocketResponse, event: object) -> None:
+        response = _get_field(event, "response")
+        response_id = _get_field(response, "id") if response is not None else None
+        if not isinstance(response_id, str) or not response_id:
+            raise UserError("Hosted multi-agent response.created did not contain a response ID.")
+        active.response_id = response_id
+        active.response_template = response
+
+    @staticmethod
+    def _record_injection_ack(active: _ActiveWebSocketResponse) -> None:
+        if not active.pending_injections:
+            raise UserError(
+                "Hosted multi-agent received response.inject.created without a pending injection."
+            )
+        pending = active.pending_injections.popleft()
+        active.pending_call_ids.discard(pending.call_id)
+        active.sent_call_ids.discard(pending.call_id)
+
+    @staticmethod
+    def _record_injection_failure(
+        active: _ActiveWebSocketResponse,
+        event: object,
+    ) -> None:
+        if not active.pending_injections:
+            raise UserError(
+                "Hosted multi-agent received response.inject.failed without a pending injection."
+            )
+        pending = active.pending_injections.popleft()
+        active.pending_call_ids.discard(pending.call_id)
+        active.sent_call_ids.discard(pending.call_id)
+
+        error = _get_field(event, "error")
+        code = _get_field(error, "code") if error is not None else None
+        if code != "response_already_completed":
+            raise UserError(
+                "Hosted multi-agent function output injection failed"
+                + (f" with code '{code}'." if isinstance(code, str) else ".")
+            )
+
+        failed_input = _get_field(event, "input")
+        if not isinstance(failed_input, list):
+            failed_input = [pending.input_item]
+        for item in failed_input:
+            active.fallback_input.append(_model_dump(item))
+
+    async def _restart_after_completed_injection(
+        self,
+        active: _ActiveWebSocketResponse,
+        create_kwargs: dict[str, Any],
+    ) -> _ActiveWebSocketResponse:
+        completed_event = active.completed_response
+        response = _get_field(completed_event, "response") if completed_event is not None else None
+        response_id = _get_field(response, "id") if response is not None else None
+        if not isinstance(response_id, str) or not response_id:
+            raise UserError(
+                "Hosted multi-agent could not continue after a completed response injection."
+            )
+        completed_usage = _get_field(response, "usage")
+        if completed_usage is not None:
+            normalized_completed_usage = _normalize_response_usage(completed_usage)
+            active.request_usages.append(normalized_completed_usage)
+            active.accumulated_usage = _merge_response_usage(
+                active.accumulated_usage,
+                normalized_completed_usage,
+            )
+        fallback_input = list(active.fallback_input)
+
+        continuation_kwargs = dict(create_kwargs)
+        continuation_kwargs["input"] = fallback_input
+        conversation = continuation_kwargs.get("conversation")
+        if conversation is not None and not self._is_omitted(conversation):
+            continuation_kwargs.pop("previous_response_id", None)
+        else:
+            continuation_kwargs["previous_response_id"] = response_id
+
+        frame, _, _ = self._prepare_websocket_request(continuation_kwargs)
+        active.response_id = None
+        active.response_template = None
+        active.pending_call_ids.clear()
+        active.sent_call_ids.clear()
+        active.pending_injections.clear()
+        active.delivered_item_keys.clear()
+        active.completed_response = None
+        active.fallback_input.clear()
+        active.request_count += 1
+        active.last_sequence_number = 0
+        await active.connection.send(frame)
+        return active
+
+    async def _iter_websocket_turn(
+        self,
+        create_kwargs: dict[str, Any],
+    ) -> AsyncIterator[ResponseStreamEvent]:
+        reached_boundary = False
+        async with self._get_request_lock():
+            active = self._active_response
+            try:
+                if active is None:
+                    active = await self._start_active_response(create_kwargs)
+                else:
+                    if active.loop is not asyncio.get_running_loop():
+                        raise UserError(
+                            "An active hosted multi-agent WebSocket response cannot be resumed "
+                            "from a different event loop."
+                        )
+                    await self._inject_function_outputs(active, create_kwargs)
+
+                current_output: list[object] = []
+                while True:
+                    if active.completed_response is not None and not active.pending_injections:
+                        if active.fallback_input:
+                            active = await self._restart_after_completed_injection(
+                                active, create_kwargs
+                            )
+                            current_output = []
+                            continue
+
+                        completed_event = active.completed_response
+                        response = _get_field(completed_event, "response")
+                        if response is None:
+                            raise UserError(
+                                "Hosted multi-agent response.completed did not contain a response."
+                            )
+                        normalized_response = _normalize_response(
+                            response,
+                            exclude_item_keys=active.delivered_item_keys,
+                            fallback_output=current_output,
+                            accumulated_usage=active.accumulated_usage,
+                            request_usages=active.request_usages,
+                            request_count=active.request_count,
+                        )
+                        payload = _model_dump(completed_event)
+                        payload["response"] = normalized_response
+                        normalized_event = _construct_event("response.completed", payload)
+                        if normalized_event is None:
+                            raise UserError(
+                                "Hosted multi-agent could not normalize response.completed."
+                            )
+                        await self._close_active_response(active)
+                        reached_boundary = True
+                        yield normalized_event
+                        return
+
+                    event = await active.connection.recv()
+                    event_type = _get_field(event, "type")
+                    sequence_number = _get_field(event, "sequence_number")
+                    if isinstance(sequence_number, int):
+                        active.last_sequence_number = sequence_number
+
+                    if event_type == "response.created":
+                        self._record_created_event(active, event)
+                    elif event_type == "response.inject.created":
+                        self._record_injection_ack(active)
+                    elif event_type == "response.inject.failed":
+                        self._record_injection_failure(active, event)
+                    elif event_type == "response.completed":
+                        active.completed_response = event
+                        continue
+                    elif event_type in {
+                        "response.failed",
+                        "response.incomplete",
+                        "error",
+                        "response.error",
+                    }:
+                        payload = _model_dump(event)
+                        response = _get_field(event, "response")
+                        if response is not None:
+                            payload["response"] = _normalize_response(
+                                response,
+                                accumulated_usage=active.accumulated_usage,
+                                request_usages=active.request_usages,
+                                request_count=active.request_count,
+                            )
+                        normalized = _construct_event(cast(str, event_type), payload)
+                        await self._close_active_response(active)
+                        reached_boundary = True
+                        yield (
+                            normalized
+                            if normalized is not None
+                            else cast(ResponseStreamEvent, event)
+                        )
+                        return
+
+                    payload = _model_dump(event)
+                    normalized_item: ResponseOutputItem | None = None
+                    if event_type in {"response.output_item.added", "response.output_item.done"}:
+                        item = _get_field(event, "item")
+                        if item is not None:
+                            normalized_item = _normalize_output_item(item)
+                            if normalized_item is not None:
+                                payload["item"] = normalized_item
+                    should_normalize = normalized_item is not None or event_type not in {
+                        "response.output_item.added",
+                        "response.output_item.done",
+                    }
+                    normalized = (
+                        _construct_event(event_type, payload)
+                        if isinstance(event_type, str) and should_normalize
+                        else None
+                    )
+                    yield normalized if normalized is not None else cast(ResponseStreamEvent, event)
+
+                    if event_type != "response.output_item.done":
+                        continue
+                    item = _get_field(event, "item")
+                    if item is None:
+                        continue
+                    current_output.append(item)
+                    if _get_field(item, "type") != _FUNCTION_CALL_TYPE:
+                        continue
+                    call_id = _get_field(item, "call_id")
+                    if not isinstance(call_id, str) or not call_id:
+                        raise UserError(
+                            "Hosted multi-agent function call did not contain a call ID."
+                        )
+                    active.pending_call_ids.add(call_id)
+                    for output_item in current_output:
+                        key = _output_item_key(output_item)
+                        if key is not None:
+                            active.delivered_item_keys.add(key)
+                    logical_response = _logical_pause_response(active, current_output)
+                    reached_boundary = True
+                    yield ResponseCompletedEvent.model_construct(
+                        type="response.completed",
+                        sequence_number=active.last_sequence_number,
+                        response=logical_response,
+                        hosted_multi_agent_pause=True,
+                    )
+                    return
+            except BaseException:
+                if not reached_boundary:
+                    with contextlib.suppress(Exception):
+                        await self._close_active_response(active)
+                raise
+
+    @overload
+    async def _fetch_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        stream: Literal[True],
+        prompt: ResponsePromptParam | None = None,
+    ) -> AsyncIterator[ResponseStreamEvent]: ...
+
+    @overload
+    async def _fetch_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        stream: Literal[False],
+        prompt: ResponsePromptParam | None = None,
+    ) -> Response: ...
+
+    async def _fetch_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[Handoff],
+        previous_response_id: str | None = None,
+        conversation_id: str | None = None,
+        stream: Literal[True] | Literal[False] = False,
+        prompt: ResponsePromptParam | None = None,
+    ) -> Response | AsyncIterator[ResponseStreamEvent]:
+        kwargs = self._build_response_create_kwargs(
+            system_instructions=system_instructions,
+            input=input,
+            model_settings=model_settings,
+            tools=tools,
+            output_schema=output_schema,
+            handoffs=handoffs,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            stream=True,
+            prompt=prompt,
+        )
+        if stream:
+            return self._iter_websocket_turn(kwargs)
+
+        final_response: Response | None = None
+        async for event in self._iter_websocket_turn(kwargs):
+            event_type = _get_field(event, "type")
+            if isinstance(event, ResponseCompletedEvent):
+                final_response = event.response
+            elif event_type in {"response.failed", "response.incomplete"}:
+                response = _get_field(event, "response")
+                raise response_terminal_failure_error(
+                    cast(str, event_type),
+                    response if isinstance(response, Response) else None,
+                )
+            elif event_type in {"error", "response.error"}:
+                raise response_error_event_failure_error(cast(str, event_type), event)
+
+        if final_response is None:
+            raise UserError(
+                "Hosted multi-agent WebSocket turn ended without a logical or terminal response."
+            )
+        return final_response

--- a/src/agents/models/_run_context.py
+++ b/src/agents/models/_run_context.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TypeVar
+
+_MODEL_RUN_OWNER: ContextVar[object | None] = ContextVar("model_run_owner", default=None)
+
+T = TypeVar("T")
+
+
+@contextmanager
+def model_run_context(owner: object) -> Iterator[None]:
+    token = _MODEL_RUN_OWNER.set(owner)
+    try:
+        yield
+    finally:
+        _MODEL_RUN_OWNER.reset(token)
+
+
+def get_model_run_owner() -> object | None:
+    return _MODEL_RUN_OWNER.get()
+
+
+async def model_run_context_stream(
+    stream: AsyncIterator[T],
+    owner: object,
+) -> AsyncIterator[T]:
+    with model_run_context(owner):
+        async for item in stream:
+            yield item

--- a/src/agents/models/interface.py
+++ b/src/agents/models/interface.py
@@ -37,6 +37,10 @@ class ModelTracing(enum.Enum):
 class Model(abc.ABC):
     """The base interface for calling an LLM."""
 
+    async def _cleanup_on_run_end(self) -> None:
+        """Release run-scoped resources after the runner finishes using this model."""
+        return None
+
     async def close(self) -> None:
         """Release any resources held by the model.
 

--- a/src/agents/models/interface.py
+++ b/src/agents/models/interface.py
@@ -37,7 +37,7 @@ class ModelTracing(enum.Enum):
 class Model(abc.ABC):
     """The base interface for calling an LLM."""
 
-    async def _cleanup_on_run_end(self) -> None:
+    async def _cleanup_on_run_end(self, owner: object) -> None:
         """Release run-scoped resources after the runner finishes using this model."""
         return None
 

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -64,7 +64,7 @@ from ..tool import (
     validate_responses_tool_search_configuration,
 )
 from ..tracing import SpanError, response_span
-from ..usage import Usage, model_usage_to_span_usage
+from ..usage import Usage, _response_usage_to_usage, model_usage_to_span_usage
 from ..util._json import _to_dump_compatible
 from ..version import __version__
 from ._openai_retry import get_openai_retry_advice
@@ -493,18 +493,7 @@ class OpenAIResponsesModel(Model):
                         }\n"""
                     )
 
-                usage = (
-                    Usage(
-                        requests=1,
-                        input_tokens=response.usage.input_tokens,
-                        output_tokens=response.usage.output_tokens,
-                        total_tokens=response.usage.total_tokens,
-                        input_tokens_details=response.usage.input_tokens_details,
-                        output_tokens_details=response.usage.output_tokens_details,
-                    )
-                    if response.usage
-                    else Usage()
-                )
+                usage = _response_usage_to_usage(response.usage) if response.usage else Usage()
                 if response.usage:
                     span_response.span_data.usage = model_usage_to_span_usage(usage)
 
@@ -619,14 +608,7 @@ class OpenAIResponsesModel(Model):
                     span_response.span_data.input = input
                 if final_response and final_response.usage:
                     span_response.span_data.usage = model_usage_to_span_usage(
-                        Usage(
-                            requests=1,
-                            input_tokens=final_response.usage.input_tokens,
-                            output_tokens=final_response.usage.output_tokens,
-                            total_tokens=final_response.usage.total_tokens,
-                            input_tokens_details=final_response.usage.input_tokens_details,
-                            output_tokens_details=final_response.usage.output_tokens_details,
-                        )
+                        _response_usage_to_usage(final_response.usage)
                     )
 
             except Exception as e:

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1518,7 +1518,7 @@ class AgentRunner:
                     )
                 raise
             finally:
-                await cleanup_model_after_run(current_agent, run_config)
+                await cleanup_model_after_run(current_agent, run_config, tool_use_tracker)
                 try:
                     try:
                         memory_input = _sandbox_memory_input(

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -82,7 +82,7 @@ from .run_internal.oai_conversation import OpenAIServerConversationTracker
 from .run_internal.prompt_cache_key import PromptCacheKeyResolver
 from .run_internal.run_grouping import resolve_run_grouping_id
 from .run_internal.run_loop import (
-    cleanup_model_after_run,
+    cleanup_models_after_run,
     get_all_tools,
     get_handoffs,
     get_output_schema,
@@ -1518,7 +1518,7 @@ class AgentRunner:
                     )
                 raise
             finally:
-                await cleanup_model_after_run(current_agent, run_config, tool_use_tracker)
+                await cleanup_models_after_run(tool_use_tracker)
                 try:
                     try:
                         memory_input = _sandbox_memory_input(

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -82,6 +82,7 @@ from .run_internal.oai_conversation import OpenAIServerConversationTracker
 from .run_internal.prompt_cache_key import PromptCacheKeyResolver
 from .run_internal.run_grouping import resolve_run_grouping_id
 from .run_internal.run_loop import (
+    cleanup_model_after_run,
     get_all_tools,
     get_handoffs,
     get_output_schema,
@@ -1517,6 +1518,7 @@ class AgentRunner:
                     )
                 raise
             finally:
+                await cleanup_model_after_run(current_agent, run_config)
                 try:
                     try:
                         memory_input = _sandbox_memory_input(

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -62,6 +62,7 @@ from ..models._response_terminal import (
     response_error_event_failure_error,
     response_terminal_failure_error,
 )
+from ..models._run_context import model_run_context, model_run_context_stream
 from ..models.interface import Model
 from ..result import RunResultStreaming
 from ..run_config import ReasoningItemIdPolicy, RunConfig
@@ -260,7 +261,11 @@ __all__ = [
 ]
 
 
-async def cleanup_model_after_run(agent: Agent[Any], run_config: RunConfig) -> None:
+async def cleanup_model_after_run(
+    agent: Agent[Any],
+    run_config: RunConfig,
+    owner: object,
+) -> None:
     """Notify an explicitly configured model that its owning run has ended."""
     model: Model | None = None
     if isinstance(run_config.model, Model):
@@ -272,7 +277,7 @@ async def cleanup_model_after_run(agent: Agent[Any], run_config: RunConfig) -> N
         return
 
     try:
-        await model._cleanup_on_run_end()
+        await model._cleanup_on_run_end(owner)
     except Exception as error:
         logger.warning("Failed to clean up model resources after run: %s", error)
 
@@ -1220,7 +1225,7 @@ async def start_streaming(
     else:
         streamed_result.is_complete = True
     finally:
-        await cleanup_model_after_run(current_agent, run_config)
+        await cleanup_model_after_run(current_agent, run_config, tool_use_tracker)
         _sync_conversation_tracking_from_tracker()
         if streamed_result._input_guardrails_task:
             try:
@@ -1501,7 +1506,7 @@ async def run_single_turn_streamed(
         failed_retry_attempts_out=stream_failed_retry_attempts,
     )
 
-    async for event in retry_stream:
+    async for event in model_run_context_stream(retry_stream, tool_use_tracker):
         streamed_result._event_queue.put_nowait(RawResponsesStreamEvent(data=event))
 
         terminal_response: Response | None = None
@@ -1893,27 +1898,28 @@ async def get_new_response(
         if server_conversation_tracker is not None:
             server_conversation_tracker.rewind_input(filtered.input)
 
-    new_response = await get_response_with_retry(
-        get_response=lambda: model.get_response(
-            system_instructions=filtered.instructions,
-            input=filtered.input,
-            model_settings=model_settings,
-            tools=all_tools,
-            output_schema=output_schema,
-            handoffs=handoffs,
-            tracing=get_model_tracing_impl(
-                run_config.tracing_disabled, run_config.trace_include_sensitive_data
+    with model_run_context(tool_use_tracker):
+        new_response = await get_response_with_retry(
+            get_response=lambda: model.get_response(
+                system_instructions=filtered.instructions,
+                input=filtered.input,
+                model_settings=model_settings,
+                tools=all_tools,
+                output_schema=output_schema,
+                handoffs=handoffs,
+                tracing=get_model_tracing_impl(
+                    run_config.tracing_disabled, run_config.trace_include_sensitive_data
+                ),
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
+                prompt=prompt_config,
             ),
+            rewind=rewind_model_request,
+            retry_settings=model_settings.retry,
+            get_retry_advice=model.get_retry_advice,
             previous_response_id=previous_response_id,
             conversation_id=conversation_id,
-            prompt=prompt_config,
-        ),
-        rewind=rewind_model_request,
-        retry_settings=model_settings.retry,
-        get_retry_advice=model.get_retry_advice,
-        previous_response_id=previous_response_id,
-        conversation_id=conversation_id,
-    )
+        )
     if server_conversation_tracker is not None:
         # Retry helpers rewind sent-input tracking before replaying a failed request. Mark the
         # filtered input as delivered again once a retry succeeds so subsequent turns only send

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -62,6 +62,7 @@ from ..models._response_terminal import (
     response_error_event_failure_error,
     response_terminal_failure_error,
 )
+from ..models.interface import Model
 from ..result import RunResultStreaming
 from ..run_config import ReasoningItemIdPolicy, RunConfig
 from ..run_context import AgentHookContext, RunContextWrapper, TContext
@@ -241,6 +242,7 @@ __all__ = [
     "check_for_final_output_from_tools",
     "get_model_tracing_impl",
     "validate_run_hooks",
+    "cleanup_model_after_run",
     "maybe_filter_model_input",
     "run_input_guardrails_with_queue",
     "start_streaming",
@@ -256,6 +258,23 @@ __all__ = [
     "get_model",
     "input_guardrail_tripwire_triggered_for_stream",
 ]
+
+
+async def cleanup_model_after_run(agent: Agent[Any], run_config: RunConfig) -> None:
+    """Notify an explicitly configured model that its owning run has ended."""
+    model: Model | None = None
+    if isinstance(run_config.model, Model):
+        model = run_config.model
+    elif run_config.model is None and isinstance(agent.model, Model):
+        model = agent.model
+
+    if model is None:
+        return
+
+    try:
+        await model._cleanup_on_run_end()
+    except Exception as error:
+        logger.warning("Failed to clean up model resources after run: %s", error)
 
 
 def _should_attach_generic_agent_error(exc: Exception) -> bool:
@@ -1201,6 +1220,7 @@ async def start_streaming(
     else:
         streamed_result.is_complete = True
     finally:
+        await cleanup_model_after_run(current_agent, run_config)
         _sync_conversation_tracking_from_tracker()
         if streamed_result._input_guardrails_task:
             try:

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -84,7 +84,7 @@ from ..tool import (
 from ..tracing import Span, SpanError, agent_span, get_current_trace, task_span, turn_span
 from ..tracing.model_tracing import get_model_tracing_impl
 from ..tracing.span_data import AgentSpanData, TaskSpanData
-from ..usage import Usage
+from ..usage import Usage, _response_usage_to_usage
 from ..util import _coro, _error_tracing
 from .agent_bindings import AgentBindings, bind_public_agent
 from .agent_runner_helpers import (
@@ -1507,14 +1507,7 @@ async def run_single_turn_streamed(
                 terminal_response.output = list(streamed_response_output)
             usage = (
                 apply_retry_attempt_usage(
-                    Usage(
-                        requests=1,
-                        input_tokens=terminal_response.usage.input_tokens,
-                        output_tokens=terminal_response.usage.output_tokens,
-                        total_tokens=terminal_response.usage.total_tokens,
-                        input_tokens_details=terminal_response.usage.input_tokens_details,
-                        output_tokens_details=terminal_response.usage.output_tokens_details,
-                    ),
+                    _response_usage_to_usage(terminal_response.usage),
                     stream_failed_retry_attempts[0],
                 )
                 if terminal_response.usage

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -63,7 +63,6 @@ from ..models._response_terminal import (
     response_terminal_failure_error,
 )
 from ..models._run_context import model_run_context, model_run_context_stream
-from ..models.interface import Model
 from ..result import RunResultStreaming
 from ..run_config import ReasoningItemIdPolicy, RunConfig
 from ..run_context import AgentHookContext, RunContextWrapper, TContext
@@ -243,7 +242,7 @@ __all__ = [
     "check_for_final_output_from_tools",
     "get_model_tracing_impl",
     "validate_run_hooks",
-    "cleanup_model_after_run",
+    "cleanup_models_after_run",
     "maybe_filter_model_input",
     "run_input_guardrails_with_queue",
     "start_streaming",
@@ -261,25 +260,13 @@ __all__ = [
 ]
 
 
-async def cleanup_model_after_run(
-    agent: Agent[Any],
-    run_config: RunConfig,
-    owner: object,
-) -> None:
-    """Notify an explicitly configured model that its owning run has ended."""
-    model: Model | None = None
-    if isinstance(run_config.model, Model):
-        model = run_config.model
-    elif run_config.model is None and isinstance(agent.model, Model):
-        model = agent.model
-
-    if model is None:
-        return
-
-    try:
-        await model._cleanup_on_run_end(owner)
-    except Exception as error:
-        logger.warning("Failed to clean up model resources after run: %s", error)
+async def cleanup_models_after_run(tool_use_tracker: AgentToolUseTracker) -> None:
+    """Notify every model resolved during the run that its owning run has ended."""
+    for model in tool_use_tracker.models:
+        try:
+            await model._cleanup_on_run_end(tool_use_tracker)
+        except Exception as error:
+            logger.warning("Failed to clean up model resources after run: %s", error)
 
 
 def _should_attach_generic_agent_error(exc: Exception) -> bool:
@@ -1225,7 +1212,7 @@ async def start_streaming(
     else:
         streamed_result.is_complete = True
     finally:
-        await cleanup_model_after_run(current_agent, run_config, tool_use_tracker)
+        await cleanup_models_after_run(tool_use_tracker)
         _sync_conversation_tracking_from_tracker()
         if streamed_result._input_guardrails_task:
             try:
@@ -1368,6 +1355,7 @@ async def run_single_turn_streamed(
 
     handoffs = await get_handoffs(execution_agent, context_wrapper)
     model = get_model(execution_agent, run_config)
+    tool_use_tracker.record_model(model)
     model_settings = get_model_settings(execution_agent, run_config)
     model_settings = maybe_reset_tool_choice(public_agent, tool_use_tracker, model_settings)
 
@@ -1845,6 +1833,7 @@ async def get_new_response(
         filtered.input = deduplicate_input_items_preferring_latest(filtered.input)
 
     model = get_model(execution_agent, run_config)
+    tool_use_tracker.record_model(model)
     model_settings = get_model_settings(execution_agent, run_config)
     model_settings = maybe_reset_tool_choice(public_agent, tool_use_tracker, model_settings)
 

--- a/src/agents/run_internal/tool_use_tracker.py
+++ b/src/agents/run_internal/tool_use_tracker.py
@@ -5,7 +5,7 @@ its state plus lightweight tool-call type utilities. Internal use only.
 
 from __future__ import annotations
 
-from typing import Any, get_args, get_origin
+from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 from .._tool_identity import get_function_tool_trace_name
 from ..agent import Agent
@@ -23,6 +23,9 @@ from ..run_state import (
     _build_agent_map,
 )
 from .run_steps import ProcessedResponse, ToolRunFunction
+
+if TYPE_CHECKING:
+    from ..models.interface import Model
 
 __all__ = [
     "AgentToolUseTracker",
@@ -55,6 +58,12 @@ class AgentToolUseTracker:
         self.agent_map: dict[str, set[str]] = {}
         # Instance-keyed list is used for runtime checks.
         self.agent_to_tools: list[tuple[Agent[Any], list[str]]] = []
+        # Model instances are tracked by identity for run-scoped resource cleanup.
+        self.models: list[Model] = []
+
+    def record_model(self, model: Model) -> None:
+        if not any(existing is model for existing in self.models):
+            self.models.append(model)
 
     def record_used_tools(self, agent: Agent[Any], tools: list[ToolRunFunction]) -> None:
         tool_names = [

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -254,6 +254,37 @@ class Usage:
             self.request_usage_entries.append(request_usage)
 
 
+def _response_usage_to_usage(response_usage: Any) -> Usage:
+    """Convert Responses API usage, including adapter-supplied per-request details."""
+    request_usages = getattr(response_usage, "_agents_sdk_request_usages", None)
+    request_count = getattr(response_usage, "_agents_sdk_request_count", 1)
+
+    if isinstance(request_usages, list):
+        usage = Usage()
+        for request_usage in request_usages:
+            usage.add(
+                Usage(
+                    requests=1,
+                    input_tokens=request_usage.input_tokens,
+                    output_tokens=request_usage.output_tokens,
+                    total_tokens=request_usage.total_tokens,
+                    input_tokens_details=request_usage.input_tokens_details,
+                    output_tokens_details=request_usage.output_tokens_details,
+                )
+            )
+        usage.requests = max(usage.requests, request_count)
+        return usage
+
+    return Usage(
+        requests=request_count,
+        input_tokens=response_usage.input_tokens,
+        output_tokens=response_usage.output_tokens,
+        total_tokens=response_usage.total_tokens,
+        input_tokens_details=response_usage.input_tokens_details,
+        output_tokens_details=response_usage.output_tokens_details,
+    )
+
+
 def _serialize_usage_details(details: Any, default: dict[str, int]) -> dict[str, Any]:
     """Serialize token details while applying the given default when empty."""
     if hasattr(details, "model_dump"):

--- a/tests/extensions/experimental/hosted_multi_agent/test_live.py
+++ b/tests/extensions/experimental/hosted_multi_agent/test_live.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+from openai import AsyncOpenAI
+
+from agents import Agent, ModelSettings, RunConfig, Runner, function_tool
+from agents.extensions.experimental.hosted_multi_agent import (
+    HostedMultiAgentConfig,
+    OpenAIHostedMultiAgentModel,
+    get_hosted_agent_metadata,
+)
+from agents.tool_context import ToolContext
+
+pytestmark = [
+    pytest.mark.allow_call_model_methods,
+    pytest.mark.skipif(
+        os.environ.get("OPENAI_RUN_LIVE_HOSTED_MULTI_AGENT_TESTS") != "1",
+        reason="Set OPENAI_RUN_LIVE_HOSTED_MULTI_AGENT_TESTS=1 to run live beta tests.",
+    ),
+]
+
+_PROPOSALS = {
+    "alpha": {"estimated_weeks": 6, "risk": "medium"},
+    "beta": {"estimated_weeks": 8, "risk": "low"},
+}
+
+
+def _tool_output(arguments: str) -> str:
+    proposal = json.loads(arguments)["proposal"]
+    return json.dumps(_PROPOSALS[proposal], sort_keys=True)
+
+
+async def _run_direct_baseline(client: AsyncOpenAI) -> tuple[str, set[str], set[str]]:
+    beta = getattr(client, "beta", None)
+    responses = getattr(beta, "responses", None)
+    connect = getattr(responses, "connect", None)
+    if not callable(connect):
+        pytest.fail("The installed openai package does not provide client.beta.responses.connect.")
+
+    tools = [
+        {
+            "type": "function",
+            "name": "get_proposal",
+            "description": "Return deterministic details for one proposal.",
+            "parameters": {
+                "type": "object",
+                "properties": {"proposal": {"type": "string", "enum": ["alpha", "beta"]}},
+                "required": ["proposal"],
+                "additionalProperties": False,
+            },
+            "strict": True,
+        }
+    ]
+    callers: set[str] = set()
+    call_ids: set[str] = set()
+    completed_response: Any | None = None
+    response_id: str | None = None
+    pending_injections = 0
+
+    async with connect(
+        extra_headers={"OpenAI-Beta": "responses_multi_agent=v1"},
+        max_retries=0,
+    ) as connection:
+        await connection.send(
+            {
+                "type": "response.create",
+                "model": "gpt-5.6-sol",
+                "input": [{"role": "user", "content": "Compare proposal alpha and proposal beta."}],
+                "instructions": (
+                    "Create two subagents. Assign proposal alpha to one and proposal beta to the "
+                    "other. Each subagent must call get_proposal, then the root must synthesize."
+                ),
+                "tools": tools,
+                "store": True,
+                "multi_agent": {"enabled": True, "max_concurrent_subagents": 2},
+            }
+        )
+
+        async for event in connection:
+            if event.type == "response.created":
+                response_id = event.response.id
+            elif event.type == "response.output_item.done" and event.item.type == "function_call":
+                if response_id is None:
+                    pytest.fail("Direct baseline received a function call before response.created.")
+                call_ids.add(event.item.call_id)
+                agent = getattr(event.item, "agent", None)
+                callers.add(getattr(agent, "agent_name", "/root"))
+                pending_injections += 1
+                await connection.send(
+                    {
+                        "type": "response.inject",
+                        "response_id": response_id,
+                        "input": [
+                            {
+                                "type": "function_call_output",
+                                "call_id": event.item.call_id,
+                                "output": _tool_output(event.item.arguments),
+                            }
+                        ],
+                    }
+                )
+            elif event.type == "response.inject.created":
+                pending_injections -= 1
+            elif event.type == "response.inject.failed":
+                pytest.fail(f"Direct baseline injection failed: {event.error}")
+            elif event.type == "response.completed":
+                completed_response = event.response
+            elif event.type in {"error", "response.failed", "response.incomplete"}:
+                pytest.fail(f"Direct baseline failed: {event}")
+
+            if completed_response is not None and pending_injections == 0:
+                break
+
+    if completed_response is None:
+        pytest.fail("Direct hosted multi-agent baseline did not complete.")
+
+    root_text: list[str] = []
+    for item in completed_response.output:
+        if (
+            item.type == "message"
+            and getattr(getattr(item, "agent", None), "agent_name", None) == "/root"
+            and getattr(item, "phase", None) == "final_answer"
+        ):
+            root_text.extend(part.text for part in item.content if part.type == "output_text")
+    return "".join(root_text), callers, call_ids
+
+
+@pytest.mark.asyncio
+async def test_live_direct_and_agents_sdk_semantic_parity() -> None:
+    if os.environ.get("OPENAI_API_KEY") in {None, "", "test_key"}:
+        pytest.fail("A real OPENAI_API_KEY is required for the live beta test.")
+
+    client = AsyncOpenAI()
+    direct_text, direct_callers, direct_call_ids = await _run_direct_baseline(client)
+    sdk_callers: set[str] = set()
+    sdk_call_ids: set[str] = set()
+
+    @function_tool
+    def get_proposal(ctx: ToolContext[Any], proposal: str) -> dict[str, object]:
+        metadata = get_hosted_agent_metadata(ctx)
+        sdk_callers.add(metadata.agent_name if metadata else "/root")
+        sdk_call_ids.add(ctx.tool_call_id)
+        return _PROPOSALS[proposal]
+
+    model = OpenAIHostedMultiAgentModel(
+        model="gpt-5.6-sol",
+        openai_client=client,
+        config=HostedMultiAgentConfig(max_concurrent_subagents=2),
+    )
+    agent = Agent(
+        name="Hosted proposal coordinator",
+        instructions=(
+            "Create two subagents. Assign proposal alpha to one and proposal beta to the other. "
+            "Each subagent must call get_proposal, then the root must synthesize."
+        ),
+        model=model,
+        model_settings=ModelSettings(
+            store=False,
+            response_include=["reasoning.encrypted_content"],
+        ),
+        tools=[get_proposal],
+    )
+    result = await Runner.run(
+        agent,
+        "Compare proposal alpha and proposal beta.",
+        run_config=RunConfig(tracing_disabled=True),
+        max_turns=6,
+    )
+
+    assert direct_text
+    assert result.final_output
+    assert len(direct_call_ids) == 2
+    assert len(sdk_call_ids) == 2
+    assert all(caller != "/root" for caller in direct_callers)
+    assert all(caller != "/root" for caller in sdk_callers)

--- a/tests/extensions/experimental/hosted_multi_agent/test_model.py
+++ b/tests/extensions/experimental/hosted_multi_agent/test_model.py
@@ -1,0 +1,996 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping, Sequence
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from openai import omit
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
+)
+from openai.types.shared.reasoning import Reasoning
+
+from agents import (
+    Agent,
+    ModelSettings,
+    ModelTracing,
+    RunConfig,
+    Runner,
+    function_tool,
+    handoff,
+)
+from agents.exceptions import UserError
+from agents.extensions.experimental.hosted_multi_agent import (
+    HostedMultiAgentConfig,
+    OpenAIHostedMultiAgentModel,
+    get_hosted_agent_metadata,
+)
+from agents.run_state import RunState
+from agents.tool_context import ToolContext
+
+pytestmark = pytest.mark.allow_call_model_methods
+
+
+def _response(response_id: str, output: Sequence[object]) -> SimpleNamespace:
+    return SimpleNamespace(id=response_id, output=list(output), usage=None)
+
+
+def _usage(
+    *,
+    input_tokens: int,
+    cached_tokens: int,
+    cache_write_tokens: int,
+    output_tokens: int,
+    reasoning_tokens: int,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        input_tokens=input_tokens,
+        input_tokens_details=SimpleNamespace(
+            cached_tokens=cached_tokens,
+            cache_write_tokens=cache_write_tokens,
+        ),
+        output_tokens=output_tokens,
+        output_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
+        total_tokens=input_tokens + output_tokens,
+    )
+
+
+def _created(response_id: str, *, sequence_number: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="response.created",
+        sequence_number=sequence_number,
+        response=_response(response_id, []),
+    )
+
+
+def _done(item: object, *, sequence_number: int, output_index: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="response.output_item.done",
+        sequence_number=sequence_number,
+        output_index=output_index,
+        item=item,
+        agent=getattr(item, "agent", None),
+    )
+
+
+def _completed(
+    response_id: str,
+    output: Sequence[object],
+    *,
+    sequence_number: int,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="response.completed",
+        sequence_number=sequence_number,
+        response=_response(response_id, output),
+    )
+
+
+def _root_final_message(text: str = "done") -> dict[str, Any]:
+    return {
+        "id": "msg_root",
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "agent": {"agent_name": "/root"},
+        "phase": "final_answer",
+        "content": [
+            {
+                "type": "output_text",
+                "text": text,
+                "annotations": [],
+                "logprobs": [],
+            }
+        ],
+    }
+
+
+def _subagent_message(text: str = "working") -> dict[str, Any]:
+    return {
+        "id": "msg_subagent",
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+        "phase": "commentary",
+        "content": [
+            {
+                "type": "output_text",
+                "text": text,
+                "annotations": [],
+                "logprobs": [],
+            }
+        ],
+    }
+
+
+def _tool_flow_events(
+    response_id: str,
+    first_items: Sequence[object],
+    final_items: Sequence[object],
+) -> list[object]:
+    events: list[object] = [_created(response_id)]
+    sequence_number = 1
+    for output_index, item in enumerate(first_items):
+        sequence_number += 1
+        events.append(_done(item, sequence_number=sequence_number, output_index=output_index))
+    sequence_number += 1
+    events.append(
+        SimpleNamespace(
+            type="response.inject.created",
+            sequence_number=sequence_number,
+            response_id=response_id,
+        )
+    )
+    for final_index, item in enumerate(final_items):
+        sequence_number += 1
+        events.append(
+            _done(
+                item,
+                sequence_number=sequence_number,
+                output_index=len(first_items) + final_index,
+            )
+        )
+    sequence_number += 1
+    events.append(
+        _completed(
+            response_id,
+            [*first_items, *final_items],
+            sequence_number=sequence_number,
+        )
+    )
+    return events
+
+
+class _DummyConnection:
+    def __init__(self, events: Sequence[object]) -> None:
+        self.events = deque(events)
+        self.sent: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def send(self, event: dict[str, Any]) -> None:
+        self.sent.append(event)
+
+    async def recv(self) -> object:
+        if not self.events:
+            raise RuntimeError("Dummy WebSocket event queue exhausted")
+        return self.events.popleft()
+
+
+class _DummyConnectionManager:
+    def __init__(self, connection: _DummyConnection) -> None:
+        self.connection = connection
+
+    async def enter(self) -> _DummyConnection:
+        return self.connection
+
+    async def __aexit__(self, *_args: object) -> None:
+        self.connection.closed = True
+
+
+class _DummyBetaResponses:
+    def __init__(self, event_batches: Sequence[Sequence[object]]) -> None:
+        self.connections = [_DummyConnection(events) for events in event_batches]
+        self._available_connections = deque(self.connections)
+        self.connect_calls: list[dict[str, Any]] = []
+
+    def connect(self, **kwargs: Any) -> _DummyConnectionManager:
+        self.connect_calls.append(kwargs)
+        return _DummyConnectionManager(self._available_connections.popleft())
+
+
+class _DummyClient:
+    def __init__(self, event_batches: Sequence[Sequence[object]]) -> None:
+        self.beta = SimpleNamespace(responses=_DummyBetaResponses(event_batches))
+
+
+def _model(
+    events: Sequence[object] | None = None,
+    *,
+    event_batches: Sequence[Sequence[object]] | None = None,
+    config: HostedMultiAgentConfig | Mapping[str, Any] | None = None,
+) -> tuple[OpenAIHostedMultiAgentModel, _DummyClient]:
+    client = _DummyClient(event_batches or [events or []])
+    model = OpenAIHostedMultiAgentModel(
+        model="gpt-5.6-sol",
+        openai_client=cast(Any, client),
+        config=config,
+    )
+    return model, client
+
+
+def test_build_request_enables_beta_and_preserves_context_management() -> None:
+    model, _ = _model(config=HostedMultiAgentConfig(max_concurrent_subagents=2))
+
+    kwargs = model._build_response_create_kwargs(
+        system_instructions="delegate",
+        input="hello",
+        model_settings=ModelSettings(
+            context_management=[{"type": "compaction", "compact_threshold": 10}]
+        ),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+    )
+
+    assert kwargs["multi_agent"] == {
+        "enabled": True,
+        "max_concurrent_subagents": 2,
+    }
+    assert kwargs["betas"] == ["responses_multi_agent=v1"]
+    assert kwargs["context_management"] == [{"type": "compaction", "compact_threshold": 10}]
+
+
+def test_model_accepts_config_mapping() -> None:
+    model, _ = _model(config={"max_concurrent_subagents": 2})
+
+    assert model.config == HostedMultiAgentConfig(max_concurrent_subagents=2)
+
+
+def test_model_accepts_omitted_client() -> None:
+    model = OpenAIHostedMultiAgentModel(
+        model="gpt-5.6-sol",
+        config={"max_concurrent_subagents": 2},
+    )
+
+    assert model._client is None
+
+
+@pytest.mark.parametrize("value", [0, -1, True])
+def test_config_rejects_non_positive_concurrency(value: int) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        HostedMultiAgentConfig(max_concurrent_subagents=value)
+
+
+def test_reserved_settings_fail_before_transport() -> None:
+    model, _ = _model()
+
+    with pytest.raises(UserError, match="through OpenAIHostedMultiAgentModel"):
+        model._build_response_create_kwargs(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(extra_args={"multi_agent": {"enabled": True}}),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+        )
+
+    with pytest.raises(UserError, match="max_tool_calls"):
+        model._build_response_create_kwargs(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(extra_args={"max_tool_calls": 1}),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+        )
+
+    with pytest.raises(UserError, match="reasoning.summary"):
+        model._build_response_create_kwargs(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(reasoning=Reasoning(summary="auto")),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+        )
+
+
+def test_sdk_handoffs_are_rejected() -> None:
+    model, _ = _model()
+    target = Agent(name="target")
+
+    with pytest.raises(UserError, match="cannot be combined with SDK handoffs"):
+        model._build_response_create_kwargs(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[handoff(target)],
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_routes_subagent_tool_call_without_exposing_hosted_items() -> None:
+    first_items = [
+        {
+            "id": "mac_1",
+            "type": "multi_agent_call",
+            "call_id": "call_spawn",
+            "action": "spawn_agent",
+            "arguments": "{}",
+            "agent": {"agent_name": "/root"},
+        },
+        {
+            "id": "fc_1",
+            "type": "function_call",
+            "call_id": "call_lookup",
+            "name": "lookup_document",
+            "arguments": '{"section":"alpha"}',
+            "status": "completed",
+            "agent": {"agent_name": "/root/researcher"},
+        },
+    ]
+    final_items = [
+        _subagent_message(),
+        {
+            "id": "maco_1",
+            "type": "multi_agent_call_output",
+            "call_id": "call_spawn",
+            "action": "spawn_agent",
+            "output": [],
+            "agent": {"agent_name": "/root"},
+        },
+        _root_final_message(),
+    ]
+    model, client = _model(_tool_flow_events("resp_1", first_items, final_items))
+    callers: list[str] = []
+
+    @function_tool
+    def lookup_document(ctx: ToolContext[Any], section: str) -> str:
+        metadata = get_hosted_agent_metadata(ctx)
+        assert metadata is not None
+        callers.append(metadata.agent_name)
+        return f"document:{section}"
+
+    agent = Agent(
+        name="SDK root",
+        instructions="Delegate the lookup and synthesize the answer.",
+        model=model,
+        tools=[lookup_document],
+    )
+
+    result = await Runner.run(
+        agent,
+        "Compare alpha.",
+        run_config=RunConfig(tracing_disabled=True),
+    )
+
+    assert result.final_output == "done"
+    assert callers == ["/root/researcher"]
+    assert [item.type for item in result.new_items] == [
+        "tool_call_item",
+        "tool_call_output_item",
+        "message_output_item",
+    ]
+
+    connection = client.beta.responses.connections[0]
+    assert connection.sent[0]["type"] == "response.create"
+    assert "stream" not in connection.sent[0]
+    assert "betas" not in connection.sent[0]
+    assert connection.sent[1] == {
+        "type": "response.inject",
+        "response_id": "resp_1",
+        "input": [
+            {
+                "type": "function_call_output",
+                "call_id": "call_lookup",
+                "output": "document:alpha",
+            }
+        ],
+    }
+    assert client.beta.responses.connect_calls[0]["extra_headers"]["OpenAI-Beta"] == (
+        "responses_multi_agent=v1"
+    )
+    assert connection.closed
+
+
+@pytest.mark.asyncio
+async def test_runner_injects_two_subagent_calls_into_one_active_response() -> None:
+    spawn = {
+        "id": "mac_two",
+        "type": "multi_agent_call",
+        "call_id": "call_spawn_two",
+        "action": "spawn_agent",
+        "arguments": "{}",
+        "agent": {"agent_name": "/root"},
+    }
+    alpha_call = {
+        "id": "fc_alpha",
+        "type": "function_call",
+        "call_id": "call_alpha",
+        "name": "get_proposal",
+        "arguments": '{"proposal":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/alpha"},
+    }
+    beta_call = {
+        "id": "fc_beta",
+        "type": "function_call",
+        "call_id": "call_beta",
+        "name": "get_proposal",
+        "arguments": '{"proposal":"beta"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/beta"},
+    }
+    alpha_message = _subagent_message("alpha complete")
+    alpha_message["id"] = "msg_alpha"
+    alpha_message["agent"] = {"agent_name": "/root/alpha"}
+    beta_message = _subagent_message("beta complete")
+    beta_message["id"] = "msg_beta"
+    beta_message["agent"] = {"agent_name": "/root/beta"}
+    root_final = _root_final_message("comparison complete")
+    output = [spawn, alpha_call, alpha_message, beta_call, beta_message, root_final]
+    events = [
+        _created("resp_two"),
+        _done(spawn, sequence_number=2, output_index=0),
+        _done(alpha_call, sequence_number=3, output_index=1),
+        SimpleNamespace(
+            type="response.inject.created",
+            sequence_number=4,
+            response_id="resp_two",
+        ),
+        _done(alpha_message, sequence_number=5, output_index=2),
+        _done(beta_call, sequence_number=6, output_index=3),
+        SimpleNamespace(
+            type="response.inject.created",
+            sequence_number=7,
+            response_id="resp_two",
+        ),
+        _done(beta_message, sequence_number=8, output_index=4),
+        _done(root_final, sequence_number=9, output_index=5),
+        _completed("resp_two", output, sequence_number=10),
+    ]
+    model, client = _model(events)
+    callers: list[str] = []
+
+    @function_tool
+    def get_proposal(ctx: ToolContext[Any], proposal: str) -> str:
+        metadata = get_hosted_agent_metadata(ctx)
+        assert metadata is not None
+        callers.append(metadata.agent_name)
+        return f"proposal:{proposal}"
+
+    result = await Runner.run(
+        Agent(name="SDK root", model=model, tools=[get_proposal]),
+        "Compare both proposals.",
+        run_config=RunConfig(tracing_disabled=True),
+    )
+
+    assert result.final_output == "comparison complete"
+    assert callers == ["/root/alpha", "/root/beta"]
+    inject_frames = [
+        frame
+        for frame in client.beta.responses.connections[0].sent
+        if frame["type"] == "response.inject"
+    ]
+    assert [frame["input"][0]["call_id"] for frame in inject_frames] == [
+        "call_alpha",
+        "call_beta",
+    ]
+    assert [item.type for item in result.new_items] == [
+        "tool_call_item",
+        "tool_call_output_item",
+        "tool_call_item",
+        "tool_call_output_item",
+        "message_output_item",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_injection_failure_after_completion_starts_continuation_response(
+    streamed: bool,
+) -> None:
+    function_call = {
+        "id": "fc_fallback",
+        "type": "function_call",
+        "call_id": "call_fallback",
+        "name": "lookup_document",
+        "arguments": '{"section":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+    }
+    function_output = {
+        "type": "function_call_output",
+        "call_id": "call_fallback",
+        "output": "document:alpha",
+    }
+    completed_first_response = _response("resp_old", [function_call])
+    completed_first_response.usage = _usage(
+        input_tokens=12,
+        cached_tokens=3,
+        cache_write_tokens=1,
+        output_tokens=4,
+        reasoning_tokens=2,
+    )
+    first_events = [
+        _created("resp_old"),
+        _done(function_call, sequence_number=2, output_index=0),
+        SimpleNamespace(
+            type="response.completed",
+            sequence_number=3,
+            response=completed_first_response,
+        ),
+        SimpleNamespace(
+            type="response.inject.failed",
+            sequence_number=4,
+            response_id="resp_old",
+            input=[function_output],
+            error=SimpleNamespace(
+                code="response_already_completed",
+                message="The response already completed.",
+            ),
+        ),
+    ]
+    final_message = _root_final_message("continued")
+    completed_second_response = _response("resp_new", [final_message])
+    completed_second_response.usage = _usage(
+        input_tokens=7,
+        cached_tokens=2,
+        cache_write_tokens=4,
+        output_tokens=3,
+        reasoning_tokens=1,
+    )
+    second_events = [
+        _created("resp_new"),
+        _done(final_message, sequence_number=2, output_index=0),
+        SimpleNamespace(
+            type="response.completed",
+            sequence_number=3,
+            response=completed_second_response,
+        ),
+    ]
+    model, client = _model([*first_events, *second_events])
+
+    @function_tool
+    def lookup_document(section: str) -> str:
+        return f"document:{section}"
+
+    agent = Agent(
+        name="SDK root",
+        model=model,
+        model_settings=ModelSettings(store=False),
+        tools=[lookup_document],
+    )
+    result: Any
+    if streamed:
+        result = Runner.run_streamed(
+            agent,
+            "Inspect alpha.",
+            run_config=RunConfig(tracing_disabled=True),
+        )
+        _ = [event async for event in result.stream_events()]
+    else:
+        result = await Runner.run(
+            agent,
+            "Inspect alpha.",
+            run_config=RunConfig(tracing_disabled=True),
+        )
+
+    assert result.final_output == "continued"
+    assert result.context_wrapper.usage.input_tokens == 19
+    assert result.context_wrapper.usage.input_tokens_details.cached_tokens == 5
+    assert (
+        getattr(
+            result.context_wrapper.usage.input_tokens_details,
+            "cache_write_tokens",
+            None,
+        )
+        == 5
+    )
+    assert result.context_wrapper.usage.output_tokens == 7
+    assert result.context_wrapper.usage.output_tokens_details.reasoning_tokens == 3
+    assert result.context_wrapper.usage.total_tokens == 26
+    assert result.context_wrapper.usage.requests == 2
+    assert len(result.context_wrapper.usage.request_usage_entries) == 2
+    assert [entry.total_tokens for entry in result.context_wrapper.usage.request_usage_entries] == [
+        16,
+        10,
+    ]
+
+    assert len(client.beta.responses.connections) == 1
+    connection = client.beta.responses.connections[0]
+    continuation_frame = connection.sent[2]
+    assert continuation_frame["type"] == "response.create"
+    assert continuation_frame["previous_response_id"] == "resp_old"
+    assert continuation_frame["input"] == [function_output]
+    assert connection.closed
+
+
+@pytest.mark.asyncio
+async def test_injection_failure_continues_with_conversation_without_previous_response_id() -> None:
+    function_call = {
+        "id": "fc_conversation",
+        "type": "function_call",
+        "call_id": "call_conversation",
+        "name": "lookup_document",
+        "arguments": '{"section":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+    }
+    function_output = {
+        "type": "function_call_output",
+        "call_id": "call_conversation",
+        "output": "document:alpha",
+    }
+    final_message = _root_final_message("continued in conversation")
+    model, client = _model(
+        [
+            _created("resp_conversation_old"),
+            _done(function_call, sequence_number=2, output_index=0),
+            _completed("resp_conversation_old", [function_call], sequence_number=3),
+            SimpleNamespace(
+                type="response.inject.failed",
+                sequence_number=4,
+                response_id="resp_conversation_old",
+                input=[function_output],
+                error=SimpleNamespace(
+                    code="response_already_completed",
+                    message="The response already completed.",
+                ),
+            ),
+            _created("resp_conversation_new"),
+            _done(final_message, sequence_number=2, output_index=0),
+            _completed("resp_conversation_new", [final_message], sequence_number=3),
+        ]
+    )
+
+    @function_tool
+    def lookup_document(section: str) -> str:
+        return f"document:{section}"
+
+    result = await Runner.run(
+        Agent(name="SDK root", model=model, tools=[lookup_document]),
+        "Inspect alpha.",
+        conversation_id="conv_123",
+        run_config=RunConfig(tracing_disabled=True),
+    )
+
+    assert result.final_output == "continued in conversation"
+    connection = client.beta.responses.connections[0]
+    continuation_frame = connection.sent[2]
+    assert continuation_frame["conversation"] == "conv_123"
+    assert "previous_response_id" not in continuation_frame
+    assert continuation_frame["input"] == [function_output]
+    assert connection.closed
+
+
+@pytest.mark.asyncio
+async def test_nonrecoverable_injection_failure_closes_active_response() -> None:
+    function_call = {
+        "id": "fc_failed",
+        "type": "function_call",
+        "call_id": "call_failed",
+        "name": "lookup_document",
+        "arguments": '{"section":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+    }
+    events = [
+        _created("resp_failed"),
+        _done(function_call, sequence_number=2, output_index=0),
+        SimpleNamespace(
+            type="response.inject.failed",
+            sequence_number=3,
+            response_id="resp_failed",
+            input=[],
+            error=SimpleNamespace(code="response_not_found", message="Missing response."),
+        ),
+    ]
+    model, client = _model(events)
+
+    @function_tool
+    def lookup_document(section: str) -> str:
+        return f"document:{section}"
+
+    with pytest.raises(UserError, match="response_not_found"):
+        await Runner.run(
+            Agent(name="SDK root", model=model, tools=[lookup_document]),
+            "Inspect alpha.",
+            run_config=RunConfig(tracing_disabled=True),
+        )
+
+    assert client.beta.responses.connections[0].closed
+    assert model._active_response is None
+
+
+@pytest.mark.asyncio
+async def test_model_close_releases_paused_response() -> None:
+    function_call = {
+        "id": "fc_close",
+        "type": "function_call",
+        "call_id": "call_close",
+        "name": "lookup_document",
+        "arguments": '{"section":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+    }
+    model, client = _model(
+        [
+            _created("resp_close"),
+            _done(function_call, sequence_number=2, output_index=0),
+        ]
+    )
+
+    response = await model.get_response(
+        system_instructions=None,
+        input="Inspect alpha.",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert response.response_id == "resp_close"
+    assert not client.beta.responses.connections[0].closed
+    await model.close()
+    assert client.beta.responses.connections[0].closed
+    assert model._active_response is None
+
+
+@pytest.mark.asyncio
+async def test_non_root_and_unknown_items_are_filtered_from_model_response() -> None:
+    output = [
+        _subagent_message(),
+        {"type": "future_beta_item", "id": "future_1"},
+        _root_final_message(),
+    ]
+    model, _ = _model(
+        [
+            _created("resp_1"),
+            *[
+                _done(item, sequence_number=index + 2, output_index=index)
+                for index, item in enumerate(output)
+            ],
+            _completed("resp_1", output, sequence_number=5),
+        ]
+    )
+
+    response = await model.get_response(
+        system_instructions=None,
+        input="hello",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert len(response.output) == 1
+    assert isinstance(response.output[0], ResponseOutputMessage)
+    assert get_hosted_agent_metadata(response.output[0]) is not None
+
+
+@pytest.mark.asyncio
+async def test_beta_usage_details_are_converted_to_stable_usage_types() -> None:
+    final_message = _root_final_message("usage")
+    terminal_response = _response("resp_usage", [final_message])
+    terminal_response.usage = SimpleNamespace(
+        input_tokens=12,
+        input_tokens_details=SimpleNamespace(cached_tokens=3, cache_write_tokens=1),
+        output_tokens=4,
+        output_tokens_details=SimpleNamespace(reasoning_tokens=2),
+        total_tokens=16,
+    )
+    model, _ = _model(
+        [
+            _created("resp_usage"),
+            _done(final_message, sequence_number=2, output_index=0),
+            SimpleNamespace(
+                type="response.completed",
+                sequence_number=3,
+                response=terminal_response,
+            ),
+        ]
+    )
+
+    response = await model.get_response(
+        system_instructions=None,
+        input="hello",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert response.usage.input_tokens == 12
+    assert response.usage.input_tokens_details.cached_tokens == 3
+    assert response.usage.output_tokens_details.reasoning_tokens == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_preserves_hosted_raw_event_and_normalizes_root_output() -> None:
+    output = [_subagent_message(), _root_final_message()]
+    model, _ = _model(
+        [
+            _created("resp_stream"),
+            _done(output[0], sequence_number=2, output_index=0),
+            _done(output[1], sequence_number=3, output_index=1),
+            _completed("resp_stream", output, sequence_number=4),
+        ]
+    )
+    events = [
+        event
+        async for event in model.stream_response(
+            system_instructions=None,
+            input="hello",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        )
+    ]
+
+    done_events = [event for event in events if isinstance(event, ResponseOutputItemDoneEvent)]
+    assert len(done_events) == 1
+    assert isinstance(done_events[0].item, ResponseOutputMessage)
+    raw_subagent_event = next(
+        event
+        for event in events
+        if getattr(event, "type", None) == "response.output_item.done"
+        and not isinstance(event, ResponseOutputItemDoneEvent)
+    )
+    assert get_hosted_agent_metadata(cast(Any, raw_subagent_event).item) is not None
+    completed_event = next(event for event in events if isinstance(event, ResponseCompletedEvent))
+    assert len(completed_event.response.output) == 1
+    assert isinstance(completed_event.response.output[0], ResponseOutputMessage)
+
+
+@pytest.mark.asyncio
+async def test_streamed_runner_routes_tools_and_emits_raw_hosted_items() -> None:
+    first_items = [
+        {
+            "id": "mac_stream",
+            "type": "multi_agent_call",
+            "call_id": "call_spawn_stream",
+            "action": "spawn_agent",
+            "arguments": "{}",
+            "agent": {"agent_name": "/root"},
+        },
+        {
+            "id": "fc_stream",
+            "type": "function_call",
+            "call_id": "call_lookup_stream",
+            "name": "lookup_document",
+            "arguments": '{"section":"beta"}',
+            "status": "completed",
+            "agent": {"agent_name": "/root/reviewer"},
+        },
+    ]
+    final_items = [_subagent_message("review complete"), _root_final_message("stream done")]
+    model, _ = _model(_tool_flow_events("resp_stream", first_items, final_items))
+    callers: list[str] = []
+
+    @function_tool
+    def lookup_document(ctx: ToolContext[Any], section: str) -> str:
+        metadata = get_hosted_agent_metadata(ctx)
+        assert metadata is not None
+        callers.append(metadata.agent_name)
+        return f"document:{section}"
+
+    agent = Agent(
+        name="SDK root",
+        instructions="Delegate and synthesize.",
+        model=model,
+        tools=[lookup_document],
+    )
+    result = Runner.run_streamed(
+        agent,
+        "Compare beta.",
+        run_config=RunConfig(tracing_disabled=True),
+    )
+    events = [event async for event in result.stream_events()]
+
+    assert result.final_output == "stream done"
+    assert callers == ["/root/reviewer"]
+    assert any(
+        event.type == "raw_response_event"
+        and getattr(event.data, "type", None) == "response.output_item.done"
+        and getattr(event.data, "item", {}).get("type") == "multi_agent_call"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_approval_run_state_resume_keeps_active_response_and_caller() -> None:
+    first_items = [
+        {
+            "id": "mac_approval",
+            "type": "multi_agent_call",
+            "call_id": "call_spawn_approval",
+            "action": "spawn_agent",
+            "arguments": "{}",
+            "agent": {"agent_name": "/root"},
+        },
+        {
+            "id": "fc_approval",
+            "type": "function_call",
+            "call_id": "call_sensitive",
+            "name": "sensitive_lookup",
+            "arguments": '{"section":"alpha"}',
+            "status": "completed",
+            "agent": {"agent_name": "/root/auditor"},
+        },
+    ]
+    final_items = [_root_final_message("approved")]
+    model, client = _model(_tool_flow_events("resp_approval", first_items, final_items))
+    callers: list[str] = []
+
+    @function_tool(needs_approval=True)
+    def sensitive_lookup(ctx: ToolContext[Any], section: str) -> str:
+        metadata = get_hosted_agent_metadata(ctx)
+        assert metadata is not None
+        callers.append(metadata.agent_name)
+        return f"sensitive:{section}"
+
+    agent = Agent(
+        name="SDK root",
+        instructions="Delegate the sensitive lookup.",
+        model=model,
+        tools=[sensitive_lookup],
+    )
+    first = await Runner.run(
+        agent,
+        "Inspect alpha.",
+        run_config=RunConfig(tracing_disabled=True),
+    )
+
+    assert len(first.interruptions) == 1
+    state = first.to_state()
+    state.approve(first.interruptions[0])
+    restored_state = await RunState.from_string(agent, state.to_string())
+
+    resumed = await Runner.run(
+        agent,
+        restored_state,
+        run_config=RunConfig(tracing_disabled=True),
+    )
+
+    assert resumed.final_output == "approved"
+    assert callers == ["/root/auditor"]
+    assert client.beta.responses.connections[0].sent[1]["type"] == "response.inject"
+    assert client.beta.responses.connections[0].sent[1]["input"][0]["call_id"] == ("call_sensitive")
+
+
+def test_missing_beta_client_has_actionable_error() -> None:
+    model = OpenAIHostedMultiAgentModel(
+        model="gpt-5.6-sol",
+        openai_client=cast(Any, SimpleNamespace()),
+    )
+
+    with pytest.raises(UserError, match="client.beta.responses"):
+        model._get_beta_responses()
+
+
+def test_default_config_omits_service_default_concurrency() -> None:
+    model, _ = _model()
+    kwargs = model._build_response_create_kwargs(
+        system_instructions=None,
+        input="hello",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+    )
+
+    assert kwargs["multi_agent"] == {"enabled": True}
+    assert kwargs["stream"] is omit

--- a/tests/extensions/experimental/hosted_multi_agent/test_model.py
+++ b/tests/extensions/experimental/hosted_multi_agent/test_model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections import deque
 from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
@@ -20,6 +21,7 @@ from agents import (
     ModelSettings,
     ModelTracing,
     RunConfig,
+    RunContextWrapper,
     Runner,
     function_tool,
     handoff,
@@ -842,6 +844,71 @@ async def test_runner_closes_paused_response_when_tool_execution_fails() -> None
     assert result.final_output == "recovered"
     assert len(client.beta.responses.connect_calls) == 2
     assert client.beta.responses.connections[1].closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_concurrent_run_does_not_consume_or_close_paused_response(
+    streamed: bool,
+) -> None:
+    function_call = {
+        "id": "fc_concurrent",
+        "type": "function_call",
+        "call_id": "call_concurrent",
+        "name": "lookup_document",
+        "arguments": '{"section":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+    }
+    final_message = _root_final_message("continued")
+    model, client = _model(_tool_flow_events("resp_concurrent", [function_call], [final_message]))
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    @function_tool
+    async def lookup_document(section: str) -> str:
+        tool_started.set()
+        await release_tool.wait()
+        return f"document:{section}"
+
+    agent = Agent(name="SDK root", model=model, tools=[lookup_document])
+    shared_context = RunContextWrapper(context=None)
+
+    async def run_agent(prompt: str) -> Any:
+        if not streamed:
+            return await Runner.run(
+                agent,
+                prompt,
+                context=shared_context,
+                run_config=RunConfig(tracing_disabled=True),
+            )
+        result = Runner.run_streamed(
+            agent,
+            prompt,
+            context=shared_context,
+            run_config=RunConfig(tracing_disabled=True),
+        )
+        _ = [event async for event in result.stream_events()]
+        return result
+
+    first_run = asyncio.create_task(run_agent("Inspect alpha."))
+    await tool_started.wait()
+    paused_response = model._active_response
+    assert paused_response is not None
+
+    try:
+        with pytest.raises(UserError, match="another agent run"):
+            await run_agent("Inspect beta.")
+
+        assert model._active_response is paused_response
+        assert len(client.beta.responses.connect_calls) == 1
+        assert not client.beta.responses.connections[0].closed
+    finally:
+        release_tool.set()
+
+    result = await first_run
+    assert result.final_output == "continued"
+    assert client.beta.responses.connections[0].closed
 
 
 @pytest.mark.asyncio

--- a/tests/extensions/experimental/hosted_multi_agent/test_model.py
+++ b/tests/extensions/experimental/hosted_multi_agent/test_model.py
@@ -29,7 +29,6 @@ from agents.extensions.experimental.hosted_multi_agent import (
     OpenAIHostedMultiAgentModel,
     get_hosted_agent_metadata,
 )
-from agents.run_state import RunState
 from agents.tool_context import ToolContext
 
 pytestmark = pytest.mark.allow_call_model_methods
@@ -910,65 +909,36 @@ async def test_streamed_runner_routes_tools_and_emits_raw_hosted_items() -> None
     )
 
 
-@pytest.mark.asyncio
-async def test_approval_run_state_resume_keeps_active_response_and_caller() -> None:
-    first_items = [
-        {
-            "id": "mac_approval",
-            "type": "multi_agent_call",
-            "call_id": "call_spawn_approval",
-            "action": "spawn_agent",
-            "arguments": "{}",
-            "agent": {"agent_name": "/root"},
-        },
-        {
-            "id": "fc_approval",
-            "type": "function_call",
-            "call_id": "call_sensitive",
-            "name": "sensitive_lookup",
-            "arguments": '{"section":"alpha"}',
-            "status": "completed",
-            "agent": {"agent_name": "/root/auditor"},
-        },
-    ]
-    final_items = [_root_final_message("approved")]
-    model, client = _model(_tool_flow_events("resp_approval", first_items, final_items))
-    callers: list[str] = []
+def test_tools_with_approval_settings_are_rejected_before_transport() -> None:
+    model, client = _model()
+
+    async def requires_approval(
+        _ctx: Any,
+        _params: dict[str, Any],
+        _call_id: str,
+    ) -> bool:
+        return False
 
     @function_tool(needs_approval=True)
-    def sensitive_lookup(ctx: ToolContext[Any], section: str) -> str:
-        metadata = get_hosted_agent_metadata(ctx)
-        assert metadata is not None
-        callers.append(metadata.agent_name)
+    def always_sensitive(section: str) -> str:
         return f"sensitive:{section}"
 
-    agent = Agent(
-        name="SDK root",
-        instructions="Delegate the sensitive lookup.",
-        model=model,
-        tools=[sensitive_lookup],
-    )
-    first = await Runner.run(
-        agent,
-        "Inspect alpha.",
-        run_config=RunConfig(tracing_disabled=True),
-    )
+    @function_tool(needs_approval=requires_approval)
+    def dynamically_sensitive(section: str) -> str:
+        return f"sensitive:{section}"
 
-    assert len(first.interruptions) == 1
-    state = first.to_state()
-    state.approve(first.interruptions[0])
-    restored_state = await RunState.from_string(agent, state.to_string())
+    for tool in (always_sensitive, dynamically_sensitive):
+        with pytest.raises(UserError, match="does not support SDK tool approval interruptions"):
+            model._build_response_create_kwargs(
+                system_instructions=None,
+                input="hello",
+                model_settings=ModelSettings(),
+                tools=[tool],
+                output_schema=None,
+                handoffs=[],
+            )
 
-    resumed = await Runner.run(
-        agent,
-        restored_state,
-        run_config=RunConfig(tracing_disabled=True),
-    )
-
-    assert resumed.final_output == "approved"
-    assert callers == ["/root/auditor"]
-    assert client.beta.responses.connections[0].sent[1]["type"] == "response.inject"
-    assert client.beta.responses.connections[0].sent[1]["input"][0]["call_id"] == ("call_sensitive")
+    assert client.beta.responses.connect_calls == []
 
 
 def test_missing_beta_client_has_actionable_error() -> None:

--- a/tests/extensions/experimental/hosted_multi_agent/test_model.py
+++ b/tests/extensions/experimental/hosted_multi_agent/test_model.py
@@ -18,6 +18,7 @@ from openai.types.shared.reasoning import Reasoning
 from agents import (
     Agent,
     MaxTurnsExceeded,
+    ModelProvider,
     ModelSettings,
     ModelTracing,
     RunConfig,
@@ -208,6 +209,16 @@ class _DummyBetaResponses:
 class _DummyClient:
     def __init__(self, event_batches: Sequence[Sequence[object]]) -> None:
         self.beta = SimpleNamespace(responses=_DummyBetaResponses(event_batches))
+
+
+class _StaticModelProvider(ModelProvider):
+    def __init__(self, model: OpenAIHostedMultiAgentModel) -> None:
+        self.model = model
+        self.requested_names: list[str | None] = []
+
+    def get_model(self, model_name: str | None) -> OpenAIHostedMultiAgentModel:
+        self.requested_names.append(model_name)
+        return self.model
 
 
 def _model(
@@ -790,6 +801,67 @@ async def test_runner_closes_paused_response_when_max_turns_is_exceeded(
                 run_config=RunConfig(tracing_disabled=True),
             )
 
+    assert client.beta.responses.connections[0].closed
+    assert model._active_response is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("model_source", ["run_config", "agent"])
+async def test_runner_cleans_up_provider_resolved_paused_response(
+    streamed: bool,
+    model_source: str,
+) -> None:
+    function_call = {
+        "id": "fc_provider",
+        "type": "function_call",
+        "call_id": "call_provider",
+        "name": "lookup_document",
+        "arguments": '{"section":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+    }
+    model, client = _model(
+        [
+            _created("resp_provider"),
+            _done(function_call, sequence_number=2, output_index=0),
+        ]
+    )
+    provider = _StaticModelProvider(model)
+
+    @function_tool
+    def lookup_document(section: str) -> str:
+        return f"document:{section}"
+
+    agent = Agent(
+        name="SDK root",
+        model="hosted" if model_source == "agent" else "unused",
+        tools=[lookup_document],
+    )
+    run_config = RunConfig(
+        model="hosted" if model_source == "run_config" else None,
+        model_provider=provider,
+        tracing_disabled=True,
+    )
+
+    with pytest.raises(MaxTurnsExceeded):
+        if streamed:
+            result = Runner.run_streamed(
+                agent,
+                "Inspect alpha.",
+                max_turns=1,
+                run_config=run_config,
+            )
+            _ = [event async for event in result.stream_events()]
+        else:
+            await Runner.run(
+                agent,
+                "Inspect alpha.",
+                max_turns=1,
+                run_config=run_config,
+            )
+
+    assert provider.requested_names == ["hosted"]
     assert client.beta.responses.connections[0].closed
     assert model._active_response is None
 

--- a/tests/extensions/experimental/hosted_multi_agent/test_model.py
+++ b/tests/extensions/experimental/hosted_multi_agent/test_model.py
@@ -183,6 +183,9 @@ class _DummyConnection:
             raise RuntimeError("Dummy WebSocket event queue exhausted")
         return self.events.popleft()
 
+    async def close(self) -> None:
+        self.closed = True
+
 
 class _DummyConnectionManager:
     def __init__(self, connection: _DummyConnection) -> None:
@@ -192,7 +195,7 @@ class _DummyConnectionManager:
         return self.connection
 
     async def __aexit__(self, *_args: object) -> None:
-        self.connection.closed = True
+        await self.connection.close()
 
 
 class _DummyBetaResponses:
@@ -1178,16 +1181,6 @@ def test_tools_with_approval_settings_are_rejected_before_transport() -> None:
             )
 
     assert client.beta.responses.connect_calls == []
-
-
-def test_missing_beta_client_has_actionable_error() -> None:
-    model = OpenAIHostedMultiAgentModel(
-        model="gpt-5.6-sol",
-        openai_client=cast(Any, SimpleNamespace()),
-    )
-
-    with pytest.raises(UserError, match="client.beta.responses"):
-        model._get_beta_responses()
 
 
 def test_default_config_omits_service_default_concurrency() -> None:

--- a/tests/extensions/experimental/hosted_multi_agent/test_model.py
+++ b/tests/extensions/experimental/hosted_multi_agent/test_model.py
@@ -16,6 +16,7 @@ from openai.types.shared.reasoning import Reasoning
 
 from agents import (
     Agent,
+    MaxTurnsExceeded,
     ModelSettings,
     ModelTracing,
     RunConfig,
@@ -742,6 +743,105 @@ async def test_model_close_releases_paused_response() -> None:
     await model.close()
     assert client.beta.responses.connections[0].closed
     assert model._active_response is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_runner_closes_paused_response_when_max_turns_is_exceeded(
+    streamed: bool,
+) -> None:
+    function_call = {
+        "id": "fc_max_turns",
+        "type": "function_call",
+        "call_id": "call_max_turns",
+        "name": "lookup_document",
+        "arguments": '{"section":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+    }
+    model, client = _model(
+        [
+            _created("resp_max_turns"),
+            _done(function_call, sequence_number=2, output_index=0),
+        ]
+    )
+
+    @function_tool
+    def lookup_document(section: str) -> str:
+        return f"document:{section}"
+
+    agent = Agent(name="SDK root", model=model, tools=[lookup_document])
+    with pytest.raises(MaxTurnsExceeded):
+        if streamed:
+            result = Runner.run_streamed(
+                agent,
+                "Inspect alpha.",
+                max_turns=1,
+                run_config=RunConfig(tracing_disabled=True),
+            )
+            _ = [event async for event in result.stream_events()]
+        else:
+            await Runner.run(
+                agent,
+                "Inspect alpha.",
+                max_turns=1,
+                run_config=RunConfig(tracing_disabled=True),
+            )
+
+    assert client.beta.responses.connections[0].closed
+    assert model._active_response is None
+
+
+@pytest.mark.asyncio
+async def test_runner_closes_paused_response_when_tool_execution_fails() -> None:
+    function_call = {
+        "id": "fc_tool_failure",
+        "type": "function_call",
+        "call_id": "call_tool_failure",
+        "name": "lookup_document",
+        "arguments": '{"section":"alpha"}',
+        "status": "completed",
+        "agent": {"agent_name": "/root/researcher"},
+    }
+    recovered_message = _root_final_message("recovered")
+    model, client = _model(
+        event_batches=[
+            [
+                _created("resp_tool_failure"),
+                _done(function_call, sequence_number=2, output_index=0),
+            ],
+            [
+                _created("resp_recovered"),
+                _done(recovered_message, sequence_number=2, output_index=0),
+                _completed("resp_recovered", [recovered_message], sequence_number=3),
+            ],
+        ]
+    )
+
+    def lookup_document(section: str) -> str:
+        raise RuntimeError(f"Unable to read {section}")
+
+    tool = function_tool(lookup_document, failure_error_function=None)
+    agent = Agent(name="SDK root", model=model, tools=[tool])
+    with pytest.raises(UserError, match="Unable to read alpha"):
+        await Runner.run(
+            agent,
+            "Inspect alpha.",
+            run_config=RunConfig(tracing_disabled=True),
+        )
+
+    assert client.beta.responses.connections[0].closed
+    assert model._active_response is None
+
+    result = await Runner.run(
+        agent,
+        "Try again.",
+        run_config=RunConfig(tracing_disabled=True),
+    )
+
+    assert result.final_output == "recovered"
+    assert len(client.beta.responses.connect_calls) == 2
+    assert client.beta.responses.connections[1].closed
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -2406,7 +2406,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.36.0"
+version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2418,9 +2418,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
 ]
 
 [[package]]
@@ -2561,7 +2561,7 @@ requires-dist = [
     { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.19.0,<2" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.4.3" },
     { name = "numpy", marker = "python_full_version >= '3.10' and extra == 'voice'", specifier = ">=2.2.0,<3" },
-    { name = "openai", specifier = ">=2.36.0,<3" },
+    { name = "openai", specifier = ">=2.45.0,<3" },
     { name = "pydantic", specifier = ">=2.12.2,<3" },
     { name = "pymongo", marker = "extra == 'mongodb'", specifier = ">=4.14" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=7" },


### PR DESCRIPTION
This pull request adds experimental OpenAI Responses hosted multi-agent support over WebSocket, including local function-tool injection, hosted-agent attribution, normalized output handling, documentation, examples, and regression coverage.

see also: https://developers.openai.com/api/docs/guides/tools-multi-agent
