### PR TITLE
fix(realtime): redact raw message payload from conversion-failure log

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -720,6 +720,8 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                     )
                 else:
                     await self._send_raw_message(converted)
+            elif _debug.DONT_LOG_MODEL_DATA:
+                logger.error("Failed to convert raw message type=%s", event.message.get("type"))
             else:
                 logger.error("Failed to convert raw message: %s", event)
         elif isinstance(event, RealtimeModelSendUserInput):

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -478,6 +478,31 @@ class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
         assert error_event.type == "error"
 
     @pytest.mark.asyncio
+    async def test_send_raw_message_conversion_failure_redacts_payload_from_logs(
+        self, model, monkeypatch
+    ):
+        """A raw client message that fails to convert must not leak its payload to the logs
+        when model-data logging is disabled."""
+        monkeypatch.setattr(
+            "agents.realtime.openai_realtime._debug.DONT_LOG_MODEL_DATA",
+            True,
+        )
+        raw = RealtimeModelSendRawMessage(
+            message={
+                "type": "invalid.event.type",
+                "other_data": {"transcript": "secret transcript"},
+            }
+        )
+
+        with patch("agents.realtime.openai_realtime.logger") as mock_logger:
+            await model.send_event(raw)
+
+        mock_logger.error.assert_called_once()
+        logged_call = str(mock_logger.error.call_args)
+        assert "secret transcript" not in logged_call
+        assert "invalid.event.type" in logged_call
+
+    @pytest.mark.asyncio
     async def test_custom_voice_response_events_update_response_sequencer(self, model, monkeypatch):
         """Dict-shaped custom voices should not block response.create sequencing."""
         payload_types: list[str] = []


### PR DESCRIPTION
### Summary

`send_event` logs the full raw client message at error level when a `RealtimeModelSendRawMessage` fails to convert. The sibling server-event log already honors `_debug.DONT_LOG_MODEL_DATA` (#3687); this gates the raw-message log the same way — keeping the non-sensitive message `type` for debugging while dropping the payload when model-data logging is disabled. Default behavior is unchanged.

### Test plan

Added `test_send_raw_message_conversion_failure_redacts_payload_from_logs`, mirroring the existing server-event redaction test. `make format`, `make lint`, `make typecheck`, and the realtime tests pass.

### Checks

- [x] I've added new tests, if relevant
- [x] I've confirmed all verification steps pass
