### PR TITLE
fix(computer): isolate provider instances across concurrent runs

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1035,7 +1035,7 @@ class AgentRunner:
                         if run_state._current_step is None:
                             run_state._current_step = NextStepRunAgain()  # type: ignore[assignment]
                     all_tools = await get_all_tools(execution_agent, context_wrapper)
-                    await initialize_computer_tools(
+                    all_tools = await initialize_computer_tools(
                         tools=all_tools, context_wrapper=context_wrapper
                     )
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -861,7 +861,9 @@ async def start_streaming(
                 break
 
             all_tools = await get_all_tools(execution_agent, context_wrapper)
-            await initialize_computer_tools(tools=all_tools, context_wrapper=context_wrapper)
+            all_tools = await initialize_computer_tools(
+                tools=all_tools, context_wrapper=context_wrapper
+            )
 
             if current_span is None:
                 handoff_names = [

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -576,15 +576,23 @@ async def initialize_computer_tools(
     *,
     tools: list[Tool],
     context_wrapper: RunContextWrapper[Any],
-) -> None:
-    """Resolve computer tools ahead of model invocation so each run gets its own instance."""
+) -> list[Tool]:
+    """Resolve computer tools and return run-local copies for model invocation."""
     computer_tools = [tool for tool in tools if isinstance(tool, ComputerTool)]
     if not computer_tools:
-        return
+        return tools
 
-    await asyncio.gather(
+    resolved_computers = await asyncio.gather(
         *(resolve_computer(tool=tool, run_context=context_wrapper) for tool in computer_tools)
     )
+    resolved_by_tool = dict(zip(computer_tools, resolved_computers, strict=True))
+
+    return [
+        dataclasses.replace(tool, computer=resolved_by_tool[tool])
+        if isinstance(tool, ComputerTool)
+        else tool
+        for tool in tools
+    ]
 
 
 def get_mapping_or_attr(target: Any, key: str) -> Any:

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -74,6 +74,7 @@ from ..tool import (
     ShellCommandOutput,
     Tool,
     ToolOrigin,
+    _computer_tool_uses_run_scoped_initializer,
     get_function_tool_origin,
     invoke_function_tool,
     maybe_invoke_function_tool_failure_error_function,
@@ -582,6 +583,10 @@ async def initialize_computer_tools(
     if not computer_tools:
         return tools
 
+    run_scoped_tools = {
+        tool for tool in computer_tools if _computer_tool_uses_run_scoped_initializer(tool)
+    }
+
     resolved_computers = await asyncio.gather(
         *(resolve_computer(tool=tool, run_context=context_wrapper) for tool in computer_tools)
     )
@@ -589,7 +594,7 @@ async def initialize_computer_tools(
 
     return [
         dataclasses.replace(tool, computer=resolved_by_tool[tool])
-        if isinstance(tool, ComputerTool)
+        if isinstance(tool, ComputerTool) and tool in run_scoped_tools
         else tool
         for tool in tools
     ]

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2107,6 +2107,11 @@ def _get_computer_initializer(tool: ComputerTool[Any]) -> ComputerConfig | None:
     return None
 
 
+def _computer_tool_uses_run_scoped_initializer(tool: ComputerTool[Any]) -> bool:
+    """Return whether the tool creates a computer for each run context."""
+    return _get_computer_initializer(tool) is not None
+
+
 def _track_resolved_computer(
     *,
     tool: ComputerTool[Any],

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -3261,8 +3261,10 @@ async def test_session_persists_only_new_step_items(monkeypatch: pytest.MonkeyPa
     async def fake_run_output_guardrails(*_: Any, **__: Any) -> list[Any]:
         return []
 
-    async def noop_initialize_computer_tools(*_: Any, **__: Any) -> None:
-        return None
+    async def noop_initialize_computer_tools(
+        *args: Any, tools: list[Any], **kwargs: Any
+    ) -> list[Any]:
+        return tools
 
     monkeypatch.setattr("agents.run.save_result_to_session", save_wrapper)
     monkeypatch.setattr(

--- a/tests/test_computer_tool_lifecycle.py
+++ b/tests/test_computer_tool_lifecycle.py
@@ -6,6 +6,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from openai.types.responses.response_computer_tool_call import (
+    ActionScreenshot,
+    ResponseComputerToolCall,
+)
 
 from agents import (
     Agent,
@@ -13,6 +17,7 @@ from agents import (
     ComputerTool,
     RunConfig,
     RunContextWrapper,
+    RunHooks,
     Runner,
     dispose_resolved_computers,
     resolve_computer,
@@ -137,6 +142,53 @@ async def test_runner_disposes_computer_after_run() -> None:
     resolved_tool = cast(ComputerTool[Any], model.last_turn_args["tools"][0])
     assert resolved_tool is not tool
     assert resolved_tool.computer is created
+
+
+@pytest.mark.asyncio
+async def test_runner_preserves_concrete_computer_tool_identity_for_hooks() -> None:
+    class IdentityHooks(RunHooks[Any]):
+        def __init__(self) -> None:
+            self.started: list[Any] = []
+            self.ended: list[Any] = []
+
+        async def on_tool_start(
+            self, context: RunContextWrapper[Any], agent: Agent[Any], tool: Any
+        ) -> None:
+            self.started.append(tool)
+
+        async def on_tool_end(
+            self,
+            context: RunContextWrapper[Any],
+            agent: Agent[Any],
+            tool: Any,
+            result: object,
+        ) -> None:
+            self.ended.append(tool)
+
+    tool = ComputerTool(computer=FakeComputer("concrete"))
+    model = FakeModel(
+        initial_output=[
+            ResponseComputerToolCall(
+                id="computer-call",
+                type="computer_call",
+                action=ActionScreenshot(type="screenshot"),
+                call_id="computer-call",
+                pending_safety_checks=[],
+                status="completed",
+            )
+        ]
+    )
+    model.set_next_output([_make_message("done")])
+    agent = Agent(name="ComputerAgent", model=model, tools=[tool])
+    hooks = IdentityHooks()
+
+    result = await Runner.run(agent, "hello", hooks=hooks)
+
+    assert result.final_output == "done"
+    assert model.first_turn_args is not None
+    assert model.first_turn_args["tools"][0] is tool
+    assert hooks.started == [tool]
+    assert hooks.ended == [tool]
 
 
 @pytest.mark.asyncio

--- a/tests/test_computer_tool_lifecycle.py
+++ b/tests/test_computer_tool_lifecycle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -10,18 +11,21 @@ from agents import (
     Agent,
     ComputerProvider,
     ComputerTool,
+    RunConfig,
     RunContextWrapper,
     Runner,
     dispose_resolved_computers,
     resolve_computer,
 )
 from agents.computer import Button, Computer, Environment
+from agents.models.openai_responses import Converter
 from tests.fake_model import FakeModel
 
 
 class FakeComputer(Computer):
-    def __init__(self, label: str = "computer") -> None:
+    def __init__(self, label: str = "computer", dimensions: tuple[int, int] = (1, 1)) -> None:
         self.label = label
+        self._dimensions = dimensions
 
     @property
     def environment(self) -> Environment:
@@ -29,7 +33,7 @@ class FakeComputer(Computer):
 
     @property
     def dimensions(self) -> tuple[int, int]:
-        return (1, 1)
+        return self._dimensions
 
     def screenshot(self) -> str:
         return "img"
@@ -130,6 +134,96 @@ async def test_runner_disposes_computer_after_run() -> None:
     create.assert_awaited_once()
     dispose.assert_awaited_once()
     dispose.assert_awaited_with(run_context=result.context_wrapper, computer=created)
+    resolved_tool = cast(ComputerTool[Any], model.last_turn_args["tools"][0])
+    assert resolved_tool is not tool
+    assert resolved_tool.computer is created
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_keep_computer_provider_instances_isolated() -> None:
+    created: list[FakeComputer] = []
+    disposed: list[FakeComputer] = []
+
+    async def create(*_: Any, **__: Any) -> FakeComputer:
+        computer = FakeComputer(
+            label=f"computer-{len(created) + 1}",
+            dimensions=(1001 + len(created), 700),
+        )
+        created.append(computer)
+        return computer
+
+    async def dispose(*_: Any, computer: FakeComputer, **__: Any) -> None:
+        disposed.append(computer)
+
+    entered_model = [asyncio.Event(), asyncio.Event()]
+    release_model = [asyncio.Event(), asyncio.Event()]
+    serialized_widths: list[int] = []
+
+    class GatedSerializationModel(FakeModel):
+        def __init__(self) -> None:
+            super().__init__(initial_output=[_make_message("done")])
+            self.set_next_output([_make_message("done")])
+            self.call_count = 0
+
+        async def get_response(
+            self,
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            *,
+            previous_response_id,
+            conversation_id,
+            prompt,
+        ):
+            call_index = self.call_count
+            self.call_count += 1
+            entered_model[call_index].set()
+            await release_model[call_index].wait()
+
+            converted = Converter.convert_tools(
+                tools=tools,
+                handoffs=handoffs,
+                model="computer-use-preview",
+            )
+            serialized_tool = cast(dict[str, Any], converted.tools[0])
+            serialized_widths.append(cast(int, serialized_tool["display_width"]))
+
+            return await super().get_response(
+                system_instructions,
+                input,
+                model_settings,
+                tools,
+                output_schema,
+                handoffs,
+                tracing,
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
+                prompt=prompt,
+            )
+
+    tool = ComputerTool(computer=ComputerProvider[FakeComputer](create=create, dispose=dispose))
+    agent = Agent(name="ComputerAgent", model=GatedSerializationModel(), tools=[tool])
+    run_config = RunConfig(tracing_disabled=True)
+
+    task_a = asyncio.create_task(Runner.run(agent, "run-a", run_config=run_config))
+    await entered_model[0].wait()
+    task_b = asyncio.create_task(Runner.run(agent, "run-b", run_config=run_config))
+    await entered_model[1].wait()
+
+    release_model[0].set()
+    result_a = await task_a
+    release_model[1].set()
+    result_b = await task_b
+
+    assert result_a.final_output == "done"
+    assert result_b.final_output == "done"
+    assert serialized_widths == [1001, 1002]
+    assert [computer.label for computer in created] == ["computer-1", "computer-2"]
+    assert disposed == created
 
 
 @pytest.mark.asyncio
@@ -168,3 +262,6 @@ async def test_streamed_run_disposes_computer_after_completion() -> None:
     create.assert_awaited_once()
     dispose.assert_awaited_once()
     dispose.assert_awaited_with(run_context=streamed_result.context_wrapper, computer=created)
+    resolved_tool = cast(ComputerTool[Any], model.last_turn_args["tools"][0])
+    assert resolved_tool is not tool
+    assert resolved_tool.computer is created

--- a/tests/test_runner_guardrail_resume.py
+++ b/tests/test_runner_guardrail_resume.py
@@ -126,8 +126,10 @@ async def test_runner_resume_preserves_guardrail_results(monkeypatch: pytest.Mon
     async def fake_get_all_tools(*_: object, **__: object) -> list[object]:
         return []
 
-    async def fake_initialize_computer_tools(*_: object, **__: object) -> None:
-        return None
+    async def fake_initialize_computer_tools(
+        *args: object, tools: list[object], **kwargs: object
+    ) -> list[object]:
+        return tools
 
     monkeypatch.setattr(run_module, "run_single_turn", fake_run_single_turn)
     monkeypatch.setattr(run_module, "run_output_guardrails", fake_run_output_guardrails)


### PR DESCRIPTION
### Summary

This pull request fixes `ComputerTool` provider isolation when the same agent is reused by concurrent runs.

Per-run computer providers were introduced in #2191 so applications can reuse an agent while creating and disposing independent computer resources for each request. The existing initialization cache is run-scoped, but model serialization still observes the mutable `computer` field on the shared tool.

`initialize_computer_tools()` now returns run-local `ComputerTool` copies for provider/factory-backed tools, bound to the computer resolved for the current `RunContextWrapper`. The original tool continues to own the existing per-run cache and disposal lifecycle, while model serialization and action processing receive stable run-local state instead of reading a shared mutable field. Tools configured with an existing concrete `Computer` retain their original identity for hooks and custom-data callbacks.

This prevents preview-compatible Responses requests from serializing another run's computer dimensions or failing when a sibling run restores the shared tool to its provider during cleanup. The change does not alter the public API, the wire payload, or the GA `computer` tool behavior.

### Test plan

- Added a controlled concurrent `Runner.run()` regression test that interleaves two runs sharing one agent and provider-backed `ComputerTool`.
- Verified that both runs serialize their own display width, both complete successfully, and each created computer is disposed exactly once.
- Extended the existing non-streamed and streamed lifecycle tests to verify that the model receives a run-local tool bound to the correct computer.
- Added a full runner tool-call regression test confirming that concrete `ComputerTool` instances preserve their identity in model input and run hooks.
- Ran the focused lifecycle and affected runner tests.
- Ran `codex review --uncommitted` with no actionable findings.
- Ran the repository verification stack with the local provider override removed and localhost excluded from the system proxy:

```bash
env -u OPENAI_BASE_URL NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 \
  bash .agents/skills/code-change-verification/scripts/run.sh
```

All formatting, lint, type-checking, and test steps passed.

### Issue number

Closes #3842

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR