### PR TITLE
fix: preserve timeout_ms=0 in coerce_shell_call instead of or-chain dropping it

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -661,11 +661,11 @@ def coerce_shell_call(tool_call: Any) -> ShellCallData:
     if not commands:
         raise ModelBehaviorError("Shell call action must include at least one command.")
 
-    timeout_value = (
-        get_mapping_or_attr(action_payload, "timeout_ms")
-        or get_mapping_or_attr(action_payload, "timeoutMs")
-        or get_mapping_or_attr(action_payload, "timeout")
-    )
+    timeout_value = get_mapping_or_attr(action_payload, "timeout_ms")
+    if timeout_value is None:
+        timeout_value = get_mapping_or_attr(action_payload, "timeoutMs")
+    if timeout_value is None:
+        timeout_value = get_mapping_or_attr(action_payload, "timeout")
     timeout_ms = int(timeout_value) if isinstance(timeout_value, int | float) else None
 
     max_length_value = get_mapping_or_attr(action_payload, "max_output_length")

--- a/tests/test_shell_call_serialization.py
+++ b/tests/test_shell_call_serialization.py
@@ -10,6 +10,19 @@ from agents.tool import ShellCallOutcome, ShellCommandOutput
 from tests.fake_model import FakeModel
 
 
+def test_coerce_shell_call_preserves_zero_timeout() -> None:
+    tool_call = {
+        "call_id": "shell-0",
+        "action": {
+            "commands": ["echo hi"],
+            "timeout_ms": 0,
+        },
+        "status": "in_progress",
+    }
+    result = run_loop.coerce_shell_call(tool_call)
+    assert result.action.timeout_ms == 0
+
+
 def test_coerce_shell_call_reads_max_output_length() -> None:
     tool_call = {
         "call_id": "shell-1",


### PR DESCRIPTION
The or-chain at tool_execution.py:664-668 silently converts timeout_ms=0 (immediate timeout) to None (no timeout) because Python or treats 0 as falsy. Adjacent max_output_length code uses the correct is None pattern at lines 671-673, confirming the or-chain is an oversight.