### PR TITLE
fix: convert assistant EasyInputMessage items with optional type/phase keys

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -634,25 +634,36 @@ class Converter:
 
             # 3) response output message => assistant
             elif resp_msg := cls.maybe_response_output_message(item):
+                contents = resp_msg["content"]
+
+                if isinstance(contents, str) or (
+                    isinstance(contents, list)
+                    and len(contents) > 0
+                    and all(
+                        isinstance(c, dict) and str(c.get("type", "")).startswith("input_")
+                        for c in contents
+                    )
+                ):
+                    # An EasyInputMessageParam with an explicit `type: "message"`:
+                    # string content or input-style parts can't appear in a real
+                    # ResponseOutputMessage, so convert the item exactly like the
+                    # untyped easy-input shape to keep the payloads identical.
+                    flush_assistant_message()
+                    typed_easy_asst: ChatCompletionAssistantMessageParam = {
+                        "role": "assistant",
+                        "content": cls.extract_text_content(contents),
+                    }
+                    result.append(typed_easy_asst)
+                    continue
+
                 # A reasoning item can be followed by an assistant message and then tool calls
                 # in the same turn, so preserve pending reasoning_content across this flush.
                 flush_assistant_message(clear_pending_reasoning_content=False)
                 new_asst = ChatCompletionAssistantMessageParam(role="assistant")
-                contents = resp_msg["content"]
 
                 text_segments = []
-                if isinstance(contents, str):
-                    # EasyInputMessageParam allows `role: "assistant"` with string content
-                    # and an explicit `type: "message"`; treat it like the untyped
-                    # easy-input shape.
-                    if contents:
-                        text_segments.append(contents)
-                    contents = []
                 for c in contents:
                     if c["type"] == "output_text":
-                        text_segments.append(c["text"])
-                    elif c["type"] == "input_text":
-                        # Easy input assistant messages carry input-style text parts.
                         text_segments.append(c["text"])
                     elif c["type"] == "refusal":
                         new_asst["refusal"] = c["refusal"]

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -243,9 +243,10 @@ class Converter:
         if not isinstance(item, dict):
             return None
 
-        keys = item.keys()
-        # EasyInputMessageParam only has these two keys
-        if keys != {"content", "role"}:
+        keys = set(item.keys())
+        # EasyInputMessageParam requires content/role; assistant messages may also
+        # carry an optional `phase` label.
+        if not {"content", "role"} <= keys or keys - {"content", "role", "phase"}:
             return None
 
         role = item.get("role", None)
@@ -640,8 +641,18 @@ class Converter:
                 contents = resp_msg["content"]
 
                 text_segments = []
+                if isinstance(contents, str):
+                    # EasyInputMessageParam allows `role: "assistant"` with string content
+                    # and an explicit `type: "message"`; treat it like the untyped
+                    # easy-input shape.
+                    if contents:
+                        text_segments.append(contents)
+                    contents = []
                 for c in contents:
                     if c["type"] == "output_text":
+                        text_segments.append(c["text"])
+                    elif c["type"] == "input_text":
+                        # Easy input assistant messages carry input-style text parts.
                         text_segments.append(c["text"])
                     elif c["type"] == "refusal":
                         new_asst["refusal"] = c["refusal"]

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -636,18 +636,27 @@ class Converter:
             elif resp_msg := cls.maybe_response_output_message(item):
                 contents = resp_msg["content"]
 
