### PR TITLE
fix(run): cancel the parallel input-guardrail task when the model turn fails

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1266,14 +1266,17 @@ class AgentRunner:
                             )
 
                             if parallel_guardrails:
+                                guardrail_task = asyncio.create_task(
+                                    run_input_guardrails(
+                                        starting_agent,
+                                        parallel_guardrails,
+                                        copy_input_items(original_input),
+                                        context_wrapper,
+                                    )
+                                )
                                 try:
                                     parallel_results, turn_result = await asyncio.gather(
-                                        run_input_guardrails(
-                                            starting_agent,
-                                            parallel_guardrails,
-                                            copy_input_items(original_input),
-                                            context_wrapper,
-                                        ),
+                                        guardrail_task,
                                         model_task,
                                     )
                                 except InputGuardrailTripwireTriggered:
@@ -1290,6 +1293,19 @@ class AgentRunner:
                                             run_state,
                                             store=store_setting,
                                         )
+                                    )
+                                    raise
+                                except BaseException:
+                                    # A non-tripwire failure (the model turn raising, or a
+                                    # guardrail raising a non-tripwire error) propagates from
+                                    # gather without cancelling the sibling task. Cancel and drain
+                                    # whichever side is still pending so it is not left running
+                                    # after the run has failed and its exception is not swallowed.
+                                    for pending_task in (guardrail_task, model_task):
+                                        if not pending_task.done():
+                                            pending_task.cancel()
+                                    await asyncio.gather(
+                                        guardrail_task, model_task, return_exceptions=True
                                     )
                                     raise
                             else:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -628,6 +628,104 @@ async def test_parallel_guardrail_trip_compat_mode_does_not_cancel_model_task():
 
 
 @pytest.mark.asyncio
+async def test_model_error_cancels_parallel_input_guardrail_task():
+    """A non-tripwire model failure must cancel the still-running guardrail task.
+
+    Without cancellation the guardrail task is orphaned and keeps running after
+    ``Runner.run`` has already raised.
+    """
+    guardrail_started = asyncio.Event()
+    guardrail_cancelled = asyncio.Event()
+    guardrail_finished = asyncio.Event()
+
+    @input_guardrail(run_in_parallel=True)
+    async def slow_parallel_check(
+        ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        guardrail_started.set()
+        try:
+            await asyncio.sleep(LONG_DELAY)
+            guardrail_finished.set()
+            return GuardrailFunctionOutput(
+                output_info="parallel_ok",
+                tripwire_triggered=False,
+            )
+        except asyncio.CancelledError:
+            guardrail_cancelled.set()
+            raise
+
+    model = FakeModel()
+
+    async def boom_get_response(*args, **kwargs):
+        # Only blow up once the guardrail is genuinely mid-flight.
+        await asyncio.wait_for(guardrail_started.wait(), timeout=1)
+        raise RuntimeError("model boom")
+
+    agent = Agent(
+        name="model_error_agent",
+        input_guardrails=[slow_parallel_check],
+        model=model,
+    )
+
+    with patch.object(model, "get_response", side_effect=boom_get_response):
+        with pytest.raises(RuntimeError, match="model boom"):
+            await Runner.run(agent, "trigger guardrail")
+
+    # By the time Runner.run returns, the guardrail task must already be
+    # cancelled rather than left running to completion in the background.
+    assert guardrail_started.is_set() is True
+    assert guardrail_cancelled.is_set() is True
+    assert guardrail_finished.is_set() is False
+
+
+@pytest.mark.asyncio
+async def test_parallel_guardrail_non_tripwire_error_not_swallowed():
+    """A non-tripwire error raised inside a parallel guardrail must propagate.
+
+    It should also cancel the in-flight model task rather than leave it running.
+    """
+    model_started = asyncio.Event()
+    model_cancelled = asyncio.Event()
+    model_finished = asyncio.Event()
+
+    @input_guardrail(run_in_parallel=True)
+    async def raising_parallel_check(
+        ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        await asyncio.wait_for(model_started.wait(), timeout=1)
+        raise ValueError("guardrail boom")
+
+    model = FakeModel()
+    original_get_response = model.get_response
+
+    async def slow_get_response(*args, **kwargs):
+        model_started.set()
+        try:
+            await asyncio.sleep(LONG_DELAY)
+            return await original_get_response(*args, **kwargs)
+        except asyncio.CancelledError:
+            model_cancelled.set()
+            raise
+        finally:
+            model_finished.set()
+
+    agent = Agent(
+        name="guardrail_error_agent",
+        input_guardrails=[raising_parallel_check],
+        model=model,
+    )
+    model.set_next_output([get_text_message("should_not_finish")])
+
+    with patch.object(model, "get_response", side_effect=slow_get_response):
+        with pytest.raises(ValueError, match="guardrail boom"):
+            await Runner.run(agent, "trigger guardrail")
+
+    await asyncio.wait_for(model_finished.wait(), timeout=1)
+    assert model_started.is_set() is True
+    assert model_cancelled.is_set() is True
+
+
+@pytest.mark.asyncio
 async def test_parallel_guardrail_may_not_prevent_tool_execution_streaming():
     tool_was_executed = False
     guardrail_executed = False


### PR DESCRIPTION
In the parallel input-guardrail path (`AgentRunner.run`), the guardrail coroutine and the model turn are awaited together with `asyncio.gather` without `return_exceptions=True`, and the only handler catches `InputGuardrailTripwireTriggered`.

If the model turn raises any other exception (a `ModelBehaviorError`, a provider `RuntimeError`) before the guardrail finishes, `gather` propagates the model error but leaves the sibling guardrail task running. It keeps making network calls and side effects after the run has already failed and returned, and an error raised inside that guardrail after `gather` resolves is silently swallowed. Guardrails default to `run_in_parallel=True`, so this is the common path whenever an input guardrail exists.

The fix wraps the guardrail coroutine in an explicit task and adds a symmetric cleanup branch: on any non-tripwire failure, cancel whichever of the guardrail and model tasks is still pending and drain both with `return_exceptions=True` before re-raising. The existing tripwire behavior and the flag-gated model-task cancellation are preserved, and the streamed path is unchanged.

This complements #3239, which cancelled sibling guardrails inside `run_input_guardrails` itself. That fix does not reach the orchestration-level `gather` in `run.py`, so when the model task is the one that raises, the guardrail task is still orphaned. This closes that gap.

Tests cover a model error cancelling the in-flight guardrail task, and a guardrail's non-tripwire error propagating and cancelling the model task; the existing tripwire tests still pass. Both new tests fail on `main` and pass with this change. Full suite: 5783 passed, 7 skipped; ruff, format, and mypy clean.
