### PR TITLE
docs: fix missing imports in dynamic instructions example

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -233,7 +233,6 @@ In most cases, you can provide instructions when you create the agent. However, 
 ```python
 from agents import Agent, RunContextWrapper
 
-
 def dynamic_instructions(
     context: RunContextWrapper[UserContext], agent: Agent[UserContext]
 ) -> str:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -231,6 +231,9 @@ triage_agent = Agent(
 In most cases, you can provide instructions when you create the agent. However, you can also provide dynamic instructions via a function. The function will receive the agent and context, and must return the prompt. Both regular and `async` functions are accepted.
 
 ```python
+from agents import Agent, RunContextWrapper
+
+
 def dynamic_instructions(
     context: RunContextWrapper[UserContext], agent: Agent[UserContext]
 ) -> str:


### PR DESCRIPTION
## What
The "Dynamic instructions" code block in docs/agents.md uses `RunContextWrapper[UserContext]` and `Agent[UserContext]` without importing anything from `agents`.

## Why
Running the example as-written raises `ImportError: name 'RunContextWrapper' is not defined`.

## Fix
Added `from agents import Agent, RunContextWrapper` before the function definition.

## Verification
Confirmed both `Agent` and `RunContextWrapper` are exported from `agents` in `src/agents/__init__.py`.