### PR TITLE
fix(logging): redact MCP tool-call and formatter errors from logs

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -724,21 +724,36 @@ class MCPUtil:
                 # pipeline (failure_error_function) can handle it.  The default handler
                 # will surface the message as a structured error result; callers who set
                 # failure_error_function=None will have the error raised as documented.
-                error_text = e.error.message if hasattr(e, "error") and e.error else str(e)
-                logger.warning(
-                    "MCP tool %s on server '%s' returned an error: %s",
-                    tool_name_for_display,
-                    server.name,
-                    error_text,
-                )
+                if _debug.DONT_LOG_TOOL_DATA:
+                    logger.warning(
+                        "MCP tool %s on server '%s' returned an error.",
+                        tool_name_for_display,
+                        server.name,
+                    )
+                else:
+                    error_text = e.error.message if hasattr(e, "error") and e.error else str(e)
+                    logger.warning(
+                        "MCP tool %s on server '%s' returned an error: %s",
+                        tool_name_for_display,
+                        server.name,
+                        error_text,
+                    )
                 raise
 
-            logger.error(
-                "Error invoking MCP tool %s on server '%s': %s",
-                tool_name_for_display,
-                server.name,
-                e,
-            )
+            if _debug.DONT_LOG_TOOL_DATA:
+                logger.error(
+                    "Error invoking MCP tool %s on server '%s': %s",
+                    tool_name_for_display,
+                    server.name,
+                    e.__class__.__name__,
+                )
+            else:
+                logger.error(
+                    "Error invoking MCP tool %s on server '%s': %s",
+                    tool_name_for_display,
+                    server.name,
+                    e,
+                )
             raise AgentsException(
                 f"Error invoking MCP tool {tool_name_for_display} on server '{server.name}': {e}"
             ) from e

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1200,7 +1200,7 @@ async def resolve_approval_rejection_message(
         )
         message = await maybe_message if inspect.isawaitable(maybe_message) else maybe_message
     except Exception as exc:
-        logger.error("Tool error formatter failed for %s: %s", tool_name, exc)
+        log_tool_action_error(f"Tool error formatter failed for {tool_name}", exc)
         return REJECTION_MESSAGE
 
     if message is None:

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 import pytest
 from inline_snapshot import snapshot
-from mcp.types import CallToolResult, ImageContent, TextContent, Tool as MCPTool
+from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult, ErrorData, ImageContent, TextContent, Tool as MCPTool
 from pydantic import BaseModel, TypeAdapter
 
 import agents._debug as _debug
@@ -807,6 +808,100 @@ async def test_mcp_invocation_crash_causes_error(caplog: pytest.LogCaptureFixtur
         await MCPUtil.invoke_mcp_tool(server, tool, ctx, "")
 
     assert "Error invoking MCP tool test_tool_1" in caplog.text
+
+
+class SecretCrashingFakeMCPServer(FakeMCPServer):
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ):
+        raise Exception("crash with SECRET_CRASH_123")
+
+
+class McpErrorFakeMCPServer(FakeMCPServer):
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        meta: dict[str, Any] | None = None,
+    ):
+        raise McpError(ErrorData(code=-32000, message="upstream said SECRET_MCP_123"))
+
+
+@pytest.mark.asyncio
+async def test_mcp_invocation_crash_redacts_error_when_dont_log_tool_data(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", True)
+
+    server = SecretCrashingFakeMCPServer()
+    server.add_tool("test_tool_1", {})
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="test_tool_1", inputSchema={})
+
+    with pytest.raises(AgentsException):
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, "")
+
+    assert "Error invoking MCP tool test_tool_1" in caplog.text
+    assert "SECRET_CRASH_123" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_invocation_crash_includes_error_when_tool_logging_enabled(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    server = SecretCrashingFakeMCPServer()
+    server.add_tool("test_tool_1", {})
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="test_tool_1", inputSchema={})
+
+    with pytest.raises(AgentsException):
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, "")
+
+    assert "SECRET_CRASH_123" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_returned_error_redacts_message_when_dont_log_tool_data(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", True)
+
+    server = McpErrorFakeMCPServer()
+    server.add_tool("test_tool_1", {})
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="test_tool_1", inputSchema={})
+
+    with pytest.raises(McpError):
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, "")
+
+    assert "MCP tool test_tool_1 on server" in caplog.text
+    assert "SECRET_MCP_123" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_returned_error_includes_message_when_tool_logging_enabled(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    server = McpErrorFakeMCPServer()
+    server.add_tool("test_tool_1", {})
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="test_tool_1", inputSchema={})
+
+    with pytest.raises(McpError):
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, "")
+
+    assert "SECRET_MCP_123" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -8,14 +8,25 @@ statements honor ``_debug.DONT_LOG_MODEL_DATA`` / ``_debug.DONT_LOG_TOOL_DATA``.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
 import pytest
 from openai import AsyncOpenAI
 
 import agents._debug as _debug
