### PR TITLE
fix: parse ls output with SELinux security-context marker

### DIFF
--- a/src/agents/sandbox/types.py
+++ b/src/agents/sandbox/types.py
@@ -56,7 +56,10 @@ class Permissions(BaseModel):
 
     @classmethod
     def from_str(cls, perms: str) -> "Permissions":
-        if len(perms) == 11 and perms[-1] in {"@", "+"}:
+        # coreutils/BSD ls append a single trailing marker to the mode field to flag
+        # alternate access methods: "+" (ACL), "@" (macOS extended attributes), and
+        # "." (SELinux security context). Strip it before parsing the 10 mode chars.
+        if len(perms) == 11 and perms[-1] in {"@", "+", "."}:
             perms = perms[:-1]
         if len(perms) != 10:
             raise ValueError(f"invalid permissions string length: {perms!r}")

--- a/tests/sandbox/test_parse_utils.py
+++ b/tests/sandbox/test_parse_utils.py
@@ -63,6 +63,28 @@ def test_parse_ls_la_accepts_special_permission_bits() -> None:
     assert not (entries[2].permissions.other & FileMode.EXEC)
 
 
+def test_parse_ls_la_strips_trailing_alternate_access_markers() -> None:
+    # coreutils/BSD ls append a single marker after the mode field: "." (SELinux
+    # security context), "+" (ACL), or "@" (macOS extended attributes).
+    output = (
+        "drwxr-xr-x. 2 root root 4096 Jan 1 00:00 selinux-dir\n"
+        "-rw-r--r--+ 1 root root  123 Jan 1 00:00 acl-file\n"
+        "-rw-r--r--@ 1 root root  456 Jan 1 00:00 xattr-file\n"
+    )
+
+    entries = parse_ls_la(output, base="/")
+
+    assert [entry.path for entry in entries] == [
+        "/selinux-dir",
+        "/acl-file",
+        "/xattr-file",
+    ]
+    assert entries[0].permissions.directory is True
+    assert entries[0].permissions.owner & FileMode.READ
+    assert entries[1].permissions.owner & FileMode.WRITE
+    assert entries[2].permissions.owner & FileMode.READ
+
+
 @pytest.mark.parametrize(
     "permissions",
     [


### PR DESCRIPTION
## Summary

`SandboxSession.ls()` crashes on SELinux-enabled hosts because the `ls -la` permission-string parser does not recognize the SELinux security-context marker (`.`) that GNU coreutils appends to the mode field.

## Problem

[`parse_ls_la`](https://github.com/openai/openai-agents-python/blob/main/src/agents/sandbox/util/parse_utils.py) takes the raw mode field (`parts[0]`) from `ls -la` output and passes it to `Permissions.from_str`. `from_str` strips a trailing 11th "alternate access method" marker, but only for `"+"` (ACL) and `"@"` (macOS extended attributes):

```python
if len(perms) == 11 and perms[-1] in {"@", "+"}:
    perms = perms[:-1]
```

On **SELinux-enabled systems** — RHEL, Fedora, CentOS, and the majority of Linux container base images — coreutils appends `"."` instead:

```
drwxr-xr-x. 2 root root 4096 Jan 1 00:00 somedir
```

That string is 11 chars but does not end in `+`/`@`, so it is **not** stripped, fails the `len(perms) != 10` guard, and raises:

```
ValueError: invalid permissions string length: 'drwxr-xr-x.'
```

The result is that `ls()` (and anything built on it) fails on any SELinux host, even though the permission bits are perfectly parseable.

## Solution

Add `"."` to the set of recognized trailing markers, so the SELinux context marker is stripped exactly like the existing `+`/`@` markers:

```python
if len(perms) == 11 and perms[-1] in {"@", "+", "."}:
    perms = perms[:-1]
```

One-line behavioral change, plus a clarifying comment. No public API change.

## Testing performed

- Added `test_parse_ls_la_strips_trailing_alternate_access_markers`, covering the `.` (SELinux), `+` (ACL), and `@` (xattr) markers together. Confirmed it **fails without the fix** (`ValueError: invalid permissions string length: 'drwxr-xr-x.'`) and passes with it.
- `uv run pytest tests/sandbox/test_parse_utils.py` — 11 passed.
- `uv run ruff format --check` and `uv run ruff check` — clean on both changed files.
- `uv run mypy` — no issues; `uv run pyright` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
