### PR TITLE
fix: reject unsupported streamed STT audio dtypes

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 from openai import AsyncOpenAI
 
 from ... import _debug
-from ...exceptions import AgentsException
+from ...exceptions import AgentsException, UserError
 from ...logger import logger
 from ...tracing import Span, SpanError, TranscriptionSpanData, transcription_span
 from ...util._error_tracing import get_trace_error
@@ -49,6 +49,8 @@ def _audio_buffer_to_base64(buffer: npt.NDArray[np.int16 | np.float32]) -> str:
         # Convert to int16.
         buffer = np.clip(buffer, -1.0, 1.0)
         buffer = (buffer * 32767).astype(np.int16)
+    elif buffer.dtype != np.int16:
+        raise UserError("Buffer must be a numpy array of int16 or float32")
     return base64.b64encode(buffer.tobytes()).decode("utf-8")
 
 

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 import pytest
 
 from agents import trace
+from agents.exceptions import UserError
 from tests.testing_processor import fetch_span_errors
 
 try:
@@ -22,7 +23,10 @@ try:
         STTModelSettings,
     )
     from agents.voice.exceptions import STTWebsocketConnectionError
-    from agents.voice.models.openai_stt import EVENT_INACTIVITY_TIMEOUT
+    from agents.voice.models.openai_stt import (
+        EVENT_INACTIVITY_TIMEOUT,
+        _audio_buffer_to_base64,
+    )
 
     from .fake_models import FakeStreamedAudioInput
 except ImportError:
@@ -219,6 +223,14 @@ async def test_stream_audio_sends_pcm16(
     np.testing.assert_array_equal(buffer, original_buffer)
 
     await session.close()
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.float64], ids=["int32", "float64"])
+def test_stream_audio_rejects_unsupported_dtype(dtype: npt.DTypeLike) -> None:
+    buffer = np.array([1, 2], dtype=dtype)
+
+    with pytest.raises(UserError, match="Buffer must be a numpy array of int16 or float32"):
+        _audio_buffer_to_base64(buffer)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes streamed OpenAI STT encoding so unsupported NumPy dtypes are rejected before their raw bytes are transmitted as PCM16 audio.

The encoder continues to pass int16 buffers through unchanged and converts float32 buffers to PCM16. Inputs such as int32 and float64 now raise UserError instead of producing incorrectly sized audio payloads.