### PR TITLE
fix: serialize model-backed rollout interruptions as dicts

### DIFF
--- a/src/agents/sandbox/memory/rollouts.py
+++ b/src/agents/sandbox/memory/rollouts.py
@@ -196,6 +196,14 @@ def terminal_metadata_for_exception(exc: BaseException) -> RolloutTerminalMetada
     )
 
 
+def _serialize_interruption_raw_item(raw_item: Any) -> Any:
+    if isinstance(raw_item, BaseModel):
+        return _to_dump_compatible(raw_item.model_dump(exclude_unset=True))
+    if isinstance(raw_item, dict):
+        return dict(raw_item)
+    return _to_dump_compatible(raw_item)
+
+
 def build_rollout_payload(
     *,
     input: str | list[TResponseInputItem],
@@ -210,10 +218,7 @@ def build_rollout_payload(
     )
 
     serialized_interruptions = [
-        _to_dump_compatible(interruption.raw_item)
-        if not isinstance(interruption.raw_item, dict)
-        else dict(interruption.raw_item)
-        for interruption in interruptions
+        _serialize_interruption_raw_item(interruption.raw_item) for interruption in interruptions
     ]
 
     payload: dict[str, Any] = {

--- a/tests/sandbox/test_memory.py
+++ b/tests/sandbox/test_memory.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
-from openai.types.responses import ResponseCustomToolCall
+from openai.types.responses import ResponseCustomToolCall, ResponseFunctionToolCall
 from openai.types.responses.response_output_message import ResponseOutputMessage
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 
@@ -24,7 +24,12 @@ from agents import (
     TResponseInputItem,
 )
 from agents.exceptions import UserError
-from agents.items import CompactionItem, MessageOutputItem, TResponseOutputItem
+from agents.items import (
+    CompactionItem,
+    MessageOutputItem,
+    ToolApprovalItem,
+    TResponseOutputItem,
+)
 from agents.result import RunResultStreaming
 from agents.run import _sandbox_memory_input
 from agents.run_context import RunContextWrapper
@@ -256,6 +261,34 @@ def test_build_rollout_payload_filters_developer_and_noisy_items() -> None:
         assistant_message.model_dump(exclude_unset=True),
     ]
     assert payload["final_output"] == "done"
+
+
+def test_build_rollout_payload_serializes_model_interruptions_as_dicts() -> None:
+    agent = Agent(name="test")
+    raw = ResponseFunctionToolCall(
+        id="fc_1",
+        call_id="call_1",
+        name="get_weather",
+        arguments='{"city":"Paris"}',
+        type="function_call",
+    )
+    approval = ToolApprovalItem(agent=agent, raw_item=raw)
+
+    payload = build_rollout_payload(
+        input="hello",
+        new_items=[],
+        final_output=None,
+        interruptions=[approval],
+        terminal_metadata=RolloutTerminalMetadata(terminal_state="interrupted"),
+    )
+
+    interruption = payload["interruptions"][0]
+    assert isinstance(interruption, dict)
+    assert interruption == raw.model_dump(exclude_unset=True)
+    assert interruption["type"] == "function_call"
+    assert interruption["call_id"] == "call_1"
+    assert interruption["name"] == "get_weather"
+    assert interruption["arguments"] == '{"city":"Paris"}'
 
 
 def test_render_phase_one_prompt_truncates_large_rollout_contents() -> None:


### PR DESCRIPTION
### Summary

Anyone using sandbox rollout memory with human-in-the-loop tool approval (`Runner` runs that get interrupted for approval) hits silent data corruption when the rollout is persisted.

`build_rollout_payload` serializes each interruption by passing `ToolApprovalItem.raw_item` straight into `_to_dump_compatible`. For an interrupted tool call, `raw_item` is a pydantic model (`ResponseFunctionToolCall`, `McpCall`, `LocalShellCall`, etc.). `_to_dump_compatible` has no `BaseModel` branch, and because pydantic v2 models are iterable (they yield `(key, value)` tuples), the model falls into the generic `Iterable` branch and is turned into a list of `[key, value]` pairs instead of a JSON object. Every other rollout section (`input`, `generated_items`) is pre-converted to dicts, so only the interruptions path passes a raw model through.

The fix `model_dump`s a model raw item before normalization, matching the existing convention in `run_state._serialize_tool_input` (dump first, then `_to_dump_compatible`). dict and other raw items are unchanged.

Before/after with the public API:

```python
from openai.types.responses import ResponseFunctionToolCall
from agents import Agent
from agents.items import ToolApprovalItem
from agents.sandbox.memory.rollouts import build_rollout_payload, RolloutTerminalMetadata

agent = Agent(name="a")
raw = ResponseFunctionToolCall(
    id="fc_1", call_id="call_1", name="get_weather",
    arguments='{"city":"Paris"}', type="function_call",
)
payload = build_rollout_payload(
    input="hello", new_items=[], final_output=None,
    interruptions=[ToolApprovalItem(agent=agent, raw_item=raw)],
    terminal_metadata=RolloutTerminalMetadata(terminal_state="interrupted"),
)
print(payload["interruptions"][0])

# Before:
# [['arguments', '{"city":"Paris"}'], ['call_id', 'call_1'], ['name', 'get_weather'],
#  ['type', 'function_call'], ['id', 'fc_1'], ['namespace', None], ['status', None]]
# After:
# {'arguments': '{"city":"Paris"}', 'call_id': 'call_1', 'name': 'get_weather',
#  'type': 'function_call', 'id': 'fc_1'}
```

### Test plan

Added `test_build_rollout_payload_serializes_model_interruptions_as_dicts` in `tests/sandbox/test_memory.py`, asserting the serialized interruption is a `dict` equal to `raw_item.model_dump(exclude_unset=True)`. Verified it passes with the fix and fails on `upstream/main` (the interruption comes back as a list of `[key, value]` pairs). `ruff format` and `ruff check` are clean on both changed files.

### Issue number

<!-- N/A -->

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass