### PR TITLE
fix(sessions): strip item id when fingerprinting Pydantic model inputs

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -243,6 +243,8 @@ def fingerprint_input_item(item: Any, *, ignore_ids_for_matching: bool = False) 
                     dict[str, Any],
                     strip_internal_input_item_metadata(cast(TResponseInputItem, payload)),
                 )
+                if ignore_ids_for_matching:
+                    payload.pop("id", None)
         elif isinstance(item, dict):
             payload = cast(
                 dict[str, Any],

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -353,6 +353,50 @@ def test_fingerprint_input_item_handles_edge_cases(monkeypatch: pytest.MonkeyPat
     assert '"id"' not in opaque_fingerprint
 
 
+def test_fingerprint_ignores_ids_for_pydantic_model_items() -> None:
+    """A Pydantic-model input item and its dict form must fingerprint identically when
+    ``ignore_ids_for_matching`` is set.
+
+    ``fingerprint_input_item`` is used with ``ignore_ids_for_matching=True`` for sessions such as
+    ``OpenAIConversationsSession`` (where item ids are server-assigned and must be ignored when
+    matching). Items can reach this helper either as dicts (e.g. re-fetched from the session via
+    ``model_dump``) or as Pydantic-model objects (e.g. Responses API output re-passed as input).
+    The id must be stripped in both cases, otherwise the two representations of the same logical
+    item produce different fingerprints and rewind/dedup matching silently fails.
+    """
+    model_item = ResponseFunctionToolCall(
+        id="fc_server_assigned",
+        call_id="call_abc",
+        name="get_weather",
+        arguments='{"city": "SF"}',
+        type="function_call",
+    )
+    # Same logical item as it comes back from the session (dict) but with a different id.
+    dict_item = cast(
+        TResponseInputItem,
+        {
+            "id": "fc_different_id",
+            "call_id": "call_abc",
+            "name": "get_weather",
+            "arguments": '{"city": "SF"}',
+            "type": "function_call",
+        },
+    )
+
+    model_fingerprint = run_items.fingerprint_input_item(model_item, ignore_ids_for_matching=True)
+    dict_fingerprint = run_items.fingerprint_input_item(dict_item, ignore_ids_for_matching=True)
+
+    assert model_fingerprint is not None
+    assert dict_fingerprint is not None
+    assert '"id"' not in model_fingerprint
+    assert model_fingerprint == dict_fingerprint
+
+    # Ids must still be retained when matching is not id-agnostic.
+    model_fingerprint_with_id = run_items.fingerprint_input_item(model_item)
+    assert model_fingerprint_with_id is not None
+    assert '"id"' in model_fingerprint_with_id
+
+
 def test_fingerprint_input_item_returns_none_when_serialization_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Problem

`fingerprint_input_item(item, ignore_ids_for_matching=True)` (in `agents/run_internal/items.py`) produces a hashable fingerprint used to match input items **while ignoring their ids**. It is called with `ignore_ids_for_matching=True` for sessions where item ids are server-assigned and must not participate in matching — notably `OpenAIConversationsSession` (`_ignore_ids_for_matching()` returns `True` for it). It backs rewind/dedup logic in `session_persistence.py` (`rewind_session_items`, `wait_for_session_cleanup`, `save_result_to_session`).

The helper has three branches depending on the input's runtime type:

- **dict** input → strips `"id"` when `ignore_ids_for_matching` is set ✅
- **fallback / opaque** input → strips `"id"` when `ignore_ids_for_matching` is set ✅
- **Pydantic-model** input (`hasattr(item, "model_dump")`) → **never stripped the `"id"`** ❌

An item can reach this helper as a dict (e.g. re-fetched from a session via `model_dump()`) **or** as a Pydantic-model object (e.g. Responses API output items re-passed as `input`). Because the `model_dump` branch kept the id, the *same logical item* fingerprinted differently depending on its representation, so id-agnostic matching silently failed. In practice this means rewind/dedup can miss a match and leave duplicate items in the conversation on retries.

The existing test `test_fingerprint_input_item_handles_edge_cases` already asserts the id is stripped for the dict and fallback branches — the model branch was simply missed when `ignore_ids_for_matching` was introduced.

Reproduction on `main`:

```python
from agents.run_internal.items import fingerprint_input_item
from openai.types.responses import ResponseFunctionToolCall

model_item = ResponseFunctionToolCall(
    id="fc_server_assigned", call_id="call_abc",
    name="get_weather", arguments='{"city":"SF"}', type="function_call",
)
dict_item = {  # same logical item, different server id
    "id": "fc_different_id", "call_id": "call_abc",
    "name": "get_weather", "arguments": '{"city":"SF"}', "type": "function_call",
}

fp_model = fingerprint_input_item(model_item, ignore_ids_for_matching=True)
fp_dict  = fingerprint_input_item(dict_item,  ignore_ids_for_matching=True)
assert fp_model == fp_dict   # FAILS on main: fp_model still contains "id"
```

### Fix

Strip `"id"` in the `model_dump` branch too when `ignore_ids_for_matching` is set, matching the other two branches. One-line change.

### Verification

- Added `test_fingerprint_ignores_ids_for_pydantic_model_items`, which fails on `main` and passes with the fix. It checks model-vs-dict fingerprint parity under `ignore_ids_for_matching=True`, and that ids are still retained when it is `False` (no behavior change to the default path).
- `uv run pytest tests/test_run_internal_items.py tests/test_agent_runner.py tests/memory tests/test_hitl_session_scenario.py tests/test_hitl_error_scenarios.py -q` → all pass (**377 passed**).
- `uv run ruff check` / `ruff format --check` on the changed files → clean.
- `uv run mypy src/agents/run_internal/items.py` → clean.