### PR TITLE
fix: redact non-tool trace error details

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1190,7 +1190,14 @@ async def start_streaming(
                         current_span,
                         SpanError(
                             message="Error in agent run",
-                            data={"error": str(e)},
+                            data={
+                                "error": _error_tracing.get_trace_error(
+                                    trace_include_sensitive_data=(
+                                        run_config.trace_include_sensitive_data
+                                    ),
+                                    error_message=str(e),
+                                )
+                            },
                         ),
                     )
                 raise
@@ -1213,7 +1220,12 @@ async def start_streaming(
                 current_span,
                 SpanError(
                     message="Error in agent run",
-                    data={"error": str(e)},
+                    data={
+                        "error": _error_tracing.get_trace_error(
+                            trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+                            error_message=str(e),
+                        )
+                    },
                 ),
             )
         streamed_result.is_complete = True

--- a/src/agents/run_internal/turn_preparation.py
+++ b/src/agents/run_internal/turn_preparation.py
@@ -80,7 +80,15 @@ async def maybe_filter_model_input(
         return updated
     except Exception as e:
         _error_tracing.attach_error_to_current_span(
-            SpanError(message="Error in call_model_input_filter", data={"error": str(e)})
+            SpanError(
+                message="Error in call_model_input_filter",
+                data={
+                    "error": _error_tracing.get_trace_error(
+                        trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+                        error_message=str(e),
+                    )
+                },
+            )
         )
         raise
 

--- a/src/agents/util/_error_tracing.py
+++ b/src/agents/util/_error_tracing.py
@@ -3,6 +3,18 @@ from typing import Any
 from ..logger import logger
 from ..tracing import Span, SpanError, get_current_span
 
+REDACTED_TRACE_ERROR_MESSAGE = "Error details are redacted."
+
+
+def get_trace_error(
+    *,
+    trace_include_sensitive_data: bool,
+    error_message: str,
+    redacted_message: str = REDACTED_TRACE_ERROR_MESSAGE,
+) -> str:
+    """Return a trace-safe error string based on the sensitive-data setting."""
+    return error_message if trace_include_sensitive_data else redacted_message
+
 
 def attach_error_to_span(span: Span[Any], error: SpanError) -> None:
     span.set_error(error)

--- a/src/agents/util/_tool_errors.py
+++ b/src/agents/util/_tool_errors.py
@@ -1,8 +1,14 @@
 """Helpers for rendering tool errors in trace-safe form."""
 
+from ._error_tracing import get_trace_error
+
 REDACTED_TOOL_ERROR_MESSAGE = "Tool execution failed. Error details are redacted."
 
 
 def get_trace_tool_error(*, trace_include_sensitive_data: bool, error_message: str) -> str:
     """Return a trace-safe tool error string based on the sensitive-data setting."""
-    return error_message if trace_include_sensitive_data else REDACTED_TOOL_ERROR_MESSAGE
+    return get_trace_error(
+        trace_include_sensitive_data=trace_include_sensitive_data,
+        error_message=error_message,
+        redacted_message=REDACTED_TOOL_ERROR_MESSAGE,
+    )

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -14,6 +14,7 @@ from ... import _debug
 from ...exceptions import AgentsException
 from ...logger import logger
 from ...tracing import Span, SpanError, TranscriptionSpanData, transcription_span
+from ...util._error_tracing import get_trace_error
 from ..exceptions import STTWebsocketConnectionError
 from ..imports import np, npt, websockets
 from ..input import AudioInput, StreamedAudioInput
@@ -433,7 +434,15 @@ class OpenAISTTModel(STTModel):
                 return response.text
             except Exception as e:
                 span.span_data.output = ""
-                span.set_error(SpanError(message=str(e), data={}))
+                span.set_error(
+                    SpanError(
+                        message=get_trace_error(
+                            trace_include_sensitive_data=trace_include_sensitive_data,
+                            error_message=str(e),
+                        ),
+                        data={},
+                    )
+                )
                 raise e
 
     async def create_session(

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -10,6 +10,7 @@ from ..exceptions import UserError
 from ..logger import logger
 from ..tracing import Span, SpeechGroupSpanData, speech_group_span, speech_span
 from ..tracing.util import time_iso
+from ..util._error_tracing import get_trace_error
 from .events import (
     VoiceStreamEvent,
     VoiceStreamEventAudio,
@@ -178,7 +179,12 @@ class StreamedAudioResult:
             except Exception as e:
                 tts_span.set_error(
                     {
-                        "message": str(e),
+                        "message": get_trace_error(
+                            trace_include_sensitive_data=(
+                                self._voice_pipeline_config.trace_include_sensitive_data
+                            ),
+                            error_message=str(e),
+                        ),
                         "data": {
                             "text": text
                             if self._voice_pipeline_config.trace_include_sensitive_data

--- a/tests/test_call_model_input_filter.py
+++ b/tests/test_call_model_input_filter.py
@@ -9,6 +9,9 @@ from agents.run import CallModelData, ModelInputData
 
 from .fake_model import FakeModel
 from .test_responses import get_text_input_item, get_text_message
+from .testing_processor import fetch_span_errors
+
+SENSITIVE_ERROR_MESSAGE = "sensitive-filter-error"
 
 
 @pytest.mark.asyncio
@@ -77,6 +80,39 @@ async def test_call_model_input_filter_invalid_return_type_raises() -> None:
             input="start",
             run_config=RunConfig(call_model_input_filter=invalid_filter),
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("trace_include_sensitive_data", "expected_error"),
+    [
+        (False, "Error details are redacted."),
+        (True, SENSITIVE_ERROR_MESSAGE),
+    ],
+)
+async def test_call_model_input_filter_error_respects_sensitive_data_setting(
+    trace_include_sensitive_data: bool,
+    expected_error: str,
+) -> None:
+    def filter_fn(_data: CallModelData[Any]) -> ModelInputData:
+        raise ValueError(SENSITIVE_ERROR_MESSAGE)
+
+    with pytest.raises(ValueError, match=SENSITIVE_ERROR_MESSAGE):
+        await Runner.run(
+            Agent(name="test", model=FakeModel(tracing_enabled=False)),
+            input="start",
+            run_config=RunConfig(
+                call_model_input_filter=filter_fn,
+                trace_include_sensitive_data=trace_include_sensitive_data,
+            ),
+        )
+
+    assert fetch_span_errors("turn") == [
+        {
+            "message": "Error in call_model_input_filter",
+            "data": {"error": expected_error},
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tracing_errors_streamed.py
+++ b/tests/test_tracing_errors_streamed.py
@@ -10,12 +10,14 @@ from typing_extensions import TypedDict
 
 from agents import (
     Agent,
+    AgentsException,
     GuardrailFunctionOutput,
     InputGuardrail,
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
     OutputGuardrail,
     OutputGuardrailTripwireTriggered,
+    RunConfig,
     RunContextWrapper,
     Runner,
     TResponseInputItem,
@@ -30,7 +32,9 @@ from .test_responses import (
     get_handoff_tool_call,
     get_text_message,
 )
-from .testing_processor import fetch_normalized_spans
+from .testing_processor import fetch_normalized_spans, fetch_span_errors
+
+SENSITIVE_ERROR_MESSAGE = "sensitive-error-detail"
 
 
 async def wait_for_normalized_spans(timeout: float = 0.2):
@@ -93,6 +97,35 @@ async def test_single_turn_model_error():
             }
         ]
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(AgentsException(SENSITIVE_ERROR_MESSAGE), id="inner-handler"),
+        pytest.param(ValueError(SENSITIVE_ERROR_MESSAGE), id="outer-handler"),
+    ],
+)
+async def test_streamed_agent_error_redacts_sensitive_data(error: Exception) -> None:
+    model = FakeModel(tracing_enabled=False)
+    model.set_next_output(error)
+
+    with pytest.raises(type(error)):
+        result = Runner.run_streamed(
+            Agent(name="test_agent", model=model),
+            input="first_test",
+            run_config=RunConfig(trace_include_sensitive_data=False),
+        )
+        async for _ in result.stream_events():
+            pass
+
+    assert fetch_span_errors("agent") == [
+        {
+            "message": "Error in agent run",
+            "data": {"error": "Error details are redacted."},
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/testing_processor.py
+++ b/tests/testing_processor.py
@@ -80,6 +80,24 @@ def fetch_events() -> list[TestSpanProcessorEvent]:
     return SPAN_PROCESSOR_TESTING._events
 
 
+def fetch_span_errors(span_type: str) -> list[dict[str, Any]]:
+    errors: list[dict[str, Any]] = []
+    for span in fetch_ordered_spans():
+        exported = span.export()
+        if not exported:
+            continue
+        span_data = exported["span_data"]
+        exported_span_type = span_data.get("type")
+        if exported_span_type == "custom" and isinstance(span_data.get("data"), dict):
+            exported_span_type = span_data["data"].get("sdk_span_type", exported_span_type)
+        if exported_span_type != span_type:
+            continue
+        error = exported.get("error")
+        if error is not None:
+            errors.append(error)
+    return errors
+
+
 def assert_no_spans():
     spans = fetch_ordered_spans()
     if spans:

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -9,8 +9,17 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from agents import trace
+from tests.testing_processor import fetch_span_errors
+
 try:
-    from agents.voice import OpenAISTTTranscriptionSession, StreamedAudioInput, STTModelSettings
+    from agents.voice import (
+        AudioInput,
+        OpenAISTTModel,
+        OpenAISTTTranscriptionSession,
+        StreamedAudioInput,
+        STTModelSettings,
+    )
     from agents.voice.exceptions import STTWebsocketConnectionError
     from agents.voice.models.openai_stt import EVENT_INACTIVITY_TIMEOUT
 
@@ -43,6 +52,34 @@ def fake_time(increment: int):
 
 
 # ===== Tests =====
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("trace_include_sensitive_data", "expected_error"),
+    [
+        (False, "Error details are redacted."),
+        (True, "sensitive-stt-error"),
+    ],
+)
+async def test_transcribe_error_respects_sensitive_data_setting(
+    trace_include_sensitive_data: bool,
+    expected_error: str,
+) -> None:
+    client = AsyncMock()
+    client.audio.transcriptions.create = AsyncMock(side_effect=RuntimeError("sensitive-stt-error"))
+    model = OpenAISTTModel(model="whisper-1", openai_client=client)
+
+    with trace("stt-error"):
+        with pytest.raises(RuntimeError, match="sensitive-stt-error"):
+            await model.transcribe(
+                AudioInput(buffer=np.zeros(2, dtype=np.int16)),
+                STTModelSettings(),
+                trace_include_sensitive_data=trace_include_sensitive_data,
+                trace_include_sensitive_audio_data=False,
+            )
+
+    assert fetch_span_errors("transcription") == [{"message": expected_error, "data": {}}]
+
+
 @pytest.mark.asyncio
 async def test_non_json_messages_should_crash():
     """This tests that non-JSON messages will raise an exception"""

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -6,7 +6,8 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from tests.testing_processor import fetch_events
+from agents import trace
+from tests.testing_processor import fetch_events, fetch_span_errors
 
 try:
     from agents.voice import (
@@ -80,6 +81,45 @@ async def test_streamed_audio_result_preserves_cross_chunk_sample_boundaries() -
             break
 
     assert audio_chunks == [np.array([1], dtype=np.int16).tobytes()]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("trace_include_sensitive_data", "expected_error"),
+    [
+        (False, "Error details are redacted."),
+        (True, "sensitive-tts-error"),
+    ],
+)
+async def test_streamed_audio_error_respects_sensitive_data_setting(
+    trace_include_sensitive_data: bool,
+    expected_error: str,
+) -> None:
+    class FailingTTS(FakeTTS):
+        async def run(self, text: str, settings: TTSModelSettings):
+            del text, settings
+            raise RuntimeError("sensitive-tts-error")
+            yield b""  # pragma: no cover
+
+    result = StreamedAudioResult(
+        FailingTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(trace_include_sensitive_data=trace_include_sensitive_data),
+    )
+    local_queue: asyncio.Queue[VoiceStreamEvent | None] = asyncio.Queue()
+
+    with trace("tts-error"):
+        with pytest.raises(RuntimeError, match="sensitive-tts-error"):
+            await result._stream_audio("sensitive input", local_queue)
+
+    assert fetch_span_errors("speech") == [
+        {
+            "message": expected_error,
+            "data": {
+                "text": "sensitive input" if trace_include_sensitive_data else "",
+            },
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes sensitive exception details leaking into trace span errors when `trace_include_sensitive_data=False`.

It introduces a neutral trace-error redaction helper and applies it to streamed agent failures, model-input-filter failures, OpenAI STT failures, and voice-pipeline TTS failures. The existing tool-specific redaction message and all behavior when sensitive tracing is enabled remain unchanged.