### PR TITLE
fix(logging): stop leaking raw exceptions in model + tool error logs

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -511,7 +511,14 @@ class OpenAIResponsesModel(Model):
                     )
                 )
                 request_id = getattr(e, "request_id", None)
-                logger.error("Error getting response: %s. (request_id: %s)", e, request_id)
+                if _debug.DONT_LOG_MODEL_DATA:
+                    logger.error(
+                        "Error getting response: %s. (request_id: %s)",
+                        e.__class__.__name__,
+                        request_id,
+                    )
+                else:
+                    logger.error("Error getting response: %s. (request_id: %s)", e, request_id)
                 raise
 
         return ModelResponse(
@@ -621,7 +628,10 @@ class OpenAIResponsesModel(Model):
                         },
                     )
                 )
-                logger.error("Error streaming response: %s", e)
+                if _debug.DONT_LOG_MODEL_DATA:
+                    logger.error("Error streaming response: %s", e.__class__.__name__)
+                else:
+                    logger.error("Error streaming response: %s", e)
                 raise
 
     @overload

--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -48,6 +48,7 @@ from .tool_execution import (
     extract_apply_patch_call_id,
     format_shell_error,
     get_trace_tool_error,
+    log_tool_action_error,
     normalize_apply_patch_result,
     normalize_max_output_length,
     normalize_shell_output,
@@ -152,7 +153,7 @@ class ComputerAction:
                             },
                         )
                     )
-                logger.error("Failed to execute computer action: %s", exc, exc_info=True)
+                log_tool_action_error("Failed to execute computer action", exc)
                 raise
 
             image_url = f"data:image/png;base64,{output}" if output else ""
@@ -557,7 +558,7 @@ class ShellAction:
                 if requested_max_output_length is not None:
                     max_output_length = requested_max_output_length
                     output_text = output_text[:max_output_length]
-                logger.error("Shell executor failed: %s", exc, exc_info=True)
+                log_tool_action_error("Shell executor failed", exc)
 
             await asyncio.gather(
                 hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text),
@@ -713,7 +714,7 @@ class CustomToolAction:
                             },
                         )
                     )
-                logger.error("Custom tool failed: %s", exc, exc_info=True)
+                log_tool_action_error("Custom tool failed", exc)
 
             raw_item = cls._raw_tool_output_item(
                 call_id,
@@ -920,7 +921,7 @@ class ApplyPatchAction:
                             },
                         )
                     )
