### PR TITLE
fix: use provider_output in ToolCallOutputItem for function rejection consistency

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -773,7 +773,7 @@ def function_rejection_item(
         output_json_schema=output_json_schema,
     )
     return ToolCallOutputItem(
-        output=rejection_message,
+        output=provider_output,
         raw_item=ItemHelpers.tool_call_output_item(
             tool_call,
             provider_output,


### PR DESCRIPTION
﻿This pull request fixes a data inconsistency in unction_rejection_item where ToolCallOutputItem.output was set to the plain-text ejection_message while aw_item contained the JSON-encoded provider_output. When output_json_schema is set for programmatic tool calls, unction_tool_error_output returns a JSON-encoded string ({"error": "..."}) instead of the plain message. Using provider_output for output ensures consistency between output and aw_item.

Fixes a latent bug where downstream consumers reading ToolCallOutputItem.output would receive plain text while the model receives JSON-encoded output, causing silent data inconsistency.
