### PR TITLE
refactor: share retry error metadata extraction

### DIFF
--- a/src/agents/models/_openai_retry.py
+++ b/src/agents/models/_openai_retry.py
@@ -1,24 +1,20 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Iterator, Mapping
+from collections.abc import Mapping
 from email.utils import parsedate_to_datetime
 from typing import Any
 
 import httpx
-from openai import APIConnectionError, APIStatusError, APITimeoutError
+from openai import APIConnectionError, APITimeoutError
 
 from ..retry import ModelRetryAdvice, ModelRetryAdviceRequest, ModelRetryNormalizedError
-
-
-def _iter_error_chain(error: Exception) -> Iterator[Exception]:
-    current: Exception | None = error
-    seen: set[int] = set()
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        yield current
-        next_error = current.__cause__ or current.__context__
-        current = next_error if isinstance(next_error, Exception) else None
+from ._retry_runtime import (
+    get_error_code as _get_error_code,
+    get_request_id as _get_request_id,
+    get_status_code as _get_status_code,
+    iter_error_chain as _iter_error_chain,
+)
 
 
 def _header_lookup(headers: Any, key: str) -> str | None:
@@ -76,46 +72,6 @@ def _parse_retry_after(value: str | None) -> float | None:
         return None
 
     return max(retry_datetime.timestamp() - time.time(), 0.0)
-
-
-def _get_status_code(error: Exception) -> int | None:
-    for candidate in _iter_error_chain(error):
-        if isinstance(candidate, APIStatusError):
-            return candidate.status_code
-        status_code = getattr(candidate, "status_code", None)
-        if isinstance(status_code, int):
-            return status_code
-        status = getattr(candidate, "status", None)
-        if isinstance(status, int):
-            return status
-    return None
-
-
-def _get_request_id(error: Exception) -> str | None:
-    for candidate in _iter_error_chain(error):
-        request_id = getattr(candidate, "request_id", None)
-        if isinstance(request_id, str):
-            return request_id
-    return None
-
-
-def _get_error_code(error: Exception) -> str | None:
-    for candidate in _iter_error_chain(error):
-        error_code = getattr(candidate, "code", None)
-        if isinstance(error_code, str):
-            return error_code
-
-        body = getattr(candidate, "body", None)
-        if isinstance(body, Mapping):
-            nested_error = body.get("error")
-            if isinstance(nested_error, Mapping):
-                nested_code = nested_error.get("code")
-                if isinstance(nested_code, str):
-                    return nested_code
-            body_code = body.get("code")
-            if isinstance(body_code, str):
-                return body_code
-    return None
 
 
 def _is_stateful_request(request: ModelRetryAdviceRequest) -> bool:

