### PR TITLE
feat(run_state): add opt-in HMAC integrity for persisted RunState

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import copy
 import dataclasses
+import hashlib
+import hmac
 import json
 import threading
 from collections import deque
@@ -727,6 +729,7 @@ class RunState(Generic[TContext, TAgent]):
         context_serializer: ContextSerializer | None = None,
         strict_context: bool = False,
         include_tracing_api_key: bool = False,
+        signing_key: str | bytes | None = None,
     ) -> dict[str, Any]:
         """Serializes the run state to a JSON-compatible dictionary.
 
@@ -737,6 +740,9 @@ class RunState(Generic[TContext, TAgent]):
             context_serializer: Optional function to serialize non-mapping context values.
             strict_context: When True, require mapping contexts or a context_serializer.
             include_tracing_api_key: When True, include the tracing API key in the trace payload.
+            signing_key: When provided, add a ``$signature`` HMAC over the serialized state so
+                tampering can be detected on resume. Pass the same key to ``from_json`` /
+                ``from_string`` to verify it.
 
         Returns:
             A dictionary representation of the run state.
@@ -847,6 +853,8 @@ class RunState(Generic[TContext, TAgent]):
         if self._sandbox is not None:
             result["sandbox"] = copy.deepcopy(self._sandbox)
 
+        if signing_key is not None:
+            result[_RUN_STATE_SIGNATURE_FIELD] = _run_state_signature(result, signing_key)
         return result
 
     def _serialize_processed_response(
@@ -1046,11 +1054,14 @@ class RunState(Generic[TContext, TAgent]):
         context_serializer: ContextSerializer | None = None,
         strict_context: bool = False,
         include_tracing_api_key: bool = False,
+        signing_key: str | bytes | None = None,
     ) -> str:
         """Serializes the run state to a JSON string.
 
         Args:
             include_tracing_api_key: When True, include the tracing API key in the trace payload.
+            signing_key: When provided, sign the serialized state so tampering can be detected on
+                resume (see ``to_json``).
 
         Returns:
             JSON string representation of the run state.
@@ -1060,6 +1071,7 @@ class RunState(Generic[TContext, TAgent]):
                 context_serializer=context_serializer,
                 strict_context=strict_context,
                 include_tracing_api_key=include_tracing_api_key,
+                signing_key=signing_key,
             ),
             indent=2,
         )
@@ -1105,6 +1117,7 @@ class RunState(Generic[TContext, TAgent]):
         context_override: ContextOverride | None = None,
         context_deserializer: ContextDeserializer | None = None,
         strict_context: bool = False,
+        signing_key: str | bytes | None = None,
     ) -> RunState[Any, Agent[Any]]:
         """Deserializes a run state from a JSON string.
 
@@ -1118,12 +1131,15 @@ class RunState(Generic[TContext, TAgent]):
                 serialized context.
             context_deserializer: Optional function to rebuild non-mapping context values.
             strict_context: When True, require a deserializer or override for non-mapping contexts.
+            signing_key: When provided, verify the state's ``$signature`` before restoring and
+                raise ``UserError`` if it is missing or does not match (fails closed).
 
         Returns:
             A reconstructed RunState instance.
 
         Raises:
-            UserError: If the string is invalid JSON or has incompatible schema version.
+            UserError: If the string is invalid JSON, has an incompatible schema version, or fails
+                signature verification.
         """
         try:
             state_json = json.loads(state_string)
@@ -1136,6 +1152,7 @@ class RunState(Generic[TContext, TAgent]):
             context_override=context_override,
             context_deserializer=context_deserializer,
             strict_context=strict_context,
+            signing_key=signing_key,
         )
 
     @staticmethod
@@ -1146,6 +1163,7 @@ class RunState(Generic[TContext, TAgent]):
         context_override: ContextOverride | None = None,
         context_deserializer: ContextDeserializer | None = None,
         strict_context: bool = False,
+        signing_key: str | bytes | None = None,
     ) -> RunState[Any, Agent[Any]]:
         """Deserializes a run state from a JSON dictionary.
 
@@ -1159,13 +1177,21 @@ class RunState(Generic[TContext, TAgent]):
                 serialized context.
             context_deserializer: Optional function to rebuild non-mapping context values.
             strict_context: When True, require a deserializer or override for non-mapping contexts.
+            signing_key: When provided, verify the state's ``$signature`` before restoring and
+                raise ``UserError`` if it is missing or does not match (fails closed). This is the
+                integrity check that makes approvals and other persisted state safe to load from an
+                untrusted store.
 
         Returns:
             A reconstructed RunState instance.
 
         Raises:
-            UserError: If the dict has incompatible schema version.
+            UserError: If the dict has an incompatible schema version or fails signature
+                verification.
         """
+        if signing_key is not None:
+            _verify_run_state_signature(state_json, signing_key)
+
         return await _build_run_state_from_json(
             initial_agent=initial_agent,
             state_json=state_json,
@@ -2666,6 +2692,38 @@ def _deserialize_tool_output_guardrail_results(
         )
         deserialized.append(ToolOutputGuardrailResult(guardrail=guardrail, output=guardrail_output))
     return deserialized
+
+
+_RUN_STATE_SIGNATURE_FIELD = "$signature"
+
+
+def _run_state_signature(payload: Mapping[str, Any], signing_key: str | bytes) -> str:
+    """Return the HMAC-SHA256 of the canonical serialization of ``payload``.
+
+    The ``$signature`` field itself is excluded so signing and verification cover the same bytes.
+    """
+    key = signing_key.encode("utf-8") if isinstance(signing_key, str) else signing_key
+    body = {k: v for k, v in payload.items() if k != _RUN_STATE_SIGNATURE_FIELD}
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hmac.new(key, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _verify_run_state_signature(payload: Mapping[str, Any], signing_key: str | bytes) -> None:
+    """Verify a persisted RunState's ``$signature``, raising ``UserError`` on failure.
+
+    Fails closed: an unsigned payload is rejected when a signing key is supplied.
+    """
+    provided = payload.get(_RUN_STATE_SIGNATURE_FIELD)
+    if not isinstance(provided, str):
+        raise UserError(
+            "RunState signature is missing; refusing to load state that was not signed with the "
+            "provided signing_key."
+        )
+    if not hmac.compare_digest(provided, _run_state_signature(payload, signing_key)):
+        raise UserError(
+            "RunState signature verification failed; the persisted state may have been tampered "
+            "with."
+        )
 
 
 async def _build_run_state_from_json(

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -7174,3 +7174,67 @@ async def test_resume_rejected_function_approval_emits_output() -> None:
         for item in resumed.new_items
     )
     assert calls == []
+
+
+class TestRunStateSigning:
+    """Optional HMAC integrity for persisted RunState (opt-in via ``signing_key``)."""
+
+    _KEY = "test-signing-key"
+
+    def _signed_state(self) -> tuple[Agent[Any], dict[str, Any]]:
+        agent = Agent(name="Agent1")
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        state = make_state(agent, context=context, original_input="input1", max_turns=2)
+        return agent, state.to_json(signing_key=self._KEY)
+
+    def test_to_json_omits_signature_by_default(self):
+        agent = Agent(name="Agent1")
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        assert "$signature" not in make_state(agent, context=context).to_json()
+
+    def test_to_json_adds_signature_when_signed(self):
+        _agent, signed = self._signed_state()
+        assert isinstance(signed["$signature"], str) and signed["$signature"]
+
+    @pytest.mark.asyncio
+    async def test_signed_state_round_trips_with_matching_key(self):
+        agent, signed = self._signed_state()
+        restored = await RunState.from_json(agent, signed, signing_key=self._KEY)
+        assert restored._current_turn == 0
+
+    @pytest.mark.asyncio
+    async def test_signed_string_round_trips(self):
+        agent = Agent(name="Agent1")
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        signed_str = make_state(agent, context=context).to_string(signing_key=self._KEY)
+        restored = await RunState.from_string(agent, signed_str, signing_key=self._KEY)
+        assert restored._max_turns == 3
+
+    @pytest.mark.asyncio
+    async def test_tampered_state_is_rejected(self):
+        agent, signed = self._signed_state()
+        # Forge a blanket approval into the signed payload (the HITL approval-bypass scenario).
+        signed["context"]["approvals"] = {"run_shell": {"approved": True, "rejected": []}}
+        with pytest.raises(UserError, match="signature verification failed"):
+            await RunState.from_json(agent, signed, signing_key=self._KEY)
+
+    @pytest.mark.asyncio
+    async def test_wrong_key_is_rejected(self):
+        agent, signed = self._signed_state()
+        with pytest.raises(UserError, match="signature verification failed"):
+            await RunState.from_json(agent, signed, signing_key="different-key")
+
+    @pytest.mark.asyncio
+    async def test_unsigned_state_rejected_when_key_required(self):
+        agent = Agent(name="Agent1")
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        unsigned = make_state(agent, context=context).to_json()
+        with pytest.raises(UserError, match="signature is missing"):
+            await RunState.from_json(agent, unsigned, signing_key=self._KEY)
+
+    @pytest.mark.asyncio
+    async def test_signature_ignored_when_no_key_provided(self):
+        # Backward compatible: a signed blob still loads when no key is supplied.
+        agent, signed = self._signed_state()
+        restored = await RunState.from_json(agent, signed)
+        assert restored._current_turn == 0


### PR DESCRIPTION
### Summary

`RunState` is a documented persist/resume boundary — the HITL example serializes paused state with `to_json()` and resumes it later with `from_json()` — but `from_json` restores the serialized blob verbatim with no authenticity check. This adds an **opt-in** integrity option:

- `to_json(…, signing_key=…)` / `to_string(…, signing_key=…)` append a top-level `$signature` = HMAC-SHA256 over the canonical serialization of the state.
- `from_json(…, signing_key=…)` / `from_string(…, signing_key=…)` verify it and raise `UserError` on mismatch or absence (fails closed).

Fully backward compatible: without a `signing_key`, behavior is unchanged; `$signature` is an additive envelope field that older readers ignore, so no `$schemaVersion` bump is required.

### Test plan

Added `TestRunStateSigning`: signed round-trip (dict + string), tamper rejection (forged approval), wrong-key rejection, unsigned-rejected-when-key-required, and signature-ignored-without-key (back-compat). `make format`, `make lint`, `make typecheck`, and the full `tests/test_run_state.py` suite (246 tests) pass.

### Checks

- [x] I've added new tests, if relevant
- [x] I've confirmed all verification steps pass
