### PR TITLE
fix: prevent KeyboardInterrupt/SystemExit from being swallowed in MCP retry cleanup

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1641,7 +1641,7 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 request_task.cancel()
             try:
                 await request_task
-            except BaseException:
+            except Exception:
                 pass
             raise
 


### PR DESCRIPTION
﻿This pull request fixes a bug in MCPServerStreamableHttp._call_tool_with_isolated_retry() where except BaseException: pass silently swallows KeyboardInterrupt and SystemExit. If a user presses Ctrl+C while a cancelled MCP request task finishes its cleanup, the KeyboardInterrupt is discarded, preventing the process from shutting down.

Changing to except Exception: ensures that fatal signals like KeyboardInterrupt and SystemExit still propagate, while non-fatal exceptions from the cancelled child task continue to be suppressed as intended.
