### PR TITLE
fix(sandbox): avoid redundant E2B workspace root creation

### DIFF
--- a/src/agents/extensions/sandbox/e2b/sandbox.py
+++ b/src/agents/extensions/sandbox/e2b/sandbox.py
@@ -820,7 +820,7 @@ class E2BSandboxSession(BaseSandboxSession):
         result = await self._exec_internal(
             "test",
             "-d",
-            self._workspace_root_path(),
+            sandbox_path_str(self._workspace_root_path()),
             timeout=self.state.timeouts.fast_op_s,
         )
         return result.ok()

--- a/src/agents/extensions/sandbox/e2b/sandbox.py
+++ b/src/agents/extensions/sandbox/e2b/sandbox.py
@@ -702,6 +702,7 @@ class E2BSandboxSession(BaseSandboxSession):
     state: E2BSandboxSessionState
     _sandbox: _E2BSandboxAPI
     _workspace_root_ready: bool
+    _skip_next_workspace_root_mkdir: bool
     _pty_lock: asyncio.Lock
     _pty_processes: dict[int, _E2BPtyProcessEntry]
     _reserved_pty_process_ids: set[int]
@@ -715,6 +716,7 @@ class E2BSandboxSession(BaseSandboxSession):
         self.state = state
         self._sandbox = _as_sandbox_api(sandbox)
         self._workspace_root_ready = state.workspace_root_ready
+        self._skip_next_workspace_root_mkdir = False
         self._pty_lock = asyncio.Lock()
         self._pty_processes = {}
         self._reserved_pty_process_ids = set()
@@ -837,6 +839,9 @@ class E2BSandboxSession(BaseSandboxSession):
                 await self._ensure_workspace_root()
             if not preserved or not self._workspace_root_ready:
                 await self._prepare_workspace_root_for_exec()
+                # The manifest applier always creates its root first. The command above has
+                # already done that, so let that one startup-only mkdir avoid the Files API.
+                self._skip_next_workspace_root_mkdir = True
         except WorkspaceStartError:
             raise
         except Exception as e:
@@ -847,6 +852,9 @@ class E2BSandboxSession(BaseSandboxSession):
         # helpers only when the helper cache now points at a different backend.
         if self._runtime_helper_cache_key != self._current_runtime_helper_cache_key():
             await self._ensure_runtime_helpers()
+
+    async def _after_start_failed(self) -> None:
+        self._skip_next_workspace_root_mkdir = False
 
     async def _shutdown_backend(self) -> None:
         # Best-effort kill of the remote sandbox.
@@ -1173,15 +1181,20 @@ class E2BSandboxSession(BaseSandboxSession):
         parents: bool = False,
         user: str | User | None = None,
     ) -> None:
+        workspace_root = self._workspace_root_path()
+        if user is None and self.normalize_path(path, for_write=True) == workspace_root:
+            if self._skip_next_workspace_root_mkdir:
+                self._skip_next_workspace_root_mkdir = False
+                return
+            # Keep the public root mkdir usable when the remote root disappeared. Remote path
+            # validation cannot run then because its helper command uses the workspace as `cwd`.
+            await self._ensure_dir(workspace_root, reason="mkdir_failed")
+            return
+
         if user is not None:
             path = await self._check_mkdir_with_exec(path, parents=parents, user=user)
         else:
             path = await self._validate_path_access(path, for_write=True)
-
-        # Startup prepares the workspace root through the command API before manifest
-        # application. Avoid making the already-ready root depend on the Files API too.
-        if path == self._workspace_root_path() and self._workspace_root_ready:
-            return
 
         if user is None and not parents:
             parent = path.parent

--- a/src/agents/extensions/sandbox/e2b/sandbox.py
+++ b/src/agents/extensions/sandbox/e2b/sandbox.py
@@ -816,21 +816,26 @@ class E2BSandboxSession(BaseSandboxSession):
             )
         self._workspace_root_ready = True
 
+    async def _workspace_root_exists(self) -> bool:
+        result = await self._exec_internal(
+            "test",
+            "-d",
+            self._workspace_root_path(),
+            timeout=self.state.timeouts.fast_op_s,
+        )
+        return result.ok()
+
     def _mark_workspace_root_ready_from_probe(self) -> None:
         super()._mark_workspace_root_ready_from_probe()
         self._workspace_root_ready = True
 
     async def _prepare_backend_workspace(self) -> None:
         try:
-            if self._workspace_state_preserved_on_start():
-                # Reconnected sandboxes may have durable workspace contents; the base start flow
-                # probes before this provider creates the root for future exec calls.
-                if not self._workspace_root_ready:
-                    await self._prepare_workspace_root_for_exec()
-            else:
-                # Fresh or recreated sandboxes need the workspace root created before snapshot
-                # hydration or full manifest materialization can write into it.
+            preserved = self._workspace_state_preserved_on_start()
+            if not preserved and not await self._workspace_root_exists():
+                # The Files API can create roots that the sandbox command user cannot create.
                 await self._ensure_workspace_root()