--- a/src/agents/models/_retry_runtime.py
+++ b/src/agents/models/_retry_runtime.py
@@ -1,8 +1,59 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
+
+from openai import APIStatusError
+
+
+def iter_error_chain(error: Exception) -> Iterator[Exception]:
+    current: Exception | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        next_error = current.__cause__ or current.__context__
+        current = next_error if isinstance(next_error, Exception) else None
+
+
+def get_status_code(error: Exception) -> int | None:
+    for candidate in iter_error_chain(error):
+        if isinstance(candidate, APIStatusError):
+            return candidate.status_code
+        for attr_name in ("status_code", "status"):
+            value = getattr(candidate, attr_name, None)
+            if isinstance(value, int):
+                return value
+    return None
+
+
+def get_request_id(error: Exception) -> str | None:
+    for candidate in iter_error_chain(error):
+        request_id = getattr(candidate, "request_id", None)
+        if isinstance(request_id, str):
+            return request_id
+    return None
+
+
+def get_error_code(error: Exception) -> str | None:
+    for candidate in iter_error_chain(error):
+        error_code = getattr(candidate, "code", None)
+        if isinstance(error_code, str):
+            return error_code
+
+        body = getattr(candidate, "body", None)
+        if isinstance(body, Mapping):
+            nested_error = body.get("error")
+            if isinstance(nested_error, Mapping):
+                nested_code = nested_error.get("code")
+                if isinstance(nested_code, str):
+                    return nested_code
+            body_code = body.get("code")
+            if isinstance(body_code, str):
+                return body_code
+    return None
+
 
 _DISABLE_PROVIDER_MANAGED_RETRIES: ContextVar[bool] = ContextVar(
     "disable_provider_managed_retries",

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -3,17 +3,21 @@ from __future__ import annotations
 import asyncio
 import random
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from email.utils import parsedate_to_datetime
 from inspect import isawaitable
 from typing import Any
 
 import httpx
-from openai import APIConnectionError, APIStatusError, APITimeoutError, BadRequestError
+from openai import APIConnectionError, APITimeoutError, BadRequestError
 
 from ..items import ModelResponse, TResponseStreamEvent
 from ..logger import logger
 from ..models._retry_runtime import (
+    get_error_code as _get_error_code,
+    get_request_id as _get_request_id,
+    get_status_code as _get_status_code,
+    iter_error_chain as _iter_error_chain,
     provider_managed_retries_disabled,
     websocket_pre_event_retries_disabled,
 )
@@ -42,16 +46,6 @@ DEFAULT_BACKOFF_MULTIPLIER = 2.0
 DEFAULT_BACKOFF_JITTER = True
 COMPATIBILITY_CONVERSATION_LOCKED_RETRIES = 3
 _RETRY_SAFE_STREAM_EVENT_TYPES = frozenset({"response.created", "response.in_progress"})
-
-
-def _iter_error_chain(error: Exception) -> Iterator[Exception]:
-    current: Exception | None = error
-    seen: set[int] = set()
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        yield current
-        next_error = current.__cause__ or current.__context__
-        current = next_error if isinstance(next_error, Exception) else None
 
 
 def _is_conversation_locked_error(error: Exception) -> bool:
@@ -116,46 +110,6 @@ def _parse_retry_after(headers: httpx.Headers | Mapping[str, str] | None) -> flo
         return None
 
     return max(retry_datetime.timestamp() - time.time(), 0.0)
-
-
-def _get_status_code(error: Exception) -> int | None:
-    for candidate in _iter_error_chain(error):
-        if isinstance(candidate, APIStatusError):
-            return candidate.status_code
-
-        for attr_name in ("status_code", "status"):
-            value = getattr(candidate, attr_name, None)
-            if isinstance(value, int):
-                return value
-
-    return None
-
-
-def _get_error_code(error: Exception) -> str | None:
-    for candidate in _iter_error_chain(error):
-        error_code = getattr(candidate, "code", None)
-        if isinstance(error_code, str):
-            return error_code
-
-        body = getattr(candidate, "body", None)
-        if isinstance(body, Mapping):
-            nested_error = body.get("error")
-            if isinstance(nested_error, Mapping):
-                nested_code = nested_error.get("code")
-                if isinstance(nested_code, str):
-                    return nested_code
-            body_code = body.get("code")
-            if isinstance(body_code, str):
-                return body_code
-    return None
-
-
-def _get_request_id(error: Exception) -> str | None:
-    for candidate in _iter_error_chain(error):
-        request_id = getattr(candidate, "request_id", None)
-        if isinstance(request_id, str):
-            return request_id
-    return None
 
 
 def _is_abort_like_error(error: Exception) -> bool:

--- a/tests/models/test_openai_retry_helpers.py
+++ b/tests/models/test_openai_retry_helpers.py
@@ -13,15 +13,18 @@ from email.utils import format_datetime
 import httpx
 
 from agents.models._openai_retry import (
-    _get_error_code,
     _get_header_value,
-    _get_status_code,
     _header_lookup,
     _parse_retry_after,
     _parse_retry_after_ms,
     get_openai_retry_advice,
 )
+from agents.models._retry_runtime import (
+    get_error_code as _get_error_code,
+    get_status_code as _get_status_code,
+)
 from agents.retry import ModelRetryAdviceRequest
+from agents.run_internal.model_retry import _normalize_retry_error
 
 
 class _HeaderError(Exception):
@@ -97,6 +100,23 @@ def test_get_error_code_from_body_mapping() -> None:
     assert _get_error_code(_NestedBody("a")) == "rate_limit_exceeded"
     assert _get_error_code(_TopLevelBody("b")) == "server_error"
     assert _get_error_code(Exception("none")) is None
+
+
+def test_provider_and_runner_retry_normalization_share_metadata() -> None:
+    class _RetryableError(Exception):
+        status_code = 429
+        request_id = "req_test"
+        body = {"error": {"code": "rate_limit_exceeded"}}
+
+    error = _RetryableError("slow down")
+    advice = get_openai_retry_advice(_make_request(error))
+    runner_normalized = _normalize_retry_error(error, None)
+
+    assert advice is not None
+    assert advice.normalized is not None
+    assert advice.normalized.status_code == runner_normalized.status_code
+    assert advice.normalized.error_code == runner_normalized.error_code
+    assert advice.normalized.request_id == runner_normalized.request_id
 
 
 def test_advice_unsafe_to_replay() -> None:


### PR DESCRIPTION
This pull request improves retry error normalization by sharing exception-chain traversal and status code, error code, and request ID extraction between OpenAI provider retry advice and runner-level retries.

It preserves the existing retry behavior and adds regression coverage confirming that both paths produce identical metadata. Header and `Retry-After` parsing remain unchanged for a separate follow-up.
