### PR TITLE
fix(models): raise UserError for conflicting provider args instead of assert

### DIFF
--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -7,6 +7,7 @@ import weakref
 import httpx
 from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 
+from ..exceptions import UserError
 from . import _openai_shared
 from .default_models import get_default_model
 from .interface import Model, ModelProvider
@@ -86,10 +87,11 @@ class OpenAIProvider(ModelProvider):
                 chunk semantics are not reliable enough for incremental processing.
         """
         if openai_client is not None:
-            assert api_key is None and base_url is None and websocket_base_url is None, (
-                "Don't provide api_key, base_url, or websocket_base_url if you provide "
-                "openai_client"
-            )
+            if api_key is not None or base_url is not None or websocket_base_url is not None:
+                raise UserError(
+                    "Don't provide api_key, base_url, or websocket_base_url if you provide "
+                    "openai_client"
+                )
             self._client: AsyncOpenAI | None = openai_client
         else:
             self._client = None

--- a/src/agents/voice/models/openai_model_provider.py
+++ b/src/agents/voice/models/openai_model_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import httpx
 from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 
+from ...exceptions import UserError
 from ...models import _openai_shared
 from ...models.openai_agent_registration import (
     OpenAIAgentRegistrationConfig,
@@ -56,9 +57,8 @@ class OpenAIVoiceModelProvider(VoiceModelProvider):
             agent_registration: Optional agent registration configuration.
         """
         if openai_client is not None:
-            assert api_key is None and base_url is None, (
-                "Don't provide api_key or base_url if you provide openai_client"
-            )
+            if api_key is not None or base_url is not None:
+                raise UserError("Don't provide api_key or base_url if you provide openai_client")
             self._client: AsyncOpenAI | None = openai_client
         else:
             self._client = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ import openai
 import pytest
 
 from agents import (
+    UserError,
     responses_websocket_session,
     set_default_openai_api,
     set_default_openai_client,
@@ -95,6 +96,27 @@ def test_set_default_openai_responses_transport():
 def test_set_default_openai_responses_transport_rejects_invalid_value():
     with pytest.raises(ValueError, match="Expected one of: 'http', 'websocket'"):
         set_default_openai_responses_transport("ws")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "conflicting_kwargs",
+    [
+        {"api_key": "other_key"},
+        {"base_url": "https://example.com"},
+        {"websocket_base_url": "wss://example.com"},
+        {
+            "api_key": "other_key",
+            "base_url": "https://example.com",
+            "websocket_base_url": "wss://example.com",
+        },
+    ],
+)
+def test_openai_provider_rejects_client_with_conflicting_args(conflicting_kwargs):
+    # Regression test for #3808: this validation used a bare `assert`, which is
+    # stripped under `python -O`, silently ignoring the conflicting arguments.
+    client = openai.AsyncOpenAI(api_key="test_key")
+    with pytest.raises(UserError, match="Don't provide"):
+        OpenAIProvider(openai_client=client, **conflicting_kwargs)
 
 
 def test_openai_provider_transport_override_beats_default():

--- a/tests/voice/test_openai_model_provider.py
+++ b/tests/voice/test_openai_model_provider.py
@@ -1,0 +1,33 @@
+# Tests for the OpenAI voice model provider (OpenAIVoiceModelProvider).
+
+import openai
+import pytest
+
+from agents.exceptions import UserError
+
+try:
+    from agents.voice.models.openai_model_provider import OpenAIVoiceModelProvider
+except ImportError:
+    pass
+
+
+@pytest.mark.parametrize(
+    "conflicting_kwargs",
+    [
+        {"api_key": "other_key"},
+        {"base_url": "https://example.com"},
+        {"api_key": "other_key", "base_url": "https://example.com"},
+    ],
+)
+def test_voice_provider_rejects_client_with_conflicting_args(conflicting_kwargs):
+    # Regression test for #3808: this validation used a bare `assert`, which is
+    # stripped under `python -O`, silently ignoring the conflicting arguments.
+    client = openai.AsyncOpenAI(api_key="test_key")
+    with pytest.raises(UserError, match="Don't provide"):
+        OpenAIVoiceModelProvider(openai_client=client, **conflicting_kwargs)
+
+
+def test_voice_provider_accepts_client_without_conflicting_args():
+    client = openai.AsyncOpenAI(api_key="test_key")
+    provider = OpenAIVoiceModelProvider(openai_client=client)
+    assert provider._get_client() is client

--- a/tests/voice/test_openai_model_provider.py
+++ b/tests/voice/test_openai_model_provider.py
@@ -4,11 +4,7 @@ import openai
 import pytest
 
 from agents.exceptions import UserError
-
-try:
-    from agents.voice.models.openai_model_provider import OpenAIVoiceModelProvider
-except ImportError:
-    pass
+from agents.voice.models.openai_model_provider import OpenAIVoiceModelProvider
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary

`OpenAIProvider.__init__()` and `OpenAIVoiceModelProvider.__init__()` validated conflicting constructor arguments (`openai_client` together with `api_key`, `base_url`, or `websocket_base_url`) with a bare `assert`. Python strips assertions under `-O`, so in optimized mode the invalid configuration was silently accepted and the explicit connection arguments were silently ignored. This could send requests to a different key or endpoint than the caller configured.

This change replaces the asserts with `UserError`, which is how the SDK reports invalid usage elsewhere. Error messages are unchanged.

### Test plan

- Added parametrized regression tests for both providers covering each conflicting argument individually and combined, plus a positive test that a client without conflicting args is still accepted.
- Verified the reproduction from the issue now raises `UserError` under both `python` and `python -O`.
- `ruff format`, `ruff check`, and `mypy` on the touched files are clean.
- Full test suite shows no new failures. The pre-existing tracing test failures on Windows reproduce on a clean checkout without this change.

### Issue number

Closes #3808

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR