### PR TITLE
fix: prevent BaseException cleanup from masking original exception in streaming

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -706,7 +706,10 @@ async def start_streaming(
             streamed_result.trace.finish(reset_current=True)
         if not streamed_result.is_complete:
             streamed_result.is_complete = True
-            streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+            try:
+                streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+            except Exception:
+                pass
         raise
 
     try:
@@ -1850,14 +1853,14 @@ async def run_single_turn(
     output_schema = get_output_schema(execution_agent)
     handoffs = await get_handoffs(execution_agent, context_wrapper)
     if server_conversation_tracker is not None:
-        input = server_conversation_tracker.prepare_input(original_input, generated_items)
+        turn_input = server_conversation_tracker.prepare_input(original_input, generated_items)
     else:
-        input = _prepare_turn_input_items(original_input, generated_items, reasoning_item_id_policy)
+        turn_input = _prepare_turn_input_items(original_input, generated_items, reasoning_item_id_policy)
 
     new_response = await get_new_response(
         bindings,
         system_prompt,
-        input,
+        turn_input,
         output_schema,
         all_tools,
         handoffs,


### PR DESCRIPTION
﻿This pull request fixes two issues in src/agents/run_internal/run_loop.py:

1. **Prevents exception masking in the streaming cleanup handler**: In the except BaseException block of start_streaming, if streamed_result._event_queue.put_nowait(QueueCompleteSentinel()) fails (e.g., queue full, event loop closed), the original exception is silently lost because aise is never reached. Wrapping the put_nowait in a try/except ensures the original exception is always re-raised.

2. **Renames input variable to 	urn_input**: The local variable input shadowed Python's built-in input() function, which is a latent bug waiting to cause a TypeError if any code within the function scope calls the builtin.
