### PR TITLE
fix: preserve dot-prefixed skip paths in Modal tar workspace excludes

### DIFF
--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -1652,7 +1652,11 @@ class ModalSandboxSession(BaseSandboxSession):
 
         excludes: list[str] = []
         for rel in sorted(skip, key=lambda p: p.as_posix()):
-            excludes.extend(["--exclude", f"./{rel.as_posix().lstrip('./')}"])
+            # Strip a leading "./" prefix only. `lstrip("./")` strips a *set* of
+            # characters, which would eat leading dots of dot-prefixed skip paths
+            # (e.g. ".venv" -> "venv"), producing a wrong exclude pattern. Match the
+            # Cloudflare backend, which uses removeprefix here.
+            excludes.extend(["--exclude", f"./{rel.as_posix().removeprefix('./')}"])
 
         cmd: list[str] = [
             "tar",

--- a/tests/extensions/sandbox/test_modal.py
+++ b/tests/extensions/sandbox/test_modal.py
@@ -1553,6 +1553,53 @@ async def test_modal_tar_persist_respects_runtime_skip_paths(
 
 
 @pytest.mark.asyncio
+async def test_modal_tar_persist_preserves_dot_prefixed_skip_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        sandbox_id="sb-123",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+    # A dot-prefixed skip path must keep its leading dot in the exclude pattern.
+    session.register_persist_workspace_skip_path(Path(".venv"))
+
+    commands: list[list[str]] = []
+
+    async def _fake_exec(
+        *command: object,
+        timeout: float | None = None,
+        shell: bool | list[str] = True,
+        user: object | None = None,
+    ) -> ExecResult:
+        _ = (timeout, shell, user)
+        rendered = [str(part) for part in command]
+        commands.append(rendered)
+        return ExecResult(stdout=b"fake-tar-bytes", stderr=b"", exit_code=0)
+
+    monkeypatch.setattr(session, "exec", _fake_exec)
+
+    archive = await session.persist_workspace()
+
+    assert archive.read() == b"fake-tar-bytes"
+    assert commands == [
+        [
+            "tar",
+            "cf",
+            "-",
+            "--exclude",
+            "./.venv",
+            "-C",
+            "/workspace",
+            ".",
+        ]
+    ]
+
+
+@pytest.mark.asyncio
 async def test_modal_snapshot_failure_restores_ephemeral_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

The Modal sandbox backend builds `tar --exclude` patterns with `str.lstrip("./")`, which strips a *character set* rather than a `./` prefix. As a result, dot-prefixed skip paths (`.venv`, `.git`, `.env`, …) lose their leading dot and are **not** excluded from the persisted workspace tar.

## Problem

In `ModalSandboxSession._persist_workspace_via_tar`:

```python
for rel in sorted(skip, key=lambda p: p.as_posix()):
    excludes.extend(["--exclude", f"./{rel.as_posix().lstrip('./')}"])
```

`str.lstrip("./")` removes any leading run of the characters `.` and `/` — it is not a prefix strip. So for a top-level dot-prefixed skip path:

- `".venv".lstrip("./")` → `"venv"`
- `".git".lstrip("./")` → `"git"`

The emitted exclude becomes `--exclude ./venv`, and `tar cf - --exclude ./venv -C <root> .` does **not** match the real `./.venv` directory — so a skip-listed / ephemeral dot directory is wrongly **included** in the persisted workspace (and, symmetrically, an unrelated `./venv` would be wrongly excluded). Skip paths are commonly dot-prefixed (`.venv`, `.git`, `.env`) via `register_persist_workspace_skip_path` or ephemeral manifest entries, so this is a realistic scenario.

The parallel Cloudflare backend already does this correctly with `removeprefix("./")`, confirming the intended prefix-strip semantics.

## Solution

Use `removeprefix("./")` (a true prefix strip) instead of `lstrip("./")`, matching the Cloudflare backend:

```python
excludes.extend(["--exclude", f"./{rel.as_posix().removeprefix('./')}"])
```

Non-dot and nested paths are unaffected (`lstrip` only ever touched leading `.`/`/`), which is why the bug was subtle.

## Testing performed

- Added `test_modal_tar_persist_preserves_dot_prefixed_skip_paths`, registering a `.venv` skip path and asserting the emitted exclude is `./.venv`. Confirmed it **fails without the fix** (produces `./venv`) and passes with it.
- `uv run pytest tests/extensions/sandbox/test_modal.py` — the skip-path tests pass (existing `logs/events.jsonl` case still green).
- `uv run ruff format --check` and `uv run ruff check` — clean on both changed files.
- `uv run mypy` — no issues; `uv run pyright` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
