### PR TITLE
docs: update W&B Weave tracing integration

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -189,7 +189,7 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 
 ### External tracing processors list
 
--   [Weights & Biases](https://weave-docs.wandb.ai/guides/integrations/openai_agents)
+-   [W&B Weave](https://docs.wandb.ai/weave/guides/integrations/agents/openai-agents-sdk)
 -   [Arize-Phoenix](https://docs.arize.com/phoenix/tracing/integrations-tracing/openai-agents-sdk)
 -   [Future AGI](https://docs.futureagi.com/future-agi/products/observability/auto-instrumentation/openai_agents)
 -   [MLflow (self-hosted/OSS)](https://mlflow.org/docs/latest/tracing/integrations/openai-agent)


### PR DESCRIPTION
### Summary

Rename the existing Weights & Biases tracing processor entry to W&B Weave and replace its legacy link with the canonical OpenAI Agents SDK integration guide.

#### User impact

Developers land on the current Weave setup documentation. This is a documentation-only link and naming correction with no runtime or API changes.

#### Privacy implications

None introduced by this PR. The linked W&B guide describes the trace data sent when users choose to enable Weave.

### Test plan

- `uv sync --group dev`
- `make build-docs` (passed; existing documentation warnings remain)
- `git diff --cached --check`
- Confirmed the linked W&B guide returns HTTP 200

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant (not relevant; documentation-only change)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (not relevant; no code changes)
- [x] I've confirmed all applicable verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

No breaking changes.