### PR TITLE
fix: guard extract_last_content refusal against None via model_construct

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -704,11 +704,11 @@ class ItemHelpers:
             # ``extract_text`` below.
             return last_content.text or ""
         elif isinstance(last_content, ResponseOutputRefusal):
-            # Unlike output text, supported provider paths only create refusal parts after
-            # receiving refusal text. A ``None`` value requires bypassing model validation
-            # with ``model_construct``, so this intentionally does not mirror the fallback
-            # above.
-            return last_content.refusal
+            # ``last_content.refusal`` is typed as ``str`` per the Responses API schema,
+            # but ``model_construct`` bypasses Pydantic validation and can produce
+            # ``None``. Coerce so callers relying on the ``-> str`` return type don't
+            # see a ``None``.
+            return last_content.refusal or ""
         else:
             raise ModelBehaviorError(f"Unexpected content type: {type(last_content)}")
 

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -90,6 +90,12 @@ def test_none_refusal_is_rejected_before_extract_last_content() -> None:
         ResponseOutputRefusal.model_validate({"refusal": None, "type": "refusal"})
 
 
+def test_extract_last_content_of_refusal_message_with_none_via_model_construct() -> None:
+    refusal = ResponseOutputRefusal.model_construct(refusal=None, type="refusal")
+    message = make_message([refusal])
+    assert ItemHelpers.extract_last_content(message) == ""
+
+
 def test_extract_last_content_non_message_returns_empty() -> None:
     # Construct some other type of output item, e.g. a tool call, to verify non-message returns "".
     tool_call = ResponseFunctionToolCall(


### PR DESCRIPTION
ItemHelpers.extract_last_content() declares -> str but returns last_content.refusal directly, risking None surfacing via model_construct (same LiteLLM bypass path already guarded for ResponseOutputText).