### PR TITLE
fix: await async callable-object dynamic instructions

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -1003,11 +1003,13 @@ class Agent(AgentBase, Generic[TContext]):
                     f"but got {len(params)}: {[p.name for p in params]}"
                 )
 
-            # Call the instructions function properly
-            if inspect.iscoroutinefunction(self.instructions):
-                return await cast(Awaitable[str], self.instructions(run_context, self))
-            else:
-                return cast(str, self.instructions(run_context, self))
+            # Call once, then await if needed. Callable instances with async
+            # ``__call__`` are not coroutine functions, so checking
+            # ``iscoroutinefunction(self.instructions)`` would skip the await.
+            result = self.instructions(run_context, self)
+            if inspect.isawaitable(result):
+                return await result
+            return result
 
         elif self.instructions is not None:
             logger.error(

--- a/src/agents/realtime/agent.py
+++ b/src/agents/realtime/agent.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Generic, cast
+from typing import Any, Generic
 
 from agents.prompts import Prompt
 
@@ -121,10 +121,13 @@ class RealtimeAgent(AgentBase, Generic[TContext]):
         if isinstance(self.instructions, str):
             return self.instructions
         elif callable(self.instructions):
-            if inspect.iscoroutinefunction(self.instructions):
-                return await cast(Awaitable[str], self.instructions(run_context, self))
-            else:
-                return cast(str, self.instructions(run_context, self))
+            # Call once, then await if needed. Callable instances with async
+            # ``__call__`` are not coroutine functions, so checking
+            # ``iscoroutinefunction(self.instructions)`` would skip the await.
+            result = self.instructions(run_context, self)
+            if inspect.isawaitable(result):
+                return await result
+            return result
         elif self.instructions is not None:
             if _debug.DONT_LOG_MODEL_DATA:
                 logger.error("Instructions must be a string or a function")

--- a/tests/realtime/test_agent.py
+++ b/tests/realtime/test_agent.py
@@ -31,6 +31,30 @@ async def test_dynamic_instructions():
 
 
 @pytest.mark.asyncio
+async def test_async_callable_object_instructions_are_awaited():
+    """Callable instances whose ``__call__`` is async must be awaited.
+
+    ``inspect.iscoroutinefunction`` returns ``False`` for the instance itself, so the
+    previous implementation returned the unawaited coroutine as the system prompt.
+    """
+
+    class AsyncInstructions:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, ctx, agt) -> str:
+            self.calls += 1
+            assert ctx.context is None
+            return "Dynamic async callable"
+
+    instructions = AsyncInstructions()
+    agent = RealtimeAgent(name="test", instructions=instructions)
+    prompt = await agent.get_system_prompt(RunContextWrapper(context=None))
+    assert prompt == "Dynamic async callable"
+    assert instructions.calls == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("redacted", [True, False])
 async def test_mutated_invalid_instructions_respect_model_data_policy(
     monkeypatch, redacted: bool

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -33,6 +33,13 @@ async def test_system_instructions():
     agent = agent.clone(instructions=async_instructions)
     assert await agent.get_system_prompt(context) == "async_123"
 
+    class AsyncCallableInstructions:
+        async def __call__(self, context: RunContextWrapper[None], agent: Agent[None]) -> str:
+            return "async_callable_123"
+
+    agent = agent.clone(instructions=AsyncCallableInstructions())
+    assert await agent.get_system_prompt(context) == "async_callable_123"
+
 
 @pytest.mark.asyncio
 async def test_handoff_with_agents():

--- a/tests/test_agent_instructions_signature.py
+++ b/tests/test_agent_instructions_signature.py
@@ -36,6 +36,40 @@ class TestInstructionsSignatureValidation:
         assert result == "Valid sync instructions"
 
     @pytest.mark.asyncio
+    async def test_async_callable_object_is_awaited(self, mock_run_context):
+        """Callable instances whose ``__call__`` is async must be awaited.
+
+        ``inspect.iscoroutinefunction`` returns ``False`` for the instance itself, so the
+        previous implementation returned the unawaited coroutine as the system prompt.
+        """
+
+        class AsyncInstructions:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def __call__(self, context, agent) -> str:
+                self.calls += 1
+                return "Valid async callable instructions"
+
+        instructions = AsyncInstructions()
+        agent = Agent(name="test_agent", instructions=instructions)
+        result = await agent.get_system_prompt(mock_run_context)
+        assert result == "Valid async callable instructions"
+        assert instructions.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_callable_object_still_works(self, mock_run_context):
+        """Sync callable instances should continue to work as dynamic instructions."""
+
+        class SyncInstructions:
+            def __call__(self, context, agent) -> str:
+                return "Valid sync callable instructions"
+
+        agent = Agent(name="test_agent", instructions=SyncInstructions())
+        result = await agent.get_system_prompt(mock_run_context)
+        assert result == "Valid sync callable instructions"
+
+    @pytest.mark.asyncio
     async def test_one_parameter_raises_error(self, mock_run_context):
         """Test that function with only one parameter raises TypeError"""
 


### PR DESCRIPTION
### Summary

This pull request fixes dynamic instructions so callable objects with async `__call__` are awaited in both `Agent.get_system_prompt` and `RealtimeAgent.get_system_prompt`.

`inspect.iscoroutinefunction(self.instructions)` is `False` for callable instances, even when `__call__` is `async def`. The previous path invoked the callable and returned the bare coroutine as `system_instructions`, so models received a coroutine object instead of the resolved prompt (and Python emitted `coroutine was never awaited`). Plain async functions already worked; this matches the await-by-result pattern already used for handoff `on_handoff` callbacks (#3211) and dynamic prompts.

Changes:
- Call the instructions callable once, then `await` when `inspect.isawaitable(result)`
- Apply the same fix to `RealtimeAgent`
- Add regressions for async and sync callable-object instructions

### Test plan

- [x] Added `test_async_callable_object_is_awaited` / `test_sync_callable_object_still_works` in `tests/test_agent_instructions_signature.py`
- [x] Extended `test_system_instructions` in `tests/test_agent_config.py`
- [x] Added `test_async_callable_object_instructions_are_awaited` in `tests/realtime/test_agent.py`
- [x] Confirmed the new async-callable tests failed on unpatched `main` (returned unawaited coroutine) and passed after the fix
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh` (format, lint, typecheck, tests) — all passed
- [x] Confirmed all verification steps pass

### Issue number

N/A — previously unreported. Same root-cause class as #3211 (handoff `on_handoff` callable objects), but for dynamic instructions on `Agent` / `RealtimeAgent`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
