### PR TITLE
docs: fix outdated code examples

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -45,7 +45,7 @@ The most common properties of an agent are:
 | `reset_tool_choice` | no | Reset `tool_choice` after a tool call (default: `True`) to avoid tool-use loops. See [Forcing tool use](#forcing-tool-use). |
 
 ```python
-from agents import Agent, ModelSettings, function_tool
+from agents import Agent, function_tool
 
 @function_tool
 def get_weather(city: str) -> str:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -745,8 +745,8 @@ orchestrator = Agent(
 )
 
 async def main():
-    context = RunContextWrapper(LanguageContext(language_preference="french_spanish"))
-    result = await Runner.run(orchestrator, "How are you?", context=context.context)
+    context = LanguageContext(language_preference="french_spanish")
+    result = await Runner.run(orchestrator, "How are you?", context=context)
     print(result.final_output)
 
 asyncio.run(main())


### PR DESCRIPTION
## Summary

This PR updates documentation examples to match the current API.

### Changes
- Removed the unused `ModelSettings` import from the `agents.md` example.
- Updated the context example in `tools.md` to pass `LanguageContext` directly to `Runner.run()` instead of `context.context`.

These are documentation-only changes and do not affect library functionality.