### PR TITLE
fix(voice): encode streamed float32 audio as PCM16

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -41,13 +41,15 @@ class WebsocketDoneSentinel:
 
 
 def _audio_to_base64(audio_data: list[npt.NDArray[np.int16 | np.float32]]) -> str:
-    concatenated_audio = np.concatenate(audio_data)
-    if concatenated_audio.dtype == np.float32:
-        # convert to int16
-        concatenated_audio = np.clip(concatenated_audio, -1.0, 1.0)
-        concatenated_audio = (concatenated_audio * 32767).astype(np.int16)
-    audio_bytes = concatenated_audio.tobytes()
-    return base64.b64encode(audio_bytes).decode("utf-8")
+    return _audio_buffer_to_base64(np.concatenate(audio_data))
+
+
+def _audio_buffer_to_base64(buffer: npt.NDArray[np.int16 | np.float32]) -> str:
+    if buffer.dtype == np.float32:
+        # Convert to int16.
+        buffer = np.clip(buffer, -1.0, 1.0)
+        buffer = (buffer * 32767).astype(np.int16)
+    return base64.b64encode(buffer.tobytes()).decode("utf-8")
 
 
 async def _wait_for_event(
@@ -267,7 +269,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                     json.dumps(
                         {
                             "type": "input_audio_buffer.append",
-                            "audio": base64.b64encode(buffer.tobytes()).decode("utf-8"),
+                            "audio": _audio_buffer_to_base64(buffer),
                         }
                     )
                 )

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -1,6 +1,7 @@
 # test_openai_stt_transcription_session.py
 
 import asyncio
+import base64
 import json
 import time
 from unittest.mock import AsyncMock, patch
@@ -163,7 +164,24 @@ async def test_session_connects_and_configures_successfully():
 
 
 @pytest.mark.asyncio
-async def test_stream_audio_sends_correct_json():
+@pytest.mark.parametrize(
+    ("buffer", "expected_pcm16"),
+    [
+        (
+            np.array([1, 2, 3, 4], dtype=np.int16),
+            np.array([1, 2, 3, 4], dtype=np.int16),
+        ),
+        (
+            np.array([-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5], dtype=np.float32),
+            np.array([-32767, -32767, -16383, 0, 16383, 32767, 32767], dtype=np.int16),
+        ),
+    ],
+    ids=["int16", "float32"],
+)
+async def test_stream_audio_sends_pcm16(
+    buffer: npt.NDArray[np.int16 | np.float32],
+    expected_pcm16: npt.NDArray[np.int16],
+) -> None:
     """
     Test that when audio is placed on the input queue, the session:
     1) Base64-encodes the data.
@@ -183,9 +201,9 @@ async def test_stream_audio_sends_correct_json():
     )
     session._websocket = mock_ws
 
-    buffer1 = np.array([1, 2, 3, 4], dtype=np.int16)
+    original_buffer = buffer.copy()
     queue: asyncio.Queue[npt.NDArray[np.int16 | np.float32] | None] = asyncio.Queue()
-    await queue.put(buffer1)
+    await queue.put(buffer)
     await queue.put(None)
 
     await session._stream_audio(queue)
@@ -197,7 +215,8 @@ async def test_stream_audio_sends_correct_json():
     ]
     assert len(append_messages) == 1, "No 'input_audio_buffer.append' message was sent."
     assert append_messages[0]["type"] == "input_audio_buffer.append"
-    assert "audio" in append_messages[0]
+    assert base64.b64decode(append_messages[0]["audio"]) == expected_pcm16.tobytes()
+    np.testing.assert_array_equal(buffer, original_buffer)
 
     await session.close()
 


### PR DESCRIPTION
### Summary

`OpenAISTTTranscriptionSession._stream_audio` base64-encoded the raw audio
buffer and sent it in `input_audio_buffer.append`. `StreamedAudioInput`
explicitly accepts `np.int16 | np.float32`, but the session configures the
realtime transcription input as int16 PCM (`{"type": "audio/pcm", "rate":
24000}`). So for **float32** input we shipped raw 32-bit IEEE-754 float bytes
(4 bytes/sample) to an endpoint expecting PCM16 (2 bytes/sample), producing
garbage/failed transcriptions. The batch/tracing path (`_audio_to_base64`)
already converted float32 → int16 correctly, so the streaming and tracing
paths disagreed.

This extracts the conversion into a shared `_audio_buffer_to_base64` helper
(clip to `[-1.0, 1.0]`, scale by `32767`, cast to `int16` — matching the
existing convention in `voice/input.py`) and uses it in both `_stream_audio`
and `_audio_to_base64`. The conversion is non-mutating (`np.clip` returns a
new array), so the buffer retained in `_turn_audio_buffer` for tracing is
unchanged and int16 input is unaffected.

### Test plan

- Parametrized coverage verifies:
  - int16 pass-through,
  - float32 clipping and PCM16 conversion,
  - exact transmitted bytes, and
  - input-buffer immutability.
- `code-change-verification`: format, lint, typecheck, and full tests passed.



### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR