### PR TITLE
docs: fix a URL in sandbox example code

### DIFF
--- a/examples/sandbox/extensions/daytona/usaspending_text2sql/schema/glossary.md
+++ b/examples/sandbox/extensions/daytona/usaspending_text2sql/schema/glossary.md
@@ -854,7 +854,7 @@ A unique identifier assigned to a federal contract, purchase order, basic orderi
 
 **Official definition:** The unique identifier of the specific award being reported. 
 
-[Read more in the Federal Acquisition Regulation](https://www.acquisition.gov/far/html/Subpart%204_16.html).
+[Read more in the Federal Acquisition Regulation](https://www.acquisition.gov/far/subpart-4.16).
 
 ## Product or Service Code (PSC)
 


### PR DESCRIPTION
 ## Summary

  Fixes the Federal Acquisition Regulation (FAR) reference link in the Daytona USASpending text-to-SQL example.

  The previous acquisition.gov URL now returns 404. This updates it to the current official FAR Subpart 4.16 page.

  ## Validation

  - Confirmed the previous URL returns HTTP 404.
  - Confirmed the replacement official URL returns HTTP 200.
  - Ran `git diff --check`.

 ### Issue number

  N/A

  - [ ] I've added new tests, if relevant (not relevant; documentation-only change).
  - [x] I've confirmed all applicable verification steps pass.