### PR TITLE
fix(blaxel): shell-quote interpolated FUSE mount options

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/mounts.py
+++ b/src/agents/extensions/sandbox/blaxel/mounts.py
@@ -322,7 +322,7 @@ async def _mount_s3(session: BaseSandboxSession, config: BlaxelCloudBucketMountC
         opts.append("ro")
 
     opts_str = ",".join(opts)
-    cmd = f"s3fs {shlex.quote(bucket)} {mount_path} -o {opts_str}"
+    cmd = f"s3fs {shlex.quote(bucket)} {mount_path} -o {shlex.quote(opts_str)}"
 
     try:
         await _exec(session, f"mkdir -p {mount_path}")
@@ -367,7 +367,7 @@ async def _mount_gcs(session: BaseSandboxSession, config: BlaxelCloudBucketMount
         opts.append("-o ro")
 
     if config.prefix:
-        opts.append(f"--only-dir={config.prefix.strip('/')}")
+        opts.append(f"--only-dir={shlex.quote(config.prefix.strip('/'))}")
 
     opts_str = " ".join(opts)
     cmd = f"gcsfuse {opts_str} {bucket} {mount_path}"

--- a/tests/extensions/sandbox/test_blaxel_mounts.py
+++ b/tests/extensions/sandbox/test_blaxel_mounts.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import shlex
+from types import SimpleNamespace
+from typing import Any
+
+from agents.extensions.sandbox.blaxel.mounts import (
+    BlaxelCloudBucketMountConfig,
+    _mount_gcs,
+    _mount_s3,
+)
+
+_INJECTION = "x; touch /tmp/pwned"
+
+
+class _RecordingSession:
+    """Minimal sandbox session that records the `sh -c` commands it is asked to run."""
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    async def exec(self, *args: Any, **kwargs: Any) -> Any:
+        if len(args) >= 3 and args[0] == "sh" and args[1] == "-c":
+            self.commands.append(args[2])
+        return SimpleNamespace(exit_code=0, stdout=b"", stderr=b"")
+
+
+async def test_s3_mount_options_are_shell_quoted() -> None:
+    session = _RecordingSession()
+    await _mount_s3(
+        session,  # type: ignore[arg-type]
+        BlaxelCloudBucketMountConfig(
+            provider="s3",
+            bucket="bucket",
+            mount_path="/mnt/data",
+            endpoint_url=f"http://{_INJECTION}",
+        ),
+    )
+    cmd = next(c for c in session.commands if c.startswith("s3fs"))
+    # The injected `; touch` must stay inside the -o option token, not become its own command.
+    assert "touch" not in shlex.split(cmd)
+
+
+async def test_gcs_mount_prefix_is_shell_quoted() -> None:
+    session = _RecordingSession()
+    await _mount_gcs(
+        session,  # type: ignore[arg-type]
+        BlaxelCloudBucketMountConfig(
+            provider="gcs",
+            bucket="bucket",
+            mount_path="/mnt/data",
+            prefix=_INJECTION,
+        ),
+    )
+    cmd = next(c for c in session.commands if c.startswith("gcsfuse"))
+    assert "touch" not in shlex.split(cmd)


### PR DESCRIPTION
### Summary

The Blaxel S3/R2/GCS mount helpers interpolate `endpoint_url`/`region` (S3/R2) and `prefix` (GCS) into the `s3fs`/`gcsfuse` command run via `sh -c` without quoting. This shell-quotes them so shell metacharacters in those values can't alter the command, matching how the core mount helpers build their commands. Normal values are unaffected.

### Test plan

Added `tests/extensions/sandbox/test_blaxel_mounts.py`: a metacharacter payload in `endpoint_url` / `prefix` stays inside the option token instead of splitting into a separate command. `make format`, `make lint`, `make typecheck`, and the sandbox test suite pass.

### Checks

- [x] I've added new tests, if relevant
- [x] I've confirmed all verification steps pass