-                logger.error("Apply patch editor failed: %s", exc, exc_info=True)
+                log_tool_action_error("Apply patch editor failed", exc)
 
             raw_item: dict[str, Any] = {
                 "type": "apply_patch_call_output",

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -21,6 +21,7 @@ from openai.types.responses.response_input_item_param import (
 from openai.types.responses.response_input_param import McpApprovalResponse
 from openai.types.responses.response_output_item import McpApprovalRequest
 
+from .. import _debug
 from .._tool_identity import (
     FunctionToolLookupKey,
     NamedToolLookupKey,
@@ -1037,6 +1038,19 @@ def format_shell_error(error: Exception | BaseException | Any) -> str:
         return str(error)
     except Exception:  # pragma: no cover - fallback only
         return repr(error)
+
+
+def log_tool_action_error(message: str, exc: Exception | BaseException) -> None:
+    """Log a tool-action failure without leaking tool data.
+
+    Tool exceptions can embed tool call arguments or output, so the exception is
+    redacted by default (matching ``_debug.DONT_LOG_TOOL_DATA``). The full exception
+    and traceback are logged only when tool-data logging is explicitly enabled.
+    """
+    if _debug.DONT_LOG_TOOL_DATA:
+        logger.error("%s: %s", message, exc.__class__.__name__)
+    else:
+        logger.error("%s: %s", message, exc, exc_info=True)
 
 
 async def with_tool_function_span(

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -1,0 +1,142 @@
+"""Error-path logging must not leak model/tool payloads when data logging is disabled.
+
+The exception attached to a ``SpanError`` is already redacted based on the tracing
+flag, but the sibling ``logger.error`` calls used to log the raw exception (and, for
+tool actions, the full traceback) unconditionally. These tests lock in that those log
+statements honor ``_debug.DONT_LOG_MODEL_DATA`` / ``_debug.DONT_LOG_TOOL_DATA``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from openai import AsyncOpenAI
+
+import agents._debug as _debug
+from agents import ModelSettings, ModelTracing, OpenAIResponsesModel, trace
+from agents.run_internal.tool_execution import log_tool_action_error
+
+_SECRET = "super secret prompt content"
+
+
+def _responses_model() -> OpenAIResponsesModel:
+    return OpenAIResponsesModel(model="test-model", openai_client=AsyncOpenAI(api_key="test"))
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_error_redacts_exception_from_logs(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    model = _responses_model()
+
+    async def raise_fetch(*args, **kwargs):
+        raise ValueError(_SECRET)
+
+    monkeypatch.setattr(model, "_fetch_response", raise_fetch)
+
+    with patch("agents.models.openai_responses.logger") as mock_logger:
+        with trace(workflow_name="test"):
+            with pytest.raises(ValueError):
+                await model.get_response(
+                    "instr",
+                    "input",
+                    ModelSettings(),
+                    [],
+                    None,
+                    [],
+                    ModelTracing.ENABLED,
+                    previous_response_id=None,
+                )
+
+    mock_logger.error.assert_called_once()
+    logged = str(mock_logger.error.call_args)
+    assert _SECRET not in logged
+    assert "ValueError" in logged
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_error_logs_exception_when_model_data_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
+    model = _responses_model()
+
+    async def raise_fetch(*args, **kwargs):
+        raise ValueError(_SECRET)
+
+    monkeypatch.setattr(model, "_fetch_response", raise_fetch)
+
+    with patch("agents.models.openai_responses.logger") as mock_logger:
+        with trace(workflow_name="test"):
+            with pytest.raises(ValueError):
+                await model.get_response(
+                    "instr",
+                    "input",
+                    ModelSettings(),
+                    [],
+                    None,
+                    [],
+                    ModelTracing.ENABLED,
+                    previous_response_id=None,
+                )
+
+    mock_logger.error.assert_called_once()
+    assert _SECRET in str(mock_logger.error.call_args)
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_error_redacts_exception_from_logs(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    model = _responses_model()
+
+    async def raise_fetch(*args, **kwargs):
+        raise ValueError(_SECRET)
+
+    monkeypatch.setattr(model, "_fetch_response", raise_fetch)
+
+    with patch("agents.models.openai_responses.logger") as mock_logger:
+        with trace(workflow_name="test"):
+            with pytest.raises(ValueError):
+                async for _ in model.stream_response(
+                    "instr",
+                    "input",
+                    ModelSettings(),
+                    [],
+                    None,
+                    [],
+                    ModelTracing.ENABLED,
+                    previous_response_id=None,
+                ):
+                    pass
+
+    mock_logger.error.assert_called_once()
+    logged = str(mock_logger.error.call_args)
+    assert _SECRET not in logged
+    assert "ValueError" in logged
+
+
+def test_log_tool_action_error_redacts_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", True)
+
+    with patch("agents.run_internal.tool_execution.logger") as mock_logger:
+        log_tool_action_error("Shell executor failed", ValueError("rm -rf /secret/path"))
+
+    mock_logger.error.assert_called_once()
+    logged = str(mock_logger.error.call_args)
+    assert "/secret/path" not in logged
+    assert "ValueError" in logged
+    # No traceback either, since it can embed the same sensitive data.
+    assert mock_logger.error.call_args.kwargs.get("exc_info") in (None, False)
+
+
+def test_log_tool_action_error_logs_full_when_tool_data_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    with patch("agents.run_internal.tool_execution.logger") as mock_logger:
+        log_tool_action_error("Shell executor failed", ValueError("rm -rf /secret/path"))
+
+    mock_logger.error.assert_called_once()
+    logged = str(mock_logger.error.call_args)
+    assert "/secret/path" in logged
+    assert mock_logger.error.call_args.kwargs.get("exc_info") is True


### PR DESCRIPTION
### Summary

- error-path logs dumped the raw exception (and the full traceback on the tool path) unconditionally, bypassing the redaction the adjacent `SpanError` already applies.
- `openai_responses.py` (get_response + stream_response): log the exception class instead of the full exception when `DONT_LOG_MODEL_DATA` is set (the default). the openai error body often echoes the request back on 400s.
- 4 tool executors (computer, shell, custom tool, apply_patch): now go through a new `log_tool_action_error` helper that redacts by default and drops `exc_info=True`. this path is redact-by-default (`DONT_LOG_TOOL_DATA=True`), so it leaked tool args/output even on a stock install.
- full detail is still logged when model/tool data logging is explicitly enabled.
- same class of fix as #3907.

### Test plan

- new `tests/test_error_logging_redaction.py`, 5 tests: both model paths (redacted by default, full when enabled) and the tool helper (both branches, plus asserts no traceback when redacted).
- `make format` and `make lint`: clean.
- `make tests`: 5159 passed. the 12 failed / 15 errors are pre-existing optional-dep gaps (litellm, sqlalchemy, voice, runloop) and are identical with these changes stashed.
- `make typecheck`: no new errors (31 pre-existing errors live in the sandbox extensions, unrelated to this change).

### Issue number

<!-- add if there is a tracking issue -->

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
