### PR TITLE
chore: enable flake8-async (ASYNC) lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ select = [
   "I",  # isort
   "B",  # flake8-bugbear
   "C4", # flake8-comprehensions
+  "ASYNC", # flake8-async blocking calls in async code
   "DTZ005", # datetime.now() without a timezone
   "G004", # logging statement uses f-string
   "RUF006", # unowned asyncio tasks
@@ -133,9 +134,9 @@ logger-objects = ["agents.logger.logger"]
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"examples/**/*.py" = ["DTZ005", "E501", "G004", "RUF006", "RUF012", "RUF100"]
+"examples/**/*.py" = ["ASYNC", "DTZ005", "E501", "G004", "RUF006", "RUF012", "RUF100"]
 "examples/**/*.ipynb" = ["RUF100"]
-"tests/**/*.py" = ["RUF006", "RUF012", "RUF100"]
+"tests/**/*.py" = ["ASYNC", "RUF006", "RUF012", "RUF100"]
 
 [tool.mypy]
 strict = true

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -264,7 +264,7 @@ class SQLAlchemySession(SessionABC):
             return
 
         assert self._init_lock is not None
-        while not self._init_lock.acquire(blocking=False):
+        while not self._init_lock.acquire(blocking=False):  # noqa: ASYNC110
             # Poll without handing lock acquisition to a background thread so
             # cancellation cannot strand the shared init lock in the acquired state.
             await asyncio.sleep(0.01)

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -132,7 +132,7 @@ async def _streamablehttp_client_with_transport(
     url: str,
     *,
     headers: dict[str, str] | None = None,
-    timeout: float | timedelta = 30,
+    timeout: float | timedelta = 30,  # noqa: ASYNC109
     sse_read_timeout: float | timedelta = 60 * 5,
     terminate_on_close: bool = True,
     httpx_client_factory: HttpClientFactory = _create_default_streamable_http_client,

--- a/src/agents/repl.py
+++ b/src/agents/repl.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
@@ -37,7 +38,7 @@ async def run_demo_loop(
     input_items: list[TResponseInputItem] = []
     while True:
         try:
-            user_input = input(" > ")
+            user_input = await asyncio.to_thread(input, " > ")
         except (EOFError, KeyboardInterrupt):
             print()
             break

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -148,7 +148,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
     async def _prepare_backend_workspace(self) -> None:
         workspace = Path(self.state.manifest.root)
         try:
-            workspace.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(workspace.mkdir, parents=True, exist_ok=True)
         except OSError as e:
             raise WorkspaceStartError(path=workspace, cause=e) from e
 
@@ -223,7 +223,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         self, *command: str | Path, timeout: float | None = None
     ) -> ExecResult:
         env, cwd = await self._resolved_exec_context()
-        workspace_root = Path(cwd).resolve()
+        workspace_root = await asyncio.to_thread(Path(cwd).resolve)
         command_parts = self._workspace_relative_command_parts(command, workspace_root)
         process_cwd, command_parts = self._shell_workspace_process_context(
             command_parts=command_parts,
@@ -276,7 +276,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
     ) -> PtyExecUpdate:
         _ = timeout
         env, cwd = await self._resolved_exec_context()
-        workspace_root = Path(cwd).resolve()
+        workspace_root = await asyncio.to_thread(Path(cwd).resolve)
         sanitized_command = self._prepare_exec_command(*command, shell=shell, user=user)
         command_parts = self._workspace_relative_command_parts(sanitized_command, workspace_root)
         process_cwd, command_parts = self._shell_workspace_process_context(
@@ -427,7 +427,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         env.update(await self.state.manifest.environment.resolve())
 
         workspace = Path(self.state.manifest.root)
-        if not workspace.exists():
+        if not await asyncio.to_thread(workspace.exists):
             raise WorkspaceRootNotFoundError(path=workspace)
 
         env["HOME"] = str(workspace)
@@ -942,7 +942,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         user: str | User,
     ) -> None:
         env, cwd = await self._resolved_exec_context()
-        workspace_root = Path(cwd).resolve()
+        workspace_root = await asyncio.to_thread(Path(cwd).resolve)
         command_parts = self._prepare_exec_command(
             "sh",
             "-c",
@@ -999,7 +999,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
 
     async def persist_workspace(self) -> io.IOBase:
         root = Path(self.state.manifest.root)
-        if not root.exists():
+        if not await asyncio.to_thread(root.exists):
             raise WorkspaceArchiveReadError(
                 path=root, context={"reason": "workspace_root_not_found"}
             )
@@ -1030,7 +1030,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
     async def hydrate_workspace(self, data: io.IOBase) -> None:
         root = Path(self.state.manifest.root)
         try:
-            root.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(root.mkdir, parents=True, exist_ok=True)
             with tarfile.open(fileobj=data, mode="r:*") as tar:
                 safe_extract_tarfile(
                     tar,


### PR DESCRIPTION
### Summary

Enables Ruff's `flake8-async` (`ASYNC`) rule, following the same approach as #3802 (enable `G004`). Turning it on surfaces a handful of **blocking calls made directly on the event-loop thread inside `async` functions**; this fixes the runtime ones by moving the blocking work off-thread with `asyncio.to_thread(...)`.

This is consistent with the direction already documented in this repo:
- `docs/release.md` notes that synchronous tool callables now run via `asyncio.to_thread(...)` "instead of running on the event loop thread."
- `docs/human_in_the_loop.md` already wraps `input()` with `run_in_executor(...)` for the same reason.
- `unix_local.py` already uses `asyncio.to_thread(...)` for other blocking IO, so these changes match the file's existing style.

### What changed

**Runtime fixes (`src/`):**
- `repl.py` — `run_demo_loop` called `input()` directly on the loop thread; now `await asyncio.to_thread(input, " > ")` (mirrors the HITL docs).
- `sandbox/sandboxes/unix_local.py` — 7 blocking `pathlib` calls (`mkdir`/`resolve`/`exists`) in `async` methods wrapped in `asyncio.to_thread(...)`.
- Two deliberate suppressions where the rule is a false positive:
  - `mcp/server.py` — `# noqa: ASYNC109`: `timeout` here is httpx client configuration, not an `asyncio` cancellation scope.
  - `extensions/memory/sqlalchemy_session.py` — `# noqa: ASYNC110`: the loop intentionally polls a `threading.Lock` with `acquire(blocking=False)` so cancellation can't strand the shared init lock; the `asyncio.Event` refactor the rule suggests would be incorrect here.

**Config (`pyproject.toml`):**
- Add `ASYNC` to the Ruff `select` list.
- Add `ASYNC` to the existing `tests/**` and `examples/**` `per-file-ignores`. The remaining `ASYNC` hits are all in tests/examples (busy-wait polling loops in tests, `time.sleep` in a test, and blocking `open()` in the HITL example) — non-production code, where these patterns are fine. This matches how the repo already carves out `RUF006`/`RUF012`/`RUF100` for tests/examples, so the rule enforces event-loop safety on library runtime code without churning test scaffolding.

With this, `ruff check .` passes cleanly across the whole repo.

If you'd prefer to take only the runtime fixes and not adopt the rule itself, I'm happy to drop the `pyproject.toml` changes — just let me know.

### Test plan

Ran the full `.agents/skills/code-change-verification/scripts/run.sh` in a CI-matching Linux container (`python:3.12`, `make sync --all-extras`, `rclone`/FUSE present) — **all commands passed**:

```
make format    -> All checks passed
make lint      -> passed
make tests     -> passed (4979 tests)
make typecheck -> passed (mypy + pyright)
code-change-verification: all commands passed
```

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant (no new behavior — mechanical off-thread wrapping + lint config)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh` (full pass in a CI-matching Linux container — format + lint + typecheck + tests all green)
- [x] I've confirmed the change-relevant checks pass
- [ ] If using Codex, I've run `/review` before submitting this PR — N/A