### PR TITLE
fix(models): preserve streamed content part order

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -1119,10 +1119,15 @@ class ChatCmplStreamHandler:
             )
             if state.provider_data:
                 assistant_msg.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+
+            content_parts: list[tuple[int, ResponseOutputText | ResponseOutputRefusal]] = []
             if state.text_content_index_and_output:
-                assistant_msg.content.append(state.text_content_index_and_output[1])
+                content_parts.append(state.text_content_index_and_output)
             if state.refusal_content_index_and_output:
-                assistant_msg.content.append(state.refusal_content_index_and_output[1])
+                content_parts.append(state.refusal_content_index_and_output)
+            assistant_msg.content.extend(
+                part for _, part in sorted(content_parts, key=lambda item: item[0])
+            )
             outputs.append(assistant_msg)
 
             # send a ResponseOutputItemDone for the assistant message

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -790,21 +790,30 @@ async def test_stream_handler_places_text_after_existing_refusal_part() -> None:
 
     events = await _collect_handler_events(*chunks)
 
+    refusal_part_added = next(
+        event
+        for event in events
+        if event.type == "response.content_part.added"
+        and isinstance(event.part, ResponseOutputRefusal)
+    )
     text_part_added = next(
         event
         for event in events
         if event.type == "response.content_part.added"
         and isinstance(event.part, ResponseOutputText)
     )
+    assert refusal_part_added.content_index == 0
     assert text_part_added.content_index == 1
 
     completed_event = next(event for event in events if event.type == "response.completed")
     assistant_item = completed_event.response.output[0]
     assert isinstance(assistant_item, ResponseOutputMessage)
-    assert isinstance(assistant_item.content[0], ResponseOutputText)
-    assert isinstance(assistant_item.content[1], ResponseOutputRefusal)
-    assert assistant_item.content[0].text == "partial"
-    assert assistant_item.content[1].refusal == "blocked"
+    assert isinstance(
+        assistant_item.content[refusal_part_added.content_index], ResponseOutputRefusal
+    )
+    assert isinstance(assistant_item.content[text_part_added.content_index], ResponseOutputText)
+    assert assistant_item.content[refusal_part_added.content_index].refusal == "blocked"
+    assert assistant_item.content[text_part_added.content_index].text == "partial"
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
## Summary

When a Chat Completions stream emits a refusal before text, the raw stream assigns `content_index=0` to the refusal and `content_index=1` to the text, but `response.completed` always assembled text before refusal. Consumers replaying raw events therefore saw a different content layout from the completed response.

This PR assembles the completed assistant message using the content indexes already assigned during streaming. Text-before-refusal behavior stays unchanged, while refusal-before-text now matches the raw event sequence. This is a focused follow-up to the pre-existing mismatch discussed in #3757 and follows the raw-event/final-response alignment required during #3769.

## Test plan

- The updated regression test fails on `origin/main` and passes with this change.
- `uv run pytest -q tests/models/test_openai_chatcompletions_stream.py` — 57 passed.
- `bash .agents/skills/code-change-verification/scripts/run.sh` — format, lint, and the full test suite passed.
- Targeted mypy and pyright checks pass for both changed files.
- The repository-wide local typecheck still reports six errors in unchanged current-main files (`archive_ops.py`, `test_any_llm_model.py`, and `test_run_step_execution.py`).

## Issue number

Follow-up to #3757; related maintainer direction in #3769.

## Checks

- [x] I added regression coverage.
- [x] I ran the full impacted test slice.
- [x] I ran the repository verification script and documented its unrelated typecheck limitation.