### PR TITLE
chore: enable RUF012 for runtime source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ select = [
   "DTZ005", # datetime.now() without a timezone
   "G004", # logging statement uses f-string
   "RUF006", # unowned asyncio tasks
+  "RUF012", # mutable class attributes without ClassVar
   "UP", # pyupgrade
 ]
 isort = { combine-as-imports = true, known-first-party = ["agents"] }
@@ -131,8 +132,8 @@ logger-objects = ["agents.logger.logger"]
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"examples/**/*.py" = ["DTZ005", "E501", "G004", "RUF006"]
-"tests/**/*.py" = ["RUF006"]
+"examples/**/*.py" = ["DTZ005", "E501", "G004", "RUF006", "RUF012"]
+"tests/**/*.py" = ["RUF006", "RUF012"]
 
 [tool.mypy]
 strict = true

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -35,7 +35,7 @@ import json
 import threading
 import weakref
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, ClassVar
 
 from ._optional_imports import raise_optional_dependency_error
 
@@ -97,8 +97,8 @@ class MongoDBSession(SessionABC):
     #   one across loops raises RuntimeError.  create_index is idempotent, so
     #   we only need the threading lock to guard the boolean done flag — no
     #   async coordination is required.
-    _init_state: dict[int, dict[tuple[str, str, str], bool]] = {}
-    _init_guard: threading.Lock = threading.Lock()
+    _init_state: ClassVar[dict[int, dict[tuple[str, str, str], bool]]] = {}
+    _init_guard: ClassVar[threading.Lock] = threading.Lock()
 
     session_settings: SessionSettings | None = None
 

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -9,7 +9,17 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequenc
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeGuard, cast, get_args, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    TypedDict,
+    TypeGuard,
+    cast,
+    get_args,
+    overload,
+)
 
 import httpx
 from openai import AsyncOpenAI, NotGiven, Omit, omit
@@ -221,7 +231,7 @@ class OpenAIResponsesWebSocketOptions(TypedDict):
 class _ResponseStreamWithRequestId:
     """Wrap an SDK event stream and retain the originating request ID."""
 
-    _TERMINAL_EVENT_TYPES = {
+    _TERMINAL_EVENT_TYPES: ClassVar[set[str]] = {
         "response.completed",
         "response.failed",
         "response.incomplete",


### PR DESCRIPTION
This pull request improves class-variable typing by enabling Ruff's `RUF012` rule for runtime source.

It marks the MongoDB session's shared initialization registry and lock, along with the Responses stream terminal-event set, as `ClassVar`. Examples and tests remain exempt because they contain intentional mutable fixture and UI class attributes.