### PR TITLE
fix: use Mapping instead of dict in get_mapping_or_attr for broader compatibility

### DIFF
--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal, cast
 
 from typing_extensions import Required, TypedDict
@@ -41,7 +41,7 @@ class SerializedFunctionToolLookupKey(TypedDict, total=False):
 
 def get_mapping_or_attr(value: Any, key: str) -> Any:
     """Read a key from either a mapping or object attribute."""
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         return value.get(key)
     return getattr(value, key, None)
 


### PR DESCRIPTION
﻿This pull request fixes a subtle type-handling inconsistency in _tool_identity.py's get_mapping_or_attr. The function used isinstance(value, dict) instead of isinstance(value, Mapping), which means any non-plain-dict mapping (e.g., OrderedDict, defaultdict, ChainMap, or a custom Mapping subclass) would fall through to getattr() and return None.

The same function in 	ool_execution.py (line 615) correctly uses isinstance(target, Mapping). This fix aligns the two implementations.