+            if not preserved or not self._workspace_root_ready:
                 await self._prepare_workspace_root_for_exec()
         except WorkspaceStartError:
             raise
@@ -1172,6 +1177,11 @@ class E2BSandboxSession(BaseSandboxSession):
             path = await self._check_mkdir_with_exec(path, parents=parents, user=user)
         else:
             path = await self._validate_path_access(path, for_write=True)
+
+        # Startup prepares the workspace root through the command API before manifest
+        # application. Avoid making the already-ready root depend on the Files API too.
+        if path == self._workspace_root_path() and self._workspace_root_ready:
+            return
 
         if user is None and not parents:
             parent = path.parent

--- a/tests/extensions/sandbox/test_e2b.py
+++ b/tests/extensions/sandbox/test_e2b.py
@@ -271,6 +271,7 @@ class _FakeE2BAsyncCommandHandle:
 class _FakeE2BFiles:
     def __init__(self) -> None:
         self.make_dir_calls: list[tuple[str, float | None]] = []
+        self.make_dir_error: BaseException | None = None
 
     async def write(
         self,
@@ -285,6 +286,8 @@ class _FakeE2BFiles:
 
     async def make_dir(self, path: str, request_timeout: float | None = None) -> bool:
         self.make_dir_calls.append((path, request_timeout))
+        if self.make_dir_error is not None:
+            raise self.make_dir_error
         return True
 
     async def read(self, path: str, format: str = "bytes") -> bytes:
@@ -888,9 +891,17 @@ async def test_e2b_start_prepares_workspace_root_for_command_cwd() -> None:
     result = await session._exec_internal("pwd", timeout=0.01)  # noqa: SLF001
 
     assert result.ok()
+    assert sandbox.files.make_dir_calls == [("/workspace", 10)]
     assert session.state.workspace_root_ready is True
     assert session._workspace_root_ready is True  # noqa: SLF001
     assert _visible_command_calls(sandbox) == [
+        {
+            "command": "test -d /workspace",
+            "timeout": 10.0,
+            "cwd": None,
+            "envs": {},
+            "user": None,
+        },
         {
             "command": "mkdir -p -- /workspace",
             "timeout": 10,
@@ -902,6 +913,35 @@ async def test_e2b_start_prepares_workspace_root_for_command_cwd() -> None:
             "command": "pwd",
             "timeout": 0.01,
             "cwd": "/workspace",
+            "envs": {},
+            "user": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_e2b_start_skips_files_api_when_workspace_root_exists() -> None:
+    session, sandbox = _session(workspace_root_ready=False)
+    sandbox.commands.exec_root_ready = True
+    sandbox.files.make_dir_error = TimeoutError("files API unavailable")
+
+    await session.start()
+
+    assert sandbox.files.make_dir_calls == []
+    assert session.state.workspace_root_ready is True
+    assert session._workspace_root_ready is True  # noqa: SLF001
+    assert _visible_command_calls(sandbox)[:2] == [
+        {
+            "command": "test -d /workspace",
+            "timeout": 10.0,
+            "cwd": None,
+            "envs": {},
+            "user": None,
+        },
+        {
+            "command": "mkdir -p -- /workspace",
+            "timeout": 10,
+            "cwd": "/",
             "envs": {},
             "user": None,
         },

--- a/tests/extensions/sandbox/test_e2b.py
+++ b/tests/extensions/sandbox/test_e2b.py
@@ -949,6 +949,20 @@ async def test_e2b_start_skips_files_api_when_workspace_root_exists() -> None:
 
 
 @pytest.mark.asyncio
+async def test_e2b_mkdir_recreates_workspace_root_when_readiness_is_stale() -> None:
+    session, sandbox = _session(workspace_root_ready=False)
+    sandbox.commands.exec_root_ready = True
+
+    await session.start()
+    sandbox.commands.exec_root_ready = False
+    command_calls_before_recovery = list(sandbox.commands.calls)
+    await session.mkdir("/workspace", parents=True)
+
+    assert sandbox.files.make_dir_calls == [("/workspace", 10)]
+    assert sandbox.commands.calls == command_calls_before_recovery
+
+
+@pytest.mark.asyncio
 async def test_e2b_start_installs_runtime_helpers() -> None:
     session, sandbox = _session(workspace_root_ready=False)
 


### PR DESCRIPTION
This pull request fixes redundant E2B Files API calls while preparing the workspace root.

Fresh sessions now probe the root through the command API and use the Files API only when the root is missing, preserving support for templates where the command user cannot create `/workspace`. Once the root is ready, manifest application no longer repeats the Files API directory creation.

This pull request resolves #3844.