### PR TITLE
chore: enable G004 logging lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ select = [
   "UP", # pyupgrade
 ]
 isort = { combine-as-imports = true, known-first-party = ["agents"] }
+logger-objects = ["agents.logger.logger"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ select = [
   "B",  # flake8-bugbear
   "C4", # flake8-comprehensions
   "DTZ005", # datetime.now() without a timezone
+  "G004", # logging statement uses f-string
   "RUF006", # unowned asyncio tasks
   "UP", # pyupgrade
 ]
@@ -129,7 +130,7 @@ isort = { combine-as-imports = true, known-first-party = ["agents"] }
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"examples/**/*.py" = ["DTZ005", "E501", "RUF006"]
+"examples/**/*.py" = ["DTZ005", "E501", "G004", "RUF006"]
 "tests/**/*.py" = ["RUF006"]
 
 [tool.mypy]

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -958,8 +958,8 @@ class Agent(AgentBase, Generic[TContext]):
 
         elif self.instructions is not None:
             logger.error(
-                f"Instructions must be a string or a callable function, "
-                f"got {type(self.instructions).__name__}"
+                "Instructions must be a string or a callable function, got %s",
+                type(self.instructions).__name__,
             )
 
         return None

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -282,7 +282,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                 # Only update turn-level usage - session usage is aggregated on demand
                 await self._update_turn_usage_internal(current_turn, result.context_wrapper.usage)
         except Exception as e:
-            self._logger.error(f"Failed to store usage for session {self.session_id}: {e}")
+            self._logger.error("Failed to store usage for session %s: %s", self.session_id, e)
 
     def _get_next_turn_number(self, branch_id: str) -> int:
         """Get the next turn number for a specific branch.
@@ -505,7 +505,7 @@ class AdvancedSQLiteSession(SQLiteSession):
 
             deleted_count = cursor.rowcount
             if deleted_count:
-                self._logger.info(f"Cleaned up {deleted_count} orphaned messages")
+                self._logger.info("Cleaned up %s orphaned messages", deleted_count)
             return deleted_count
 
     def _classify_message_type(self, item: TResponseInputItem) -> str:
@@ -653,7 +653,11 @@ class AdvancedSQLiteSession(SQLiteSession):
         self._current_branch_id = branch_name
 
         self._logger.debug(
-            f"Created branch '{branch_name}' from turn {turn_number} ('{turn_content}') in '{old_branch}'"  # noqa: E501
+            "Created branch '%s' from turn %s ('%s') in '%s'",
+            branch_name,
+            turn_number,
+            turn_content,
+            old_branch,
         )
         return branch_name
 
@@ -711,7 +715,7 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         old_branch = self._current_branch_id
         self._current_branch_id = branch_id
-        self._logger.info(f"Switched from branch '{old_branch}' to '{branch_id}'")
+        self._logger.info("Switched from branch '%s' to '%s'", old_branch, branch_id)
 
     async def delete_branch(self, branch_id: str, force: bool = False) -> None:
         """Delete a branch and all its associated data.
@@ -792,8 +796,11 @@ class AdvancedSQLiteSession(SQLiteSession):
         )
 
         self._logger.info(
-            f"Deleted branch '{branch_id}': {structure_deleted} message entries, "
-            f"{usage_deleted} usage entries, {orphaned_messages_deleted} orphaned messages"
+            "Deleted branch '%s': %s message entries, %s usage entries, %s orphaned messages",
+            branch_id,
+            structure_deleted,
+            usage_deleted,
+            orphaned_messages_deleted,
         )
 
     async def list_branches(self) -> list[dict[str, Any]]:
@@ -1317,7 +1324,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                     try:
                         input_details_json = json.dumps(usage_data.input_tokens_details.__dict__)
                     except (TypeError, ValueError) as e:
-                        self._logger.warning(f"Failed to serialize input tokens details: {e}")
+                        self._logger.warning("Failed to serialize input tokens details: %s", e)
                         input_details_json = None
 
                 if (
@@ -1327,7 +1334,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                     try:
                         output_details_json = json.dumps(usage_data.output_tokens_details.__dict__)
                     except (TypeError, ValueError) as e:
-                        self._logger.warning(f"Failed to serialize output tokens details: {e}")
+                        self._logger.warning("Failed to serialize output tokens details: %s", e)
                         output_details_json = None
 
                 with closing(conn.cursor()) as cursor:

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -504,7 +504,7 @@ class AnyLLMModel(Model):
                     )
                 else:
                     finish_reason = first_choice.finish_reason if first_choice else "-"
-                    logger.debug(f"LLM resp had no message. finish_reason: {finish_reason}")
+                    logger.debug("LLM resp had no message. finish_reason: %s", finish_reason)
 
             usage = (
                 Usage(

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -247,13 +247,12 @@ class LitellmModel(Model):
             else:
                 if message is not None:
                     logger.debug(
-                        f"""LLM resp:\n{
-                            json.dumps(message.model_dump(), indent=2, ensure_ascii=False)
-                        }\n"""
+                        "LLM resp:\n%s\n",
+                        json.dumps(message.model_dump(), indent=2, ensure_ascii=False),
                     )
                 else:
                     finish_reason = first_choice.finish_reason if first_choice else "-"
-                    logger.debug(f"LLM resp had no message. finish_reason: {finish_reason}")
+                    logger.debug("LLM resp had no message. finish_reason: %s", finish_reason)
 
             if hasattr(response, "usage"):
                 response_usage = response.usage
@@ -497,12 +496,14 @@ class LitellmModel(Model):
                 ensure_ascii=False,
             )
             logger.debug(
-                f"Calling Litellm model: {self.model}\n"
-                f"{messages_json}\n"
-                f"Tools:\n{tools_json}\n"
-                f"Stream: {stream}\n"
-                f"Tool choice: {tool_choice}\n"
-                f"Response format: {response_format}\n"
+                "Calling Litellm model: %s\n%s\nTools:\n%s\nStream: %s\n"
+                "Tool choice: %s\nResponse format: %s\n",
+                self.model,
+                messages_json,
+                tools_json,
+                stream,
+                tool_choice,
+                response_format,
             )
 
         reasoning_effort = self._get_reasoning_effort(model_settings)

--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -148,8 +148,9 @@ class ToolOutputTrimmer:
 
         if trimmed_count > 0:
             logger.debug(
-                f"ToolOutputTrimmer: trimmed {trimmed_count} tool output(s), "
-                f"saved ~{chars_saved} chars"
+                "ToolOutputTrimmer: trimmed %s tool output(s), saved ~%s chars",
+                trimmed_count,
+                chars_saved,
             )
 
         return _ModelInputData(input=new_items, instructions=model_data.instructions)

--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -260,10 +260,10 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
             except asyncio.CancelledError as exc:
                 if not self.suppress_cancelled_error:
                     raise
-                logger.debug(f"Cleanup cancelled for MCP server '{server.name}': {exc}")
+                logger.debug("Cleanup cancelled for MCP server '%s': %s", server.name, exc)
                 self.errors[server] = exc
             except Exception as exc:
-                logger.exception(f"Failed to cleanup MCP server '{server.name}': {exc}")
+                logger.exception("Failed to cleanup MCP server '%s': %s", server.name, exc)
                 self.errors[server] = exc
 
     async def _run_with_timeout(
@@ -302,7 +302,7 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
             self._active_servers = list(self._all_servers)
 
     def _record_failure(self, server: MCPServer, exc: BaseException, phase: str) -> None:
-        logger.exception(f"Failed to {phase} MCP server '{server.name}': {exc}")
+        logger.exception("Failed to %s MCP server '%s': %s", phase, server.name, exc)
         if server not in self._failed_server_set:
             self.failed_servers.append(server)
             self._failed_server_set.add(server)
@@ -340,10 +340,10 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
             except asyncio.CancelledError as exc:
                 if not self.suppress_cancelled_error:
                     raise
-                logger.debug(f"Cleanup cancelled for MCP server '{server.name}': {exc}")
+                logger.debug("Cleanup cancelled for MCP server '%s': %s", server.name, exc)
                 self.errors[server] = exc
             except Exception as exc:
-                logger.exception(f"Failed to cleanup MCP server '{server.name}': {exc}")
+                logger.exception("Failed to cleanup MCP server '%s': %s", server.name, exc)
                 self.errors[server] = exc
 
     async def _connect_all_parallel(self, servers: list[MCPServer]) -> None:

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -160,7 +160,7 @@ async def _streamablehttp_client_with_transport(
     async with client:
         async with anyio.create_task_group() as tg:
             try:
-                logger.debug(f"Connecting to StreamableHTTP endpoint: {url}")
+                logger.debug("Connecting to StreamableHTTP endpoint: %s", url)
 
                 def start_get_stream() -> None:
                     tg.start_soon(transport.handle_get_stream, client, read_stream_writer)
@@ -691,7 +691,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                     filtered_tools.append(tool)
             except Exception as e:
                 logger.error(
-                    f"Error applying tool filter to tool '{tool.name}' on server '{self.name}': {e}"
+                    "Error applying tool filter to tool '%s' on server '%s': %s",
+                    tool.name,
+                    self.name,
+                    e,
                 )
                 # On error, exclude the tool for safety
                 continue
@@ -815,14 +818,15 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         cleanup_error
                     ):
                         logger.debug(
-                            f"Ignoring cancel scope error during cleanup of MCP server "
-                            f"'{self.name}': {cleanup_error}"
+                            "Ignoring cancel scope error during cleanup of MCP server '%s': %s",
+                            self.name,
+                            cleanup_error,
                         )
                     else:
                         # Log other cleanup errors but don't raise - original error is more
                         # important
                         logger.warning(
-                            f"Error during cleanup of MCP server '{self.name}': {cleanup_error}"
+                            "Error during cleanup of MCP server '%s': %s", self.name, cleanup_error
                         )
 
     async def list_tools(
@@ -1000,7 +1004,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             try:
                 await self.exit_stack.aclose()
             except asyncio.CancelledError as e:
-                logger.debug(f"Cleanup cancelled for MCP server '{self.name}': {e}")
+                logger.debug("Cleanup cancelled for MCP server '%s': %s", self.name, e)
                 raise
             except BaseExceptionGroup as eg:
                 # Extract HTTP errors from ExceptionGroup raised during cleanup
@@ -1027,7 +1031,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                     else:
                         # Normal teardown - log but don't raise
                         logger.warning(
-                            f"HTTP error during cleanup of MCP server '{self.name}': {http_error}"
+                            "HTTP error during cleanup of MCP server '%s': %s",
+                            self.name,
+                            http_error,
                         )
                 elif connect_error:
                     if is_failed_connection_cleanup:
@@ -1035,7 +1041,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         raise UserError(error_message) from connect_error
                     else:
                         logger.warning(
-                            f"Connection error during cleanup of MCP server '{self.name}': {connect_error}"  # noqa: E501
+                            "Connection error during cleanup of MCP server '%s': %s",
+                            self.name,
+                            connect_error,  # noqa: E501
                         )
                 elif timeout_error:
                     if is_failed_connection_cleanup:
@@ -1043,7 +1051,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         raise UserError(error_message) from timeout_error
                     else:
                         logger.warning(
-                            f"Timeout error during cleanup of MCP server '{self.name}': {timeout_error}"  # noqa: E501
+                            "Timeout error during cleanup of MCP server '%s': %s",
+                            self.name,
+                            timeout_error,  # noqa: E501
                         )
                 else:
                     # No HTTP error found, suppress RuntimeError about cancel scopes
@@ -1052,16 +1062,16 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         for exc in eg.exceptions
                     )
                     if has_cancel_scope_error:
-                        logger.debug(f"Ignoring cancel scope error during cleanup: {eg}")
+                        logger.debug("Ignoring cancel scope error during cleanup: %s", eg)
                     else:
-                        logger.error(f"Error cleaning up server: {eg}")
+                        logger.error("Error cleaning up server: %s", eg)
             except Exception as e:
                 # Suppress RuntimeError about cancel scopes - this is a known issue with the MCP
                 # library when background tasks fail during async generator cleanup
                 if isinstance(e, RuntimeError) and "cancel scope" in str(e):
-                    logger.debug(f"Ignoring cancel scope error during cleanup: {e}")
+                    logger.debug("Ignoring cancel scope error during cleanup: %s", e)
                 else:
-                    logger.error(f"Error cleaning up server: {e}")
+                    logger.error("Error cleaning up server: %s", e)
             finally:
                 self.session = None
                 self._get_session_id = None

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -546,7 +546,7 @@ class MCPUtil:
                 schema = ensure_strict_json_schema(copy.deepcopy(schema))
                 is_strict = True
             except Exception as e:
-                logger.info(f"Error converting MCP schema to strict mode: {e}")
+                logger.info("Error converting MCP schema to strict mode: %s", e)
 
         needs_approval: (
             bool | Callable[[RunContextWrapper[Any], dict[str, Any], str], Awaitable[bool]]
@@ -684,9 +684,9 @@ class MCPUtil:
             )
 
         if _debug.DONT_LOG_TOOL_DATA:
-            logger.debug(f"Invoking MCP tool {tool_name_for_display}")
+            logger.debug("Invoking MCP tool %s", tool_name_for_display)
         else:
-            logger.debug(f"Invoking MCP tool {tool_name_for_display} with input {input_json}")
+            logger.debug("Invoking MCP tool %s with input %s", tool_name_for_display, input_json)
 
         try:
             resolved_meta = await cls._resolve_meta(server, context, tool.name, json_data)
@@ -726,22 +726,27 @@ class MCPUtil:
                 # failure_error_function=None will have the error raised as documented.
                 error_text = e.error.message if hasattr(e, "error") and e.error else str(e)
                 logger.warning(
-                    f"MCP tool {tool_name_for_display} on server '{server.name}' "
-                    f"returned an error: {error_text}"
+                    "MCP tool %s on server '%s' returned an error: %s",
+                    tool_name_for_display,
+                    server.name,
+                    error_text,
                 )
                 raise
 
             logger.error(
-                f"Error invoking MCP tool {tool_name_for_display} on server '{server.name}': {e}"
+                "Error invoking MCP tool %s on server '%s': %s",
+                tool_name_for_display,
+                server.name,
+                e,
             )
             raise AgentsException(
                 f"Error invoking MCP tool {tool_name_for_display} on server '{server.name}': {e}"
             ) from e
 
         if _debug.DONT_LOG_TOOL_DATA:
-            logger.debug(f"MCP tool {tool_name_for_display} completed.")
+            logger.debug("MCP tool %s completed.", tool_name_for_display)
         else:
-            logger.debug(f"MCP tool {tool_name_for_display} returned {result}")
+            logger.debug("MCP tool %s returned %s", tool_name_for_display, result)
 
         # If structured content is requested and available, use it exclusively
         tool_output: ToolOutput
@@ -792,7 +797,7 @@ class MCPUtil:
                 }
             else:
                 logger.warning(
-                    f"Current span is not a FunctionSpanData, skipping tool output: {current_span}"
+                    "Current span is not a FunctionSpanData, skipping tool output: %s", current_span
                 )
 
         return tool_output

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -196,14 +196,18 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
 
         if not should_compact:
             logger.debug(
-                f"skip: decision hook declined compaction for {self._response_id} "
-                f"(mode={resolved_mode})"
+                "skip: decision hook declined compaction for %s (mode=%s)",
+                self._response_id,
+                resolved_mode,
             )
             return
 
         self._deferred_response_id = None
         logger.debug(
-            f"compact: start for {self._response_id} using {self.model} (mode={resolved_mode})"
+            "compact: start for %s using %s (mode=%s)",
+            self._response_id,
+            self.model,
+            resolved_mode,
         )
 
         compact_kwargs: dict[str, Any] = {"model": self.model}
@@ -228,9 +232,11 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         self._session_items = output_items
 
         logger.debug(
-            f"compact: done for {self._response_id} "
-            f"(mode={resolved_mode}, output={len(output_items)}, "
-            f"candidates={len(self._compaction_candidate_items)})"
+            "compact: done for %s (mode=%s, output=%s, candidates=%s)",
+            self._response_id,
+            resolved_mode,
+            len(output_items),
+            len(self._compaction_candidate_items),
         )
 
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
@@ -367,7 +373,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         self._session_items = history
 
         logger.debug(
-            f"candidates: initialized (history={len(history)}, candidates={len(candidates)})"
+            "candidates: initialized (history=%s, candidates=%s)",
+            len(history),
+            len(candidates),
         )
         return (candidates[:], history[:])
 

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -149,7 +149,7 @@ class OpenAIChatCompletionsModel(Model):
         except asyncio.CancelledError:
             pass
         except Exception as exc:
-            logger.debug(f"Background stream cleanup failed after cancellation: {exc}")
+            logger.debug("Background stream cleanup failed after cancellation: %s", exc)
 
     def _validate_official_openai_input_content_types(
         self, request_input: str | list[TResponseInputItem]
@@ -246,7 +246,7 @@ class OpenAIChatCompletionsModel(Model):
                     )
                 else:
                     finish_reason = first_choice.finish_reason if first_choice else "-"
-                    logger.debug(f"LLM resp had no message. finish_reason: {finish_reason}")
+                    logger.debug("LLM resp had no message. finish_reason: %s", finish_reason)
 
             usage = (
                 Usage(
@@ -388,7 +388,7 @@ class OpenAIChatCompletionsModel(Model):
                     except Exception as exc:
                         if yielded_terminal_event:
                             logger.debug(
-                                f"Ignoring stream cleanup error after terminal event: {exc}"
+                                "Ignoring stream cleanup error after terminal event: %s", exc
                             )
                         else:
                             raise
@@ -544,11 +544,12 @@ class OpenAIChatCompletionsModel(Model):
                 ensure_ascii=False,
             )
             logger.debug(
-                f"{messages_json}\n"
-                f"Tools:\n{tools_json}\n"
-                f"Stream: {stream}\n"
-                f"Tool choice: {tool_choice}\n"
-                f"Response format: {response_format}\n"
+                "%s\nTools:\n%s\nStream: %s\nTool choice: %s\nResponse format: %s\n",
+                messages_json,
+                tools_json,
+                stream,
+                tool_choice,
+                response_format,
             )
 
         reasoning_effort = model_settings.reasoning.effort if model_settings.reasoning else None

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -297,7 +297,7 @@ class _ResponseStreamWithRequestId:
             await self._cleanup_once()
         except Exception as exc:
             if self._yielded_terminal_event:
-                logger.debug(f"Ignoring stream cleanup error after terminal event: {exc}")
+                logger.debug("Ignoring stream cleanup error after terminal event: %s", exc)
                 return
             raise
 
@@ -449,7 +449,7 @@ class OpenAIResponsesModel(Model):
         except asyncio.CancelledError:
             pass
         except Exception as exc:
-            logger.debug(f"Background stream cleanup failed after cancellation: {exc}")
+            logger.debug("Background stream cleanup failed after cancellation: %s", exc)
 
     async def get_response(
         self,
@@ -483,14 +483,12 @@ class OpenAIResponsesModel(Model):
                     logger.debug("LLM responded")
                 else:
                     logger.debug(
-                        "LLM resp:\n"
-                        f"""{
-                            json.dumps(
-                                [x.model_dump() for x in response.output],
-                                indent=2,
-                                ensure_ascii=False,
-                            )
-                        }\n"""
+                        "LLM resp:\n%s\n",
+                        json.dumps(
+                            [x.model_dump() for x in response.output],
+                            indent=2,
+                            ensure_ascii=False,
+                        ),
                     )
 
                 usage = _response_usage_to_usage(response.usage) if response.usage else Usage()
@@ -510,7 +508,7 @@ class OpenAIResponsesModel(Model):
                     )
                 )
                 request_id = getattr(e, "request_id", None)
-                logger.error(f"Error getting response: {e}. (request_id: {request_id})")
+                logger.error("Error getting response: %s. (request_id: %s)", e, request_id)
                 raise
 
         return ModelResponse(
@@ -596,7 +594,7 @@ class OpenAIResponsesModel(Model):
                         except Exception as exc:
                             if yielded_terminal_event:
                                 logger.debug(
-                                    f"Ignoring stream cleanup error after terminal event: {exc}"
+                                    "Ignoring stream cleanup error after terminal event: %s", exc
                                 )
                             else:
                                 raise
@@ -620,7 +618,7 @@ class OpenAIResponsesModel(Model):
                         },
                     )
                 )
