### PR TITLE
fix: retry pre-response WebSocket overload errors

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1031,6 +1031,15 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
                 replay_safety="safe",
                 reason=str(request.error),
             )
+        if (
+            isinstance(request.error, ResponsesWebSocketError)
+            and request.error.event_type == "error"
+            and request.error.code == "server_is_overloaded"
+        ):
+            return ModelRetryAdvice(
+                suggested=True,
+                reason=str(request.error),
+            )
         return super().get_retry_advice(request)
 
     def _get_ws_request_lock(self) -> asyncio.Lock:

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4009,6 +4009,91 @@ def test_websocket_get_retry_advice_allows_stateless_receive_timeout_retry() -> 
     assert advice.replay_safety is None
 
 
+@pytest.mark.allow_call_model_methods
+@pytest.mark.parametrize("previous_response_id", [None, "resp_prev"])
+def test_websocket_get_retry_advice_marks_pre_response_overload_retryable(
+    previous_response_id: str | None,
+) -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = ResponsesWebSocketError(
+        {
+            "type": "error",
+            "error": {
+                "type": "service_unavailable_error",
+                "code": "server_is_overloaded",
+                "message": "Our servers are currently overloaded. Please try again later.",
+            },
+        }
+    )
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=False,
+            previous_response_id=previous_response_id,
+        )
+    )
+
+    assert advice is not None
+    assert advice.suggested is True
+    assert advice.replay_safety is None
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_get_retry_advice_keeps_partial_overload_unsafe() -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = ResponsesWebSocketError(
+        {
+            "type": "error",
+            "error": {
+                "type": "service_unavailable_error",
+                "code": "server_is_overloaded",
+                "message": "Our servers are currently overloaded. Please try again later.",
+            },
+        }
+    )
+    setattr(error, "_openai_agents_ws_replay_safety", "unsafe")  # noqa: B010
+    setattr(error, "_openai_agents_ws_response_started", True)  # noqa: B010
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=False,
+        )
+    )
+
+    assert advice is not None
+    assert advice.suggested is False
+    assert advice.replay_safety == "unsafe"
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_get_retry_advice_ignores_other_pre_response_error_codes() -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = ResponsesWebSocketError(
+        {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "invalid_request",
+                "message": "Invalid request.",
+            },
+        }
+    )
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=False,
+        )
+    )
+
+    assert advice is None
+
+
 def test_get_client_disables_provider_managed_retries_when_requested() -> None:
     class DummyClient:
         def __init__(self):


### PR DESCRIPTION
This pull request resolves #3969 by treating a pre-response Responses WebSocket `server_is_overloaded` error as provider-recommended retry advice.

The change preserves the existing safety boundaries: overload errors observed after response processing begins remain non-retryable, stateful requests still require explicit replay-safety approval, and other WebSocket error codes are unaffected.