### PR TITLE
fix: compare inspect sentinels by identity in function_schema

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -355,7 +355,7 @@ def function_schema(
         first_name, first_param = params[0]
         # Prefer the evaluated type hint if available
         ann = type_hints.get(first_name, first_param.annotation)
-        if ann != inspect._empty:
+        if ann is not inspect._empty:
             origin = get_origin(ann) or ann
             if origin is RunContextWrapper or origin is ToolContext:
                 takes_context = True  # Mark that the function takes context
@@ -367,7 +367,7 @@ def function_schema(
     # For parameters other than the first, raise error if any use RunContextWrapper or ToolContext.
     for name, param in params[1:]:
         ann = type_hints.get(name, param.annotation)
-        if ann != inspect._empty:
+        if ann is not inspect._empty:
             origin = get_origin(ann) or ann
             if origin is RunContextWrapper or origin is ToolContext:
                 raise UserError(
@@ -385,7 +385,7 @@ def function_schema(
         default = param.default
 
         # If there's no type hint, assume `Any`
-        if ann == inspect._empty:
+        if ann is inspect._empty:
             ann = Any
 
         # If a docstring param description exists, use it
@@ -439,12 +439,12 @@ def function_schema(
                     field_info_from_annotated,
                     description=field_description or field_info_from_annotated.description,
                 )
-                if default != inspect._empty and not isinstance(default, FieldInfo):
+                if default is not inspect._empty and not isinstance(default, FieldInfo):
                     merged = FieldInfo.merge_field_infos(merged, default=default)
                 elif isinstance(default, FieldInfo):
                     merged = FieldInfo.merge_field_infos(merged, default)
                 fields[name] = (ann, merged)
-            elif default == inspect._empty:
+            elif default is inspect._empty:
                 # Required field
                 fields[name] = (
                     ann,

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1069,10 +1069,12 @@ def test_variadic_param_descriptions_preserved(func, style):
 class _ElementwiseEqual:
     """Mimics numpy-array equality: ``==`` returns a container whose truthiness raises."""
 
-    def __eq__(self, other: object) -> "_ElementwiseEqual":
+    # Annotated ``Any`` like numpy's own stubs: elementwise ``__eq__`` does not
+    # return ``bool``.
+    def __eq__(self, other: object) -> Any:
         return _ElementwiseEqual()
 
-    def __ne__(self, other: object) -> "_ElementwiseEqual":
+    def __ne__(self, other: object) -> Any:
         return _ElementwiseEqual()
 
     def __bool__(self) -> bool:

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1064,3 +1064,66 @@ def test_variadic_param_descriptions_preserved(func, style):
     assert properties["x"]["description"] == "The base value."
     assert properties["numbers"]["description"] == "The numbers to add."
     assert properties["kwargs"]["description"] == "Extra options."
+
+
+class _ElementwiseEqual:
+    """Mimics numpy-array equality: ``==`` returns a container whose truthiness raises."""
+
+    def __eq__(self, other: object) -> "_ElementwiseEqual":
+        return _ElementwiseEqual()
+
+    def __ne__(self, other: object) -> "_ElementwiseEqual":
+        return _ElementwiseEqual()
+
+    def __bool__(self) -> bool:
+        raise ValueError("The truth value of an elementwise comparison is ambiguous.")
+
+    def __hash__(self) -> int:
+        return 0
+
+
+class _AlwaysEqual:
+    """A default value whose ``__eq__`` answers True for anything, including sentinels."""
+
+    def __eq__(self, other: object) -> bool:
+        return True
+
+    def __ne__(self, other: object) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return 0
+
+
+_ELEMENTWISE_DEFAULT = _ElementwiseEqual()
+_ALWAYS_EQUAL_DEFAULT = _AlwaysEqual()
+
+
+def test_default_with_elementwise_eq_does_not_crash():
+    """Defaults must be compared to the inspect sentinel by identity: a numpy-style
+    default whose ``==`` returns a non-boolean container used to crash schema creation."""
+
+    def score(x: int, weights: Any = _ELEMENTWISE_DEFAULT) -> int:
+        return x
+
+    fs = function_schema(score, strict_json_schema=False)
+    assert "weights" not in fs.params_json_schema.get("required", [])
+
+    parsed = fs.params_pydantic_model(x=1)
+    args, kwargs = fs.to_call_args(parsed)
+    assert isinstance((args + list(kwargs.values()))[-1], _ElementwiseEqual)
+
+
+def test_default_with_always_true_eq_stays_optional():
+    """A default whose ``__eq__`` answers True used to be mistaken for the no-default
+    sentinel, silently marking the parameter required and discarding the default."""
+
+    def strip(text: str, punctuation: Any = _ALWAYS_EQUAL_DEFAULT) -> str:
+        return text
+
+    fs = function_schema(strip, strict_json_schema=False)
+    assert fs.params_json_schema.get("required", []) == ["text"]
+
+    parsed = fs.params_pydantic_model(text="hi")
+    args, kwargs = fs.to_call_args(parsed)
+    assert isinstance((args + list(kwargs.values()))[-1], _AlwaysEqual)


### PR DESCRIPTION
### Summary

`function_schema` compares parameter defaults (and annotations) to `inspect._empty` with `==`/`!=`, which invokes the user-supplied value's `__eq__`. Two observable failures on valid Python functions:

1. **Crash at decoration time** — a default with elementwise equality semantics (a numpy array is the canonical case) makes `default != inspect._empty` return an array, whose truthiness raises:
   ```python
   @function_tool
   def score(x: int, weights: Any = np.array([1.0, 2.0])) -> int: ...
   # ValueError: The truth value of an array with more than one element is ambiguous.
   ```
   Verified with real numpy; the regression test uses a dependency-free stub with the same `__eq__` shape.

2. **Silent contract violation** — a default whose `__eq__` answers `True` (mocks, sentinels, some DSL objects) satisfies `default == inspect._empty`, so the parameter is marked **required** in the schema and its default silently discarded.

The `inspect` module's documented convention is identity comparison (`param.default is Parameter.empty`); the sentinel is a unique object precisely so user values can never influence the check. This PR switches all five sentinel comparisons in the file to `is`/`is not` — the two default checks above (the observable bugs) and the three annotation checks, which carry the same latent hazard. Identity is behavior-preserving for every value without a pathological `__eq__`.

### Test plan

- Two regression tests with pure-Python stubs (no numpy dependency): an elementwise-`__eq__` default must build a schema, stay optional, and round-trip through `to_call_args`; an always-`True`-`__eq__` default must not be marked required. Both fail on `main` and pass with the fix.
- `make format`, `make lint`, `make typecheck`, `make tests` all pass.

### Issue number

None — found by reading `function_schema.py` (same pass that produced #3956).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
