### PR TITLE
fix: include colon in empty-content transcript summary lines

### DIFF
--- a/src/agents/handoffs/history.py
+++ b/src/agents/handoffs/history.py
@@ -429,7 +429,10 @@ def _format_transcript_item_legacy(item: TResponseInputItem) -> str:
         if isinstance(name, str) and name:
             prefix = f"{prefix} ({name})"
         content_str = _stringify_content(item.get("content"))
-        return f"{prefix}: {content_str}" if content_str else prefix
+        # Always emit the colon, even for empty content: _parse_summary_line requires one to
+        # find the role/content split, so a bare "role" line (no colon) fails to parse and the
+        # turn silently vanishes on the next re-nesting hop.
+        return f"{prefix}: {content_str}"
 
     item_type = item.get("type", "item")
     rest = {k: v for k, v in item.items() if k not in ("type", "provider_data")}

--- a/tests/test_extension_filters.py
+++ b/tests/test_extension_filters.py
@@ -1029,6 +1029,32 @@ def test_nest_handoff_history_parse_summary_line_empty_stripped() -> None:
     assert "Hello" in final_summary["content"] or "Reply" in final_summary["content"]
 
 
+def test_nest_handoff_history_preserves_role_bearing_turn_with_empty_content() -> None:
+    """A role-bearing turn with empty content (e.g. a tool-call-only assistant turn) must
+    survive a second nesting hop. Its formatted summary line used to omit the colon when
+    content was empty ("assistant" instead of "assistant: "), and _parse_summary_line
+    requires a colon to split role from content, so the turn silently vanished on re-parse.
+    """
+    first_data = handoff_data(
+        input_history=(
+            _get_user_input_item("Hello"),
+            cast(TResponseInputItem, {"role": "assistant", "content": ""}),
+            _get_user_input_item("Continue"),
+        ),
+    )
+    first_nested = nest_handoff_history(first_data)
+    assert isinstance(first_nested.input_history, tuple)
+    first_summary = _as_message(first_nested.input_history[0])
+    assert "assistant:" in first_summary["content"]
+
+    # Nest a second time: this flattens and re-parses the first hop's summary lines.
+    second_data = handoff_data(input_history=first_nested.input_history)
+    second_nested = nest_handoff_history(second_data)
+    assert isinstance(second_nested.input_history, tuple)
+    second_summary = _as_message(second_nested.input_history[0])
+    assert "assistant:" in second_summary["content"]
+
+
 def _get_mcp_call_input_item() -> TResponseInputItem:
     return cast(
         TResponseInputItem,


### PR DESCRIPTION
`_format_transcript_item_legacy` in `src/agents/handoffs/history.py` formats each transcript item as a `"role: content"` line inside the `<CONVERSATION HISTORY>` block that `nest_handoff_history` builds when summarizing a prior handoff. When an item's content is empty (a role-bearing turn with nothing but tool calls, since the calls themselves are omitted from the summary and leave `content` blank), the function returns a bare `"role"` line with no colon.

`_parse_summary_line` re-parses that same summary text on a later handoff (a third hop, since the second hop's history already contains the first hop's summary nested inside it) by splitting on the first colon: `role_part, sep, remainder = stripped.partition(":")`, returning `None` when there is no colon. A bare `"assistant"` line fails that split and the turn is silently dropped, no error, no warning. Over more chained handoffs the transcript progressively loses every role-bearing turn whose content happened to be empty at format time.

## Fix

Always emit the colon in `_format_transcript_item_legacy`, even when content is empty (`"assistant: "` instead of `"assistant"`). `_parse_summary_line` already reconstructs an empty remainder correctly (no `content` key gets added to the parsed item), so this only restores the missing role marker; formatting and parsing of non-empty content lines is unchanged.

## Verification

Reproduced directly through `_build_summary_message` and `_flatten_nested_history_messages`, the real round-trip functions: a 3-turn transcript with one empty-content assistant turn recovers only 2 turns on main, 3 on the branch. Added `test_nest_handoff_history_preserves_role_bearing_turn_with_empty_content` to `tests/test_extension_filters.py`, driven through the public `nest_handoff_history` entry point across two nesting hops; it fails on main and passes on the branch.

Ran `.agents/skills/code-change-verification/scripts/run.sh` (format, lint, typecheck, tests). `make format`, `make lint`, and `make typecheck` (mypy + pyright, full repo) are all clean. `make tests` has one failure, `test_runner_preserves_unix_local_lifecycle_state_across_pause_and_resume`, from a missing `rclone` binary in this sandboxed container; I confirmed it reproduces identically on unmodified main, so it is a pre-existing environment gap, not something this change touches. Everything else in the suite passes (5689 passed, 4 skipped in the parallel run; 28 passed, 5 skipped in the serial run).
