### PR TITLE
fix(memory): validate table names to prevent SQL injection in SQLiteSession

### DIFF
--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import sqlite3
 import threading
 from collections.abc import Iterator
@@ -12,6 +13,53 @@ from typing import ClassVar
 from ..items import TResponseInputItem
 from .session import SessionABC
 from .session_settings import SessionSettings, resolve_session_limit
+
+# SQL keywords that are not allowed as table names
+_SQL_KEYWORDS = frozenset(
+    {
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "DROP",
+        "CREATE",
+        "ALTER",
+        "TABLE",
+        "FROM",
+        "WHERE",
+        "JOIN",
+        "UNION",
+        "ORDER",
+        "GROUP",
+        "HAVING",
+        "LIMIT",
+        "OFFSET",
+    }
+)
+
+
+def _validate_table_name(table_name: str) -> None:
+    """Validate that a table name is a safe SQL identifier.
+
+    Args:
+        table_name: The table name to validate
+
+    Raises:
+        ValueError: If the table name is invalid
+    """
+    if not table_name:
+        raise ValueError("Table name cannot be empty")
+
+    # Check format: alphanumeric + underscore, must start with letter or underscore
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", table_name):
+        raise ValueError(
+            f"Invalid table name '{table_name}': must contain only alphanumeric "
+            "characters and underscores, and start with a letter or underscore"
+        )
+
+    # Check for SQL keywords
+    if table_name.upper() in _SQL_KEYWORDS:
+        raise ValueError(f"Invalid table name '{table_name}': SQL keyword not allowed")
 
 
 class SQLiteSession(SessionABC):
@@ -46,6 +94,10 @@ class SQLiteSession(SessionABC):
             session_settings: Session configuration settings including default limit for
                 retrieving items. If None, uses default SessionSettings().
         """
+        # Validate table names to prevent SQL injection
+        _validate_table_name(sessions_table)
+        _validate_table_name(messages_table)
+
         self.session_id = session_id
         self.session_settings = session_settings or SessionSettings()
         self.db_path = db_path

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1815,3 +1815,84 @@ async def test_output_tokens_details_persisted_when_input_details_missing():
     assert turn_usage["output_tokens_details"] == {"reasoning_tokens": 42}
     assert turn_usage["input_tokens_details"] is None
     session.close()
+
+
+async def test_table_name_validation_rejects_malicious_input():
+    """Regression test for SQL injection via malicious table names."""
+    # Test malicious table name with SQL injection attempt
+    with pytest.raises(ValueError, match="Invalid table name"):
+        AdvancedSQLiteSession(
+            session_id="injection_test",
+            messages_table="agent_messages; DROP TABLE agent_sessions--",
+        )
+
+    # Test malicious table name with UNION injection
+    with pytest.raises(ValueError, match="Invalid table name"):
+        AdvancedSQLiteSession(
+            session_id="injection_test",
+            messages_table="agent_messages UNION SELECT * FROM users",
+        )
+
+    # Test SQL keyword as table name
+    with pytest.raises(ValueError, match="SQL keyword not allowed"):
+        AdvancedSQLiteSession(
+            session_id="keyword_test",
+            sessions_table="SELECT",
+        )
+
+    # Test empty table name
+    with pytest.raises(ValueError, match="Table name cannot be empty"):
+        AdvancedSQLiteSession(
+            session_id="empty_test",
+            messages_table="",
+        )
+
+    # Test table name starting with number
+    with pytest.raises(ValueError, match="Invalid table name"):
+        AdvancedSQLiteSession(
+            session_id="number_test",
+            messages_table="123_messages",
+        )
+
+    # Test table name with special characters
+    with pytest.raises(ValueError, match="Invalid table name"):
+        AdvancedSQLiteSession(
+            session_id="special_test",
+            sessions_table="agent-sessions",
+        )
+
+
+async def test_table_name_validation_accepts_valid_input():
+    """Test that valid table names are accepted."""
+    # Test valid alphanumeric table names
+    session1 = AdvancedSQLiteSession(
+        session_id="valid_test1",
+        sessions_table="my_sessions",
+        messages_table="my_messages",
+        create_tables=True,
+    )
+    assert session1.sessions_table == "my_sessions"
+    assert session1.messages_table == "my_messages"
+    session1.close()
+
+    # Test valid table name starting with underscore
+    session2 = AdvancedSQLiteSession(
+        session_id="valid_test2",
+        sessions_table="_sessions",
+        messages_table="_messages",
+        create_tables=True,
+    )
+    assert session2.sessions_table == "_sessions"
+    assert session2.messages_table == "_messages"
+    session2.close()
+
+    # Test valid table name with numbers
+    session3 = AdvancedSQLiteSession(
+        session_id="valid_test3",
+        sessions_table="sessions_v2",
+        messages_table="messages_2024",
+        create_tables=True,
+    )
+    assert session3.sessions_table == "sessions_v2"
+    assert session3.messages_table == "messages_2024"
+    session3.close()


### PR DESCRIPTION
The `SQLiteSession` and `AdvancedSQLiteSession` classes accepted table names as constructor parameters without validation, then interpolated them directly into SQL queries via f-strings. This allowed SQL injection if a caller passed malicious identifiers through the `sessions_table` or `messages_table` parameters. While data values like `session_id` and `branch_id` were correctly parameterized with `?`, table names were the only unparameterized identifiers across 10+ methods.

The fix adds a `_validate_table_name()` function in `src/agents/memory/sqlite_session.py` that validates table names against a strict pattern: alphanumeric characters and underscores only, must start with a letter or underscore, and rejects SQL keywords. Validation is applied in `SQLiteSession.__init__()` before assigning the table name attributes. Since `AdvancedSQLiteSession` forwards kwargs to the parent constructor, validation applies automatically to both classes.

Added regression tests covering malicious injection attempts (semicolons, UNION clauses, SQL keywords) as well as valid table name patterns to ensure legitimate use cases continue to work.

Fixes #3816
