### PR TITLE
docs: fix streamed audio API rendering

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -81,11 +81,11 @@ class StreamedAudioInput:
     def __init__(self):
         self.queue: asyncio.Queue[npt.NDArray[np.int16 | np.float32] | None] = asyncio.Queue()
 
-    async def add_audio(self, audio: npt.NDArray[np.int16 | np.float32] | None):
+    async def add_audio(self, audio: npt.NDArray[np.int16 | np.float32] | None) -> None:
         """Adds more audio data to the stream.
 
         Args:
             audio: The audio data to add. Must be a numpy array of int16 or float32 or None.
-              If None passed, it indicates the end of the stream.
+                If None passed, it indicates the end of the stream.
         """
         await self.queue.put(audio)


### PR DESCRIPTION
## What
- add the explicit `None` return annotation to `StreamedAudioInput.add_audio`
- align the `None` continuation line so Griffe renders it as part of the `audio` parameter description

## Why
The generated API docs currently report confusing indentation for this docstring, which can detach the end-of-stream behavior from the parameter description.

## Test
- `uv run pytest tests/voice/test_input.py -q` (8 passed)
- `uv run ruff check src/agents/voice/input.py`
- `uv run pyright src/agents/voice/input.py`
- `uv run mkdocs build` (passed; the `voice/input.py` indentation warning is gone)

The repository-wide verification script was also attempted; it is currently blocked in this checkout by missing optional Runloop/LiteLLM/SQLAlchemy/Temporal dependencies and unrelated realtime test failures.