### PR TITLE
fix: await async callable-object callbacks

### DIFF
--- a/src/agents/realtime/handoffs.py
+++ b/src/agents/realtime/handoffs.py
@@ -166,16 +166,14 @@ def realtime_handoff(
                 strict=True,
             )
             input_func = cast(OnHandoffWithInput[THandoffInput], on_handoff)
-            if inspect.iscoroutinefunction(input_func):
-                await input_func(ctx, validated_input)
-            else:
-                input_func(ctx, validated_input)
+            result = input_func(ctx, validated_input)
+            if inspect.isawaitable(result):
+                await result
         elif on_handoff is not None:
             no_input_func = cast(OnHandoffWithoutInput, on_handoff)
-            if inspect.iscoroutinefunction(no_input_func):
-                await no_input_func(ctx)
-            else:
-                no_input_func(ctx)
+            result = no_input_func(ctx)
+            if inspect.isawaitable(result):
+                await result
 
         return agent
 

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -688,14 +688,10 @@ async def check_for_final_output_from_tools(
                 )
         return ToolsToFinalOutputResult(is_final_output=False, final_output=None)
     elif callable(agent.tool_use_behavior):
-        if inspect.iscoroutinefunction(agent.tool_use_behavior):
-            return await cast(
-                Awaitable[ToolsToFinalOutputResult],
-                agent.tool_use_behavior(context_wrapper, tool_results),
-            )
-        return cast(
-            ToolsToFinalOutputResult, agent.tool_use_behavior(context_wrapper, tool_results)
-        )
+        result = agent.tool_use_behavior(context_wrapper, tool_results)
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     logger.error("Invalid tool_use_behavior: %s", agent.tool_use_behavior)
     raise UserError(f"Invalid tool_use_behavior: {agent.tool_use_behavior}")

--- a/tests/realtime/test_realtime_handoffs.py
+++ b/tests/realtime/test_realtime_handoffs.py
@@ -263,6 +263,34 @@ async def test_realtime_handoff_async_on_handoff_without_input_runs() -> None:
     assert called == [True]
 
 
+@pytest.mark.asyncio
+async def test_realtime_handoff_async_callable_objects_are_awaited() -> None:
+    class WithInput:
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        async def __call__(self, ctx: RunContextWrapper[Any], value: int) -> None:
+            self.calls.append(value)
+
+    class NoInput:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, ctx: RunContextWrapper[Any]) -> None:
+            self.calls += 1
+
+    rt = RealtimeAgent(name="async_callable")
+    with_input = WithInput()
+    with_input_handoff = realtime_handoff(rt, on_handoff=with_input, input_type=int)
+    assert await with_input_handoff.on_invoke_handoff(RunContextWrapper(None), "7") is rt
+    assert with_input.calls == [7]
+
+    no_input = NoInput()
+    no_input_handoff = realtime_handoff(rt, on_handoff=no_input)
+    assert await no_input_handoff.on_invoke_handoff(RunContextWrapper(None), "") is rt
+    assert no_input.calls == 1
+
+
 class StrictInput(BaseModel):
     name: str
     age: int

--- a/tests/test_tool_use_behavior.py
+++ b/tests/test_tool_use_behavior.py
@@ -139,6 +139,43 @@ async def test_custom_tool_use_behavior_async() -> None:
 
 
 @pytest.mark.asyncio
+async def test_custom_tool_use_behavior_async_callable_object() -> None:
+    """Async callable objects should be awaited and invoked exactly once."""
+
+    class Behavior:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(
+            self,
+            context: RunContextWrapper,
+            results: list[FunctionToolResult],
+        ) -> ToolsToFinalOutputResult:
+            self.calls += 1
+            assert len(results) == 2
+            return ToolsToFinalOutputResult(
+                is_final_output=True,
+                final_output="async_callable",
+            )
+
+    behavior = Behavior()
+    agent = Agent(name="test", tool_use_behavior=behavior)
+    tool_results = [
+        _make_function_tool_result(agent, "ignored1"),
+        _make_function_tool_result(agent, "ignored2"),
+    ]
+    result = await run_loop.check_for_final_output_from_tools(
+        agent=agent,
+        tool_results=tool_results,
+        context_wrapper=RunContextWrapper(context=None),
+    )
+
+    assert result.is_final_output is True
+    assert result.final_output == "async_callable"
+    assert behavior.calls == 1
+
+
+@pytest.mark.asyncio
 async def test_invalid_tool_use_behavior_raises() -> None:
     """If tool_use_behavior is invalid, we should raise a UserError."""
     agent = Agent(name="test")


### PR DESCRIPTION
This pull request fixes `realtime_handoff` and custom `tool_use_behavior` callbacks whose callable objects implement async `__call__`. They are similar changes to https://github.com/openai/openai-agents-python/pull/3942

The runtime now invokes each callback exactly once and awaits based on the returned value instead of relying on `inspect.iscoroutinefunction`. This preserves existing synchronous and async-function behavior while correctly supporting the declared awaitable callback contract. Regression coverage includes both Realtime handoff signatures and exact-once custom tool-use behavior.
