### PR TITLE
fix: use last_agent property in pretty_print_run_result_streaming to avoid None crash

### DIFF
--- a/src/agents/util/_pretty_print.py
+++ b/src/agents/util/_pretty_print.py
@@ -53,7 +53,7 @@ def pretty_print_run_error_details(result: "RunErrorDetails") -> str:
 
 def pretty_print_run_result_streaming(result: "RunResultStreaming") -> str:
     output = "RunResultStreaming:"
-    output += f'\n- Current agent: Agent(name="{result.current_agent.name}", ...)'
+    output += f'\n- Current agent: Agent(name="{result.last_agent.name}", ...)'
     output += f"\n- Current turn: {result.current_turn}"
     output += f"\n- Max turns: {result.max_turns}"
     output += f"\n- Is complete: {result.is_complete}"


### PR DESCRIPTION
﻿This pull request fixes a crash in pretty_print_run_result_streaming that occurs when _release_last_agent_reference() has been called. That method sets current_agent to None via __dict__, causing esult.current_agent.name to raise AttributeError.

The sibling function pretty_print_result already uses the correct esult.last_agent property (line 28), which handles the None case by falling back to a weakref. This fix aligns pretty_print_run_result_streaming with the same pattern.
