### PR TITLE
refactor: share retry-after parsing

### DIFF
--- a/src/agents/models/_openai_retry.py
+++ b/src/agents/models/_openai_retry.py
@@ -1,77 +1,16 @@
 from __future__ import annotations
 
-import time
-from collections.abc import Mapping
-from email.utils import parsedate_to_datetime
-from typing import Any
-
-import httpx
 from openai import APIConnectionError, APITimeoutError
 
 from ..retry import ModelRetryAdvice, ModelRetryAdviceRequest, ModelRetryNormalizedError
 from ._retry_runtime import (
     get_error_code as _get_error_code,
+    get_error_header as _get_header_value,
     get_request_id as _get_request_id,
+    get_retry_after,
     get_status_code as _get_status_code,
     iter_error_chain as _iter_error_chain,
 )
-
-
-def _header_lookup(headers: Any, key: str) -> str | None:
-    normalized_key = key.lower()
-    if isinstance(headers, httpx.Headers):
-        value = headers.get(key)
-        return value if isinstance(value, str) else None
-    if isinstance(headers, Mapping):
-        for header_name, header_value in headers.items():
-            if str(header_name).lower() == normalized_key and isinstance(header_value, str):
-                return header_value
-    return None
-
-
-def _get_header_value(error: Exception, key: str) -> str | None:
-    for candidate in _iter_error_chain(error):
-        response = getattr(candidate, "response", None)
-        if isinstance(response, httpx.Response):
-            header_value = _header_lookup(response.headers, key)
-            if header_value is not None:
-                return header_value
-
-        for attr_name in ("headers", "response_headers"):
-            header_value = _header_lookup(getattr(candidate, attr_name, None), key)
-            if header_value is not None:
-                return header_value
-
-    return None
-
-
-def _parse_retry_after_ms(value: str | None) -> float | None:
-    if value is None:
-        return None
-    try:
-        parsed = float(value) / 1000.0
-    except ValueError:
-        return None
-    return parsed if parsed >= 0 else None
-
-
-def _parse_retry_after(value: str | None) -> float | None:
-    if value is None:
-        return None
-
-    try:
-        parsed = float(value)
-    except ValueError:
-        parsed = None
-    if parsed is not None:
-        return parsed if parsed >= 0 else None
-
-    try:
-        retry_datetime = parsedate_to_datetime(value)
-    except (TypeError, ValueError, IndexError):
-        return None
-
-    return max(retry_datetime.timestamp() - time.time(), 0.0)
 
 
 def _is_stateful_request(request: ModelRetryAdviceRequest) -> bool:
@@ -119,9 +58,7 @@ def get_openai_retry_advice(request: ModelRetryAdviceRequest) -> ModelRetryAdvic
             reason=str(error),
         )
 
-    retry_after = _parse_retry_after_ms(_get_header_value(error, "retry-after-ms"))
-    if retry_after is None:
-        retry_after = _parse_retry_after(_get_header_value(error, "retry-after"))
+    retry_after = get_retry_after(error)
 
     normalized = _build_normalized_error(error, retry_after=retry_after)
     stateful_request = _is_stateful_request(request)

--- a/src/agents/models/_retry_runtime.py
+++ b/src/agents/models/_retry_runtime.py
@@ -33,18 +33,25 @@ def header_lookup(headers: Any, key: str) -> str | None:
     return None
 
 
+def _get_candidate_header(candidate: Exception, key: str) -> str | None:
+    response = getattr(candidate, "response", None)
+    if isinstance(response, httpx.Response):
+        header_value = header_lookup(response.headers, key)
+        if header_value is not None:
+            return header_value
+
+    for attr_name in ("headers", "response_headers"):
+        header_value = header_lookup(getattr(candidate, attr_name, None), key)
+        if header_value is not None:
+            return header_value
+    return None
+
+
 def get_error_header(error: Exception, key: str) -> str | None:
     for candidate in iter_error_chain(error):
-        response = getattr(candidate, "response", None)
-        if isinstance(response, httpx.Response):
-            header_value = header_lookup(response.headers, key)
-            if header_value is not None:
-                return header_value
-
-        for attr_name in ("headers", "response_headers"):
-            header_value = header_lookup(getattr(candidate, attr_name, None), key)
-            if header_value is not None:
-                return header_value
+        header_value = _get_candidate_header(candidate, key)
+        if header_value is not None:
+            return header_value
     return None
 
 
@@ -77,10 +84,15 @@ def parse_retry_after_value(value: str | None) -> float | None:
 
 
 def get_retry_after(error: Exception) -> float | None:
