### PR TITLE
fix: improve AnyLLM and LiteLLM provider compatibility

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -981,9 +981,28 @@ class AnyLLMModel(Model):
     def _normalize_response(self, response: Any) -> Response:
         if isinstance(response, Response):
             return response
-        if isinstance(response, BaseModel):
-            return Response.model_validate(response.model_dump())
-        return Response.model_validate(response)
+
+        payload = response.model_dump() if isinstance(response, BaseModel) else response
+        if isinstance(payload, dict):
+            usage = payload.get("usage")
+            if isinstance(usage, dict):
+                input_tokens_details = usage.get("input_tokens_details")
+                if (
+                    isinstance(input_tokens_details, dict)
+                    and "cache_write_tokens" not in input_tokens_details
+                ):
+                    payload = {
+                        **payload,
+                        "usage": {
+                            **usage,
+                            "input_tokens_details": {
+                                **input_tokens_details,
+                                "cache_write_tokens": 0,
+                            },
+                        },
+                    }
+
+        return Response.model_validate(payload)
 
     def _normalize_chat_completion_response(self, response: Any) -> ChatCompletion:
         if isinstance(response, ChatCompletion):

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -574,6 +574,11 @@ class LitellmModel(Model):
         if model_settings.extra_args:
             extra_kwargs.update(model_settings.extra_args)
 
+        if converted_tools:
+            # SDK tools are already converted to ordinary function tools, so LiteLLM's proxy-only
+            # MCP discovery would add unsupported server dependencies without handling them.
+            extra_kwargs.setdefault("_skip_mcp_handler", True)
+
         if should_disable_provider_managed_retries():
             # Preserve provider-managed retries on the first attempt, but make runner retries the
             # sole retry layer by forcing LiteLLM's retry knobs off on replay attempts.

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -214,6 +214,18 @@ class GenericChatCompletionPayload(BaseModel):
     usage: Any
 
 
+class GenericResponsesPayload(BaseModel):
+    id: str
+    created_at: float
+    model: str
+    object: str
+    output: list[Any]
+    parallel_tool_calls: bool
+    tool_choice: Any
+    tools: list[Any]
+    usage: Any
+
+
 async def _empty_chat_stream() -> AsyncIterator[ChatCompletionChunk]:
     if False:
         yield ChatCompletionChunk(
@@ -408,6 +420,40 @@ async def test_any_llm_responses_path_is_used_when_supported(monkeypatch) -> Non
     assert kwargs["extra_headers"]["User-Agent"] == f"Agents/Python {__version__}"
     assert response.response_id == "resp_123"
     assert response.output[0].content[0].text == "Hello"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload_type", ["dict", "basemodel"])
+async def test_any_llm_responses_path_defaults_missing_cache_write_tokens(
+    monkeypatch: pytest.MonkeyPatch, payload_type: str
+) -> None:
+    response_payload = _response("Hello").model_dump()
+    response_payload["usage"]["input_tokens_details"].pop("cache_write_tokens")
+    response: Any = response_payload
+    if payload_type == "basemodel":
+        response = GenericResponsesPayload.model_validate(response_payload)
+
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=response)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(model="openai/gpt-5.4-mini")
+
+    normalized = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert normalized.output[0].content[0].text == "Hello"
+    assert normalized.usage.input_tokens_details.cache_write_tokens == 0
+    assert "cache_write_tokens" not in response_payload["usage"]["input_tokens_details"]
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_litellm_extra_body.py
+++ b/tests/models/test_litellm_extra_body.py
@@ -4,6 +4,7 @@ import litellm
 import pytest
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
 
+from agents import function_tool
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
@@ -46,6 +47,43 @@ async def test_extra_body_is_forwarded(monkeypatch):
     assert captured["extra_body"] == {"cached_content": "some_cache", "foo": 123}
     assert "cached_content" not in captured
     assert "foo" not in captured
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("override", [None, False])
+async def test_function_tools_skip_litellm_proxy_mcp_discovery(monkeypatch, override):
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        captured.update(kwargs)
+        msg = Message(role="assistant", content="ok")
+        choice = Choices(index=0, message=msg)
+        return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
+
+    @function_tool
+    def lookup() -> str:
+        """Return a deterministic result."""
+        return "ok"
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    settings = ModelSettings(
+        extra_args={"_skip_mcp_handler": override} if override is not None else None
+    )
+    model = LitellmModel(model="test-model")
+
+    await model.get_response(
+        system_instructions=None,
+        input=[],
+        model_settings=settings,
+        tools=[lookup],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+
+    assert captured["_skip_mcp_handler"] is (True if override is None else override)
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
This pull request fixes two provider compatibility issues that surface when installing the SDK with current optional dependencies.

- Normalize AnyLLM Responses API payloads that omit `cache_write_tokens`, preventing validation failures with newer OpenAI Python SDK versions.
- Skip LiteLLM's proxy MCP discovery for SDK-managed function tools, avoiding undeclared `fastapi` and `orjson` dependencies while preserving explicit caller overrides.
- Add regression coverage for dictionary and Pydantic response payloads, along with LiteLLM function-tool behavior and caller overrides.