### PR TITLE
docs: add inspeximus to community session implementations

### DIFF
--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -687,6 +687,7 @@ The community has developed additional session implementations:
 | Package | Description |
 |---------|-------------|
 | [openai-django-sessions](https://pypi.org/project/openai-django-sessions/) | Django ORM-based sessions for any Django-supported database (PostgreSQL, MySQL, SQLite, and more) |
+| [inspeximus](https://pypi.org/project/inspeximus/) | File-backed sessions with no server and no dependencies; the same store can erase one user's turns and leave a signed tombstone in their place |
 
 If you've built a session implementation, please feel free to submit a documentation PR to add it here!
 


### PR DESCRIPTION
Adds one row to the community session implementations table, per the standing invitation at the end of that section.

[`inspeximus`](https://pypi.org/project/inspeximus/) (MIT, zero-dependency core) implements the `Session` protocol as `inspeximus.integrations.openai_agents.InspeximusSession`, backed by a JSON file — no server and no extra install beyond the package itself.

```python
from agents import Agent, Runner
from inspeximus.integrations.openai_agents import InspeximusSession

session = InspeximusSession("user-42", path="sessions.json")
Runner.run_sync(agent, "hi", session=session)
```

### Checked against `SQLiteSession`

Rather than assert "drop-in", I ran both implementations through the same scenarios and compared the observable results: round-trip ordering, `limit` returning the latest N oldest-first, `limit=0`, LIFO `pop_item` and `None` on empty, `clear_session` (including on an already-empty session), adding an empty list, and isolation between two session ids. 13 checks, no differences, on `openai-agents 0.18.3`. The audit runs in CI, and it has a falsification mode that swallows writes — if that mode still passed, the comparison would be proving nothing.

The one thing it adds beyond persistence: `session.forget_subject(request_id=...)` hard-deletes a user's turns across sessions and leaves a signed, content-free tombstone, so the erasure is provable and does not read as tampering.

To be straight about scope: a `Session` is a verbatim turn log, so the library's supersession features do not silently rewrite replayed messages. This row is about the session backend only.

### AI disclosure

This contribution was drafted with AI assistance. A human reviewed it, and the parity numbers above come from a run rather than from the README.
