### PR TITLE
fix: guard incomplete tool calls in non-buffered Chat Completions stream (#3861)

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -48,6 +48,8 @@ from openai.types.responses.response_reasoning_text_done_event import (
 )
 from openai.types.responses.response_usage import OutputTokensDetails
 
+from agents.exceptions import ModelBehaviorError
+
 from ..exceptions import ModelBehaviorError, UserError
 from ..items import TResponseStreamEvent
 from ..logger import logger
@@ -1060,6 +1062,18 @@ class ChatCmplStreamHandler:
                 # Function call was not streamed (fallback to old behavior)
                 # This handles edge cases where function name never arrived
                 output_index = output_layout.function_call_output_index(state, index)
+
+                # Guard against incomplete tool calls: if name or call_id is
+                # missing, raise ModelBehaviorError like the buffered path does.
+                if not function_call.name:
+                    raise ModelBehaviorError(
+                        "Chat Completions tool call stream ended without a function name."
+                    )
+                if not function_call.call_id:
+                    raise ModelBehaviorError(
+                        "Chat Completions tool call stream ended without a tool call id."
+                    )
+
                 fallback_func_call_item = cls._function_call_item(
                     state,
                     function_call,

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -48,8 +48,6 @@ from openai.types.responses.response_reasoning_text_done_event import (
 )
 from openai.types.responses.response_usage import OutputTokensDetails
 
-from agents.exceptions import ModelBehaviorError
-
 from ..exceptions import ModelBehaviorError, UserError
 from ..items import TResponseStreamEvent
 from ..logger import logger


### PR DESCRIPTION
The non-buffered path in handle_stream creates ResponseFunctionToolCall
with empty name and call_id when a stream ends without providing those
fields, then emits it via the fallback-to-old-behavior branch. The
buffered path already raises ModelBehaviorError for the same condition.

Add the same guard in the non-buffered fallback path: raise
ModelBehaviorError when name or call_id is missing, matching the
buffered path's behavior and preventing silent emission of unusable
tool calls.
