### PR TITLE
chore: enable flake8-async for runtime source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ select = [
   "I",  # isort
   "B",  # flake8-bugbear
   "C4", # flake8-comprehensions
+  "ASYNC", # flake8-async
   "DTZ005", # datetime.now() without a timezone
   "G004", # logging statement uses f-string
   "RUF006", # unowned asyncio tasks
@@ -133,9 +134,9 @@ logger-objects = ["agents.logger.logger"]
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"examples/**/*.py" = ["DTZ005", "E501", "G004", "RUF006", "RUF012", "RUF100"]
+"examples/**/*.py" = ["ASYNC", "DTZ005", "E501", "G004", "RUF006", "RUF012", "RUF100"]
 "examples/**/*.ipynb" = ["RUF100"]
-"tests/**/*.py" = ["RUF006", "RUF012", "RUF100"]
+"tests/**/*.py" = ["ASYNC", "RUF006", "RUF012", "RUF100"]
 
 [tool.mypy]
 strict = true

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -264,7 +264,7 @@ class SQLAlchemySession(SessionABC):
             return
 
         assert self._init_lock is not None
-        while not self._init_lock.acquire(blocking=False):
+        while not self._init_lock.acquire(blocking=False):  # noqa: ASYNC110
             # Poll without handing lock acquisition to a background thread so
             # cancellation cannot strand the shared init lock in the acquired state.
             await asyncio.sleep(0.01)

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -132,7 +132,8 @@ async def _streamablehttp_client_with_transport(
     url: str,
     *,
     headers: dict[str, str] | None = None,
-    timeout: float | timedelta = 30,
+    # This configures the HTTP client rather than an async cancellation scope.
+    timeout: float | timedelta = 30,  # noqa: ASYNC109
     sse_read_timeout: float | timedelta = 60 * 5,
     terminate_on_close: bool = True,
     httpx_client_factory: HttpClientFactory = _create_default_streamable_http_client,


### PR DESCRIPTION
This pull request enables Ruff's flake8-async rule family for runtime source while retaining the repository's existing examples and tests exemptions.

It adds targeted suppressions for two intentional runtime patterns: the MCP HTTP client timeout parameter is configuration rather than a cancellation scope, and SQLAlchemy initialization deliberately polls a non-blocking thread lock so cancellation cannot strand the lock after background acquisition. No runtime behavior or public API is changed.