-                logger.error(f"Error streaming response: {e}")
+                logger.error("Error streaming response: %s", e)
                 raise
 
     @overload
@@ -796,14 +794,16 @@ class OpenAIResponsesModel(Model):
                 ensure_ascii=False,
             )
             logger.debug(
-                f"Calling LLM {self.model} with input:\n"
-                f"{input_json}\n"
-                f"Tools:\n{tools_json}\n"
-                f"Stream: {stream}\n"
-                f"Tool choice: {tool_choice_param}\n"
-                f"Response format: {response_format}\n"
-                f"Previous response id: {previous_response_id}\n"
-                f"Conversation id: {conversation_id}\n"
+                "Calling LLM %s with input:\n%s\nTools:\n%s\nStream: %s\nTool choice: %s\n"
+                "Response format: %s\nPrevious response id: %s\nConversation id: %s\n",
+                self.model,
+                input_json,
+                tools_json,
+                stream,
+                tool_choice_param,
+                response_format,
+                previous_response_id,
+                conversation_id,
             )
 
         extra_args = dict(model_settings.extra_args or {})

--- a/src/agents/realtime/agent.py
+++ b/src/agents/realtime/agent.py
@@ -125,6 +125,6 @@ class RealtimeAgent(AgentBase, Generic[TContext]):
             else:
                 return cast(str, self.instructions(run_context, self))
         elif self.instructions is not None:
