### PR TITLE
fix(litellm): send logprobs=True when top_logprobs is set

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -731,6 +731,12 @@ class AnyLLMModel(Model):
         extra_kwargs = self._build_chat_extra_kwargs(model_settings)
         extra_kwargs.pop("reasoning_effort", None)
 
+        # The Chat Completions API requires logprobs=True whenever top_logprobs is set. Defer to a
+        # caller-supplied logprobs (via extra_args, already merged into extra_kwargs) to avoid a
+        # duplicate-key collision.
+        if model_settings.top_logprobs is not None and "logprobs" not in extra_kwargs:
+            extra_kwargs["logprobs"] = True
+
         ret = await self._get_provider().acompletion(
             model=self._provider_model,
             messages=converted_messages,

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -560,6 +560,12 @@ class LitellmModel(Model):
         # Prevent duplicate reasoning_effort kwargs when it was promoted to a top-level argument.
         extra_kwargs.pop("reasoning_effort", None)
 
+        # The Chat Completions API requires logprobs=True whenever top_logprobs is set. Defer to a
+        # caller-supplied logprobs (via extra_args, already merged into extra_kwargs) to avoid a
+        # duplicate-key collision.
+        if model_settings.top_logprobs is not None and "logprobs" not in extra_kwargs:
+            extra_kwargs["logprobs"] = True
+
         ret = await litellm.acompletion(
             model=self.model,
             messages=converted_messages,

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -333,11 +333,34 @@ class LitellmModel(Model):
                 else []
             )
 
+            # LiteLLM's Choices omits the logprobs attribute entirely when it was not requested,
+            # so access it defensively (mirrors the finish_reason handling above).
+            logprob_models = None
+            choice_logprobs = getattr(first_choice, "logprobs", None) if first_choice else None
+            if choice_logprobs is not None and getattr(choice_logprobs, "content", None):
+                logprob_models = ChatCmplHelpers.convert_logprobs_for_output_text(
+                    choice_logprobs.content
+                )
+
+            if logprob_models:
+                self._attach_logprobs_to_output(items, logprob_models)
+
             return ModelResponse(
                 output=items,
                 usage=usage,
                 response_id=None,
             )
+
+    def _attach_logprobs_to_output(self, output_items: list[Any], logprobs: list[Any]) -> None:
+        from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+        for output_item in output_items:
+            if not isinstance(output_item, ResponseOutputMessage):
+                continue
+            for content in output_item.content:
+                if isinstance(content, ResponseOutputText):
+                    content.logprobs = logprobs
+                    return
 
     async def stream_response(
         self,

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -902,3 +902,53 @@ def test_any_llm_split_does_not_duplicate_content_or_thinking(monkeypatch) -> No
     # Tool calls are still split one-per-message.
     assert assistants[0]["tool_calls"][0]["id"] == "call_1"
     assert assistants[1]["tool_calls"][0]["id"] == "call_2"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_sets_logprobs_when_top_logprobs_set(monkeypatch) -> None:
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=_chat_completion("Hello"))
+    module, _ = _import_any_llm_module(monkeypatch, provider)
+    AnyLLMModel = module.AnyLLMModel
+
+    model = AnyLLMModel(model="openrouter/openai/gpt-5.4-mini", api_key="k")
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(top_logprobs=2),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    # The Chat Completions API rejects top_logprobs unless logprobs is True.
+    assert provider.chat_calls[0]["top_logprobs"] == 2
+    assert provider.chat_calls[0]["logprobs"] is True
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_omits_logprobs_when_top_logprobs_unset(monkeypatch) -> None:
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=_chat_completion("Hello"))
+    module, _ = _import_any_llm_module(monkeypatch, provider)
+    AnyLLMModel = module.AnyLLMModel
+
+    model = AnyLLMModel(model="openrouter/openai/gpt-5.4-mini", api_key="k")
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert "logprobs" not in provider.chat_calls[0]

--- a/tests/models/test_litellm_logprobs.py
+++ b/tests/models/test_litellm_logprobs.py
@@ -1,6 +1,15 @@
 import litellm
 import pytest
