### PR TITLE
Docs/fix hooks example await outside function

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -280,6 +280,8 @@ Typical hook timing:
 Use `RunHooks` when you want a single observer for the whole workflow, and `AgentHooks` when one agent needs custom side effects.
 
 ```python
+import asyncio
+
 from agents import Agent, RunHooks, Runner
 
 
@@ -294,9 +296,14 @@ class LoggingHooks(RunHooks):
         print(f"{agent.name} finished with usage: {context.usage}")
 
 
-agent = Agent(name="Assistant", instructions="Be concise.")
-result = await Runner.run(agent, "Explain quines", hooks=LoggingHooks())
-print(result.final_output)
+async def main():
+    agent = Agent(name="Assistant", instructions="Be concise.")
+    result = await Runner.run(agent, "Explain quines", hooks=LoggingHooks())
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 For the full callback surface, see the [Lifecycle API reference](ref/lifecycle.md).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -95,8 +95,10 @@ You can also generate the prompt dynamically at run time:
 
 ```python
 from dataclasses import dataclass
+import asyncio
 
 from agents import Agent, GenerateDynamicPromptData, Runner
+
 
 @dataclass
 class PromptContext:
@@ -114,11 +116,22 @@ async def build_prompt(data: GenerateDynamicPromptData):
 
 
 agent = Agent(name="Prompted assistant", prompt=build_prompt)
-result = await Runner.run(
-    agent,
-    "Say hello",
-    context=PromptContext(prompt_id="pmpt_123", poem_style="limerick"),
-)
+
+
+async def main():
+    result = await Runner.run(
+        agent,
+        "Say hello",
+        context=PromptContext(
+            prompt_id="pmpt_123",
+            poem_style="limerick",
+        ),
+    )
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Context


### PR DESCRIPTION
## What
The lifecycle hooks example in `docs/agents.md` used `await` at module level outside an `async def` function, which raises `SyntaxError: 'await' outside function` on Python 3.10+.

## Why
Running the example as-written produces a syntax error. Verified locally.

## Fix
- Added `import asyncio`
- Wrapped the agent run in `async def main():`
- Added `if __name__ == "__main__": asyncio.run(main())`

## Verification
Confirmed the corrected code parses without syntax errors via `ast.parse()`. The pattern matches all other runnable examples in the same file.