### PR TITLE
fix: prevent list aliasing in _populate_state_from_result

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -120,7 +120,7 @@ def _populate_state_from_result(
     if isinstance(model_input_items, list):
         state._generated_items = list(model_input_items)
     else:
-        state._generated_items = result.new_items
+        state._generated_items = list(result.new_items)
     state._session_items = list(result.new_items)
     snapshot_refs = _state_snapshot_owned_item_refs(result, state._original_input)
     live_refs = rebase_nested_history_owned_item_refs(


### PR DESCRIPTION
In _populate_state_from_result, when _model_input_items is not set on the result, state._generated_items was assigned a bare reference to result.new_items instead of a copy. Since state._generated_items can be mutated (e.g., appending items during interruption approval), this silently corrupted result.new_items — the primary public API for consuming agent output. The fix makes a defensive copy via list().