### PR TITLE
fix: add default=str fallback to RunState.to_string for non-serializable types

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1066,6 +1066,7 @@ class RunState(Generic[TContext, TAgent]):
                 include_tracing_api_key=include_tracing_api_key,
             ),
             indent=2,
+            default=str,
         )
 
     def set_trace(self, trace: Trace | None) -> None:


### PR DESCRIPTION
﻿This pull request adds default=str to the json.dumps() call in RunState.to_string(). Without this fallback, if any value in the serialized state contains a non-JSON-serializable type (e.g., datetime, Decimal, UUID), 	o_string() would raise TypeError instead of producing a usable string representation.

The _ensure_json_compatible helper at line 1314 already uses default=str as a safety net. This fix brings 	o_string() in line with the same defensive pattern used elsewhere in the codebase.
