### PR TITLE
fix: remove unnecessary list wrapping in serialize_usage

### DIFF
--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -323,9 +323,9 @@ def serialize_usage(usage: Usage) -> dict[str, Any]:
     return {
         "requests": usage.requests,
         "input_tokens": usage.input_tokens,
-        "input_tokens_details": [input_details],
+        "input_tokens_details": input_details,
         "output_tokens": usage.output_tokens,
-        "output_tokens_details": [output_details],
+        "output_tokens_details": output_details,
         "total_tokens": usage.total_tokens,
         "request_usage_entries": [
             _serialize_request_entry(entry) for entry in usage.request_usage_entries

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -1826,9 +1826,9 @@ class TestSerializationRoundTrip:
         new_state = await RunState.from_string(agent, str_data)
 
         assert serialized["$schemaVersion"] == CURRENT_SCHEMA_VERSION
-        assert serialized["context"]["usage"]["input_tokens_details"] == [
-            {"cached_tokens": 3, "cache_write_tokens": 7}
-        ]
+        assert serialized["context"]["usage"]["input_tokens_details"] == {
+            "cached_tokens": 3, "cache_write_tokens": 7
+        }
         assert new_state._context is not None
         assert new_state._context.usage.requests == 5
         assert new_state._context.usage is not None
@@ -2160,9 +2160,9 @@ class TestSerializationRoundTrip:
                 "usage": {
                     "requests": 0,
                     "input_tokens": 0,
-                    "input_tokens_details": [],
+                    "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
                     "output_tokens": 0,
-                    "output_tokens_details": [],
+                    "output_tokens_details": {"reasoning_tokens": 0},
                     "total_tokens": 0,
                     "request_usage_entries": [],
                 },

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -493,7 +493,7 @@ def test_usage_serialization_preserves_cache_write_tokens() -> None:
     serialized = serialize_usage(usage)
     restored = deserialize_usage(serialized)
 
-    assert serialized["input_tokens_details"] == [{"cached_tokens": 3, "cache_write_tokens": 7}]
+    assert serialized["input_tokens_details"] == {"cached_tokens": 3, "cache_write_tokens": 7}
     assert getattr(restored.input_tokens_details, "cache_write_tokens", None) == 7
     assert (
         getattr(


### PR DESCRIPTION
## Summary

\serialize_usage()\ was wrapping \input_tokens_details\ and \output_tokens_details\ in lists (\[input_details]\ and \[output_details]\), but these fields are single objects in the \Usage\ dataclass. This caused inconsistent serialization compared to \model_usage_to_span_usage()\.

## Changes
- Removed list wrapping from \serialize_usage\ output
- Updated tests to match the correct (non-list) format

## Test Plan
- [x] Existing tests updated to expect correct format
- [x] No functional changes to deserialization (defensive list handling preserved)