### PR TITLE
fix: include device nodes when parsing ls output

### DIFF
--- a/src/agents/sandbox/util/parse_utils.py
+++ b/src/agents/sandbox/util/parse_utils.py
@@ -20,15 +20,20 @@ def parse_ls_la(output: str, *, base: str) -> list[FileEntry]:
         permissions_str = parts[0]
         owner = parts[2]
         group = parts[3]
-        if parts[4].endswith(","):
-            # Character and block devices print "major, minor" in place of the
-            # size column, which shifts every following field by one. `stat`
-            # reports size 0 for device nodes.
-            parts = line.split(maxsplit=9)
-            if len(parts) < 10:
-                continue
+        # Character and block devices report a device identifier in place of the
+        # size column, in one of two formats. `stat` reports size 0 for them.
+        if permissions_str[:1] in {"c", "b"}:
             size = 0
-            name = parts[9]
+            if parts[4].endswith(","):
+                # GNU coreutils prints "major, minor", which occupies two
+                # fields and shifts every following field by one.
+                parts = line.split(maxsplit=9)
+                if len(parts) < 10:
+                    continue
+                name = parts[9]
+            else:
+                # BSD ls prints a single hexadecimal identifier, e.g. 0x3000002.
+                name = parts[8]
         else:
             try:
                 size = int(parts[4])

--- a/src/agents/sandbox/util/parse_utils.py
+++ b/src/agents/sandbox/util/parse_utils.py
@@ -20,10 +20,21 @@ def parse_ls_la(output: str, *, base: str) -> list[FileEntry]:
         permissions_str = parts[0]
         owner = parts[2]
         group = parts[3]
-        try:
-            size = int(parts[4])
-        except ValueError:
-            continue
+        if parts[4].endswith(","):
+            # Character and block devices print "major, minor" in place of the
+            # size column, which shifts every following field by one. `stat`
+            # reports size 0 for device nodes.
+            parts = line.split(maxsplit=9)
+            if len(parts) < 10:
+                continue
+            size = 0
+            name = parts[9]
+        else:
+            try:
+                size = int(parts[4])
+            except ValueError:
+                continue
+            name = parts[8]
 
         kind_map: dict[str, EntryKind] = {
             "d": EntryKind.DIRECTORY,
@@ -37,7 +48,6 @@ def parse_ls_la(output: str, *, base: str) -> list[FileEntry]:
         if permissions_str[:1] not in {"d", "-"} and len(permissions_str) >= 2:
             permissions_str = "-" + permissions_str[1:]
 
-        name = parts[8]
         if kind == EntryKind.SYMLINK and " -> " in name:
             name = name.split(" -> ", 1)[0]
 

--- a/tests/sandbox/test_parse_utils.py
+++ b/tests/sandbox/test_parse_utils.py
@@ -85,6 +85,28 @@ def test_parse_ls_la_strips_trailing_alternate_access_markers() -> None:
     assert entries[2].permissions.owner & FileMode.READ
 
 
+def test_parse_ls_la_includes_device_nodes() -> None:
+    # Character and block devices print "major, minor" in place of the single
+    # size column, which shifts every following field by one.
+    output = (
+        "-rw-r--r-- 1 root root      123 Jan  1 00:00 regular.txt\n"
+        "crw-rw-rw- 1 root root     1, 3 Jan  1 00:00 null\n"
+        "brw-rw---- 1 root disk     8, 0 Jan  1 00:00 sda\n"
+    )
+
+    entries = parse_ls_la(output, base="/dev")
+
+    assert [entry.path for entry in entries] == [
+        "/dev/regular.txt",
+        "/dev/null",
+        "/dev/sda",
+    ]
+    assert entries[1].kind == EntryKind.OTHER
+    assert entries[1].size == 0
+    assert entries[2].owner == "root"
+    assert entries[2].group == "disk"
+
+
 @pytest.mark.parametrize(
     "permissions",
     [

--- a/tests/sandbox/test_parse_utils.py
+++ b/tests/sandbox/test_parse_utils.py
@@ -85,9 +85,9 @@ def test_parse_ls_la_strips_trailing_alternate_access_markers() -> None:
     assert entries[2].permissions.owner & FileMode.READ
 
 
-def test_parse_ls_la_includes_device_nodes() -> None:
-    # Character and block devices print "major, minor" in place of the single
-    # size column, which shifts every following field by one.
+def test_parse_ls_la_includes_gnu_device_nodes() -> None:
+    # GNU coreutils prints "major, minor" in place of the single size column,
+    # which shifts every following field by one.
     output = (
         "-rw-r--r-- 1 root root      123 Jan  1 00:00 regular.txt\n"
         "crw-rw-rw- 1 root root     1, 3 Jan  1 00:00 null\n"
@@ -105,6 +105,28 @@ def test_parse_ls_la_includes_device_nodes() -> None:
     assert entries[1].size == 0
     assert entries[2].owner == "root"
     assert entries[2].group == "disk"
+
+
+def test_parse_ls_la_includes_bsd_device_nodes() -> None:
+    # BSD ls prints a single hexadecimal device identifier instead of the
+    # "major, minor" pair, so the fields are not shifted.
+    output = (
+        "-rw-r--r--  1 root  wheel           123 Jan  1 00:00 regular.txt\n"
+        "crw-rw-rw-  1 root  wheel     0x3000002 Jan  1 00:00 null\n"
+        "brw-r-----  1 root  operator  0x1000000 Jan  1 00:00 disk0\n"
+    )
+
+    entries = parse_ls_la(output, base="/dev")
+
+    assert [entry.path for entry in entries] == [
+        "/dev/regular.txt",
+        "/dev/null",
+        "/dev/disk0",
+    ]
+    assert entries[1].kind == EntryKind.OTHER
+    assert entries[1].size == 0
+    assert entries[2].owner == "root"
+    assert entries[2].group == "operator"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary

`parse_ls_la` silently drops every character and block device, so `SandboxSession.ls()` omits them from its results without any error or warning.

`ls -la` prints `major, minor` in place of the size column for device nodes, which shifts every following field by one:

```
-rw-r--r-- 1 root root      123 Jan  1 00:00 regular.txt
crw-rw-rw- 1 root root     1, 3 Jan  1 00:00 null
```

`int(parts[4])` then parses `"1,"`, raises `ValueError`, and the `except` branch `continue`s past the line — the swallowed exception is what makes the loss silent. Listing `/dev` returns only the non-device entries.

This detects the device form and re-splits with the extra field accounted for, reporting `size = 0` to match what `stat` reports for device nodes. Regular files, directories, symlinks, and the existing SELinux/ACL/xattr marker handling are unaffected.

### Test plan

Added `test_parse_ls_la_includes_device_nodes` to `tests/sandbox/test_parse_utils.py`, covering a character device, a block device, and a regular file in one listing, asserting the paths, kind, size, owner and group.

Before the change the new test fails, showing the silent drop:

```
AssertionError: assert ['/dev/regular.txt'] == ['/dev/regula...', '/dev/sda']
  Right contains 2 more items, first extra item: '/dev/null'
```

After the change:

- `uv run pytest tests/sandbox/test_parse_utils.py` — 12 passed
- `uv run pytest tests/sandbox/` — 912 passed, 1 skipped
- `.agents/skills/code-change-verification/scripts/run.sh` — all commands passed (`make tests` in 94s, `make typecheck` in 265s)

### Issue number

None — found while reading `src/agents/sandbox/util/parse_utils.py`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
