### PR TITLE
fix(models): extract reasoning content for replay from content items and object instances

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -852,14 +852,44 @@ class Converter:
                     )
 
                 if should_replay:
-                    summary_items = reasoning_item.get("summary", [])
-                    if summary_items:
-                        reasoning_texts = []
-                        for summary_item in summary_items:
-                            if isinstance(summary_item, dict) and summary_item.get("text"):
-                                reasoning_texts.append(summary_item["text"])
-                        if reasoning_texts:
-                            pending_reasoning_content = "\n".join(reasoning_texts)
+                    reasoning_texts: list[str] = []
+                    summary_items = (
+                        reasoning_item.get("summary")
+                        if isinstance(reasoning_item, dict)
+                        else getattr(reasoning_item, "summary", None)
+                    ) or []
+                    for summary_item in summary_items:
+                        text = (
+                            summary_item.get("text")
+                            if isinstance(summary_item, dict)
+                            else getattr(summary_item, "text", None)
+                        )
+                        if text:
+                            reasoning_texts.append(text)
+
+                    if not reasoning_texts:
+                        content_items = (
+                            reasoning_item.get("content")
+                            if isinstance(reasoning_item, dict)
+                            else getattr(reasoning_item, "content", None)
+                        ) or []
+                        for content_item in content_items:
+                            item_type = (
+                                content_item.get("type")
+                                if isinstance(content_item, dict)
+                                else getattr(content_item, "type", None)
+                            )
+                            if item_type == "reasoning_text":
+                                text = (
+                                    content_item.get("text")
+                                    if isinstance(content_item, dict)
+                                    else getattr(content_item, "text", None)
+                                )
+                                if text:
+                                    reasoning_texts.append(text)
+
+                    if reasoning_texts:
+                        pending_reasoning_content = "\n".join(reasoning_texts)
 
             # 8) compaction items => reject for chat completions
             elif isinstance(item, dict) and item.get("type") == "compaction":

--- a/tests/models/test_reasoning_content_replay_hook.py
+++ b/tests/models/test_reasoning_content_replay_hook.py
@@ -401,3 +401,94 @@ async def test_litellm_hook_can_enable_reasoning_content_replay(monkeypatch) -> 
     assert contexts[0].model == REASONING_CONTENT_MODEL_B
     assert contexts[0].base_url is None
     assert contexts[0].reasoning.origin_model == REASONING_CONTENT_MODEL_B
+
+
+def test_converter_replays_reasoning_content_from_content_items() -> None:
+    def should_replay_reasoning_content(_context: ReasoningContentReplayContext) -> bool:
+        return True
+
+    items = [
+        {"role": "user", "content": "What's the weather in Tokyo?"},
+        {
+            "id": "__fake_id__",
+            "summary": [],
+            "content": [{"type": "reasoning_text", "text": "Reasoning from content block."}],
+            "type": "reasoning",
+            "provider_data": {"model": REASONING_CONTENT_MODEL_A},
+        },
+        {
+            "arguments": '{"city": "Tokyo"}',
+            "call_id": "call_weather_123",
+            "name": "get_weather",
+            "type": "function_call",
+            "id": "__fake_id__",
+        },
+    ]
+
+    messages = Converter.items_to_messages(
+        items,  # type: ignore[arg-type]
+        model=REASONING_CONTENT_MODEL_A,
+        should_replay_reasoning_content=should_replay_reasoning_content,
+    )
+
+    assistant = _assistant_with_tool_calls(messages)
+    assert assistant["reasoning_content"] == "Reasoning from content block."
+
+
+def test_converter_replays_reasoning_content_from_summary_and_content_objects() -> None:
+    from openai.types.responses.response_reasoning_item import Content, Summary
+
+    def should_replay_reasoning_content(_context: ReasoningContentReplayContext) -> bool:
+        return True
+
+    items_summary_obj = [
+        {"role": "user", "content": "What's the weather in Tokyo?"},
+        {
+            "id": "__fake_id__",
+            "summary": [Summary(text="Reasoning from Summary object.", type="summary_text")],
+            "content": [],
+            "type": "reasoning",
+            "provider_data": {"model": REASONING_CONTENT_MODEL_A},
+        },
+        {
+            "arguments": '{"city": "Tokyo"}',
+            "call_id": "call_weather_123",
+            "name": "get_weather",
+            "type": "function_call",
+            "id": "__fake_id__",
+        },
+    ]
+
+    messages_summary = Converter.items_to_messages(
+        items_summary_obj,  # type: ignore[arg-type]
+        model=REASONING_CONTENT_MODEL_A,
+        should_replay_reasoning_content=should_replay_reasoning_content,
+    )
+    assistant_summary = _assistant_with_tool_calls(messages_summary)
+    assert assistant_summary["reasoning_content"] == "Reasoning from Summary object."
+
+    items_content_obj = [
+        {"role": "user", "content": "What's the weather in Tokyo?"},
+        {
+            "id": "__fake_id__",
+            "summary": [],
+            "content": [Content(text="Reasoning from Content object.", type="reasoning_text")],
+            "type": "reasoning",
+            "provider_data": {"model": REASONING_CONTENT_MODEL_A},
+        },
+        {
+            "arguments": '{"city": "Tokyo"}',
+            "call_id": "call_weather_123",
+            "name": "get_weather",
+            "type": "function_call",
+            "id": "__fake_id__",
+        },
+    ]
+
+    messages_content = Converter.items_to_messages(
+        items_content_obj,  # type: ignore[arg-type]
+        model=REASONING_CONTENT_MODEL_A,
+        should_replay_reasoning_content=should_replay_reasoning_content,
+    )
+    assistant_content = _assistant_with_tool_calls(messages_content)
+    assert assistant_content["reasoning_content"] == "Reasoning from Content object."


