### PR TITLE
feat: support GPT-5.6 request controls

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -338,7 +338,8 @@ When you are using the OpenAI Responses API, several request fields already have
 - `truncation`: Set `"auto"` to let the Responses API drop the oldest conversation items instead of failing when context would overflow.
 - `store`: Control whether the generated response is stored server-side for later retrieval. This matters for follow-up workflows that rely on response IDs, and for session compaction flows that may need to fall back to local input when `store=False`.
 - `context_management`: Configure server-side context handling such as Responses compaction with `compact_threshold`.
-- `prompt_cache_retention`: Keep cached prompt prefixes around longer, for example with `"24h"`.
+- `prompt_cache_retention`: Configure extended retention for earlier model families, for example
+  with `"24h"`.
 - `prompt_cache_options`: Select implicit or explicit prompt caching and, for GPT-5.6, configure a `"30m"` cache TTL.
 - `response_include`: Request richer response payloads such as `web_search_call.action.sources`, `file_search_call.results`, or `reasoning.encrypted_content`.
 - `top_logprobs`: Request top-token logprobs for output text. The SDK also adds `message.output_text.logprobs` automatically.
@@ -349,13 +350,12 @@ from agents import Agent, ModelSettings
 
 research_agent = Agent(
     name="Research agent",
-    model="gpt-5.5",
+    model="gpt-5.6-sol",
     model_settings=ModelSettings(
         parallel_tool_calls=False,
         truncation="auto",
         store=True,
         context_management=[{"type": "compaction", "compact_threshold": 200000}],
-        prompt_cache_retention="24h",
         prompt_cache_options={"mode": "explicit", "ttl": "30m"},
         response_include=["web_search_call.action.sources"],
         top_logprobs=5,
@@ -389,7 +389,9 @@ result = await Runner.run(
 )
 ```
 
-`prompt_cache_retention` remains available for models that use the earlier retention control. Do not combine a direct `ModelSettings` field with the same key in `extra_args`.
+`prompt_cache_retention` remains available for earlier model families that use the legacy
+retention control. Do not combine a direct `ModelSettings` field with the same key in
+`extra_args`.
 
 When you set `store=False`, the Responses API does not keep that response available for later server-side retrieval. This is useful for stateless or zero-data-retention style flows, but it also means features that would otherwise reuse response IDs need to rely on locally managed state instead. For example, [`OpenAIResponsesCompactionSession`][agents.memory.openai_responses_compaction_session.OpenAIResponsesCompactionSession] switches its default `"auto"` compaction path to input-based compaction when the last response was not stored. See the [Sessions guide](../sessions/index.md#openai-responses-compaction-sessions).
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -72,6 +72,29 @@ my_agent = Agent(
 
 For lower latency, using `reasoning.effort="none"` with GPT-5 models is recommended.
 
+GPT-5.6 also supports reasoning mode, persisted reasoning context, and the `"max"` effort level through the existing `reasoning` setting. These controls are available on the Responses API path:
+
+```python
+from openai.types.shared import Reasoning
+from agents import Agent, ModelSettings
+
+agent = Agent(
+    name="Deep research agent",
+    model="gpt-5.6-sol",
+    model_settings=ModelSettings(
+        reasoning=Reasoning(
+            mode="pro",
+            effort="max",
+            context="all_turns",
+        ),
+    ),
+)
+```
+
+`reasoning.mode` and `reasoning.context` are Responses-only settings. Chat Completions uses only `reasoning.effort`, and the supported effort levels depend on the model and API surface. Use the Responses API for GPT-5.6 `"max"` effort. The Chat Completions adapter ignores mode and context with a warning; set `strict_feature_validation=True` on the OpenAI provider to turn that warning into an error.
+
+When using `context="all_turns"`, preserve the conversation through `previous_response_id`, a server-side conversation, or by replaying prior reasoning items. For stateless `store=False` calls, include `reasoning.encrypted_content` in the response and replay those reasoning items on the next request.
+
 #### ComputerTool model selection
 
 If an agent includes [`ComputerTool`][agents.tool.ComputerTool], the effective model on the actual Responses request determines which computer-tool payload the SDK sends. Explicit `gpt-5.5` requests use the GA built-in `computer` tool, while explicit `computer-use-preview` requests keep the older `computer_use_preview` payload.
@@ -316,6 +339,7 @@ When you are using the OpenAI Responses API, several request fields already have
 - `store`: Control whether the generated response is stored server-side for later retrieval. This matters for follow-up workflows that rely on response IDs, and for session compaction flows that may need to fall back to local input when `store=False`.
 - `context_management`: Configure server-side context handling such as Responses compaction with `compact_threshold`.
 - `prompt_cache_retention`: Keep cached prompt prefixes around longer, for example with `"24h"`.
+- `prompt_cache_options`: Select implicit or explicit prompt caching and, for GPT-5.6, configure a `"30m"` cache TTL.
 - `response_include`: Request richer response payloads such as `web_search_call.action.sources`, `file_search_call.results`, or `reasoning.encrypted_content`.
 - `top_logprobs`: Request top-token logprobs for output text. The SDK also adds `message.output_text.logprobs` automatically.
 - `retry`: Opt in to runner-managed retry settings for model calls. See [Runner-managed retries](#runner-managed-retries).
@@ -332,11 +356,40 @@ research_agent = Agent(
         store=True,
         context_management=[{"type": "compaction", "compact_threshold": 200000}],
         prompt_cache_retention="24h",
+        prompt_cache_options={"mode": "explicit", "ttl": "30m"},
         response_include=["web_search_call.action.sources"],
         top_logprobs=5,
     ),
 )
 ```
+
+With explicit prompt caching, add a breakpoint to the content part that ends the reusable prefix. The same `ModelSettings.prompt_cache_options` field is passed through on Responses and Chat Completions requests, and the Chat Completions converter preserves breakpoints on text, image, audio, and file content parts.
+
+```python
+from agents import Runner
+
+result = await Runner.run(
+    research_agent,
+    [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": "Reusable background material...",
+                    "prompt_cache_breakpoint": {"mode": "explicit"},
+                },
+                {
+                    "type": "input_text",
+                    "text": "Analyze the latest question.",
+                },
+            ],
+        }
+    ],
+)
+```
+
+`prompt_cache_retention` remains available for models that use the earlier retention control. Do not combine a direct `ModelSettings` field with the same key in `extra_args`.
 
 When you set `store=False`, the Responses API does not keep that response available for later server-side retrieval. This is useful for stateless or zero-data-retention style flows, but it also means features that would otherwise reuse response IDs need to rely on locally managed state instead. For example, [`OpenAIResponsesCompactionSession`][agents.memory.openai_responses_compaction_session.OpenAIResponsesCompactionSession] switches its default `"auto"` compaction path to input-based compaction when the last response was not stored. See the [Sessions guide](../sessions/index.md#openai-responses-compaction-sessions).
 

--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any, Literal, TypeAlias, cast
 from openai import Omit as _Omit
 from openai._types import Body, Query
 from openai.types.responses import ResponseIncludable
-from openai.types.responses.response_create_params import ContextManagement
+from openai.types.responses.response_create_params import ContextManagement, PromptCacheOptions
 from openai.types.shared import Reasoning
 from pydantic import GetCoreSchemaHandler, TypeAdapter
 from pydantic.dataclasses import dataclass
@@ -79,6 +79,7 @@ _TRACEABLE_MODEL_SETTING_FIELDS = (
     "top_logprobs",
     "retry",
     "context_management",
+    "prompt_cache_options",
 )
 
 
@@ -189,6 +190,13 @@ class ModelSettings:
 
     For example, use ``[{"type": "compaction", "compact_threshold": 200000}]``
     to enable server-side compaction when the rendered context crosses a token threshold.
+    """
+
+    prompt_cache_options: PromptCacheOptions | None = None
+    """Prompt-cache configuration for OpenAI API requests.
+
+    Use ``{"mode": "explicit", "ttl": "30m"}`` with content-part cache breakpoints to
+    control which prompt prefixes are eligible for caching.
     """
 
     def resolve(self, override: ModelSettings | None) -> ModelSettings:

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any, Literal, cast
 
 from openai import Omit, omit
@@ -349,7 +349,9 @@ class Converter:
             if not isinstance(text, str):
                 raise UserError(f"Only text content is supported here, got: {content_part}")
             # Cast the normalized dict because we are constructing a TypedDict alias by hand.
-            return cast(ResponseInputTextParam, {"type": "input_text", "text": text})
+            normalized_text: dict[str, Any] = {"type": "input_text", "text": text}
+            cls._copy_prompt_cache_breakpoint(content_part, normalized_text)
+            return cast(ResponseInputTextParam, normalized_text)
 
         if content_type != "image_url":
             return content_part
@@ -366,8 +368,15 @@ class Converter:
         detail = image_payload.get("detail")
         if detail is not None:
             normalized["detail"] = detail
+        cls._copy_prompt_cache_breakpoint(content_part, normalized)
         # Cast the normalized dict because we are constructing a TypedDict alias by hand.
         return cast(ResponseInputImageParam, normalized)
+
+    @staticmethod
+    def _copy_prompt_cache_breakpoint(source: Mapping[str, Any], target: dict[str, Any]) -> None:
+        prompt_cache_breakpoint = source.get("prompt_cache_breakpoint")
+        if prompt_cache_breakpoint is not None:
+            target["prompt_cache_breakpoint"] = prompt_cache_breakpoint
 
     @classmethod
     def extract_all_content(
@@ -381,12 +390,12 @@ class Converter:
             c = cls._normalize_input_content_part_alias(c)
             if isinstance(c, dict) and c.get("type") == "input_text":
                 casted_text_param = cast(ResponseInputTextParam, c)
-                out.append(
-                    ChatCompletionContentPartTextParam(
-                        type="text",
-                        text=casted_text_param["text"],
-                    )
-                )
+                text_part: dict[str, Any] = {
+                    "type": "text",
+                    "text": casted_text_param["text"],
+                }
+                cls._copy_prompt_cache_breakpoint(c, text_part)
+                out.append(cast(ChatCompletionContentPartTextParam, text_part))
             elif isinstance(c, dict) and c.get("type") == "input_image":
                 casted_image_param = cast(ResponseInputImageParam, c)
                 if "image_url" not in casted_image_param or not casted_image_param["image_url"]:
@@ -398,15 +407,15 @@ class Converter:
                     # Chat Completions only supports auto/low/high, so preserve the caller's
                     # highest-fidelity intent with the closest available value.
                     detail = "high"
-                out.append(
-                    ChatCompletionContentPartImageParam(
-                        type="image_url",
-                        image_url={
-                            "url": casted_image_param["image_url"],
-                            "detail": detail,
-                        },
-                    )
-                )
+                image_part: dict[str, Any] = {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": casted_image_param["image_url"],
+                        "detail": detail,
+                    },
+                }
+                cls._copy_prompt_cache_breakpoint(c, image_part)
+                out.append(cast(ChatCompletionContentPartImageParam, image_part))
             elif isinstance(c, dict) and c.get("type") == "video_url":
                 video_payload = c.get("video_url")
                 if not isinstance(video_payload, dict) or not video_payload.get("url"):
@@ -437,15 +446,15 @@ class Converter:
                     raise UserError(
                         f"input_audio requires both data and format {casted_audio_param}"
                     )
-                out.append(
-                    ChatCompletionContentPartInputAudioParam(
-                        type="input_audio",
-                        input_audio={
-                            "data": audio_data,
-                            "format": audio_format,
-                        },
-                    )
-                )
+                audio_part: dict[str, Any] = {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": audio_data,
+                        "format": audio_format,
+                    },
+                }
+                cls._copy_prompt_cache_breakpoint(c, audio_part)
+                out.append(cast(ChatCompletionContentPartInputAudioParam, audio_part))
             elif isinstance(c, dict) and c.get("type") == "input_file":
                 casted_file_param = cast(ResponseInputFileParam, c)
                 if "file_data" not in casted_file_param or not casted_file_param["file_data"]:
@@ -457,7 +466,9 @@ class Converter:
                 if "filename" in casted_file_param and casted_file_param["filename"]:
                     filedata["filename"] = casted_file_param["filename"]
 
-                out.append(File(type="file", file=filedata))
+                file_part: dict[str, Any] = {"type": "file", "file": filedata}
+                cls._copy_prompt_cache_breakpoint(c, file_part)
+                out.append(cast(File, file_part))
             else:
                 raise UserError(f"Unknown content: {c}")
         return out

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -68,6 +68,7 @@ class OpenAIChatCompletionsModel(Model):
         self._buffer_streamed_tool_calls = buffer_streamed_tool_calls
         self._has_warned_unsupported_prompt = False
         self._has_warned_unsupported_conversation_state = False
+        self._has_warned_unsupported_reasoning_settings = False
 
     def _non_null_or_omit(self, value: Any) -> Any:
         return value if value is not None else omit
@@ -93,6 +94,34 @@ class OpenAIChatCompletionsModel(Model):
                 message,
             )
             self._has_warned_unsupported_prompt = True
+
+    def _handle_unsupported_reasoning_settings(self, model_settings: ModelSettings) -> None:
+        reasoning = model_settings.reasoning
+        if reasoning is None:
+            return
+
+        unsupported = [
+            name for name in ("mode", "context") if getattr(reasoning, name, None) is not None
+        ]
+        if not unsupported:
+            return
+
+        unsupported_params = ", ".join(f"reasoning.{name}" for name in unsupported)
+        message = (
+            f"OpenAIChatCompletionsModel does not support {unsupported_params}. "
+            "These reasoning settings require the Responses API; Chat Completions only "
+            "uses reasoning.effort."
+        )
+        if self._strict_feature_validation:
+            raise UserError(message)
+
+        if not self._has_warned_unsupported_reasoning_settings:
+            logger.warning(
+                "%s Ignoring unsupported reasoning settings; enable strict feature validation "
+                "to raise an error instead.",
+                message,
+            )
+            self._has_warned_unsupported_reasoning_settings = True
 
     def get_retry_advice(self, request: ModelRetryAdviceRequest) -> ModelRetryAdvice | None:
         return get_openai_retry_advice(request)
@@ -461,6 +490,7 @@ class OpenAIChatCompletionsModel(Model):
         prompt: ResponsePromptParam | None = None,
     ) -> ChatCompletion | tuple[Response, AsyncStream[ChatCompletionChunk]]:
         self._handle_unsupported_prompt(prompt)
+        self._handle_unsupported_reasoning_settings(model_settings)
         self._validate_official_openai_input_content_types(input)
         converted_messages = Converter.items_to_messages(
             input,
@@ -549,6 +579,7 @@ class OpenAIChatCompletionsModel(Model):
             "verbosity": self._non_null_or_omit(model_settings.verbosity),
             "top_logprobs": self._non_null_or_omit(model_settings.top_logprobs),
             "prompt_cache_retention": self._non_null_or_omit(model_settings.prompt_cache_retention),
+            "prompt_cache_options": self._non_null_or_omit(model_settings.prompt_cache_options),
             "extra_headers": self._merge_headers(model_settings),
             "extra_query": model_settings.extra_query,
             "extra_body": model_settings.extra_body,
@@ -564,7 +595,9 @@ class OpenAIChatCompletionsModel(Model):
         ):
             create_kwargs["logprobs"] = True
         duplicate_extra_arg_keys = sorted(
-            set(create_kwargs).intersection(model_settings.extra_args or {})
+            key
+            for key in model_settings.extra_args or {}
+            if key in create_kwargs and not isinstance(create_kwargs[key], Omit)
         )
         if duplicate_extra_arg_keys:
             if len(duplicate_extra_arg_keys) == 1:

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -839,6 +839,7 @@ class OpenAIResponsesModel(Model):
             "text": response_format,
             "store": self._non_null_or_omit(model_settings.store),
             "prompt_cache_retention": self._non_null_or_omit(model_settings.prompt_cache_retention),
+            "prompt_cache_options": self._non_null_or_omit(model_settings.prompt_cache_options),
             "reasoning": self._non_null_or_omit(model_settings.reasoning),
             "metadata": self._non_null_or_omit(model_settings.metadata),
             "context_management": self._non_null_or_omit(model_settings.context_management),
@@ -1366,10 +1367,18 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
 
     def _merge_websocket_headers(self, extra_headers: Mapping[str, Any]) -> dict[str, str]:
         headers: dict[str, str] = {}
-        for key, value in self._client.default_headers.items():
-            if _is_openai_omitted_value(value):
-                continue
-            headers[key] = str(value)
+        for source in (
+            getattr(self._client, "auth_headers", {}),
+            self._client.default_headers,
+        ):
+            for key, value in source.items():
+                if _is_openai_omitted_value(value):
+                    continue
+                header_key = str(key)
+                for existing_key in list(headers):
+                    if existing_key.lower() == header_key.lower():
+                        del headers[existing_key]
+                headers[header_key] = str(value)
 
         for key, value in extra_headers.items():
             if isinstance(value, NotGiven):

--- a/tests/model_settings/test_serialization.py
+++ b/tests/model_settings/test_serialization.py
@@ -76,6 +76,7 @@ def test_all_fields_serialization() -> None:
             ),
         ),
         context_management=[{"type": "compaction", "compact_threshold": 200000}],
+        prompt_cache_options={"mode": "explicit", "ttl": "30m"},
     )
 
     # Verify that every single field is set to a non-None value
@@ -86,6 +87,28 @@ def test_all_fields_serialization() -> None:
 
     # Now, lets serialize the ModelSettings instance to a JSON string
     verify_serialization(model_settings)
+
+
+def test_gpt_5_6_reasoning_and_prompt_cache_serialization() -> None:
+    model_settings = ModelSettings(
+        reasoning=Reasoning(mode="pro", effort="max", context="all_turns"),
+        prompt_cache_options={"mode": "explicit", "ttl": "30m"},
+    )
+
+    serialized_reasoning = model_settings.to_json_dict()["reasoning"]
+    assert serialized_reasoning["context"] == "all_turns"
+    assert serialized_reasoning["effort"] == "max"
+    assert serialized_reasoning["mode"] == "pro"
+    assert model_settings.to_traceable_dict()["prompt_cache_options"] == {
+        "mode": "explicit",
+        "ttl": "30m",
+    }
+
+
+def test_prompt_cache_options_is_appended_to_public_field_order() -> None:
+    field_names = [field.name for field in fields(ModelSettings)]
+
+    assert field_names[-2:] == ["context_management", "prompt_cache_options"]
 
 
 def test_extra_args_serialization() -> None:

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -33,6 +33,7 @@ from openai.types.responses import (
     ResponseOutputRefusal,
     ResponseOutputText,
 )
+from openai.types.shared import Reasoning
 
 from agents import (
     Agent,
@@ -722,7 +723,11 @@ async def test_fetch_response_non_stream(monkeypatch) -> None:
         result = await model._fetch_response(
             system_instructions="sys",
             input="hi",
-            model_settings=ModelSettings(),
+            model_settings=ModelSettings(
+                reasoning=Reasoning(effort="xhigh"),
+                prompt_cache_retention="24h",
+                prompt_cache_options={"mode": "explicit", "ttl": "30m"},
+            ),
             tools=[],
             output_schema=None,
             handoffs=[],
@@ -744,6 +749,42 @@ async def test_fetch_response_non_stream(monkeypatch) -> None:
     assert kwargs["tool_choice"] is omit
     assert kwargs["response_format"] is omit
     assert kwargs["stream_options"] is omit
+    assert kwargs["reasoning_effort"] == "xhigh"
+    assert kwargs["prompt_cache_retention"] == "24h"
+    assert kwargs["prompt_cache_options"] == {"mode": "explicit", "ttl": "30m"}
+
+
+def test_chat_completions_warns_once_for_responses_only_reasoning_settings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    model = OpenAIChatCompletionsModel(
+        model="gpt-5.6-sol",
+        openai_client=cast(Any, object()),
+    )
+    model_settings = ModelSettings(
+        reasoning=Reasoning(mode="pro", effort="max", context="all_turns")
+    )
+    caplog.set_level(logging.WARNING, logger="openai.agents")
+
+    model._handle_unsupported_reasoning_settings(model_settings)
+    model._handle_unsupported_reasoning_settings(model_settings)
+
+    assert caplog.text.count("Ignoring unsupported reasoning settings") == 1
+    assert "reasoning.mode" in caplog.text
+    assert "reasoning.context" in caplog.text
+
+
+def test_chat_completions_rejects_responses_only_reasoning_settings_in_strict_mode() -> None:
+    model = OpenAIChatCompletionsModel(
+        model="gpt-5.6-sol",
+        openai_client=cast(Any, object()),
+        strict_feature_validation=True,
+    )
+
+    with pytest.raises(UserError, match="reasoning.mode"):
+        model._handle_unsupported_reasoning_settings(
+            ModelSettings(reasoning=Reasoning(mode="pro", context="all_turns"))
+        )
 
 
 @pytest.mark.allow_call_model_methods
@@ -756,6 +797,30 @@ async def test_custom_base_url_prompt_cache_key_uses_model_settings_only() -> No
 
     assert "prompt_cache_key" not in default_kwargs
     assert explicit_kwargs["prompt_cache_key"] == "cache-key"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_extra_args_prompt_cache_options_allowed_when_direct_field_is_omitted() -> None:
+    prompt_cache_options = {"mode": "explicit", "ttl": "30m"}
+
+    kwargs = await _run_chat_completions_model_with_custom_base_url(
+        model_settings=ModelSettings(extra_args={"prompt_cache_options": prompt_cache_options})
+    )
+
+    assert kwargs["prompt_cache_options"] == prompt_cache_options
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_duplicate_prompt_cache_options_rejected() -> None:
+    with pytest.raises(TypeError, match="multiple values.*prompt_cache_options"):
+        await _run_chat_completions_model_with_custom_base_url(
+            model_settings=ModelSettings(
+                prompt_cache_options={"mode": "explicit", "ttl": "30m"},
+                extra_args={"prompt_cache_options": {"mode": "implicit"}},
+            )
+        )
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -24,7 +24,7 @@ These tests exercise both conversion directions:
 from __future__ import annotations
 
 import logging
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import pytest
 from openai import omit
@@ -532,6 +532,59 @@ def test_extract_all_content_handles_input_audio():
             "input_audio": {"data": "AAA=", "format": "wav"},
         }
     ]
+
+
+def test_extract_all_content_preserves_prompt_cache_breakpoints() -> None:
+    breakpoint = {"mode": "explicit"}
+    content: list[dict[str, Any]] = [
+        {
+            "type": "input_text",
+            "text": "one",
+            "prompt_cache_breakpoint": breakpoint,
+        },
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/image.png",
+            "prompt_cache_breakpoint": breakpoint,
+        },
+        {
+            "type": "input_audio",
+            "input_audio": {"data": "AAA=", "format": "wav"},
+            "prompt_cache_breakpoint": breakpoint,
+        },
+        {
+            "type": "input_file",
+            "file_data": "data:text/plain;base64,SGVsbG8=",
+            "filename": "hello.txt",
+            "prompt_cache_breakpoint": breakpoint,
+        },
+    ]
+
+    parts = Converter.extract_all_content(content)
+
+    assert isinstance(parts, list)
+    assert [part["prompt_cache_breakpoint"] for part in parts] == [breakpoint] * 4
+
+
+def test_raw_chat_content_aliases_preserve_prompt_cache_breakpoints() -> None:
+    breakpoint = {"mode": "explicit"}
+
+    parts = Converter.extract_all_content(
+        cast(
+            list[dict[str, Any]],
+            [
+                {"type": "text", "text": "one", "prompt_cache_breakpoint": breakpoint},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                    "prompt_cache_breakpoint": breakpoint,
+                },
+            ],
+        )
+    )
+
+    assert isinstance(parts, list)
+    assert [part["prompt_cache_breakpoint"] for part in parts] == [breakpoint, breakpoint]
 
 
 def test_extract_all_content_rejects_invalid_input_audio():

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 from openai import NOT_GIVEN, APIConnectionError, AsyncOpenAI, RateLimitError, omit
 from openai.types.responses import ResponseCompletedEvent, ResponseErrorEvent
-from openai.types.responses.response_create_params import ContextManagement
+from openai.types.responses.response_create_params import ContextManagement, PromptCacheOptions
 from openai.types.shared.reasoning import Reasoning
 
 from agents import (
@@ -136,10 +136,8 @@ class DummyWSClient:
         self.base_url = httpx.URL("https://api.openai.com/v1/")
         self.websocket_base_url = None
         self.default_query: dict[str, Any] = {}
-        self.default_headers = {
-            "Authorization": "Bearer test-key",
-            "User-Agent": "AsyncOpenAI/Python test",
-        }
+        self.auth_headers = {"Authorization": "Bearer test-key"}
+        self.default_headers = {"User-Agent": "AsyncOpenAI/Python test"}
         self.timeout: Any = None
         self.refresh_calls = 0
 
@@ -904,6 +902,81 @@ def test_build_response_create_kwargs_includes_context_management():
     )
 
     assert kwargs["context_management"] == context_management
+
+
+@pytest.mark.allow_call_model_methods
+def test_build_response_create_kwargs_includes_gpt_5_6_request_controls():
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-5.6-sol", openai_client=client)  # type: ignore[arg-type]
+    reasoning = Reasoning(mode="pro", effort="max", context="all_turns")
+    prompt_cache_options: PromptCacheOptions = {"mode": "explicit", "ttl": "30m"}
+
+    kwargs = model._build_response_create_kwargs(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(
+            reasoning=reasoning,
+            prompt_cache_retention="24h",
+            prompt_cache_options=prompt_cache_options,
+        ),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        previous_response_id="resp-previous",
+        conversation_id=None,
+        stream=False,
+        prompt=None,
+    )
+
+    assert kwargs["reasoning"] is reasoning
+    assert kwargs["prompt_cache_retention"] == "24h"
+    assert kwargs["prompt_cache_options"] == prompt_cache_options
+    assert kwargs["previous_response_id"] == "resp-previous"
+
+
+@pytest.mark.allow_call_model_methods
+def test_build_response_create_kwargs_rejects_duplicate_prompt_cache_options_extra_args():
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-5.6-sol", openai_client=client)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="multiple values.*prompt_cache_options"):
+        model._build_response_create_kwargs(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(
+                prompt_cache_options={"mode": "explicit", "ttl": "30m"},
+                extra_args={"prompt_cache_options": {"mode": "implicit"}},
+            ),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            previous_response_id=None,
+            conversation_id=None,
+            stream=False,
+            prompt=None,
+        )
+
+
+@pytest.mark.allow_call_model_methods
+def test_build_response_create_kwargs_allows_prompt_cache_options_extra_args_when_direct_omitted():
+    client = DummyWSClient()
+    model = OpenAIResponsesModel(model="gpt-5.6-sol", openai_client=client)  # type: ignore[arg-type]
+    prompt_cache_options = {"mode": "explicit", "ttl": "30m"}
+
+    kwargs = model._build_response_create_kwargs(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(extra_args={"prompt_cache_options": prompt_cache_options}),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        previous_response_id=None,
+        conversation_id=None,
+        stream=False,
+        prompt=None,
+    )
+
+    assert kwargs["prompt_cache_options"] == prompt_cache_options
 
 
 @pytest.mark.allow_call_model_methods
@@ -1707,7 +1780,10 @@ async def test_websocket_model_reuses_connection_and_sends_response_create_frame
     first = await model.get_response(
         system_instructions=None,
         input="hi",
-        model_settings=ModelSettings(reasoning=Reasoning(effort="medium", summary="detailed")),
+        model_settings=ModelSettings(
+            reasoning=Reasoning(mode="pro", effort="max", context="all_turns"),
+            prompt_cache_options={"mode": "explicit", "ttl": "30m"},
+        ),
         tools=[],
         output_schema=None,
         handoffs=[],
@@ -1730,7 +1806,15 @@ async def test_websocket_model_reuses_connection_and_sends_response_create_frame
     assert len(opened) == 1
     assert ws.sent_messages[0]["type"] == "response.create"
     assert ws.sent_messages[0]["stream"] is True
-    assert ws.sent_messages[0]["reasoning"] == {"effort": "medium", "summary": "detailed"}
+    assert ws.sent_messages[0]["reasoning"] == {
+        "context": "all_turns",
+        "effort": "max",
+        "mode": "pro",
+    }
+    assert ws.sent_messages[0]["prompt_cache_options"] == {
+        "mode": "explicit",
+        "ttl": "30m",
+    }
     assert ws.sent_messages[1]["type"] == "response.create"
     assert ws.sent_messages[1]["stream"] is True
     assert ws.sent_messages[1]["previous_response_id"] == "resp-1"
@@ -3232,6 +3316,42 @@ async def test_websocket_model_get_response_uses_client_default_timeout_when_ove
         )
 
     assert ws.close_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_prepare_websocket_request_includes_client_auth_headers():
+    client = DummyWSClient()
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    _frame, _ws_url, headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+        }
+    )
+
+    assert headers["Authorization"] == "Bearer test-key"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_model_default_headers_override_auth_case_insensitively():
+    client = DummyWSClient()
+    client.default_headers["authorization"] = "Bearer override-key"
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=client)  # type: ignore[arg-type]
+
+    _frame, _ws_url, headers = await model._prepare_websocket_request(
+        {
+            "model": "gpt-4",
+            "input": "hi",
+            "stream": True,
+        }
+    )
+
+    assert headers["authorization"] == "Bearer override-key"
+    assert "Authorization" not in headers
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/test_prompt_cache_key.py
+++ b/tests/test_prompt_cache_key.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from openai.types.responses.response_create_params import ContextManagement
+from openai.types.responses.response_create_params import ContextManagement, PromptCacheOptions
 
 from agents import Agent, ModelSettings, RunConfig, Runner
 
@@ -165,6 +165,24 @@ async def test_runner_preserves_context_management_when_adding_prompt_cache_key(
     assert sent_model_settings.context_management == context_management
     assert sent_model_settings.extra_args == {"prompt_cache_key": _sent_prompt_cache_key(model)}
     assert model_settings.context_management == context_management
+    assert model_settings.extra_args is None
+
+
+@pytest.mark.asyncio
+async def test_runner_preserves_prompt_cache_options_when_adding_prompt_cache_key() -> None:
+    model = PromptCacheFakeModel()
+    model.set_next_output([get_text_message("done")])
+    prompt_cache_options: PromptCacheOptions = {"mode": "explicit", "ttl": "30m"}
+    model_settings = ModelSettings(prompt_cache_options=prompt_cache_options)
+    agent = Agent(name="test", model=model, model_settings=model_settings)
+
+    await Runner.run(agent, "hi")
+
+    assert _sent_prompt_cache_key(model) is not None
+    sent_model_settings = _sent_model_settings(model)
+    assert sent_model_settings.prompt_cache_options == prompt_cache_options
+    assert sent_model_settings.extra_args == {"prompt_cache_key": _sent_prompt_cache_key(model)}
+    assert model_settings.prompt_cache_options == prompt_cache_options
     assert model_settings.extra_args is None
 
 


### PR DESCRIPTION
This pull request adds GPT-5.6 reasoning and prompt-cache controls across the OpenAI Responses and Chat Completions model paths.

It adds `ModelSettings.prompt_cache_options`, forwards GPT-5.6 reasoning mode and context through Responses HTTP and WebSocket transports, and preserves explicit cache breakpoints when converting Chat text, image, audio, and file content. Chat Completions continues to use `reasoning.effort` while warning, or raising under strict validation, when Responses-only reasoning settings are supplied.

The change also fixes Responses WebSocket authentication header propagation, preserves `extra_args` compatibility, and updates the documentation to separate GPT-5.6 explicit caching from legacy retention controls. Multimodal breakpoint availability remains dependent on the selected model and API surface.

see also: https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.6