### PR TITLE
fix: support async callable objects as function tools

### DIFF
--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -18,6 +18,19 @@ FunctionToolLookupKey = (
 NamedToolLookupKey = FunctionToolLookupKey | str
 
 
+def validate_function_tool_fallback_name(name: str) -> str:
+    """Return an API-safe generated tool name or require an explicit override."""
+    if 1 <= len(name) <= 64 and all(
+        char.isascii() and (char.isalnum() or char in {"_", "-"}) for char in name
+    ):
+        return name
+    raise UserError(
+        f"Cannot derive a function tool name from callable class {name!r}. Generated names must "
+        "contain only ASCII letters, digits, underscores, or hyphens and be at most 64 "
+        "characters. Pass name_override to function_tool()."
+    )
+
+
 class SerializedFunctionToolLookupKey(TypedDict, total=False):
     """Serialized representation of a function-tool lookup key."""
 

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -49,6 +49,7 @@ from ._config_coercion import coerce_pydantic_config
 from ._tool_identity import (
     get_explicit_function_tool_namespace,
     tool_qualified_name,
+    validate_function_tool_fallback_name,
     validate_function_tool_lookup_configuration,
     validate_function_tool_namespace_shape,
 )
@@ -2201,6 +2202,7 @@ def _validate_function_tool_output(
 def _normalize_function_tool_callable(
     func: ToolFunction[...],
     docstring_style: DocstringStyle | None,
+    name_override: str | None,
 ) -> tuple[ToolFunction[...], str | None]:
     """Adapt one plain callable instance to the existing function-tool pipeline."""
     if isinstance(func, functools.partial):
@@ -2313,7 +2315,10 @@ def _normalize_function_tool_callable(
         adapter = sync_adapter
 
     adapter_metadata = cast(Any, adapter)
-    adapter_metadata.__name__ = type(func).__name__
+    fallback_name = type(func).__name__
+    adapter_metadata.__name__ = (
+        fallback_name if name_override else validate_function_tool_fallback_name(fallback_name)
+    )
     class_doc = inspect.getdoc(type(func))
     call_doc = inspect.cleandoc(call_descriptor.__doc__) if call_descriptor.__doc__ else None
     adapter_metadata.__doc__ = call_doc or class_doc
@@ -2468,6 +2473,7 @@ def function_tool(
         the_func, callable_description = _normalize_function_tool_callable(
             the_func,
             docstring_style,
+            name_override,
         )
         is_sync_function_tool = not inspect.iscoroutinefunction(the_func)
         schema = function_schema(

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -4,14 +4,16 @@ import ast
 import asyncio
 import copy
 import dataclasses
+import functools
 import inspect
 import json
 import math
+import typing
 import weakref
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from types import UnionType
+from types import FunctionType, UnionType
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -40,7 +42,7 @@ from openai.types.responses.tool_param import CodeInterpreter, ImageGeneration, 
 from openai.types.responses.web_search_tool import Filters as WebSearchToolFilters
 from openai.types.responses.web_search_tool_param import UserLocation
 from pydantic import BaseModel, TypeAdapter, ValidationError, model_validator
-from typing_extensions import NotRequired, ParamSpec, TypedDict
+from typing_extensions import NotRequired, ParamSpec, Self, TypeAliasType, TypedDict
 
 from . import _debug
 from ._config_coercion import coerce_pydantic_config
@@ -2196,6 +2198,131 @@ def _validate_function_tool_output(
         ) from error
 
 
+def _normalize_function_tool_callable(
+    func: ToolFunction[...],
+) -> ToolFunction[...]:
+    """Adapt one plain callable instance to the existing function-tool pipeline."""
+    if isinstance(func, functools.partial):
+        raise UserError(
+            "Unsupported callable object: function_tool does not infer functools.partial "
+            "contracts. Use an explicit wrapper function."
+        )
+    if inspect.isroutine(func) or inspect.isclass(func):
+        return func
+
+    try:
+        instance_vars = vars(func)
+    except TypeError:
+        instance_vars = {}
+    missing = object()
+    if (
+        inspect.getattr_static(func, "__wrapped__", missing) is not missing
+        or inspect.getattr_static(func, "__signature__", missing) is not missing
+        or "__annotations__" in instance_vars
+        or "__annotate__" in instance_vars
+    ):
+        raise UserError(
+            "Unsupported callable wrapper: function_tool only infers plain callable instances. "
+            "Use an explicit wrapper function."
+        )
+
+    call_owner = next(
+        (owner for owner in type(func).__mro__ if "__call__" in owner.__dict__),
+        None,
+    )
+    if call_owner is None:
+        raise UserError("Unsupported callable object: no inspectable __call__ method was found.")
+    call_descriptor = call_owner.__dict__["__call__"]
+    if (
+        not isinstance(call_descriptor, FunctionType)
+        or hasattr(call_descriptor, "__wrapped__")
+        or hasattr(call_descriptor, "__signature__")
+    ):
+        raise UserError(
+            "Unsupported callable object: function_tool supports instances with a plain "
+            "__call__ method. Use an explicit wrapper function for partials, decorated methods, "
+            "built-in callables, or custom descriptors."
+        )
+    if getattr(call_owner, "__type_params__", ()) or getattr(call_owner, "__parameters__", ()):
+        raise UserError(
+            "Unsupported generic callable object: use an explicit wrapper function with concrete "
+            "parameter and return annotations."
+        )
+
+    call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
+    signature = inspect.signature(call_method)
+    globalns = dict(getattr(call_method, "__globals__", {}))
+    localns = dict(vars(call_owner))
+    localns[call_owner.__name__] = call_owner
+    try:
+        type_hints = get_type_hints(
+            call_method,
+            globalns=globalns,
+            localns=localns,
+            include_extras=True,
+        )
+    except (NameError, TypeError) as error:
+        raise UserError(
+            "Unsupported callable object annotations: use an explicit wrapper function with "
+            "annotations resolvable from its module."
+        ) from error
+
+    native_self = getattr(typing, "Self", Self)
+    native_alias_type = getattr(typing, "TypeAliasType", TypeAliasType)
+    alias_types = (TypeAliasType, native_alias_type)
+
+    def contains_specialized_annotation(annotation: Any) -> bool:
+        origin = get_origin(annotation)
+        if (
+            isinstance(annotation, (TypeVar, *alias_types))
+            or isinstance(origin, alias_types)
+            or annotation in (Self, native_self)
+        ):
+            return True
+        return any(contains_specialized_annotation(arg) for arg in get_args(annotation))
+
+    if any(contains_specialized_annotation(annotation) for annotation in type_hints.values()):
+        raise UserError(
+            "Unsupported generic or aliased callable object annotations: use an explicit wrapper "
+            "function with concrete parameter and return annotations."
+        )
+    for name, parameter in signature.parameters.items():
+        annotation = type_hints.get(name, parameter.annotation)
+        if annotation is inspect.Signature.empty:
+            continue
+        plain_annotation = _unwrap_annotated_type(annotation)
+        origin = get_origin(plain_annotation) or plain_annotation
+        if origin is RunContextWrapper or origin is ToolContext:
+            raise UserError(
+                "Unsupported callable object context parameter: use an explicit wrapper function "
+                "to receive RunContextWrapper or ToolContext."
+            )
+
+    if inspect.iscoroutinefunction(call_method):
+
+        async def async_adapter(*args: Any, **kwargs: Any) -> Any:
+            return await call_method(*args, **kwargs)
+
+        adapter: Callable[..., Any] = async_adapter
+    else:
+
+        def sync_adapter(*args: Any, **kwargs: Any) -> Any:
+            return call_method(*args, **kwargs)
+
+        adapter = sync_adapter
+
+    adapter_metadata = cast(Any, adapter)
+    adapter_metadata.__name__ = type(func).__name__
+    adapter_metadata.__doc__ = inspect.getdoc(func) or inspect.getdoc(call_method)
+    adapter_metadata.__annotations__ = {
+        name: annotation
+        for name, annotation in type_hints.items()
+        if name == "return" or name in signature.parameters
+    }
+    adapter_metadata.__signature__ = signature
+    return cast("ToolFunction[...]", adapter)
+
+
 @overload
 def function_tool(
     func: ToolFunction[...],
@@ -2330,6 +2457,7 @@ def function_tool(
     """
 
     def _create_function_tool(the_func: ToolFunction[...]) -> FunctionTool:
+        the_func = _normalize_function_tool_callable(the_func)
         is_sync_function_tool = not inspect.iscoroutinefunction(the_func)
         schema = function_schema(
             func=the_func,

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -55,7 +55,7 @@ from ._tool_identity import (
 from .computer import AsyncComputer, Computer
 from .editor import ApplyPatchEditor, ApplyPatchOperation
 from .exceptions import ModelBehaviorError, ToolTimeoutError, UserError
-from .function_schema import DocstringStyle, function_schema
+from .function_schema import DocstringStyle, function_schema, generate_func_documentation
 from .logger import log_tool_action_warning, logger
 from .run_context import RunContextWrapper
 from .strict_schema import ensure_strict_json_schema
@@ -2200,7 +2200,8 @@ def _validate_function_tool_output(
 
 def _normalize_function_tool_callable(
     func: ToolFunction[...],
-) -> ToolFunction[...]:
+    docstring_style: DocstringStyle | None,
+) -> tuple[ToolFunction[...], str | None]:
     """Adapt one plain callable instance to the existing function-tool pipeline."""
     if isinstance(func, functools.partial):
         raise UserError(
@@ -2208,7 +2209,7 @@ def _normalize_function_tool_callable(
             "contracts. Use an explicit wrapper function."
         )
     if inspect.isroutine(func) or inspect.isclass(func):
-        return func
+        return func, None
 
     try:
         instance_vars = vars(func)
@@ -2313,14 +2314,21 @@ def _normalize_function_tool_callable(
 
     adapter_metadata = cast(Any, adapter)
     adapter_metadata.__name__ = type(func).__name__
-    adapter_metadata.__doc__ = inspect.getdoc(func) or inspect.getdoc(call_method)
+    class_doc = inspect.getdoc(type(func))
+    call_doc = inspect.cleandoc(call_descriptor.__doc__) if call_descriptor.__doc__ else None
+    adapter_metadata.__doc__ = call_doc or class_doc
     adapter_metadata.__annotations__ = {
         name: annotation
         for name, annotation in type_hints.items()
         if name == "return" or name in signature.parameters
     }
     adapter_metadata.__signature__ = signature
-    return cast("ToolFunction[...]", adapter)
+    class_description = (
+        generate_func_documentation(type(func), docstring_style).description
+        if class_doc and call_doc
+        else None
+    )
+    return cast("ToolFunction[...]", adapter), class_description
 
 
 @overload
@@ -2457,12 +2465,16 @@ def function_tool(
     """
 
     def _create_function_tool(the_func: ToolFunction[...]) -> FunctionTool:
-        the_func = _normalize_function_tool_callable(the_func)
+        the_func, callable_description = _normalize_function_tool_callable(
+            the_func,
+            docstring_style,
+        )
         is_sync_function_tool = not inspect.iscoroutinefunction(the_func)
         schema = function_schema(
             func=the_func,
             name_override=name_override,
-            description_override=description_override,
+            description_override=description_override
+            or (callable_description if use_docstring_info else None),
             docstring_style=docstring_style,
             use_docstring_info=use_docstring_info,
             strict_json_schema=strict_mode,

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -845,6 +845,55 @@ async def test_function_tool_bad_json_includes_payload_when_tool_logging_enabled
 
 
 @pytest.mark.asyncio
+async def test_function_tool_argument_logging_excludes_live_context(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    context_secret = "CONTEXT_SECRET_SENTINEL"
+    model_argument = "MODEL_ARGUMENT_SENTINEL"
+
+    class SensitiveContext:
+        def __repr__(self) -> str:
+            return context_secret
+
+    def echo(ctx: ToolContext[Any], value: str) -> str:
+        assert isinstance(ctx.context, SensitiveContext)
+        return value
+
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    tool = function_tool(echo)
+    live_context = ToolContext(
+        SensitiveContext(),
+        tool_name=tool.name,
+        tool_call_id="sensitive-context",
+        tool_arguments=json.dumps({"value": model_argument}),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="openai.agents"):
+        assert (
+            await tool.on_invoke_tool(
+                live_context,
+                json.dumps({"value": model_argument}),
+            )
+            == model_argument
+        )
+
+    records = [
+        record for record in caplog.records if record.msg == "Tool call args: %s, kwargs: %s"
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert model_argument in logging.Formatter().format(record)
+    assert context_secret not in repr(record.__dict__)
+    assert isinstance(record.args, tuple)
+    logged_args, logged_kwargs = record.args
+    assert isinstance(logged_args, list)
+    assert isinstance(logged_kwargs, dict)
+    assert live_context not in logged_args
+    assert live_context not in logged_kwargs.values()
+
+
+@pytest.mark.asyncio
 async def test_default_failure_error_function_survives_deepcopy() -> None:
     def boom() -> None:
         raise RuntimeError("kapow")

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -8,7 +8,7 @@ import operator
 import sys
 from collections.abc import Callable
 from types import ModuleType
-from typing import Any, Generic, TypeVar, cast
+from typing import Annotated, Any, Generic, TypeVar, cast
 
 import pytest
 from inline_snapshot import snapshot
@@ -340,6 +340,28 @@ async def test_callable_object_uses_call_docstring_when_class_docstring_missing(
         "type": "integer",
     }
     assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
+
+
+def test_callable_object_combines_class_summary_with_call_parameter_docs() -> None:
+    class AsyncCallable:
+        """Configure a reusable multiplier."""
+
+        async def __call__(self, value: Annotated[int, "Annotated fallback."]) -> int:
+            """Multiply a value.
+
+            Args:
+                value: The value supplied to this invocation.
+            """
+            return value * 2
+
+    tool = function_tool(AsyncCallable())
+
+    assert tool.description == "Configure a reusable multiplier."
+    assert tool.params_json_schema["properties"]["value"] == {
+        "description": "The value supplied to this invocation.",
+        "title": "Value",
+        "type": "integer",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -364,6 +364,19 @@ def test_callable_object_combines_class_summary_with_call_parameter_docs() -> No
     }
 
 
+@pytest.mark.parametrize("class_name", ["Café", "A" * 65])
+def test_callable_object_requires_override_for_invalid_fallback_name(class_name: str) -> None:
+    async def call(self: Any, value: int) -> int:
+        return value
+
+    handler = type(class_name, (), {"__call__": call})()
+
+    with pytest.raises(UserError, match="Pass name_override"):
+        function_tool(handler)
+
+    assert function_tool(handler, name_override="safe_name").name == "safe_name"
+
+
 @pytest.mark.asyncio
 async def test_async_callable_object_works_with_configured_function_tool() -> None:
     class AsyncCallable:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -1,12 +1,21 @@
+from __future__ import annotations
+
 import asyncio
+import functools
 import inspect
 import json
-from typing import Any
+import operator
+import sys
+from collections.abc import Callable
+from types import ModuleType
+from typing import Any, Generic, TypeVar, cast
 
 import pytest
 from inline_snapshot import snapshot
+from pydantic import BaseModel
+from typing_extensions import Self
 
-from agents import function_tool
+from agents import UserError, function_tool
 from agents.run_context import RunContextWrapper
 from agents.tool_context import ToolContext
 
@@ -20,6 +29,9 @@ def ctx_wrapper() -> ToolContext[DummyContext]:
     return ToolContext(
         context=DummyContext(), tool_name="dummy", tool_call_id="1", tool_arguments=""
     )
+
+
+CallableValueT = TypeVar("CallableValueT")
 
 
 @function_tool
@@ -261,6 +273,491 @@ def test_decorator_timeout_configuration_is_applied() -> None:
     assert timeout_configured_tool.timeout_seconds == 1.25
     assert timeout_configured_tool.timeout_behavior == "raise_exception"
     assert timeout_configured_tool.timeout_error_function is sync_error_handler
+
+
+@pytest.mark.asyncio
+async def test_async_callable_object_works_as_bare_function_tool() -> None:
+    class AsyncCallable:
+        """Double a value.
+
+        Args:
+            value: The value to double.
+        """
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, value: int) -> int:
+            self.calls += 1
+            await asyncio.sleep(0)
+            return value * 2
+
+    handler = AsyncCallable()
+    tool = function_tool(handler)
+
+    assert tool.name == "AsyncCallable"
+    assert tool.description == "Double a value."
+    assert tool.params_json_schema["properties"]["value"] == {
+        "description": "The value to double.",
+        "title": "Value",
+        "type": "integer",
+    }
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
+    assert handler.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_slotted_async_callable_object_works_as_function_tool() -> None:
+    class AsyncCallable:
+        __slots__ = ()
+
+        async def __call__(self, value: int) -> int:
+            return value * 2
+
+    tool = function_tool(AsyncCallable())
+
+    assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
+
+
+@pytest.mark.asyncio
+async def test_callable_object_uses_call_docstring_when_class_docstring_missing() -> None:
+    class AsyncCallable:
+        async def __call__(self, value: int) -> int:
+            """Double a value.
+
+            Args:
+                value: The value to double.
+            """
+            return value * 2
+
+    tool = function_tool(AsyncCallable())
+
+    assert tool.description == "Double a value."
+    assert tool.params_json_schema["properties"]["value"] == {
+        "description": "The value to double.",
+        "title": "Value",
+        "type": "integer",
+    }
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
+
+
+@pytest.mark.asyncio
+async def test_async_callable_object_works_with_configured_function_tool() -> None:
+    class AsyncCallable:
+        async def __call__(self, value: int) -> int:
+            return value + 1
+
+    configured_function_tool = function_tool(
+        name_override="increment",
+        description_override="Increment a value.",
+        timeout=1,
+    )
+    tool = configured_function_tool(AsyncCallable())
+
+    assert tool.name == "increment"
+    assert tool.description == "Increment a value."
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 5
+
+
+@pytest.mark.asyncio
+async def test_callable_object_invokes_the_resolved_call_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Handler:
+        async def __call__(self, value: int) -> int:
+            return value + 1
+
+    handler = Handler()
+    tool = function_tool(handler)
+
+    async def replacement(self: Handler, value: int) -> int:
+        return value + 100
+
+    monkeypatch.setattr(Handler, "__call__", replacement)
+
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 5
+
+
+@pytest.mark.asyncio
+async def test_sync_callable_object_preserves_awaitable_result() -> None:
+    class AwaitableReturningCallable:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, value: int) -> Any:
+            self.calls += 1
+
+            async def result() -> int:
+                return value * 3
+
+            return result()
+
+    handler = AwaitableReturningCallable()
+    tool = function_tool(handler)
+
+    returned = await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}')
+    assert inspect.isawaitable(returned)
+    assert handler.calls == 1
+    assert await returned == 12
+
+
+@pytest.mark.asyncio
+async def test_sync_function_preserves_awaitable_result() -> None:
+    async def result() -> int:
+        return 12
+
+    awaitable = result()
+
+    def handler() -> Any:
+        return awaitable
+
+    tool = function_tool(handler)
+
+    returned = await tool.on_invoke_tool(ctx_wrapper(), "{}")
+    assert returned is awaitable
+    assert await returned == 12
+
+
+def test_callable_contract_rejects_unknown_call_descriptor() -> None:
+    class CustomDescriptor:
+        def __get__(self, instance: Any, owner: type[Any]) -> Callable[..., Any]:
+            return lambda value: value
+
+    class Handler:
+        __call__ = CustomDescriptor()
+
+    with pytest.raises(UserError, match="Unsupported callable object"):
+        function_tool(Handler())
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        "partial",
+        "partialmethod",
+        "staticmethod",
+        "classmethod",
+        "decorated-call",
+        "update-wrapper",
+        "published-annotations",
+        "published-annotate",
+        "custom-signature",
+        "method-signature",
+        "local-annotation",
+        "singledispatchmethod",
+        "builtin",
+        "nested-wrapper",
+        "context",
+        "keyword-only-context",
+        "variadic-context",
+        "context-with-kwargs",
+        "generic",
+        "generic-signature",
+        "self",
+        "pydantic-generic",
+        pytest.param(
+            "pep695-generic",
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 12),
+                reason="PEP 695 requires Python 3.12",
+            ),
+        ),
+        pytest.param(
+            "pep695-context-alias",
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 12),
+                reason="PEP 695 requires Python 3.12",
+            ),
+        ),
+    ],
+)
+def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> None:
+    async def target(value: int) -> int:
+        return value
+
+    if shape == "partial":
+        handler: Any = functools.partial(target, 1)
+    elif shape == "partialmethod":
+
+        class PartialMethodHandler:
+            __call__ = functools.partialmethod(target, 1)
+
+        handler = PartialMethodHandler()
+    elif shape == "staticmethod":
+
+        class StaticMethodHandler:
+            __call__ = staticmethod(target)
+
+        handler = StaticMethodHandler()
+    elif shape == "classmethod":
+
+        class ClassMethodHandler:
+            __call__: Any = classmethod(cast(Any, target))
+
+        handler = ClassMethodHandler()
+    elif shape == "decorated-call":
+
+        class DecoratedCallHandler:
+            @functools.wraps(target)
+            async def __call__(self, *args: Any, **kwargs: Any) -> int:
+                return await target(*args, **kwargs)
+
+        handler = DecoratedCallHandler()
+    elif shape == "update-wrapper":
+
+        class UpdatedWrapper:
+            def __init__(self, wrapped: Any) -> None:
+                self.wrapped = wrapped
+                functools.update_wrapper(self, wrapped)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return self.wrapped(*args, **kwargs)
+
+        handler = UpdatedWrapper(target)
+    elif shape == "published-annotations":
+
+        class PublishedAnnotationsHandler:
+            def __init__(self) -> None:
+                self.__annotations__ = {"value": int, "return": int}
+
+            async def __call__(self, value: int) -> int:
+                return value
+
+        handler = PublishedAnnotationsHandler()
+    elif shape == "published-annotate":
+
+        class PublishedAnnotateHandler:
+            def __init__(self) -> None:
+                self.__annotate__ = lambda _format: {"value": int, "return": int}
+
+            async def __call__(self, value: int) -> int:
+                return value
+
+        handler = PublishedAnnotateHandler()
+    elif shape == "custom-signature":
+
+        class CustomSignatureHandler:
+            __signature__ = inspect.Signature(
+                [
+                    inspect.Parameter(
+                        "value",
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=int,
+                    )
+                ]
+            )
+
+            async def __call__(self, *args: Any, **kwargs: Any) -> int:
+                return cast(int, args[0])
+
+        handler = CustomSignatureHandler()
+    elif shape == "method-signature":
+
+        class MethodSignatureHandler:
+            async def __call__(self, value: int) -> int:
+                return value
+
+        cast(Any, MethodSignatureHandler.__call__).__signature__ = inspect.Signature(
+            [
+                inspect.Parameter(
+                    "value",
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=int,
+                )
+            ]
+        )
+        handler = MethodSignatureHandler()
+    elif shape == "local-annotation":
+
+        class LocalPayload(BaseModel):
+            value: int
+
+        class LocalAnnotationHandler:
+            async def __call__(self, value: LocalPayload) -> int:
+                return value.value
+
+        handler = LocalAnnotationHandler()
+    elif shape == "singledispatchmethod":
+
+        class SingleDispatchHandler:
+            __call__ = functools.singledispatchmethod(target)
+
+        handler = SingleDispatchHandler()
+    elif shape == "builtin":
+        handler = operator.itemgetter(0)
+    elif shape == "nested-wrapper":
+
+        class NestedHandler:
+            async def __call__(self, value: int) -> int:
+                return value
+
+        class NestedWrapper:
+            def __init__(self, wrapped: Any) -> None:
+                self.wrapped = wrapped
+                functools.update_wrapper(self, wrapped)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return self.wrapped(*args, **kwargs)
+
+        handler = NestedWrapper(NestedHandler())
+    elif shape == "context":
+
+        class ContextHandler:
+            async def __call__(self, ctx: ToolContext[Any], value: int) -> int:
+                return value
+
+        handler = ContextHandler()
+    elif shape == "keyword-only-context":
+
+        class KeywordOnlyContextHandler:
+            async def __call__(self, *, ctx: ToolContext[Any], value: int) -> int:
+                return value
+
+        handler = KeywordOnlyContextHandler()
+    elif shape == "variadic-context":
+
+        class VariadicContextHandler:
+            async def __call__(self, *ctx: ToolContext[Any]) -> int:
+                return len(ctx)
+
+        handler = VariadicContextHandler()
+    elif shape == "context-with-kwargs":
+
+        class ContextWithKwargsHandler:
+            async def __call__(self, ctx: ToolContext[Any], **kwargs: Any) -> int:
+                return len(kwargs)
+
+        handler = ContextWithKwargsHandler()
+    elif shape == "generic":
+
+        class GenericHandler(Generic[CallableValueT]):
+            async def __call__(self, value: CallableValueT) -> CallableValueT:
+                return value
+
+        handler = GenericHandler[int]()
+    elif shape == "generic-signature":
+
+        class GenericSignatureHandler(Generic[CallableValueT]):
+            __signature__ = inspect.Signature(
+                [
+                    inspect.Parameter(
+                        "value",
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation="CallableValueT",
+                    )
+                ]
+            )
+
+            async def __call__(self, *args: Any, **kwargs: Any) -> CallableValueT:
+                return cast(CallableValueT, args[0])
+
+        handler = GenericSignatureHandler[int]()
+    elif shape == "self":
+
+        class SelfHandler:
+            async def __call__(self, other: Self) -> Self:
+                return other
+
+        handler = SelfHandler()
+    elif shape == "pydantic-generic":
+
+        class PydanticGenericHandler(BaseModel, Generic[CallableValueT]):
+            async def __call__(self, value: CallableValueT) -> CallableValueT:
+                return value
+
+        handler = PydanticGenericHandler[int]()
+    elif shape == "pep695-generic":
+        namespace: dict[str, Any] = {}
+        exec(
+            "from __future__ import annotations\n"
+            "class Handler[T]:\n"
+            "    async def __call__(self, value: T) -> T:\n"
+            "        return value\n",
+            namespace,
+        )
+        handler = namespace["Handler"][int]()
+    elif shape == "pep695-context-alias":
+        namespace = {"Any": Any, "ToolContext": ToolContext}
+        exec(
+            "type LiveContext = ToolContext[Any]\n"
+            "class AliasContextHandler:\n"
+            "    async def __call__(self, ctx: LiveContext, value: int) -> int:\n"
+            "        return value\n",
+            namespace,
+        )
+        handler = namespace["AliasContextHandler"]()
+    else:
+        raise AssertionError(f"Unhandled shape: {shape}")
+
+    with pytest.raises(
+        UserError,
+        match="explicit wrapper function|Unsupported generic|annotations resolvable",
+    ):
+        function_tool(handler)
+
+
+@pytest.mark.asyncio
+async def test_callable_object_resolves_class_scoped_call_annotations() -> None:
+    class BaseHandler:
+        class Payload(BaseModel):
+            value: int
+
+        async def __call__(self, payload: Payload) -> int:
+            return payload.value
+
+    class Handler(BaseHandler):
+        pass
+
+    tool = function_tool(Handler())
+
+    assert tool.params_json_schema["properties"]["payload"] == {"$ref": "#/$defs/Payload"}
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"payload": {"value": 4}}') == 4
+
+
+def test_inherited_callable_resolves_defining_module_annotations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_module_name = "tests._callable_base_module"
+    subclass_module_name = "tests._callable_subclass_module"
+    base_module = ModuleType(base_module_name)
+    subclass_module = ModuleType(subclass_module_name)
+    monkeypatch.setitem(sys.modules, base_module_name, base_module)
+    monkeypatch.setitem(sys.modules, subclass_module_name, subclass_module)
+
+    exec(
+        "from __future__ import annotations\n"
+        "from pydantic import BaseModel\n"
+        "class Payload(BaseModel):\n"
+        "    value: int\n"
+        "class BaseHandler:\n"
+        "    async def __call__(self, payload: Payload) -> int:\n"
+        "        return payload.value\n",
+        base_module.__dict__,
+    )
+    subclass_module.__dict__["BaseHandler"] = base_module.__dict__["BaseHandler"]
+    exec(
+        "from __future__ import annotations\nclass Handler(BaseHandler):\n    pass\n",
+        subclass_module.__dict__,
+    )
+
+    tool = function_tool(subclass_module.__dict__["Handler"]())
+
+    assert tool.params_json_schema["properties"]["payload"]["$ref"] == "#/$defs/Payload"
+
+
+@pytest.mark.asyncio
+async def test_callable_object_ignores_class_state_annotations() -> None:
+    class Handler:
+        value: str
+
+        async def __call__(self, value: int) -> int:
+            return value * 2
+
+    tool = function_tool(Handler())
+
+    assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
 
 
 def test_function_tool_timeout_arguments_are_keyword_only() -> None:

