### PR TITLE
fix: propagate tool execution exceptions instead of silently swallowing them

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1976,7 +1976,7 @@ class _FunctionToolBatchExecutor:
                 if not invoke_task.cancelled():
                     invoke_failure = invoke_task.exception()
                     if isinstance(invoke_failure, BaseException) and not isinstance(
-                        invoke_failure, Exception
+                        invoke_failure, asyncio.CancelledError
                     ):
                         raise invoke_failure from cancel_exc
             else:

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -3567,3 +3567,27 @@ async def test_execute_tools_emits_hosted_mcp_rejection_reason_from_explicit_mes
     assert responses[0].raw_item["approve"] is False
     assert responses[0].raw_item["approval_request_id"] == "mcp-approval-reject-reason"
     assert responses[0].raw_item["reason"] == "Denied by policy"
+
+
+@pytest.mark.parametrize(
+    ("exception", "old_re_raises", "new_re_raises"),
+    [
+        pytest.param(asyncio.CancelledError(), True, False, id="CancelledError"),
+        pytest.param(ValueError(), False, True, id="ValueError"),
+        pytest.param(KeyboardInterrupt(), True, True, id="KeyboardInterrupt"),
+        pytest.param(RuntimeError(), False, True, id="RuntimeError"),
+    ],
+)
+def test_await_invoke_task_failure_condition(
+    exception: BaseException,
+    old_re_raises: bool,
+    new_re_raises: bool,
+) -> None:
+    """The _await_invoke_task condition change makes the intent explicit:
+    only CancelledError should be suppressed; all other BaseException types
+    (including regular Exception subclasses) should propagate.
+    """
+    old_condition = not isinstance(exception, Exception)
+    new_condition = not isinstance(exception, asyncio.CancelledError)
+    assert old_condition == old_re_raises
+    assert new_condition == new_re_raises


### PR DESCRIPTION
Fix condition in \_await_invoke_task\ to propagate regular \Exception\ subclasses during cancellation instead of silently swallowing them.