### PR TITLE
fix: prevent duplicate re-persistence of tool output items in session store

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -372,7 +372,7 @@ async def save_result_to_session(
     if run_state and new_items and new_run_items:
         missing_outputs = [
             item
-            for item in new_items
+            for item in new_items[:already_persisted]
             if item.type == "tool_call_output_item" and item not in new_run_items
         ]
         if missing_outputs:


### PR DESCRIPTION
In save_result_to_session, the missing_outputs scan searched the entire new_items list for tool_call_output_items not yet in new_run_items. This caused already-persisted tool outputs to be re-prepended on every streaming save call, leading to unbounded session storage growth. The fix limits the scan to the already-persisted portion of the list.