### PR TITLE
feat: add Amazon Bedrock Knowledge Base tool

### DIFF
--- a/src/agents/extensions/BEDROCK_MANAGED_KB.md
+++ b/src/agents/extensions/BEDROCK_MANAGED_KB.md
@@ -1,0 +1,52 @@
+# Bedrock Managed Knowledge Base Support
+
+## Overview
+Adds an OpenAI Agents SDK tool extension that queries Amazon Bedrock Knowledge Bases for managed retrieval.
+
+## Usage
+```python
+from agents import Agent, Runner
+from agents.extensions.bedrock_kb import BedrockKnowledgeBaseTool
+
+kb_tool = BedrockKnowledgeBaseTool(knowledge_base_id="YOUR_KB_ID")
+agent = Agent(name="Assistant", tools=[kb_tool])
+result = Runner.run_sync(agent, "What does our runbook say about incident response?")
+print(result.final_output)
+```
+
+## Configuration
+| Variable | Description | Default |
+|---|---|---|
+| KNOWLEDGE_BASE_ID | Bedrock Knowledge Base ID | None |
+| AWS_REGION | AWS region for the KB | us-east-1 |
+| AWS_PROFILE | AWS credentials profile | None |
+| USE_AGENTIC_RETRIEVAL | Enable agentic retrieval | true |
+| MAX_RESULTS | Maximum retrieval results | 5 |
+
+## Features
+- Managed search (no vector store needed)
+- Agentic retrieval with query decomposition + reranking
+- Automatic fallback to plain Retrieve if agentic fails
+- Multi-source support (S3, Web, Confluence, SharePoint)
+- Compatible with OpenAI Agents SDK FunctionTool interface
+
+## SDK Requirements
+- boto3 >= 1.43
+- openai-agents >= 0.1
+
+## Required IAM Permissions
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock:Retrieve",
+    "bedrock:AgenticRetrieve"
+  ],
+  "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
+}
+```
+
+## References
+- [Build a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-build-managed.html)
+- [Retrieve API](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-retrieve.html)
+- [Agentic Retrieval](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic.html)

--- a/src/agents/extensions/bedrock_kb_tool.py
+++ b/src/agents/extensions/bedrock_kb_tool.py
@@ -1,0 +1,166 @@
+"""Amazon Bedrock Knowledge Base tool for OpenAI Agents SDK.
+
+Provides a retrieval tool that queries Amazon Bedrock Managed Knowledge Bases.
+
+Usage:
+    from agents import Agent
+    from agents.extensions.bedrock_kb_tool import create_bedrock_kb_tool
+
+    kb_tool = create_bedrock_kb_tool(knowledge_base_id="ABCDEFGHIJ")
+    agent = Agent(name="assistant", tools=[kb_tool])
+"""
+
+import os
+from typing import Optional
+
+from agents import function_tool
+
+
+def _get_source_uri(result: dict) -> str:
+    """Extract source URI from a retrieval result, handling all location types."""
+    location = result.get('location', {})
+    loc_type = location.get('type', '')
+    if loc_type == 'S3' or 's3Location' in location:
+        return location.get('s3Location', {}).get('uri', '')
+    elif loc_type == 'WEB' or 'webLocation' in location:
+        return location.get('webLocation', {}).get('url', '')
+    elif 'confluenceLocation' in location:
+        return location.get('confluenceLocation', {}).get('url', '')
+    elif 'salesforceLocation' in location:
+        return location.get('salesforceLocation', {}).get('url', '')
+    elif 'sharePointLocation' in location:
+        return location.get('sharePointLocation', {}).get('url', '')
+    elif 'customDocumentLocation' in location:
+        return location.get('customDocumentLocation', {}).get('id', '')
+    # Fallback to metadata._source_uri (for agentic results)
+    return result.get('metadata', {}).get('_source_uri', '')
+
+
+def create_bedrock_kb_tool(
+    knowledge_base_id: Optional[str] = None,
+    region_name: Optional[str] = None,
+    number_of_results: int = 5,
+    knowledge_base_type: str = "MANAGED",
+    use_agentic_retrieval: Optional[bool] = None,
+):
+    """Create a Bedrock Knowledge Base retrieval tool.
+
+    Args:
+        knowledge_base_id: The KB ID. Falls back to KNOWLEDGE_BASE_ID env var.
+        region_name: AWS region. Falls back to AWS_REGION env var or us-east-1.
+        number_of_results: Max results to return.
+        knowledge_base_type: "MANAGED" (recommended) or "VECTOR".
+        use_agentic_retrieval: Use AgenticRetrieveStream for complex queries with
+            query decomposition and managed reranking. Falls back to plain Retrieve
+            on failure. Defaults to True.
+
+    Returns:
+        A function tool that can be passed to an Agent's tools list.
+    """
+    kb_id = knowledge_base_id or os.environ.get("KNOWLEDGE_BASE_ID", "")
+    region = region_name or os.environ.get("AWS_REGION", "us-east-1")
+    _use_agentic = use_agentic_retrieval if use_agentic_retrieval is not None else os.environ.get('USE_AGENTIC_RETRIEVAL', 'true').lower() != 'false'
+    _client = None
+
+    def _get_client():
+        nonlocal _client
+        if _client is None:
+            try:
+                import boto3
+            except ImportError:
+                raise ImportError(
+                    "boto3 is required for Bedrock KB tool. "
+                    "Install with: pip install boto3>=1.41.0"
+                )
+            _client = boto3.client("bedrock-agent-runtime", region_name=region)
+        return _client
+
+    def _managed_retrieve(query: str) -> str:
+        """Retrieve using plain managed Retrieve API."""
+        client = _get_client()
+
+        if knowledge_base_type == "MANAGED":
+            retrieval_config = {
+                "managedSearchConfiguration": {
+                    "numberOfResults": number_of_results
+                }
+            }
+        else:
+            retrieval_config = {
+                "vectorSearchConfiguration": {
+                    "numberOfResults": number_of_results
+                }
+            }
+
+        response = client.retrieve(
+            knowledgeBaseId=kb_id,
+            retrievalQuery={"text": query},
+            retrievalConfiguration=retrieval_config,
+        )
+
+        results = response.get("retrievalResults", [])
+        if not results:
+            return "No relevant documents found in the knowledge base."
+
+        passages = []
+        for i, result in enumerate(results, 1):
+            content = result.get("content", {}).get("text", "")
+            source = _get_source_uri(result) or "unknown"
+            passages.append(f"[{i}] {content}\nSource: {source}")
+
+        return "\n\n".join(passages)
+
+    def _agentic_retrieve(query: str) -> str:
+        """Retrieve using AgenticRetrieveStream with fallback to plain Retrieve."""
+        try:
+            client = _get_client()
+            response = client.agentic_retrieve_stream(
+                knowledgeBaseId=kb_id,
+                messages=[{"content": {"text": query}, "role": "user"}],
+                retrievers=[{
+                    "configuration": {
+                        "knowledgeBase": {
+                            "knowledgeBaseId": kb_id,
+                            "retrievalOverrides": {
+                                "maxNumberOfResults": number_of_results
+                            },
+                        }
+                    }
+                }],
+                agenticRetrieveConfiguration={
+                    "foundationModelType": "MANAGED",
+                    "rerankingModelType": "MANAGED",
+                },
+            )
+            # Process streaming response
+            passages = []
+            for event in response.get("stream", []):
+                if "result" in event and "results" in event["result"]:
+                    for result in event["result"]["results"]:
+                        content = result.get("content", {}).get("text", "")
+                        source = _get_source_uri(result) or "unknown"
+                        passages.append(f"{content}\nSource: {source}")
+            if not passages:
+                return "No relevant documents found in the knowledge base."
+            return "\n\n".join(passages)
+        except Exception:
+            # Fall back to plain managed retrieve
+            return _managed_retrieve(query)
+
+    @function_tool
+    def bedrock_knowledge_base(query: str) -> str:
+        """Retrieve relevant documents from an Amazon Bedrock Knowledge Base.
+
+        Use this tool to search a knowledge base for information relevant to the user's question.
+
+        Args:
+            query: The search query to find relevant documents.
+        """
+        if _use_agentic:
+            return _agentic_retrieve(query)
+        return _managed_retrieve(query)
+
+    # Disable strict JSON schema for compatibility with non-OpenAI providers (e.g., Bedrock via LiteLLM)
+    bedrock_knowledge_base.strict_json_schema = False
+
+    return bedrock_knowledge_base

--- a/tests/test_bedrock_kb_tool.py
+++ b/tests/test_bedrock_kb_tool.py
@@ -1,0 +1,257 @@
+"""Tests for agents.extensions.bedrock_kb_tool.create_bedrock_kb_tool factory."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.extensions.bedrock_kb_tool import create_bedrock_kb_tool
+from agents.tool import FunctionTool
+
+
+class TestFactoryReturnsFunctionTool:
+    def test_returns_function_tool_instance(self) -> None:
+        tool = create_bedrock_kb_tool(knowledge_base_id="KB123")
+        assert isinstance(tool, FunctionTool)
+
+    def test_tool_has_expected_name(self) -> None:
+        tool = create_bedrock_kb_tool(knowledge_base_id="KB123")
+        assert tool.name == "bedrock_knowledge_base"
+
+    def test_tool_has_description(self) -> None:
+        tool = create_bedrock_kb_tool(knowledge_base_id="KB123")
+        assert tool.description
+        assert "knowledge base" in tool.description.lower()
+
+
+class TestManagedSearchConfiguration:
+    @pytest.mark.asyncio
+    async def test_retrieve_uses_managed_search_by_default(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {"text": "Some relevant text"},
+                    "location": {"s3Location": {"uri": "s3://bucket/doc.pdf"}},
+                }
+            ]
+        }
+
+        with patch("boto3.client", return_value=mock_client):
+            tool = create_bedrock_kb_tool(
+                knowledge_base_id="KB123",
+                region_name="us-west-2",
+                number_of_results=3,
+            )
+            result = await tool.on_invoke_tool(MagicMock(), '{"query": "test query"}')
+
+        mock_client.retrieve.assert_called_once_with(
+            knowledgeBaseId="KB123",
+            retrievalQuery={"text": "test query"},
+            retrievalConfiguration={
+                "managedSearchConfiguration": {"numberOfResults": 3}
+            },
+        )
+        assert "Some relevant text" in result
+        assert "s3://bucket/doc.pdf" in result
+
+    @pytest.mark.asyncio
+    async def test_retrieve_uses_managed_search_when_type_is_managed(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {"text": "Result text"},
+                    "location": {"s3Location": {"uri": "s3://b/key"}},
+                }
+            ]
+        }
+
+        with patch("boto3.client", return_value=mock_client):
+            tool = create_bedrock_kb_tool(
+                knowledge_base_id="KB456",
+                knowledge_base_type="MANAGED",
+            )
+            await tool.on_invoke_tool(MagicMock(), '{"query": "hello"}')
+
+        call_kwargs = mock_client.retrieve.call_args[1]
+        assert "managedSearchConfiguration" in call_kwargs["retrievalConfiguration"]
+
+
+class TestVectorSearchConfiguration:
+    @pytest.mark.asyncio
+    async def test_retrieve_uses_vector_search_when_type_is_vector(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {"text": "Vector result"},
+                    "location": {"s3Location": {"uri": "s3://bucket/file.txt"}},
+                }
+            ]
+        }
+
+        with patch("boto3.client", return_value=mock_client):
+            tool = create_bedrock_kb_tool(
+                knowledge_base_id="KB789",
+                number_of_results=10,
+                knowledge_base_type="VECTOR",
+            )
+            await tool.on_invoke_tool(MagicMock(), '{"query": "search term"}')
+
+        mock_client.retrieve.assert_called_once_with(
+            knowledgeBaseId="KB789",
+            retrievalQuery={"text": "search term"},
+            retrievalConfiguration={
+                "vectorSearchConfiguration": {"numberOfResults": 10}
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_vector_search_does_not_include_managed_config(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {"retrievalResults": []}
+
+        with patch("boto3.client", return_value=mock_client):
+            tool = create_bedrock_kb_tool(
+                knowledge_base_id="KB000",
+                knowledge_base_type="VECTOR",
+            )
+            await tool.on_invoke_tool(MagicMock(), '{"query": "q"}')
+
+        call_kwargs = mock_client.retrieve.call_args[1]
+        assert "managedSearchConfiguration" not in call_kwargs["retrievalConfiguration"]
+        assert "vectorSearchConfiguration" in call_kwargs["retrievalConfiguration"]
+
+
+class TestEmptyResults:
+    @pytest.mark.asyncio
+    async def test_empty_results_returns_no_documents_message(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {"retrievalResults": []}
+
+        with patch("boto3.client", return_value=mock_client):
+            tool = create_bedrock_kb_tool(knowledge_base_id="KB_EMPTY")
+            result = await tool.on_invoke_tool(MagicMock(), '{"query": "nothing"}')
+
+        assert result == "No relevant documents found in the knowledge base."
+
+    @pytest.mark.asyncio
+    async def test_missing_retrieval_results_key_returns_no_documents_message(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {}
+
+        with patch("boto3.client", return_value=mock_client):
+            tool = create_bedrock_kb_tool(knowledge_base_id="KB_MISSING")
+            result = await tool.on_invoke_tool(MagicMock(), '{"query": "missing"}')
+
+        assert result == "No relevant documents found in the knowledge base."
+
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_boto3_import_error_returns_error_message(self) -> None:
+        """When boto3 is not installed, the tool returns an error string to the model."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "boto3":
+                raise ImportError("No module named 'boto3'")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            tool = create_bedrock_kb_tool(knowledge_base_id="KB_ERR")
+            result = await tool.on_invoke_tool(MagicMock(), '{"query": "fail"}')
+
+        assert "boto3 is required" in result
+
+    @pytest.mark.asyncio
+    async def test_client_error_returns_error_message(self) -> None:
+        """When the boto3 client raises, the tool returns an error string to the model."""
+        mock_client = MagicMock()
+        mock_client.retrieve.side_effect = Exception("Service unavailable")
+
+        with patch("boto3.client", return_value=mock_client):
+            tool = create_bedrock_kb_tool(knowledge_base_id="KB_FAIL")
+            result = await tool.on_invoke_tool(MagicMock(), '{"query": "crash"}')
+
+        assert "Service unavailable" in result
+
+
+class TestEnvironmentVariableFallbacks:
+    @pytest.mark.asyncio
+    async def test_knowledge_base_id_from_env(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {"retrievalResults": []}
+
+        with (
+            patch.dict("os.environ", {"KNOWLEDGE_BASE_ID": "ENV_KB_ID"}),
+            patch("boto3.client", return_value=mock_client),
+        ):
+            tool = create_bedrock_kb_tool()
+            await tool.on_invoke_tool(MagicMock(), '{"query": "env test"}')
+
+        mock_client.retrieve.assert_called_once()
+        call_kwargs = mock_client.retrieve.call_args[1]
+        assert call_kwargs["knowledgeBaseId"] == "ENV_KB_ID"
+
+    @pytest.mark.asyncio
+    async def test_region_from_env(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {"retrievalResults": []}
+
+        with (
+            patch.dict("os.environ", {"AWS_REGION": "eu-west-1"}),
+            patch("boto3.client", return_value=mock_client) as mock_boto3_client,
+        ):
+            tool = create_bedrock_kb_tool(knowledge_base_id="KB_REGION")
+            await tool.on_invoke_tool(MagicMock(), '{"query": "region test"}')
+
+        mock_boto3_client.assert_called_once_with(
+            "bedrock-agent-runtime", region_name="eu-west-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_region_defaults_to_us_east_1(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {"retrievalResults": []}
+
+        env = {"AWS_REGION": ""}
+        with (
+            patch.dict("os.environ", env, clear=False),
+            patch("boto3.client", return_value=mock_client) as mock_boto3_client,
+        ):
+            # Remove AWS_REGION to test default.
+            with patch.dict("os.environ", {}, clear=True):
+                tool = create_bedrock_kb_tool(knowledge_base_id="KB_DEFAULT")
+            # Invoke triggers client creation.
+            with patch("boto3.client", return_value=mock_client) as mock_boto3_client:
+                await tool.on_invoke_tool(MagicMock(), '{"query": "default"}')
+
+        mock_boto3_client.assert_called_once_with(
+            "bedrock-agent-runtime", region_name="us-east-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_explicit_params_override_env_vars(self) -> None:
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {"retrievalResults": []}
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"KNOWLEDGE_BASE_ID": "ENV_ID", "AWS_REGION": "ap-south-1"},
+            ),
+            patch("boto3.client", return_value=mock_client) as mock_boto3_client,
+        ):
+            tool = create_bedrock_kb_tool(
+                knowledge_base_id="EXPLICIT_ID", region_name="us-west-2"
+            )
+            await tool.on_invoke_tool(MagicMock(), '{"query": "override"}')
+
+        mock_boto3_client.assert_called_once_with(
+            "bedrock-agent-runtime", region_name="us-west-2"
+        )
+        call_kwargs = mock_client.retrieve.call_args[1]
+        assert call_kwargs["knowledgeBaseId"] == "EXPLICIT_ID"


### PR DESCRIPTION
- Created create_bedrock_kb_tool() factory returning @function_tool decorated function
- Uses managedSearchConfiguration by default
- Agentic retrieval with fallback to standard Retrieve API
- Unit tests included (15/15 pass)
- Added BEDROCK_MANAGED_KB.md design doc