### PR TITLE
chore: exempt OpenAI package from dependency cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,8 +211,10 @@ format-command = "ruff format --stdin-filename {filename}"
 
 [tool.uv]
 exclude-newer = "7 days"
+exclude-newer-package = { openai = false }
 index-strategy = "first-index"
 
 [tool.uv.pip]
 exclude-newer = "7 days"
+exclude-newer-package = { openai = false }
 index-strategy = "first-index"

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,9 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+openai = false
+
 [[package]]
 name = "aiofiles"
 version = "24.1.0"


### PR DESCRIPTION
This pull request updates the uv resolution policy to exempt only the `openai` package from the repository's seven-day dependency cooldown. All other packages remain subject to the existing cooldown, and the lockfile records the exemption for reproducible frozen CI installs.

The change does not upgrade `openai` or modify runtime behavior. It allows maintainers to adopt newly released OpenAI Python versions without disabling the supply-chain delay for unrelated dependencies.