### PR TITLE
fix: preserve *args/**kwargs docstring descriptions in tool schemas

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -233,7 +233,10 @@ def generate_func_documentation(
     )
 
     param_descriptions: dict[str, str] = {
-        param.name: param.description
+        # Google and NumPy style docstrings write variadic parameters with their
+        # stars ("*args:", "**kwargs:") and griffe returns those names verbatim.
+        # Strip the stars so lookups by the signature parameter name succeed.
+        param.name.lstrip("*"): param.description
         for section in parsed
         if section.kind == DocstringSectionKind.parameters
         for param in section.value

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1008,3 +1008,59 @@ def test_google_docstring_after_section_body_matches_blank_line_form():
 
     assert fixed.description == control.description
     assert fixed.params_json_schema["properties"] == control.params_json_schema["properties"]
+
+
+def starred_args_google_function(x: int, *numbers: float, **kwargs: str) -> str:
+    """Add numbers to a base.
+
+    Args:
+        x: The base value.
+        *numbers: The numbers to add.
+        **kwargs: Extra options.
+    """
+    return f"{x} {numbers} {kwargs}"
+
+
+def starred_args_numpy_function(x: int, *numbers: float, **kwargs: str) -> str:
+    """Add numbers to a base.
+
+    Parameters
+    ----------
+    x : int
+        The base value.
+    *numbers : float
+        The numbers to add.
+    **kwargs : str
+        Extra options.
+    """
+    return f"{x} {numbers} {kwargs}"
+
+
+def starred_args_sphinx_function(x: int, *numbers: float, **kwargs: str) -> str:
+    """Add numbers to a base.
+
+    :param x: The base value.
+    :param numbers: The numbers to add.
+    :param kwargs: Extra options.
+    """
+    return f"{x} {numbers} {kwargs}"
+
+
+@pytest.mark.parametrize(
+    "func,style",
+    [
+        (starred_args_google_function, "google"),
+        (starred_args_numpy_function, "numpy"),
+        (starred_args_sphinx_function, "sphinx"),
+    ],
+)
+def test_variadic_param_descriptions_preserved(func, style):
+    """Google and NumPy style docstrings write variadic parameters with their stars
+    ("*numbers:", "**kwargs:"). The parsed descriptions must still attach to the bare
+    signature names in the JSON schema, matching the sphinx form."""
+    fs = function_schema(func, docstring_style=style, strict_json_schema=False)
+
+    properties = fs.params_json_schema.get("properties", {})
+    assert properties["x"]["description"] == "The base value."
+    assert properties["numbers"]["description"] == "The numbers to add."
+    assert properties["kwargs"]["description"] == "Extra options."


### PR DESCRIPTION
### Summary

Google and NumPy style docstrings write variadic parameters with their stars (`*numbers:`, `**kwargs:`), and griffe returns those names verbatim. `generate_func_documentation` keyed `param_descriptions` by that verbatim name, while `function_schema` looks descriptions up by the bare signature parameter name — so `*args`/`**kwargs` descriptions were silently dropped from the tool JSON schema for those two styles. Sphinx style (`:param numbers:`) has no stars and carried them through, and `function_schema` already plumbs the description into the `VAR_POSITIONAL`/`VAR_KEYWORD` `Field(...)` calls, so the loss was purely a key mismatch. griffe warnings are suppressed during parsing, which made it fully silent.

The fix strips the stars when building the description map (`param.name.lstrip("*")`). Python identifiers cannot begin with `*`, so this is a no-op for every non-variadic key.

Before, documenting the same function per each style's own convention behaved inconsistently:

```
google_style:   'numbers': None            'kwargs': None
numpy_style:    'numbers': None            'kwargs': None
sphinx_style:   'numbers': 'the numbers …' 'kwargs': 'extra options.'
```

After, all three styles carry the descriptions into `params_json_schema`.

### Test plan

- Added `test_variadic_param_descriptions_preserved`, parametrized over google/numpy/sphinx docstrings for the same `(x, *numbers, **kwargs)` function, asserting all three descriptions land in the schema properties. The google and numpy cases fail without the fix; sphinx passes before and after, pinning the consistency claim.
- `make format`, `make lint`, `make typecheck` (mypy + pyright), and `make tests` all pass locally.

### Issue number

None — found while reading `function_schema.py`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
