### PR TITLE
fix: redact Blaxel unmount paths in logging

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/mounts.py
+++ b/src/agents/extensions/sandbox/blaxel/mounts.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from .... import _debug
 from ....logger import log_tool_action_warning
 from ....sandbox.entries import GCSMount, Mount, R2Mount, S3Mount
 from ....sandbox.entries.mounts.base import MountStrategyBase
@@ -407,18 +408,37 @@ async def _unmount_bucket(session: BaseSandboxSession, mount_path: str) -> None:
     result = await _exec(session, f"fusermount -u {path}")
     if result.exit_code == 0:
         return
-    logger.debug("fusermount failed for %s (exit %d), trying umount", mount_path, result.exit_code)
+    if _debug.DONT_LOG_TOOL_DATA:
+        logger.debug("fusermount failed (exit %d), trying umount", result.exit_code)
+    else:
+        logger.debug(
+            "fusermount failed for %s (exit %d), trying umount",
+            mount_path,
+            result.exit_code,
+        )
     # Fallback to regular umount.
     result = await _exec(session, f"umount {path}")
     if result.exit_code == 0:
         return
-    logger.debug("umount failed for %s (exit %d), trying lazy umount", mount_path, result.exit_code)
+    if _debug.DONT_LOG_TOOL_DATA:
+        logger.debug("umount failed (exit %d), trying lazy umount", result.exit_code)
+    else:
+        logger.debug(
+            "umount failed for %s (exit %d), trying lazy umount",
+            mount_path,
+            result.exit_code,
+        )
     # Last resort: lazy unmount.
     result = await _exec(session, f"umount -l {path}")
     if result.exit_code != 0:
-        logger.warning(
-            "all unmount attempts failed for %s (last exit %d)", mount_path, result.exit_code
-        )
+        if _debug.DONT_LOG_TOOL_DATA:
+            logger.warning("all unmount attempts failed (last exit %d)", result.exit_code)
+        else:
+            logger.warning(
+                "all unmount attempts failed for %s (last exit %d)",
+                mount_path,
+                result.exit_code,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -3628,18 +3628,59 @@ class TestDriveMounts:
 
 class TestUnmountBucketLogging:
     @pytest.mark.asyncio
-    async def test_unmount_all_attempts_fail_logs_warning(self) -> None:
+    @pytest.mark.parametrize(
+        ("model_redacted", "tool_redacted"),
+        [(False, True), (True, True), (False, False), (True, False)],
+    )
+    async def test_unmount_all_attempts_follow_tool_data_policy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        model_redacted: bool,
+        tool_redacted: bool,
+    ) -> None:
         from agents.extensions.sandbox.blaxel.mounts import _unmount_bucket
 
+        mount_path = "/mnt/SECRET_BUCKET_PATH"
         session = _FakeMountSession()
         session._next_results = [
             _FakeExecResultForMount(exit_code=1),  # fusermount fails
             _FakeExecResultForMount(exit_code=1),  # umount fails
             _FakeExecResultForMount(exit_code=1),  # umount -l fails
         ]
+        monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", model_redacted)
+        monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", tool_redacted)
+        caplog.set_level(logging.DEBUG, logger="agents.extensions.sandbox.blaxel.mounts")
+
         # Should not raise, just log warning.
-        await _unmount_bucket(session, "/mnt/test")  # type: ignore[arg-type]
+        await _unmount_bucket(session, mount_path)  # type: ignore[arg-type]
+
         assert len(session.exec_calls) == 3
+        records = [
+            record
+            for record in caplog.records
+            if record.name == "agents.extensions.sandbox.blaxel.mounts"
+        ]
+        assert len(records) == 3
+        assert [record.levelno for record in records] == [
+            logging.DEBUG,
+            logging.DEBUG,
+            logging.WARNING,
+        ]
+        for record in records:
+            assert record.exc_info is None
+            assert record.exc_text is None
+            assert all(value is not mount_path for value in record.__dict__.values())
+
+        rendered = [logging.Formatter().format(record) for record in records]
+        if tool_redacted:
+            assert all(mount_path not in message for message in rendered)
+            assert [record.args for record in records] == [(1,), (1,), (1,)]
+        else:
+            assert all(mount_path in message for message in rendered)
+            for record in records:
+                assert isinstance(record.args, tuple)
+                assert mount_path in record.args
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request fixes a sensitive logging leak in the Blaxel bucket unmount fallback. When tool-data logging is disabled, failed unmount diagnostics no longer attach or render the configured mount path, while retaining exit codes and fixed operational messages.

Diagnostic mode continues to include the mount path, and the existing `fusermount -u` to `umount` to `umount -l` fallback sequence remains unchanged.