-    retry_after = parse_retry_after_ms(get_error_header(error, "retry-after-ms"))
-    if retry_after is not None:
-        return retry_after
-    return parse_retry_after_value(get_error_header(error, "retry-after"))
+    for candidate in iter_error_chain(error):
+        retry_after = parse_retry_after_ms(_get_candidate_header(candidate, "retry-after-ms"))
+        if retry_after is not None:
+            return retry_after
+
+        retry_after = parse_retry_after_value(_get_candidate_header(candidate, "retry-after"))
+        if retry_after is not None:
+            return retry_after
+    return None
 
 
 def get_status_code(error: Exception) -> int | None:

--- a/src/agents/models/_retry_runtime.py
+++ b/src/agents/models/_retry_runtime.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
+from email.utils import parsedate_to_datetime
+from typing import Any
 
+import httpx
 from openai import APIStatusError
 
 
@@ -15,6 +19,68 @@ def iter_error_chain(error: Exception) -> Iterator[Exception]:
         yield current
         next_error = current.__cause__ or current.__context__
         current = next_error if isinstance(next_error, Exception) else None
+
+
+def header_lookup(headers: Any, key: str) -> str | None:
+    normalized_key = key.lower()
+    if isinstance(headers, httpx.Headers):
+        value = headers.get(key)
+        return value if isinstance(value, str) else None
+    if isinstance(headers, Mapping):
+        for header_name, header_value in headers.items():
+            if str(header_name).lower() == normalized_key and isinstance(header_value, str):
+                return header_value
+    return None
+
+
+def get_error_header(error: Exception, key: str) -> str | None:
+    for candidate in iter_error_chain(error):
+        response = getattr(candidate, "response", None)
+        if isinstance(response, httpx.Response):
+            header_value = header_lookup(response.headers, key)
+            if header_value is not None:
+                return header_value
+
+        for attr_name in ("headers", "response_headers"):
+            header_value = header_lookup(getattr(candidate, attr_name, None), key)
+            if header_value is not None:
+                return header_value
+    return None
+
+
+def parse_retry_after_ms(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value) / 1000.0
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def parse_retry_after_value(value: str | None) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        parsed = float(value)
+    except ValueError:
+        parsed = None
+    if parsed is not None:
+        return parsed if parsed >= 0 else None
+
+    try:
+        retry_datetime = parsedate_to_datetime(value)
+    except (TypeError, ValueError, IndexError):
+        return None
+    return max(retry_datetime.timestamp() - time.time(), 0.0)
+
+
+def get_retry_after(error: Exception) -> float | None:
+    retry_after = parse_retry_after_ms(get_error_header(error, "retry-after-ms"))
+    if retry_after is not None:
+        return retry_after
+    return parse_retry_after_value(get_error_header(error, "retry-after"))
 
 
 def get_status_code(error: Exception) -> int | None:

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import random
-import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
-from email.utils import parsedate_to_datetime
 from inspect import isawaitable
 from typing import Any
 
