### PR TITLE
feat: add tool decorator alias

### DIFF
--- a/src/agents/decorators.py
+++ b/src/agents/decorators.py
@@ -1,0 +1,19 @@
+"""Public decorators for defining Agents SDK components.
+
+`tool` is an alias for `function_tool`.
+"""
+
+from .guardrail import input_guardrail, output_guardrail
+from .tool import function_tool
+from .tool_guardrails import tool_input_guardrail, tool_output_guardrail
+
+tool = function_tool
+
+__all__ = [
+    "function_tool",
+    "input_guardrail",
+    "output_guardrail",
+    "tool",
+    "tool_input_guardrail",
+    "tool_output_guardrail",
+]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,42 @@
+import types
+
+from typing_extensions import assert_type
+
+import agents.decorators as decorators_module
+import agents.tool as tool_module
+from agents import (
+    FunctionTool,
+    function_tool,
+    input_guardrail,
+    output_guardrail,
+    tool_input_guardrail,
+    tool_output_guardrail,
+)
+from agents.decorators import function_tool as decorators_function_tool, tool
+
+
+def test_decorator_module_preserves_existing_imports_and_identities() -> None:
+    assert isinstance(decorators_module, types.ModuleType)
+    assert isinstance(tool_module, types.ModuleType)
+    assert decorators_function_tool is function_tool
+    assert tool is function_tool
+    assert decorators_module.input_guardrail is input_guardrail
+    assert decorators_module.output_guardrail is output_guardrail
+    assert decorators_module.tool_input_guardrail is tool_input_guardrail
+    assert decorators_module.tool_output_guardrail is tool_output_guardrail
+    assert tool_module.function_tool is function_tool
+
+
+def test_tool_alias_supports_bare_and_configured_decorator_forms() -> None:
+    @tool
+    def bare_alias() -> str:
+        return "bare"
+
+    @tool(name_override="configured_alias")
+    async def configured_alias() -> str:
+        return "configured"
+
+    assert_type(bare_alias, FunctionTool)
+    assert_type(configured_alias, FunctionTool)
+    assert bare_alias.name == "bare_alias"
+    assert configured_alias.name == "configured_alias"


### PR DESCRIPTION
This pull request adds an `agents.decorators` module that provides a shorter `tool` alias for `function_tool` and re-exports the SDK's existing public decorators.

The alias preserves exact runtime and typing behavior while avoiding a package-root naming conflict with the existing `agents.tool` module. `function_tool` remains fully supported and importable from both `agents` and `agents.decorators`; it is not deprecated.

The function-tools documentation now recommends `@tool` for new code and includes the new decorators API reference.