### PR TITLE
docs: document compact tracing hierarchy

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -31,6 +31,8 @@ The Agents SDK includes built-in tracing, collecting a comprehensive record of e
 By default, the SDK traces the following:
 
 -   The entire `Runner.{run, run_sync, run_streamed}()` is wrapped in a `trace()`.
+-   Each runner invocation is wrapped in a `task_span()`.
+-   Each model turn is wrapped in a `turn_span()`.
 -   Each time an agent runs, it is wrapped in `agent_span()`
 -   LLM generations are wrapped in `generation_span()`
 -   Function tool calls are each wrapped in `function_span()`
@@ -41,6 +43,18 @@ By default, the SDK traces the following:
 -   Related audio spans may be parented under a `speech_group_span()`
 
 By default, the trace is named "Agent workflow". You can set this name if you use `trace`, or you can configure the name and other properties with the [`RunConfig`][agents.run.RunConfig].
+
+If you want a more compact hierarchy, disable the automatic task and turn spans for a run. Agent, generation, function, guardrail, handoff, and custom spans are still recorded.
+
+```python
+from agents import RunConfig, Runner
+
+result = await Runner.run(
+    agent,
+    "Hello",
+    run_config=RunConfig(tracing={"include_task_and_turn_spans": False}),
+)
+```
 
 In addition, you can set up [custom trace processors](#custom-tracing-processors) to push traces to other destinations (as a replacement, or secondary destination).
 


### PR DESCRIPTION
## What
- list the automatic task and turn spans in the tracing guide
- show how to disable those wrapper spans for a more compact hierarchy
- clarify that other automatic and custom spans remain enabled

## Why
`include_task_and_turn_spans` is now available per run, but the tracing guide does not yet show how to use it or describe what remains recorded.

## Test
- `uv run mkdocs build`
- `git diff --check`
- validated the documented `RunConfig` construction in Python