### PR TITLE
fix: fail closed for callable needs_approval on invalid/non-object JSON

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -548,12 +548,17 @@ class RealtimeSession(RealtimeModelListener):
     ) -> bool:
         """Evaluate a function tool's needs_approval setting with parsed args."""
         needs_setting = getattr(function_tool, "needs_approval", False)
-        parsed_args: dict[str, Any] = {}
         if callable(needs_setting):
             try:
-                parsed_args = json.loads(tool_call.arguments or "{}")
+                parsed = json.loads(tool_call.arguments or "{}")
             except json.JSONDecodeError:
-                parsed_args = {}
+                # Fail closed: invalid JSON must not look like "empty safe args".
+                return True
+            if not isinstance(parsed, dict):
+                return True
+            parsed_args: dict[str, Any] = parsed
+        else:
+            parsed_args = {}
         return await evaluate_needs_approval_setting(
             needs_setting,
             self._context_wrapper,

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1208,13 +1208,23 @@ async def function_needs_approval(
     context_wrapper: RunContextWrapper[Any],
     tool_call: ResponseFunctionToolCall,
 ) -> bool:
-    """Evaluate a function tool's needs_approval setting with parsed args."""
-    parsed_args: dict[str, Any] = {}
+    """Evaluate a function tool's needs_approval setting with parsed args.
+
+    For callable approval predicates, invalid or non-object JSON arguments fail
+    closed (require approval) instead of evaluating the predicate on ``{}``.
+    """
     if callable(function_tool.needs_approval):
         try:
-            parsed_args = json.loads(tool_call.arguments or "{}")
+            parsed = json.loads(tool_call.arguments or "{}")
         except json.JSONDecodeError:
-            parsed_args = {}
+            # Fail closed: invalid JSON must not look like "empty safe args".
+            return True
+        if not isinstance(parsed, dict):
+            # Fail closed: predicates document dict params; null/list must not reach .get.
+            return True
+        parsed_args: dict[str, Any] = parsed
+    else:
+        parsed_args = {}
     needs_approval = await evaluate_needs_approval_setting(
         function_tool.needs_approval,
         context_wrapper,

--- a/tests/test_function_needs_approval_invalid_json.py
+++ b/tests/test_function_needs_approval_invalid_json.py
@@ -1,0 +1,74 @@
+"""Regression: callable needs_approval must fail closed on bad tool JSON (#3863)."""
+
+from __future__ import annotations
+
+import pytest
+from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
+
+from agents import function_tool
+from agents.run_context import RunContextWrapper
+from agents.run_internal.tool_execution import function_needs_approval
+
+
+async def _needs_if_refund(_ctx, params, _call_id) -> bool:
+    return "refund" in str(params.get("subject", "")).lower()
+
+
+@function_tool(needs_approval=_needs_if_refund)
+async def send_email(subject: str, body: str) -> str:
+    return f"Sent {subject}"
+
+
+@function_tool(needs_approval=True)
+async def always_gated(subject: str) -> str:
+    return subject
+
+
+def _call(arguments: str) -> ResponseFunctionToolCall:
+    return ResponseFunctionToolCall(
+        type="function_call",
+        name="send_email",
+        call_id="call_test",
+        arguments=arguments,
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_arguments_fail_closed_for_callable_needs_approval() -> None:
+    ctx = RunContextWrapper(context=None)
+    # Contains "REFUND" text but is not valid JSON — previously parsed as {}.
+    bad = _call('{"subject": "REFUND request", "body": "please refund"')
+    assert await function_needs_approval(send_email, ctx, bad) is True
+
+
+@pytest.mark.asyncio
+async def test_non_object_json_fail_closed_for_callable_needs_approval() -> None:
+    ctx = RunContextWrapper(context=None)
+    for arguments in ("null", "[]", '"x"', "1"):
+        assert await function_needs_approval(send_email, ctx, _call(arguments)) is True
+
+
+@pytest.mark.asyncio
+async def test_valid_refund_json_still_requires_approval() -> None:
+    ctx = RunContextWrapper(context=None)
+    good = _call('{"subject": "REFUND request", "body": "please refund"}')
+    assert await function_needs_approval(send_email, ctx, good) is True
+
+
+@pytest.mark.asyncio
+async def test_valid_non_refund_json_skips_approval() -> None:
+    ctx = RunContextWrapper(context=None)
+    good = _call('{"subject": "hello", "body": "world"}')
+    assert await function_needs_approval(send_email, ctx, good) is False
+
+
+@pytest.mark.asyncio
+async def test_bool_needs_approval_true_unaffected_by_invalid_json() -> None:
+    ctx = RunContextWrapper(context=None)
+    bad = ResponseFunctionToolCall(
+        type="function_call",
+        name="always_gated",
+        call_id="call_bool",
+        arguments='{"subject": "x"',
+    )
+    assert await function_needs_approval(always_gated, ctx, bad) is True


### PR DESCRIPTION
## Summary

Fixes #3863.

When `needs_approval` is a **callable**, invalid tool-call JSON was previously swallowed and replaced with `{}` before the predicate ran. Content-based gates (e.g. `"refund" in params.get("subject", "")`) then returned `False` and skipped HITL.

This change fails closed:

- `JSONDecodeError` → require approval (`True`)
- non-`dict` JSON (`null`, `[]`, scalars) → require approval (`True`)
- valid object JSON → unchanged predicate behavior
- bool `needs_approval=True` → unchanged

Same fix in the realtime session path.

## Test plan

- [x] `pytest tests/test_function_needs_approval_invalid_json.py` (5 passed)
- [x] Covers invalid JSON, non-object JSON, valid refund/non-refund, bool path