### PR TITLE
feat: add progressive learning examples for SDK internals #3770

### DIFF
--- a/examples/learn/00_setup_check.py
+++ b/examples/learn/00_setup_check.py
@@ -1,0 +1,56 @@
+"""Example 00: Environment setup check.
+
+Prints SDK version, Python, dependencies, and model backend connectivity.
+Usage: python examples/00_setup_check.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+
+def check_static():
+    import agents
+    from agents.run import Runner
+
+    print("=== Static Environment ===")
+    print(f"  Python:     {sys.version.split()[0]}")
+    print(f"  openai-agents: {agents.__version__ if hasattr(agents, '__version__') else 'unknown'}")
+    try:
+        from importlib.metadata import version
+
+        print(f"  openai:     {version('openai-agents')} (meta)")
+        print(f"  pydantic:   {version('pydantic')}")
+        print(f"  griffe:     {version('griffe')}")
+    except Exception as e:
+        print(f"  meta lookup: {e}")
+    print(f"  Runner entrypoints: {[m for m in dir(Runner) if m.startswith('run_')]}")
+
+
+async def check_live():
+    from config import BASE_URL, MODEL, MODEL_NAME  # type: ignore[import-not-found]
+
+    from agents import Agent, Runner
+
+    print("\n Runtime ")
+    print(f"  base_url:   {BASE_URL}")
+    print(f"  model:      {MODEL_NAME}")
+
+    agent = Agent(
+        name="SetupCheck",
+        instructions="Reply in one sentence.",
+        model=MODEL,
+    )
+    result = await Runner.run(agent, "ping")
+    print(f"  final:      {result.final_output!r}")
+    print(f"  raw count:  {len(result.raw_responses)}")
+    print(f"  new_items:  {len(result.new_items)}")
+    print(f"  usage:      {result.context_wrapper.usage}")
+
+
+if __name__ == "__main__":
+    check_static()
+    asyncio.run(check_live())
+    print("\n Setup OK. Proceed to run 01 -> 15 in order.")

--- a/examples/learn/01_runner_loop.py
+++ b/examples/learn/01_runner_loop.py
@@ -1,0 +1,92 @@
+"""Example 01: Runner core loop.
+
+Principle (see docs/architecture.md §1):
+Runner.run follows a 4-step loop - 1) Call model 2) Get final output 3) Get handoff 4) Get tool call
+Source: agents/run.py:768-1498 (AgentRunner main loop)
+      agents/run.py:450-1564 (AgentRunner.run overall)
+
+Observe three things in this example:
+  - Single turn, single step: Model returns message once, no tool call -> takes FinalOutput branch
+  - With tool: Model might call tool, triggering two rounds "tool call -> model again -> final"
+  - Use lifecycle hooks to print "every beat in the loop"
+
+Usage: python examples/01_runner_loop.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import MODEL  # type: ignore[import-not-found]
+
+from agents import Agent, RunHooks, Runner, function_tool
+
+
+#  1) A "heartbeat" hook injected into the runner
+class HeartbeatHooks(RunHooks):
+    async def on_agent_start(self, context, agent):
+        print(f"   [hook] on_agent_start: {agent.name}")
+
+    async def on_llm_start(self, context, agent, system_prompt, input_items):
+        print(f"   [hook] on_llm_start:  agent={agent.name} items={len(input_items)}")
+
+    async def on_llm_end(self, context, agent, response):
+        print(f"   [hook] on_llm_end:    output_items={len(response.output)}")
+
+    async def on_tool_start(self, context, agent, tool):
+        print(f"   [hook] on_tool_start: {tool.name}")
+
+    async def on_tool_end(self, context, agent, tool, result):
+        print(f"   [hook] on_tool_end:   {tool.name} -> {str(result)[:60]}")
+
+    async def on_agent_end(self, context, agent, output):
+        print(f"   [hook] on_agent_end:  {agent.name} final={str(output)[:60]}")
+
+
+#  2) A tool to observe the loop taking the "tool call -> call model again" branch
+@function_tool
+def word_count(text: str) -> int:
+    """Count words in a string (Chinese by char, English by word)."""
+    cn = sum(1 for c in text if "\u4e00" <= c <= "\u9fff")
+    en = len([w for w in text.split() if any(c.isalpha() for c in w)])
+    return cn + en
+
+
+async def scenario(label: str, agent: Agent, prompt: str, hooks):
+    print(f"\n {label} ")
+    result = await Runner.run(agent, prompt, hooks=hooks)
+    print(f"   Turns (new_items count): {len(result.new_items)}")
+    print(f"   Final agent:           {result.last_agent.name}")
+    print(f"   final_output:         {result.final_output}")
+
+
+async def main():
+    hooks = HeartbeatHooks()
+
+    # Scenario A: No tool. Model returns once -> NextStepFinalOutput
+    plain = Agent(
+        name="PlainAgent",
+        instructions="Answer in one or two sentences.",
+        model=MODEL,
+    )
+    await scenario("A) Single turn, no tool", plain, "Hello", hooks)
+
+    # Scenario B: With tool. Model calls word_count -> NextStepRunAgain -> returns final in next round
+    tool_agent = Agent(
+        name="ToolAgent",
+        instructions="When the user provides text, you must first count it using word_count, then tell the user the result.",
+        model=MODEL,
+        tools=[word_count],
+    )
+    await scenario(
+        "B) With tool -> at least 2 rounds",
+        tool_agent,
+        "Count the words in this sentence: 'OpenAI Agents SDK is great'",
+        hooks,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/learn/02_lifecycle_hooks.py
+++ b/examples/learn/02_lifecycle_hooks.py
@@ -1,0 +1,120 @@
+"""Example 02: RunHooks vs AgentHooks.
+
+Principle:
+- RunHooks is bound to Runner.run(hooks=...), observes the whole run (including handoffs)
+- AgentHooks is bound to agent.hooks = ..., observes only this agent's events
+- Event set: on_agent_start / on_agent_end / on_llm_start / on_llm_end /
+         on_tool_start / on_tool_end / on_handoff
+Source: agents/lifecycle.py:13-200
+
+Observe:
+  1) RunHooks receives events from all agents; AgentHooks receives only its own
+  2) on_handoff triggers only once in RunHooks (cross-agent perspective)
+  3) on_agent_start triggers every turn (whenever current_agent switches)
+
+Usage: python examples/02_lifecycle_hooks.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from agent_defs.math_agent import math_agent  # type: ignore[import-not-found]
+from agent_defs.triage_agent import triage_agent  # type: ignore[import-not-found]
+from agent_defs.weather_agent import weather_agent  # type: ignore[import-not-found]
+
+from agents import AgentHooks, RunHooks, Runner
+
+
+class GlobalRunLog(RunHooks):
+    def __init__(self):
+        self.events: list[str] = []
+
+    def _log(self, tag: str, agent: str):
+        self.events.append(f"[RUN ] {tag} {agent}")
+
+    async def on_agent_start(self, context, agent):
+        self._log("agent_start", agent.name)
+
+    async def on_agent_end(self, context, agent, output):
+        self._log("agent_end", agent.name)
+
+    async def on_llm_start(self, context, agent, system_prompt, input_items):
+        self._log("llm_start", agent.name)
+
+    async def on_llm_end(self, context, agent, response):
+        self._log("llm_end", agent.name)
+
+    async def on_tool_start(self, context, agent, tool):
+        self._log("tool_start", f"{agent.name}/{tool.name}")
+
+    async def on_tool_end(self, context, agent, tool, result):
+        self._log("tool_end", f"{agent.name}/{tool.name}")
+
+    async def on_handoff(self, context, from_agent, to_agent):
+        self._log("HANDOFF", f"{from_agent.name} -> {to_agent.name}")
+
+
+class PerAgentLog(AgentHooks):
+    """Bound to a single agent, receives only events triggered by itself"""
+
+    def __init__(self, owner: str):
+        self.owner = owner
+        self.events: list[str] = []
+
+    def _log(self, tag: str):
+        self.events.append(f"[AGENT {self.owner}] {tag}")
+
+    async def on_start(self, context, agent):
+        self._log("on_start")
+
+    async def on_end(self, context, agent, output):
+        self._log("on_end")
+
+    async def on_llm_start(self, context, agent, system_prompt, input_items):
+        self._log("llm_start")
+
+    async def on_llm_end(self, context, agent, response):
+        self._log("llm_end")
+
+    async def on_tool_start(self, context, agent, tool):
+        self._log(f"tool_start/{tool.name}")
+
+    async def on_tool_end(self, context, agent, tool, result):
+        self._log(f"tool_end/{tool.name}")
+
+
+async def main():
+    run_log = GlobalRunLog()
+
+    # Bind a "self-only" AgentHooks to math_agent
+    math_log = PerAgentLog("MathAgent")
+    math_agent.hooks = math_log
+    weather_log = PerAgentLog("WeatherAgent")
+    weather_agent.hooks = weather_log
+
+    print(">>> User: What is 3 plus 5?\n")
+    result = await Runner.run(triage_agent, "What is 3 plus 5?", hooks=run_log)
+    print(f"<<< Agent: {result.final_output}\n")
+
+    print("=== Events received by global RunHooks ===")
+    for e in run_log.events:
+        print(" ", e)
+    print(f"\n=== MathAgent's own hooks received ({len(math_log.events)} items) ===")
+    for e in math_log.events:
+        print(" ", e)
+    print(
+        f"\n WeatherAgent's own hooks received ({len(weather_log.events)} items, should be 0) ==="
+    )
+    for e in weather_log.events:
+        print(" ", e)
+
+    print("\nObserve:")
+    print(" - RunHooks contains HANDOFF: triage -> math_agent")
+    print(" - MathAgent's AgentHooks has events; WeatherAgent has none (didn't switch to it)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/learn/03_function_tool_introspection.py
+++ b/examples/learn/03_function_tool_introspection.py
@@ -1,0 +1,76 @@
+"""Example 03: @function_tool internal mechanism.
+
+Principle (agents/function_schema.py:224-424):
+  @function_tool translates a Python function into a FunctionTool, process:
+    1) griffe parses docstring (Google/NumPy/Sphinx auto-detected)
+    2) typing.get_type_hints gets type hints, strips Annotated to get description
+    3) inspect.signature gets parameters; first RunContextWrapper/ToolContext auto-marked as takes_context
+    4) pydantic.create_model dynamically builds an "args model"
+    5) ensure_strict_json_schema makes schema strict mode (OpenAI requirement)
+  On call: JSON args -> pydantic validate -> func(**kwargs)
+
+Observe three things:
+  - tool.params_json_schema: actual strict schema sent to LLM (see how description comes from docstring)
+  - tool.name / tool.description: how function name and docstring are derived
+  - Simulate LLM calling tool: tool.on_invoke_tool(ctx, json_str)
+
+Usage: python examples/03_function_tool_introspection.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from tools.calculator import add, divide  # type: ignore[import-not-found]
+from tools.weather import get_weather  # type: ignore[import-not-found]
+
+from agents.run_context import RunContextWrapper
+from agents.tool_context import ToolContext
+
+
+def show_schema(tool):
+    print(f"  name:        {tool.name}")
+    print(f"  description: {tool.description!r}")
+    print("  schema.properties:")
+    for prop_name, prop in tool.params_json_schema.get("properties", {}).items():
+        print(f"    - {prop_name}: {prop.get('type')!r}  desc={prop.get('description')!r}")
+    print(f"  required: {tool.params_json_schema.get('required')}")
+    print("  Full JSON schema (excerpt):")
+    print(json.dumps(tool.params_json_schema, indent=2, ensure_ascii=False)[:600] + "...")
+
+
+def simulate_invoke(tool, label, json_args):
+    print(f"\n  {label}: Tool triggered by LLM, passed JSON args = {json_args!r}")
+    # ToolContext has many fields, we mock it
+    ctx = ToolContext(
+        context=RunContextWrapper(context=None),
+        tool_name=tool.name,
+        tool_call_id="call_test_001",
+        tool_arguments=json_args,
+    )
+    # on_invoke_tool is async
+    import asyncio
+
+    result = asyncio.run(tool.on_invoke_tool(ctx, json_args))
+    print(f"  on_invoke_tool() returns: {result!r}")
+
+
+def main():
+    print("\n weather.get_weather")
+    show_schema(get_weather)
+    simulate_invoke(get_weather, "LLM passes city='Beijing'", '{"city": "Beijing"}')
+
+    print("\n calculator.add")
+    show_schema(add)
+    simulate_invoke(add, "LLM passes 5+3", '{"a": 5, "b": 3}')
+
+    print("\n calculator.divide (with edge case)")
+    show_schema(divide)
+    simulate_invoke(divide, "LLM passes 100/4", '{"a": 100, "b": 4}')
+    simulate_invoke(divide, "LLM passes 1/0 (boundary)", '{"a": 1, "b": 0}')
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/learn/04_tool_use_behavior.py
+++ b/examples/learn/04_tool_use_behavior.py
@@ -1,0 +1,131 @@
+"""Example 04: tool_use_behavior - "Next step" control after tool execution.
+
+Principle (agents/agent.py:345-365, 4 valid values):
+  - "run_llm_again" (default): Feed tool result back to LLM, let LLM decide final
+  - "stop_on_first_tool": First tool output used as final directly, skips LLM
+  - StopAtTools(stop_at_tool_names=[...]): Stops when any tool in list is triggered
+  - ToolsToFinalOutputFunction: Custom (ctx, tool_results) -> ToolsToFinalOutputResult
+                                  (returns dataclass, not raw string)
+
+Compare scenarios to see behavioral differences.
+
+Usage: python examples/04_tool_use_behavior.py
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import MODEL  # type: ignore[import-not-found]
+
+from agents import (
+    Agent,
+    RunContextWrapper,
+    Runner,
+    StopAtTools,
+    ToolsToFinalOutputResult,
+    function_tool,
+)
+
+
+@function_tool
+def lookup_user(user_id: int) -> str:
+    """Look up user information.
+
+    Args:
+        user_id: User ID
+    """
+    return json.dumps({"id": user_id, "name": "Alice", "role": "admin"}, ensure_ascii=False)
+
+
+@function_tool
+def send_email(to: str, subject: str, body: str) -> str:
+    """Send email.
+
+    Args:
+        to:      Recipient
+        subject: Subject
+        body:    Body
+    """
+    return f"Sent email to {to}: {subject}"
+
+
+#  Scenario 1: Default run_llm_again 
+def make_default_agent():
+    return Agent(
+        name="DefaultAgent",
+        instructions="Call lookup_user for user info; call send_email for email. Keep answers concise.",
+        model=MODEL,
+        tools=[lookup_user, send_email],
+    )
+
+
+#  Scenario 2: stop_on_first_tool 
+def make_stop_agent():
+    return Agent(
+        name="StopAgent",
+        instructions="Call lookup_user for user info.",
+        model=MODEL,
+        tools=[lookup_user, send_email],
+        tool_use_behavior="stop_on_first_tool",
+    )
+
+
+#  Scenario 3: StopAtTools - Stop only on send_email 
+def make_stop_at_email_agent():
+    return Agent(
+        name="StopAtEmailAgent",
+        instructions="Call lookup_user for user info; call send_email when user asks to send email.",
+        model=MODEL,
+        tools=[lookup_user, send_email],
+        tool_use_behavior=StopAtTools(stop_at_tool_names=["send_email"]),
+    )
+
+
+#  Scenario 4: Custom function - Must return ToolsToFinalOutputResult 
+def custom_final(ctx: RunContextWrapper, tool_results: list[Any]) -> ToolsToFinalOutputResult:
+    """Return None to continue; return ToolsToFinalOutputResult to end."""
+    for r in tool_results:
+        if r.tool.name == "lookup_user":
+            return ToolsToFinalOutputResult(
+                is_final_output=True,
+                final_output=f"[Custom wrapper] {r.output}",
+            )
+    return ToolsToFinalOutputResult(is_final_output=False, final_output=None)
+
+
+def make_custom_agent():
+    return Agent(
+        name="CustomAgent",
+        instructions="Call lookup_user for user info.",
+        model=MODEL,
+        tools=[lookup_user],
+        tool_use_behavior=custom_final,
+    )
+
+
+async def run(label: str, agent: Agent, prompt: str):
+    print(f"\n {label}")
+    print(f"  tool_use_behavior = {agent.tool_use_behavior}")
+    result = await Runner.run(agent, prompt)
+    print(f"  final_output:     {result.final_output}")
+    print(f"  new_items count:  {len(result.new_items)}")
+    # See type of each item
+
+    types = [type(it).__name__ for it in result.new_items]
+    print(f"  item type sequence: {types}")
+
+
+async def main():
+    await run("A) Default run_llm_again", make_default_agent(), "Look up info for user 42")
+    await run("B) stop_on_first_tool", make_stop_agent(), "Look up info for user 42")
+    await run("C) StopAtTools(send_email)", make_stop_at_email_agent(), "Look up info for user 42")
+    await run("D) Custom function custom_final", make_custom_agent(), "Look up info for user 42")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/learn/05_handoff_mechanics.py
+++ b/examples/learn/05_handoff_mechanics.py
@@ -1,0 +1,150 @@
+"""Example 05: internal implementation of handoff.
+
+Principle (agents/handoffs/__init__.py:93-280):
+  handoff(agent) registers a function tool named transfer_to_<agent_name> from the model's perspective
+  - tool_name: default "transfer_to_<agent_name>", can be changed via tool_name_override
+  - tool_description: default "<handoff_description>", can be changed via tool_description_override
+  - on_handoff(ctx, [input_data]): runs when triggered by model (used for side effects / fetching data)
+  - input_type: Pydantic schema, model can pass structured parameters to on_handoff
+  - input_filter(HandoffInputData) -> HandoffInputData: controls the context seen by the new agent
+  - is_enabled: bool or callable, dynamic switch
+
+Observe four things:
+  1) print the schema of the "virtual tool" registered by handoff, see what it looks like
+  2) on_handoff actually triggers
+  3) how input_type uses Pydantic to let the model pass structured reasons
+  4) is_enabled dynamic disable
+
+Usage: python examples/05_handoff_mechanics.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from pprint import pprint
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import MODEL  # type: ignore[import-not-found]
+from pydantic import BaseModel
+
+from agents import Agent, RunContextWrapper, Runner, handoff
+
+# 1) A basic handoff: only look at on_handoff side effect
+on_log = []
+
+
+def record_handoff(ctx):
+    on_log.append(f"on_handoff fired at {ctx.usage.requests} requests used")
+
+
+basic_agent = Agent(
+    name="BasicAgent",
+    instructions="I am BasicAgent.",
+    model=MODEL,
+)
+handoff_basic = handoff(
+    agent=basic_agent,
+    on_handoff=record_handoff,
+)
+
+
+# 2) Handoff with input_type: model must pass reason
+class EscalationData(BaseModel):
+    reason: str
+    severity: int
+
+
+def record_escalation(ctx: RunContextWrapper, data: EscalationData):
+    on_log.append(f"ESCALATE reason={data.reason!r} severity={data.severity}")
+
+
+escalation_agent = Agent(
+    name="EscalationAgent",
+    instructions="I am EscalationAgent, handling high priority issues.",
+    model=MODEL,
+)
+handoff_escalate = handoff(
+    agent=escalation_agent,
+    on_handoff=record_escalation,
+    input_type=EscalationData,
+)
+
+
+# 3) is_enabled dynamic switch: judge whether escalation is possible based on context
+flag = {"can_escalate": True}
+
+
+def can_escalate(ctx, _data) -> bool:
+    return flag["can_escalate"]
+
+
+def record_blocked(ctx, _data):
+    on_log.append("block: cannot escalate right now")
+
+
+escalation_agent2 = Agent(
+    name="EscalationAgent2",
+    instructions="I am EscalationAgent2.",
+    model=MODEL,
+)
+handoff_conditional = handoff(
+    agent=escalation_agent2,
+    on_handoff=record_blocked,
+    input_type=EscalationData,
+    is_enabled=can_escalate,
+)
+
+
+#  Main agent: route based on user_role 
+triage = Agent(
+    name="Triage",
+    instructions=(
+        "You are Triage.\n"
+        "- Normal issues: handoff to BasicAgent\n"
+        "- Needs escalation: handoff to EscalationAgent, passing reason and severity (1-5) when calling"
+    ),
+    model=MODEL,
+    handoffs=[handoff_basic, handoff_escalate, handoff_conditional],
+)
+
+
+async def main():
+    # First look at what tools each handoff registered
+    print("=== Virtual tools registered by handoff ===")
+    for h in triage.handoffs:
+        name = getattr(h, "tool_name", "unknown")
+        description = getattr(h, "tool_description", "")
+        agent_name = getattr(h, "agent_name", "unknown")
+        print(f"\nname:        {name}")
+        print(f"description: {description[:120]}")
+        print(f"agent_name:  {agent_name}")
+        print("input_json_schema:")
+        pprint(getattr(h, "input_json_schema", {}))
+        print(f"is_enabled:  {getattr(h, 'is_enabled', True)}")
+
+    print("\n Scenario 1: Normal handoff ")
+    on_log.clear()
+    flag["can_escalate"] = True
+    r1 = await Runner.run(triage, "Hello, just chatting")
+    print(f"final agent:    {r1.last_agent.name}")
+    print(f"final_output:   {r1.final_output}")
+    print(f"on_log:         {on_log}")
+
+    print("\n Scenario 2: input_type escalation ")
+    on_log.clear()
+    r2 = await Runner.run(triage, "Online payment failed, please escalate to P0 urgent handling")
+    print(f"final agent:    {r2.last_agent.name}")
+    print(f"final_output:   {r2.final_output}")
+    print(f"on_log:         {on_log}")
+
+    print("\n Scenario 3: is_enabled closes escalation ")
+    on_log.clear()
+    flag["can_escalate"] = False
+    r3 = await Runner.run(triage, "Payment failed, must escalate to P0")
+    print(f"final agent:    {r3.last_agent.name}")
+    print(f"on_log:         {on_log}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/learn/06_agent_as_tool.py
+++ b/examples/learn/06_agent_as_tool.py
@@ -1,0 +1,104 @@
+"""Example 06: agent.as_tool() - Manager pattern.
+
+Principle (agents/agent.py:508-936):
+  agent.as_tool(tool_name, tool_description) wraps an agent into a FunctionTool,
+  allowing another agent to "call" it (unlike handoff: control returns to main agent after call).
+  - control flow: main agent stays; expert agent runs sub-Runner.run and feeds final_output back
+  - parameters: Pydantic BaseModel, determines what parameters main agent can pass
+  - custom_output_extractor: extracts parts from sub-run result to return as tool
+  - needs_approval: True -> uses HITL flow (see example 10)
+  - on_stream: True -> forwards streaming events from sub-run
+
+Comparison:
+  - handoff: transfers control, sub-agent takes over the whole turn
+  - as_tool: main agent collects all expert results before continuing
+
+Usage: python examples/06_agent_as_tool.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import MODEL  # type: ignore[import-not-found]
+from pydantic import BaseModel, Field
+from tools.calculator import CALCULATOR_TOOLS  # type: ignore[import-not-found]
+
+from agents import Agent, Runner
+
+# 1) An "expert agent", only does addition
+adder_agent = Agent(
+    name="AdderAgent",
+    instructions="Add two numbers. Give result directly, no nonsense.",
+    model=MODEL,
+)
+
+
+# 2) Wrap as FunctionTool via as_tool, and define structured input
+class AddArgs(BaseModel):
+    a: int = Field(description="First number")
+    b: int = Field(description="Second number")
+
+
+adder_tool = adder_agent.as_tool(
+    tool_name="add_numbers",
+    tool_description="Add two numbers and return result",
+    parameters=AddArgs,
+)
+
+
+# 3) An "expert agent" for long text summarization
+summarizer_agent = Agent(
+    name="SummarizerAgent",
+    instructions="Summarize the user's text in one sentence.",
+    model=MODEL,
+)
+
+summarize_tool = summarizer_agent.as_tool(
+    tool_name="summarize",
+    tool_description="Compress a long text into one sentence",
+)
+
+
+# 4) A "manager agent" using the two experts above
+manager = Agent(
+    name="ManagerAgent",
+    instructions=(
+        "You are manager agent.\n"
+        "User gives task:\n"
+        "  - Arithmetic issue -> call add_numbers\n"
+        "  - Summarization issue -> call summarize\n"
+        "Tell user the result after calling."
+    ),
+    model=MODEL,
+    tools=[adder_tool, summarize_tool, *CALCULATOR_TOOLS],
+)
+
+
+async def main():
+    # See the tool list received by manager
+    print("=== Tool list received by ManagerAgent ===")
+    for t in manager.tools:
+        name = getattr(t, "name", "unknown")
+        desc = getattr(t, "description", "")
+        print(f"  - {name}: {desc[:60]}")
+    print()
+
+    queries = [
+        "Calculate 7 plus 9 using add_numbers",
+        "Summarize using summarize: 'OpenAI Agents SDK is a Python framework for building multi-agent systems, core concepts include Agent, Runner, Tools, Handoffs, Guardrails, Sessions and Tracing.'",
+        "Add 1 and 2 first, then add 3 and 4",
+    ]
+    for q in queries:
+        print(f">>> User: {q}")
+        result = await Runner.run(manager, q)
+        print(f"<<< Agent: {result.final_output}")
+        print(
+            f"   new_items count: {len(result.new_items)}  last_agent: {result.last_agent.name}\n"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/learn/07_context_split.py
+++ b/examples/learn/07_context_split.py
@@ -1,0 +1,118 @@
+"""Example 07: Context split - RunContextWrapper.context vs instructions/input.
+
+Principle (agents/run_context.py:43, agents/run.py:540):
+  - RunContextWrapper.context is the Python-side "shared bag"
+    - You define your own dataclass/BaseModel type
+    - Shared across tool / guardrail / handoff callbacks
+    - Never sent to LLM (only visible in your own Python code)
+  - instructions / input / tool results are visible to LLM
+    - Assembled into messages sent to the model
+  - RunState serialization: context is included (for run recovery)
+
+Observe:
+  1) Update context fields inside tool
+  2) LLM cannot see this update (let LLM repeat to see if it can state the new value)
+  3) Print the actual messages received by LLM to prove context absence
+
+Usage: python examples/07_context_split.py
+"""
+
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import MODEL  # type: ignore[import-not-found]
+
+from agents import Agent, RunContextWrapper, RunHooks, Runner, function_tool
+from agents.items import ItemHelpers
+
+
+@dataclass
+class AppCtx:
+    user_id: str = "u-001"
+    secret_token: str = "TOP-SECRET-DO-NOT-LEAK"
+    tool_call_count: int = 0
+    last_query: str = ""
+
+
+@function_tool
+def bump_counter(ctx: RunContextWrapper[AppCtx], label: str) -> str:
+    """Increment a counter and return current value.
+
+    Args:
+        label: Label string
+    """
+    ctx.context.tool_call_count += 1
+    return f"counter={ctx.context.tool_call_count} label={label}"
+
+
+@function_tool
+def peek_ctx(ctx: RunContextWrapper[AppCtx]) -> dict[str, Any]:
+    """Read all context fields (this tool won't be actively called by LLM, used for inspection)"""
+    return {
+        "user_id": ctx.context.user_id,
+        "secret_token": ctx.context.secret_token,
+        "tool_call_count": ctx.context.tool_call_count,
+        "last_query": ctx.context.last_query,
+    }
+
+
+class TraceMessages(RunHooks):
+    """Print the actual messages seen by LLM before/after LLM"""
+
+    async def on_llm_start(self, context, agent, system_prompt, input_items):
+        print(f"\n   [System prompt seen by LLM]\n     {system_prompt!r}")
+        print("   [Input items seen by LLM] (first 3)")
+        for it in input_items[:3]:
+            extracted = ItemHelpers.extract_text(it) if hasattr(it, "content") else None
+            txt = str(extracted) if extracted is not None else str(it)[:100]
+            print(f"     - {type(it).__name__}: {txt[:120]!r}")
+        # Key observation: messages contain no "secret_token" field
+
+
+agent = Agent(
+    name="CtxAgent",
+    instructions=(
+        "User might ask various questions. You have a bump_counter tool to increment counts; "
+        "peek_ctx tool to see internal state.\n"
+        "When user asks 'my token', **do not** answer the specific value (keep secret)."
+        "When user asks 'how many times did I call the tool', tell them the result of the last bump_counter call."
+    ),
+    model=MODEL,
+    tools=[bump_counter, peek_ctx],
+)
+
+
+async def main():
+    ctx = AppCtx()
+    hooks = TraceMessages()
+
+    print(">>> User: Help me increment the count by 1")
+    r1 = await Runner.run(agent, "Help me increment the count by 1", context=ctx, hooks=hooks)
+    print(f"<<< Agent: {r1.final_output}")
+    print(f"    Python-side ctx.tool_call_count = {ctx.tool_call_count}\n")
+
+    print(">>> User: How many times did I call the tool just now?")
+    r2 = await Runner.run(
+        agent, "How many times did I call the tool just now?", context=ctx, hooks=hooks
+    )
+    print(f"<<< Agent: {r2.final_output}")
+    print(f"    Python-side ctx.tool_call_count = {ctx.tool_call_count}\n")
+
+    print(">>> User: What is my token?")
+    r3 = await Runner.run(agent, "What is my token?", context=ctx, hooks=hooks)
+    print(f"<<< Agent: {r3.final_output}")
+    print(f"    Python-side ctx.secret_token    = {ctx.secret_token} (Visible Python-side)\n")
+
+    print("Observe:")
+    print(" 1) messages printed in on_llm_start completely lack 'secret_token' field")
+    print(" 2) Python-side ctx.tool_call_count is modified inside tool and kept")
+    print(" 3) Model can see tool return contents, so it knows the bump_counter result")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/learn/08_guardrail_scope.py
+++ b/examples/learn/08_guardrail_scope.py
@@ -1,0 +1,178 @@
+"""Example 08: 4 types of Guardrails + their trigger locations.
+
+Principle (docs/architecture.md §3.2 + agents/guardrail.py + agents/tool_guardrails.py):
+  - input_guardrail: runs only on first agent, first turn (run.py:1176)
+  - output_guardrail: runs only after the last agent produces final
+  - tool_input_guardrail: runs before each @function_tool call (order determined by ToolExecutionConfig)
+  - tool_output_guardrail: runs after each @function_tool call
+  - run_in_parallel=True (default) -> input guardrail races with first LLM, may burn tokens
+  - run_in_parallel=False -> input guardrail blocks, doesn't waste tokens on tripwire
+
+Observe:
+  1) Tripwire trigger locations for the three guardrails
+  2) run_in_parallel behavior of input guardrail
+  3) Which guardrails still run during handoff?
+
+Usage: python examples/08_guardrail_scope.py
+"""
+
+import asyncio
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from agent_defs.triage_agent import triage_agent  # type: ignore[import-not-found]
+from config import MODEL  # type: ignore[import-not-found]
+
+from agents import (
+    Agent,
+    GuardrailFunctionOutput,
+    RunHooks,
+    Runner,
+    ToolGuardrailFunctionOutput,
+    ToolInputGuardrailData,
+    ToolOutputGuardrailData,
+    function_tool,
+    input_guardrail,
+    output_guardrail,
+    tool_input_guardrail,
+    tool_output_guardrail,
+)
+
+fired = []
+
+
+# --- 1) input guardrail: blocking mode (does not burn tokens) ---
+@input_guardrail(run_in_parallel=False)
+async def block_injection(ctx, agent, input):
+    text = input if isinstance(input, str) else str(input)
+    triggered = "ignore_previous" in text.lower()
+    fired.append(("input_guardrail", "blocked" if triggered else "passed"))
+    return GuardrailFunctionOutput(
+        output_info={"text": text[:60]},
+        tripwire_triggered=triggered,
+    )
+
+
+# --- 2) output guardrail ---
+@output_guardrail
+async def block_phone_in_output(ctx, agent, output):
+    triggered = bool(re.search(r"1[3-9]\d{9}", output))
+    fired.append(("output_guardrail", "blocked" if triggered else "passed"))
+    return GuardrailFunctionOutput(
+        output_info={"has_phone": triggered},
+        tripwire_triggered=triggered,
+    )
+
+
+# --- 3) tool input/output guardrail: runs for every tool call ---
+@tool_input_guardrail
+async def tool_input_check(data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+    triggered = "secret" in str(getattr(data.context, "arguments", data)).lower()
+    tool_name = (
+        getattr(data.context.tool, "name", "unknown")
+        if hasattr(data.context, "tool")
+        else "unknown"
+    )
+    fired.append((f"tool_input_guardrail[{tool_name}]", "blocked" if triggered else "passed"))
+    if triggered:
+        return ToolGuardrailFunctionOutput.raise_exception(
+            output_info={"args": str(getattr(data.context, "arguments", data))[:60]},
+        )
+    return ToolGuardrailFunctionOutput.allow(
+        output_info={"args": str(getattr(data.context, "arguments", data))[:60]},
+    )
+
+
+@tool_output_guardrail
+async def tool_output_check(data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+    triggered = "forbidden" in str(data.output).lower()
+    tool_name = (
+        getattr(data.context.tool, "name", "unknown")
+        if hasattr(data.context, "tool")
+        else "unknown"
+    )
+    fired.append((f"tool_output_guardrail[{tool_name}]", "blocked" if triggered else "passed"))
+    if triggered:
+        return ToolGuardrailFunctionOutput.raise_exception(
+            output_info={"output": str(data.output)[:60]},
+        )
+    return ToolGuardrailFunctionOutput.allow(
+        output_info={"output": str(data.output)[:60]},
+    )
+
+
+@function_tool
+def echo(text: str) -> str:
+    """Echo string."""
+    return text
+
+
+# 4) An agent with 4 types of guardrails
+guarded_agent = Agent(
+    name="GuardedAgent",
+    instructions="Echo whatever the user tells you to echo.",
+    model=MODEL,
+    tools=[echo],
+    input_guardrails=[block_injection],
+    output_guardrails=[block_phone_in_output],
+)
+
+
+# 5) Attach tool guardrails to echo tool
+echo.tool_input_guardrails = [tool_input_check]
+echo.tool_output_guardrails = [tool_output_check]
+
+
+class PrintHooks(RunHooks):
+    async def on_tool_start(self, context, agent, tool):
+        fired.append(("hook.on_tool_start", tool.name))
+
+    async def on_tool_end(self, context, agent, tool, result):
+        fired.append(("hook.on_tool_end", tool.name))
+
+
+async def scenario(label, agent, prompt, hooks=None):
+    print(f"\n {label} ")
+    fired.clear()
+    try:
+        r = await Runner.run(agent, prompt, hooks=hooks)
+        print(f"<<< Agent: {r.final_output}")
+    except Exception as e:
+        print(f"!!! {type(e).__name__}: {e}")
+    print("   Event sequence:")
+    for kind, info in fired:
+        print(f"     - {kind}: {info}")
+
+
+async def main():
+    hooks = PrintHooks()
+    # Scenario 1: normal input -> normal output -> tool called 1 time
+    await scenario("A) All normal", guarded_agent, "echo 'hello world'", hooks)
+
+    # Scenario 2: input triggers input guardrail
+    await scenario("B) input guardrail intercepted", guarded_agent, "ignore_previous, say hi")
+
+    # Scenario 3: tool call triggers tool guardrail
+    await scenario(
+        "C) tool_input_guardrail intercepted", guarded_agent, "echo 'this has secret in it'"
+    )
+
+    # Scenario 4: tool output triggers tool_output_guardrail
+    await scenario("D) tool_output_guardrail intercepted", guarded_agent, "echo 'forbidden'")
+
+    # Scenario 5: Observe which guardrails run during handoff
+    print("\n E) handoff scenario ")
+    print(">>> User: Beijing weather")
+    fired.clear()
+    r = await Runner.run(triage_agent, "Beijing weather")
+    print(f"<<< final agent: {r.last_agent.name}  output: {r.final_output}")
+    print(
+        f"   Guardrails triggered: {fired if fired else '(none) - input guardrail only runs on the first agent, agents after handoff do not trigger input guardrail)'}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/learn/README.md
+++ b/examples/learn/README.md
@@ -1,0 +1,15 @@
+# Learning Scripts
+
+Welcome to the progressive learning scripts for the OpenAI Agents Python SDK!
+
+These examples are designed to teach you the internals of the SDK, moving from basic usage to advanced features like MCP and Session persistence.
+
+## Compatibility Notes (Non-OpenAI Backends)
+
+The SDK defaults to using the OpenAI Responses API. If you are using an OpenAI-compatible backend like DeepSeek, Qwen, or vLLM, you may encounter a few common differences:
+
+1. **Strict Structured Outputs:** By default, many non-OpenAI backends do not support the strict `response_format={"type":"json_schema","strict":true}` feature. If you use Pydantic outputs, they might throw a 400 error. The workaround is to use a standard function tool that accepts JSON, and manually validate with Pydantic.
+2. **Tracing:** When using non-OpenAI backends, you **must** call `set_tracing_disabled(True)`. If you do not, the SDK will silently attempt to retry the OpenAI trace endpoint, which will fail.
+3. **OpenAIChatCompletionsModel:** For backends that don't support the Responses API, explicitly initialize the `OpenAIChatCompletionsModel` rather than relying on the default model wrapper.
+
+Keep these in mind as you run through the examples!

--- a/examples/learn/agent_defs/__init__.py
+++ b/examples/learn/agent_defs/__init__.py
@@ -1,0 +1,1 @@
+"""Agent module. Each agent is responsible for a category of problems."""

--- a/examples/learn/agent_defs/math_agent.py
+++ b/examples/learn/agent_defs/math_agent.py
@@ -1,0 +1,17 @@
+"""Math Agent - Holds the calculator toolset."""
+
+from config import MODEL  # type: ignore[import-not-found]
+from tools.calculator import CALCULATOR_TOOLS  # type: ignore[import-not-found]
+
+from agents import Agent
+
+math_agent = Agent(
+    name="MathAgent",
+    instructions=(
+        "You are a math assistant, only use tools to complete addition, subtraction, multiplication, and division.\n"
+        "When the user gives you an expression (e.g., '3 plus 5' or '12 * 7'), you must call the corresponding tool, "
+        "then tell the user the result in one sentence. Do not give arithmetic answers out of thin air."
+    ),
+    model=MODEL,
+    tools=CALCULATOR_TOOLS,
+)

--- a/examples/learn/agent_defs/triage_agent.py
+++ b/examples/learn/agent_defs/triage_agent.py
@@ -1,0 +1,20 @@
+"""Triage Agent - Main entry point, hands off conversations to specialists based on intent."""
+
+from config import MODEL  # type: ignore[import-not-found]
+
+from agent_defs.math_agent import math_agent  # type: ignore[import-not-found]
+from agent_defs.weather_agent import weather_agent  # type: ignore[import-not-found]
+from agents import Agent
+
+triage_agent = Agent(
+    name="TriageAgent",
+    instructions=(
+        "You are the receptionist for a multi-capability assistant.\n"
+        "- Arithmetic / math questions -> handoff to MathAgent\n"
+        "- Weather / temperature / rain / city weather -> handoff to WeatherAgent\n"
+        "- Answer other casual chat briefly yourself (one or two sentences).\n"
+        "Do not use tools to do the specialist's job yourself after handoff."
+    ),
+    model=MODEL,
+    handoffs=[math_agent, weather_agent],
+)

--- a/examples/learn/agent_defs/weather_agent.py
+++ b/examples/learn/agent_defs/weather_agent.py
@@ -1,0 +1,17 @@
+"""Weather Agent - Holds the weather tool."""
+
+from config import MODEL  # type: ignore[import-not-found]
+from tools.weather import WEATHER_TOOLS  # type: ignore[import-not-found]
+
+from agents import Agent
+
+weather_agent = Agent(
+    name="WeatherAgent",
+    instructions=(
+        "You are a weather assistant. When the user asks about the weather in a city, call the get_weather tool, "
+        "then give a one-sentence reply about the weather (temperature, condition, humidity). "
+        "If the tool returns an error field, tell the error exactly as is to the user."
+    ),
+    model=MODEL,
+    tools=WEATHER_TOOLS,
+)

--- a/examples/learn/config.py
+++ b/examples/learn/config.py
@@ -1,0 +1,32 @@
+"""Unified config: env loading + OpenAI client construction + Chat Completions model.
+
+All examples can simply use `from config import MODEL` to get the model instance.  # type: ignore[import-not-found]
+"""
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from openai import AsyncOpenAI
+
+from agents import OpenAIChatCompletionsModel, set_tracing_disabled
+
+load_dotenv(Path(__file__).parent / ".env")
+
+# Compat fallback: openai-agents SDK expects OPENAI_API_KEY by default
+if "SECAUTH_OPENAI_API_KEY" in os.environ and "OPENAI_API_KEY" not in os.environ:
+    os.environ["OPENAI_API_KEY"] = os.environ["SECAUTH_OPENAI_API_KEY"]
+
+BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.deepseek.com/v1").rstrip("/")
+MODEL_NAME = os.getenv("OPENAI_MODEL", "deepseek-v4-pro")
+
+# Disable trace reporting to OpenAI platform (DeepSeek / other compatible backends have no trace endpoint)
+set_tracing_disabled(disabled=True)
+
+
+def get_client() -> AsyncOpenAI:
+    return AsyncOpenAI(base_url=BASE_URL)
+
+
+# Ready for Agent use: model=MODEL
+MODEL = OpenAIChatCompletionsModel(model=MODEL_NAME, openai_client=get_client())

--- a/examples/learn/tools/__init__.py
+++ b/examples/learn/tools/__init__.py
@@ -1,0 +1,3 @@
+"""Tools module. openai-agents uses @function_tool to convert standard functions into tools that can be called by LLMs.
+The docstring automatically becomes the tool description, and type annotations automatically generate the JSON schema.
+"""

--- a/examples/learn/tools/calculator.py
+++ b/examples/learn/tools/calculator.py
@@ -1,0 +1,37 @@
+"""Basic arithmetic tools - demonstrates @function_tool decorator + type hints + docstring auto schema."""
+
+from agents import function_tool
+
+
+@function_tool
+def add(a: int, b: int) -> int:
+    """Add two integers.
+
+    Args:
+        a: The first integer
+        b: The second integer
+    """
+    return a + b
+
+
+@function_tool
+def subtract(a: int, b: int) -> int:
+    """Calculate a minus b."""
+    return a - b
+
+
+@function_tool
+def multiply(a: int, b: int) -> int:
+    """Multiply two integers."""
+    return a * b
+
+
+@function_tool
+def divide(a: float, b: float) -> float | str:
+    """Calculate a divided by b. If b is 0, return an error string instead of raising an exception."""
+    if b == 0:
+        return "error: division by zero"
+    return a / b
+
+
+CALCULATOR_TOOLS = [add, subtract, multiply, divide]

--- a/examples/learn/tools/knowledge.py
+++ b/examples/learn/tools/knowledge.py
@@ -1,0 +1,36 @@
+"""Knowledge query tool - demonstrates simulating a knowledge base with mock data."""
+
+from typing import Any
+
+from agents import function_tool
+
+_KB = {
+    "openai-agents": "OpenAI official multi-agent SDK, supports tools/handoffs/guardrails/session/tracing. pip install openai-agents",
+    "agent": "In openai-agents, Agent is the core object containing name/instructions/model/tools/handoffs/output_type etc.",
+    "function_tool": "Python functions decorated with @function_tool are automatically converted to LLM-callable tools; docstring and type hints generate JSON schema.",
+    "handoff": "Let one Agent pass control to another, often used for intent routing (triage agent + multiple specialists).",
+    "guardrail": "input_guardrails check before user input enters Agent, output_guardrails check before Agent output returns.",
+    "session": "openai-agents provides SQLiteSession (local file by default) and other abstractions to automatically maintain multi-turn chat history.",
+    "runner": "Runner.run / run_sync / run_streamed are three entrypoints to execute an Agent (async/sync/streaming).",
+    "tracing": "Trace is enabled by default, recording the span tree for each run, can connect to OpenAI platform / OTel / Console.",
+}
+
+
+@function_tool
+def lookup(term: str) -> dict[str, Any]:
+    """Query openai-agents related terms in the local mini knowledge base.
+
+    Args:
+        term: Term string, e.g., 'handoff' / 'guardrail' / 'session'.
+    """
+    term_l = term.strip().lower()
+    if term_l in _KB:
+        return {"term": term, "found": True, "definition": _KB[term_l]}
+    # Fuzzy matching
+    for k, v in _KB.items():
+        if term_l in k or k in term_l:
+            return {"term": term, "found": True, "matched": k, "definition": v}
+    return {"term": term, "found": False, "definition": "Term not found in knowledge base"}
+
+
+KNOWLEDGE_TOOLS = [lookup]

--- a/examples/learn/tools/weather.py
+++ b/examples/learn/tools/weather.py
@@ -1,0 +1,37 @@
+"""Weather tool - demonstrates returning structured data (dict) as tool result."""
+
+from typing import Any
+
+from agents import function_tool
+
+# Mock data used for teaching project to avoid external dependencies
+_MOCK_WEATHER = {
+    "beijing": {"city": "Beijing", "temp_c": 22, "condition": "Sunny", "humidity": 35},
+    "shanghai": {"city": "Shanghai", "temp_c": 26, "condition": "Cloudy", "humidity": 70},
+    "guangzhou": {"city": "Guangzhou", "temp_c": 30, "condition": "Thunderstorms", "humidity": 85},
+    "shenzhen": {"city": "Shenzhen", "temp_c": 29, "condition": "Cloudy", "humidity": 78},
+    "tokyo": {"city": "Tokyo", "temp_c": 18, "condition": "Overcast", "humidity": 60},
+    "london": {"city": "London", "temp_c": 12, "condition": "Light Rain", "humidity": 88},
+    "new york": {"city": "New York", "temp_c": 15, "condition": "Sunny", "humidity": 50},
+}
+
+
+@function_tool
+def get_weather(city: str) -> dict[str, Any]:
+    """Query the current weather for a specific city. Only supports cities in the mock dictionary.
+
+    Args:
+        city: City english name (lowercase) or Chinese name, e.g., 'beijing' / '北京'.
+    """
+    key = city.strip().lower()
+    # Map Chinese names directly to keys
+    cn_to_en = {"北京": "beijing", "上海": "shanghai", "广州": "guangzhou", "深圳": "shenzhen"}
+    key = cn_to_en.get(key, key)
+    if key in _MOCK_WEATHER:
+        return _MOCK_WEATHER[key]
+    return {
+        "error": f"Weather data for {city} not found (mock mode only supports: beijing/shanghai/guangzhou/shenzhen/tokyo/london/new york)"
+    }
+
+
+WEATHER_TOOLS = [get_weather]


### PR DESCRIPTION
## Summary

Closes #3770

This PR introduces a curated, progressive set of learning examples to the "examples/learn" directory. These examples are specifically designed to document advanced SDK internals and guide new users from basic usage to complex orchestration. 

**Changes Included:**
- Added progressive learning scripts covering core abstractions:
  - `Runner` lifecycle and Event Hooks
  - Tool Use Behaviors ("stop_on_first_tool", custom final outputs)
  - Handoff Mechanics and Routing
  - Agent-as-a-Tool paradigms
  - Context Isolation and Context Splitting
  - Guardrail Scopes ("input_guardrail", "output_guardrail", "tool_guardrail")
- Configured a local ".env" and "config.py" setup to easily switch between OpenAI and compatible backends (like DeepSeek).
- Verified strict typing across all examples (utilizing correct ToolGuardrailFunctionOutput types).
- Fully translated all code comments and string literals to English.

## Test Plan

 Verified "examples/learn" scripts manually.
 Executed local verification stack (make format, make lint, make typecheck). 
 All 14 example files passed ruff check, ruff format, mypy, and pyright checks cleanly.
