### PR TITLE
fix(handoffs): avoid duplicating forwarded messages in nested handoff history

### DIFF
--- a/src/agents/handoffs/history.py
+++ b/src/agents/handoffs/history.py
@@ -78,6 +78,15 @@ def nest_handoff_history(
     normalized_history = _normalize_input_history(handoff_input_data.input_history)
     flattened_history = _flatten_nested_history_messages(normalized_history)
 
+    # A previous handoff may have forwarded a message verbatim alongside a
+    # summary that already records it. Such a message reappears here as a
+    # pre-handoff item, so track what the summarized history already covers and
+    # skip re-adding it to the transcript. Otherwise it would be listed twice
+    # inside the summary, with the duplication compounding on every handoff.
+    summarized_keys = {
+        key for item in flattened_history if (key := _summary_dedupe_key(item)) is not None
+    }
+
     # Convert items to plain inputs for the transcript summary.
     pre_items_as_inputs: list[TResponseInputItem] = []
     filtered_pre_items: list[RunItem] = []
@@ -85,10 +94,14 @@ def nest_handoff_history(
         if isinstance(run_item, ToolApprovalItem):
             continue
         plain_input = _run_item_to_plain_input(run_item)
-        pre_items_as_inputs.append(plain_input)
+        if not _is_already_summarized(plain_input, summarized_keys):
+            pre_items_as_inputs.append(plain_input)
         if _should_forward_pre_item(plain_input):
             filtered_pre_items.append(run_item)
 
+    # ``new_items`` are produced by the current agent turn, so they are never
+    # forwarded copies of something the summary already records. They are kept
+    # verbatim, even when they happen to serialize identically to an earlier item.
     new_items_as_inputs: list[TResponseInputItem] = []
     filtered_input_items: list[RunItem] = []
     for run_item in handoff_input_data.new_items:
@@ -221,6 +234,19 @@ def _flatten_nested_history_messages(
             continue
         flattened.append(deepcopy(item))
     return flattened
+
+
+def _summary_dedupe_key(item: TResponseInputItem) -> str | None:
+    payload = {k: v for k, v in item.items() if k != "provider_data"}
+    try:
+        return json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_already_summarized(item: TResponseInputItem, summarized_keys: set[str]) -> bool:
+    key = _summary_dedupe_key(item)
+    return key is not None and key in summarized_keys
 
 
 def _extract_nested_history_transcript(

--- a/tests/test_handoff_history_duplication.py
+++ b/tests/test_handoff_history_duplication.py
@@ -6,6 +6,7 @@ in the input sent to the next agent.
 """
 
 import json
+import re
 from typing import Any, cast
 
 import pytest
@@ -247,6 +248,31 @@ class TestHandoffHistoryDuplicationFix:
         assert nested.input_items is not None
         assert len(nested.input_items) == 1, "MessageOutputItem should be preserved in input_items"
         assert isinstance(nested.input_items[0], MessageOutputItem)
+
+    def test_new_items_are_kept_when_identical_to_summarized_history(self):
+        """Verify a current-turn item is never dropped as "already summarized".
+
+        ``new_items`` are produced by the current agent turn, so they are never
+        forwarded copies of a message the summary already records. An item that
+        happens to serialize identically to one already in the history must still
+        be recorded in the transcript, otherwise the current turn silently loses
+        an output.
+        """
+        agent = _create_mock_agent()
+        message_item = _create_message_item(agent)
+
+        handoff_data = HandoffInputData(
+            input_history=(message_item.to_input_item(),),
+            pre_handoff_items=(),
+            new_items=(message_item,),
+        )
+
+        nested = nest_handoff_history(handoff_data)
+
+        summary = str(cast(dict[str, Any], nested.input_history[0]).get("content", ""))
+        assert summary.count("Hello!") == 2, (
+            f"current-turn message must not be dropped as a duplicate, got: {summary}"
+        )
 
     def test_reasoning_items_are_filtered_from_input_items(self):
         """Verify ReasoningItem in new_items is filtered from input_items.
@@ -524,3 +550,51 @@ async def test_to_input_list_normalized_uses_custom_filter_input_items() -> None
     assert len(normalized_input) == 3
     assert "function_call" not in normalized_types
     assert "function_call_output" not in normalized_types
+
+
+@pytest.mark.asyncio
+async def test_nested_handoff_chain_does_not_duplicate_summary_records() -> None:
+    """A chain of handoffs must not duplicate records inside the summary block.
+
+    Each agent's pre-handoff message is both summarized and forwarded verbatim
+    to the next agent. When the next agent hands off again, the verbatim copy is
+    re-summarized alongside the previous summary that already contains it, so the
+    same message ends up listed twice inside a single <CONVERSATION HISTORY>
+    block, and the duplication compounds on every subsequent handoff.
+    """
+    names = ["A", "B", "C", "D"]
+    models = [FakeModel() for _ in names]
+    agents = [Agent(name=name, model=model) for name, model in zip(names, models, strict=True)]
+    for i in range(len(agents) - 1):
+        agents[i].handoffs = [agents[i + 1]]
+
+    for i in range(len(agents) - 1):
+        models[i].add_multiple_turn_outputs(
+            [[get_text_message(f"{names[i]}: msg"), get_handoff_tool_call(agents[i + 1])]]
+        )
+    models[-1].add_multiple_turn_outputs([[get_text_message("D: final")]])
+
+    await Runner.run(
+        agents[0],
+        input="user_question",
+        run_config=RunConfig(nest_handoff_history=True),
+    )
+
+    final_input = models[-1].last_turn_args["input"]
+    summary = str(cast(dict[str, Any], final_input[0]).get("content", ""))
+    start = summary.index("<CONVERSATION HISTORY>") + len("<CONVERSATION HISTORY>")
+    end = summary.index("</CONVERSATION HISTORY>")
+    # Drop the ``N.`` ordering prefix so records are compared by content only.
+    records = [
+        re.sub(r"^\d+\.\s*", "", line.strip())
+        for line in summary[start:end].splitlines()
+        if line.strip()
+    ]
+
+    # No two records inside the summary block should be identical.
+    assert len(records) == len(set(records)), f"summary has duplicate records: {records}"
+
+    # Each intermediate agent's message must appear exactly once in the summary.
+    for name in names[:-1]:
+        count = summary.count(f"{name}: msg")
+        assert count == 1, f"{name}: msg should appear once in the summary, got {count}"


### PR DESCRIPTION
### Summary

Anyone using `RunConfig(nest_handoff_history=True)` (or `handoff(..., nest_handoff_history=True)`) with a chain of handoffs — the common triage -> specialist -> specialist pattern — gets a corrupted conversation summary: each agent's own pre-handoff message is listed twice inside the downstream `<CONVERSATION HISTORY>` block, and the duplication compounds with every additional hop.

Root cause: an agent's pre-handoff message is both summarized into the transcript and forwarded verbatim to the next agent (this dual behavior is intentional and covered by existing tests). On the *next* handoff that verbatim copy arrives as a `pre_handoff_item`, and `nest_handoff_history` unconditionally re-added every pre/new item to the transcript (`history.py`) — right next to the flattened previous summary that already contained the same message. So the message appeared as two byte-identical numbered records in a single summary. At each further hop the forwarded copy is re-summarized again, so across a 4-agent chain A's and B's messages each show up twice in D's summary. This feeds the model a repeated transcript and wastes tokens, with the waste growing with chain length.

The minimal fix: before adding a pre/new item to the summarized transcript, check whether the flattened history already records an identical item, and skip it if so. Forwarding behavior is unchanged, and the single-hop "message appears in the summary and is forwarded verbatim" behavior is preserved — only the duplicate *within* the summary is removed.

Before/after using the public API:

```python
import asyncio
from agents import Agent, RunConfig, Runner
from tests.fake_model import FakeModel
from tests.test_responses import get_text_message, get_handoff_tool_call

async def main():
    models = [FakeModel() for _ in range(4)]
    names = ["A", "B", "C", "D"]
    agents = [Agent(name=names[i], model=models[i]) for i in range(4)]
    for i in range(3):
        agents[i].handoffs = [agents[i + 1]]
    for i in range(3):
        models[i].add_multiple_turn_outputs(
            [[get_text_message(f"{names[i]}: msg"), get_handoff_tool_call(agents[i + 1])]]
        )
    models[3].add_multiple_turn_outputs([[get_text_message("D: final")]])
    await Runner.run(agents[0], input="USERQ", run_config=RunConfig(nest_handoff_history=True))
    print(models[3].last_turn_args["input"][0]["content"])

asyncio.run(main())
```

Before this fix, agent D's `<CONVERSATION HISTORY>` lists `A: msg` twice (records #2 and #5) and `B: msg` twice (records #6 and #9). After the fix, each intermediate agent's message appears exactly once in the summary.

### Test plan

Added `tests/test_handoff_history_duplication.py::test_nested_handoff_chain_does_not_duplicate_summary_records`, which runs a 4-agent handoff chain with `nest_handoff_history=True` and asserts (a) no two records inside the final agent's `<CONVERSATION HISTORY>` block are identical and (b) each intermediate agent's message appears exactly once in the summary.

- New test passes with the fix; reverting only `src/agents/handoffs/history.py` to `main` makes it fail (`12 == 10`, two duplicate records).
- Full handoff suite green: `pytest tests/ -k handoff` -> 198 passed. This includes the existing single-hop tests that assert the current-turn message is present in the downstream summary, which remain unchanged.
- `ruff format`, `ruff check`, and `mypy src/agents/handoffs/history.py` are clean.

### Issue number

<!-- Fill in if there is a tracking issue -->

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass

### Relation to #2171

Issue #2171 (now closed) covered the single-hop case: a message appearing both in the summary and forwarded verbatim to the immediate next agent. That fix is intact and its tests still pass unchanged.

What remains, and what this PR addresses, is the **multi-hop** residue: on the *second and later* handoffs the forwarded copy arrives as a `pre_handoff_item` and gets re-summarized alongside the flattened prior summary that already contains it, so the duplication compounds with chain length. This is why the existing single-hop tests never caught it. The new test exercises a 4-agent chain rather than a single handoff.

Since this is residual behaviour beyond #2171's original scope rather than a regression of it, the PR intentionally does not auto-close that issue.
