### PR TITLE
fix: prevent stale prepared-item identity reuse

### DIFF
--- a/src/agents/run_internal/oai_conversation.py
+++ b/src/agents/run_internal/oai_conversation.py
@@ -114,6 +114,9 @@ def _untrack_object(items: list[Any], candidate: Any) -> None:
             return
 
 
+_PreparedItemSource = tuple[TResponseInputItem, TResponseInputItem]
+
+
 @dataclass
 class OpenAIServerConversationTracker:
     """Track server-side conversation state for conversation-aware runs.
@@ -152,7 +155,8 @@ class OpenAIServerConversationTracker:
 
     # Mapping from normalized prepared items back to their original source objects so that
     # mark_input_as_sent() can mark the right object identities after the model call succeeds.
-    prepared_item_sources: dict[int, TResponseInputItem] = field(default_factory=dict)
+    # Keep the prepared item alive so its object ID cannot be reused before the input is marked.
+    prepared_item_sources: dict[int, _PreparedItemSource] = field(default_factory=dict)
     prepared_item_sources_by_fingerprint: dict[str, list[TResponseInputItem]] = field(
         default_factory=dict
     )
@@ -438,6 +442,9 @@ class OpenAIServerConversationTracker:
         generated_items: list[RunItem],
     ) -> list[TResponseInputItem]:
         """Assemble the next model input while skipping duplicates and approvals."""
+        self.prepared_item_sources.clear()
+        self.prepared_item_sources_by_fingerprint.clear()
+
         prepared_initial_items: list[TResponseInputItem] = []
         prepared_generated_items: list[TResponseInputItem] = []
         generated_item_sources: dict[int, TResponseInputItem] = {}
@@ -533,46 +540,33 @@ class OpenAIServerConversationTracker:
     ) -> None:
         if source_item is None:
             source_item = prepared_item
-        self.prepared_item_sources[id(prepared_item)] = source_item
+        self.prepared_item_sources[id(prepared_item)] = (prepared_item, source_item)
         fingerprint = _fingerprint_for_tracker(prepared_item)
         if fingerprint:
             self.prepared_item_sources_by_fingerprint.setdefault(fingerprint, []).append(
                 source_item
             )
 
-    def _resolve_prepared_item_source(self, item: TResponseInputItem) -> TResponseInputItem:
-        source_item = self.prepared_item_sources.get(id(item))
-        if source_item is not None:
-            return source_item
-
-        fingerprint = _fingerprint_for_tracker(item)
-        if not fingerprint:
-            return item
-
-        source_items = self.prepared_item_sources_by_fingerprint.get(fingerprint)
-        if not source_items:
-            return item
-        return source_items[0]
-
     def _consume_prepared_item_source(self, item: TResponseInputItem) -> TResponseInputItem:
-        source_item = self._resolve_prepared_item_source(item)
-        direct_source = self.prepared_item_sources.pop(id(item), None)
+        direct_entry = self.prepared_item_sources.get(id(item))
+        direct_source = None
+        if direct_entry is not None and direct_entry[0] is item:
+            self.prepared_item_sources.pop(id(item), None)
+            direct_source = direct_entry[1]
 
         fingerprint = _fingerprint_for_tracker(item)
         if not fingerprint:
-            return source_item
+            return direct_source if direct_source is not None else item
 
         source_items = self.prepared_item_sources_by_fingerprint.get(fingerprint)
         if not source_items:
-            return source_item
+            return direct_source if direct_source is not None else item
 
-        target_source = direct_source if direct_source is not None else source_item
+        source_item = direct_source if direct_source is not None else source_items[0]
         for index, candidate in enumerate(source_items):
-            if candidate is target_source:
+            if candidate is source_item:
                 source_items.pop(index)
                 break
-        else:
-            source_items.pop(0)
 
         if not source_items:
             self.prepared_item_sources_by_fingerprint.pop(fingerprint, None)

--- a/tests/test_server_conversation_tracker.py
+++ b/tests/test_server_conversation_tracker.py
@@ -5,6 +5,7 @@ import pytest
 from openai.types.responses import ResponseFunctionToolCall
 from openai.types.responses.response_output_item import McpCall, McpListTools, McpListToolsTool
 
+import agents.run_internal.oai_conversation as oai_conversation
 from agents import Agent, HostedMCPTool
 from agents.items import (
     MCPListToolsItem,
@@ -259,8 +260,24 @@ def test_mark_input_as_sent_and_rewind_input_respects_remaining_initial_input() 
     assert tracker.remaining_initial_input == [pending_1]
 
 
-def test_mark_input_as_sent_uses_raw_generated_source_for_rebuilt_filtered_item() -> None:
+def test_mark_input_as_sent_ignores_stale_id_for_rebuilt_filtered_item(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     tracker = OpenAIServerConversationTracker(conversation_id="conv2b", previous_response_id=None)
+    stale_raw_item = {
+        "type": "function_call_output",
+        "call_id": "call-stale",
+        "output": "stale",
+    }
+    stale_generated_items = [
+        DummyRunItem(stale_raw_item, type="function_call_output_item"),
+    ]
+    stale_prepared = tracker.prepare_input(
+        original_input=[],
+        generated_items=cast(list[Any], stale_generated_items),
+    )
+    stale_prepared_id = id(stale_prepared[0])
+
     raw_generated_item = {
         "type": "function_call_output",
         "call_id": "call-2b",
@@ -274,11 +291,22 @@ def test_mark_input_as_sent_uses_raw_generated_source_for_rebuilt_filtered_item(
         original_input=[],
         generated_items=cast(list[Any], generated_items),
     )
+    assert stale_prepared_id not in tracker.prepared_item_sources
+
     rebuilt_filtered_item = cast(TResponseInputItem, dict(cast(dict[str, Any], prepared[0])))
+    real_id = id
+
+    def _id_with_stale_collision(item: Any) -> int:
+        if item is rebuilt_filtered_item:
+            return stale_prepared_id
+        return real_id(item)
+
+    monkeypatch.setattr(oai_conversation, "id", _id_with_stale_collision, raising=False)
 
     tracker.mark_input_as_sent([rebuilt_filtered_item])
 
     assert any(item is raw_generated_item for item in tracker.sent_items)
+    assert all(item is not stale_raw_item for item in tracker.sent_items)
     assert all(item is not rebuilt_filtered_item for item in tracker.sent_items)
 
     prepared_again = tracker.prepare_input(


### PR DESCRIPTION
This pull request fixes server-managed conversation tracking when a model input filter rebuilds prepared input items and a stale Python object ID is reused.

It scopes prepared-item mappings to the current preparation batch, keeps prepared objects alive until inputs are marked, and accepts direct mappings only when object identity matches. Fingerprint fallback continues to resolve rebuilt items without scanning the entire mapping.

The regression test deterministically reproduces a stale ID collision and verifies that the correct raw source is marked as sent and is not resent on the following turn.