### PR TITLE
docs: fix missing imports in context code example

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -128,6 +128,11 @@ Agents are generic on their `context` type. Context is a dependency-injection to
 Read the [context guide](context.md) for the full `RunContextWrapper` surface, shared usage tracking, nested `tool_input`, and serialization caveats.
 
 ```python
+from dataclasses import dataclass
+
+from agents import Agent
+
+
 @dataclass
 class UserContext:
     name: str


### PR DESCRIPTION
## What
The "Context" code block in docs/agents.md uses `@dataclass` and `Agent[UserContext]` without importing either.

## Why
Running the example as-written raises `NameError` / `ImportError` because `dataclass` is not imported and `Agent` is not imported from `agents`.

## Fix
Added `from dataclasses import dataclass` and `from agents import Agent` before the class definition.

## Verification
Confirmed `Agent` is exported from `agents` in `src/agents/__init__.py`.