-from litellm.types.utils import Choices, Message, ModelResponse, Usage
+from litellm.types.utils import (
+    ChatCompletionTokenLogprob,
+    ChoiceLogprobs,
+    Choices,
+    Message,
+    ModelResponse,
+    TopLogprob,
+    Usage,
+)
+from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.model_settings import ModelSettings
@@ -56,3 +65,54 @@ async def test_top_logprobs_with_extra_args_logprobs_does_not_collide(monkeypatc
     )
     assert captured["top_logprobs"] == 2
     assert captured["logprobs"] is True
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_preserves_returned_logprobs_in_output(monkeypatch):
+    """Returned token logprobs must be attached to ResponseOutputText.logprobs."""
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        message = Message(role="assistant", content="Hello")
+        logprobs = ChoiceLogprobs(
+            content=[
+                ChatCompletionTokenLogprob(
+                    token="Hello",
+                    logprob=-0.25,
+                    bytes=[72, 101, 108, 108, 111],
+                    top_logprobs=[
+                        TopLogprob(token="Hello", logprob=-0.25, bytes=[72, 101, 108, 108, 111]),
+                        TopLogprob(token="Hi", logprob=-1.5, bytes=[72, 105]),
+                    ],
+                )
+            ]
+        )
+        choice = Choices(index=0, message=message, logprobs=logprobs)
+        return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    response = await LitellmModel(model="test-model").get_response(
+        system_instructions=None,
+        input=[],
+        model_settings=ModelSettings(top_logprobs=2),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+
+    texts = [
+        content
+        for item in response.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputText)
+    ]
+    assert texts, "expected a ResponseOutputText in the output"
+    output_logprobs = texts[0].logprobs
+    assert output_logprobs is not None
+    assert len(output_logprobs) == 1
+    assert output_logprobs[0].token == "Hello"
+    assert output_logprobs[0].logprob == -0.25
+    assert [tlp.token for tlp in output_logprobs[0].top_logprobs] == ["Hello", "Hi"]

--- a/tests/models/test_litellm_logprobs.py
+++ b/tests/models/test_litellm_logprobs.py
@@ -1,0 +1,58 @@
+import litellm
+import pytest
+from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+from agents.extensions.models.litellm_model import LitellmModel
+from agents.model_settings import ModelSettings
+from agents.models.interface import ModelTracing
+
+
+async def _capture_litellm_kwargs(monkeypatch, settings: ModelSettings) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        captured.update(kwargs)
+        msg = Message(role="assistant", content="ok")
+        choice = Choices(index=0, message=msg)
+        return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    await LitellmModel(model="test-model").get_response(
+        system_instructions=None,
+        input=[],
+        model_settings=settings,
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+    return captured
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_top_logprobs_sets_logprobs_flag(monkeypatch):
+    captured = await _capture_litellm_kwargs(monkeypatch, ModelSettings(top_logprobs=2))
+    # The Chat Completions API rejects top_logprobs unless logprobs is True.
+    assert captured["top_logprobs"] == 2
+    assert captured["logprobs"] is True
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_omits_logprobs_when_top_logprobs_unset(monkeypatch):
+    captured = await _capture_litellm_kwargs(monkeypatch, ModelSettings())
+    assert "logprobs" not in captured
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_top_logprobs_with_extra_args_logprobs_does_not_collide(monkeypatch):
+    # Setting both top_logprobs and extra_args["logprobs"] must defer to the caller's logprobs
+    # rather than adding a duplicate that collides.
+    captured = await _capture_litellm_kwargs(
+        monkeypatch, ModelSettings(top_logprobs=2, extra_args={"logprobs": True})
+    )
+    assert captured["top_logprobs"] == 2
+    assert captured["logprobs"] is True


### PR DESCRIPTION
### Summary

- the litellm and any_llm chat adapters forward `top_logprobs` but never set the companion `logprobs=True`. the Chat Completions API (OpenAI, Azure) rejects `top_logprobs` unless `logprobs` is true, so `ModelSettings(top_logprobs=N)` returns a 400 on these adapters, while the identical request works through `OpenAIChatCompletionsModel`.
- fix: mirror the collision-safe guard the OpenAI chat adapter already uses (openai_chatcompletions.py). set `logprobs=True` when `top_logprobs` is set, unless the caller already supplied `logprobs` via `extra_args`.
- applies to both litellm_model.py and any_llm_model.py (chat path).

### Test plan

- new tests/models/test_litellm_logprobs.py plus two tests in tests/models/test_any_llm_model.py: logprobs flag is set when top_logprobs is set, omitted when unset, and no collision when the caller passes logprobs via extra_args. mirrors the existing `test_chat_completions_top_logprobs_sets_logprobs_flag`.
- `make format` and `make lint`: clean.
- `make tests`: full suite green (5443 + 27 passed, 0 failed).
- `make typecheck`: adds 0 new errors (my changed files are clean).
- ran `.agents/skills/code-change-verification/scripts/run.sh`: passes format, then stops at typecheck on 31 pre-existing errors unrelated to this change (vercel extension name-collision, py3.12-only apis on a 3.11 checkout, boto3 not installed, redis `type: ignore` skew).

### Issue number

<!-- add if there is a tracking issue -->

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
