### PR TITLE
fix: retry pre-response WebSocket server errors

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1034,7 +1034,10 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
         if (
             isinstance(request.error, ResponsesWebSocketError)
             and request.error.event_type == "error"
-            and request.error.code == "server_is_overloaded"
+            and (
+                request.error.code == "server_is_overloaded"
+                or (request.error.error_type == "server_error" and request.error.code is None)
+            )
         ):
             return ModelRetryAdvice(
                 suggested=True,

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4041,15 +4041,81 @@ def test_websocket_get_retry_advice_marks_pre_response_overload_retryable(
 
 
 @pytest.mark.allow_call_model_methods
-def test_websocket_get_retry_advice_keeps_partial_overload_unsafe() -> None:
+@pytest.mark.parametrize("previous_response_id", [None, "resp_prev"])
+def test_websocket_get_retry_advice_marks_pre_response_server_error_retryable(
+    previous_response_id: str | None,
+) -> None:
     model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
     error = ResponsesWebSocketError(
         {
             "type": "error",
             "error": {
-                "type": "service_unavailable_error",
-                "code": "server_is_overloaded",
-                "message": "Our servers are currently overloaded. Please try again later.",
+                "type": "server_error",
+                "code": None,
+                "message": "Sorry, something went wrong.",
+            },
+        }
+    )
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=True,
+            previous_response_id=previous_response_id,
+        )
+    )
+
+    assert advice is not None
+    assert advice.suggested is True
+    assert advice.replay_safety is None
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_get_retry_advice_does_not_override_non_transient_error_code() -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = ResponsesWebSocketError(
+        {
+            "type": "error",
+            "error": {
+                "type": "server_error",
+                "code": "invalid_request_error",
+                "message": "Invalid request.",
+            },
+        }
+    )
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=True,
+        )
+    )
+
+    assert advice is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.parametrize(
+    ("error_type", "code"),
+    [
+        ("service_unavailable_error", "server_is_overloaded"),
+        ("server_error", None),
+    ],
+)
+def test_websocket_get_retry_advice_keeps_partial_transient_error_unsafe(
+    error_type: str,
+    code: str | None,
+) -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = ResponsesWebSocketError(
+        {
+            "type": "error",
+            "error": {
+                "type": error_type,
+                "code": code,
+                "message": "Transient provider error.",
             },
         }
     )


### PR DESCRIPTION
### Summary

This pull request fixes Responses WebSocket `server_error` frames bypassing provider-suggested model retry policies when they arrive before response processing begins.

It classifies the reported `error_type="server_error"` and `code=None` frame as retryable while preserving the existing overload behavior and replay-safety boundaries. Coded non-transient errors remain unaffected, and stateful continuations remain subject to the existing replay-safety gate.

### Test plan

- `uv run pytest tests/models/test_openai_responses.py -k 'websocket_get_retry_advice' -q` (`19 passed`)
- `uv run pytest tests/models/test_openai_responses.py -q` (`126 passed`)
- `.agents/skills/code-change-verification/scripts/run.sh` (format, lint, full tests, mypy, and pyright passed)
- Independent specification and code-quality reviews passed on the final diff

### Issue number

Closes #3990

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR (not applicable; Codex was not used)