--- a/tests/test_programmatic_tool_calling.py
+++ b/tests/test_programmatic_tool_calling.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
+from collections.abc import Awaitable, Coroutine
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal, cast
 
@@ -81,6 +83,11 @@ PROGRAM_CALLER = {"type": "program", "caller_id": PROGRAM_CALL_ID}
 class InventoryOutput(BaseModel):
     sku: str
     available_units: int
+
+
+class InventoryAwaitable(Awaitable[InventoryOutput]):
+    def __await__(self) -> Any:
+        raise NotImplementedError
 
 
 class InventoryDict(TypedDict):
@@ -258,6 +265,49 @@ def test_function_tool_infers_typed_dict_and_dataclass_output_schemas() -> None:
     assert dataclass_tool.output_json_schema is not None
     assert dataclass_tool.output_json_schema["type"] == "object"
     assert dataclass_tool.output_json_schema["additionalProperties"] is False
+
+
+@pytest.mark.parametrize(
+    "return_annotation",
+    [
+        Awaitable[InventoryOutput],
+        Coroutine[Any, Any, InventoryOutput],
+        InventoryAwaitable,
+        Awaitable[InventoryOutput] | InventoryOutput,
+        Awaitable,
+        Coroutine,
+    ],
+)
+def test_sync_callable_does_not_infer_through_awaitable_output(
+    return_annotation: Any,
+) -> None:
+    class LookupInventory:
+        def __call__(self) -> Any:
+            raise AssertionError("The handler must not run during tool construction.")
+
+    cast(Any, LookupInventory.__call__).__annotations__["return"] = return_annotation
+
+    with pytest.raises(UserError, match="programmatic function tool return annotation"):
+        function_tool(LookupInventory(), allowed_callers=["programmatic"])
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12")
+def test_sync_callable_does_not_infer_through_pep695_awaitable_alias() -> None:
+    namespace = {
+        "Any": Any,
+        "Awaitable": Awaitable,
+        "InventoryOutput": InventoryOutput,
+    }
+    exec(
+        "type OutputAwaitable = Awaitable[InventoryOutput]\n"
+        "class LookupInventory:\n"
+        "    def __call__(self) -> OutputAwaitable:\n"
+        "        raise AssertionError\n",
+        namespace,
+    )
+
+    with pytest.raises(UserError, match="explicit wrapper function"):
+        function_tool(namespace["LookupInventory"](), allowed_callers=["programmatic"])
 
 
 def test_function_tool_treats_annotated_plain_returns_as_untyped() -> None:


### PR DESCRIPTION
This pull request fixes function tool creation and invocation for callable objects, including instances with async `__call__` methods.

Callable objects now use their class name as a safe fallback tool name and resolve annotations from `__call__` when generating the function schema. Async callable objects are invoked without being misclassified as synchronous, while synchronous callables that return an awaitable have that result awaited exactly once.

Regression coverage includes bare and configured `function_tool` usage, schema generation, timeout compatibility, and single-invocation behavior.