### PR TITLE
fix: preserve None from tool_use_behavior final output

### DIFF
--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -201,14 +201,14 @@ async def _maybe_finalize_from_tool_results(
     if not check_tool_use.is_final_output:
         return None
 
-    if not public_agent.output_type or public_agent.output_type is str:
-        check_tool_use.final_output = str(check_tool_use.final_output)
-
     if check_tool_use.final_output is None:
         logger.error(
             "Model returned a final output of None. Not raising an error because we assume"
             "you know what you're doing."
         )
+    elif not public_agent.output_type or public_agent.output_type is str:
+        # Preserve None above; only stringify concrete values for plain-text agents.
+        check_tool_use.final_output = str(check_tool_use.final_output)
 
     return await execute_final_output(
         public_agent=public_agent,

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -3567,6 +3567,74 @@ async def test_tool_use_behavior_custom_function():
 
 
 @pytest.mark.asyncio
+async def test_tool_use_behavior_preserves_none_final_output() -> None:
+    """Custom tool_use_behavior may return final_output=None; do not coerce it to 'None'."""
+
+    def behavior(
+        context: RunContextWrapper[Any], results: list[FunctionToolResult]
+    ) -> ToolsToFinalOutputResult:
+        assert results
+        return ToolsToFinalOutputResult(is_final_output=True, final_output=None)
+
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("foo", "tool_result")],
+        tool_use_behavior=behavior,
+    )
+    model.set_next_output([get_function_tool_call("foo", None)])
+
+    result = await Runner.run(agent, input="user_message")
+    assert result.final_output is None
+
+
+@pytest.mark.asyncio
+async def test_stop_on_first_tool_preserves_none_tool_output() -> None:
+    """stop_on_first_tool should preserve a tool's None output instead of the string 'None'."""
+
+    @function_tool
+    def returns_none() -> str | None:
+        return None
+
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[returns_none],
+        tool_use_behavior="stop_on_first_tool",
+    )
+    model.set_next_output([get_function_tool_call("returns_none", "{}")])
+
+    result = await Runner.run(agent, input="user_message")
+    assert result.final_output is None
+
+
+@pytest.mark.asyncio
+async def test_tool_use_behavior_preserves_none_final_output_streamed() -> None:
+    """Streamed runs must preserve None final_output from tool_use_behavior as well."""
+
+    def behavior(
+        context: RunContextWrapper[Any], results: list[FunctionToolResult]
+    ) -> ToolsToFinalOutputResult:
+        return ToolsToFinalOutputResult(is_final_output=True, final_output=None)
+
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("foo", "tool_result")],
+        tool_use_behavior=behavior,
+    )
+    model.set_next_output([get_function_tool_call("foo", None)])
+
+    result = Runner.run_streamed(agent, input="user_message")
+    async for _ in result.stream_events():
+        pass
+    assert result.final_output is None
+
+
+@pytest.mark.asyncio
 async def test_model_settings_override():
     model = FakeModel()
     agent = Agent(


### PR DESCRIPTION
### Summary

When `tool_use_behavior` (or `stop_on_first_tool`) produces `is_final_output=True` with `final_output=None`, `_maybe_finalize_from_tool_results` previously called `str(None)` before the intentional `None` guard. That coerced the result to the string `"None"`, made the nearby "final output of None" log unreachable, and caused both `Runner.run` and `Runner.run_streamed` to return `"None"` instead of `None`.

This pull request fixes that by checking for `None` first and only stringifying concrete values for plain-text agents.

**Affected component:** `src/agents/run_internal/turn_resolution.py` (`_maybe_finalize_from_tool_results`)

**Problem:** `final_output=None` from tool-use finalization became the string `"None"`.

**Corrected behavior:** `None` is preserved; non-`None` plain-text values still go through `str(...)`.

**Root cause:** `str(check_tool_use.final_output)` ran before the `is None` branch.

**Why minimal:** One branch reorder in the shared finalization helper; streamed and non-streamed paths both call it. No public API changes.

**Regression tests:** Custom `tool_use_behavior` returning `None`, `stop_on_first_tool` with a tool that returns `None`, and the streamed equivalent.

**Compatibility:** Corrects buggy released behavior present since at least `v0.18.3`. Callers that depended on receiving the literal string `"None"` were relying on the bug; the existing log message and dead `is None` check document that `None` was intended to survive.

**Non-goals:** No changes to approval/rejection behavior, async awaitability of callable objects, session backends, or structured-output agents (those already skip the `str(...)` path).

### Test plan

- [x] Pre-fix reproduction failed with `assert 'None' is None` on current `upstream/main` (`59763339`)
- [x] `uv run pytest tests/test_agent_runner.py::test_tool_use_behavior_preserves_none_final_output tests/test_agent_runner.py::test_stop_on_first_tool_preserves_none_tool_output tests/test_agent_runner.py::test_tool_use_behavior_preserves_none_final_output_streamed tests/test_agent_runner.py::test_tool_use_behavior_custom_function tests/test_agent_runner.py::test_tool_use_behavior_first_output tests/test_tool_use_behavior.py -q` → 13 passed
- [x] Streamed regression repeated 5× → all passed
- [x] `bash .agents/skills/code-change-verification/scripts/run.sh` → format, lint, typecheck, and tests all passed
- [x] `git diff --check` → clean
- [x] No OpenAI API key or live model calls used (FakeModel only)

### Issue number

N/A — small correctness fix submitted directly per common repository practice.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