-            logger.error(f"Instructions must be a string or a function, got {self.instructions}")
+            logger.error("Instructions must be a string or a function, got %s", self.instructions)
 
         return None

--- a/src/agents/realtime/audio_formats.py
+++ b/src/agents/realtime/audio_formats.py
@@ -26,7 +26,7 @@ def to_realtime_audio_format(
             elif input_audio_format in ["g711_alaw", "audio/pcma", "pcma"]:
                 format = AudioPCMA(type="audio/pcma")
             else:
-                logger.debug(f"Unknown input_audio_format: {input_audio_format}")
+                logger.debug("Unknown input_audio_format: %s", input_audio_format)
         elif isinstance(input_audio_format, Mapping):
             fmt_type = input_audio_format.get("type")
             rate = input_audio_format.get("rate")
@@ -38,7 +38,7 @@ def to_realtime_audio_format(
                     pcm_rate = 24000
                 else:
                     logger.debug(
-                        f"Unknown pcm rate in input_audio_format mapping: {input_audio_format}"
+                        "Unknown pcm rate in input_audio_format mapping: %s", input_audio_format
                     )
                     pcm_rate = 24000
                 format = AudioPCM(type="audio/pcm", rate=pcm_rate)
@@ -47,7 +47,7 @@ def to_realtime_audio_format(
             elif fmt_type == "audio/pcma":
                 format = AudioPCMA(type="audio/pcma")
             else:
-                logger.debug(f"Unknown input_audio_format mapping: {input_audio_format}")
+                logger.debug("Unknown input_audio_format mapping: %s", input_audio_format)
         else:
             format = input_audio_format
     return format

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -214,7 +214,7 @@ def _log_server_event_validation_failure(event: Any, error: BaseException) -> st
             _server_event_validation_summary(error),
         )
     else:
-        logger.error(f"Failed to validate server event: {event}", exc_info=True)
+        logger.error("Failed to validate server event: %s", event, exc_info=True)
 
     return str(event_type)
 
@@ -715,7 +715,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 else:
                     await self._send_raw_message(converted)
             else:
-                logger.error(f"Failed to convert raw message: {event}")
+                logger.error("Failed to convert raw message: %s", event)
         elif isinstance(event, RealtimeModelSendUserInput):
             await self._send_user_input(event)
         elif isinstance(event, RealtimeModelSendAudio):
@@ -918,10 +918,10 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
 
         if current_item_id is None or elapsed_ms is None:
             logger.debug(
-                "Skipping interrupt. "
-                f"Item id: {current_item_id}, "
-                f"elapsed ms: {elapsed_ms}, "
-                f"content index: {current_item_content_index}"
+                "Skipping interrupt. Item id: %s, elapsed ms: %s, content index: %s",
+                current_item_id,
+                elapsed_ms,
+                current_item_content_index,
             )
         else:
             current_item_content_index = current_item_content_index or 0
@@ -946,10 +946,11 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                     await self._send_raw_message(converted)
             else:
                 logger.debug(
-                    "Didn't interrupt bc elapsed ms is < 0. "
-                    f"Item id: {current_item_id}, "
-                    f"elapsed ms: {elapsed_ms}, "
-                    f"content index: {current_item_content_index}"
+                    "Didn't interrupt bc elapsed ms is < 0. Item id: %s, "
+                    "elapsed ms: %s, content index: %s",
+                    current_item_id,
+                    elapsed_ms,
+                    current_item_content_index,
                 )
 
         session = self._created_session
@@ -1181,11 +1182,12 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                         and not self._ongoing_response
                     ):
                         logger.debug(
-                            "Skipping truncate because playback appears complete. "
-                            f"Item id: {playback_item_id}, "
-                            f"elapsed ms: {effective_elapsed_ms}, "
-                            f"content index: {playback_content_index}, "
-                            f"audio length ms: {max_audio_ms}"
+                            "Skipping truncate because playback appears complete. Item id: %s, "
+                            "elapsed ms: %s, content index: %s, audio length ms: %s",
+                            playback_item_id,
+                            effective_elapsed_ms,
+                            playback_content_index,
+                            max_audio_ms,
                         )
                     else:
                         if max_audio_ms is not None:

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -305,7 +305,7 @@ async def _close_async_iterator_quietly(iterator: Any | None) -> None:
     try:
         await _close_async_iterator(iterator)
     except Exception as exc:
-        logger.debug(f"Ignoring retry stream cleanup error: {exc}")
+        logger.debug("Ignoring retry stream cleanup error: %s", exc)
 
 
 def _get_stream_event_type(event: TResponseStreamEvent) -> str | None:

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1230,7 +1230,7 @@ async def start_streaming(
                         raise InputGuardrailTripwireTriggered(first_trigger)
             except Exception as e:
                 logger.debug(
-                    f"Error in streamed_result finalize for agent {current_agent.name} - {e}"
+                    "Error in streamed_result finalize for agent %s - %s", current_agent.name, e
                 )
         try:
             await dispose_resolved_computers(run_context=context_wrapper)

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -3181,9 +3181,9 @@ def _deserialize_items(
         agent, agent_name = _resolve_agent_info(item_data, item_type)
         if not agent:
             if agent_name:
-                logger.warning(f"Agent {agent_name} not found, skipping item")
+                logger.warning("Agent %s not found, skipping item", agent_name)
             else:
-                logger.warning(f"Item missing agent field, skipping: {item_type}")
+                logger.warning("Item missing agent field, skipping: %s", item_type)
             continue
 
         raw_item_data = item_data["raw_item"]
@@ -3339,7 +3339,7 @@ def _deserialize_items(
         except UserError:
             raise
         except Exception as e:
-            logger.warning(f"Failed to deserialize item of type {item_type}: {e}")
+            logger.warning("Failed to deserialize item of type %s: %s", item_type, e)
             continue
 
     return result

--- a/src/agents/sandbox/manifest_render.py
+++ b/src/agents/sandbox/manifest_render.py
@@ -35,15 +35,17 @@ def _truncate_manifest_description(description: str, max_chars: int | None) -> s
     if len(marker) >= max_chars:
         truncated = marker[:max_chars]
         logger.warning(
-            f"Manifest description exceeded {max_chars} characters "
-            f"and was truncated to {len(truncated)} characters."
+            "Manifest description exceeded %s characters and was truncated to %s characters.",
+            max_chars,
+            len(truncated),
         )
         return truncated
     if len(truncated) > max_chars:
         truncated = truncated[:max_chars]
     logger.warning(
-        f"Manifest description exceeded {max_chars} characters "
-        f"and was truncated to {len(truncated)} characters."
+        "Manifest description exceeded %s characters and was truncated to %s characters.",
+        max_chars,
+        len(truncated),
     )
     return truncated
 

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -1561,13 +1561,13 @@ def _build_handled_function_tool_error_handler(
             f"{log_label} {function_tool.name}" if include_tool_name_in_log_messages else log_label
         )
         if _debug.DONT_LOG_TOOL_DATA:
-            logger.debug(f"{log_prefix} failed")
+            logger.debug("%s failed", log_prefix)
             return
 
         if include_input_json_in_logs:
-            logger.error(f"{log_prefix} failed: {input_json} {error}", exc_info=error)
+            logger.error("%s failed: %s %s", log_prefix, input_json, error, exc_info=error)
         else:
-            logger.error(f"{log_prefix} failed: {error}", exc_info=error)
+            logger.error("%s failed: %s", log_prefix, error, exc_info=error)
 
     return _on_handled_error
 
@@ -1601,9 +1601,9 @@ def _parse_function_tool_json_input(*, tool_name: str, input_json: str) -> dict[
 def _log_function_tool_invocation(*, tool_name: str, input_json: str) -> None:
     """Log the start of a tool invocation with the current redaction policy."""
     if _debug.DONT_LOG_TOOL_DATA:
-        logger.debug(f"Invoking tool {tool_name}")
+        logger.debug("Invoking tool %s", tool_name)
     else:
-        logger.debug(f"Invoking tool {tool_name} with input {input_json}")
+        logger.debug("Invoking tool %s with input %s", tool_name, input_json)
 
 
 def default_tool_error_function(ctx: RunContextWrapper[Any], error: Exception) -> str:
@@ -1992,7 +1992,7 @@ def function_tool(
             args, kwargs_dict = schema.to_call_args(parsed)
 
             if not _debug.DONT_LOG_TOOL_DATA:
-                logger.debug(f"Tool call args: {args}, kwargs: {kwargs_dict}")
+                logger.debug("Tool call args: %s, kwargs: %s", args, kwargs_dict)
 
             if not is_sync_function_tool:
                 if schema.takes_context:
@@ -2006,9 +2006,9 @@ def function_tool(
                     result = await asyncio.to_thread(the_func, *args, **kwargs_dict)
 
             if _debug.DONT_LOG_TOOL_DATA:
-                logger.debug(f"Tool {tool_name} completed.")
+                logger.debug("Tool %s completed.", tool_name)
             else:
-                logger.debug(f"Tool {tool_name} returned {result}")
+                logger.debug("Tool %s returned %s", tool_name, result)
 
             return result
 

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -168,7 +168,7 @@ class BackendSpanExporter(TracingExporter):
 
                     # If the response is successful, break out of the loop
                     if response.status_code < 300:
-                        logger.debug(f"Exported {len(grouped)} items")
+                        logger.debug("Exported %s items", len(grouped))
                         break
 
                     # If the response is a client error (4xx), we won't retry
@@ -182,11 +182,11 @@ class BackendSpanExporter(TracingExporter):
 
                     # For 5xx or other unexpected codes, treat it as transient and retry
                     logger.warning(
-                        f"[non-fatal] Tracing: server error {response.status_code}, retrying."
+                        "[non-fatal] Tracing: server error %s, retrying.", response.status_code
                     )
                 except httpx.RequestError as exc:
                     # Network or other I/O error, we'll retry
-                    logger.warning(f"[non-fatal] Tracing: request failed: {exc}")
+                    logger.warning("[non-fatal] Tracing: request failed: %s", exc)
 
                 # If we reach here, we need to retry or give up
                 if attempt >= self.max_retries:

--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -107,7 +107,7 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
             try:
                 processor.on_trace_start(trace)
             except Exception as e:
-                logger.error(f"Error in trace processor {processor} during on_trace_start: {e}")
+                logger.error("Error in trace processor %s during on_trace_start: %s", processor, e)
 
     def on_trace_end(self, trace: Trace) -> None:
         """
@@ -117,7 +117,7 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
             try:
                 processor.on_trace_end(trace)
             except Exception as e:
-                logger.error(f"Error in trace processor {processor} during on_trace_end: {e}")
+                logger.error("Error in trace processor %s during on_trace_end: %s", processor, e)
 
     def on_span_start(self, span: Span[Any]) -> None:
         """
@@ -127,7 +127,7 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
             try:
                 processor.on_span_start(span)
             except Exception as e:
-                logger.error(f"Error in trace processor {processor} during on_span_start: {e}")
+                logger.error("Error in trace processor %s during on_span_start: %s", processor, e)
 
     def on_span_end(self, span: Span[Any]) -> None:
         """
@@ -137,7 +137,7 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
             try:
                 processor.on_span_end(span)
             except Exception as e:
-                logger.error(f"Error in trace processor {processor} during on_span_end: {e}")
+                logger.error("Error in trace processor %s during on_span_end: %s", processor, e)
 
     def shutdown(self, timeout: float | None = None) -> None:
         """
@@ -158,7 +158,7 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
                 else:
                     processor.shutdown()
             except Exception as e:
-                logger.error(f"Error shutting down trace processor {processor}: {e}")
+                logger.error("Error shutting down trace processor %s: %s", processor, e)
 
     def force_flush(self):
         """
@@ -168,7 +168,7 @@ class SynchronousMultiTracingProcessor(TracingProcessor):
             try:
                 processor.force_flush()
             except Exception as e:
-                logger.error(f"Error flushing trace processor {processor}: {e}")
+                logger.error("Error flushing trace processor %s: %s", processor, e)
 
 
 class TraceProvider(ABC):
@@ -337,12 +337,12 @@ class DefaultTraceProvider(TraceProvider):
         """
         self._refresh_disabled_flag()
         if self._disabled or disabled:
-            logger.debug(f"Tracing is disabled. Not creating trace {name}")
+            logger.debug("Tracing is disabled. Not creating trace %s", name)
             return NoOpTrace()
 
         trace_id = trace_id or self.gen_trace_id()
 
-        logger.debug(f"Creating trace {name} with id {trace_id}")
+        logger.debug("Creating trace %s with id %s", name, trace_id)
 
         return TraceImpl(
             name=name,
@@ -367,7 +367,7 @@ class DefaultTraceProvider(TraceProvider):
         tracing_api_key: str | None = None
         trace_metadata: dict[str, Any] | None = None
         if self._disabled or disabled:
-            logger.debug(f"Tracing is disabled. Not creating span {span_data}")
+            logger.debug("Tracing is disabled. Not creating span %s", span_data)
             return NoOpSpan(span_data)
         if _is_noop_id(span_id):
             logger.debug("Span id is no-op, returning NoOpSpan")
@@ -384,7 +384,7 @@ class DefaultTraceProvider(TraceProvider):
                 return NoOpSpan(span_data)
             elif _is_noop_trace(current_trace) or _is_noop_span(current_span):
                 logger.debug(
-                    f"Parent {current_span} or {current_trace} is no-op, returning NoOpSpan"
+                    "Parent %s or %s is no-op, returning NoOpSpan", current_span, current_trace
                 )
                 return NoOpSpan(span_data)
 
@@ -396,7 +396,7 @@ class DefaultTraceProvider(TraceProvider):
 
         elif isinstance(parent, Trace):
             if _is_noop_trace(parent):
-                logger.debug(f"Parent {parent} is no-op, returning NoOpSpan")
+                logger.debug("Parent %s is no-op, returning NoOpSpan", parent)
                 return NoOpSpan(span_data)
             trace_id = parent.trace_id
             parent_id = None
@@ -405,14 +405,14 @@ class DefaultTraceProvider(TraceProvider):
             trace_metadata = getattr(parent, "metadata", None)
         elif isinstance(parent, Span):
             if _is_noop_span(parent):
-                logger.debug(f"Parent {parent} is no-op, returning NoOpSpan")
+                logger.debug("Parent %s is no-op, returning NoOpSpan", parent)
                 return NoOpSpan(span_data)
             parent_id = parent.span_id
             trace_id = parent.trace_id
             tracing_api_key = parent.tracing_api_key
             trace_metadata = parent.trace_metadata
 
-        logger.debug(f"Creating span {span_data} with id {span_id}")
+        logger.debug("Creating span %s with id %s", span_data, span_id)
 
         return SpanImpl(
             trace_id=trace_id,
@@ -433,7 +433,7 @@ class DefaultTraceProvider(TraceProvider):
         try:
             self._multi_processor.force_flush()
         except Exception as e:
-            logger.error(f"Error flushing trace provider: {e}")
+            logger.error("Error flushing trace provider: %s", e)
 
     def shutdown(self, timeout: float | None = None) -> None:
         self._refresh_disabled_flag()
@@ -444,4 +444,4 @@ class DefaultTraceProvider(TraceProvider):
             _safe_debug("Shutting down trace provider")
             self._multi_processor.shutdown(timeout=timeout)
         except Exception as e:
-            logger.error(f"Error shutting down trace provider: {e}")
+            logger.error("Error shutting down trace provider: %s", e)

--- a/src/agents/tracing/scope.py
+++ b/src/agents/tracing/scope.py
@@ -40,7 +40,7 @@ class Scope:
 
     @classmethod
     def set_current_trace(cls, trace: "Trace | None") -> "contextvars.Token[Trace | None]":
-        logger.debug(f"Setting current trace: {trace.trace_id if trace else None}")
+        logger.debug("Setting current trace: %s", trace.trace_id if trace else None)
         return _current_trace.set(trace)
 
     @classmethod

--- a/src/agents/util/_error_tracing.py
+++ b/src/agents/util/_error_tracing.py
@@ -13,4 +13,4 @@ def attach_error_to_current_span(error: SpanError) -> None:
     if span:
         attach_error_to_span(span, error)
     else:
-        logger.warning(f"No span to add error {error} to")
+        logger.warning("No span to add error %s to", error)

--- a/src/agents/util/_transforms.py
+++ b/src/agents/util/_transforms.py
@@ -13,9 +13,11 @@ def transform_string_function_style(name: str, *, warn_on_whitespace: bool = Tru
         warn_on_whitespace or transformed_name != whitespace_normalized_name
     ):
         logger.warning(
-            f"Tool name {name!r} contains invalid characters for function calling and has been "
-            f"transformed to {final_name!r}. Please use only letters, digits, and underscores "
-            "to avoid potential naming conflicts."
+            "Tool name %r contains invalid characters for function calling and has been "
+            "transformed to %r. Please use only letters, digits, and underscores to avoid "
+            "potential naming conflicts.",
+            name,
+            final_name,
         )
 
     return final_name

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -210,7 +210,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             if _debug.DONT_LOG_MODEL_DATA:
                 logger.debug("Session updated")
             else:
-                logger.debug(f"Session updated: {event}")
+                logger.debug("Session updated: %s", event)
         except TimeoutError as e:
             wrapped_err = STTWebsocketConnectionError(
                 "Timeout waiting for transcription_session.updated event"

--- a/src/agents/voice/pipeline.py
+++ b/src/agents/voice/pipeline.py
@@ -103,7 +103,7 @@ class VoicePipeline:
                     await output._turn_done()
                     await output._done()
                 except Exception as e:
-                    logger.error(f"Error processing single turn: {e}")
+                    logger.error("Error processing single turn: %s", e)
                     await output._add_error(e)
                     raise e
 
@@ -129,7 +129,7 @@ class VoicePipeline:
                         async for intro_text in self.workflow.on_start():
                             await output._add_text(intro_text)
                     except Exception as e:
-                        logger.warning(f"on_start() failed: {e}")
+                        logger.warning("on_start() failed: %s", e)
 
                     transcription_session = await self._get_stt_model().create_session(
                         audio_input,
@@ -144,7 +144,7 @@ class VoicePipeline:
                             await output._add_text(text_event)
                         await output._turn_done()
                 except Exception as e:
-                    logger.error(f"Error processing turns: {e}")
+                    logger.error("Error processing turns: %s", e)
                     await output._add_error(e)
                     raise e
                 finally:

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -186,7 +186,7 @@ class StreamedAudioResult:
                         },
                     }
                 )
-                logger.error(f"Error streaming audio: {e}")
+                logger.error("Error streaming audio: %s", e)
 
                 # Signal completion for whole session because of error
                 await local_queue.put(VoiceStreamEventLifecycle(event="session_ended"))
@@ -302,7 +302,7 @@ class StreamedAudioResult:
                 break
             if isinstance(event, VoiceStreamEventError):
                 self._stored_exception = event.error
-                logger.error(f"Error processing output: {event.error}")
+                logger.error("Error processing output: %s", event.error)
                 break
             if event is None:
                 break


### PR DESCRIPTION
This pull request improves logging consistency by enabling Ruff's `G004` rule for runtime code and replacing eager f-string formatting with lazy logging arguments.

Examples remain exempt from the new rule, matching the existing lint policy for incrementally adopted checks. Log messages and runtime behavior remain unchanged.