@@ -16,6 +14,7 @@ from ..logger import logger
 from ..models._retry_runtime import (
     get_error_code as _get_error_code,
     get_request_id as _get_request_id,
+    get_retry_after as _get_retry_after,
     get_status_code as _get_status_code,
     iter_error_chain as _iter_error_chain,
     provider_managed_retries_disabled,
@@ -52,64 +51,6 @@ def _is_conversation_locked_error(error: Exception) -> bool:
     return (
         isinstance(error, BadRequestError) and getattr(error, "code", "") == "conversation_locked"
     )
-
-
-def _get_header_value(headers: Any, key: str) -> str | None:
-    normalized_key = key.lower()
-    if isinstance(headers, httpx.Headers):
-        value = headers.get(key)
-        return value if isinstance(value, str) else None
-    if isinstance(headers, Mapping):
-        for header_name, header_value in headers.items():
-            if str(header_name).lower() == normalized_key and isinstance(header_value, str):
-                return header_value
-    return None
-
-
-def _extract_headers(error: Exception) -> httpx.Headers | Mapping[str, str] | None:
-    for candidate in _iter_error_chain(error):
-        response = getattr(candidate, "response", None)
-        if isinstance(response, httpx.Response):
-            return response.headers
-
-        for attr_name in ("headers", "response_headers"):
-            headers = getattr(candidate, attr_name, None)
-            if isinstance(headers, httpx.Headers | Mapping):
-                return headers
-
-    return None
-
-
-def _parse_retry_after(headers: httpx.Headers | Mapping[str, str] | None) -> float | None:
-    if headers is None:
-        return None
-
-    retry_after_ms = _get_header_value(headers, "retry-after-ms")
-    if retry_after_ms is not None:
-        try:
-            parsed_ms = float(retry_after_ms) / 1000.0
-        except ValueError:
-            parsed_ms = None
-        if parsed_ms is not None and parsed_ms >= 0:
-            return parsed_ms
-
-    retry_after = _get_header_value(headers, "retry-after")
-    if retry_after is None:
-        return None
-
-    try:
-        parsed_seconds = float(retry_after)
-    except ValueError:
-        parsed_seconds = None
-    if parsed_seconds is not None:
-        return parsed_seconds if parsed_seconds >= 0 else None
-
-    try:
-        retry_datetime = parsedate_to_datetime(retry_after)
-    except (TypeError, ValueError, IndexError):
-        return None
-
-    return max(retry_datetime.timestamp() - time.time(), 0.0)
 
 
 def _is_abort_like_error(error: Exception) -> bool:
@@ -165,7 +106,7 @@ def _normalize_retry_error(
         error_code=_get_error_code(error),
         message=str(error),
         request_id=_get_request_id(error),
-        retry_after=_parse_retry_after(_extract_headers(error)),
+        retry_after=_get_retry_after(error),
         is_abort=_is_abort_like_error(error),
         is_network_error=_is_network_like_error(error),
         is_timeout=any(

--- a/tests/models/test_openai_retry_helpers.py
+++ b/tests/models/test_openai_retry_helpers.py
@@ -16,6 +16,7 @@ from agents.models._openai_retry import get_openai_retry_advice
 from agents.models._retry_runtime import (
     get_error_code as _get_error_code,
     get_error_header as _get_header_value,
+    get_retry_after,
     get_status_code as _get_status_code,
     header_lookup as _header_lookup,
     parse_retry_after_ms as _parse_retry_after_ms,
@@ -74,6 +75,13 @@ def test_parse_retry_after_numeric_and_http_date() -> None:
     assert parsed is not None and parsed > 0
 
     assert _parse_retry_after("definitely not a date") is None
+
+
+def test_get_retry_after_preserves_outer_exception_precedence() -> None:
+    outer = _HeaderError("wrapped", headers={"retry-after": "2"})
+    outer.__cause__ = _HeaderError("provider", headers={"retry-after-ms": "1500"})
+
+    assert get_retry_after(outer) == 2.0
 
 
 def test_get_status_code_from_status_code_and_status_attrs() -> None:

--- a/tests/models/test_openai_retry_helpers.py
+++ b/tests/models/test_openai_retry_helpers.py
@@ -12,16 +12,14 @@ from email.utils import format_datetime
 
 import httpx
 
-from agents.models._openai_retry import (
-    _get_header_value,
-    _header_lookup,
-    _parse_retry_after,
-    _parse_retry_after_ms,
-    get_openai_retry_advice,
-)
+from agents.models._openai_retry import get_openai_retry_advice
 from agents.models._retry_runtime import (
     get_error_code as _get_error_code,
+    get_error_header as _get_header_value,
     get_status_code as _get_status_code,
+    header_lookup as _header_lookup,
+    parse_retry_after_ms as _parse_retry_after_ms,
+    parse_retry_after_value as _parse_retry_after,
 )
 from agents.retry import ModelRetryAdviceRequest
 from agents.run_internal.model_retry import _normalize_retry_error
@@ -107,8 +105,13 @@ def test_provider_and_runner_retry_normalization_share_metadata() -> None:
         status_code = 429
         request_id = "req_test"
         body = {"error": {"code": "rate_limit_exceeded"}}
+        headers = {"retry-after-ms": "1500"}
 
-    error = _RetryableError("slow down")
+    class _WrapperError(Exception):
+        headers = {"x-other": "ignored"}
+
+    error = _WrapperError("wrapped")
+    error.__cause__ = _RetryableError("slow down")
     advice = get_openai_retry_advice(_make_request(error))
     runner_normalized = _normalize_retry_error(error, None)
 
@@ -117,6 +120,8 @@ def test_provider_and_runner_retry_normalization_share_metadata() -> None:
     assert advice.normalized.status_code == runner_normalized.status_code
     assert advice.normalized.error_code == runner_normalized.error_code
     assert advice.normalized.request_id == runner_normalized.request_id
+    assert advice.normalized.retry_after == runner_normalized.retry_after
+    assert runner_normalized.retry_after == 1.5
 
 
 def test_advice_unsafe_to_replay() -> None:


### PR DESCRIPTION
This pull request improves retry normalization by sharing error-header extraction and `Retry-After` parsing between OpenAI provider advice and runner-level retries.

It preserves the existing parsing rules while aligning exception-chain handling, allowing the runner to find retry headers on an inner exception even when an outer exception exposes unrelated headers.
