### PR TITLE
fix(models): route falsey mapped providers

### DIFF
--- a/src/agents/models/multi_provider.py
+++ b/src/agents/models/multi_provider.py
@@ -204,7 +204,10 @@ class MultiProvider(ModelProvider):
     ) -> tuple[ModelProvider, str | None]:
         # Explicit provider_map entries are the least surprising routing mechanism, so they always
         # win over the built-in OpenAI alias and unknown-prefix fallback behavior.
-        if self.provider_map and (provider := self.provider_map.get_provider(prefix)):
+        if (
+            self.provider_map is not None
+            and (provider := self.provider_map.get_provider(prefix)) is not None
+        ):
             return provider, stripped_model_name
 
         if prefix in {"litellm", "any-llm"}:

--- a/tests/models/test_map.py
+++ b/tests/models/test_map.py
@@ -198,6 +198,27 @@ def test_provider_map_entries_override_openai_prefix_mode(monkeypatch):
     assert captured_model["value"] == "gpt-4o"
 
 
+def test_provider_map_routes_to_falsey_provider():
+    captured_model: dict[str, Any] = {}
+    expected_model = object()
+
+    class FalseyProvider:
+        def __bool__(self) -> bool:
+            return False
+
+        def get_model(self, model_name: str | None):
+            captured_model["value"] = model_name
+            return expected_model
+
+    provider_map = MultiProviderMap()
+    provider_map.add_provider("custom", cast(Any, FalseyProvider()))
+
+    result = MultiProvider(provider_map=provider_map).get_model("custom/test-model")
+
+    assert result is expected_model
+    assert captured_model["value"] == "test-model"
+
+
 def test_multi_provider_rejects_invalid_prefix_modes():
     bad_openai_prefix_mode: Any = "invalid"
     bad_unknown_prefix_mode: Any = "invalid"


### PR DESCRIPTION
### Summary

This pull request fixes `MultiProvider` routing for explicitly mapped provider objects that evaluate to false. The prefix resolver now distinguishes a missing map entry with `is not None`, so an explicit `MultiProviderMap` entry continues to win over built-in and unknown-prefix behavior regardless of the provider's truth value.

### Test plan

- Added `test_provider_map_routes_to_falsey_provider`, which failed with `UserError: Unknown prefix: custom` before the fix and passes afterward.
- `tests/models/test_map.py`: 15 passed.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`:
  - format, lint, mypy, and pyright passed.
  - the managed environment's full suite reached 5,747 passed and 3 skipped; 22 local websocket and Unix sandbox tests failed because the execution sandbox denied local listener/process operations with `Operation not permitted`.
  - an unsandboxed rerun could not start because the environment's approval service had exhausted its usage allowance. The remaining full-suite gate is therefore left to CI.

### Issue number

N/A - found through code-path review; no existing issue or pull request covers falsey mapped-provider routing.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
