### PR TITLE
fix(mcp): cleanup cancelled servers during connect failure

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -283,9 +283,12 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
                 self._remove_failed_server(server)
                 self.errors.pop(server, None)
         except asyncio.CancelledError as exc:
+            # Always record so connect_all()'s failure cleanup includes this server.
+            # Re-raising without recording left partially-opened servers uncleaned
+            # (especially under `async with`, where __aexit__ never runs).
+            self._record_failure(server, exc, phase="connect")
             if not self.suppress_cancelled_error:
                 raise
-            self._record_failure(server, exc, phase="connect")
         except Exception as exc:
             self._record_failure(server, exc, phase="connect")
             if raise_on_error:

--- a/tests/mcp/test_mcp_server_manager.py
+++ b/tests/mcp/test_mcp_server_manager.py
@@ -173,15 +173,23 @@ class CleanupAwareServer(MCPServer):
 
 
 class CancelledServer(MCPServer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.resource_open = False
+        self.cleanup_calls = 0
+
     @property
     def name(self) -> str:
         return "cancelled"
 
     async def connect(self) -> None:
+        # Simulate a transport that opened resources before cancellation.
+        self.resource_open = True
         raise asyncio.CancelledError()
 
     async def cleanup(self) -> None:
-        return None
+        self.cleanup_calls += 1
+        self.resource_open = False
 
     async def list_tools(
         self, run_context: RunContextWrapper[Any] | None = None, agent: Any | None = None
@@ -548,5 +556,28 @@ async def test_manager_cleanup_runs_on_cancelled_error_during_connect() -> None:
         with pytest.raises(asyncio.CancelledError):
             await manager.connect_all()
         assert server.cleanup_calls == 1
+        # The cancelled server must be recorded and cleaned by connect_all()'s
+        # failure path — callers cannot rely on a later cleanup_all() because
+        # `async with` never reaches __aexit__ when __aenter__ raises.
+        assert cancelled_server in manager.failed_servers
+        assert cancelled_server.cleanup_calls == 1
+        assert cancelled_server.resource_open is False
     finally:
         await manager.cleanup_all()
+
+
+@pytest.mark.asyncio
+async def test_manager_async_with_cleans_cancelled_server_when_unsuppressed() -> None:
+    server = CleanupAwareServer()
+    cancelled_server = CancelledServer()
+
+    with pytest.raises(asyncio.CancelledError):
+        async with MCPServerManager(
+            [server, cancelled_server],
+            suppress_cancelled_error=False,
+        ):
+            raise AssertionError("context body should not run when connect raises")
+
+    assert server.cleanup_calls == 1
+    assert cancelled_server.cleanup_calls == 1
+    assert cancelled_server.resource_open is False


### PR DESCRIPTION
### Summary

When `MCPServerManager` is configured with `suppress_cancelled_error=False`, a `CancelledError` raised during `connect()` was re-raised **without** recording the server as failed. Sequential `connect_all()` failure cleanup only walks `connected_servers + failed_servers`, so the cancelled server was skipped. Under the recommended `async with MCPServerManager(...)` pattern, `__aexit__` never runs if `__aenter__` raises, so there is no later chance to call `cleanup_all()` — leaving transports / subprocesses / sessions open.

This aligns `CancelledError` handling with the existing `BaseException` path: always `_record_failure(...)` first, then re-raise when suppression is disabled.

### Root cause

In `_attempt_connect`:

```python
except asyncio.CancelledError as exc:
    if not self.suppress_cancelled_error:
        raise  # never recorded → never cleaned by connect_all failure path
    self._record_failure(server, exc, phase="connect")
```

Neighboring `BaseException` handling already records before re-raising, and the lifecycle reference requires partial connection failures to close every context already entered.

### Reproduction

```python
async with MCPServerManager([ok_server, cancelled_server], suppress_cancelled_error=False):
    ...
# CancelledError propagates; cancelled_server.cleanup() was never called
```

Before this change: cancelled server stays `resource_open=True`, `cleanup_calls=0`.
After this change: `connect_all()` failure cleanup runs `cleanup()` on the cancelled server.

### Solution

Record the cancelled server via `_record_failure` before optionally re-raising, so `connect_all()`'s sequential failure cleanup includes it (same contract as fatal `BaseException` connect failures).

### Test plan

- [x] Strengthened `test_manager_cleanup_runs_on_cancelled_error_during_connect` to assert the cancelled server is recorded and cleaned by `connect_all()` itself
- [x] Added `test_manager_async_with_cleans_cancelled_server_when_unsuppressed` covering the `async with` leak path
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh` (format, lint, typecheck, full tests) — all passed
- [x] `git diff --check` clean

### Issue number

N/A — found via code-path review; no existing issue/PR covering this exact gap (nearby MCP cleanup work targets stdio semaphore / exit-stack reconnect issues, not this manager cancellation recording path).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

### Compatibility and risk

- Default `suppress_cancelled_error=True` behavior is unchanged (still records and does not re-raise).
- Only the unsuppressed path gains recording-before-raise, matching documented cleanup expectations.
- No public API shape changes.

### Validation

```text
make format / make lint — pass
make typecheck — pass
make tests — pass
code-change-verification — all commands passed
```

