### PR TITLE
fix(tracing): enforce max_batch_size during force_flush and shutdown in BatchTraceProcessor

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -668,8 +668,8 @@ class BatchTraceProcessor(TracingProcessor):
         self._export_batches(force=True, deadline=self._shutdown_deadline)
 
     def _export_batches(self, force: bool = False, deadline: float | None = None):
-        """Drains the queue and exports in batches. If force=True, export everything.
-        Otherwise, export up to `max_batch_size` repeatedly until the queue is completely empty.
+        """Drains the queue and exports in batches of up to `max_batch_size` until the queue
+        is completely empty.
         """
         with self._export_lock:
             while True:
@@ -682,9 +682,7 @@ class BatchTraceProcessor(TracingProcessor):
                 items_to_export: list[Span[Any] | Trace] = []
 
                 # Gather a batch of spans up to max_batch_size
-                while not self._queue.empty() and (
-                    force or len(items_to_export) < self._max_batch_size
-                ):
+                while not self._queue.empty() and len(items_to_export) < self._max_batch_size:
                     try:
                         items_to_export.append(self._queue.get_nowait())
                     except queue.Empty:

--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -642,13 +642,13 @@ class BatchTraceProcessor(TracingProcessor):
                 )
         else:
             # No background thread: process any remaining items synchronously.
-            self._export_batches(force=True, deadline=deadline)
+            self._export_batches(deadline=deadline)
 
     def force_flush(self):
         """
         Forces an immediate flush of all queued spans.
         """
-        self._export_batches(force=True)
+        self._export_batches()
 
     def _run(self):
         while not self._shutdown_event.is_set():
@@ -657,7 +657,7 @@ class BatchTraceProcessor(TracingProcessor):
 
             # If it's time for a scheduled flush or queue is above the trigger threshold
             if current_time >= self._next_export_time or queue_size >= self._export_trigger_size:
-                self._export_batches(force=False)
+                self._export_batches()
                 # Reset the next scheduled flush time
                 self._next_export_time = time.time() + self._schedule_delay
             else:
@@ -665,9 +665,9 @@ class BatchTraceProcessor(TracingProcessor):
                 time.sleep(0.2)
 
         # Final drain after shutdown
-        self._export_batches(force=True, deadline=self._shutdown_deadline)
+        self._export_batches(deadline=self._shutdown_deadline)
 
-    def _export_batches(self, force: bool = False, deadline: float | None = None):
+    def _export_batches(self, deadline: float | None = None):
         """Drains the queue and exports in batches of up to `max_batch_size` until the queue
         is completely empty.
         """

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -133,15 +133,14 @@ def test_batch_trace_processor_force_flush(mocked_exporter):
 
     processor.force_flush()
 
-    # Ensure exporter.export was called with all items
-    # Because max_batch_size=2, it may have been called multiple times
-    total_exported = 0
-    for call_args in mocked_exporter.export.call_args_list:
-        batch = call_args[0][0]  # first positional arg to export() is the items list
-        total_exported += len(batch)
+    # Ensure exporter.export was called with all items in batches respecting max_batch_size=2
+    exported_batches = [call_args[0][0] for call_args in mocked_exporter.export.call_args_list]
+    total_exported = sum(len(batch) for batch in exported_batches)
 
-    # We pushed 3 items; ensure they all got exported
+    # We pushed 3 items; ensure they all got exported across 2 batches (sizes 2 and 1)
     assert total_exported == 3
+    assert len(exported_batches) == 2
+    assert all(len(batch) <= 2 for batch in exported_batches)
 
     processor.shutdown()
 

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -139,8 +139,7 @@ def test_batch_trace_processor_force_flush(mocked_exporter):
 
     # We pushed 3 items; ensure they all got exported across 2 batches (sizes 2 and 1)
     assert total_exported == 3
-    assert len(exported_batches) == 2
-    assert all(len(batch) <= 2 for batch in exported_batches)
+    assert [len(batch) for batch in exported_batches] == [2, 1]
 
     processor.shutdown()
 


### PR DESCRIPTION
### Summary

When `force_flush()` or `shutdown()` is called on `BatchTraceProcessor`, `_export_batches(force=True)` was called. In `_export_batches`, the inner loop condition contained `force or len(items_to_export) < self._max_batch_size`. Because `force` evaluated to `True`, the `max_batch_size` limit was completely bypassed during queue draining.

As a result, all queued items (even thousands of spans) were gathered into a single exported batch. When sent to the HTTP exporter (`BackendSpanExporter`), giant single payloads lead to HTTP 413 (Payload Too Large) errors, request timeouts, or connection failures, stranding or dropping queued telemetry.

This PR removes the `force or` condition from the inner batch collector so that `_export_batches` always enforces `max_batch_size` on every batch passed to `exporter.export()`, while the outer loop continues draining the queue until empty.

### Test plan

1. Updated existing `test_batch_trace_processor_force_flush` unit test in `tests/test_trace_processor.py` to assert that exported batches strictly respect `max_batch_size` (e.g. 3 queued items with `max_batch_size=2` are exported as 2 separate batches of sizes `[2, 1]`).
2. Ran complete repository verification:
   - `make format-check`
   - `make lint`
   - `make typecheck`
   - `make tests`

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR