### PR TITLE
fix: resolve voice pipeline deadlock on TTS error and retrieve background task exceptions

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -733,7 +733,6 @@ class OpenAIResponsesModel(Model):
         prompt: ResponsePromptParam | None = None,
     ) -> dict[str, Any]:
         list_input = ItemHelpers.input_to_new_input_list(input)
-        list_input = _to_dump_compatible(list_input)
         list_input = self._remove_openai_responses_api_incompatible_fields(list_input)
 
         if model_settings.parallel_tool_calls and tools:

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -733,6 +733,7 @@ class OpenAIResponsesModel(Model):
         prompt: ResponsePromptParam | None = None,
     ) -> dict[str, Any]:
         list_input = ItemHelpers.input_to_new_input_list(input)
+        list_input = _to_dump_compatible(list_input)
         list_input = self._remove_openai_responses_api_incompatible_fields(list_input)
 
         if model_settings.parallel_tool_calls and tools:

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -196,6 +196,7 @@ class StreamedAudioResult:
 
                 # Signal completion for whole session because of error
                 await local_queue.put(VoiceStreamEventLifecycle(event="session_ended"))
+                await local_queue.put(None)
                 raise e
 
     async def _add_text(self, text: str):
@@ -292,7 +293,10 @@ class StreamedAudioResult:
             self.text_generation_task.cancel()
 
     def _check_errors(self):
-        for task in self._tasks:
+        all_tasks = list(self._tasks)
+        if self.text_generation_task is not None:
+            all_tasks.append(self.text_generation_task)
+        for task in all_tasks:
             if task.done():
                 if task.exception():
                     self._stored_exception = task.exception()

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -194,9 +194,10 @@ class StreamedAudioResult:
                 )
                 logger.error("Error streaming audio: %s", e)
 
-                # Signal completion for whole session because of error
-                await local_queue.put(VoiceStreamEventLifecycle(event="session_ended"))
+                await self._add_error(e)
                 await local_queue.put(None)
+                if self.text_generation_task is not None and not self.text_generation_task.done():
+                    self.text_generation_task.cancel()
                 raise e
 
     async def _add_text(self, text: str):
@@ -297,7 +298,7 @@ class StreamedAudioResult:
         if self.text_generation_task is not None:
             all_tasks.append(self.text_generation_task)
         for task in all_tasks:
-            if task.done():
+            if task.done() and not task.cancelled():
                 if task.exception():
                     self._stored_exception = task.exception()
                     break


### PR DESCRIPTION
This pull request fixes three issues in the voice pipeline error handling:

1. **Deadlock when TTS streaming fails** — When \_stream_audio\ encounters an exception, the error handler now puts the error on the public queue (via \_add_error\) and cancels the producer task instead of putting \session_ended\ on the local queue. Previously, \stream()\ would see the \session_ended\ event, enter the \syncio.shield\ path, and hang indefinitely waiting for a producer that hadn't finished.

2. **Background task exception never retrieved** — \_check_errors\ only inspected \_stream_audio\ tasks, missing \	ext_generation_task\. Added it to the check with a \	ask.cancelled()\ guard to prevent \CancelledError\ from being raised.

3. **No \None\ sentinel on error** — When a TTS task fails, the dispatcher's inner loop needed a \None\ sentinel to break out of the segment's local queue processing.