### PR TITLE
fix: keep parameter descriptions for docstrings without a summary line

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -165,8 +165,13 @@ def generate_func_documentation(
     if not doc:
         return FuncDocumentation(name=name, description=None, param_descriptions=None)
 
+    # griffe's Google parser treats the first line of the docstring as the summary. When a
+    # docstring omits the summary and opens directly with a section header (e.g. "Args:"), that
+    # header gets swallowed into the description and every parameter description is dropped.
+    # inspect.getdoc() strips the leading blank line that would otherwise mark an empty summary,
+    # so re-add one here to keep the section intact.
     with _suppress_griffe_logging():
-        docstring = Docstring(doc, lineno=1, parser=style or _detect_docstring_style(doc))
+        docstring = Docstring("\n" + doc, lineno=1, parser=style or _detect_docstring_style(doc))
         parsed = docstring.parse()
 
     description: str | None = next(

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -885,3 +885,24 @@ def test_function_with_annotated_field_multiple_constraints():
 
     with pytest.raises(ValidationError):  # zero factor
         fs.params_pydantic_model(**{"score": 50, "factor": 0.0})
+
+
+def test_docstring_without_summary_keeps_param_descriptions():
+    """A Google-style docstring that opens directly with the Args section (no summary line)
+    should still have its parameter descriptions parsed rather than swallowed as the summary."""
+
+    def func(a: int, b: str):
+        """
+        Args:
+            a: the first argument
+            b: the second argument
+        """
+        return f"{a}-{b}"
+
+    fs = function_schema(func)
+
+    properties = fs.params_json_schema.get("properties", {})
+    assert properties.get("a").get("description") == "the first argument"
+    assert properties.get("b").get("description") == "the second argument"
+    # The Args block is a section, not free text, so there is no function description.
+    assert fs.description is None


### PR DESCRIPTION
No linked issue — found while reading `function_schema.py`.

### Summary

A function tool silently loses **all** of its parameter descriptions when the docstring omits a summary line and opens directly with the `Args:` section — a very common style when the opening `"""` is on its own line:

```python
@function_tool
def lookup(query: str, limit: int):
    """
    Args:
        query: the search query
        limit: max results to return
    """
    ...
```

Before this change the generated schema for `query`/`limit` has **no `description`**, and the function description wrongly becomes the raw `Args:` block, so the model never sees the parameter descriptions.

### Root cause

`generate_func_documentation` passes `inspect.getdoc(func)` to griffe's `Docstring`. griffe's Google parser treats the docstring's first line as the summary, and `inspect.getdoc()` strips the leading blank line that would otherwise mark an empty summary. An `Args:`-first docstring therefore has its whole section swallowed as the summary and every parameter description dropped.

### Fix

Re-add a leading newline before parsing, so griffe sees an empty summary and parses the section normally:

```python
docstring = Docstring("\n" + doc, ...)
```

This only changes the previously-broken case. I ran a matrix over google/numpy/sphinx docstrings with and without summaries — every shape except the broken one is byte-identical, and docstrings that begin with a summary keep their description exactly as before.

### Test

Added `test_docstring_without_summary_keeps_param_descriptions` to `tests/test_function_schema.py` (fails before, passes after). `test_function_schema.py`, `test_function_tool.py`, `test_function_tool_decorator.py`, and `test_strict_schema.py` pass (104 tests); `ruff` check + format clean.
