### PR TITLE
fix: fail closed on invalid callable approval arguments

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -25,7 +25,7 @@ from ..run_context import RunContextWrapper, TContext
 from ..tool import DEFAULT_APPROVAL_REJECTION_MESSAGE, FunctionTool, Tool, invoke_function_tool
 from ..tool_context import ToolContext
 from ..tool_guardrails import ToolInputGuardrailData
-from ..util._approvals import evaluate_needs_approval_setting
+from ..util._approvals import evaluate_needs_approval_setting, parse_function_tool_arguments
 from ._tool_filtering import filter_enabled_tools
 from ._tool_validation import validate_realtime_tool_names
 from .agent import RealtimeAgent
@@ -550,10 +550,10 @@ class RealtimeSession(RealtimeModelListener):
         needs_setting = getattr(function_tool, "needs_approval", False)
         parsed_args: dict[str, Any] = {}
         if callable(needs_setting):
-            try:
-                parsed_args = json.loads(tool_call.arguments or "{}")
-            except json.JSONDecodeError:
-                parsed_args = {}
+            parsed_args_result = parse_function_tool_arguments(tool_call.arguments)
+            if parsed_args_result is None:
+                return True
+            parsed_args = parsed_args_result
         return await evaluate_needs_approval_setting(
             needs_setting,
             self._context_wrapper,

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -91,7 +91,7 @@ from ..tool_guardrails import (
 )
 from ..tracing import Span, SpanError, function_span, get_current_trace
 from ..util import _coro, _error_tracing
-from ..util._approvals import evaluate_needs_approval_setting
+from ..util._approvals import evaluate_needs_approval_setting, parse_function_tool_arguments
 from ..util._custom_data import maybe_extract_custom_data, merge_custom_data
 from ..util._tool_errors import get_trace_tool_error
 from ..util._types import MaybeAwaitable
@@ -1211,10 +1211,10 @@ async def function_needs_approval(
     """Evaluate a function tool's needs_approval setting with parsed args."""
     parsed_args: dict[str, Any] = {}
     if callable(function_tool.needs_approval):
-        try:
-            parsed_args = json.loads(tool_call.arguments or "{}")
-        except json.JSONDecodeError:
-            parsed_args = {}
+        parsed_args_result = parse_function_tool_arguments(tool_call.arguments)
+        if parsed_args_result is None:
+            return True
+        parsed_args = parsed_args_result
     needs_approval = await evaluate_needs_approval_setting(
         function_tool.needs_approval,
         context_wrapper,

--- a/src/agents/util/_approvals.py
+++ b/src/agents/util/_approvals.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 from collections.abc import Callable
 from typing import Any
 
@@ -8,6 +9,15 @@ from ..exceptions import UserError
 
 # Keep this helper here so both run_internal and realtime can import it without
 # creating cross-package dependencies.
+
+
+def parse_function_tool_arguments(arguments: str | None) -> dict[str, Any] | None:
+    """Return parsed object arguments, or None when an approval policy cannot inspect them."""
+    try:
+        parsed = json.loads(arguments or "{}")
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
 
 
 async def evaluate_needs_approval_setting(

--- a/src/agents/util/_approvals.py
+++ b/src/agents/util/_approvals.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NoReturn
 
 from ..exceptions import UserError
 
@@ -11,11 +11,18 @@ from ..exceptions import UserError
 # creating cross-package dependencies.
 
 
+def _reject_nonstandard_json_constant(value: str) -> NoReturn:
+    raise ValueError(f"Invalid JSON constant: {value}")
+
+
 def parse_function_tool_arguments(arguments: str | None) -> dict[str, Any] | None:
     """Return parsed object arguments, or None when an approval policy cannot inspect them."""
     try:
-        parsed = json.loads(arguments or "{}")
-    except json.JSONDecodeError:
+        parsed = json.loads(
+            arguments or "{}",
+            parse_constant=_reject_nonstandard_json_constant,
+        )
+    except ValueError:
         return None
     return parsed if isinstance(parsed, dict) else None
 

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2568,6 +2568,82 @@ class TestToolCallExecution:
         assert approval_event.call_id == tool_call_event.call_id
         assert approval_event.tool == mock_function_tool
 
+    @pytest.mark.parametrize("arguments", ['{"subject": "refund"', "null", "[]"])
+    @pytest.mark.asyncio
+    async def test_callable_function_approval_fails_closed_for_invalid_arguments(
+        self, mock_model, arguments: str
+    ) -> None:
+        approval_inputs: list[dict[str, Any]] = []
+        tool_inputs: list[str] = []
+
+        async def needs_approval(_ctx: Any, params: dict[str, Any], _call_id: str) -> bool:
+            approval_inputs.append(params)
+            return False
+
+        async def invoke_tool(_ctx: ToolContext[Any], raw_arguments: str) -> str:
+            tool_inputs.append(raw_arguments)
+            return "sent"
+
+        tool = FunctionTool(
+            name="send_email",
+            description="Send an email.",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=invoke_tool,
+            needs_approval=needs_approval,
+        )
+        agent = RealtimeAgent(name="agent", tools=[tool])
+        session = RealtimeSession(mock_model, agent, None, run_config={"async_tool_calls": False})
+        tool_call_event = RealtimeModelToolCallEvent(
+            name=tool.name,
+            call_id="call-invalid",
+            arguments=arguments,
+        )
+
+        await session._handle_tool_call(tool_call_event)
+
+        assert tool_call_event.call_id in session._pending_tool_calls
+        assert approval_inputs == []
+        assert tool_inputs == []
+        approval_event = await session._event_queue.get()
+        assert isinstance(approval_event, RealtimeToolApprovalRequired)
+
+    @pytest.mark.asyncio
+    async def test_callable_function_approval_receives_valid_object_arguments(
+        self, mock_model
+    ) -> None:
+        approval_inputs: list[dict[str, Any]] = []
+        tool_inputs: list[str] = []
+
+        async def needs_approval(_ctx: Any, params: dict[str, Any], _call_id: str) -> bool:
+            approval_inputs.append(params)
+            return False
+
+        async def invoke_tool(_ctx: ToolContext[Any], raw_arguments: str) -> str:
+            tool_inputs.append(raw_arguments)
+            return "sent"
+
+        tool = FunctionTool(
+            name="send_email",
+            description="Send an email.",
+            params_json_schema={"type": "object", "properties": {"subject": {"type": "string"}}},
+            on_invoke_tool=invoke_tool,
+            needs_approval=needs_approval,
+        )
+        agent = RealtimeAgent(name="agent", tools=[tool])
+        session = RealtimeSession(mock_model, agent, None, run_config={"async_tool_calls": False})
+        arguments = '{"subject": "status update"}'
+        tool_call_event = RealtimeModelToolCallEvent(
+            name=tool.name,
+            call_id="call-valid",
+            arguments=arguments,
+        )
+
+        await session._handle_tool_call(tool_call_event)
+
+        assert approval_inputs == [{"subject": "status update"}]
+        assert tool_inputs == [arguments]
+        assert tool_call_event.call_id not in session._pending_tool_calls
+
     @pytest.mark.asyncio
     async def test_tool_input_guardrail_rejects_before_realtime_function_execution(
         self, mock_model

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -2568,7 +2568,17 @@ class TestToolCallExecution:
         assert approval_event.call_id == tool_call_event.call_id
         assert approval_event.tool == mock_function_tool
 
-    @pytest.mark.parametrize("arguments", ['{"subject": "refund"', "null", "[]"])
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            '{"subject": "refund"',
+            "null",
+            "[]",
+            '{"amount": NaN}',
+            '{"amount": Infinity}',
+            '{"amount": -Infinity}',
+        ],
+    )
     @pytest.mark.asyncio
     async def test_callable_function_approval_fails_closed_for_invalid_arguments(
         self, mock_model, arguments: str

--- a/tests/test_hitl_error_scenarios.py
+++ b/tests/test_hitl_error_scenarios.py
@@ -882,7 +882,17 @@ async def test_function_needs_approval_invalid_type_raises() -> None:
         await Runner.run(agent, "run invalid")
 
 
-@pytest.mark.parametrize("arguments", ['{"subject": "refund"', "null", "[]"])
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        '{"subject": "refund"',
+        "null",
+        "[]",
+        '{"amount": NaN}',
+        '{"amount": Infinity}',
+        '{"amount": -Infinity}',
+    ],
+)
 @pytest.mark.asyncio
 async def test_callable_function_approval_fails_closed_for_invalid_arguments(
     arguments: str,

--- a/tests/test_hitl_error_scenarios.py
+++ b/tests/test_hitl_error_scenarios.py
@@ -58,7 +58,7 @@ from agents.run_internal.tool_planning import (
     _select_function_tool_runs_for_resume,
 )
 from agents.run_state import RunState as RunStateClass
-from agents.tool import HostedMCPTool
+from agents.tool import FunctionTool, HostedMCPTool
 from agents.usage import Usage
 
 from .fake_model import FakeModel
@@ -880,6 +880,81 @@ async def test_function_needs_approval_invalid_type_raises() -> None:
 
     with pytest.raises(UserError, match="needs_approval"):
         await Runner.run(agent, "run invalid")
+
+
+@pytest.mark.parametrize("arguments", ['{"subject": "refund"', "null", "[]"])
+@pytest.mark.asyncio
+async def test_callable_function_approval_fails_closed_for_invalid_arguments(
+    arguments: str,
+) -> None:
+    """Uninspectable function arguments must require approval before a manual tool can run."""
+    approval_inputs: list[dict[str, Any]] = []
+    tool_inputs: list[str] = []
+
+    async def needs_approval(_ctx: Any, params: dict[str, Any], _call_id: str) -> bool:
+        approval_inputs.append(params)
+        return False
+
+    async def invoke_tool(_ctx: Any, raw_arguments: str) -> str:
+        tool_inputs.append(raw_arguments)
+        return "sent"
+
+    tool = FunctionTool(
+        name="send_email",
+        description="Send an email.",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=invoke_tool,
+        needs_approval=needs_approval,
+    )
+    model, agent = make_model_and_agent(tools=[tool])
+    model.set_next_output(
+        [make_function_tool_call(tool.name, arguments=arguments, call_id="call-invalid")]
+    )
+
+    result = await Runner.run(agent, "send an email")
+
+    assert len(result.interruptions) == 1
+    assert result.interruptions[0].tool_name == tool.name
+    assert approval_inputs == []
+    assert tool_inputs == []
+
+
+@pytest.mark.asyncio
+async def test_callable_function_approval_receives_valid_object_arguments() -> None:
+    """Valid object arguments should preserve callable approval behavior."""
+    approval_inputs: list[dict[str, Any]] = []
+    tool_inputs: list[str] = []
+
+    async def needs_approval(_ctx: Any, params: dict[str, Any], _call_id: str) -> bool:
+        approval_inputs.append(params)
+        return False
+
+    async def invoke_tool(_ctx: Any, raw_arguments: str) -> str:
+        tool_inputs.append(raw_arguments)
+        return "sent"
+
+    tool = FunctionTool(
+        name="send_email",
+        description="Send an email.",
+        params_json_schema={"type": "object", "properties": {"subject": {"type": "string"}}},
+        on_invoke_tool=invoke_tool,
+        needs_approval=needs_approval,
+    )
+    arguments = '{"subject": "status update"}'
+    model, agent = make_model_and_agent(tools=[tool])
+    model.add_multiple_turn_outputs(
+        [
+            [make_function_tool_call(tool.name, arguments=arguments, call_id="call-valid")],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = await Runner.run(agent, "send an email")
+
+    assert result.final_output == "done"
+    assert approval_inputs
+    assert all(params == {"subject": "status update"} for params in approval_inputs)
+    assert tool_inputs == [arguments]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes callable function-tool approval policies that could fail open when model arguments contained malformed or non-object JSON.

Runner and Realtime now treat arguments that cannot be inspected as requiring approval without invoking the policy callback. Valid JSON objects continue through the existing callable approval flow unchanged. Regression coverage verifies both the fail-closed behavior and the valid-object path for directly constructed `FunctionTool` instances.

This pull request resolves #3863.