### PR TITLE
chore: remove unused noqa directives

### DIFF
--- a/src/agents/extensions/experimental/codex/codex_tool.py
+++ b/src/agents/extensions/experimental/codex/codex_tool.py
@@ -532,7 +532,7 @@ def _validate_default_run_context_thread_id_suffix(value: str) -> str:
 def _parse_tool_input(parameters_model: type[BaseModel], input_json: str) -> BaseModel:
     try:
         json_data = json.loads(input_json) if input_json else {}
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         if _debug.DONT_LOG_TOOL_DATA:
             logger.debug("Invalid JSON input for codex tool")
         else:
@@ -933,7 +933,7 @@ def _store_thread_id_in_run_context(
 
     try:
         setattr(context, key, thread_id)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise UserError(
             f'Unable to store Codex thread_id in run context field "{key}". '
             "Use a mutable dict context or set a writable attribute."
@@ -965,7 +965,7 @@ def _set_pydantic_context_value(context: BaseModel, key: str, value: str) -> boo
     if key in model_fields:
         try:
             setattr(context, key, value)
-        except Exception:  # noqa: BLE001
+        except Exception:
             return False
         return True
 
@@ -974,7 +974,7 @@ def _set_pydantic_context_value(context: BaseModel, key: str, value: str) -> boo
         return True
     except ValueError:
         pass
-    except Exception:  # noqa: BLE001
+    except Exception:
         return False
 
     state = getattr(context, "__dict__", None)

--- a/src/agents/extensions/experimental/codex/thread.py
+++ b/src/agents/extensions/experimental/codex/thread.py
@@ -150,7 +150,7 @@ class Thread:
                         ) from exc
                     try:
                         parsed = _parse_event(item)
-                    except Exception as exc:  # noqa: BLE001
+                    except Exception as exc:
                         raise RuntimeError(f"Failed to parse event: {item}") from exc
                     if isinstance(parsed, ThreadStartedEvent):
                         # Capture the thread id so callers can resume later.

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1043,7 +1043,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         logger.warning(
                             "Connection error during cleanup of MCP server '%s': %s",
                             self.name,
-                            connect_error,  # noqa: E501
+                            connect_error,
                         )
                 elif timeout_error:
                     if is_failed_connection_cleanup:
@@ -1053,7 +1053,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         logger.warning(
                             "Timeout error during cleanup of MCP server '%s': %s",
                             self.name,
-                            timeout_error,  # noqa: E501
+                            timeout_error,
                         )
                 else:
                     # No HTTP error found, suppress RuntimeError about cancel scopes

--- a/src/agents/retry.py
+++ b/src/agents/retry.py
@@ -145,8 +145,8 @@ def _mark_retry_capabilities(
     retries_safe_transport_errors: bool,
     retries_all_transient_errors: bool,
 ) -> RetryPolicy:
-    setattr(policy, _RETRIES_SAFE_TRANSPORT_ERRORS_ATTR, retries_safe_transport_errors)  # noqa: B010
-    setattr(policy, _RETRIES_ALL_TRANSIENT_ERRORS_ATTR, retries_all_transient_errors)  # noqa: B010
+    setattr(policy, _RETRIES_SAFE_TRANSPORT_ERRORS_ATTR, retries_safe_transport_errors)
+    setattr(policy, _RETRIES_ALL_TRANSIENT_ERRORS_ATTR, retries_all_transient_errors)
     return policy
 
 


### PR DESCRIPTION
This pull request improves lint hygiene by removing nine `noqa` directives that do not suppress any currently enabled violation.

Directives still required by the existing `E501`, `B010`, `F401`, and `UP007` rules remain in place. The cleanup changes comments only and leaves the executable AST unchanged.