### PR TITLE
fix: use last_agent property in RunResultStreaming._create_error_details

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -866,7 +866,7 @@ class RunResultStreaming(RunResultBase):
             input=self.input,
             new_items=self.new_items,
             raw_responses=self.raw_responses,
-            last_agent=self.current_agent,
+            last_agent=self.last_agent,
             context_wrapper=self.context_wrapper,
             input_guardrail_results=self.input_guardrail_results,
             output_guardrail_results=self.output_guardrail_results,

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -860,13 +860,20 @@ class RunResultStreaming(RunResultBase):
         if self._stored_exception:
             raise self._stored_exception
 
-    def _create_error_details(self) -> RunErrorDetails:
-        """Return a `RunErrorDetails` object considering the current attributes of the class."""
+    def _create_error_details(self) -> RunErrorDetails | None:
+        """Return a `RunErrorDetails` object considering the current attributes of the class.
+        Returns ``None`` when the current agent can no longer be resolved, preserving the
+        original terminal exception.
+        """
+        try:
+            last_agent = self.last_agent
+        except AgentsException:
+            return None
         return RunErrorDetails(
             input=self.input,
             new_items=self.new_items,
             raw_responses=self.raw_responses,
-            last_agent=self.last_agent,
+            last_agent=last_agent,
             context_wrapper=self.context_wrapper,
             input_guardrail_results=self.input_guardrail_results,
             output_guardrail_results=self.output_guardrail_results,

--- a/tests/test_result_cast.py
+++ b/tests/test_result_cast.py
@@ -300,6 +300,63 @@ def test_run_result_agent_tool_invocation_returns_immutable_metadata() -> None:
         cast(Any, invocation).tool_name = "other"
 
 
+def test_run_result_streaming_create_error_details_with_retained_weakref() -> None:
+    agent = Agent(name="error-detail-agent")
+    streaming_result = RunResultStreaming(
+        input="error",
+        new_items=[],
+        raw_responses=[],
+        final_output=None,
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+        tool_input_guardrail_results=[],
+        tool_output_guardrail_results=[],
+        context_wrapper=RunContextWrapper(context=None),
+        current_agent=agent,
+        current_turn=0,
+        max_turns=1,
+        _current_agent_output_schema=None,
+        trace=None,
+        interruptions=[],
+    )
+
+    streaming_result.release_agents()
+    details = streaming_result._create_error_details()
+    assert details is not None
+    assert details.last_agent.name == "error-detail-agent"
+
+
+def test_run_result_streaming_create_error_details_with_collected_weakref() -> None:
+    agent = Agent(name="collected-agent")
+    streaming_result = RunResultStreaming(
+        input="error",
+        new_items=[],
+        raw_responses=[],
+        final_output=None,
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+        tool_input_guardrail_results=[],
+        tool_output_guardrail_results=[],
+        context_wrapper=RunContextWrapper(context=None),
+        current_agent=agent,
+        current_turn=0,
+        max_turns=1,
+        _current_agent_output_schema=None,
+        trace=None,
+        interruptions=[],
+    )
+
+    streaming_result.release_agents()
+    agent_ref = weakref.ref(agent)
+    del agent
+    gc.collect()
+
+    assert agent_ref() is None
+    # last_agent raises AgentsException, so _create_error_details should return None
+    details = streaming_result._create_error_details()
+    assert details is None
+
+
 def test_run_result_streaming_agent_tool_invocation_returns_metadata() -> None:
     agent = Agent(name="streaming-tool-agent")
     tool_ctx = ToolContext(


### PR DESCRIPTION
﻿This pull request fixes RunResultStreaming._create_error_details() which reads self.current_agent directly instead of self.last_agent. When _release_last_agent_reference() has been called, current_agent is set to None via __dict__, causing RunErrorDetails to be constructed with last_agent=None — a type violation that can cause AttributeError downstream when accessing .name on the error details.

The last_agent property handles the None case by falling back to a stored weakref, matching the type contract of RunErrorDetails.last_agent: Agent[Any].
