### PR TITLE
fix: redact Realtime and RunState diagnostics

### DIFF
--- a/src/agents/logger.py
+++ b/src/agents/logger.py
@@ -7,6 +7,7 @@ from . import _debug
 logger = logging.getLogger("openai.agents")
 
 _DiagnosticExtra = Callable[[], Mapping[str, object]]
+_DiagnosticArgs = Callable[[], tuple[object, ...]]
 _DIAGNOSTIC_CONTEXT_FIELD = "openai_agents_diagnostic_context"
 
 
@@ -242,3 +243,24 @@ def log_model_and_tool_action_warning(
         stacklevel=stacklevel,
         diagnostic_extra=diagnostic_extra,
     )
+
+
+def log_model_and_tool_data_warning(
+    target_logger: logging.Logger,
+    redacted_message: str,
+    *,
+    diagnostic_message: str,
+    diagnostic_args: _DiagnosticArgs | None = None,
+    stacklevel: int = 2,
+) -> None:
+    """Log mixed model/tool data only when both data policies allow it."""
+    if _debug.DONT_LOG_MODEL_DATA or _debug.DONT_LOG_TOOL_DATA:
+        target_logger.warning(redacted_message, stacklevel=stacklevel)
+        return
+
+    try:
+        args = diagnostic_args() if diagnostic_args is not None else ()
+    except Exception:
+        target_logger.warning(redacted_message, stacklevel=stacklevel)
+        return
+    target_logger.warning(diagnostic_message, *args, stacklevel=stacklevel)

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -195,36 +195,18 @@ AllRealtimeServerEvents = Annotated[
 ServerEventTypeAdapter: TypeAdapter[AllRealtimeServerEvents] | None = None
 
 
-def _server_event_validation_summary(error: BaseException) -> str:
-    if isinstance(error, pydantic.ValidationError):
-        return f"{error.error_count()} validation error(s)"
-
-    if not _debug.DONT_LOG_MODEL_DATA:
-        return type(error).__name__
-    return "validation failed"
-
-
-def _server_event_identity(event: Any) -> tuple[Any, Any]:
+def _server_event_type(event: Any) -> Any:
     if not isinstance(event, dict):
-        return "unknown", None
+        return "unknown"
 
-    return event.get("type", "unknown"), event.get("event_id")
+    return event.get("type", "unknown")
 
 
-def _log_server_event_validation_failure(event: Any, error: BaseException) -> str:
-    event_type, event_id = _server_event_identity(event)
-
+def _log_server_event_validation_failure(event: Any) -> None:
     if _debug.DONT_LOG_MODEL_DATA:
-        logger.error(
-            "Failed to validate server event type=%s event_id=%s: %s",
-            event_type,
-            event_id,
-            _server_event_validation_summary(error),
-        )
+        logger.error("Failed to validate server event")
     else:
         logger.error("Failed to validate server event: %s", event, exc_info=True)
-
-    return str(event_type)
 
 
 @dataclass(frozen=True)
@@ -723,7 +705,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 else:
                     await self._send_raw_message(converted)
             elif _debug.DONT_LOG_MODEL_DATA:
-                logger.error("Failed to convert raw message type=%s", event.message.get("type"))
+                logger.error("Failed to convert raw message")
             else:
                 logger.error("Failed to convert raw message: %s", event)
         elif isinstance(event, RealtimeModelSendUserInput):
@@ -1140,11 +1122,12 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 validation_event
             )
         except pydantic.ValidationError as e:
-            _log_server_event_validation_failure(event, e)
+            _log_server_event_validation_failure(event)
             await self._emit_event(RealtimeModelErrorEvent(error=e))
             return
         except Exception as e:
