### PR TITLE
refactor(sandbox): share Runloop rclone setup

### DIFF
--- a/src/agents/extensions/sandbox/runloop/mounts.py
+++ b/src/agents/extensions/sandbox/runloop/mounts.py
@@ -10,14 +10,12 @@ from ....sandbox.entries.mounts.patterns import RcloneMountPattern
 from ....sandbox.errors import MountConfigError
 from ....sandbox.materialization import MaterializedFile
 from ....sandbox.session.base_sandbox_session import BaseSandboxSession
+from .._rclone import (
+    ensure_rclone as _ensure_rclone,
+    rclone_pattern_for_session as _rclone_pattern_for_session,
+)
 
 _APT = "DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes apt-get -o Dpkg::Use-Pty=0"
-_RCLONE_CHECK = "command -v rclone >/dev/null 2>&1 || test -x /usr/local/bin/rclone"
-_INSTALL_RCLONE_COMMANDS = (
-    f"{_APT} update -qq",
-    f"{_APT} install -y -qq curl unzip ca-certificates",
-    "curl -fsSL https://rclone.org/install.sh | bash",
-)
 _INSTALL_FUSE_COMMANDS = (
     f"{_APT} update -qq",
     f"{_APT} install -y -qq fuse3",
@@ -98,68 +96,6 @@ async def _ensure_fuse_support(session: BaseSandboxSession) -> None:
             message="failed to make /dev/fuse accessible",
             context={"exit_code": chmod_result.exit_code},
         )
-
-
-async def _ensure_rclone(session: BaseSandboxSession) -> None:
-    rclone = await session.exec("sh", "-lc", _RCLONE_CHECK, shell=False)
-    if rclone.ok():
-        return
-
-    apt = await session.exec("sh", "-lc", "command -v apt-get >/dev/null 2>&1", shell=False)
-    if not apt.ok():
-        raise MountConfigError(
-            message="rclone is not installed and apt-get is unavailable; preinstall rclone",
-            context={"package": "rclone"},
-        )
-
-    for command in _INSTALL_RCLONE_COMMANDS:
-        install = await session.exec("sh", "-lc", command, shell=False, timeout=300, user="root")
-        if not install.ok():
-            raise MountConfigError(
-                message="failed to install rclone",
-                context={"package": "rclone", "exit_code": install.exit_code},
-            )
-
-    rclone = await session.exec("sh", "-lc", _RCLONE_CHECK, shell=False)
-    if not rclone.ok():
-        raise MountConfigError(
-            message="rclone was installed but is still not available on PATH",
-            context={"package": "rclone"},
-        )
-
-
-async def _default_user_ids(session: BaseSandboxSession) -> tuple[str, str] | None:
-    result = await session.exec("sh", "-lc", "id -u; id -g", shell=False, timeout=30)
-    if not result.ok():
-        return None
-
-    lines = result.stdout.decode("utf-8", errors="replace").splitlines()
-    if len(lines) < 2 or not lines[0].isdigit() or not lines[1].isdigit():
-        return None
-    return lines[0], lines[1]
-
-
-def _append_option(args: list[str], option: str, *values: str) -> None:
-    if option not in args:
-        args.extend([option, *values])
-
-
-async def _rclone_pattern_for_session(
-    session: BaseSandboxSession,
-    pattern: RcloneMountPattern,
-) -> RcloneMountPattern:
-    if pattern.mode != "fuse":
-        return pattern
-
-    extra_args = list(pattern.extra_args)
-    _append_option(extra_args, "--allow-other")
-    user_ids = await _default_user_ids(session)
-    if user_ids is not None:
-        uid, gid = user_ids
-        _append_option(extra_args, "--uid", uid)
-        _append_option(extra_args, "--gid", gid)
-
-    return pattern.model_copy(update={"extra_args": extra_args})
 
 
 def _assert_runloop_session(session: BaseSandboxSession) -> None:

--- a/tests/extensions/sandbox/test_runloop_mounts.py
+++ b/tests/extensions/sandbox/test_runloop_mounts.py
@@ -135,7 +135,7 @@ def test_runloop_session_guard_accepts_correct_type() -> None:
 
 @pytest.mark.asyncio
 async def test_runloop_ensure_rclone_installs_with_root_apt() -> None:
-    from agents.extensions.sandbox.runloop.mounts import _ensure_rclone
+    from agents.extensions.sandbox._rclone import ensure_rclone
 
     session = _FakeRunloopMountSession(
         [
@@ -147,7 +147,7 @@ async def test_runloop_ensure_rclone_installs_with_root_apt() -> None:
         ]
     )
 
-    await _ensure_rclone(session)
+    await ensure_rclone(session)
 
     assert session.exec_calls[:2] == [
         "sh -lc command -v rclone >/dev/null 2>&1 || test -x /usr/local/bin/rclone",
@@ -215,10 +215,10 @@ async def test_runloop_ensure_fuse_installs_missing_fusermount() -> None:
 
 @pytest.mark.asyncio
 async def test_runloop_rclone_pattern_adds_fuse_access_args() -> None:
-    from agents.extensions.sandbox.runloop.mounts import _rclone_pattern_for_session
+    from agents.extensions.sandbox._rclone import rclone_pattern_for_session
 
     session = _FakeRunloopMountSession([_exec_ok(stdout=b"1000\n1000\n")])
 
-    pattern = await _rclone_pattern_for_session(session, RcloneMountPattern(mode="fuse"))
+    pattern = await rclone_pattern_for_session(session, RcloneMountPattern(mode="fuse"))
 
     assert pattern.extra_args == ["--allow-other", "--uid", "1000", "--gid", "1000"]


### PR DESCRIPTION
This pull request improves Runloop cloud bucket mount setup by migrating its duplicated rclone installation and per-session FUSE option logic to the shared internal helper.

Runloop retains its provider-specific FUSE availability checks and fuse3 installation behavior while sharing the same rclone commands, root execution, user ID detection, explicit option preservation, and error behavior as E2B.