### PR TITLE
fix: remove redundant deep copy in input preprocessing

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -733,7 +733,6 @@ class OpenAIResponsesModel(Model):
         prompt: ResponsePromptParam | None = None,
     ) -> dict[str, Any]:
         list_input = ItemHelpers.input_to_new_input_list(input)
-        list_input = _to_dump_compatible(list_input)
         list_input = self._remove_openai_responses_api_incompatible_fields(list_input)
 
         if model_settings.parallel_tool_calls and tools:


### PR DESCRIPTION
ItemHelpers.input_to_new_input_list() already calls _to_dump_compatible() internally (items.py:772). The caller in OpenAIResponsesModel._create_request() was calling it a second time, creating an unnecessary deep copy of the entire input history on every model turn. For multi-turn conversations with large histories this doubles memory and CPU overhead.