### PR TITLE
fix: strip orphaned assistant ids per reasoning pairing, not list-wide

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -391,20 +391,32 @@ def _strip_orphaned_assistant_ids(
     because the API expects the paired reasoning item for each assistant message
     ID.  This function detects and removes those orphaned IDs so the compacted
     history can be used safely.
+
+    A reasoning item pairs with the next non-reasoning item that follows it (the
+    same convention ``_drop_reasoning_items_preceding_dropped_calls`` uses), so
+    pairing is tracked per message rather than once for the whole list: a
+    compacted output can legitimately mix a message whose own reasoning item
+    survived with one whose reasoning item was dropped elsewhere in the same
+    output.
     """
     if not items:
         return items
 
-    has_reasoning = any(
-        isinstance(item, dict) and item.get("type") == "reasoning" for item in items
-    )
-    if has_reasoning:
-        return items
-
     cleaned: list[TResponseInputItem] = []
+    has_paired_reasoning = False
     for item in items:
-        if isinstance(item, dict) and item.get("role") == "assistant" and "id" in item:
+        if isinstance(item, dict) and item.get("type") == "reasoning":
+            has_paired_reasoning = True
+            cleaned.append(item)
+            continue
+        if (
+            isinstance(item, dict)
+            and item.get("role") == "assistant"
+            and "id" in item
+            and not has_paired_reasoning
+        ):
             item = {k: v for k, v in item.items() if k != "id"}  # type: ignore[assignment]
+        has_paired_reasoning = False
         cleaned.append(item)
     return cleaned
 

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -1257,6 +1257,24 @@ class TestStripOrphanedAssistantIds:
         for item in result:
             assert "id" not in item
 
+    def test_strips_id_from_message_after_a_differently_paired_reasoning(self) -> None:
+        """A surviving reasoning item elsewhere in the output must not preserve an id
+        on an assistant message whose own reasoning item did not survive."""
+        items: list[TResponseInputItem] = [
+            cast(TResponseInputItem, {"type": "reasoning", "id": "rs_1", "content": "..."}),
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "id": "msg_1", "content": "paired"},
+            ),
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "id": "msg_2", "content": "orphaned"},
+            ),
+        ]
+        result = _strip_orphaned_assistant_ids(items)
+        assert result[1].get("id") == "msg_1"
+        assert "id" not in result[2]
+
 
 class TestCompactionStripsOrphanedIds:
     """Regression test for #2727: gpt-5.4 compact retains assistant msg IDs after
@@ -1334,6 +1352,39 @@ class TestCompactionStripsOrphanedIds:
         stored_items = mock_session.add_items.call_args[0][0]
         assistant_items = [i for i in stored_items if i.get("role") == "assistant"]
         assert assistant_items[0]["id"] == "msg_aaa"
+
+    @pytest.mark.asyncio
+    async def test_run_compaction_strips_only_the_unpaired_id_in_a_mixed_output(self) -> None:
+        """A compacted output can mix a message whose own reasoning item survived with one
+        whose reasoning item did not; only the unpaired message's id should be stripped."""
+        mock_session = self.create_mock_session()
+        mock_session.get_items.return_value = [
+            cast(TResponseInputItem, {"type": "message", "role": "assistant", "content": f"m{i}"})
+            for i in range(DEFAULT_COMPACTION_THRESHOLD)
+        ]
+
+        mock_compact_response = MagicMock()
+        mock_compact_response.output = [
+            {"type": "reasoning", "id": "rs_111", "content": "thinking..."},
+            {"type": "message", "role": "assistant", "id": "msg_paired", "content": "answer 1"},
+            {"type": "message", "role": "assistant", "id": "msg_orphaned", "content": "answer 2"},
+        ]
+
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(return_value=mock_compact_response)
+
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=mock_session,
+            client=mock_client,
+        )
+
+        await session.run_compaction({"response_id": "resp-123"})
+
+        stored_items = mock_session.add_items.call_args[0][0]
+        assistant_items = [i for i in stored_items if i.get("role") == "assistant"]
+        assert assistant_items[0]["id"] == "msg_paired"
+        assert "id" not in assistant_items[1]
 
 
 class TestTypeGuard:


### PR DESCRIPTION
`_strip_orphaned_assistant_ids` (`src/agents/memory/openai_responses_compaction_session.py`) is supposed to strip the `id` from an assistant message whose paired reasoning item did not survive `responses.compact`, since the Responses API rejects an id whose reasoning item is missing (the #2727 bug). The check it actually ran was `any(item.type == "reasoning" for item in items)`: if any reasoning item is present anywhere in the compacted output, the function returned every item untouched, including an assistant message whose own reasoning item was dropped elsewhere in the same output.

A reasoning item pairs with the next non-reasoning item that follows it, the same convention `_drop_reasoning_items_preceding_dropped_calls` in `run_internal/items.py` uses. So a compacted output can legitimately mix a message whose reasoning survived with one whose reasoning did not, and the list-wide check treats the whole output as paired the moment one reasoning item survives anywhere. The orphaned message keeps its id, and the next `responses.create` call carries the same invalid-id shape #2727 already fixed for the simpler case.

## Fix

Track pairing per adjacent (reasoning, next-item) pair instead of once for the whole list: an id is only kept when the immediately preceding reasoning item survived.

## Verification

Reproduced end to end through `OpenAIResponsesCompactionSession.run_compaction()`, the real public entry point, not the helper directly: a `responses.compact` output shaped `[reasoning(rs_1), assistant(msg_1, paired), assistant(msg_2, orphaned)]` stored `msg_2` with its id intact on main. Added a regression test at that level plus a narrower unit test on `_strip_orphaned_assistant_ids` directly; both fail on main and pass with the fix (differential run, main vs branch, with `module.__file__` provenance checked on each side).

Ran the full `tests/memory/` suite (150 tests, all pass) plus `ruff format --check`, `ruff check`, and `mypy` scoped to the changed file (all clean). I did not make a live call to the Responses API; the existing #2727 test already established that this shape of stored id is what the API rejects, and this PR only widens the same guard's pairing check, it does not touch the API-rejection premise itself.
