### PR TITLE
fix(visualization): escape multiline DOT names

### DIFF
--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -9,11 +9,17 @@ from agents.handoffs import Handoff
 def _escape_label(name: str) -> str:
     """Escape a name for use inside a Graphviz double-quoted ID or label.
 
-    Backslashes are escaped first, then double quotes, so a name containing
-    either character does not terminate the DOT string early or produce
-    malformed output.
+    Backslashes are escaped first, then double quotes and line breaks, so a name
+    containing any of these characters does not terminate the DOT string early
+    or produce malformed output.
     """
-    return name.replace("\\", "\\\\").replace('"', '\\"')
+    return (
+        name.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\r\n", "\\n")
+        .replace("\r", "\\n")
+        .replace("\n", "\\n")
+    )
 
 
 def get_main_graph(agent: Agent) -> str:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -207,6 +207,22 @@ def test_names_with_quotes_and_backslashes_are_escaped(mock_agent):
     assert '"__start__" -> "Weird\\"Name";' in edges
 
 
+def test_names_with_line_breaks_are_escaped(mock_agent):
+    """Line breaks in names must be encoded instead of splitting quoted DOT strings."""
+    mock_agent.name = "Agent\nName"
+    mock_agent.tools[0].name = "CRLF\r\nTool"
+    mock_agent.tools[1].name = "CR\rTool"
+
+    nodes = get_all_nodes(mock_agent)
+    edges = get_all_edges(mock_agent)
+
+    assert '"Agent\\nName" [label="Agent\\nName"' in nodes
+    assert '"CRLF\\nTool"' in nodes
+    assert '"CR\\nTool"' in nodes
+    assert '"__start__" -> "Agent\\nName";' in edges
+    assert '"Agent\nName"' not in nodes
+
+
 def test_draw_graph_with_real_agent_no_handoffs():
     """Test that draw_graph works with a real Agent object without handoffs.
 


### PR DESCRIPTION
This pull request fixes malformed Graphviz DOT output when agent, tool, MCP server, or handoff names contain physical line breaks.

### Summary

- Encode line breaks in visualization names using Graphviz's `\n` escape.
- Normalize LF, CRLF, and lone CR without changing ordinary names or literal backslash sequences.
- Add regression coverage for multiline node labels, identifiers, and edges.

### Test plan

- `uv run pytest -s tests/test_visualization.py -k line_breaks`
- `uv run pytest -s tests/test_visualization.py`
- `.agents/skills/code-change-verification/scripts/run.sh`
- `git diff --check upstream/main..HEAD`
- Codex `/review`

### Issue number

N/A — newly discovered unreported bug.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR