### PR TITLE
fix(strict_schema): reject empty additionalProperties mappings

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -90,7 +90,10 @@ def _ensure_strict_json_schema(
     elif (
         typ == "object"
         and "additionalProperties" in json_schema
-        and json_schema["additionalProperties"]
+        # Compare with ``is not False`` rather than truthiness: OpenAPI/MCP schemas often use
+        # ``additionalProperties: {}`` (an empty schema meaning "allow anything"). That value is
+        # falsy in Python, so a truthiness check would silently leave a non-strict schema in place.
+        and json_schema["additionalProperties"] is not False
     ):
         raise UserError(
             "additionalProperties should not be set for object types. This could be because "

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -56,6 +56,40 @@ def test_object_with_true_additional_properties():
         ensure_strict_json_schema(schema)
 
 
+def test_object_with_empty_dict_additional_properties():
+    # OpenAPI/MCP schemas commonly use ``additionalProperties: {}`` to mean "allow anything".
+    # That empty mapping is falsy in Python, but it is still non-strict and must be rejected.
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "additionalProperties": {},
+    }
+    with pytest.raises(UserError):
+        ensure_strict_json_schema(schema)
+
+
+def test_object_with_schema_additional_properties():
+    # A non-empty additionalProperties schema is also non-strict and must be rejected.
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "additionalProperties": {"type": "string"},
+    }
+    with pytest.raises(UserError):
+        ensure_strict_json_schema(schema)
+
+
+def test_object_with_false_additional_properties_is_allowed():
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    result = ensure_strict_json_schema(schema)
+    assert result["additionalProperties"] is False
+    assert result["required"] == ["a"]
+
+
 def test_array_items_processing_and_default_removal():
     # When processing an array, the items schema is processed recursively.
     # Also, any "default": None should be removed.


### PR DESCRIPTION
### Summary

`ensure_strict_json_schema()` failed to reject `additionalProperties: {}`, a common OpenAPI/MCP encoding for “allow any extra properties”. Because `{}` is falsy in Python, the existing truthiness check treated it as strict-safe and left a non-strict schema in place.

This completes the intent of #356: any `additionalProperties` value other than `False` on an object schema must raise `UserError`.

### Root cause

In #356 the guard was changed from `is True` to a truthiness check so dict/`Mapping` schemas would be rejected. Empty mappings (`{}`) are falsy, so they still slipped through even though they mean “allow anything” in JSON Schema.

### Reproduction

```python
from agents.strict_schema import ensure_strict_json_schema

schema = {
    "type": "object",
    "properties": {"a": {"type": "string"}},
    "additionalProperties": {},
}
ensure_strict_json_schema(schema)
# Before: returns schema with additionalProperties still {}
# After: raises UserError
```

With MCP `convert_schemas_to_strict=True`, the previous behavior could mark tools as `strict_json_schema=True` while still shipping `additionalProperties: {}`, which OpenAI structured outputs reject. Raising now correctly triggers the existing non-strict fallback path in `MCPUtil.to_function_tool`.

### Solution

Compare with `is not False` instead of truthiness, matching the documented contract that only `False` is allowed under strict conversion.

### Test plan

- [x] Added regression tests for `additionalProperties: {}`, a non-empty schema object, and explicit `False`
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh` (`make format`, `make lint`, `make typecheck`, `make tests`)
- [x] Confirmed all verification steps pass
- [x] `git diff --check` clean

### Issue number

N/A — previously unreported gap left by #356 / #345.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

### Compatibility and risk

- Low risk, one-condition change.
- Schemas that previously kept `additionalProperties: {}` under strict conversion now raise `UserError`, which is the intended strict-mode behavior (same as `True` / non-empty schemas).
- MCP callers using `convert_schemas_to_strict=True` fall back to non-strict with the original schema instead of sending an invalid strict schema to the API.

### Related prior work

- #356 / #345: intended to reject non-`False` `additionalProperties` values, including dict/Mapping forms
- #3317 / #3318: adjacent empty-schema mutation fix (different bug)