### PR TITLE
fix: preserve streamed session input across model retries

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1049,11 +1049,6 @@ async def start_streaming(
                         server_conversation_tracker,
                         pending_server_items=pending_server_items,
                         session=session,
-                        session_items_to_rewind=(
-                            streamed_result._original_input_for_persistence
-                            if session is not None and server_conversation_tracker is None
-                            else None
-                        ),
                         reasoning_item_id_policy=resolved_reasoning_item_id_policy,
                         prompt_cache_key_resolver=prompt_cache_key_resolver,
                         error_handlers=error_handlers,
@@ -1285,7 +1280,6 @@ async def run_single_turn_streamed(
     all_tools: list[Tool],
     server_conversation_tracker: OpenAIServerConversationTracker | None = None,
     session: Session | None = None,
-    session_items_to_rewind: list[TResponseInputItem] | None = None,
     pending_server_items: list[RunItem] | None = None,
     reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
     prompt_cache_key_resolver: PromptCacheKeyResolver | None = None,
@@ -1486,8 +1480,6 @@ async def run_single_turn_streamed(
     model_settings = model_settings_with_prompt_cache_key(model_settings, prompt_cache_key)
 
     async def rewind_model_request() -> None:
-        items_to_rewind = session_items_to_rewind if session_items_to_rewind is not None else []
-        await rewind_session_items(session, items_to_rewind, server_conversation_tracker)
         if server_conversation_tracker is not None:
             server_conversation_tracker.rewind_input(filtered.input)
 

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -61,7 +61,7 @@ from .utils.hitl import (
     queue_function_call_and_text,
     resume_streamed_after_first_approval,
 )
-from .utils.simple_session import SimpleListSession
+from .utils.simple_session import CountingSession, SimpleListSession
 
 
 def _conversation_locked_error() -> BadRequestError:
@@ -367,6 +367,39 @@ async def test_streamed_run_preserves_request_usage_entries_after_retry() -> Non
     assert usage.request_usage_entries[1].input_tokens == 10
     assert usage.request_usage_entries[1].output_tokens == 5
     assert usage.request_usage_entries[1].total_tokens == 15
+
+
+@pytest.mark.asyncio
+async def test_streamed_model_retry_does_not_rewind_committed_session_input() -> None:
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            APIConnectionError(
+                message="connection error",
+                request=httpx.Request("POST", "https://example.com"),
+            ),
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        model_settings=ModelSettings(
+            retry=ModelRetrySettings(
+                max_retries=1,
+                policy=retry_policies.network_error(),
+            )
+        ),
+    )
+    session = CountingSession(history=[get_text_input_item("previous")])
+
+    result = Runner.run_streamed(agent, input="test", session=session)
+    async for _ in result.stream_events():
+        pass
+
+    saved_items = await session.get_items()
+    assert [item.get("role") for item in saved_items] == ["user", "user", "assistant"]
+    assert session.pop_calls == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes streamed model retries incorrectly removing user input that was already committed to a local session.

Streaming now treats committed local session input as owned by the run rather than by an individual model attempt. The streamed retry callback no longer rewinds local session items and only restores server-managed conversation tracking when applicable. The non-streaming retry behavior remains unchanged.

The regression coverage verifies that prior history, the current user input, and the assistant response remain intact without invoking `Session.pop_item()`.

This pull request resolves #3852.