### PR TITLE
docs: make dynamic prompt example runnable in standard Python scripts

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -95,8 +95,10 @@ You can also generate the prompt dynamically at run time:
 
 ```python
 from dataclasses import dataclass
+import asyncio
 
 from agents import Agent, GenerateDynamicPromptData, Runner
+
 
 @dataclass
 class PromptContext:
@@ -114,11 +116,22 @@ async def build_prompt(data: GenerateDynamicPromptData):
 
 
 agent = Agent(name="Prompted assistant", prompt=build_prompt)
-result = await Runner.run(
-    agent,
-    "Say hello",
-    context=PromptContext(prompt_id="pmpt_123", poem_style="limerick"),
-)
+
+
+async def main():
+    result = await Runner.run(
+        agent,
+        "Say hello",
+        context=PromptContext(
+            prompt_id="pmpt_123",
+            poem_style="limerick",
+        ),
+    )
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Context


### PR DESCRIPTION
## Summary

This PR updates the dynamic prompt example to make it directly runnable as a standard Python script.

The current example uses `await Runner.run(...)` at the top level, which is only valid in environments that support top-level `await` (such as Jupyter notebooks). Running the example as a regular `.py` file results in a syntax error.

## Changes

- Add an `async main()` function.
- Execute it using `asyncio.run(main())`.
- Import `asyncio`.
- Preserve the original example behavior.

## Why

This improves the developer experience by ensuring the documentation example works when copied into a standalone Python script without requiring additional modifications.