### PR TITLE
fix: preserve streamed session input across model retries

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1486,7 +1486,11 @@ async def run_single_turn_streamed(
     model_settings = model_settings_with_prompt_cache_key(model_settings, prompt_cache_key)
 
     async def rewind_model_request() -> None:
-        items_to_rewind = session_items_to_rewind if session_items_to_rewind is not None else []
+        items_to_rewind = []
+        # Streaming persists local session input before the request, so a model retry must not
+        # remove that committed turn.
+        if not streamed_result._stream_input_persisted and session_items_to_rewind is not None:
+            items_to_rewind = session_items_to_rewind
         await rewind_session_items(session, items_to_rewind, server_conversation_tracker)
         if server_conversation_tracker is not None:
             server_conversation_tracker.rewind_input(filtered.input)

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -370,6 +370,38 @@ async def test_streamed_run_preserves_request_usage_entries_after_retry() -> Non
 
 
 @pytest.mark.asyncio
+async def test_streamed_model_retry_preserves_session_input() -> None:
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            APIConnectionError(
+                message="connection error",
+                request=httpx.Request("POST", "https://example.com"),
+            ),
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        model_settings=ModelSettings(
+            retry=ModelRetrySettings(
+                max_retries=1,
+                policy=retry_policies.network_error(),
+            )
+        ),
+    )
+    session = SimpleListSession()
+
+    result = Runner.run_streamed(agent, input="test", session=session)
+    async for _ in result.stream_events():
+        pass
+
+    saved_items = await session.get_items()
+    assert [item.get("role") for item in saved_items] == ["user", "assistant"]
+
+
+@pytest.mark.asyncio
 async def test_streamed_run_preserves_request_usage_entries_after_conversation_locked_retry() -> (
     None
 ):


### PR DESCRIPTION
### Summary

Streamed runs persist the current user input to a local session before starting the model request. When that request was retried, the retry callback removed the committed input, while the successful retry only persisted the assistant output. The resulting session could therefore contain an answer without the user turn that produced it.

This change keeps already-persisted local session input out of the model retry rewind. Server-managed conversation rewind behavior is unchanged.

A regression test covers a streamed request that fails once with a retryable connection error and then succeeds, confirming that the session retains exactly one user turn and one assistant turn.

### Test plan

```text
pytest tests/test_agent_runner_streamed.py::test_streamed_model_retry_preserves_session_input tests/test_agent_runner_streamed.py::test_streamed_run_preserves_request_usage_entries_after_retry tests/test_agent_runner_streamed.py::test_streamed_run_preserves_request_usage_entries_after_conversation_locked_retry -q
```

### Issue number

Closes #3852

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
