### PR TITLE
fix: mark realtime session as closed before CancelledError on cycle detection

### DIFF
--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -299,7 +299,8 @@ class RealtimeSession(RealtimeModelListener):
         if cleanup_task is not None and (
             current_task in self._guardrail_tasks or current_task in self._tool_call_tasks
         ):
-            # Cleanup is already waiting for this tracked task, so waiting here would form a cycle.
+            self._closing = True
+            self._closed = True
             raise asyncio.CancelledError
 
         if cleanup_task is None:


### PR DESCRIPTION
When RealtimeSession.close() detects that the current task is a tracked guardrail or tool call task, it raises CancelledError to avoid a cycle (the cleanup task is already waiting for this tracked task). However, it did not set _closed = True before raising, leaving the session in an inconsistent state where subsequent calls to close() would attempt cleanup again. The fix sets both _closing and _closed before raising.