### PR TITLE
fix: preserve callable function tool compatibility

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2293,15 +2293,15 @@ def _normalize_function_tool_callable(
         )
     )
     has_supported_wrapped_target = wrapped is missing or (
-        inspect.isroutine(wrapped) and not inspect.iscoroutinefunction(wrapped)
+        isinstance(wrapped, FunctionType)
+        and not inspect.iscoroutinefunction(wrapped)
+        and not hasattr(wrapped, "__wrapped__")
+        and not hasattr(wrapped, "__signature__")
     )
     has_released_function_contract = (
         not inspect.iscoroutinefunction(call_descriptor)
         and has_supported_wrapped_target
-        and (
-            (wrapped is not missing and inspect.isroutine(wrapped))
-            or has_explicit_function_metadata
-        )
+        and (wrapped is not missing or has_explicit_function_metadata)
     )
     if has_released_function_contract:
         signature = inspect.signature(func)

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2260,38 +2260,6 @@ def _validate_function_tool_callable_annotations(
         )
 
 
-def _function_tool_wrapped_target_is_sync(target: object) -> bool:
-    """Return whether every dispatch in a wrapper chain is safely synchronous."""
-    missing = object()
-    active: set[int] = set()
-
-    def resolve(current: object) -> bool:
-        current_id = id(current)
-        if current_id in active or isinstance(current, functools.partial):
-            return False
-        active.add(current_id)
-        try:
-            signature_override = inspect.getattr_static(current, "__signature__", missing)
-            if signature_override is not missing and signature_override is not None:
-                return False
-
-            if inspect.iscoroutinefunction(current):
-                return False
-            if not inspect.isroutine(current):
-                if not callable(current):
-                    return False
-                call_descriptor = inspect.getattr_static(type(current), "__call__", missing)
-                if not isinstance(call_descriptor, FunctionType) or not resolve(call_descriptor):
-                    return False
-
-            nested = inspect.getattr_static(current, "__wrapped__", missing)
-            return nested is missing or resolve(nested)
-        finally:
-            active.remove(current_id)
-
-    return resolve(target)
-
-
 def _normalize_function_tool_callable(
     func: ToolFunction[...],
     docstring_style: DocstringStyle | None,
@@ -2306,6 +2274,22 @@ def _normalize_function_tool_callable(
         )
     if inspect.isroutine(func) or inspect.isclass(func):
         return func, None
+
+    try:
+        instance_vars = vars(func)
+    except TypeError:
+        instance_vars = {}
+    missing = object()
+    if (
+        inspect.getattr_static(func, "__wrapped__", missing) is not missing
+        or inspect.getattr_static(func, "__signature__", missing) is not missing
+        or "__annotations__" in instance_vars
+        or "__annotate__" in instance_vars
+    ):
+        raise UserError(
+            "Unsupported callable wrapper: function_tool only infers plain callable instances. "
+            "Use an explicit wrapper function."
+        )
 
     call_owner = next(
         (owner for owner in type(func).__mro__ if "__call__" in owner.__dict__),
@@ -2322,7 +2306,7 @@ def _normalize_function_tool_callable(
     if (
         not isinstance(call_descriptor, FunctionType)
         or hasattr(call_descriptor, "__wrapped__")
-        or getattr(call_descriptor, "__signature__", None) is not None
+        or hasattr(call_descriptor, "__signature__")
     ):
         raise UserError(
             "Unsupported callable object: function_tool supports instances with a plain "
@@ -2330,54 +2314,18 @@ def _normalize_function_tool_callable(
             "built-in callables, or custom descriptors."
         )
 
-    try:
-        instance_vars = vars(func)
-    except TypeError:
-        instance_vars = {}
-    missing = object()
-    wrapped = inspect.getattr_static(func, "__wrapped__", missing)
-    signature_override = inspect.getattr_static(func, "__signature__", missing)
-    published_annotations = inspect.getattr_static(func, "__annotations__", missing)
-    published_annotate = inspect.getattr_static(func, "__annotate__", missing)
-    published_name = inspect.getattr_static(func, "__name__", missing)
-    if signature_override is not missing and signature_override is not None:
-        raise UserError(
-            "Unsupported callable wrapper: function_tool only infers plain callable instances. "
-            "Use an explicit wrapper function."
-        )
-    has_instance_function_metadata = (
-        "__annotations__" in instance_vars or "__annotate__" in instance_vars
-    )
-    has_named_class_function_metadata = isinstance(published_name, str) and (
-        published_annotations is not missing or published_annotate is not missing
-    )
-    has_function_metadata = has_instance_function_metadata or has_named_class_function_metadata
-    has_released_function_contract = (
-        not inspect.iscoroutinefunction(call_descriptor)
-        and (wrapped is not missing or has_function_metadata)
-        and (wrapped is missing or _function_tool_wrapped_target_is_sync(wrapped))
-    )
-    if not has_released_function_contract and (wrapped is not missing or has_function_metadata):
-        raise UserError(
-            "Unsupported callable wrapper: function_tool only infers plain callable instances. "
-            "Use an explicit wrapper function."
-        )
-
     call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
-    signature = inspect.signature(func if has_released_function_contract else call_method)
+    signature = inspect.signature(call_method)
+    globalns = dict(getattr(call_method, "__globals__", {}))
+    localns = dict(vars(call_owner))
+    localns[call_owner.__name__] = call_owner
     try:
-        if has_released_function_contract:
-            type_hints = get_type_hints(func, include_extras=True)
-        else:
-            globalns = dict(getattr(call_method, "__globals__", {}))
-            localns = dict(vars(call_owner))
-            localns[call_owner.__name__] = call_owner
-            type_hints = get_type_hints(
-                call_method,
-                globalns=globalns,
-                localns=localns,
-                include_extras=True,
-            )
+        type_hints = get_type_hints(
+            call_method,
+            globalns=globalns,
+            localns=localns,
+            include_extras=True,
+        )
     except (NameError, TypeError) as error:
         raise UserError(
             "Unsupported callable object annotations: use an explicit wrapper function with "
@@ -2401,15 +2349,8 @@ def _normalize_function_tool_callable(
 
     adapter_metadata = cast(Any, adapter)
     fallback_name = type(func).__name__
-    published_fallback_name = (
-        published_name
-        if has_released_function_contract and isinstance(published_name, str)
-        else fallback_name
-    )
     adapter_metadata.__name__ = (
-        fallback_name
-        if name_override
-        else validate_function_tool_fallback_name(published_fallback_name)
+        fallback_name if name_override else validate_function_tool_fallback_name(fallback_name)
     )
     adapter_metadata.__annotations__ = {
         name: annotation
@@ -2419,9 +2360,6 @@ def _normalize_function_tool_callable(
     adapter_metadata.__signature__ = signature
     if not use_docstring_info:
         adapter_metadata.__doc__ = None
-        class_description = None
-    elif has_released_function_contract:
-        adapter_metadata.__doc__ = inspect.getdoc(func)
         class_description = None
     else:
         class_doc = inspect.getdoc(type(func))

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2254,10 +2254,39 @@ def _validate_function_tool_callable_annotations(
             )
 
 
+def _function_tool_wrapped_target_is_sync(target: object) -> bool:
+    """Return whether a wrapper chain has one safely synchronous callable endpoint."""
+    missing = object()
+    current = target
+    seen: set[int] = set()
+
+    while True:
+        current_id = id(current)
+        if current_id in seen or isinstance(current, functools.partial):
+            return False
+        seen.add(current_id)
+
+        signature_override = inspect.getattr_static(current, "__signature__", missing)
+        if signature_override is not missing and signature_override is not None:
+            return False
+
+        nested = inspect.getattr_static(current, "__wrapped__", missing)
+        if nested is missing:
+            break
+        current = nested
+
+    if not callable(current) or inspect.iscoroutinefunction(current):
+        return False
+
+    call_descriptor = inspect.getattr_static(type(current), "__call__", missing)
+    return call_descriptor is missing or not inspect.iscoroutinefunction(call_descriptor)
+
+
 def _normalize_function_tool_callable(
     func: ToolFunction[...],
     docstring_style: DocstringStyle | None,
     name_override: str | None,
+    use_docstring_info: bool,
 ) -> tuple[ToolFunction[...], str | None]:
     """Adapt one plain callable instance to the existing function-tool pipeline."""
     if isinstance(func, functools.partial):
@@ -2306,29 +2335,19 @@ def _normalize_function_tool_callable(
             "Unsupported callable wrapper: function_tool only infers plain callable instances. "
             "Use an explicit wrapper function."
         )
-    has_explicit_function_metadata = (
-        "__annotations__" in instance_vars
-        or "__annotate__" in instance_vars
-        or (
-            isinstance(published_name, str)
-            and (published_annotations is not missing or published_annotate is not missing)
-        )
+    has_instance_function_metadata = (
+        "__annotations__" in instance_vars or "__annotate__" in instance_vars
     )
-    has_supported_wrapped_target = wrapped is missing or (
-        not isinstance(wrapped, functools.partial)
-        and inspect.isroutine(wrapped)
-        and not inspect.iscoroutinefunction(wrapped)
-        and not hasattr(wrapped, "__wrapped__")
-        and getattr(wrapped, "__signature__", None) is None
-    )
+    has_named_class_function_metadata = (
+        name_override is not None or isinstance(published_name, str)
+    ) and (published_annotations is not missing or published_annotate is not missing)
+    has_function_metadata = has_instance_function_metadata or has_named_class_function_metadata
     has_released_function_contract = (
         not inspect.iscoroutinefunction(call_descriptor)
-        and has_supported_wrapped_target
-        and (wrapped is not missing or has_explicit_function_metadata)
+        and (wrapped is not missing or has_function_metadata)
+        and (wrapped is missing or _function_tool_wrapped_target_is_sync(wrapped))
     )
-    if not has_released_function_contract and (
-        wrapped is not missing or has_explicit_function_metadata
-    ):
+    if not has_released_function_contract and (wrapped is not missing or has_function_metadata):
         raise UserError(
             "Unsupported callable wrapper: function_tool only infers plain callable instances. "
             "Use an explicit wrapper function."
@@ -2388,7 +2407,10 @@ def _normalize_function_tool_callable(
         if name == "return" or name in signature.parameters
     }
     adapter_metadata.__signature__ = signature
-    if has_released_function_contract:
+    if not use_docstring_info:
+        adapter_metadata.__doc__ = None
+        class_description = None
+    elif has_released_function_contract:
         adapter_metadata.__doc__ = inspect.getdoc(func)
         class_description = None
     else:
@@ -2541,6 +2563,7 @@ def function_tool(
             the_func,
             docstring_style,
             name_override,
+            use_docstring_info,
         )
         is_sync_function_tool = not inspect.iscoroutinefunction(the_func)
         schema = function_schema(

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -13,7 +13,7 @@ import weakref
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from types import FunctionType, MethodType, UnionType
+from types import FunctionType, UnionType
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -21,6 +21,8 @@ from typing import (
     Concatenate,
     Generic,
     Literal,
+    ParamSpecArgs,
+    ParamSpecKwargs,
     Protocol,
     TypeVar,
     Union,
@@ -42,7 +44,13 @@ from openai.types.responses.tool_param import CodeInterpreter, ImageGeneration, 
 from openai.types.responses.web_search_tool import Filters as WebSearchToolFilters
 from openai.types.responses.web_search_tool_param import UserLocation
 from pydantic import BaseModel, TypeAdapter, ValidationError, model_validator
-from typing_extensions import NotRequired, ParamSpec, Self, TypeAliasType, TypedDict
+from typing_extensions import (
+    NotRequired,
+    ParamSpec,
+    Self,
+    TypeAliasType,
+    TypedDict,
+)
 
 from . import _debug
 from ._config_coercion import coerce_pydantic_config
@@ -2207,12 +2215,13 @@ def _validate_function_tool_callable_annotations(
     native_self = getattr(typing, "Self", Self)
     native_alias_type = getattr(typing, "TypeAliasType", TypeAliasType)
     alias_types = (TypeAliasType, native_alias_type)
+    generic_types = (TypeVar, ParamSpec, ParamSpecArgs, ParamSpecKwargs)
 
     def contains_specialized_annotation(annotation: Any) -> bool:
         origin = get_origin(annotation)
         if (
-            isinstance(annotation, (TypeVar, *alias_types))
-            or isinstance(origin, alias_types)
+            isinstance(annotation, (*generic_types, *alias_types))
+            or isinstance(origin, (*generic_types, *alias_types))
             or annotation in (Self, native_self)
         ):
             return True
@@ -2306,7 +2315,7 @@ def _normalize_function_tool_callable(
         )
     )
     has_supported_wrapped_target = wrapped is missing or (
-        isinstance(wrapped, FunctionType | MethodType)
+        inspect.isroutine(wrapped)
         and not inspect.iscoroutinefunction(wrapped)
         and not hasattr(wrapped, "__wrapped__")
         and getattr(wrapped, "__signature__", None) is None

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2330,8 +2330,6 @@ def _normalize_function_tool_callable(
             "built-in callables, or custom descriptors."
         )
 
-    call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
-    call_parameter_names = set(inspect.signature(call_method).parameters)
     try:
         instance_vars = vars(func)
     except TypeError:
@@ -2350,13 +2348,9 @@ def _normalize_function_tool_callable(
     has_instance_function_metadata = (
         "__annotations__" in instance_vars or "__annotate__" in instance_vars
     )
-    class_annotations_match_call = isinstance(published_annotations, Mapping) and any(
-        name == "return" or name in call_parameter_names for name in published_annotations
+    has_named_class_function_metadata = isinstance(published_name, str) and (
+        published_annotations is not missing or published_annotate is not missing
     )
-    has_named_class_function_metadata = (
-        isinstance(published_name, str)
-        and (published_annotations is not missing or published_annotate is not missing)
-    ) or (name_override is not None and class_annotations_match_call)
     has_function_metadata = has_instance_function_metadata or has_named_class_function_metadata
     has_released_function_contract = (
         not inspect.iscoroutinefunction(call_descriptor)
@@ -2369,6 +2363,7 @@ def _normalize_function_tool_callable(
             "Use an explicit wrapper function."
         )
 
+    call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
     signature = inspect.signature(func if has_released_function_contract else call_method)
     try:
         if has_released_function_contract:

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2281,7 +2281,7 @@ def _function_tool_wrapped_target_is_sync(target: object) -> bool:
                 if not callable(current):
                     return False
                 call_descriptor = inspect.getattr_static(type(current), "__call__", missing)
-                if call_descriptor is missing or not resolve(call_descriptor):
+                if not isinstance(call_descriptor, FunctionType) or not resolve(call_descriptor):
                     return False
 
             nested = inspect.getattr_static(current, "__wrapped__", missing)

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2218,7 +2218,15 @@ def _validate_function_tool_callable_annotations(
             return True
         return any(contains_specialized_annotation(arg) for arg in get_args(annotation))
 
-    if any(contains_specialized_annotation(annotation) for annotation in type_hints.values()):
+    contract_annotations = [
+        type_hints.get(name, parameter.annotation)
+        for name, parameter in signature.parameters.items()
+    ]
+    contract_annotations.append(type_hints.get("return", signature.return_annotation))
+    if any(
+        annotation is not inspect.Signature.empty and contains_specialized_annotation(annotation)
+        for annotation in contract_annotations
+    ):
         raise UserError(
             "Unsupported generic or aliased callable object annotations: use an explicit wrapper "
             "function with concrete parameter and return annotations."
@@ -2266,7 +2274,7 @@ def _normalize_function_tool_callable(
     if (
         not isinstance(call_descriptor, FunctionType)
         or hasattr(call_descriptor, "__wrapped__")
-        or hasattr(call_descriptor, "__signature__")
+        or getattr(call_descriptor, "__signature__", None) is not None
     ):
         raise UserError(
             "Unsupported callable object: function_tool supports instances with a plain "
@@ -2284,7 +2292,7 @@ def _normalize_function_tool_callable(
     published_annotations = inspect.getattr_static(func, "__annotations__", missing)
     published_annotate = inspect.getattr_static(func, "__annotate__", missing)
     published_name = inspect.getattr_static(func, "__name__", missing)
-    if signature_override is not missing:
+    if signature_override is not missing and signature_override is not None:
         raise UserError(
             "Unsupported callable wrapper: function_tool only infers plain callable instances. "
             "Use an explicit wrapper function."
@@ -2301,7 +2309,7 @@ def _normalize_function_tool_callable(
         isinstance(wrapped, FunctionType)
         and not inspect.iscoroutinefunction(wrapped)
         and not hasattr(wrapped, "__wrapped__")
-        and not hasattr(wrapped, "__signature__")
+        and getattr(wrapped, "__signature__", None) is None
     )
     has_released_function_contract = (
         not inspect.iscoroutinefunction(call_descriptor)

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -13,7 +13,7 @@ import weakref
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from types import FunctionType, UnionType
+from types import FunctionType, MethodType, UnionType
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -2306,7 +2306,7 @@ def _normalize_function_tool_callable(
         )
     )
     has_supported_wrapped_target = wrapped is missing or (
-        isinstance(wrapped, FunctionType)
+        isinstance(wrapped, FunctionType | MethodType)
         and not inspect.iscoroutinefunction(wrapped)
         and not hasattr(wrapped, "__wrapped__")
         and getattr(wrapped, "__signature__", None) is None

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2199,11 +2199,31 @@ def _validate_function_tool_output(
         ) from error
 
 
-def _reject_function_tool_callable_context(
+def _validate_function_tool_callable_annotations(
     signature: inspect.Signature,
     type_hints: dict[str, Any],
 ) -> None:
-    """Reject context injection for callable objects before tool invocation."""
+    """Reject unsupported callable object annotations before tool invocation."""
+    native_self = getattr(typing, "Self", Self)
+    native_alias_type = getattr(typing, "TypeAliasType", TypeAliasType)
+    alias_types = (TypeAliasType, native_alias_type)
+
+    def contains_specialized_annotation(annotation: Any) -> bool:
+        origin = get_origin(annotation)
+        if (
+            isinstance(annotation, (TypeVar, *alias_types))
+            or isinstance(origin, alias_types)
+            or annotation in (Self, native_self)
+        ):
+            return True
+        return any(contains_specialized_annotation(arg) for arg in get_args(annotation))
+
+    if any(contains_specialized_annotation(annotation) for annotation in type_hints.values()):
+        raise UserError(
+            "Unsupported generic or aliased callable object annotations: use an explicit wrapper "
+            "function with concrete parameter and return annotations."
+        )
+
     for name, parameter in signature.parameters.items():
         annotation = type_hints.get(name, parameter.annotation)
         if annotation is inspect.Signature.empty:
@@ -2238,6 +2258,11 @@ def _normalize_function_tool_callable(
     if call_owner is None:
         raise UserError("Unsupported callable object: no inspectable __call__ method was found.")
     call_descriptor = call_owner.__dict__["__call__"]
+    if getattr(call_owner, "__type_params__", ()) or getattr(call_owner, "__parameters__", ()):
+        raise UserError(
+            "Unsupported generic callable object: use an explicit wrapper function with concrete "
+            "parameter and return annotations."
+        )
 
     try:
         instance_vars = vars(func)
@@ -2246,27 +2271,33 @@ def _normalize_function_tool_callable(
     missing = object()
     wrapped = inspect.getattr_static(func, "__wrapped__", missing)
     signature_override = inspect.getattr_static(func, "__signature__", missing)
+    published_annotations = inspect.getattr_static(func, "__annotations__", missing)
+    published_annotate = inspect.getattr_static(func, "__annotate__", missing)
     published_name = inspect.getattr_static(func, "__name__", missing)
-    wraps_async_routine = (
-        wrapped is not missing
-        and inspect.isroutine(wrapped)
-        and inspect.iscoroutinefunction(wrapped)
+    has_explicit_function_metadata = (
+        "__annotations__" in instance_vars
+        or "__annotate__" in instance_vars
+        or (
+            isinstance(published_name, str)
+            and (published_annotations is not missing or published_annotate is not missing)
+        )
+    )
+    has_supported_wrapped_target = wrapped is missing or (
+        inspect.isroutine(wrapped) and not inspect.iscoroutinefunction(wrapped)
     )
     has_released_function_contract = (
         isinstance(call_descriptor, FunctionType)
         and not inspect.iscoroutinefunction(call_descriptor)
-        and not wraps_async_routine
+        and has_supported_wrapped_target
         and (
             (wrapped is not missing and inspect.isroutine(wrapped))
-            or "__annotations__" in instance_vars
-            or "__annotate__" in instance_vars
-            or isinstance(published_name, str)
+            or has_explicit_function_metadata
         )
     )
     if has_released_function_contract:
         signature = inspect.signature(func)
         type_hints = get_type_hints(func, include_extras=True)
-        _reject_function_tool_callable_context(signature, type_hints)
+        _validate_function_tool_callable_annotations(signature, type_hints)
         # Synchronous function-like callables with explicit metadata already flowed through
         # function_schema() in released versions. Preserve that path instead of reinterpreting it.
         return func, None
@@ -2274,8 +2305,7 @@ def _normalize_function_tool_callable(
     if (
         wrapped is not missing
         or signature_override is not missing
-        or "__annotations__" in instance_vars
-        or "__annotate__" in instance_vars
+        or has_explicit_function_metadata
     ):
         raise UserError(
             "Unsupported callable wrapper: function_tool only infers plain callable instances. "
@@ -2292,12 +2322,6 @@ def _normalize_function_tool_callable(
             "__call__ method. Use an explicit wrapper function for partials, decorated methods, "
             "built-in callables, or custom descriptors."
         )
-    if getattr(call_owner, "__type_params__", ()) or getattr(call_owner, "__parameters__", ()):
-        raise UserError(
-            "Unsupported generic callable object: use an explicit wrapper function with concrete "
-            "parameter and return annotations."
-        )
-
     call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
     signature = inspect.signature(call_method)
     globalns = dict(getattr(call_method, "__globals__", {}))
@@ -2316,26 +2340,7 @@ def _normalize_function_tool_callable(
             "annotations resolvable from its module."
         ) from error
 
-    native_self = getattr(typing, "Self", Self)
-    native_alias_type = getattr(typing, "TypeAliasType", TypeAliasType)
-    alias_types = (TypeAliasType, native_alias_type)
-
-    def contains_specialized_annotation(annotation: Any) -> bool:
-        origin = get_origin(annotation)
-        if (
-            isinstance(annotation, (TypeVar, *alias_types))
-            or isinstance(origin, alias_types)
-            or annotation in (Self, native_self)
-        ):
-            return True
-        return any(contains_specialized_annotation(arg) for arg in get_args(annotation))
-
-    if any(contains_specialized_annotation(annotation) for annotation in type_hints.values()):
-        raise UserError(
-            "Unsupported generic or aliased callable object annotations: use an explicit wrapper "
-            "function with concrete parameter and return annotations."
-        )
-    _reject_function_tool_callable_context(signature, type_hints)
+    _validate_function_tool_callable_annotations(signature, type_hints)
 
     if inspect.iscoroutinefunction(call_method):
 

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2330,6 +2330,8 @@ def _normalize_function_tool_callable(
             "built-in callables, or custom descriptors."
         )
 
+    call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
+    call_parameter_names = set(inspect.signature(call_method).parameters)
     try:
         instance_vars = vars(func)
     except TypeError:
@@ -2348,9 +2350,13 @@ def _normalize_function_tool_callable(
     has_instance_function_metadata = (
         "__annotations__" in instance_vars or "__annotate__" in instance_vars
     )
+    class_annotations_match_call = isinstance(published_annotations, Mapping) and any(
+        name == "return" or name in call_parameter_names for name in published_annotations
+    )
     has_named_class_function_metadata = (
-        name_override is not None or isinstance(published_name, str)
-    ) and (published_annotations is not missing or published_annotate is not missing)
+        isinstance(published_name, str)
+        and (published_annotations is not missing or published_annotate is not missing)
+    ) or (name_override is not None and class_annotations_match_call)
     has_function_metadata = has_instance_function_metadata or has_named_class_function_metadata
     has_released_function_contract = (
         not inspect.iscoroutinefunction(call_descriptor)
@@ -2363,7 +2369,6 @@ def _normalize_function_tool_callable(
             "Use an explicit wrapper function."
         )
 
-    call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
     signature = inspect.signature(func if has_released_function_contract else call_method)
     try:
         if has_released_function_contract:

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2263,6 +2263,16 @@ def _normalize_function_tool_callable(
             "Unsupported generic callable object: use an explicit wrapper function with concrete "
             "parameter and return annotations."
         )
+    if (
+        not isinstance(call_descriptor, FunctionType)
+        or hasattr(call_descriptor, "__wrapped__")
+        or hasattr(call_descriptor, "__signature__")
+    ):
+        raise UserError(
+            "Unsupported callable object: function_tool supports instances with a plain "
+            "__call__ method. Use an explicit wrapper function for partials, decorated methods, "
+            "built-in callables, or custom descriptors."
+        )
 
     try:
         instance_vars = vars(func)
@@ -2286,8 +2296,7 @@ def _normalize_function_tool_callable(
         inspect.isroutine(wrapped) and not inspect.iscoroutinefunction(wrapped)
     )
     has_released_function_contract = (
-        isinstance(call_descriptor, FunctionType)
-        and not inspect.iscoroutinefunction(call_descriptor)
+        not inspect.iscoroutinefunction(call_descriptor)
         and has_supported_wrapped_target
         and (
             (wrapped is not missing and inspect.isroutine(wrapped))
@@ -2312,16 +2321,6 @@ def _normalize_function_tool_callable(
             "Use an explicit wrapper function."
         )
 
-    if (
-        not isinstance(call_descriptor, FunctionType)
-        or hasattr(call_descriptor, "__wrapped__")
-        or hasattr(call_descriptor, "__signature__")
-    ):
-        raise UserError(
-            "Unsupported callable object: function_tool supports instances with a plain "
-            "__call__ method. Use an explicit wrapper function for partials, decorated methods, "
-            "built-in callables, or custom descriptors."
-        )
     call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
     signature = inspect.signature(call_method)
     globalns = dict(getattr(call_method, "__globals__", {}))

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2284,6 +2284,11 @@ def _normalize_function_tool_callable(
     published_annotations = inspect.getattr_static(func, "__annotations__", missing)
     published_annotate = inspect.getattr_static(func, "__annotate__", missing)
     published_name = inspect.getattr_static(func, "__name__", missing)
+    if signature_override is not missing:
+        raise UserError(
+            "Unsupported callable wrapper: function_tool only infers plain callable instances. "
+            "Use an explicit wrapper function."
+        )
     has_explicit_function_metadata = (
         "__annotations__" in instance_vars
         or "__annotate__" in instance_vars
@@ -2303,18 +2308,8 @@ def _normalize_function_tool_callable(
         and has_supported_wrapped_target
         and (wrapped is not missing or has_explicit_function_metadata)
     )
-    if has_released_function_contract:
-        signature = inspect.signature(func)
-        type_hints = get_type_hints(func, include_extras=True)
-        _validate_function_tool_callable_annotations(signature, type_hints)
-        # Synchronous function-like callables with explicit metadata already flowed through
-        # function_schema() in released versions. Preserve that path instead of reinterpreting it.
-        return func, None
-
-    if (
-        wrapped is not missing
-        or signature_override is not missing
-        or has_explicit_function_metadata
+    if not has_released_function_contract and (
+        wrapped is not missing or has_explicit_function_metadata
     ):
         raise UserError(
             "Unsupported callable wrapper: function_tool only infers plain callable instances. "
@@ -2322,17 +2317,20 @@ def _normalize_function_tool_callable(
         )
 
     call_method = cast(Callable[..., Any], call_descriptor.__get__(func, type(func)))
-    signature = inspect.signature(call_method)
-    globalns = dict(getattr(call_method, "__globals__", {}))
-    localns = dict(vars(call_owner))
-    localns[call_owner.__name__] = call_owner
+    signature = inspect.signature(func if has_released_function_contract else call_method)
     try:
-        type_hints = get_type_hints(
-            call_method,
-            globalns=globalns,
-            localns=localns,
-            include_extras=True,
-        )
+        if has_released_function_contract:
+            type_hints = get_type_hints(func, include_extras=True)
+        else:
+            globalns = dict(getattr(call_method, "__globals__", {}))
+            localns = dict(vars(call_owner))
+            localns[call_owner.__name__] = call_owner
+            type_hints = get_type_hints(
+                call_method,
+                globalns=globalns,
+                localns=localns,
+                include_extras=True,
+            )
     except (NameError, TypeError) as error:
         raise UserError(
             "Unsupported callable object annotations: use an explicit wrapper function with "
@@ -2356,23 +2354,34 @@ def _normalize_function_tool_callable(
 
     adapter_metadata = cast(Any, adapter)
     fallback_name = type(func).__name__
-    adapter_metadata.__name__ = (
-        fallback_name if name_override else validate_function_tool_fallback_name(fallback_name)
+    published_fallback_name = (
+        published_name
+        if has_released_function_contract and isinstance(published_name, str)
+        else fallback_name
     )
-    class_doc = inspect.getdoc(type(func))
-    call_doc = inspect.cleandoc(call_descriptor.__doc__) if call_descriptor.__doc__ else None
-    adapter_metadata.__doc__ = call_doc or class_doc
+    adapter_metadata.__name__ = (
+        fallback_name
+        if name_override
+        else validate_function_tool_fallback_name(published_fallback_name)
+    )
     adapter_metadata.__annotations__ = {
         name: annotation
         for name, annotation in type_hints.items()
         if name == "return" or name in signature.parameters
     }
     adapter_metadata.__signature__ = signature
-    class_description = (
-        generate_func_documentation(type(func), docstring_style).description
-        if class_doc and call_doc
-        else None
-    )
+    if has_released_function_contract:
+        adapter_metadata.__doc__ = inspect.getdoc(func)
+        class_description = None
+    else:
+        class_doc = inspect.getdoc(type(func))
+        call_doc = inspect.cleandoc(call_descriptor.__doc__) if call_descriptor.__doc__ else None
+        adapter_metadata.__doc__ = call_doc or class_doc
+        class_description = (
+            generate_func_documentation(type(func), docstring_style).description
+            if class_doc and call_doc
+            else None
+        )
     return cast("ToolFunction[...]", adapter), class_description
 
 

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2241,45 +2241,55 @@ def _validate_function_tool_callable_annotations(
             "function with concrete parameter and return annotations."
         )
 
-    for name, parameter in signature.parameters.items():
+    for index, (name, parameter) in enumerate(signature.parameters.items()):
         annotation = type_hints.get(name, parameter.annotation)
         if annotation is inspect.Signature.empty:
             continue
         plain_annotation = _unwrap_annotated_type(annotation)
         origin = get_origin(plain_annotation) or plain_annotation
-        if origin is RunContextWrapper or origin is ToolContext:
-            raise UserError(
-                "Unsupported callable object context parameter: use an explicit wrapper function "
-                "to receive RunContextWrapper or ToolContext."
-            )
+        if origin is not RunContextWrapper and origin is not ToolContext:
+            continue
+        if index == 0 and parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            continue
+        raise UserError(
+            "Unsupported callable object context parameter: RunContextWrapper or ToolContext "
+            "must be the first positional parameter. Use an explicit wrapper function."
+        )
 
 
 def _function_tool_wrapped_target_is_sync(target: object) -> bool:
-    """Return whether a wrapper chain has one safely synchronous callable endpoint."""
+    """Return whether every dispatch in a wrapper chain is safely synchronous."""
     missing = object()
-    current = target
-    seen: set[int] = set()
+    active: set[int] = set()
 
-    while True:
+    def resolve(current: object) -> bool:
         current_id = id(current)
-        if current_id in seen or isinstance(current, functools.partial):
+        if current_id in active or isinstance(current, functools.partial):
             return False
-        seen.add(current_id)
+        active.add(current_id)
+        try:
+            signature_override = inspect.getattr_static(current, "__signature__", missing)
+            if signature_override is not missing and signature_override is not None:
+                return False
 
-        signature_override = inspect.getattr_static(current, "__signature__", missing)
-        if signature_override is not missing and signature_override is not None:
-            return False
+            if inspect.iscoroutinefunction(current):
+                return False
+            if not inspect.isroutine(current):
+                if not callable(current):
+                    return False
+                call_descriptor = inspect.getattr_static(type(current), "__call__", missing)
+                if call_descriptor is missing or not resolve(call_descriptor):
+                    return False
 
-        nested = inspect.getattr_static(current, "__wrapped__", missing)
-        if nested is missing:
-            break
-        current = nested
+            nested = inspect.getattr_static(current, "__wrapped__", missing)
+            return nested is missing or resolve(nested)
+        finally:
+            active.remove(current_id)
 
-    if not callable(current) or inspect.iscoroutinefunction(current):
-        return False
-
-    call_descriptor = inspect.getattr_static(type(current), "__call__", missing)
-    return call_descriptor is missing or not inspect.iscoroutinefunction(call_descriptor)
+    return resolve(target)
 
 
 def _normalize_function_tool_callable(

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2315,7 +2315,8 @@ def _normalize_function_tool_callable(
         )
     )
     has_supported_wrapped_target = wrapped is missing or (
-        inspect.isroutine(wrapped)
+        not isinstance(wrapped, functools.partial)
+        and inspect.isroutine(wrapped)
         and not inspect.iscoroutinefunction(wrapped)
         and not hasattr(wrapped, "__wrapped__")
         and getattr(wrapped, "__signature__", None) is None

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2199,6 +2199,24 @@ def _validate_function_tool_output(
         ) from error
 
 
+def _reject_function_tool_callable_context(
+    signature: inspect.Signature,
+    type_hints: dict[str, Any],
+) -> None:
+    """Reject context injection for callable objects before tool invocation."""
+    for name, parameter in signature.parameters.items():
+        annotation = type_hints.get(name, parameter.annotation)
+        if annotation is inspect.Signature.empty:
+            continue
+        plain_annotation = _unwrap_annotated_type(annotation)
+        origin = get_origin(plain_annotation) or plain_annotation
+        if origin is RunContextWrapper or origin is ToolContext:
+            raise UserError(
+                "Unsupported callable object context parameter: use an explicit wrapper function "
+                "to receive RunContextWrapper or ToolContext."
+            )
+
+
 def _normalize_function_tool_callable(
     func: ToolFunction[...],
     docstring_style: DocstringStyle | None,
@@ -2229,9 +2247,15 @@ def _normalize_function_tool_callable(
     wrapped = inspect.getattr_static(func, "__wrapped__", missing)
     signature_override = inspect.getattr_static(func, "__signature__", missing)
     published_name = inspect.getattr_static(func, "__name__", missing)
+    wraps_async_routine = (
+        wrapped is not missing
+        and inspect.isroutine(wrapped)
+        and inspect.iscoroutinefunction(wrapped)
+    )
     has_released_function_contract = (
         isinstance(call_descriptor, FunctionType)
         and not inspect.iscoroutinefunction(call_descriptor)
+        and not wraps_async_routine
         and (
             (wrapped is not missing and inspect.isroutine(wrapped))
             or "__annotations__" in instance_vars
@@ -2240,6 +2264,9 @@ def _normalize_function_tool_callable(
         )
     )
     if has_released_function_contract:
+        signature = inspect.signature(func)
+        type_hints = get_type_hints(func, include_extras=True)
+        _reject_function_tool_callable_context(signature, type_hints)
         # Synchronous function-like callables with explicit metadata already flowed through
         # function_schema() in released versions. Preserve that path instead of reinterpreting it.
         return func, None
@@ -2308,17 +2335,7 @@ def _normalize_function_tool_callable(
             "Unsupported generic or aliased callable object annotations: use an explicit wrapper "
             "function with concrete parameter and return annotations."
         )
-    for name, parameter in signature.parameters.items():
-        annotation = type_hints.get(name, parameter.annotation)
-        if annotation is inspect.Signature.empty:
-            continue
-        plain_annotation = _unwrap_annotated_type(annotation)
-        origin = get_origin(plain_annotation) or plain_annotation
-        if origin is RunContextWrapper or origin is ToolContext:
-            raise UserError(
-                "Unsupported callable object context parameter: use an explicit wrapper function "
-                "to receive RunContextWrapper or ToolContext."
-            )
+    _reject_function_tool_callable_context(signature, type_hints)
 
     if inspect.iscoroutinefunction(call_method):
 

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2206,7 +2206,10 @@ def _normalize_function_tool_callable(
 ) -> tuple[ToolFunction[...], str | None]:
     """Adapt one plain callable instance to the existing function-tool pipeline."""
     if isinstance(func, functools.partial):
-        return func, None
+        raise UserError(
+            "Unsupported callable object: function_tool does not infer functools.partial "
+            "contracts. Use an explicit wrapper function."
+        )
     if inspect.isroutine(func) or inspect.isclass(func):
         return func, None
 
@@ -2231,7 +2234,6 @@ def _normalize_function_tool_callable(
         and not inspect.iscoroutinefunction(call_descriptor)
         and (
             (wrapped is not missing and inspect.isroutine(wrapped))
-            or signature_override is not missing
             or "__annotations__" in instance_vars
             or "__annotate__" in instance_vars
             or isinstance(published_name, str)
@@ -2260,8 +2262,8 @@ def _normalize_function_tool_callable(
     ):
         raise UserError(
             "Unsupported callable object: function_tool supports instances with a plain "
-            "__call__ method. Use an explicit wrapper function for partial methods, decorated "
-            "methods, built-in callables, or custom descriptors."
+            "__call__ method. Use an explicit wrapper function for partials, decorated methods, "
+            "built-in callables, or custom descriptors."
         )
     if getattr(call_owner, "__type_params__", ()) or getattr(call_owner, "__parameters__", ()):
         raise UserError(

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2206,28 +2206,9 @@ def _normalize_function_tool_callable(
 ) -> tuple[ToolFunction[...], str | None]:
     """Adapt one plain callable instance to the existing function-tool pipeline."""
     if isinstance(func, functools.partial):
-        raise UserError(
-            "Unsupported callable object: function_tool does not infer functools.partial "
-            "contracts. Use an explicit wrapper function."
-        )
+        return func, None
     if inspect.isroutine(func) or inspect.isclass(func):
         return func, None
-
-    try:
-        instance_vars = vars(func)
-    except TypeError:
-        instance_vars = {}
-    missing = object()
-    if (
-        inspect.getattr_static(func, "__wrapped__", missing) is not missing
-        or inspect.getattr_static(func, "__signature__", missing) is not missing
-        or "__annotations__" in instance_vars
-        or "__annotate__" in instance_vars
-    ):
-        raise UserError(
-            "Unsupported callable wrapper: function_tool only infers plain callable instances. "
-            "Use an explicit wrapper function."
-        )
 
     call_owner = next(
         (owner for owner in type(func).__mro__ if "__call__" in owner.__dict__),
@@ -2236,6 +2217,42 @@ def _normalize_function_tool_callable(
     if call_owner is None:
         raise UserError("Unsupported callable object: no inspectable __call__ method was found.")
     call_descriptor = call_owner.__dict__["__call__"]
+
+    try:
+        instance_vars = vars(func)
+    except TypeError:
+        instance_vars = {}
+    missing = object()
+    wrapped = inspect.getattr_static(func, "__wrapped__", missing)
+    signature_override = inspect.getattr_static(func, "__signature__", missing)
+    published_name = inspect.getattr_static(func, "__name__", missing)
+    has_released_function_contract = (
+        isinstance(call_descriptor, FunctionType)
+        and not inspect.iscoroutinefunction(call_descriptor)
+        and (
+            (wrapped is not missing and inspect.isroutine(wrapped))
+            or signature_override is not missing
+            or "__annotations__" in instance_vars
+            or "__annotate__" in instance_vars
+            or isinstance(published_name, str)
+        )
+    )
+    if has_released_function_contract:
+        # Synchronous function-like callables with explicit metadata already flowed through
+        # function_schema() in released versions. Preserve that path instead of reinterpreting it.
+        return func, None
+
+    if (
+        wrapped is not missing
+        or signature_override is not missing
+        or "__annotations__" in instance_vars
+        or "__annotate__" in instance_vars
+    ):
+        raise UserError(
+            "Unsupported callable wrapper: function_tool only infers plain callable instances. "
+            "Use an explicit wrapper function."
+        )
+
     if (
         not isinstance(call_descriptor, FunctionType)
         or hasattr(call_descriptor, "__wrapped__")
@@ -2243,8 +2260,8 @@ def _normalize_function_tool_callable(
     ):
         raise UserError(
             "Unsupported callable object: function_tool supports instances with a plain "
-            "__call__ method. Use an explicit wrapper function for partials, decorated methods, "
-            "built-in callables, or custom descriptors."
+            "__call__ method. Use an explicit wrapper function for partial methods, decorated "
+            "methods, built-in callables, or custom descriptors."
         )
     if getattr(call_owner, "__type_params__", ()) or getattr(call_owner, "__parameters__", ()):
         raise UserError(

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -495,16 +495,22 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
         expected_description = "Double the value."
     elif metadata_kind == "nested-sync-wrapper":
 
-        @functools.wraps(target)
-        def sync_bridge(*args: Any, **kwargs: Any) -> Any:
-            return target(*args, **kwargs)
+        class SyncIntermediate:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, target)
+
+            @functools.wraps(target)
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return target(*args, **kwargs)
+
+        intermediate = SyncIntermediate()
 
         class NestedSyncWrapperHandler:
             def __init__(self) -> None:
-                functools.update_wrapper(self, sync_bridge)
+                functools.update_wrapper(self, intermediate)
 
             def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return sync_bridge(*args, **kwargs)
+                return intermediate(*args, **kwargs)
 
         handler = NestedSyncWrapperHandler()
         expected_name = "target"
@@ -610,18 +616,66 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
 
 
 @pytest.mark.asyncio
+async def test_released_sync_metadata_wrapper_preserves_tool_context() -> None:
+    def target(ctx: ToolContext[Any], value: int) -> str:
+        return f"{ctx.tool_name}:{value}"
+
+    class Handler:
+        def __init__(self) -> None:
+            functools.update_wrapper(self, target)
+
+        def __call__(self, *args: Any, **kwargs: Any) -> str:
+            return target(*args, **kwargs)
+
+    tool = function_tool(Handler())
+
+    assert list(tool.params_json_schema["properties"]) == ["value"]
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == "dummy:4"
+
+
+@pytest.mark.asyncio
+async def test_released_sync_metadata_wrapper_preserves_positional_only_run_context() -> None:
+    def target(ctx: RunContextWrapper[Any], /, value: int) -> str:
+        return f"{ctx.context.data}:{value}"
+
+    class Handler:
+        def __init__(self) -> None:
+            functools.update_wrapper(self, target)
+
+        def __call__(self, *args: Any, **kwargs: Any) -> str:
+            return target(*args, **kwargs)
+
+    tool = function_tool(Handler())
+
+    assert list(tool.params_json_schema["properties"]) == ["value"]
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == "something:4"
+
+
+@pytest.mark.asyncio
+async def test_async_callable_object_preserves_positional_context() -> None:
+    class Handler:
+        async def __call__(self, ctx: ToolContext[Any], value: int) -> str:
+            return f"{ctx.tool_name}:{value}"
+
+    tool = function_tool(Handler(), name_override="handler")
+
+    assert list(tool.params_json_schema["properties"]) == ["value"]
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == "dummy:4"
+
+
+@pytest.mark.asyncio
 async def test_callable_docstring_opt_out_does_not_read_dynamic_doc() -> None:
     class RaisingDoc:
         def __get__(self, instance: Any, owner: type[Any] | None = None) -> str:
             raise AssertionError("The callable docstring should not be read.")
 
     class Handler:
-        __doc__ = RaisingDoc()
         __annotations__ = {"value": int, "return": int}
 
         def __call__(self, value: Any) -> int:
             return cast(int, value) * 2
 
+    cast(Any, Handler).__doc__ = RaisingDoc()
     tool = function_tool(
         Handler(),
         name_override="handler",
@@ -726,14 +780,15 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
                 reason="Callable-instance partials are routines on Python 3.14",
             ),
         ),
+        "sync-wrapper-decorated-async-callable-target",
+        "sync-wrapper-async-intermediate-sync-target",
         "sync-wrapper-nested-async-target",
         "metadata-typevar-wrapper",
         "metadata-paramspec-wrapper",
         "metadata-keyword-only-context",
-        "context",
         "keyword-only-context",
         "variadic-context",
-        "context-with-kwargs",
+        "non-first-context",
         "generic",
         "generic-signature",
         "self",
@@ -981,6 +1036,45 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return async_callable_partial(*args, **kwargs)
 
         handler = SyncWrapperAsyncCallablePartialTarget()
+    elif shape == "sync-wrapper-decorated-async-callable-target":
+
+        class DecoratedAsyncCallable:
+            @functools.wraps(target)
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return target(*args, **kwargs)
+
+        callable_target = DecoratedAsyncCallable()
+
+        class SyncWrapperDecoratedAsyncCallableTarget:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, callable_target)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return callable_target(*args, **kwargs)
+
+        handler = SyncWrapperDecoratedAsyncCallableTarget()
+    elif shape == "sync-wrapper-async-intermediate-sync-target":
+
+        def sync_target(value: int) -> int:
+            return value
+
+        class AsyncIntermediate:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, sync_target)
+
+            async def __call__(self, *args: Any, **kwargs: Any) -> int:
+                return sync_target(*args, **kwargs)
+
+        intermediate = AsyncIntermediate()
+
+        class SyncOuterWrapper:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, intermediate)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return intermediate(*args, **kwargs)
+
+        handler = SyncOuterWrapper()
     elif shape == "sync-wrapper-nested-async-target":
 
         @functools.wraps(target)
@@ -1041,13 +1135,6 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return contextual_target(ctx=ctx, value=value)
 
         handler = MetadataKeywordOnlyContextHandler()
-    elif shape == "context":
-
-        class ContextHandler:
-            async def __call__(self, ctx: ToolContext[Any], value: int) -> int:
-                return value
-
-        handler = ContextHandler()
     elif shape == "keyword-only-context":
 
         class KeywordOnlyContextHandler:
@@ -1062,13 +1149,13 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return len(ctx)
 
         handler = VariadicContextHandler()
-    elif shape == "context-with-kwargs":
+    elif shape == "non-first-context":
 
-        class ContextWithKwargsHandler:
-            async def __call__(self, ctx: ToolContext[Any], **kwargs: Any) -> int:
-                return len(kwargs)
+        class NonFirstContextHandler:
+            async def __call__(self, value: int, ctx: ToolContext[Any]) -> int:
+                return value
 
-        handler = ContextWithKwargsHandler()
+        handler = NonFirstContextHandler()
     elif shape == "generic":
 
         class GenericHandler(Generic[CallableValueT]):

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -397,6 +397,24 @@ async def test_async_callable_object_works_with_configured_function_tool() -> No
 
 
 @pytest.mark.asyncio
+async def test_configured_async_callable_ignores_annotated_class_state() -> None:
+    class AsyncCallable:
+        factor: int
+
+        def __init__(self, factor: int) -> None:
+            self.factor = factor
+
+        async def __call__(self, value: int) -> int:
+            return value * self.factor
+
+    tool = function_tool(AsyncCallable(3), name_override="multiply")
+
+    assert list(tool.params_json_schema["properties"]) == ["value"]
+    assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 12
+
+
+@pytest.mark.asyncio
 async def test_callable_object_invokes_the_resolved_call_method(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -460,9 +460,11 @@ async def test_sync_function_preserves_awaitable_result() -> None:
     "metadata_kind",
     [
         "update-wrapper",
+        "nested-sync-wrapper",
         "bound-method",
         "signature-none",
         "published-annotations",
+        "class-published-annotations",
         "published-name",
         "extra-annotation",
     ],
@@ -489,6 +491,22 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
                 return target(*args, **kwargs)
 
         handler = UpdatedWrapperHandler()
+        expected_name = "target"
+        expected_description = "Double the value."
+    elif metadata_kind == "nested-sync-wrapper":
+
+        @functools.wraps(target)
+        def sync_bridge(*args: Any, **kwargs: Any) -> Any:
+            return target(*args, **kwargs)
+
+        class NestedSyncWrapperHandler:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, sync_bridge)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return sync_bridge(*args, **kwargs)
+
+        handler = NestedSyncWrapperHandler()
         expected_name = "target"
         expected_description = "Double the value."
     elif metadata_kind == "bound-method":
@@ -536,6 +554,21 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
         tool_kwargs = {"name_override": "published_annotations", "use_docstring_info": False}
         expected_name = "published_annotations"
         expected_description = ""
+    elif metadata_kind == "class-published-annotations":
+
+        class ClassPublishedAnnotationsHandler:
+            __annotations__ = {"value": int, "return": int}
+
+            def __call__(self, value: Any) -> int:
+                return cast(int, value) * 2
+
+        handler = ClassPublishedAnnotationsHandler()
+        tool_kwargs = {
+            "name_override": "class_published_annotations",
+            "use_docstring_info": False,
+        }
+        expected_name = "class_published_annotations"
+        expected_description = ""
     elif metadata_kind == "published-name":
 
         class PublishedNameHandler:
@@ -574,6 +607,30 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
     assert tool.description == expected_description
     assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
     assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == expected_result
+
+
+@pytest.mark.asyncio
+async def test_callable_docstring_opt_out_does_not_read_dynamic_doc() -> None:
+    class RaisingDoc:
+        def __get__(self, instance: Any, owner: type[Any] | None = None) -> str:
+            raise AssertionError("The callable docstring should not be read.")
+
+    class Handler:
+        __doc__ = RaisingDoc()
+        __annotations__ = {"value": int, "return": int}
+
+        def __call__(self, value: Any) -> int:
+            return cast(int, value) * 2
+
+    tool = function_tool(
+        Handler(),
+        name_override="handler",
+        use_docstring_info=False,
+    )
+
+    assert tool.description == ""
+    assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
 
 
 @pytest.mark.skipif(

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any, Generic, TypeVar, cast
 import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel
-from typing_extensions import Self
+from typing_extensions import ParamSpec, Self
 
 from agents import UserError, function_tool
 from agents.run_context import RunContextWrapper
@@ -32,6 +32,7 @@ def ctx_wrapper() -> ToolContext[DummyContext]:
 
 
 CallableValueT = TypeVar("CallableValueT")
+CallableParams = ParamSpec("CallableParams")
 
 
 @function_tool
@@ -499,10 +500,11 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
 
         class BoundMethodHandler:
             def __init__(self, service: Service) -> None:
-                functools.update_wrapper(self, service.method)
+                self.method = service.method
+                functools.update_wrapper(self, self.method)
 
             def __call__(self, value: int) -> int:
-                return self.__wrapped__(value)
+                return self.method(value)
 
         handler = BoundMethodHandler(Service())
         expected_name = "method"
@@ -576,6 +578,27 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
 
 @pytest.mark.skipif(
     sys.version_info < (3, 14),
+    reason="Built-in callable type hints require Python 3.14",
+)
+@pytest.mark.asyncio
+async def test_released_sync_builtin_wrapper_remains_supported() -> None:
+    class Handler:
+        def __init__(self) -> None:
+            self.routine = len
+            functools.update_wrapper(self, self.routine)
+
+        def __call__(self, value: Any) -> int:
+            return self.routine(value)
+
+    tool = function_tool(Handler(), use_docstring_info=False)
+
+    assert tool.name == "len"
+    assert list(tool.params_json_schema["properties"]) == ["obj"]
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"obj": [1, 2, 3]}') == 3
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
     reason="Lazy annotations require Python 3.14",
 )
 @pytest.mark.asyncio
@@ -641,6 +664,7 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "sync-wrapper-async-partial-target",
         "sync-wrapper-nested-async-target",
         "metadata-typevar-wrapper",
+        "metadata-paramspec-wrapper",
         "metadata-keyword-only-context",
         "context",
         "keyword-only-context",
@@ -855,10 +879,11 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
 
         class SyncWrapperAsyncBoundMethodTarget:
             def __init__(self, service: Service) -> None:
-                functools.update_wrapper(self, service.method)
+                self.method = service.method
+                functools.update_wrapper(self, self.method)
 
             def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return self.__wrapped__(*args, **kwargs)
+                return self.method(*args, **kwargs)
 
         handler = SyncWrapperAsyncBoundMethodTarget(Service())
     elif shape == "sync-wrapper-async-partial-target":
@@ -903,6 +928,26 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return identity(value)
 
         handler = MetadataTypeVarWrapper()
+    elif shape == "metadata-paramspec-wrapper":
+
+        def forwarding_target(*args: Any, **kwargs: Any) -> int:
+            return len(args) + len(kwargs)
+
+        paramspec_metadata = cast(Any, CallableParams)
+        forwarding_target.__annotations__ = {
+            "args": paramspec_metadata.args,
+            "kwargs": paramspec_metadata.kwargs,
+            "return": int,
+        }
+
+        class MetadataParamSpecWrapper:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, forwarding_target)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> int:
+                return forwarding_target(*args, **kwargs)
+
+        handler = MetadataParamSpecWrapper()
     elif shape == "metadata-keyword-only-context":
 
         def contextual_target(*, ctx: ToolContext[Any], value: int) -> int:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -527,6 +527,7 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "staticmethod",
         "classmethod",
         "decorated-call",
+        "sync-decorated-call-with-metadata",
         "published-annotations",
         "published-annotate",
         "custom-signature",
@@ -597,6 +598,21 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return await target(*args, **kwargs)
 
         handler = DecoratedCallHandler()
+    elif shape == "sync-decorated-call-with-metadata":
+
+        def sync_target(value: int) -> int:
+            return value
+
+        class SyncDecoratedCallWithMetadata:
+            def __init__(self) -> None:
+                self.__name__ = "sync_target"
+                self.__annotations__ = {"value": int, "return": int}
+
+            @functools.wraps(sync_target)
+            def __call__(self, *args: Any, **kwargs: Any) -> int:
+                return sync_target(*args, **kwargs)
+
+        handler = SyncDecoratedCallWithMetadata()
     elif shape == "published-annotations":
 
         class PublishedAnnotationsHandler:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -454,6 +454,92 @@ async def test_sync_function_preserves_awaitable_result() -> None:
     assert await returned == 12
 
 
+@pytest.mark.asyncio
+async def test_released_partial_callable_contract_remains_supported() -> None:
+    def multiply(value: int, factor: int = 2) -> int:
+        return value * factor
+
+    tool = function_tool(
+        functools.partial(multiply, factor=3),
+        name_override="multiply",
+        use_docstring_info=False,
+    )
+
+    assert tool.params_json_schema["properties"]["factor"]["default"] == 3
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 12
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "metadata_kind",
+    ["update-wrapper", "published-annotations", "custom-signature", "published-name"],
+)
+async def test_released_sync_callable_metadata_contract_remains_supported(
+    metadata_kind: str,
+) -> None:
+    def target(value: int) -> int:
+        return value * 2
+
+    tool_kwargs: dict[str, Any] = {}
+    handler: Any
+    if metadata_kind == "update-wrapper":
+
+        class UpdatedWrapperHandler:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, target)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return target(*args, **kwargs)
+
+        handler = UpdatedWrapperHandler()
+    elif metadata_kind == "published-annotations":
+
+        class PublishedAnnotationsHandler:
+            def __init__(self) -> None:
+                self.__annotations__ = {"value": int, "return": int}
+
+            def __call__(self, value: Any) -> int:
+                return cast(int, value) * 2
+
+        handler = PublishedAnnotationsHandler()
+        tool_kwargs = {"name_override": "published_annotations", "use_docstring_info": False}
+    elif metadata_kind == "custom-signature":
+
+        class CustomSignatureHandler:
+            __signature__ = inspect.Signature(
+                [
+                    inspect.Parameter(
+                        "value",
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=int,
+                    )
+                ]
+            )
+
+            def __call__(self, value: Any) -> int:
+                return cast(int, value) * 2
+
+        handler = CustomSignatureHandler()
+        tool_kwargs = {"name_override": "custom_signature", "use_docstring_info": False}
+    elif metadata_kind == "published-name":
+
+        class PublishedNameHandler:
+            __name__ = "published_name"
+            __annotations__ = {"value": int, "return": int}
+
+            def __call__(self, value: Any) -> int:
+                return cast(int, value) * 2
+
+        handler = PublishedNameHandler()
+    else:
+        raise AssertionError(f"Unhandled metadata kind: {metadata_kind}")
+
+    tool = function_tool(handler, **tool_kwargs)
+
+    assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
+
+
 def test_callable_contract_rejects_unknown_call_descriptor() -> None:
     class CustomDescriptor:
         def __get__(self, instance: Any, owner: type[Any]) -> Callable[..., Any]:
@@ -469,12 +555,10 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
 @pytest.mark.parametrize(
     "shape",
     [
-        "partial",
         "partialmethod",
         "staticmethod",
         "classmethod",
         "decorated-call",
-        "update-wrapper",
         "published-annotations",
         "published-annotate",
         "custom-signature",
@@ -511,9 +595,8 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
     async def target(value: int) -> int:
         return value
 
-    if shape == "partial":
-        handler: Any = functools.partial(target, 1)
-    elif shape == "partialmethod":
+    handler: Any
+    if shape == "partialmethod":
 
         class PartialMethodHandler:
             __call__ = functools.partialmethod(target, 1)
@@ -539,17 +622,6 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return await target(*args, **kwargs)
 
         handler = DecoratedCallHandler()
-    elif shape == "update-wrapper":
-
-        class UpdatedWrapper:
-            def __init__(self, wrapped: Any) -> None:
-                self.wrapped = wrapped
-                functools.update_wrapper(self, wrapped)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return self.wrapped(*args, **kwargs)
-
-        handler = UpdatedWrapper(target)
     elif shape == "published-annotations":
 
         class PublishedAnnotationsHandler:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -6,14 +6,14 @@ import inspect
 import json
 import operator
 import sys
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from types import ModuleType
 from typing import Annotated, Any, Generic, TypeVar, cast
 
 import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel
-from typing_extensions import ParamSpec, Self
+from typing_extensions import Self
 
 from agents import UserError, function_tool
 from agents.run_context import RunContextWrapper
@@ -32,7 +32,6 @@ def ctx_wrapper() -> ToolContext[DummyContext]:
 
 
 CallableValueT = TypeVar("CallableValueT")
-CallableParams = ParamSpec("CallableParams")
 
 
 @function_tool
@@ -475,186 +474,6 @@ async def test_sync_function_preserves_awaitable_result() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "metadata_kind",
-    [
-        "update-wrapper",
-        "nested-sync-wrapper",
-        "bound-method",
-        "signature-none",
-        "published-annotations",
-        "published-name",
-        "extra-annotation",
-    ],
-)
-async def test_released_sync_callable_metadata_contract_remains_supported(
-    metadata_kind: str,
-) -> None:
-    def target(value: int) -> int:
-        """Double the value."""
-        return value * 2
-
-    tool_kwargs: dict[str, Any] = {}
-    expected_name: str
-    expected_description: str
-    expected_result = 8
-    handler: Any
-    if metadata_kind == "update-wrapper":
-
-        class UpdatedWrapperHandler:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, target)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return target(*args, **kwargs)
-
-        handler = UpdatedWrapperHandler()
-        expected_name = "target"
-        expected_description = "Double the value."
-    elif metadata_kind == "nested-sync-wrapper":
-
-        class SyncIntermediate:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, target)
-
-            @functools.wraps(target)
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return target(*args, **kwargs)
-
-        intermediate = SyncIntermediate()
-
-        class NestedSyncWrapperHandler:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, intermediate)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return intermediate(*args, **kwargs)
-
-        handler = NestedSyncWrapperHandler()
-        expected_name = "target"
-        expected_description = "Double the value."
-    elif metadata_kind == "bound-method":
-
-        class Service:
-            def method(self, value: int) -> int:
-                """Triple the value."""
-                return value * 3
-
-        class BoundMethodHandler:
-            def __init__(self, service: Service) -> None:
-                self.method = service.method
-                functools.update_wrapper(self, self.method)
-
-            def __call__(self, value: int) -> int:
-                return self.method(value)
-
-        handler = BoundMethodHandler(Service())
-        expected_name = "method"
-        expected_description = "Triple the value."
-        expected_result = 12
-    elif metadata_kind == "signature-none":
-
-        class SignatureNoneHandler:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, target)
-                self.__signature__ = None
-
-            def __call__(self, value: int) -> int:
-                return target(value)
-
-        handler = SignatureNoneHandler()
-        expected_name = "target"
-        expected_description = "Double the value."
-    elif metadata_kind == "published-annotations":
-
-        class PublishedAnnotationsHandler:
-            def __init__(self) -> None:
-                self.__annotations__ = {"value": int, "return": int}
-
-            def __call__(self, value: Any) -> int:
-                return cast(int, value) * 2
-
-        handler = PublishedAnnotationsHandler()
-        tool_kwargs = {"name_override": "published_annotations", "use_docstring_info": False}
-        expected_name = "published_annotations"
-        expected_description = ""
-    elif metadata_kind == "published-name":
-
-        class PublishedNameHandler:
-            __name__ = "published_name"
-            __annotations__ = {"value": int, "return": int}
-
-            def __call__(self, value: Any) -> int:
-                return cast(int, value) * 2
-
-        handler = PublishedNameHandler()
-        expected_name = "published_name"
-        expected_description = inspect.getdoc(PublishedNameHandler) or ""
-    elif metadata_kind == "extra-annotation":
-
-        class ExtraAnnotationHandler:
-            def __init__(self) -> None:
-                self.__name__ = "extra_annotation"
-                self.__annotations__ = {
-                    "value": int,
-                    "return": int,
-                    "cache": CallableValueT,
-                }
-
-            def __call__(self, value: Any) -> int:
-                return cast(int, value) * 2
-
-        handler = ExtraAnnotationHandler()
-        expected_name = "extra_annotation"
-        expected_description = inspect.getdoc(ExtraAnnotationHandler) or ""
-    else:
-        raise AssertionError(f"Unhandled metadata kind: {metadata_kind}")
-
-    tool = function_tool(handler, **tool_kwargs)
-
-    assert tool.name == expected_name
-    assert tool.description == expected_description
-    assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
-    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == expected_result
-
-
-@pytest.mark.asyncio
-async def test_released_sync_metadata_wrapper_preserves_tool_context() -> None:
-    def target(ctx: ToolContext[Any], value: int) -> str:
-        return f"{ctx.tool_name}:{value}"
-
-    class Handler:
-        def __init__(self) -> None:
-            functools.update_wrapper(self, target)
-
-        def __call__(self, *args: Any, **kwargs: Any) -> str:
-            return target(*args, **kwargs)
-
-    tool = function_tool(Handler())
-
-    assert list(tool.params_json_schema["properties"]) == ["value"]
-    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == "dummy:4"
-
-
-@pytest.mark.asyncio
-async def test_released_sync_metadata_wrapper_preserves_positional_only_run_context() -> None:
-    def target(ctx: RunContextWrapper[Any], /, value: int) -> str:
-        return f"{ctx.context.data}:{value}"
-
-    class Handler:
-        def __init__(self) -> None:
-            functools.update_wrapper(self, target)
-
-        def __call__(self, *args: Any, **kwargs: Any) -> str:
-            return target(*args, **kwargs)
-
-    tool = function_tool(Handler())
-
-    assert list(tool.params_json_schema["properties"]) == ["value"]
-    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == "something:4"
-
-
-@pytest.mark.asyncio
 async def test_async_callable_object_preserves_positional_context() -> None:
     class Handler:
         async def __call__(self, ctx: ToolContext[Any], value: int) -> str:
@@ -688,58 +507,6 @@ async def test_callable_docstring_opt_out_does_not_read_dynamic_doc() -> None:
     assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason="Built-in callable type hints require Python 3.14",
-)
-@pytest.mark.asyncio
-async def test_released_sync_builtin_wrapper_remains_supported() -> None:
-    class Handler:
-        def __init__(self) -> None:
-            self.routine = len
-            functools.update_wrapper(self, self.routine)
-
-        def __call__(self, value: Any) -> int:
-            return self.routine(value)
-
-    tool = function_tool(Handler(), use_docstring_info=False)
-
-    assert tool.name == "len"
-    assert list(tool.params_json_schema["properties"]) == ["obj"]
-    assert await tool.on_invoke_tool(ctx_wrapper(), '{"obj": [1, 2, 3]}') == 3
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 14),
-    reason="Lazy annotations require Python 3.14",
-)
-@pytest.mark.asyncio
-async def test_released_lazy_callable_annotations_are_evaluated_once() -> None:
-    annotation_calls = 0
-
-    class Handler:
-        def __init__(self) -> None:
-            self.__name__ = "handler"
-
-            def annotate(_format: Any) -> dict[str, Any]:
-                nonlocal annotation_calls
-                annotation_calls += 1
-                if annotation_calls > 1:
-                    raise RuntimeError("Lazy annotations were evaluated more than once.")
-                return {"value": int, "return": int}
-
-            self.__annotate__ = annotate
-
-        def __call__(self, value: Any) -> int:
-            return cast(int, value) * 2
-
-    tool = function_tool(Handler(), use_docstring_info=False)
-
-    assert annotation_calls == 1
-    assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
-    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
-
-
 def test_callable_contract_rejects_unknown_call_descriptor() -> None:
     class CustomDescriptor:
         def __get__(self, instance: Any, owner: type[Any]) -> Callable[..., Any]:
@@ -760,34 +527,15 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "staticmethod",
         "classmethod",
         "decorated-call",
-        "sync-decorated-call-with-metadata",
+        "update-wrapper",
         "published-annotations",
         "published-annotate",
         "custom-signature",
-        "metadata-custom-signature",
-        "sync-custom-signature",
         "method-signature",
         "local-annotation",
         "singledispatchmethod",
         "builtin",
         "nested-wrapper",
-        "sync-wrapper-async-target",
-        "sync-wrapper-async-bound-method-target",
-        "sync-wrapper-async-partial-target",
-        pytest.param(
-            "sync-wrapper-async-callable-partial-target",
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 14),
-                reason="Callable-instance partials are routines on Python 3.14",
-            ),
-        ),
-        "sync-wrapper-decorated-async-callable-target",
-        "sync-wrapper-async-intermediate-sync-target",
-        "sync-wrapper-custom-call-descriptor-target",
-        "sync-wrapper-nested-async-target",
-        "metadata-typevar-wrapper",
-        "metadata-paramspec-wrapper",
-        "metadata-keyword-only-context",
         "keyword-only-context",
         "variadic-context",
         "non-first-context",
@@ -844,21 +592,17 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return await target(*args, **kwargs)
 
         handler = DecoratedCallHandler()
-    elif shape == "sync-decorated-call-with-metadata":
+    elif shape == "update-wrapper":
 
-        def sync_target(value: int) -> int:
-            return value
+        class UpdatedWrapper:
+            def __init__(self, wrapped: Any) -> None:
+                self.wrapped = wrapped
+                functools.update_wrapper(self, wrapped)
 
-        class SyncDecoratedCallWithMetadata:
-            def __init__(self) -> None:
-                self.__name__ = "sync_target"
-                self.__annotations__ = {"value": int, "return": int}
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return self.wrapped(*args, **kwargs)
 
-            @functools.wraps(sync_target)
-            def __call__(self, *args: Any, **kwargs: Any) -> int:
-                return sync_target(*args, **kwargs)
-
-        handler = SyncDecoratedCallWithMetadata()
+        handler = UpdatedWrapper(target)
     elif shape == "published-annotations":
 
         class PublishedAnnotationsHandler:
@@ -896,43 +640,6 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return cast(int, args[0])
 
         handler = CustomSignatureHandler()
-    elif shape == "metadata-custom-signature":
-
-        class MetadataCustomSignatureHandler:
-            __signature__ = inspect.Signature(
-                [
-                    inspect.Parameter(
-                        "value",
-                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=int,
-                    )
-                ]
-            )
-
-            def __init__(self) -> None:
-                self.__annotations__ = {"value": int, "return": int}
-
-            def __call__(self) -> int:
-                return 1
-
-        handler = MetadataCustomSignatureHandler()
-    elif shape == "sync-custom-signature":
-
-        class SyncCustomSignatureHandler:
-            __signature__ = inspect.Signature(
-                [
-                    inspect.Parameter(
-                        "value",
-                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=int,
-                    )
-                ]
-            )
-
-            def __call__(self, value: Any) -> int:
-                return cast(int, value)
-
-        handler = SyncCustomSignatureHandler()
     elif shape == "method-signature":
 
         class MethodSignatureHandler:
@@ -982,192 +689,6 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return self.wrapped(*args, **kwargs)
 
         handler = NestedWrapper(NestedHandler())
-    elif shape == "sync-wrapper-async-target":
-
-        class SyncWrapperAsyncTarget:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, target)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return target(*args, **kwargs)
-
-        handler = SyncWrapperAsyncTarget()
-    elif shape == "sync-wrapper-async-bound-method-target":
-
-        class Service:
-            async def method(self, value: int) -> int:
-                return value
-
-        class SyncWrapperAsyncBoundMethodTarget:
-            def __init__(self, service: Service) -> None:
-                self.method = service.method
-                functools.update_wrapper(self, self.method)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return self.method(*args, **kwargs)
-
-        handler = SyncWrapperAsyncBoundMethodTarget(Service())
-    elif shape == "sync-wrapper-async-partial-target":
-        async_partial = functools.partial(target)
-
-        class SyncWrapperAsyncPartialTarget:
-            def __init__(self) -> None:
-                functools.update_wrapper(
-                    self,
-                    async_partial,
-                    assigned=("__annotations__",),
-                )
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return async_partial(*args, **kwargs)
-
-        handler = SyncWrapperAsyncPartialTarget()
-    elif shape == "sync-wrapper-async-callable-partial-target":
-
-        class AsyncCallable:
-            async def __call__(self, value: int) -> int:
-                return value
-
-        async_callable_partial = functools.partial(AsyncCallable())
-
-        class SyncWrapperAsyncCallablePartialTarget:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, async_callable_partial)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return async_callable_partial(*args, **kwargs)
-
-        handler = SyncWrapperAsyncCallablePartialTarget()
-    elif shape == "sync-wrapper-decorated-async-callable-target":
-
-        class DecoratedAsyncCallable:
-            @functools.wraps(target)
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return target(*args, **kwargs)
-
-        callable_target = DecoratedAsyncCallable()
-
-        class SyncWrapperDecoratedAsyncCallableTarget:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, callable_target)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return callable_target(*args, **kwargs)
-
-        handler = SyncWrapperDecoratedAsyncCallableTarget()
-    elif shape == "sync-wrapper-async-intermediate-sync-target":
-
-        def sync_target(value: int) -> int:
-            return value
-
-        class AsyncIntermediate:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, sync_target)
-
-            async def __call__(self, *args: Any, **kwargs: Any) -> int:
-                return sync_target(*args, **kwargs)
-
-        intermediate = AsyncIntermediate()
-
-        class SyncOuterWrapper:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, intermediate)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return intermediate(*args, **kwargs)
-
-        handler = SyncOuterWrapper()
-    elif shape == "sync-wrapper-custom-call-descriptor-target":
-
-        class AsyncCallDescriptor:
-            def __get__(
-                self,
-                instance: Any,
-                owner: type[Any] | None = None,
-            ) -> Callable[[int], Awaitable[int]]:
-                async def bound(value: int) -> int:
-                    return value
-
-                return bound
-
-            def __call__(self, value: int) -> int:
-                return value
-
-        class DescriptorTarget:
-            __call__ = AsyncCallDescriptor()
-
-        descriptor_target: Any = DescriptorTarget()
-        descriptor_target.__name__ = "descriptor_target"
-        descriptor_target.__annotations__ = {"value": int, "return": int}
-
-        class SyncWrapperCustomCallDescriptorTarget:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, descriptor_target)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return descriptor_target(*args, **kwargs)
-
-        handler = SyncWrapperCustomCallDescriptorTarget()
-    elif shape == "sync-wrapper-nested-async-target":
-
-        @functools.wraps(target)
-        def sync_bridge(*args: Any, **kwargs: Any) -> Any:
-            return target(*args, **kwargs)
-
-        class SyncWrapperNestedAsyncTarget:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, sync_bridge)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                return sync_bridge(*args, **kwargs)
-
-        handler = SyncWrapperNestedAsyncTarget()
-    elif shape == "metadata-typevar-wrapper":
-
-        def identity(value: CallableValueT) -> CallableValueT:
-            return value
-
-        class MetadataTypeVarWrapper:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, identity)
-
-            def __call__(self, value: Any) -> Any:
-                return identity(value)
-
-        handler = MetadataTypeVarWrapper()
-    elif shape == "metadata-paramspec-wrapper":
-
-        def forwarding_target(*args: Any, **kwargs: Any) -> int:
-            return len(args) + len(kwargs)
-
-        paramspec_metadata = cast(Any, CallableParams)
-        forwarding_target.__annotations__ = {
-            "args": paramspec_metadata.args,
-            "kwargs": paramspec_metadata.kwargs,
-            "return": int,
-        }
-
-        class MetadataParamSpecWrapper:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, forwarding_target)
-
-            def __call__(self, *args: Any, **kwargs: Any) -> int:
-                return forwarding_target(*args, **kwargs)
-
-        handler = MetadataParamSpecWrapper()
-    elif shape == "metadata-keyword-only-context":
-
-        def contextual_target(*, ctx: ToolContext[Any], value: int) -> int:
-            return value
-
-        class MetadataKeywordOnlyContextHandler:
-            def __init__(self) -> None:
-                functools.update_wrapper(self, contextual_target)
-
-            def __call__(self, *, ctx: ToolContext[Any], value: int) -> int:
-                return contextual_target(ctx=ctx, value=value)
-
-        handler = MetadataKeywordOnlyContextHandler()
     elif shape == "keyword-only-context":
 
         class KeywordOnlyContextHandler:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -6,7 +6,7 @@ import inspect
 import json
 import operator
 import sys
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from types import ModuleType
 from typing import Annotated, Any, Generic, TypeVar, cast
 
@@ -782,6 +782,7 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         ),
         "sync-wrapper-decorated-async-callable-target",
         "sync-wrapper-async-intermediate-sync-target",
+        "sync-wrapper-custom-call-descriptor-target",
         "sync-wrapper-nested-async-target",
         "metadata-typevar-wrapper",
         "metadata-paramspec-wrapper",
@@ -1075,6 +1076,37 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return intermediate(*args, **kwargs)
 
         handler = SyncOuterWrapper()
+    elif shape == "sync-wrapper-custom-call-descriptor-target":
+
+        class AsyncCallDescriptor:
+            def __get__(
+                self,
+                instance: Any,
+                owner: type[Any] | None = None,
+            ) -> Callable[[int], Awaitable[int]]:
+                async def bound(value: int) -> int:
+                    return value
+
+                return bound
+
+            def __call__(self, value: int) -> int:
+                return value
+
+        class DescriptorTarget:
+            __call__ = AsyncCallDescriptor()
+
+        descriptor_target: Any = DescriptorTarget()
+        descriptor_target.__name__ = "descriptor_target"
+        descriptor_target.__annotations__ = {"value": int, "return": int}
+
+        class SyncWrapperCustomCallDescriptorTarget:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, descriptor_target)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return descriptor_target(*args, **kwargs)
+
+        handler = SyncWrapperCustomCallDescriptorTarget()
     elif shape == "sync-wrapper-nested-async-target":
 
         @functools.wraps(target)

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -662,6 +662,13 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "sync-wrapper-async-target",
         "sync-wrapper-async-bound-method-target",
         "sync-wrapper-async-partial-target",
+        pytest.param(
+            "sync-wrapper-async-callable-partial-target",
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 14),
+                reason="Callable-instance partials are routines on Python 3.14",
+            ),
+        ),
         "sync-wrapper-nested-async-target",
         "metadata-typevar-wrapper",
         "metadata-paramspec-wrapper",
@@ -901,6 +908,22 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return async_partial(*args, **kwargs)
 
         handler = SyncWrapperAsyncPartialTarget()
+    elif shape == "sync-wrapper-async-callable-partial-target":
+
+        class AsyncCallable:
+            async def __call__(self, value: int) -> int:
+                return value
+
+        async_callable_partial = functools.partial(AsyncCallable())
+
+        class SyncWrapperAsyncCallablePartialTarget:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, async_callable_partial)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return async_callable_partial(*args, **kwargs)
+
+        handler = SyncWrapperAsyncCallablePartialTarget()
     elif shape == "sync-wrapper-nested-async-target":
 
         @functools.wraps(target)

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -463,9 +463,12 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
     metadata_kind: str,
 ) -> None:
     def target(value: int) -> int:
+        """Double the value."""
         return value * 2
 
     tool_kwargs: dict[str, Any] = {}
+    expected_name: str
+    expected_description: str
     handler: Any
     if metadata_kind == "update-wrapper":
 
@@ -477,6 +480,8 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
                 return target(*args, **kwargs)
 
         handler = UpdatedWrapperHandler()
+        expected_name = "target"
+        expected_description = "Double the value."
     elif metadata_kind == "published-annotations":
 
         class PublishedAnnotationsHandler:
@@ -488,6 +493,8 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
 
         handler = PublishedAnnotationsHandler()
         tool_kwargs = {"name_override": "published_annotations", "use_docstring_info": False}
+        expected_name = "published_annotations"
+        expected_description = ""
     elif metadata_kind == "published-name":
 
         class PublishedNameHandler:
@@ -498,11 +505,46 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
                 return cast(int, value) * 2
 
         handler = PublishedNameHandler()
+        expected_name = "published_name"
+        expected_description = inspect.getdoc(PublishedNameHandler) or ""
     else:
         raise AssertionError(f"Unhandled metadata kind: {metadata_kind}")
 
     tool = function_tool(handler, **tool_kwargs)
 
+    assert tool.name == expected_name
+    assert tool.description == expected_description
+    assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Lazy annotations require Python 3.14",
+)
+@pytest.mark.asyncio
+async def test_released_lazy_callable_annotations_are_evaluated_once() -> None:
+    annotation_calls = 0
+
+    class Handler:
+        def __init__(self) -> None:
+            self.__name__ = "handler"
+
+            def annotate(_format: Any) -> dict[str, Any]:
+                nonlocal annotation_calls
+                annotation_calls += 1
+                if annotation_calls > 1:
+                    raise RuntimeError("Lazy annotations were evaluated more than once.")
+                return {"value": int, "return": int}
+
+            self.__annotate__ = annotate
+
+        def __call__(self, value: Any) -> int:
+            return cast(int, value) * 2
+
+    tool = function_tool(Handler(), use_docstring_info=False)
+
+    assert annotation_calls == 1
     assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
     assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
 
@@ -531,6 +573,7 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "published-annotations",
         "published-annotate",
         "custom-signature",
+        "metadata-custom-signature",
         "sync-custom-signature",
         "method-signature",
         "local-annotation",
@@ -651,6 +694,26 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return cast(int, args[0])
 
         handler = CustomSignatureHandler()
+    elif shape == "metadata-custom-signature":
+
+        class MetadataCustomSignatureHandler:
+            __signature__ = inspect.Signature(
+                [
+                    inspect.Parameter(
+                        "value",
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=int,
+                    )
+                ]
+            )
+
+            def __init__(self) -> None:
+                self.__annotations__ = {"value": int, "return": int}
+
+            def __call__(self) -> int:
+                return 1
+
+        handler = MetadataCustomSignatureHandler()
     elif shape == "sync-custom-signature":
 
         class SyncCustomSignatureHandler:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -536,6 +536,8 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "singledispatchmethod",
         "builtin",
         "nested-wrapper",
+        "sync-wrapper-async-target",
+        "metadata-keyword-only-context",
         "context",
         "keyword-only-context",
         "variadic-context",
@@ -696,6 +698,29 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return self.wrapped(*args, **kwargs)
 
         handler = NestedWrapper(NestedHandler())
+    elif shape == "sync-wrapper-async-target":
+
+        class SyncWrapperAsyncTarget:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, target)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return target(*args, **kwargs)
+
+        handler = SyncWrapperAsyncTarget()
+    elif shape == "metadata-keyword-only-context":
+
+        def contextual_target(*, ctx: ToolContext[Any], value: int) -> int:
+            return value
+
+        class MetadataKeywordOnlyContextHandler:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, contextual_target)
+
+            def __call__(self, *, ctx: ToolContext[Any], value: int) -> int:
+                return contextual_target(ctx=ctx, value=value)
+
+        handler = MetadataKeywordOnlyContextHandler()
     elif shape == "context":
 
         class ContextHandler:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -455,24 +455,9 @@ async def test_sync_function_preserves_awaitable_result() -> None:
 
 
 @pytest.mark.asyncio
-async def test_released_partial_callable_contract_remains_supported() -> None:
-    def multiply(value: int, factor: int = 2) -> int:
-        return value * factor
-
-    tool = function_tool(
-        functools.partial(multiply, factor=3),
-        name_override="multiply",
-        use_docstring_info=False,
-    )
-
-    assert tool.params_json_schema["properties"]["factor"]["default"] == 3
-    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 12
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "metadata_kind",
-    ["update-wrapper", "published-annotations", "custom-signature", "published-name"],
+    ["update-wrapper", "published-annotations", "published-name"],
 )
 async def test_released_sync_callable_metadata_contract_remains_supported(
     metadata_kind: str,
@@ -503,24 +488,6 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
 
         handler = PublishedAnnotationsHandler()
         tool_kwargs = {"name_override": "published_annotations", "use_docstring_info": False}
-    elif metadata_kind == "custom-signature":
-
-        class CustomSignatureHandler:
-            __signature__ = inspect.Signature(
-                [
-                    inspect.Parameter(
-                        "value",
-                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=int,
-                    )
-                ]
-            )
-
-            def __call__(self, value: Any) -> int:
-                return cast(int, value) * 2
-
-        handler = CustomSignatureHandler()
-        tool_kwargs = {"name_override": "custom_signature", "use_docstring_info": False}
     elif metadata_kind == "published-name":
 
         class PublishedNameHandler:
@@ -555,6 +522,7 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
 @pytest.mark.parametrize(
     "shape",
     [
+        "partial",
         "partialmethod",
         "staticmethod",
         "classmethod",
@@ -562,6 +530,7 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "published-annotations",
         "published-annotate",
         "custom-signature",
+        "sync-custom-signature",
         "method-signature",
         "local-annotation",
         "singledispatchmethod",
@@ -596,7 +565,9 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
         return value
 
     handler: Any
-    if shape == "partialmethod":
+    if shape == "partial":
+        handler = functools.partial(target, 1)
+    elif shape == "partialmethod":
 
         class PartialMethodHandler:
             __call__ = functools.partialmethod(target, 1)
@@ -659,6 +630,23 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return cast(int, args[0])
 
         handler = CustomSignatureHandler()
+    elif shape == "sync-custom-signature":
+
+        class SyncCustomSignatureHandler:
+            __signature__ = inspect.Signature(
+                [
+                    inspect.Parameter(
+                        "value",
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        annotation=int,
+                    )
+                ]
+            )
+
+            def __call__(self, value: Any) -> int:
+                return cast(int, value)
+
+        handler = SyncCustomSignatureHandler()
     elif shape == "method-signature":
 
         class MethodSignatureHandler:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -459,6 +459,7 @@ async def test_sync_function_preserves_awaitable_result() -> None:
     "metadata_kind",
     [
         "update-wrapper",
+        "bound-method",
         "signature-none",
         "published-annotations",
         "published-name",
@@ -475,6 +476,7 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
     tool_kwargs: dict[str, Any] = {}
     expected_name: str
     expected_description: str
+    expected_result = 8
     handler: Any
     if metadata_kind == "update-wrapper":
 
@@ -488,6 +490,24 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
         handler = UpdatedWrapperHandler()
         expected_name = "target"
         expected_description = "Double the value."
+    elif metadata_kind == "bound-method":
+
+        class Service:
+            def method(self, value: int) -> int:
+                """Triple the value."""
+                return value * 3
+
+        class BoundMethodHandler:
+            def __init__(self, service: Service) -> None:
+                functools.update_wrapper(self, service.method)
+
+            def __call__(self, value: int) -> int:
+                return self.__wrapped__(value)
+
+        handler = BoundMethodHandler(Service())
+        expected_name = "method"
+        expected_description = "Triple the value."
+        expected_result = 12
     elif metadata_kind == "signature-none":
 
         class SignatureNoneHandler:
@@ -551,7 +571,7 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
     assert tool.name == expected_name
     assert tool.description == expected_description
     assert tool.params_json_schema["properties"]["value"]["type"] == "integer"
-    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 8
+    assert await tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == expected_result
 
 
 @pytest.mark.skipif(
@@ -617,6 +637,7 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "builtin",
         "nested-wrapper",
         "sync-wrapper-async-target",
+        "sync-wrapper-async-bound-method-target",
         "sync-wrapper-async-partial-target",
         "sync-wrapper-nested-async-target",
         "metadata-typevar-wrapper",
@@ -826,6 +847,20 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return target(*args, **kwargs)
 
         handler = SyncWrapperAsyncTarget()
+    elif shape == "sync-wrapper-async-bound-method-target":
+
+        class Service:
+            async def method(self, value: int) -> int:
+                return value
+
+        class SyncWrapperAsyncBoundMethodTarget:
+            def __init__(self, service: Service) -> None:
+                functools.update_wrapper(self, service.method)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return self.__wrapped__(*args, **kwargs)
+
+        handler = SyncWrapperAsyncBoundMethodTarget(Service())
     elif shape == "sync-wrapper-async-partial-target":
         async_partial = functools.partial(target)
 

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -537,6 +537,8 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "builtin",
         "nested-wrapper",
         "sync-wrapper-async-target",
+        "sync-wrapper-async-partial-target",
+        "metadata-typevar-wrapper",
         "metadata-keyword-only-context",
         "context",
         "keyword-only-context",
@@ -708,6 +710,34 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return target(*args, **kwargs)
 
         handler = SyncWrapperAsyncTarget()
+    elif shape == "sync-wrapper-async-partial-target":
+        async_partial = functools.partial(target)
+
+        class SyncWrapperAsyncPartialTarget:
+            def __init__(self) -> None:
+                functools.update_wrapper(
+                    self,
+                    async_partial,
+                    assigned=("__annotations__",),
+                )
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return async_partial(*args, **kwargs)
+
+        handler = SyncWrapperAsyncPartialTarget()
+    elif shape == "metadata-typevar-wrapper":
+
+        def identity(value: CallableValueT) -> CallableValueT:
+            return value
+
+        class MetadataTypeVarWrapper:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, identity)
+
+            def __call__(self, value: Any) -> Any:
+                return identity(value)
+
+        handler = MetadataTypeVarWrapper()
     elif shape == "metadata-keyword-only-context":
 
         def contextual_target(*, ctx: ToolContext[Any], value: int) -> int:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -539,6 +539,7 @@ def test_callable_contract_rejects_unknown_call_descriptor() -> None:
         "nested-wrapper",
         "sync-wrapper-async-target",
         "sync-wrapper-async-partial-target",
+        "sync-wrapper-nested-async-target",
         "metadata-typevar-wrapper",
         "metadata-keyword-only-context",
         "context",
@@ -741,6 +742,20 @@ def test_unsupported_callable_shapes_require_explicit_wrappers(shape: str) -> No
                 return async_partial(*args, **kwargs)
 
         handler = SyncWrapperAsyncPartialTarget()
+    elif shape == "sync-wrapper-nested-async-target":
+
+        @functools.wraps(target)
+        def sync_bridge(*args: Any, **kwargs: Any) -> Any:
+            return target(*args, **kwargs)
+
+        class SyncWrapperNestedAsyncTarget:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, sync_bridge)
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return sync_bridge(*args, **kwargs)
+
+        handler = SyncWrapperNestedAsyncTarget()
     elif shape == "metadata-typevar-wrapper":
 
         def identity(value: CallableValueT) -> CallableValueT:

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -457,7 +457,13 @@ async def test_sync_function_preserves_awaitable_result() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "metadata_kind",
-    ["update-wrapper", "published-annotations", "published-name"],
+    [
+        "update-wrapper",
+        "signature-none",
+        "published-annotations",
+        "published-name",
+        "extra-annotation",
+    ],
 )
 async def test_released_sync_callable_metadata_contract_remains_supported(
     metadata_kind: str,
@@ -480,6 +486,19 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
                 return target(*args, **kwargs)
 
         handler = UpdatedWrapperHandler()
+        expected_name = "target"
+        expected_description = "Double the value."
+    elif metadata_kind == "signature-none":
+
+        class SignatureNoneHandler:
+            def __init__(self) -> None:
+                functools.update_wrapper(self, target)
+                self.__signature__ = None
+
+            def __call__(self, value: int) -> int:
+                return target(value)
+
+        handler = SignatureNoneHandler()
         expected_name = "target"
         expected_description = "Double the value."
     elif metadata_kind == "published-annotations":
@@ -507,6 +526,23 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
         handler = PublishedNameHandler()
         expected_name = "published_name"
         expected_description = inspect.getdoc(PublishedNameHandler) or ""
+    elif metadata_kind == "extra-annotation":
+
+        class ExtraAnnotationHandler:
+            def __init__(self) -> None:
+                self.__name__ = "extra_annotation"
+                self.__annotations__ = {
+                    "value": int,
+                    "return": int,
+                    "cache": CallableValueT,
+                }
+
+            def __call__(self, value: Any) -> int:
+                return cast(int, value) * 2
+
+        handler = ExtraAnnotationHandler()
+        expected_name = "extra_annotation"
+        expected_description = inspect.getdoc(ExtraAnnotationHandler) or ""
     else:
         raise AssertionError(f"Unhandled metadata kind: {metadata_kind}")
 

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -399,6 +399,7 @@ async def test_async_callable_object_works_with_configured_function_tool() -> No
 @pytest.mark.asyncio
 async def test_configured_async_callable_ignores_annotated_class_state() -> None:
     class AsyncCallable:
+        value: str
         factor: int
 
         def __init__(self, factor: int) -> None:
@@ -482,7 +483,6 @@ async def test_sync_function_preserves_awaitable_result() -> None:
         "bound-method",
         "signature-none",
         "published-annotations",
-        "class-published-annotations",
         "published-name",
         "extra-annotation",
     ],
@@ -577,21 +577,6 @@ async def test_released_sync_callable_metadata_contract_remains_supported(
         handler = PublishedAnnotationsHandler()
         tool_kwargs = {"name_override": "published_annotations", "use_docstring_info": False}
         expected_name = "published_annotations"
-        expected_description = ""
-    elif metadata_kind == "class-published-annotations":
-
-        class ClassPublishedAnnotationsHandler:
-            __annotations__ = {"value": int, "return": int}
-
-            def __call__(self, value: Any) -> int:
-                return cast(int, value) * 2
-
-        handler = ClassPublishedAnnotationsHandler()
-        tool_kwargs = {
-            "name_override": "class_published_annotations",
-            "use_docstring_info": False,
-        }
-        expected_name = "class_published_annotations"
         expected_description = ""
     elif metadata_kind == "published-name":
 
@@ -688,10 +673,8 @@ async def test_callable_docstring_opt_out_does_not_read_dynamic_doc() -> None:
             raise AssertionError("The callable docstring should not be read.")
 
     class Handler:
-        __annotations__ = {"value": int, "return": int}
-
-        def __call__(self, value: Any) -> int:
-            return cast(int, value) * 2
+        def __call__(self, value: int) -> int:
+            return value * 2
 
     cast(Any, Handler).__doc__ = RaisingDoc()
     tool = function_tool(


### PR DESCRIPTION
This pull request fixes a compatibility regression in callable function tool normalization.

Plain callable instances continue to use the existing normalized execution pipeline, while `functools.partial` objects and synchronous function-like callables with explicit metadata retain the `function_schema()` behavior supported in the latest release. Ambiguous asynchronous wrappers, descriptors, generic callables, and context-injecting callables remain unsupported and require an explicit wrapper function.

see also: https://github.com/openai/openai-agents-python/pull/3949