### PR TITLE
fix(run): allow empty streamed model input

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1488,8 +1488,6 @@ async def run_single_turn_streamed(
         # Track only the items actually sent after call_model_input_filter runs. Retry helpers
         # explicitly rewind this state before replaying a failed request.
         server_conversation_tracker.mark_input_as_sent(filtered.input)
-    if not filtered.input and server_conversation_tracker is None:
-        raise RuntimeError("Prepared model input is empty")
 
     await asyncio.gather(
         hooks.on_llm_start(context_wrapper, public_agent, filtered.instructions, filtered.input),

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -141,6 +141,20 @@ async def test_simple_first_run():
 
 
 @pytest.mark.asyncio
+async def test_empty_list_input_reaches_model():
+    model = FakeModel()
+    agent = Agent(name="test", model=model)
+    model.set_next_output([get_text_message("first")])
+
+    result = Runner.run_streamed(agent, input=[])
+    async for _ in result.stream_events():
+        pass
+
+    assert result.final_output == "first"
+    assert model.last_turn_args["input"] == []
+
+
+@pytest.mark.asyncio
 async def test_streamed_tool_not_found_behavior_returns_error_to_model() -> None:
     model = FakeModel()
     agent = Agent(name="test", model=model)


### PR DESCRIPTION
### Summary

This pull request fixes a streaming-only input restriction in `Runner.run_streamed()`.

The non-streaming Runner paths pass an empty prepared item list to the configured model, but the streamed path raised `RuntimeError("Prepared model input is empty")` before model invocation. Removing that path-specific guard restores Runner parity and lets each configured model or provider decide whether it accepts empty input.

### Test plan

- Added a public-interface regression test that streams a run from `input=[]`, verifies the fake model receives the empty list, and verifies the run completes.
- Confirmed the test fails on pristine `upstream/main` with the expected `RuntimeError`.
- Ran the focused regression twice after the fix.
- Ran `tests/test_agent_runner.py` and `tests/test_agent_runner_streamed.py`: 212 passed.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck, and the full test suite all passed.
- Ran `git diff --check`.

### Issue number

Closes #3994

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
