### PR TITLE
docs: fix conversation example imports

### DIFF
--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -303,7 +303,6 @@ You can manually manage conversation history using the [`RunResultBase.to_input_
 ```python
 from agents import Agent, Runner, trace
 
-
 async def main():
     agent = Agent(name="Assistant", instructions="Reply very concisely.")
 

--- a/docs/running_agents.md
+++ b/docs/running_agents.md
@@ -301,6 +301,9 @@ At the end of the agent run, you can choose what to show to the user. For exampl
 You can manually manage conversation history using the [`RunResultBase.to_input_list()`][agents.result.RunResultBase.to_input_list] method to get the inputs for the next turn:
 
 ```python
+from agents import Agent, Runner, trace
+
+
 async def main():
     agent = Agent(name="Assistant", instructions="Reply very concisely.")
 
@@ -323,7 +326,7 @@ async def main():
 For a simpler approach, you can use [Sessions](sessions/index.md) to automatically handle conversation history without manually calling `.to_input_list()`:
 
 ```python
-from agents import Agent, Runner, SQLiteSession
+from agents import Agent, Runner, SQLiteSession, trace
 
 async def main():
     agent = Agent(name="Assistant", instructions="Reply very concisely.")


### PR DESCRIPTION
## What

Add the missing SDK imports to both conversation-management examples in the running agents guide.

## Why

The manual example references `Agent`, `Runner`, and `trace` without importing them, while the session example imports the agent and session classes but still uses `trace` without importing it. Copying either snippet currently raises `NameError`.

## Test

- `uv run mkdocs build`
- `uv run python` import check for `Agent`, `Runner`, `SQLiteSession`, and `trace`
- `git diff --check`