### PR TITLE
fix(chatcmpl): keep thinking-block signatures bound to their own block

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -149,9 +149,14 @@ class Converter:
 
             # Store thinking blocks for Anthropic compatibility
             if hasattr(message, "thinking_blocks") and message.thinking_blocks:
-                # Store thinking text in content and signature in encrypted_content
+                # Store thinking text in content and signature in encrypted_content.
+                # Emit exactly one signature slot per reasoning_text content item so the
+                # two lists stay index-aligned. Blocks with text but no signature get an
+                # empty-string placeholder; that keeps a later block's signature bound to
+                # its own block instead of shifting onto an earlier unsigned one.
                 reasoning_item.content = []
                 signatures: list[str] = []
+                has_signature = False
                 for block in message.thinking_blocks:
                     if isinstance(block, dict):
                         thinking_text = block.get("thinking", "")
@@ -159,12 +164,14 @@ class Converter:
                             reasoning_item.content.append(
                                 Content(text=thinking_text, type="reasoning_text")
                             )
-                        # Store the signature if present
-                        if signature := block.get("signature"):
-                            signatures.append(signature)
+                            signature = block.get("signature")
+                            signatures.append(signature or "")
+                            if signature:
+                                has_signature = True
 
-                # Store the signatures in encrypted_content with newline delimiter
-                if signatures:
+                # Only populate encrypted_content when at least one real signature exists,
+                # so the all-unsigned case leaves it unset as before.
+                if has_signature:
                     reasoning_item.encrypted_content = "\n".join(signatures)
 
             items.append(reasoning_item)
@@ -826,9 +833,12 @@ class Converter:
                                 "type": "thinking",
                                 "thinking": content_item.get("text", ""),
                             }
-                            # Add signatures if available
-                            if signatures:
-                                thinking_block["signature"] = signatures.pop(0)
+                            # Signatures are index-aligned with the reasoning_text items.
+                            # Pop the slot for this block; an empty placeholder means the
+                            # block had no signature, so leave it off.
+                            signature = signatures.pop(0) if signatures else ""
+                            if signature:
+                                thinking_block["signature"] = signature
                             reconstructed_thinking_blocks.append(thinking_block)
 
                     # Store thinking blocks as pending for the next assistant message

--- a/tests/models/test_anthropic_thinking_blocks.py
+++ b/tests/models/test_anthropic_thinking_blocks.py
@@ -305,6 +305,112 @@ def test_items_to_messages_preserves_positional_bool_arguments():
     )
 
 
+def _roundtrip_thinking_blocks(
+    thinking_blocks: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Round-trip a set of thinking blocks through message_to_output_items and back.
+
+    Returns the reconstructed thinking blocks (the ``thinking`` content parts) from the
+    rebuilt assistant message, so tests can assert each block keeps its own signature.
+    """
+    message = InternalChatCompletionMessage(
+        role="assistant",
+        content="Here is the answer.",
+        reasoning_content="Reasoning across multiple thinking blocks.",
+        thinking_blocks=cast(Any, thinking_blocks),
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id="call_hetero",
+                type="function",
+                function=Function(name="get_weather", arguments='{"city": "Tokyo"}'),
+            )
+        ],
+    )
+
+    output_items = Converter.message_to_output_items(message)
+
+    items_as_dicts: list[dict[str, Any]] = []
+    for item in output_items:
+        if hasattr(item, "model_dump"):
+            items_as_dicts.append(item.model_dump())
+        else:
+            items_as_dicts.append(cast(dict[str, Any], item))
+
+    messages = Converter.items_to_messages(
+        items_as_dicts,  # type: ignore[arg-type]
+        model="claude-sonnet-4",
+        preserve_thinking_blocks=True,
+    )
+
+    assistant_messages = [
+        msg for msg in messages if msg.get("role") == "assistant" and msg.get("tool_calls")
+    ]
+    assert len(assistant_messages) == 1, "Should have exactly one assistant message with tool calls"
+
+    content = assistant_messages[0].get("content")
+    assert isinstance(content, list), "Assistant message content should be a list"
+    return [part for part in content if part.get("type") == "thinking"]
+
+
+def test_heterogeneous_signatures_unsigned_then_signed():
+    """A block with text-but-no-signature must not steal the next block's signature.
+
+    This is the core regression: with the old forward/reverse paths the reasoning text
+    and the signatures lived in two independently filtered lists, so an unsigned first
+    block shifted the second block's signature onto itself via ``pop(0)``.
+    """
+    blocks = _roundtrip_thinking_blocks(
+        [
+            {"type": "thinking", "thinking": "A-no-sig"},
+            {"type": "thinking", "thinking": "B-has-sig", "signature": "SIG_B"},
+        ]
+    )
+
+    assert len(blocks) == 2
+    assert blocks[0].get("thinking") == "A-no-sig"
+    assert blocks[0].get("signature") is None, "Unsigned block must stay unsigned"
+    assert blocks[1].get("thinking") == "B-has-sig"
+    assert blocks[1].get("signature") == "SIG_B", "Signed block must keep its own signature"
+
+
+def test_heterogeneous_signatures_signed_then_unsigned():
+    """A signed block followed by an unsigned one keeps its signature; the other stays None."""
+    blocks = _roundtrip_thinking_blocks(
+        [
+            {"type": "thinking", "thinking": "A-has-sig", "signature": "SIG_A"},
+            {"type": "thinking", "thinking": "B-no-sig"},
+        ]
+    )
+
+    assert len(blocks) == 2
+    assert blocks[0].get("thinking") == "A-has-sig"
+    assert blocks[0].get("signature") == "SIG_A"
+    assert blocks[1].get("thinking") == "B-no-sig"
+    assert blocks[1].get("signature") is None
+
+
+def test_heterogeneous_signatures_with_signature_only_block():
+    """A signature-only (redacted-style) block interleaved must not misalign the others.
+
+    The reverse path can only rebuild thinking blocks from ``reasoning_text`` content
+    items, so a text-less block is not reconstructed; the important guarantee is that its
+    presence does not shift signatures onto the wrong text-bearing blocks.
+    """
+    blocks = _roundtrip_thinking_blocks(
+        [
+            {"type": "thinking", "thinking": "A-no-sig"},
+            {"type": "thinking", "signature": "SIG_ONLY"},
+            {"type": "thinking", "thinking": "C-has-sig", "signature": "SIG_C"},
+        ]
+    )
+
+    assert len(blocks) == 2, "Only the two text-bearing blocks should be reconstructed"
+    assert blocks[0].get("thinking") == "A-no-sig"
+    assert blocks[0].get("signature") is None
+    assert blocks[1].get("thinking") == "C-has-sig"
+    assert blocks[1].get("signature") == "SIG_C"
+
+
 def test_anthropic_thinking_blocks_without_tool_calls():
     """
     Test for models with extended thinking WITHOUT tool calls.


### PR DESCRIPTION
When Anthropic thinking blocks are converted to reasoning items and back, the reasoning text and the signatures were built into two lists filtered by different conditions: a content item was added only for blocks that had thinking text, while a signature was added only for blocks that carried one. The reverse path then re-paired them positionally with `signatures.pop(0)`. Once the blocks are not uniformly signed, the lists are not index-aligned, so a block with text but no signature pulls a later block's signature onto itself and the real one is lost. Anthropic then rejects the mismatched blocks.

This shows up on the heterogeneous-signature path (thinking blocks arriving from LiteLLM or other adapters where some blocks lack a signature), not vanilla single-provider Anthropic where every block is signed.

The forward path now emits one signature slot per `reasoning_text` content item, using an empty placeholder when a text block has no signature, so `encrypted_content` stays aligned with the content items. The reverse path treats an empty slot as "no signature" and guards the pop. Fully-signed round-trips are unchanged.

Added round-trip tests for unsigned-then-signed, signed-then-unsigned, and a signature-only block interleaved. The full suite passes; the new tests fail against `main` without the source change.
