### PR TITLE
fix: isolate unit tests from ambient proxy settings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import sys
+from collections.abc import MutableMapping
 
 import pytest
 
@@ -12,6 +14,32 @@ from agents.tracing.provider import DefaultTraceProvider
 from agents.tracing.setup import set_trace_provider
 
 from .testing_processor import SPAN_PROCESSOR_TESTING
+
+_PROXY_ENVIRONMENT_VARIABLES = (
+    "ALL_PROXY",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "all_proxy",
+    "http_proxy",
+    "https_proxy",
+)
+_PROXY_OPT_IN_ENVIRONMENT_VARIABLE = "OPENAI_AGENTS_TEST_USE_PROXY"
+
+
+def _remove_ambient_proxy_environment(environment: MutableMapping[str, str]) -> None:
+    """Keep unit tests independent from host proxy configuration."""
+    if environment.get(_PROXY_OPT_IN_ENVIRONMENT_VARIABLE, "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }:
+        return
+
+    for variable in _PROXY_ENVIRONMENT_VARIABLES:
+        environment.pop(variable, None)
+
+
+_remove_ambient_proxy_environment(os.environ)
 
 collect_ignore: list[str] = []
 
@@ -50,8 +78,6 @@ def setup_span_processor():
 # monkeypatch.delenv("OPENAI_API_KEY", ...) to remove it locally.
 @pytest.fixture(scope="session", autouse=True)
 def ensure_openai_api_key():
-    import os
-
     if not os.environ.get("OPENAI_API_KEY"):
         os.environ["OPENAI_API_KEY"] = "test_key"
 

--- a/tests/test_test_environment.py
+++ b/tests/test_test_environment.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from .conftest import (
+    _PROXY_ENVIRONMENT_VARIABLES,
+    _PROXY_OPT_IN_ENVIRONMENT_VARIABLE,
+    _remove_ambient_proxy_environment,
+)
+
+
+def test_remove_ambient_proxy_environment_clears_proxy_variables() -> None:
+    environment = {
+        variable: "socks5h://127.0.0.1:1234" for variable in _PROXY_ENVIRONMENT_VARIABLES
+    }
+    environment["UNRELATED"] = "preserved"
+
+    _remove_ambient_proxy_environment(environment)
+
+    assert all(variable not in environment for variable in _PROXY_ENVIRONMENT_VARIABLES)
+    assert environment["UNRELATED"] == "preserved"
+
+
+@pytest.mark.parametrize("opt_in", ["1", "true", "TRUE", "yes", "YES"])
+def test_remove_ambient_proxy_environment_preserves_proxy_variables_when_opted_in(
+    opt_in: str,
+) -> None:
+    environment = {
+        _PROXY_OPT_IN_ENVIRONMENT_VARIABLE: opt_in,
+        "ALL_PROXY": "socks5h://127.0.0.1:1234",
+    }
+
+    _remove_ambient_proxy_environment(environment)
+
+    assert environment["ALL_PROXY"] == "socks5h://127.0.0.1:1234"


### PR DESCRIPTION
This pull request fixes unit-test failures caused by inherited host SOCKS proxy settings being applied during HTTPX and OpenAI client construction when `socksio` is not installed.

It clears uppercase and lowercase `ALL_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` variables when the standard unit-test configuration loads. Developers can preserve proxy settings explicitly with `OPENAI_AGENTS_TEST_USE_PROXY=1`.

Focused coverage verifies both the default isolation and explicit opt-in behavior. Live integration-test proxy handling remains unchanged.