### PR TITLE
remove unnecessary RunContextWrapper wrapping in tool enabling example

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -45,7 +45,7 @@ The most common properties of an agent are:
 | `reset_tool_choice` | no | Reset `tool_choice` after a tool call (default: `True`) to avoid tool-use loops. See [Forcing tool use](#forcing-tool-use). |
 
 ```python
-from agents import Agent, ModelSettings, function_tool
+from agents import Agent, function_tool
 
 @function_tool
 def get_weather(city: str) -> str:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -745,8 +745,8 @@ orchestrator = Agent(
 )
 
 async def main():
-    context = RunContextWrapper(LanguageContext(language_preference="french_spanish"))
-    result = await Runner.run(orchestrator, "How are you?", context=context.context)
+    context = LanguageContext(language_preference="french_spanish")
+    result = await Runner.run(orchestrator, "How are you?", context=context)
     print(result.final_output)
 
 asyncio.run(main())


### PR DESCRIPTION
This pull request fixes a confusing code pattern in the "Conditional tool enabling" example in `docs/tools.md`. The example created a `RunContextWrapper(LanguageContext(...))` instance only to immediately extract `.                                                    
     context` on the next line. Since `Runner.run()` accepts the raw context object directly, the wrapping is unnecessary and may mislead readers into thinking they need to construct `RunContextWrapper` themselves. The fix              Connect from 75+ providers to       
     creates `LanguageContext` directly and passes it to `Runner.run()` without the intermediate wrapper. 