### PR TITLE
docs: repair tracing integration links

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -205,7 +205,7 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 
 -   [Weights & Biases](https://weave-docs.wandb.ai/guides/integrations/openai_agents)
 -   [Arize-Phoenix](https://docs.arize.com/phoenix/tracing/integrations-tracing/openai-agents-sdk)
--   [Future AGI](https://docs.futureagi.com/future-agi/products/observability/auto-instrumentation/openai_agents)
+-   [Future AGI](https://docs.futureagi.com/docs/tracing/auto/openai_agents/)
 -   [MLflow (self-hosted/OSS)](https://mlflow.org/docs/latest/tracing/integrations/openai-agent)
 -   [MLflow (Databricks hosted)](https://docs.databricks.com/aws/en/mlflow/mlflow-tracing#-automatic-tracing)
 -   [Braintrust](https://braintrust.dev/docs/guides/traces/integrations#openai-agents-sdk)
@@ -225,7 +225,7 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [Agenta](https://docs.agenta.ai/observability/integrations/openai-agents)
 -   [PostHog](https://posthog.com/docs/llm-analytics/installation/openai-agents)
 -   [Traccia](https://traccia.ai/docs/integrations/openai-agents)
--   [PromptLayer](https://docs.promptlayer.com/languages/integrations#openai-agents-sdk)
+-   [PromptLayer](https://docs.promptlayer.com/features/integrations#openai-agents-sdk)
 -   [HoneyHive](https://docs.honeyhive.ai/v2/integrations/openai-agents)
 -   [Asqav](https://www.asqav.com/docs/integrations#openai-agents)
 -   [Datadog](https://docs.datadoghq.com/llm_observability/instrumentation/auto_instrumentation/?tab=python#openai-agents)


### PR DESCRIPTION
  ### Summary

  Repair two broken links in the external tracing processors list:

  - Update Future AGI to its current OpenAI Agents SDK tracing guide.
  - Update PromptLayer to its current OpenAI Agents SDK telemetry integration section.

  ### User impact

  Developers can again reach the vendor-maintained setup guides for both tracing integrations.

  ### Privacy implications

  None. This change only updates documentation links.

  ### Test plan

  - Confirmed both replacement URLs return HTTP 200 with `curl -L`.
  - Confirmed the two previous URLs return HTTP 404.
  - Ran `UV_NO_SYNC=1 uv run mkdocs build`.
  - Ran `git diff --check`.

  ### Issue number

  N/A

  ### Checks

  - [ ] I've added new tests, if relevant (not relevant; documentation-only change).
  - [x] I've confirmed all applicable verification steps pass.

  No breaking changes.