### PR TITLE
Reject conflicting OpenAI client args without assert

### DIFF
--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -7,6 +7,7 @@ import weakref
 import httpx
 from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 
+from ..exceptions import UserError
 from . import _openai_shared
 from .default_models import get_default_model
 from .interface import Model, ModelProvider
@@ -86,10 +87,11 @@ class OpenAIProvider(ModelProvider):
                 chunk semantics are not reliable enough for incremental processing.
         """
         if openai_client is not None:
-            assert api_key is None and base_url is None and websocket_base_url is None, (
-                "Don't provide api_key, base_url, or websocket_base_url if you provide "
-                "openai_client"
-            )
+            if api_key is not None or base_url is not None or websocket_base_url is not None:
+                raise UserError(
+                    "Don't provide api_key, base_url, or websocket_base_url if you provide "
+                    "openai_client"
+                )
             self._client: AsyncOpenAI | None = openai_client
         else:
             self._client = None

--- a/src/agents/voice/models/openai_model_provider.py
+++ b/src/agents/voice/models/openai_model_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import httpx
 from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 
+from ...exceptions import UserError
 from ...models import _openai_shared
 from ...models.openai_agent_registration import (
     OpenAIAgentRegistrationConfig,
@@ -56,9 +57,8 @@ class OpenAIVoiceModelProvider(VoiceModelProvider):
             agent_registration: Optional agent registration configuration.
         """
         if openai_client is not None:
-            assert api_key is None and base_url is None, (
-                "Don't provide api_key or base_url if you provide openai_client"
-            )
+            if api_key is not None or base_url is not None:
+                raise UserError("Don't provide api_key or base_url if you provide openai_client")
             self._client: AsyncOpenAI | None = openai_client
         else:
             self._client = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ import openai
 import pytest
 
 from agents import (
+    UserError,
     responses_websocket_session,
     set_default_openai_api,
     set_default_openai_client,
@@ -17,6 +18,7 @@ from agents.models import _openai_shared
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
 from agents.models.openai_responses import OpenAIResponsesModel, OpenAIResponsesWSModel
+from agents.voice.models.openai_model_provider import OpenAIVoiceModelProvider
 
 
 def test_cc_no_default_key_errors(monkeypatch):
@@ -36,6 +38,29 @@ def test_cc_set_default_openai_client():
     set_default_openai_client(client)
     chat_model = OpenAIProvider(use_responses=False).get_model("gpt-4")
     assert chat_model._client.api_key == "test_key"  # type: ignore
+
+
+def test_openai_provider_rejects_client_with_conflicting_connection_args():
+    client = openai.AsyncOpenAI(api_key="test_key")
+
+    with pytest.raises(UserError, match="Don't provide api_key, base_url, or websocket_base_url"):
+        OpenAIProvider(
+            openai_client=client,
+            api_key="different_key",
+            base_url="https://example.com/v1",
+            websocket_base_url="wss://example.com/v1",
+        )
+
+
+def test_openai_voice_provider_rejects_client_with_conflicting_connection_args():
+    client = openai.AsyncOpenAI(api_key="test_key")
+
+    with pytest.raises(UserError, match="Don't provide api_key or base_url"):
+        OpenAIVoiceModelProvider(
+            openai_client=client,
+            api_key="different_key",
+            base_url="https://example.com/v1",
+        )
 
 
 def test_resp_no_default_key_errors(monkeypatch):


### PR DESCRIPTION
## Summary
- Replace assertion-based OpenAI client argument validation with stable `UserError` exceptions.
- Apply the same validation to the voice model provider.
- Add regression coverage for conflicting `openai_client` connection arguments.

## Tests
- `uv run pytest -q tests/test_config.py`
- `uv run python -O -c "from openai import AsyncOpenAI; from agents.models.openai_provider import OpenAIProvider; c=AsyncOpenAI(api_key='client-key'); OpenAIProvider(openai_client=c, api_key='different-key', base_url='https://example.com')"` verifies optimized mode still raises `UserError`.

Closes #3808
