### PR TITLE
refactor(sandbox): share core PTY output collection

### DIFF
--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -49,6 +49,7 @@ from ..session import SandboxSession, SandboxSessionState
 from ..session.base_sandbox_session import BaseSandboxSession
 from ..session.dependencies import Dependencies
 from ..session.manager import Instrumentation
+from ..session.pty_output import collect_pty_output
 from ..session.pty_types import (
     PTY_PROCESSES_MAX,
     PTY_PROCESSES_WARNING,
@@ -57,7 +58,6 @@ from ..session.pty_types import (
     clamp_pty_yield_time_ms,
     process_id_to_prune_from_meta,
     resolve_pty_write_yield_time_ms,
-    truncate_text_by_tokens,
 )
 from ..session.runtime_helpers import RESOLVE_WORKSPACE_PATH_HELPER, RuntimeHelperScript
 from ..session.sandbox_client import BaseSandboxClient, BaseSandboxClientOptions
@@ -1190,36 +1190,14 @@ class DockerSandboxSession(BaseSandboxSession):
         yield_time_ms: int,
         max_output_tokens: int | None,
     ) -> tuple[bytes, int | None]:
-        deadline = time.monotonic() + (yield_time_ms / 1000)
-        output = bytearray()
-
-        while True:
-            async with entry.output_lock:
-                while entry.output_chunks:
-                    output.extend(entry.output_chunks.popleft())
-
-            if time.monotonic() >= deadline:
-                break
-
-            if entry.output_closed.is_set():
-                async with entry.output_lock:
-                    while entry.output_chunks:
-                        output.extend(entry.output_chunks.popleft())
-                break
-
-            remaining_s = deadline - time.monotonic()
-            if remaining_s <= 0:
-                break
-
-            try:
-                await asyncio.wait_for(entry.output_notify.wait(), timeout=remaining_s)
-            except asyncio.TimeoutError:
-                break
-            entry.output_notify.clear()
-
-        text = output.decode("utf-8", errors="replace")
-        truncated_text, original_token_count = truncate_text_by_tokens(text, max_output_tokens)
-        return truncated_text.encode("utf-8", errors="replace"), original_token_count
+        return await collect_pty_output(
+            output_chunks=entry.output_chunks,
+            output_lock=entry.output_lock,
+            output_notify=entry.output_notify,
+            is_done=entry.output_closed.is_set,
+            yield_time_ms=yield_time_ms,
+            max_output_tokens=max_output_tokens,
+        )
 
     async def _finalize_pty_update(
         self,

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -45,6 +45,7 @@ from ..session import SandboxSession, SandboxSessionState
 from ..session.base_sandbox_session import BaseSandboxSession
 from ..session.dependencies import Dependencies
 from ..session.manager import Instrumentation
+from ..session.pty_output import collect_pty_output
 from ..session.pty_types import (
     PTY_PROCESSES_MAX,
     PTY_PROCESSES_WARNING,
@@ -53,7 +54,6 @@ from ..session.pty_types import (
     clamp_pty_yield_time_ms,
     process_id_to_prune_from_meta,
     resolve_pty_write_yield_time_ms,
-    truncate_text_by_tokens,
 )
 from ..session.sandbox_client import BaseSandboxClient, BaseSandboxClientOptions
 from ..session.workspace_payloads import coerce_write_payload
@@ -483,36 +483,14 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         yield_time_ms: int,
         max_output_tokens: int | None,
     ) -> tuple[bytes, int | None]:
-        deadline = time.monotonic() + (yield_time_ms / 1000)
-        output = bytearray()
-
-        while True:
-            async with entry.output_lock:
-                while entry.output_chunks:
-                    output.extend(entry.output_chunks.popleft())
-
-            if time.monotonic() >= deadline:
-                break
-
-            if entry.output_closed.is_set():
-                async with entry.output_lock:
-                    while entry.output_chunks:
-                        output.extend(entry.output_chunks.popleft())
-                break
-
-            remaining_s = deadline - time.monotonic()
-            if remaining_s <= 0:
-                break
-
-            try:
-                await asyncio.wait_for(entry.output_notify.wait(), timeout=remaining_s)
-            except asyncio.TimeoutError:
-                break
-            entry.output_notify.clear()
-
-        text = output.decode("utf-8", errors="replace")
-        truncated_text, original_token_count = truncate_text_by_tokens(text, max_output_tokens)
-        return truncated_text.encode("utf-8", errors="replace"), original_token_count
+        return await collect_pty_output(
+            output_chunks=entry.output_chunks,
+            output_lock=entry.output_lock,
+            output_notify=entry.output_notify,
+            is_done=entry.output_closed.is_set,
+            yield_time_ms=yield_time_ms,
+            max_output_tokens=max_output_tokens,
+        )
 
     async def _finalize_pty_update(
         self,

--- a/src/agents/sandbox/session/pty_output.py
+++ b/src/agents/sandbox/session/pty_output.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from collections.abc import Callable
+
+from .pty_types import truncate_text_by_tokens
+
+
+async def collect_pty_output(
+    *,
+    output_chunks: deque[bytes],
+    output_lock: asyncio.Lock,
+    output_notify: asyncio.Event,
+    is_done: Callable[[], bool],
+    yield_time_ms: int,
+    max_output_tokens: int | None,
+) -> tuple[bytes, int | None]:
+    """Collect and truncate PTY output until the deadline or provider completion."""
+    deadline = time.monotonic() + (yield_time_ms / 1000)
+    output = bytearray()
+
+    while True:
+        async with output_lock:
+            while output_chunks:
+                output.extend(output_chunks.popleft())
+
+        if time.monotonic() >= deadline:
+            break
+
+        if is_done():
+            async with output_lock:
+                while output_chunks:
+                    output.extend(output_chunks.popleft())
+            break
+
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            break
+
+        try:
+            await asyncio.wait_for(output_notify.wait(), timeout=remaining_s)
+        except asyncio.TimeoutError:
+            break
+        output_notify.clear()
+
+    text = output.decode("utf-8", errors="replace")
+    truncated, original_token_count = truncate_text_by_tokens(text, max_output_tokens)
+    return truncated.encode("utf-8", errors="replace"), original_token_count

--- a/tests/sandbox/test_pty_output.py
+++ b/tests/sandbox/test_pty_output.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+
+import pytest
+
+from agents.sandbox.session.pty_output import collect_pty_output
+
+
+@pytest.mark.asyncio
+async def test_collect_pty_output_waits_for_notification() -> None:
+    output_chunks: deque[bytes] = deque()
+    output_lock = asyncio.Lock()
+    output_notify = asyncio.Event()
+    done = False
+
+    async def produce_output() -> None:
+        nonlocal done
+        await asyncio.sleep(0)
+        async with output_lock:
+            output_chunks.append(b"notified output")
+        done = True
+        output_notify.set()
+
+    producer_task = asyncio.create_task(produce_output())
+    output, original_token_count = await collect_pty_output(
+        output_chunks=output_chunks,
+        output_lock=output_lock,
+        output_notify=output_notify,
+        is_done=lambda: done,
+        yield_time_ms=500,
+        max_output_tokens=None,
+    )
+    await producer_task
+
+    assert output == b"notified output"
+    assert original_token_count is None
+
+
+@pytest.mark.asyncio
+async def test_collect_pty_output_drains_chunks_added_when_done() -> None:
+    output_chunks = deque([b"before done"])
+
+    def mark_done() -> bool:
+        output_chunks.append(b" after done")
+        return True
+
+    output, original_token_count = await collect_pty_output(
+        output_chunks=output_chunks,
+        output_lock=asyncio.Lock(),
+        output_notify=asyncio.Event(),
+        is_done=mark_done,
+        yield_time_ms=500,
+        max_output_tokens=None,
+    )
+
+    assert output == b"before done after done"
+    assert original_token_count is None


### PR DESCRIPTION
This pull request improves PTY output collection by extracting the duplicated deadline, notification, completion-drain, decoding, and token-truncation logic into a shared internal helper.

Unix Local and Docker now delegate to the shared collector while retaining their existing provider-specific completion state and output buffers. Blaxel and Daytona remain unchanged for a separate follow-up.