### PR DESCRIPTION
This pull request fixes a correctness bug in `ChatCmplConverter.items_to_messages` where reasoning content was not extracted when replaying reasoning items that stored reasoning text in `content` items or used typed `Summary`/`Content` object instances.

### Summary
When replaying reasoning items into Chat Completions requests (e.g. for DeepSeek models or custom replay hooks via `should_replay_reasoning_content`), `ChatCmplConverter.items_to_messages` previously only checked `summary` dict entries (`summary_item.get("text")` where `isinstance(summary_item, dict)`). Reasoning items whose text resides in `content` (such as `reasoning_text` entries emitted by 3rd-party providers or non-summary reasoning items) or whose `summary`/`content` contains `Summary`/`Content` object instances were ignored, causing `reasoning_content` to be omitted from subsequent assistant messages.

### Affected Component
`src/agents/models/chatcmpl_converter.py` (`ChatCmplConverter.items_to_messages`)

### Observed Behavior
1. If a reasoning item's reasoning text is stored in `content` (`[{"type": "reasoning_text", "text": "..."}]`) with `summary: []`, `items_to_messages` evaluated `summary_items` to `[]`, leaving `pending_reasoning_content` as `None`.
2. If a reasoning item's `summary` or `content` holds `Summary`/`Content` object instances (from `openai.types.responses.response_reasoning_item`), `isinstance(..., dict)` evaluated to `False`, skipping attribute access and leaving `pending_reasoning_content` as `None`.
3. In both cases, `reasoning_content` was missing on the resulting assistant message, breaking session history and reasoning replay for models requiring reasoning history before tool calls.

### Expected Behavior
`ChatCmplConverter.items_to_messages` should extract reasoning text from `summary` items (supporting both `dict` keys and object attributes) and fall back to `content` items of type `reasoning_text` when `summary` is empty or missing, ensuring complete reasoning history replay across all item representations.

### Root Cause
`ChatCmplConverter.items_to_messages` only inspected `reasoning_item.get("summary", [])` and strictly guarded each element with `isinstance(summary_item, dict) and summary_item.get("text")`. It did not check `content` when `summary` was empty, nor did it handle object attributes for `Summary` or `Content` instances.

### Why the Fix is Minimal
The change in `src/agents/models/chatcmpl_converter.py` only updates the reasoning text extraction block inside `if should_replay:`:
1. Safely checks `summary_items` for both `dict` (`.get("text")`) and object (`getattr(..., "text")`) representations.
2. Falls back to `content_items` for `reasoning_text` parts if `summary` yields no text.
3. Preserves all existing APIs, signatures, and default behaviors.

### Regression Tests
Added two unit tests in `tests/models/test_reasoning_content_replay_hook.py`:
- `test_converter_replays_reasoning_content_from_content_items`: verifies replaying reasoning content from `content` items when `summary` is empty.
- `test_converter_replays_reasoning_content_from_summary_and_content_objects`: verifies replaying reasoning content when `summary` or `content` contain `Summary`/`Content` object instances.

Both tests failed with `KeyError: 'reasoning_content'` on `upstream/main` before the fix and pass cleanly after it.

### Exact Validation Results
- Targeted tests: `uv run pytest tests/models/test_reasoning_content_replay_hook.py -v` (9 passed)
- Model test suite: `uv run pytest tests/models/ -q` (591 passed)
- Full verification stack:
  - `make format`: 0 files modified
  - `make lint`: All checks passed!
  - `make typecheck`: All checks passed!
  - `bash .agents/skills/code-change-verification/scripts/run.sh`: Passed cleanly!
  - `git diff --check`: Passed with 0 errors.

### Compatibility and Risk
- **Risk**: None. Backward compatible with all existing usage.
- **Public API**: No public API or function signature changes.

### Related Issue
N/A — previously unreported correctness bug

### Confirmation
Codex `/review` was run and verified.