### PR TITLE
fix: use mode=json in _serialize_raw_item_value to prevent non-serializable types

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1292,7 +1292,7 @@ def _transform_field_names(
 def _serialize_raw_item_value(raw_item: Any) -> Any:
     """Return a serializable representation of a raw item."""
     if hasattr(raw_item, "model_dump"):
-        return raw_item.model_dump(exclude_unset=True)
+        return raw_item.model_dump(mode="json", exclude_unset=True)
     if isinstance(raw_item, dict):
         return dict(raw_item)
     return raw_item


### PR DESCRIPTION
﻿This pull request fixes _serialize_raw_item_value in un_state.py which calls model_dump() without mode="json". This can return non-JSON-serializable Python types (e.g., datetime, Decimal, Path) when the Pydantic model contains such fields, causing TypeError downstream when json.dumps() is called in 	o_string().

Adding mode="json" ensures the model's fields are converted to JSON-safe types before serialization, matching the pattern used elsewhere in the codebase (e.g., ealtime/session.py line 114).
