### PR TITLE
docs: document tool decorator alias

### DIFF
--- a/docs/ref/decorators.md
+++ b/docs/ref/decorators.md
@@ -1,0 +1,7 @@
+# `Decorators`
+
+## `tool`
+
+`tool` is an alias for `function_tool`. Import it from `agents.decorators`.
+
+::: agents.decorators

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -252,6 +252,8 @@ You can use any Python function as a tool. The Agents SDK will set up the tool a
 
 We use Python's `inspect` module to extract the function signature, along with [`griffe`](https://mkdocstrings.github.io/griffe/) to parse docstrings and `pydantic` for schema creation.
 
+For new code, import [`tool`](ref/decorators.md#tool) from `agents.decorators`. It is a shorter alias for `function_tool` with the same runtime and typing behavior. The existing `function_tool` decorator remains fully supported.
+
 When you are using OpenAI Responses models, `@function_tool(defer_loading=True)` hides a function tool until `ToolSearchTool()` loads it. You can also group related function tools with [`tool_namespace()`][agents.tool.tool_namespace]. See [Hosted tool search](#hosted-tool-search) for the full setup and constraints.
 
 ```python
@@ -259,14 +261,15 @@ import json
 
 from typing_extensions import TypedDict, Any
 
-from agents import Agent, FunctionTool, RunContextWrapper, function_tool
+from agents import Agent, FunctionTool, RunContextWrapper
+from agents.decorators import tool
 
 
 class Location(TypedDict):
     lat: float
     long: float
 
-@function_tool  # (1)!
+@tool  # (1)!
 async def fetch_weather(location: Location) -> str:
     # (2)!
     """Fetch the weather for a given location.
@@ -278,7 +281,7 @@ async def fetch_weather(location: Location) -> str:
     return "sunny"
 
 
-@function_tool(name_override="fetch_data")  # (3)!
+@tool(name_override="fetch_data")  # (3)!
 def read_file(ctx: RunContextWrapper[Any], path: str, directory: str | None = None) -> str:
     """Read the contents of a file.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ plugins:
                     - Run error handlers: ref/run_error_handlers.md
                     - Memory: ref/memory.md
                     - REPL: ref/repl.md
+                    - Decorators: ref/decorators.md
                     - Tools: ref/tool.md
                     - Tool context: ref/tool_context.md
                     - Results: ref/result.md


### PR DESCRIPTION
### Summary

- recommend the new `agents.decorators.tool` alias in the function-tools guide
- update the primary example while clarifying that `function_tool` remains supported
- add the decorators module to the API reference

This follows the documentation work deferred from #3920 and makes the new public alias discoverable.

### Test plan

- `uv run mkdocs build`
- import/configured-decorator smoke test with `uv run python`
- `git diff --check`

### Issue number

Follow-up to #3920

### Checks

- [x] I've added new tests, if relevant (not relevant; documentation only)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (not required for docs-only changes)
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