-            event_type = _log_server_event_validation_failure(event, e)
+            _log_server_event_validation_failure(event)
+            event_type = str(_server_event_type(event))
             exception_event = RealtimeModelExceptionEvent(
                 exception=e,
                 context=f"Failed to validate server event: {event_type}",

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -81,7 +81,11 @@ from .items import (
     coerce_tool_search_call_raw_item,
     coerce_tool_search_output_raw_item,
 )
-from .logger import log_model_and_tool_action_warning, logger
+from .logger import (
+    log_model_and_tool_action_warning,
+    log_model_and_tool_data_warning,
+    logger,
+)
 from .run_context import RunContextWrapper
 from .run_internal.items import (
     NestedHistoryOwnedItemRef,
@@ -3556,6 +3560,18 @@ def _deserialize_items(
 
     result: list[RunItem] = []
 
+    def _capture_diagnostic_args(*values: object) -> Callable[[], tuple[object, ...]]:
+        def diagnostic_args() -> tuple[object, ...]:
+            return values
+
+        return diagnostic_args
+
+    def _capture_diagnostic_extra(**values: object) -> Callable[[], Mapping[str, object]]:
+        def diagnostic_extra() -> Mapping[str, object]:
+            return values
+
+        return diagnostic_extra
+
     def _resolve_agent_info(
         item_data: Mapping[str, Any], item_type: str
     ) -> tuple[Agent[Any] | None, str | None]:
@@ -3591,9 +3607,19 @@ def _deserialize_items(
         agent, agent_name = _resolve_agent_info(item_data, item_type)
         if not agent:
             if agent_name:
-                logger.warning("Agent %s not found, skipping item", agent_name)
+                log_model_and_tool_data_warning(
+                    logger,
+                    "Agent not found, skipping item",
+                    diagnostic_message="Agent %s not found, skipping item",
+                    diagnostic_args=_capture_diagnostic_args(agent_name),
+                )
             else:
-                logger.warning("Item missing agent field, skipping: %s", item_type)
+                log_model_and_tool_data_warning(
+                    logger,
+                    "Item missing agent field, skipping",
+                    diagnostic_message="Item missing agent field, skipping: %s",
+                    diagnostic_args=_capture_diagnostic_args(item_type),
+                )
             continue
 
         raw_item_data = item_data["raw_item"]
@@ -3682,11 +3708,14 @@ def _deserialize_items(
                 if not source_agent or not target_agent:
                     source_name = item_data.get("source_agent")
                     target_name = item_data.get("target_agent")
-                    logger.warning(
-                        "Skipping handoff_output_item: could not resolve agents "
-                        "(source=%s, target=%s).",
-                        source_name,
-                        target_name,
+                    log_model_and_tool_data_warning(
+                        logger,
+                        "Skipping handoff output item: could not resolve agents",
+                        diagnostic_message=(
+                            "Skipping handoff_output_item: could not resolve agents "
+                            "(source=%s, target=%s)."
+                        ),
+                        diagnostic_args=_capture_diagnostic_args(source_name, target_name),
                     )
                     continue
 
@@ -3753,7 +3782,10 @@ def _deserialize_items(
             raise
         except Exception as e:
             log_model_and_tool_action_warning(
-                logger, f"Failed to deserialize item of type {item_type}", e
+                logger,
+                "Failed to deserialize item",
+                e,
+                diagnostic_extra=_capture_diagnostic_extra(item_type=item_type),
             )
             continue
 

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import time
 from types import SimpleNamespace
 from typing import Any, cast
@@ -448,59 +449,145 @@ class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
         assert error_event.type == "error"
 
     @pytest.mark.asyncio
-    async def test_handle_invalid_event_schema_redacts_payload_from_logs(self, model, monkeypatch):
-        """Test that invalid event logs omit payload data when model data logging is disabled."""
+    async def test_handle_invalid_event_schema_redacts_event_from_logs(
+        self, model, monkeypatch, caplog
+    ):
+        """Invalid event logs omit all event data when model data logging is disabled."""
         mock_listener = AsyncMock()
         model.add_listener(mock_listener)
         monkeypatch.setattr(
             "agents.realtime.openai_realtime._debug.DONT_LOG_MODEL_DATA",
             True,
         )
+        caplog.set_level(logging.ERROR, logger="openai.agents")
 
         invalid_event = {
-            "type": "response.output_audio.delta",
-            "event_id": "evt_123",
-            "delta": "secret transcript",
+            "type": "SECRET_EVENT_TYPE",
+            "event_id": "SECRET_EVENT_ID",
+            "delta": "SECRET_EVENT_PAYLOAD",
         }
 
-        with patch("agents.realtime.openai_realtime.logger") as mock_logger:
-            await model._handle_ws_event(invalid_event)
+        await model._handle_ws_event(invalid_event)
 
-        mock_logger.error.assert_called_once()
-        logged_call = str(mock_logger.error.call_args)
-        assert "secret transcript" not in logged_call
-        assert "response.output_audio.delta" in logged_call
-        assert "evt_123" in logged_call
-        assert mock_logger.error.call_args.kwargs.get("exc_info") is not True
+        records = [
+            record for record in caplog.records if record.msg == "Failed to validate server event"
+        ]
+        assert len(records) == 1
+        record = records[0]
+        assert record.args == ()
+        assert record.exc_info is None
+        assert record.exc_text is None
+        assert invalid_event not in record.__dict__.values()
+        rendered = logging.Formatter().format(record)
+        assert rendered == "Failed to validate server event"
+        assert "SECRET_EVENT_TYPE" not in rendered
+        assert "SECRET_EVENT_ID" not in rendered
+        assert "SECRET_EVENT_PAYLOAD" not in rendered
 
         assert mock_listener.on_event.call_count == 2
         error_event = mock_listener.on_event.call_args_list[1][0][0]
         assert error_event.type == "error"
 
     @pytest.mark.asyncio
-    async def test_send_raw_message_conversion_failure_redacts_payload_from_logs(
-        self, model, monkeypatch
+    async def test_handle_invalid_event_schema_preserves_diagnostics_when_enabled(
+        self, model, monkeypatch, caplog
     ):
-        """A raw client message that fails to convert must not leak its payload to the logs
-        when model-data logging is disabled."""
+        """Invalid event logs retain event data when model data logging is enabled."""
+        mock_listener = AsyncMock()
+        model.add_listener(mock_listener)
+        monkeypatch.setattr(
+            "agents.realtime.openai_realtime._debug.DONT_LOG_MODEL_DATA",
+            False,
+        )
+        caplog.set_level(logging.ERROR, logger="openai.agents")
+
+        invalid_event = {
+            "type": "diagnostic.event",
+            "event_id": "diagnostic_event_id",
+            "delta": "diagnostic payload",
+        }
+
+        await model._handle_ws_event(invalid_event)
+
+        records = [
+            record
+            for record in caplog.records
+            if record.msg == "Failed to validate server event: %s"
+        ]
+        assert len(records) == 1
+        record = records[0]
+        assert record.args == invalid_event
+        assert record.exc_info is not None
+        rendered = logging.Formatter().format(record)
+        assert "diagnostic.event" in rendered
+        assert "diagnostic_event_id" in rendered
+        assert "diagnostic payload" in rendered
+
+        assert mock_listener.on_event.call_count == 2
+        error_event = mock_listener.on_event.call_args_list[1][0][0]
+        assert error_event.type == "error"
+
+    @pytest.mark.asyncio
+    async def test_send_raw_message_conversion_failure_redacts_event_from_logs(
+        self, model, monkeypatch, caplog
+    ):
+        """A raw client message that fails to convert must not leak event data to logs."""
         monkeypatch.setattr(
             "agents.realtime.openai_realtime._debug.DONT_LOG_MODEL_DATA",
             True,
         )
+        caplog.set_level(logging.ERROR, logger="openai.agents")
         raw = RealtimeModelSendRawMessage(
             message={
-                "type": "invalid.event.type",
-                "other_data": {"transcript": "secret transcript"},
+                "type": "SECRET_RAW_EVENT_TYPE",
+                "other_data": {"transcript": "SECRET_RAW_EVENT_PAYLOAD"},
             }
         )
 
-        with patch("agents.realtime.openai_realtime.logger") as mock_logger:
-            await model.send_event(raw)
+        await model.send_event(raw)
 
-        mock_logger.error.assert_called_once()
-        logged_call = str(mock_logger.error.call_args)
-        assert "secret transcript" not in logged_call
-        assert "invalid.event.type" in logged_call
+        records = [
+            record for record in caplog.records if record.msg == "Failed to convert raw message"
+        ]
+        assert len(records) == 1
+        record = records[0]
+        assert record.args == ()
+        assert record.exc_info is None
+        assert record.exc_text is None
+        assert raw not in record.__dict__.values()
+        rendered = logging.Formatter().format(record)
+        assert rendered == "Failed to convert raw message"
+        assert "SECRET_RAW_EVENT_TYPE" not in rendered
+        assert "SECRET_RAW_EVENT_PAYLOAD" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_send_raw_message_conversion_failure_preserves_diagnostics_when_enabled(
+        self, model, monkeypatch, caplog
+    ):
+        """A raw conversion failure retains event data when model data logging is enabled."""
+        monkeypatch.setattr(
+            "agents.realtime.openai_realtime._debug.DONT_LOG_MODEL_DATA",
+            False,
+        )
+        caplog.set_level(logging.ERROR, logger="openai.agents")
+        raw = RealtimeModelSendRawMessage(
+            message={
+                "type": "diagnostic.raw.event",
+                "other_data": {"transcript": "diagnostic transcript"},
+            }
+        )
+
+        await model.send_event(raw)
+
+        records = [
+            record for record in caplog.records if record.msg == "Failed to convert raw message: %s"
+        ]
+        assert len(records) == 1
+        record = records[0]
+        assert record.args == (raw,)
+        rendered = logging.Formatter().format(record)
+        assert "diagnostic.raw.event" in rendered
+        assert "diagnostic transcript" in rendered
 
     @pytest.mark.asyncio
     async def test_custom_voice_response_events_update_response_sequencer(self, model, monkeypatch):

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -23,6 +23,7 @@ from openai import AsyncOpenAI
 
 import agents._debug as _debug
 from agents import (
+    Agent,
     ModelSettings,
     ModelTracing,
     OpenAIResponsesModel,
@@ -37,6 +38,7 @@ from agents.logger import (
     log_model_and_tool_action_debug,
     log_model_and_tool_action_error,
     log_model_and_tool_action_warning,
+    log_model_and_tool_data_warning,
     log_tool_action_debug,
     log_tool_action_error as log_shared_tool_action_error,
     log_tool_action_warning,
@@ -45,6 +47,7 @@ from agents.run_internal.tool_execution import (
     log_tool_action_error,
     resolve_approval_rejection_message,
 )
+from agents.run_state import _deserialize_items
 from agents.tracing.processor_interface import TracingProcessor
 from agents.tracing.provider import SynchronousMultiTracingProcessor
 from agents.tracing.spans import Span
@@ -88,6 +91,14 @@ class _TruthinessException(Exception):
         return False
 
 
+class _HostileValue:
+    def __str__(self) -> str:
+        raise AssertionError("redacted logging inspected __str__")
+
+    def __repr__(self) -> str:
+        raise AssertionError("redacted logging inspected __repr__")
+
+
 class _FailingTracingProcessor(TracingProcessor):
     def __init__(self) -> None:
         self.str_calls = 0
@@ -125,6 +136,15 @@ def _emit_shared_error_for_location(test_logger, helper) -> None:
 
 def _emit_tool_execution_error_for_location() -> None:
     log_tool_action_error("Fixed operational message", ValueError("failure"))
+
+
+def _emit_data_warning_for_location(test_logger) -> None:
+    log_model_and_tool_data_warning(
+        test_logger,
+        "Fixed operational warning",
+        diagnostic_message="Warning for %s",
+        diagnostic_args=lambda: ("diagnostic-value",),
+    )
 
 
 def _responses_model() -> OpenAIResponsesModel:
@@ -380,6 +400,176 @@ def test_shared_error_helper_ignores_diagnostic_extra_failure(monkeypatch) -> No
     assert record.exc_info is not None
     assert record.exc_info[1] is error
     assert "original failure" in logging.Formatter().format(record)
+
+
+def test_shared_data_warning_does_not_inspect_or_attach_redacted_arguments(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    test_logger = logging.Logger("sensitive-logging-data-warning")
+    handler = _RecordingHandler()
+    test_logger.addHandler(handler)
+    hostile = _HostileValue()
+
+    log_model_and_tool_data_warning(
+        test_logger,
+        "Fixed operational warning",
+        diagnostic_message="Warning for %s",
+        diagnostic_args=lambda: (hostile,),
+    )
+
+    assert len(handler.records) == 1
+    record = handler.records[0]
+    assert record.msg == "Fixed operational warning"
+    assert record.args == ()
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert hostile not in record.__dict__.values()
+    assert logging.Formatter().format(record) == "Fixed operational warning"
+
+
+def test_shared_data_warning_preserves_diagnostics_when_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    test_logger = logging.Logger("sensitive-logging-data-warning")
+    handler = _RecordingHandler()
+    test_logger.addHandler(handler)
+    diagnostic_value = "diagnostic-agent"
+
+    log_model_and_tool_data_warning(
+        test_logger,
+        "Fixed operational warning",
+        diagnostic_message="Warning for %s",
+        diagnostic_args=lambda: (diagnostic_value,),
+    )
+
+    assert len(handler.records) == 1
+    record = handler.records[0]
+    assert record.msg == "Warning for %s"
+    assert record.args == (diagnostic_value,)
+    assert logging.Formatter().format(record) == "Warning for diagnostic-agent"
+
+
+def test_shared_data_warning_falls_back_when_diagnostic_arguments_fail(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    test_logger = logging.Logger("sensitive-logging-data-warning")
+    handler = _RecordingHandler()
+    test_logger.addHandler(handler)
+
+    def diagnostic_args() -> tuple[object, ...]:
+        raise RuntimeError("SECRET_DIAGNOSTIC_ARGUMENT_FAILURE")
+
+    log_model_and_tool_data_warning(
+        test_logger,
+        "Fixed operational warning",
+        diagnostic_message="Warning for %s",
+        diagnostic_args=diagnostic_args,
+    )
+
+    assert len(handler.records) == 1
+    record = handler.records[0]
+    assert record.msg == "Fixed operational warning"
+    assert record.args == ()
+    assert record.exc_info is None
+    assert "SECRET_DIAGNOSTIC_ARGUMENT_FAILURE" not in logging.Formatter().format(record)
+
+
+def test_shared_data_warning_preserves_direct_caller_location(monkeypatch) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    test_logger = logging.Logger("sensitive-logging-data-warning-location")
+    handler = _RecordingHandler()
+    test_logger.addHandler(handler)
+
+    _emit_data_warning_for_location(test_logger)
+
+    record = handler.records[0]
+    assert Path(record.pathname).resolve() == Path(__file__).resolve()
+    assert record.funcName == "_emit_data_warning_for_location"
+
+
+@pytest.mark.parametrize(
+    ("model_redacted", "tool_redacted"),
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+        (False, False),
+    ],
+)
+@pytest.mark.parametrize(
+    ("scenario", "secrets", "redacted_message"),
+    [
+        (
+            "missing_agent",
+            ("SECRET_AGENT_NAME",),
+            "Agent not found, skipping item",
+        ),
+        (
+            "missing_agent_field",
+            ("SECRET_ITEM_TYPE",),
+            "Item missing agent field, skipping",
+        ),
+        (
+            "missing_handoff_agents",
+            ("SECRET_SOURCE_AGENT", "SECRET_TARGET_AGENT"),
+            "Skipping handoff output item: could not resolve agents",
+        ),
+    ],
+)
+def test_run_state_deserialization_warnings_follow_both_data_policies(
+    monkeypatch,
+    model_redacted: bool,
+    tool_redacted: bool,
+    scenario: str,
+    secrets: tuple[str, ...],
+    redacted_message: str,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", model_redacted)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", tool_redacted)
+    known_agent = Agent(name="KnownAgent")
+    if scenario == "missing_agent":
+        item_data = {
+            "type": "message_output_item",
+            "agent": secrets[0],
+            "raw_item": {},
+        }
+    elif scenario == "missing_agent_field":
+        item_data = {
+            "type": secrets[0],
+            "raw_item": {},
+        }
+    else:
+        item_data = {
+            "type": "handoff_output_item",
+            "agent": "KnownAgent",
+            "source_agent": secrets[0],
+            "target_agent": secrets[1],
+            "raw_item": {},
+        }
+
+    test_logger = logging.Logger("sensitive-logging-run-state")
+    handler = _RecordingHandler()
+    test_logger.addHandler(handler)
+    with patch("agents.run_state.logger", test_logger):
+        result = _deserialize_items([item_data], {"KnownAgent": known_agent})
+
+    assert result == []
+    assert len(handler.records) == 1
+    record = handler.records[0]
+    rendered = logging.Formatter().format(record)
+    redacted = model_redacted or tool_redacted
+    if redacted:
+        assert record.msg == redacted_message
+        assert record.args == ()
+        assert record.exc_info is None
+        assert record.exc_text is None
+        assert rendered == redacted_message
+        for secret in secrets:
+            assert secret not in rendered
+            assert secret not in record.__dict__.values()
+    else:
+        for secret in secrets:
+            assert secret in rendered
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request fixes sensitive diagnostic logging that retained Realtime event identifiers and serialized RunState agent metadata while data logging was disabled.

### Summary

- Emits fixed, argument-free messages for redacted Realtime validation and raw-message conversion failures.
- Redacts serialized RunState agent, item-type, and handoff identities whenever either model or tool data logging is disabled.
- Preserves detailed values in explicitly enabled diagnostic mode.
- Adds complete `LogRecord`, hostile-value, policy-matrix, fallback, and caller-location coverage.

### Test plan

- [x] Focused Realtime, RunState, and sensitive-logging tests
- [x] Sensitive-logging inventory tests and manual caller review
- [x] `.agents/skills/code-change-verification/scripts/run.sh`
- [x] Format, lint, typecheck, and full tests pass

### Checks

- [x] I've added new tests
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] I've run `/review` before submitting this PR