-from agents import ModelSettings, ModelTracing, OpenAIResponsesModel, trace
-from agents.run_internal.tool_execution import log_tool_action_error
+from agents import (
+    ModelSettings,
+    ModelTracing,
+    OpenAIResponsesModel,
+    RunConfig,
+    RunContextWrapper,
+    trace,
+)
+from agents.run_internal.tool_execution import (
+    log_tool_action_error,
+    resolve_approval_rejection_message,
+)
 
 _SECRET = "super secret prompt content"
 
@@ -140,3 +151,45 @@ def test_log_tool_action_error_logs_full_when_tool_data_enabled(monkeypatch) -> 
     logged = str(mock_logger.error.call_args)
     assert "/secret/path" in logged
     assert mock_logger.error.call_args.kwargs.get("exc_info") is True
+
+
+@pytest.mark.asyncio
+async def test_approval_rejection_formatter_error_redacts_exception(monkeypatch, caplog) -> None:
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", True)
+
+    def boom(_args):
+        raise ValueError("formatter blew up SECRET_FMT_123")
+
+    result = await resolve_approval_rejection_message(
+        context_wrapper=RunContextWrapper(context=None),
+        run_config=RunConfig(tool_error_formatter=boom),
+        tool_type="function",
+        tool_name="my_tool",
+        call_id="call_1",
+    )
+
+    assert isinstance(result, str) and result
+    assert "Tool error formatter failed for my_tool" in caplog.text
+    assert "SECRET_FMT_123" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_approval_rejection_formatter_error_logs_full_when_enabled(
+    monkeypatch, caplog
+) -> None:
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    def boom(_args):
+        raise ValueError("formatter blew up SECRET_FMT_123")
+
+    await resolve_approval_rejection_message(
+        context_wrapper=RunContextWrapper(context=None),
+        run_config=RunConfig(tool_error_formatter=boom),
+        tool_type="function",
+        tool_name="my_tool",
+        call_id="call_1",
+    )
+
+    assert "SECRET_FMT_123" in caplog.text


### PR DESCRIPTION
### Summary

- `invoke_mcp_tool` logged the MCP error message and the raw exception unconditionally, even though the input/output logs right next to them already gate on `DONT_LOG_TOOL_DATA`. same class as the merged #3910 / #3907.
- mcp/util.py: gate the McpError warning and the generic-exception error log on `DONT_LOG_TOOL_DATA`. server and tool names stay; the error content redacts to the exception class by default, full detail only when tool-data logging is enabled. the re-raised exceptions are left intact, since they are the FunctionTool failure-pipeline contract.
- tool_execution.py: route the tool-error-formatter failure log through the existing `log_tool_action_error` helper.

### Test plan

- tests/mcp/test_mcp_util.py: 4 new tests covering both MCP error paths (McpError and a generic crash), redacted by default and full when enabled, asserting the secret payload is or isn't in the logs.
- tests/test_error_logging_redaction.py: 2 new tests for the approval-rejection formatter-failure path.
- `make format` and `make lint`: clean.
- `make tests`: full suite green (5400 + 27 passed, 0 failed).
- `make typecheck`: adds 0 new errors, confirmed identical with these changes stashed. the 35 pre-existing errors are unrelated (vercel extension, py3.12-only apis on a 3.11 checkout, boto3 not installed, dep-version `type: ignore` skew).

### Issue number

<!-- add if there is a tracking issue -->

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