-                if isinstance(contents, str) or (
+                is_easy_input_content = isinstance(contents, str) or (
                     isinstance(contents, list)
                     and len(contents) > 0
-                    and all(
-                        isinstance(c, dict) and str(c.get("type", "")).startswith("input_")
+                    and not any(
+                        isinstance(c, dict)
+                        and c.get("type") in ("output_text", "refusal", "output_audio")
                         for c in contents
                     )
-                ):
+                )
+                if is_easy_input_content and set(item.keys()) <= {
+                    "content",
+                    "role",
+                    "type",
+                    "phase",
+                }:
                     # An EasyInputMessageParam with an explicit `type: "message"`:
                     # string content or input-style parts can't appear in a real
                     # ResponseOutputMessage, so convert the item exactly like the
-                    # untyped easy-input shape to keep the payloads identical.
+                    # untyped easy-input shape to keep the payloads identical. Items
+                    # with unknown extra keys are rejected below, matching the
+                    # untyped shape's unknown-key handling.
                     flush_assistant_message()
                     typed_easy_asst: ChatCompletionAssistantMessageParam = {
                         "role": "assistant",
@@ -655,6 +664,11 @@ class Converter:
                     }
                     result.append(typed_easy_asst)
                     continue
+                if is_easy_input_content:
+                    # Easy-input-style content with unexpected extra keys: reject it
+                    # like the untyped easy-input shape does, rather than falling
+                    # into the output-message loop below.
+                    raise UserError(f"Unhandled item type or structure: {item}")
 
                 # A reasoning item can be followed by an assistant message and then tool calls
                 # in the same turn, so preserve pending reasoning_content across this flush.

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -658,9 +658,12 @@ class Converter:
                     # with unknown extra keys are rejected below, matching the
                     # untyped shape's unknown-key handling.
                     flush_assistant_message()
+                    easy_contents = cast(
+                        "str | Iterable[ResponseInputContentWithAudioParam]", contents
+                    )
                     typed_easy_asst: ChatCompletionAssistantMessageParam = {
                         "role": "assistant",
-                        "content": cls.extract_text_content(contents),
+                        "content": cls.extract_text_content(easy_contents),
                     }
                     result.append(typed_easy_asst)
                     continue

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -754,3 +754,35 @@ def test_assistant_messages_in_history():
     assert messages[1]["content"] == "Hello?"
     assert messages[2]["role"] == "user"
     assert messages[2]["content"] == "What was my Name?"
+
+
+def test_assistant_easy_input_message_optional_keys():
+    """EasyInputMessageParam allows optional `type` and `phase` keys and an
+    input-style content list on assistant messages; all variants should convert
+    like the bare {role, content} shape rather than crashing.
+    """
+    items: list = [
+        {"role": "assistant", "content": "hello", "type": "message"},
+        {"role": "assistant", "content": "hello", "phase": "final_answer"},
+        {
+            "role": "assistant",
+            "content": "hello",
+            "type": "message",
+            "phase": "final_answer",
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "input_text", "text": "hello"}],
+            "type": "message",
+        },
+    ]
+    for item in items:
+        messages = Converter.items_to_messages([item])
+        assert messages == [{"role": "assistant", "content": "hello"}], item
+
+
+def test_easy_input_message_rejects_unknown_extra_keys():
+    with pytest.raises(UserError):
+        Converter.items_to_messages(
+            [{"role": "assistant", "content": "hello", "unexpected_key": True}]
+        )

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -804,3 +804,43 @@ def test_easy_input_message_rejects_unknown_extra_keys():
         Converter.items_to_messages(
             [{"role": "assistant", "content": "hello", "unexpected_key": True}]
         )
+    # The explicitly typed shape must reject unknown keys the same way.
+    with pytest.raises(UserError):
+        Converter.items_to_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": "hello",
+                    "type": "message",
+                    "unexpected_key": True,
+                }
+            ]
+        )
+
+
+def test_typed_easy_input_message_content_part_parity():
+    """Content part shapes that the untyped easy-input path supports must behave
+    identically when the optional `type: "message"` key is present.
+    """
+    part_contents: list = [
+        # Raw Chat Completions text part alias, normalized by extract_text_content.
+        [{"type": "text", "text": "hi"}],
+        # Non-text input parts are filtered out by extract_text_content (both paths).
+        [{"type": "input_image", "image_url": "http://example.com/image.png"}],
+    ]
+    for content in part_contents:
+        untyped = Converter.items_to_messages([{"role": "assistant", "content": content}])
+        typed = Converter.items_to_messages(
+            [{"role": "assistant", "content": content, "type": "message"}]
+        )
+        assert typed == untyped, content
+    # Genuine output-message dicts still route through the output-message branch.
+    assert Converter.items_to_messages(
+        [
+            {
+                "role": "assistant",
+                "type": "message",
+                "content": [{"type": "output_text", "text": "out", "annotations": []}],
+            }
+        ]
+    ) == [{"role": "assistant", "content": "out"}]

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -759,26 +759,44 @@ def test_assistant_messages_in_history():
 def test_assistant_easy_input_message_optional_keys():
     """EasyInputMessageParam allows optional `type` and `phase` keys and an
     input-style content list on assistant messages; all variants should convert
-    like the bare {role, content} shape rather than crashing.
+    exactly like the equivalent bare {role, content} shape rather than crashing
+    or producing a divergent payload.
     """
-    items: list = [
-        {"role": "assistant", "content": "hello", "type": "message"},
-        {"role": "assistant", "content": "hello", "phase": "final_answer"},
-        {
-            "role": "assistant",
-            "content": "hello",
-            "type": "message",
-            "phase": "final_answer",
-        },
-        {
-            "role": "assistant",
-            "content": [{"type": "input_text", "text": "hello"}],
-            "type": "message",
-        },
+    contents: list = [
+        "hello",
+        "",  # empty content must be preserved, not dropped
+        [{"type": "input_text", "text": "hello"}],
+        [
+            {"type": "input_text", "text": "part one"},
+            {"type": "input_text", "text": "part two"},
+        ],
     ]
-    for item in items:
-        messages = Converter.items_to_messages([item])
-        assert messages == [{"role": "assistant", "content": "hello"}], item
+    optional_keys: list[dict] = [
+        {"type": "message"},
+        {"phase": "final_answer"},
+        {"type": "message", "phase": "final_answer"},
+    ]
+    for content in contents:
+        untyped = Converter.items_to_messages([{"role": "assistant", "content": content}])
+        for extra in optional_keys:
+            item = {"role": "assistant", "content": content, **extra}
+            assert Converter.items_to_messages([item]) == untyped, item
+    # Concrete shapes, for clarity:
+    assert Converter.items_to_messages(
+        [{"role": "assistant", "content": "hello", "type": "message"}]
+    ) == [{"role": "assistant", "content": "hello"}]
+    assert Converter.items_to_messages(
+        [{"role": "assistant", "content": "", "type": "message"}]
+    ) == [{"role": "assistant", "content": ""}]
+    assert Converter.items_to_messages(
+        [
+            {
+                "role": "assistant",
+                "content": [{"type": "input_text", "text": "hello"}],
+                "type": "message",
+            }
+        ]
+    ) == [{"role": "assistant", "content": [{"type": "text", "text": "hello"}]}]
 
 
 def test_easy_input_message_rejects_unknown_extra_keys():


### PR DESCRIPTION
### Summary

`Converter.items_to_messages` crashes on valid assistant `EasyInputMessage` items that carry the type's optional keys. Per the installed SDK, `EasyInputMessageParam` allows `role: "assistant"`, an optional `type: "message"`, and an optional `phase` — whose docstring says "when sending follow-up requests, preserve and resend phase on all assistant messages — dropping it can degrade performance". Anyone following that guidance with a Chat Completions/LiteLLM model hits this.

What happens today for each valid shape (`main` @ 65886fa1):

| item | result |
|---|---|
| `{"role": "assistant", "content": "hello", "type": "message"}` | `TypeError: string indices must be integers` |
| `{"role": "assistant", "content": [{"type": "input_text", ...}], "type": "message"}` | `UserError: Unknown content type in ResponseOutputMessage` |
| `{"role": "assistant", "content": "hello", "phase": "final_answer"}` | `UserError: Unhandled item type or structure` |
| `{"role": "assistant", "content": "hello"}` (control) | works |

Root cause is a two-step miss: `maybe_easy_input_message` requires the key set to be *exactly* `{content, role}`, so any optional key disqualifies; the item is then either claimed by the `ResponseOutputMessage` branch — which assumes a list of output parts — or falls through entirely. The Responses model path accepts these same items, so this also breaks Responses↔ChatCompletions parity.

### Fix

- `maybe_easy_input_message`: require `content`/`role`, tolerate the optional `phase` key, still reject unknown keys.
- Output-message branch: handle string content and `input_text` parts for explicitly-typed easy-input assistant messages.

`phase` is intentionally dropped from the constructed Chat Completions message (no equivalent field), and both paths build fresh dicts so no stray keys leak into the payload.

### Tests

Added regression tests covering all four crash variants (fail on `main`, pass with the fix) plus a guard that unknown extra keys are still rejected. `tests/models/`: 462 passed locally (litellm-dependent files skipped — dependency not installed locally); ruff check/format clean on touched files.

*Prepared with AI assistance; I reviewed the change and ran the repros and test suites locally.*
