### PR TITLE
fix: pin and verify rclone sandbox installs

### DIFF
--- a/.github/scripts/update_rclone_pin.py
+++ b/.github/scripts/update_rclone_pin.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -101,6 +102,47 @@ def _release_published_at(release: dict[str, object]) -> datetime:
     return published_at.astimezone(timezone.utc)
 
 
+def _asset_observed_at(release: dict[str, object], asset_name: str) -> datetime:
+    asset = _asset(release, asset_name)
+    timestamps: list[datetime] = []
+    for field in ("created_at", "updated_at"):
+        value = asset.get(field)
+        if not isinstance(value, str):
+            raise RuntimeError(f"rclone release asset {asset_name} is missing {field}")
+        try:
+            timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise RuntimeError(
+                f"rclone release asset {asset_name} has invalid {field}: {value}"
+            ) from exc
+        if timestamp.tzinfo is None:
+            raise RuntimeError(
+                f"rclone release asset {asset_name} {field} has no timezone: {value}"
+            )
+        timestamps.append(timestamp.astimezone(timezone.utc))
+    return max(timestamps)
+
+
+def _required_asset_names(version: str) -> tuple[str, ...]:
+    archives = tuple(f"rclone-v{version}-linux-{arch}.zip" for arch in _RCLONE_ARCHES)
+    return ("SHA256SUMS", *archives)
+
+
+def _validate_cooldown(
+    subject: str,
+    observed_at: datetime,
+    *,
+    cooldown_days: int,
+    now: datetime,
+) -> None:
+    eligible_at = observed_at + timedelta(days=cooldown_days)
+    if eligible_at > now:
+        raise RuntimeError(
+            f"{subject} is still in its {cooldown_days}-day cooldown "
+            f"(eligible at {eligible_at.isoformat()})"
+        )
+
+
 def _validate_stable_release(
     release: dict[str, object],
     *,
@@ -110,12 +152,18 @@ def _validate_stable_release(
     version = _release_version(release)
     if release.get("draft") is not False or release.get("prerelease") is not False:
         raise RuntimeError(f"rclone v{version} is not a stable published release")
-    published_at = _release_published_at(release)
-    eligible_at = published_at + timedelta(days=cooldown_days)
-    if eligible_at > now:
-        raise RuntimeError(
-            f"rclone v{version} is still in its {cooldown_days}-day cooldown "
-            f"(eligible at {eligible_at.isoformat()})"
+    _validate_cooldown(
+        f"rclone v{version}",
+        _release_published_at(release),
+        cooldown_days=cooldown_days,
+        now=now,
+    )
+    for asset_name in _required_asset_names(version):
+        _validate_cooldown(
+            f"rclone v{version} asset {asset_name}",
+            _asset_observed_at(release, asset_name),
+            cooldown_days=cooldown_days,
+            now=now,
         )
 
 
@@ -161,6 +209,19 @@ def _asset_sha256(release: dict[str, object], asset_name: str) -> str:
     if not isinstance(digest, str) or re.fullmatch(r"sha256:[0-9a-fA-F]{64}", digest) is None:
         raise RuntimeError(f"rclone release asset {asset_name} is missing its SHA256 digest")
     return digest.removeprefix("sha256:").lower()
+
+
+def _validate_download_sha256(
+    release: dict[str, object],
+    asset_name: str,
+    content: bytes,
+) -> None:
+    expected = _asset_sha256(release, asset_name)
+    actual = hashlib.sha256(content).hexdigest()
+    if actual != expected:
+        raise RuntimeError(
+            f"downloaded rclone release asset {asset_name} does not match GitHub's digest"
+        )
 
 
 def _parse_sha256s(text: str, version: str) -> dict[str, str]:
@@ -230,7 +291,9 @@ def fetch_pin(
             f"requested rclone v{_normalized_version(version)}, got v{resolved_version}"
         )
     checksums_url = _asset_url(release, "SHA256SUMS")
-    checksums = _fetch_bytes(checksums_url).decode("utf-8")
+    checksums_content = _fetch_bytes(checksums_url)
+    _validate_download_sha256(release, "SHA256SUMS", checksums_content)
+    checksums = checksums_content.decode("utf-8")
     sha256_by_arch = _parse_sha256s(checksums, resolved_version)
     _validate_asset_sha256s(release, resolved_version, sha256_by_arch)
     return RclonePin(

--- a/.github/scripts/update_rclone_pin.py
+++ b/.github/scripts/update_rclone_pin.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import cast
+from urllib import error, parse, request
+
+_RCLONE_RELEASES_API = "https://api.github.com/repos/rclone/rclone/releases"
+_DEFAULT_COOLDOWN_DAYS = 7
+_RUNTIME_PIN_PATH = Path("src/agents/extensions/sandbox/_rclone.py")
+_DOCKER_PIN_PATH = Path("examples/sandbox/docker/Dockerfile.mount")
+_PYTHON_PIN_BEGIN = "# BEGIN RCLONE RELEASE PIN"
+_PYTHON_PIN_END = "# END RCLONE RELEASE PIN"
+_DOCKER_PIN_BEGIN = "# BEGIN RCLONE RELEASE PIN"
+_DOCKER_PIN_END = "# END RCLONE RELEASE PIN"
+_RCLONE_ARCHES = ("386", "amd64", "arm", "arm-v6", "arm-v7", "arm64")
+_DOCKER_ARCHES = ("amd64", "arm64")
+_SHA256_LINE = re.compile(r"^([0-9a-fA-F]{64})\s+\*?(\S+)$")
+
+
+@dataclass(frozen=True)
+class RclonePin:
+    version: str
+    sha256_by_arch: dict[str, str]
+
+
+def _headers(url: str) -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "openai-agents-python-rclone-pin-updater",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token and parse.urlparse(url).hostname == "api.github.com":
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_bytes(url: str) -> bytes:
+    req = request.Request(url, headers=_headers(url))
+    try:
+        with request.urlopen(req, timeout=30) as response:
+            return response.read()
+    except error.HTTPError as exc:
+        raise RuntimeError(f"failed to fetch {url}: HTTP {exc.code}") from exc
+    except error.URLError as exc:
+        raise RuntimeError(f"failed to fetch {url}: {exc.reason}") from exc
+
+
+def _fetch_json_object(url: str) -> dict[str, object]:
+    payload = json.loads(_fetch_bytes(url))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"expected a JSON object from {url}")
+    return cast(dict[str, object], payload)
+
+
+def _fetch_json_array(url: str) -> list[dict[str, object]]:
+    payload = json.loads(_fetch_bytes(url))
+    if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+        raise RuntimeError(f"expected a JSON array of objects from {url}")
+    return cast(list[dict[str, object]], payload)
+
+
+def _normalized_version(value: str) -> str:
+    version = value.removeprefix("v")
+    if re.fullmatch(r"\d+\.\d+\.\d+", version) is None:
+        raise ValueError(f"invalid rclone version: {value}")
+    return version
+
+
+def _release_url(version: str | None) -> str:
+    if version is None:
+        return f"{_RCLONE_RELEASES_API}?per_page=100"
+    tag = parse.quote(f"v{_normalized_version(version)}", safe="")
+    return f"{_RCLONE_RELEASES_API}/tags/{tag}"
+
+
+def _release_version(release: dict[str, object]) -> str:
+    tag_name = release.get("tag_name")
+    if not isinstance(tag_name, str):
+        raise RuntimeError("rclone release metadata is missing tag_name")
+    return _normalized_version(tag_name)
+
+
+def _release_published_at(release: dict[str, object]) -> datetime:
+    value = release.get("published_at")
+    if not isinstance(value, str):
+        raise RuntimeError("rclone release metadata is missing published_at")
+    try:
+        published_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RuntimeError(f"rclone release has invalid published_at: {value}") from exc
+    if published_at.tzinfo is None:
+        raise RuntimeError(f"rclone release published_at has no timezone: {value}")
+    return published_at.astimezone(timezone.utc)
+
+
+def _validate_stable_release(
+    release: dict[str, object],
+    *,
+    cooldown_days: int,
+    now: datetime,
+) -> None:
+    version = _release_version(release)
+    if release.get("draft") is not False or release.get("prerelease") is not False:
+        raise RuntimeError(f"rclone v{version} is not a stable published release")
+    published_at = _release_published_at(release)
+    eligible_at = published_at + timedelta(days=cooldown_days)
+    if eligible_at > now:
+        raise RuntimeError(
+            f"rclone v{version} is still in its {cooldown_days}-day cooldown "
+            f"(eligible at {eligible_at.isoformat()})"
+        )
+
+
+def _latest_stable_release(
+    releases: list[dict[str, object]],
+    *,
+    cooldown_days: int,
+    now: datetime,
+) -> dict[str, object]:
+    eligible: list[tuple[datetime, dict[str, object]]] = []
+    for release in releases:
+        try:
+            _validate_stable_release(release, cooldown_days=cooldown_days, now=now)
+        except (RuntimeError, ValueError):
+            continue
+        eligible.append((_release_published_at(release), release))
+    if not eligible:
+        raise RuntimeError(
+            f"no stable rclone release has completed the {cooldown_days}-day cooldown"
+        )
+    return max(eligible, key=lambda item: item[0])[1]
+
+
+def _asset(release: dict[str, object], asset_name: str) -> dict[str, object]:
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        raise RuntimeError("rclone release metadata is missing assets")
+    for asset in assets:
+        if isinstance(asset, dict) and asset.get("name") == asset_name:
+            return cast(dict[str, object], asset)
+    raise RuntimeError(f"rclone release is missing {asset_name}")
+
+
+def _asset_url(release: dict[str, object], asset_name: str) -> str:
+    url = _asset(release, asset_name).get("browser_download_url")
+    if not isinstance(url, str):
+        raise RuntimeError(f"rclone release asset {asset_name} is missing its download URL")
+    return url
+
+
+def _asset_sha256(release: dict[str, object], asset_name: str) -> str:
+    digest = _asset(release, asset_name).get("digest")
+    if not isinstance(digest, str) or re.fullmatch(r"sha256:[0-9a-fA-F]{64}", digest) is None:
+        raise RuntimeError(f"rclone release asset {asset_name} is missing its SHA256 digest")
+    return digest.removeprefix("sha256:").lower()
+
+
+def _parse_sha256s(text: str, version: str) -> dict[str, str]:
+    filenames = {f"rclone-v{version}-linux-{arch}.zip": arch for arch in _RCLONE_ARCHES}
+    sha256_by_arch: dict[str, str] = {}
+    for line in text.splitlines():
+        match = _SHA256_LINE.fullmatch(line.strip())
+        if match is None:
+            continue
+        digest, filename = match.groups()
+        arch = filenames.get(filename)
+        if arch is not None:
+            sha256_by_arch[arch] = digest.lower()
+
+    missing = [arch for arch in _RCLONE_ARCHES if arch not in sha256_by_arch]
+    if missing:
+        raise RuntimeError(
+            f"rclone v{version} SHA256SUMS is missing Linux archives for: {', '.join(missing)}"
+        )
+    return sha256_by_arch
+
+
+def _validate_asset_sha256s(
+    release: dict[str, object],
+    version: str,
+    sha256_by_arch: dict[str, str],
+) -> None:
+    for arch in _RCLONE_ARCHES:
+        asset_name = f"rclone-v{version}-linux-{arch}.zip"
+        asset_sha256 = _asset_sha256(release, asset_name)
+        if asset_sha256 != sha256_by_arch[arch]:
+            raise RuntimeError(
+                f"rclone v{version} SHA256SUMS does not match GitHub's digest for {asset_name}"
+            )
+
+
+def fetch_pin(
+    version: str | None = None,
+    *,
+    cooldown_days: int = _DEFAULT_COOLDOWN_DAYS,
+    now: datetime | None = None,
+) -> RclonePin:
+    if cooldown_days < 0:
+        raise ValueError("cooldown days must be zero or greater")
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None:
+        raise ValueError("current time must include a timezone")
+    current_time = current_time.astimezone(timezone.utc)
+
+    if version is None:
+        releases = _fetch_json_array(_release_url(None))
+        release = _latest_stable_release(
+            releases,
+            cooldown_days=cooldown_days,
+            now=current_time,
+        )
+    else:
+        release = _fetch_json_object(_release_url(version))
+        _validate_stable_release(
+            release,
+            cooldown_days=cooldown_days,
+            now=current_time,
+        )
+    resolved_version = _release_version(release)
+    if version is not None and resolved_version != _normalized_version(version):
+        raise RuntimeError(
+            f"requested rclone v{_normalized_version(version)}, got v{resolved_version}"
+        )
+    checksums_url = _asset_url(release, "SHA256SUMS")
+    checksums = _fetch_bytes(checksums_url).decode("utf-8")
+    sha256_by_arch = _parse_sha256s(checksums, resolved_version)
+    _validate_asset_sha256s(release, resolved_version, sha256_by_arch)
+    return RclonePin(
+        version=resolved_version,
+        sha256_by_arch=sha256_by_arch,
+    )
+
+
+def _python_pin_block(pin: RclonePin) -> str:
+    lines = [
+        _PYTHON_PIN_BEGIN,
+        f'_RCLONE_VERSION = "{pin.version}"',
+        "_RCLONE_SHA256_BY_ARCH = {",
+    ]
+    for arch in _RCLONE_ARCHES:
+        lines.append(f'    "{arch}": "{pin.sha256_by_arch[arch]}",')
+    lines.extend(["}", _PYTHON_PIN_END])
+    return "\n".join(lines)
+
+
+def _docker_pin_block(pin: RclonePin) -> str:
+    lines = [_DOCKER_PIN_BEGIN, f"ARG RCLONE_VERSION={pin.version}"]
+    for arch in _DOCKER_ARCHES:
+        variable_arch = arch.upper().replace("-", "_")
+        lines.append(f"ARG RCLONE_SHA256_LINUX_{variable_arch}={pin.sha256_by_arch[arch]}")
+    lines.append(_DOCKER_PIN_END)
+    return "\n".join(lines)
+
+
+def _replace_marked_block(text: str, begin: str, end: str, replacement: str) -> str:
+    if text.count(begin) != 1 or text.count(end) != 1:
+        raise RuntimeError(f"expected exactly one pin block delimited by {begin!r} and {end!r}")
+    start = text.index(begin)
+    finish = text.index(end, start) + len(end)
+    return f"{text[:start]}{replacement}{text[finish:]}"
+
+
+def apply_pin(repo_root: Path, pin: RclonePin, *, check: bool) -> list[Path]:
+    updates = (
+        (
+            repo_root / _RUNTIME_PIN_PATH,
+            _PYTHON_PIN_BEGIN,
+            _PYTHON_PIN_END,
+            _python_pin_block(pin),
+        ),
+        (
+            repo_root / _DOCKER_PIN_PATH,
+            _DOCKER_PIN_BEGIN,
+            _DOCKER_PIN_END,
+            _docker_pin_block(pin),
+        ),
+    )
+    changed: list[Path] = []
+    for path, begin, end, replacement in updates:
+        current = path.read_text()
+        updated = _replace_marked_block(current, begin, end, replacement)
+        if updated == current:
+            continue
+        changed.append(path)
+        if not check:
+            path.write_text(updated)
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update the verified rclone release pinned by sandbox installers."
+    )
+    parser.add_argument(
+        "--version",
+        help="rclone version to pin, with or without a leading v (default: latest stable)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report stale pin blocks without modifying files",
+    )
+    parser.add_argument(
+        "--cooldown-days",
+        type=int,
+        default=_DEFAULT_COOLDOWN_DAYS,
+        help=(
+            "minimum age of a stable release before it is eligible "
+            f"(default: {_DEFAULT_COOLDOWN_DAYS})"
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args()
+
+    try:
+        pin = fetch_pin(args.version, cooldown_days=args.cooldown_days)
+        changed = apply_pin(args.repo_root.resolve(), pin, check=args.check)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if not changed:
+        print(f"rclone v{pin.version} pin is current")
+        return 0
+
+    relative_paths = [str(path.relative_to(args.repo_root.resolve())) for path in changed]
+    if args.check:
+        print(
+            f"::error title=Stale rclone pin::rclone v{pin.version} differs in "
+            f"{', '.join(relative_paths)}",
+            file=sys.stderr,
+        )
+        print(
+            f"Run: python .github/scripts/update_rclone_pin.py --version {pin.version}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"updated rclone v{pin.version} pin in {', '.join(relative_paths)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 sync:
 	uv sync --all-extras --all-packages --group dev
 
+.PHONY: update-rclone-pin
+update-rclone-pin:
+	uv run python .github/scripts/update_rclone_pin.py --cooldown-days $(or $(RCLONE_COOLDOWN_DAYS),7) $(if $(RCLONE_VERSION),--version $(RCLONE_VERSION))
+
 .PHONY: format
 format: 
 	uv run ruff format

--- a/examples/sandbox/docker/Dockerfile.mount
+++ b/examples/sandbox/docker/Dockerfile.mount
@@ -1,4 +1,11 @@
 FROM ubuntu:22.04
+
+# BEGIN RCLONE RELEASE PIN
+ARG RCLONE_VERSION=1.74.4
+ARG RCLONE_SHA256_LINUX_AMD64=fe435e0c36228e7c2f116a8701f01127bb1f694005fc11d1f27186c8bca4115d
+ARG RCLONE_SHA256_LINUX_ARM64=97685285c9ad6a0cf17d5844115d2a67245af6444db672187074bd9c358de419
+# END RCLONE RELEASE PIN
+
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -38,8 +45,20 @@ RUN set -eux \
     && mount-s3 --version \
     && curl -fsSL https://amazon-efs-utils.aws.com/efs-utils-installer.sh | sh -s -- --install \
     && mount.s3files --version \
-    && curl -fsSL https://rclone.org/install.sh | bash \
+    && arch="$(dpkg --print-architecture)" \
+    && case "$arch" in \
+        amd64) rclone_arch="amd64"; rclone_sha256="$RCLONE_SHA256_LINUX_AMD64" ;; \
+        arm64) rclone_arch="arm64"; rclone_sha256="$RCLONE_SHA256_LINUX_ARM64" ;; \
+        *) echo "unsupported rclone arch: $arch" >&2; exit 1 ;; \
+    esac \
+    && rclone_archive="rclone-v${RCLONE_VERSION}-linux-${rclone_arch}.zip" \
+    && rclone_url="https://downloads.rclone.org/v${RCLONE_VERSION}/${rclone_archive}" \
+    && curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+        --output "/tmp/${rclone_archive}" "$rclone_url" \
+    && printf '%s  %s\n' "$rclone_sha256" "/tmp/${rclone_archive}" | sha256sum --check --strict - \
+    && unzip -q "/tmp/${rclone_archive}" -d /tmp/rclone \
+    && install -m 0755 "/tmp/rclone/${rclone_archive%.zip}/rclone" /usr/local/bin/rclone \
     && rclone version \
     && touch /etc/fuse.conf \
     && grep -qxF 'user_allow_other' /etc/fuse.conf || echo 'user_allow_other' >> /etc/fuse.conf \
-    && rm -rf /var/lib/apt/lists/* /tmp/mount-s3.deb
+    && rm -rf /var/lib/apt/lists/* /tmp/mount-s3.deb /tmp/rclone /tmp/rclone-v*.zip

--- a/examples/sandbox/docker/Dockerfile.mount
+++ b/examples/sandbox/docker/Dockerfile.mount
@@ -60,5 +60,5 @@ RUN set -eux \
     && install -m 0755 "/tmp/rclone/${rclone_archive%.zip}/rclone" /usr/local/bin/rclone \
     && rclone version \
     && touch /etc/fuse.conf \
-    && grep -qxF 'user_allow_other' /etc/fuse.conf || echo 'user_allow_other' >> /etc/fuse.conf \
+    && (grep -qxF 'user_allow_other' /etc/fuse.conf || echo 'user_allow_other' >> /etc/fuse.conf) \
     && rm -rf /var/lib/apt/lists/* /tmp/mount-s3.deb /tmp/rclone /tmp/rclone-v*.zip

--- a/src/agents/extensions/sandbox/_rclone.py
+++ b/src/agents/extensions/sandbox/_rclone.py
@@ -6,11 +6,84 @@ from ...sandbox.session.base_sandbox_session import BaseSandboxSession
 
 _APT = "DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes apt-get -o Dpkg::Use-Pty=0"
 _RCLONE_CHECK = "command -v rclone >/dev/null 2>&1 || test -x /usr/local/bin/rclone"
-_INSTALL_RCLONE_COMMANDS = (
+_RCLONE_CHECKSUM_MISMATCH_EXIT = 86
+
+# BEGIN RCLONE RELEASE PIN
+_RCLONE_VERSION = "1.74.4"
+_RCLONE_SHA256_BY_ARCH = {
+    "386": "7feee086d7ff72652c5a91ef4b4a576941ccd33b2929772a2d70471904e516f0",
+    "amd64": "fe435e0c36228e7c2f116a8701f01127bb1f694005fc11d1f27186c8bca4115d",
+    "arm": "8135524b9b85111fa512f10a3fa191736a8d4d6ac3b3169af0763503744e95c9",
+    "arm-v6": "c9e1048feb597938884c0fff314d5d9a002599933cb94ce17fee19599cbfa3f1",
+    "arm-v7": "75844809d25d2534da96220727e7746a300e30ec8c676ca98c47affe5a752e7b",
+    "arm64": "97685285c9ad6a0cf17d5844115d2a67245af6444db672187074bd9c358de419",
+}
+# END RCLONE RELEASE PIN
+
+_INSTALL_RCLONE_PREREQUISITES = (
     f"{_APT} update -qq",
-    f"{_APT} install -y -qq curl unzip ca-certificates",
-    "curl -fsSL https://rclone.org/install.sh | bash",
+    f"{_APT} install -y -qq ca-certificates coreutils curl unzip",
 )
+
+
+def _rclone_arch(machine: str) -> str | None:
+    normalized = machine.strip().lower()
+    if normalized in {"x86_64", "amd64"}:
+        return "amd64"
+    if normalized == "x86" or (
+        len(normalized) == 4
+        and normalized[0] == "i"
+        and normalized[1] in {"3", "4", "5", "6"}
+        and normalized[2:] == "86"
+    ):
+        return "386"
+    if normalized in {"aarch64", "arm64"}:
+        return "arm64"
+    if normalized.startswith("armv7"):
+        return "arm-v7"
+    if normalized.startswith("armv6"):
+        return "arm-v6"
+    if normalized.startswith("arm"):
+        return "arm"
+    return None
+
+
+def _rclone_install_command(arch: str, sha256: str) -> str:
+    archive = f"rclone-v{_RCLONE_VERSION}-linux-{arch}.zip"
+    url = f"https://downloads.rclone.org/v{_RCLONE_VERSION}/{archive}"
+    return "\n".join(
+        [
+            "set -eu",
+            'tmp_dir="$(mktemp -d)"',
+            'target_tmp=""',
+            "cleanup() {",
+            '    rm -rf "$tmp_dir"',
+            '    if [ -n "$target_tmp" ]; then rm -f "$target_tmp"; fi',
+            "}",
+            "trap cleanup EXIT",
+            "trap 'exit 1' HUP INT TERM",
+            f"archive='{archive}'",
+            f"expected_sha256='{sha256}'",
+            f"url='{url}'",
+            (
+                "curl --fail --location --silent --show-error --proto '=https' "
+                '--tlsv1.2 --output "$tmp_dir/$archive" "$url"'
+            ),
+            (
+                'if ! printf \'%s  %s\\n\' "$expected_sha256" "$tmp_dir/$archive" '
+                "| sha256sum --check --strict -; then"
+            ),
+            f"    exit {_RCLONE_CHECKSUM_MISMATCH_EXIT}",
+            "fi",
+            'unzip -q "$tmp_dir/$archive" -d "$tmp_dir/unpacked"',
+            "install -d -m 0755 /usr/local/bin",
+            'target_tmp="$(mktemp /usr/local/bin/.rclone.XXXXXX)"',
+            ('install -m 0755 "$tmp_dir/unpacked/${archive%.zip}/rclone" "$target_tmp"'),
+            'mv -f "$target_tmp" /usr/local/bin/rclone',
+            'target_tmp=""',
+            (f"/usr/local/bin/rclone version | head -n 1 | grep -Fx 'rclone v{_RCLONE_VERSION}'"),
+        ]
+    )
 
 
 async def ensure_rclone(session: BaseSandboxSession) -> None:
@@ -25,7 +98,16 @@ async def ensure_rclone(session: BaseSandboxSession) -> None:
             context={"package": "rclone"},
         )
 
-    for command in _INSTALL_RCLONE_COMMANDS:
+    machine_result = await session.exec("uname", "-m", shell=False, timeout=30)
+    machine = machine_result.stdout.decode("utf-8", errors="replace").strip()
+    arch = _rclone_arch(machine) if machine_result.ok() else None
+    if arch is None:
+        raise MountConfigError(
+            message="rclone is not installed and this architecture is unsupported",
+            context={"package": "rclone", "architecture": machine or "unknown"},
+        )
+
+    for command in _INSTALL_RCLONE_PREREQUISITES:
         install = await session.exec(
             "sh",
             "-lc",
@@ -40,11 +122,35 @@ async def ensure_rclone(session: BaseSandboxSession) -> None:
                 context={"package": "rclone", "exit_code": install.exit_code},
             )
 
+    install = await session.exec(
+        "sh",
+        "-lc",
+        _rclone_install_command(arch, _RCLONE_SHA256_BY_ARCH[arch]),
+        shell=False,
+        timeout=300,
+        user="root",
+    )
+    if install.exit_code == _RCLONE_CHECKSUM_MISMATCH_EXIT:
+        raise MountConfigError(
+            message="rclone archive checksum verification failed",
+            context={"package": "rclone", "version": _RCLONE_VERSION, "architecture": arch},
+        )
+    if not install.ok():
+        raise MountConfigError(
+            message="failed to install rclone",
+            context={
+                "package": "rclone",
+                "version": _RCLONE_VERSION,
+                "architecture": arch,
+                "exit_code": install.exit_code,
+            },
+        )
+
     rclone = await session.exec("sh", "-lc", _RCLONE_CHECK, shell=False)
     if not rclone.ok():
         raise MountConfigError(
             message="rclone was installed but is still not available on PATH",
-            context={"package": "rclone"},
+            context={"package": "rclone", "version": _RCLONE_VERSION, "architecture": arch},
         )
 
 

--- a/src/agents/extensions/sandbox/_rclone.py
+++ b/src/agents/extensions/sandbox/_rclone.py
@@ -79,9 +79,13 @@ def _rclone_install_command(arch: str, sha256: str) -> str:
             "install -d -m 0755 /usr/local/bin",
             'target_tmp="$(mktemp /usr/local/bin/.rclone.XXXXXX)"',
             ('install -m 0755 "$tmp_dir/unpacked/${archive%.zip}/rclone" "$target_tmp"'),
+            'version_output="$("$target_tmp" version)"',
+            (
+                f"printf '%s\\n' \"$version_output\" | head -n 1 "
+                f"| grep -Fx 'rclone v{_RCLONE_VERSION}'"
+            ),
             'mv -f "$target_tmp" /usr/local/bin/rclone',
             'target_tmp=""',
-            (f"/usr/local/bin/rclone version | head -n 1 | grep -Fx 'rclone v{_RCLONE_VERSION}'"),
         ]
     )
 

--- a/tests/extensions/sandbox/test_e2b.py
+++ b/tests/extensions/sandbox/test_e2b.py
@@ -141,14 +141,15 @@ async def test_e2b_ensure_fuse_uses_root_chmod() -> None:
 
 
 @pytest.mark.asyncio
-async def test_e2b_ensure_rclone_installs_with_root_apt() -> None:
+async def test_e2b_ensure_rclone_installs_verified_release() -> None:
     session = _FakeMountSession(
         [
             _exec_fail(),  # rclone missing
             _exec_ok(),  # apt-get present
+            _exec_ok(stdout=b"x86_64\n"),  # supported release architecture
             _exec_ok(),  # apt-get update succeeds
-            _exec_ok(),  # package install succeeds
-            _exec_ok(),  # upstream rclone install succeeds
+            _exec_ok(),  # prerequisite install succeeds
+            _exec_ok(),  # verified rclone install succeeds
             _exec_ok(),  # rclone now present
         ]
     )
@@ -159,20 +160,20 @@ async def test_e2b_ensure_rclone_installs_with_root_apt() -> None:
         "sh -lc command -v rclone >/dev/null 2>&1 || test -x /usr/local/bin/rclone",
         "sh -lc command -v apt-get >/dev/null 2>&1",
     ]
-    assert session.exec_calls[2] == (
+    assert session.exec_calls[2] == "uname -m"
+    assert session.exec_calls[3] == (
         "sudo -u root -- sh -lc DEBIAN_FRONTEND=noninteractive "
         "DEBCONF_NOWARNINGS=yes apt-get -o Dpkg::Use-Pty=0 update -qq"
     )
-    assert session.exec_calls[3] == (
+    assert session.exec_calls[4] == (
         "sudo -u root -- sh -lc DEBIAN_FRONTEND=noninteractive "
         "DEBCONF_NOWARNINGS=yes apt-get -o Dpkg::Use-Pty=0 install -y -qq "
-        "curl unzip ca-certificates"
+        "ca-certificates coreutils curl unzip"
     )
-    assert (
-        session.exec_calls[4]
-        == "sudo -u root -- sh -lc curl -fsSL https://rclone.org/install.sh | bash"
-    )
-    assert session.exec_calls[5] == (
+    assert session.exec_calls[5].startswith("sudo -u root -- sh -lc set -eu\n")
+    assert "sha256sum --check --strict -" in session.exec_calls[5]
+    assert "rclone.org/install.sh" not in session.exec_calls[5]
+    assert session.exec_calls[6] == (
         "sh -lc command -v rclone >/dev/null 2>&1 || test -x /usr/local/bin/rclone"
     )
 

--- a/tests/extensions/sandbox/test_rclone.py
+++ b/tests/extensions/sandbox/test_rclone.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pytest
+
+from agents.extensions.sandbox._rclone import (
+    _RCLONE_CHECKSUM_MISMATCH_EXIT,
+    _RCLONE_SHA256_BY_ARCH,
+    _RCLONE_VERSION,
+    _rclone_arch,
+    _rclone_install_command,
+    ensure_rclone,
+)
+from agents.sandbox.errors import MountConfigError
+from agents.sandbox.types import ExecResult
+
+
+def _result(*, exit_code: int = 0, stdout: bytes = b"") -> ExecResult:
+    return ExecResult(stdout=stdout, stderr=b"", exit_code=exit_code)
+
+
+class _FakeSession:
+    def __init__(self, results: list[ExecResult]) -> None:
+        self.results = results
+        self.calls: list[tuple[tuple[str, ...], dict[str, object]]] = []
+
+    async def exec(self, *command: str, **kwargs: object) -> ExecResult:
+        self.calls.append((command, kwargs))
+        return self.results.pop(0)
+
+
+@pytest.mark.parametrize(
+    ("machine", "expected"),
+    [
+        ("x86_64", "amd64"),
+        ("amd64", "amd64"),
+        ("i386", "386"),
+        ("i686", "386"),
+        ("x86", "386"),
+        ("aarch64", "arm64"),
+        ("arm64", "arm64"),
+        ("armv7l", "arm-v7"),
+        ("armv6l", "arm-v6"),
+        ("armv5l", "arm"),
+    ],
+)
+def test_rclone_arch_maps_upstream_linux_archives(machine: str, expected: str) -> None:
+    assert _rclone_arch(machine) == expected
+
+
+def test_rclone_arch_rejects_unknown_machine() -> None:
+    assert _rclone_arch("mips64") is None
+
+
+def test_rclone_install_command_pins_and_verifies_archive() -> None:
+    sha256 = _RCLONE_SHA256_BY_ARCH["amd64"]
+
+    command = _rclone_install_command("amd64", sha256)
+
+    archive = f"rclone-v{_RCLONE_VERSION}-linux-amd64.zip"
+    assert f"https://downloads.rclone.org/v{_RCLONE_VERSION}/{archive}" in command
+    assert "github.com" not in command
+    assert f"expected_sha256='{sha256}'" in command
+    assert "sha256sum --check --strict -" in command
+    assert "mktemp /usr/local/bin/.rclone.XXXXXX" in command
+    assert 'mv -f "$target_tmp" /usr/local/bin/rclone' in command
+    assert "curl -fsSL https://rclone.org/install.sh | bash" not in command
+
+
+@pytest.mark.asyncio
+async def test_ensure_rclone_preserves_preinstalled_binary() -> None:
+    session = _FakeSession([_result()])
+
+    await ensure_rclone(session)  # type: ignore[arg-type]
+
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_rclone_rejects_unsupported_architecture_before_install() -> None:
+    session = _FakeSession(
+        [
+            _result(exit_code=1),
+            _result(),
+            _result(stdout=b"mips64\n"),
+        ]
+    )
+
+    with pytest.raises(MountConfigError, match="architecture is unsupported") as exc_info:
+        await ensure_rclone(session)  # type: ignore[arg-type]
+
+    assert exc_info.value.context["architecture"] == "mips64"
+    assert len(session.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_ensure_rclone_reports_checksum_mismatch() -> None:
+    session = _FakeSession(
+        [
+            _result(exit_code=1),
+            _result(),
+            _result(stdout=b"x86_64\n"),
+            _result(),
+            _result(),
+            _result(exit_code=_RCLONE_CHECKSUM_MISMATCH_EXIT),
+        ]
+    )
+
+    with pytest.raises(MountConfigError, match="checksum verification failed") as exc_info:
+        await ensure_rclone(session)  # type: ignore[arg-type]
+
+    assert exc_info.value.context == {
+        "package": "rclone",
+        "version": _RCLONE_VERSION,
+        "architecture": "amd64",
+    }
+    assert len(session.calls) == 6

--- a/tests/extensions/sandbox/test_rclone.py
+++ b/tests/extensions/sandbox/test_rclone.py
@@ -62,6 +62,11 @@ def test_rclone_install_command_pins_and_verifies_archive() -> None:
     assert f"expected_sha256='{sha256}'" in command
     assert "sha256sum --check --strict -" in command
     assert "mktemp /usr/local/bin/.rclone.XXXXXX" in command
+    verify_execution = 'version_output="$("$target_tmp" version)"'
+    verify_version = f"grep -Fx 'rclone v{_RCLONE_VERSION}'"
+    atomic_replace = 'mv -f "$target_tmp" /usr/local/bin/rclone'
+    assert command.index(verify_execution) < command.index(verify_version)
+    assert command.index(verify_version) < command.index(atomic_replace)
     assert 'mv -f "$target_tmp" /usr/local/bin/rclone' in command
     assert "curl -fsSL https://rclone.org/install.sh | bash" not in command
 

--- a/tests/extensions/sandbox/test_runloop_mounts.py
+++ b/tests/extensions/sandbox/test_runloop_mounts.py
@@ -135,7 +135,7 @@ def test_runloop_session_guard_accepts_correct_type() -> None:
 
 @pytest.mark.asyncio
 async def test_runloop_ensure_rclone_installs_verified_release() -> None:
-    from agents.extensions.sandbox._rclone import ensure_rclone
+    from agents.extensions.sandbox._rclone import _RCLONE_VERSION, ensure_rclone
 
     session = _FakeRunloopMountSession(
         [
@@ -166,7 +166,7 @@ async def test_runloop_ensure_rclone_installs_verified_release() -> None:
         "ca-certificates coreutils curl unzip"
     )
     assert session.exec_calls[5].startswith("sudo -u root -- sh -lc set -eu\n")
-    assert "rclone-v1.74.4-linux-arm64.zip" in session.exec_calls[5]
+    assert f"rclone-v{_RCLONE_VERSION}-linux-arm64.zip" in session.exec_calls[5]
     assert "sha256sum --check --strict -" in session.exec_calls[5]
     assert session.exec_calls[6] == (
         "sh -lc command -v rclone >/dev/null 2>&1 || test -x /usr/local/bin/rclone"

--- a/tests/extensions/sandbox/test_runloop_mounts.py
+++ b/tests/extensions/sandbox/test_runloop_mounts.py
@@ -134,12 +134,14 @@ def test_runloop_session_guard_accepts_correct_type() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runloop_ensure_rclone_installs_with_root_apt() -> None:
+async def test_runloop_ensure_rclone_installs_verified_release() -> None:
     from agents.extensions.sandbox._rclone import ensure_rclone
 
     session = _FakeRunloopMountSession(
         [
             _exec_fail(),
+            _exec_ok(),
+            _exec_ok(stdout=b"aarch64\n"),
             _exec_ok(),
             _exec_ok(),
             _exec_ok(),
@@ -153,20 +155,20 @@ async def test_runloop_ensure_rclone_installs_with_root_apt() -> None:
         "sh -lc command -v rclone >/dev/null 2>&1 || test -x /usr/local/bin/rclone",
         "sh -lc command -v apt-get >/dev/null 2>&1",
     ]
-    assert session.exec_calls[2] == (
+    assert session.exec_calls[2] == "uname -m"
+    assert session.exec_calls[3] == (
         "sudo -u root -- sh -lc DEBIAN_FRONTEND=noninteractive "
         "DEBCONF_NOWARNINGS=yes apt-get -o Dpkg::Use-Pty=0 update -qq"
     )
-    assert session.exec_calls[3] == (
+    assert session.exec_calls[4] == (
         "sudo -u root -- sh -lc DEBIAN_FRONTEND=noninteractive "
         "DEBCONF_NOWARNINGS=yes apt-get -o Dpkg::Use-Pty=0 install -y -qq "
-        "curl unzip ca-certificates"
+        "ca-certificates coreutils curl unzip"
     )
-    assert (
-        session.exec_calls[4]
-        == "sudo -u root -- sh -lc curl -fsSL https://rclone.org/install.sh | bash"
-    )
-    assert session.exec_calls[5] == (
+    assert session.exec_calls[5].startswith("sudo -u root -- sh -lc set -eu\n")
+    assert "rclone-v1.74.4-linux-arm64.zip" in session.exec_calls[5]
+    assert "sha256sum --check --strict -" in session.exec_calls[5]
+    assert session.exec_calls[6] == (
         "sh -lc command -v rclone >/dev/null 2>&1 || test -x /usr/local/bin/rclone"
     )
 

--- a/tests/test_update_rclone_pin.py
+++ b/tests/test_update_rclone_pin.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,14 +36,24 @@ def _release(
     version: str,
     published_at: str,
     *,
+    asset_observed_at: str | None = None,
     draft: bool = False,
     prerelease: bool = False,
 ) -> dict[str, object]:
+    asset_timestamp = asset_observed_at or published_at
     return {
         "tag_name": f"v{version}",
         "published_at": published_at,
         "draft": draft,
         "prerelease": prerelease,
+        "assets": [
+            {
+                "name": asset_name,
+                "created_at": asset_timestamp,
+                "updated_at": asset_timestamp,
+            }
+            for asset_name in updater._required_asset_names(version)
+        ],
     }
 
 
@@ -63,6 +75,26 @@ def test_latest_stable_release_respects_default_cooldown() -> None:
     assert updater._release_version(selected) == "1.74.4"
 
 
+def test_latest_stable_release_skips_release_with_fresh_assets() -> None:
+    now = datetime(2026, 7, 22, tzinfo=timezone.utc)
+    releases = [
+        _release(
+            "1.75.0",
+            "2026-07-01T00:00:00Z",
+            asset_observed_at="2026-07-20T00:00:00Z",
+        ),
+        _release("1.74.4", "2026-07-08T00:00:00Z"),
+    ]
+
+    selected = updater._latest_stable_release(
+        releases,
+        cooldown_days=updater._DEFAULT_COOLDOWN_DAYS,
+        now=now,
+    )
+
+    assert updater._release_version(selected) == "1.74.4"
+
+
 def test_stable_release_cooldown_is_customizable() -> None:
     release = _release("1.75.0", "2026-07-20T00:00:00Z")
     now = datetime(2026, 7, 22, tzinfo=timezone.utc)
@@ -71,6 +103,37 @@ def test_stable_release_cooldown_is_customizable() -> None:
         updater._validate_stable_release(release, cooldown_days=7, now=now)
 
     updater._validate_stable_release(release, cooldown_days=2, now=now)
+
+
+@pytest.mark.parametrize(
+    "asset_name",
+    updater._required_asset_names("1.74.4"),
+)
+def test_stable_release_cooldown_covers_every_required_asset(asset_name: str) -> None:
+    release = _release("1.74.4", "2026-07-01T00:00:00Z")
+    asset = updater._asset(release, asset_name)
+    asset["created_at"] = "2026-07-20T00:00:00Z"
+    asset["updated_at"] = "2026-07-20T00:00:00Z"
+
+    with pytest.raises(RuntimeError, match=re.escape(f"asset {asset_name}")):
+        updater._validate_stable_release(
+            release,
+            cooldown_days=7,
+            now=datetime(2026, 7, 22, tzinfo=timezone.utc),
+        )
+
+
+def test_stable_release_cooldown_uses_latest_asset_timestamp() -> None:
+    release = _release("1.74.4", "2026-07-01T00:00:00Z")
+    asset = updater._asset(release, "SHA256SUMS")
+    asset["updated_at"] = "2026-07-20T00:00:00Z"
+
+    with pytest.raises(RuntimeError, match="asset SHA256SUMS"):
+        updater._validate_stable_release(
+            release,
+            cooldown_days=7,
+            now=datetime(2026, 7, 22, tzinfo=timezone.utc),
+        )
 
 
 @pytest.mark.parametrize(
@@ -147,6 +210,23 @@ def test_validate_asset_sha256s_requires_github_asset_match() -> None:
 
     with pytest.raises(RuntimeError, match="does not match GitHub"):
         updater._validate_asset_sha256s(release, version, sha256_by_arch)
+
+
+def test_validate_download_sha256_requires_github_asset_match() -> None:
+    content = b"rclone checksums"
+    release = {
+        "assets": [
+            {
+                "name": "SHA256SUMS",
+                "digest": f"sha256:{hashlib.sha256(content).hexdigest()}",
+            }
+        ]
+    }
+
+    updater._validate_download_sha256(release, "SHA256SUMS", content)
+
+    with pytest.raises(RuntimeError, match="does not match GitHub"):
+        updater._validate_download_sha256(release, "SHA256SUMS", b"changed")
 
 
 def test_apply_pin_updates_and_checks_both_consumers(tmp_path: Path) -> None:

--- a/tests/test_update_rclone_pin.py
+++ b/tests/test_update_rclone_pin.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_updater() -> ModuleType:
+    path = Path(__file__).parents[1] / ".github/scripts/update_rclone_pin.py"
+    spec = importlib.util.spec_from_file_location("update_rclone_pin", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+updater = _load_updater()
+
+
+def _checksums(version: str) -> str:
+    return "\n".join(
+        f"{index:064x}  rclone-v{version}-linux-{arch}.zip"
+        for index, arch in enumerate(updater._RCLONE_ARCHES, start=1)
+    )
+
+
+def _release(
+    version: str,
+    published_at: str,
+    *,
+    draft: bool = False,
+    prerelease: bool = False,
+) -> dict[str, object]:
+    return {
+        "tag_name": f"v{version}",
+        "published_at": published_at,
+        "draft": draft,
+        "prerelease": prerelease,
+    }
+
+
+def test_latest_stable_release_respects_default_cooldown() -> None:
+    now = datetime(2026, 7, 22, tzinfo=timezone.utc)
+    releases = [
+        _release("1.75.0", "2026-07-20T00:00:00Z"),
+        _release("1.74.5", "2026-07-10T00:00:00Z", prerelease=True),
+        _release("1.74.4", "2026-07-08T00:00:00Z"),
+        _release("1.74.3", "2026-07-01T00:00:00Z"),
+    ]
+
+    selected = updater._latest_stable_release(
+        releases,
+        cooldown_days=updater._DEFAULT_COOLDOWN_DAYS,
+        now=now,
+    )
+
+    assert updater._release_version(selected) == "1.74.4"
+
+
+def test_stable_release_cooldown_is_customizable() -> None:
+    release = _release("1.75.0", "2026-07-20T00:00:00Z")
+    now = datetime(2026, 7, 22, tzinfo=timezone.utc)
+
+    with pytest.raises(RuntimeError, match="7-day cooldown"):
+        updater._validate_stable_release(release, cooldown_days=7, now=now)
+
+    updater._validate_stable_release(release, cooldown_days=2, now=now)
+
+
+@pytest.mark.parametrize(
+    ("draft", "prerelease"),
+    [(True, False), (False, True)],
+)
+def test_release_selection_rejects_drafts_and_prereleases(
+    draft: bool,
+    prerelease: bool,
+) -> None:
+    release = _release(
+        "1.74.4",
+        "2026-07-01T00:00:00Z",
+        draft=draft,
+        prerelease=prerelease,
+    )
+
+    with pytest.raises(RuntimeError, match="not a stable published release"):
+        updater._validate_stable_release(
+            release,
+            cooldown_days=0,
+            now=datetime(2026, 7, 22, tzinfo=timezone.utc),
+        )
+
+
+def test_parse_sha256s_requires_every_runtime_architecture() -> None:
+    version = "1.2.3"
+
+    parsed = updater._parse_sha256s(_checksums(version), version)
+
+    assert list(parsed) == list(updater._RCLONE_ARCHES)
+    assert parsed["amd64"] == f"{2:064x}"
+
+
+def test_headers_do_not_send_github_token_to_release_asset_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "secret")
+
+    assert (
+        updater._headers("https://api.github.com/repos/rclone/rclone/releases/latest")[
+            "Authorization"
+        ]
+        == "Bearer secret"
+    )
+    assert "Authorization" not in updater._headers(
+        "https://github.com/rclone/rclone/releases/download/v1.2.3/SHA256SUMS"
+    )
+
+
+def test_parse_sha256s_rejects_incomplete_release() -> None:
+    with pytest.raises(RuntimeError, match="arm64"):
+        updater._parse_sha256s(
+            "1" * 64 + "  rclone-v1.2.3-linux-amd64.zip\n",
+            "1.2.3",
+        )
+
+
+def test_validate_asset_sha256s_requires_github_asset_match() -> None:
+    version = "1.2.3"
+    sha256_by_arch = updater._parse_sha256s(_checksums(version), version)
+    release = {
+        "assets": [
+            {
+                "name": f"rclone-v{version}-linux-{arch}.zip",
+                "digest": f"sha256:{sha256_by_arch[arch]}",
+            }
+            for arch in updater._RCLONE_ARCHES
+        ]
+    }
+
+    updater._validate_asset_sha256s(release, version, sha256_by_arch)
+    release["assets"][0]["digest"] = f"sha256:{'f' * 64}"
+
+    with pytest.raises(RuntimeError, match="does not match GitHub"):
+        updater._validate_asset_sha256s(release, version, sha256_by_arch)
+
+
+def test_apply_pin_updates_and_checks_both_consumers(tmp_path: Path) -> None:
+    runtime_path = tmp_path / updater._RUNTIME_PIN_PATH
+    docker_path = tmp_path / updater._DOCKER_PIN_PATH
+    runtime_path.parent.mkdir(parents=True)
+    docker_path.parent.mkdir(parents=True)
+    runtime_path.write_text(
+        f"before\n{updater._PYTHON_PIN_BEGIN}\nold\n{updater._PYTHON_PIN_END}\nafter\n"
+    )
+    docker_path.write_text(
+        f"before\n{updater._DOCKER_PIN_BEGIN}\nold\n{updater._DOCKER_PIN_END}\nafter\n"
+    )
+    pin = updater.RclonePin(
+        version="1.2.3",
+        sha256_by_arch=updater._parse_sha256s(_checksums("1.2.3"), "1.2.3"),
+    )
+
+    assert updater.apply_pin(tmp_path, pin, check=True) == [runtime_path, docker_path]
+    assert "old" in runtime_path.read_text()
+
+    assert updater.apply_pin(tmp_path, pin, check=False) == [runtime_path, docker_path]
+    assert updater.apply_pin(tmp_path, pin, check=True) == []
+    assert '_RCLONE_VERSION = "1.2.3"' in runtime_path.read_text()
+    assert "ARG RCLONE_VERSION=1.2.3" in docker_path.read_text()


### PR DESCRIPTION
This pull request fixes the unverified rclone installation used by sandbox mount provisioning. The previous implementation downloaded and executed a mutable installer as root; the new implementation pins rclone v1.74.4, selects the appropriate Linux archive, verifies an embedded SHA256 digest, and installs the verified binary atomically.

It also updates the Docker mount example and adds `make update-rclone-pin` as the maintainer entrypoint. The updater selects the latest published, non-draft, non-prerelease rclone release after a configurable seven-day cooldown and verifies upstream checksums against GitHub's server-computed asset digests. Runtime downloads remain on the versioned `downloads.rclone.org` endpoint and do not depend on GitHub Releases.

This pull request resolves #3909.