### PR TITLE
fix: coerce structured tool outputs for stop_on_first_tool

### DIFF
--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from typing import Any, Literal, cast
 
@@ -182,6 +183,25 @@ __all__ = [
 ]
 
 
+def _coerce_tool_final_output_for_plain_text(final_output: Any) -> str:
+    """Convert a tool-produced final output into a plain-text agent result.
+
+    Structured tool outputs (`ToolOutputText`, images, files, and TypedDict forms) must not be
+    coerced through Pydantic/`dict` `__str__`/`__repr__`. Reuse the same structured conversion
+    used for tool wire payloads so plain-text agents receive the text content or stable JSON.
+    """
+    structured_output = ItemHelpers._convert_tool_output_as_structured(final_output)
+    if structured_output is not None:
+        if len(structured_output) == 1:
+            first_item = cast(Mapping[str, Any], structured_output[0])
+            if first_item.get("type") == "input_text":
+                text = first_item.get("text")
+                if isinstance(text, str):
+                    return text
+        return json.dumps(structured_output, ensure_ascii=False)
+    return str(final_output)
+
+
 async def _maybe_finalize_from_tool_results(
     *,
     public_agent: Agent[TContext],
@@ -202,7 +222,9 @@ async def _maybe_finalize_from_tool_results(
         return None
 
     if not public_agent.output_type or public_agent.output_type is str:
-        check_tool_use.final_output = str(check_tool_use.final_output)
+        check_tool_use.final_output = _coerce_tool_final_output_for_plain_text(
+            check_tool_use.final_output
+        )
 
     if check_tool_use.final_output is None:
         logger.error(

--- a/tests/test_tool_use_behavior.py
+++ b/tests/test_tool_use_behavior.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, cast
 
 import pytest
@@ -11,7 +12,11 @@ from agents import (
     Agent,
     FunctionToolResult,
     RunContextWrapper,
+    Runner,
     ToolCallOutputItem,
+    ToolOutputImage,
+    ToolOutputText,
+    ToolOutputTextDict,
     ToolsToFinalOutputResult,
     UserError,
     function_tool,
@@ -19,7 +24,8 @@ from agents import (
 )
 from agents.run_internal import run_loop
 
-from .test_responses import get_function_tool
+from .fake_model import FakeModel
+from .test_responses import get_function_tool, get_function_tool_call
 
 
 def _make_function_tool_result(
@@ -261,3 +267,127 @@ async def test_stop_at_tool_names_supports_public_and_qualified_names_for_namesp
         context_wrapper=RunContextWrapper(context=None),
     )
     assert result.is_final_output is True
+    assert result.final_output == "billing-output"
+
+
+@pytest.mark.asyncio
+async def test_stop_on_first_tool_coerces_tool_output_text_to_plain_text() -> None:
+    """Structured ToolOutputText must become its text, not a Pydantic __str__ repr."""
+
+    @function_tool
+    def text_tool() -> ToolOutputText:
+        return ToolOutputText(text="hello structured")
+
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("text_tool", "{}")])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[text_tool],
+        tool_use_behavior="stop_on_first_tool",
+    )
+
+    result = await Runner.run(agent, "hi")
+    assert result.final_output == "hello structured"
+    assert "type=" not in result.final_output
+
+
+@pytest.mark.asyncio
+async def test_stop_on_first_tool_coerces_tool_output_text_dict_to_plain_text() -> None:
+    @function_tool
+    def text_tool() -> ToolOutputTextDict:
+        return {"type": "text", "text": "hello from dict"}
+
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("text_tool", "{}")])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[text_tool],
+        tool_use_behavior="stop_on_first_tool",
+    )
+
+    result = await Runner.run(agent, "hi")
+    assert result.final_output == "hello from dict"
+
+
+@pytest.mark.asyncio
+async def test_stop_at_tool_names_coerces_tool_output_text_to_plain_text() -> None:
+    @function_tool
+    def text_tool() -> ToolOutputText:
+        return ToolOutputText(text="stopped structured")
+
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("text_tool", "{}")])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[text_tool],
+        tool_use_behavior={"stop_at_tool_names": ["text_tool"]},
+    )
+
+    result = await Runner.run(agent, "hi")
+    assert result.final_output == "stopped structured"
+
+
+@pytest.mark.asyncio
+async def test_stop_on_first_tool_coerces_tool_output_image_without_pydantic_repr() -> None:
+    @function_tool
+    def image_tool() -> ToolOutputImage:
+        return ToolOutputImage(image_url="data:image/png;base64,AAAA")
+
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("image_tool", "{}")])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[image_tool],
+        tool_use_behavior="stop_on_first_tool",
+    )
+
+    result = await Runner.run(agent, "hi")
+    assert isinstance(result.final_output, str)
+    assert "type='image'" not in result.final_output
+    assert "image_url=" not in result.final_output
+    parsed = json.loads(result.final_output)
+    assert parsed == [{"type": "input_image", "image_url": "data:image/png;base64,AAAA"}]
+
+
+@pytest.mark.asyncio
+async def test_stop_on_first_tool_structured_output_streamed() -> None:
+    @function_tool
+    def text_tool() -> ToolOutputText:
+        return ToolOutputText(text="streamed structured")
+
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("text_tool", "{}")])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[text_tool],
+        tool_use_behavior="stop_on_first_tool",
+    )
+
+    result = Runner.run_streamed(agent, "hi")
+    async for _ in result.stream_events():
+        pass
+    assert result.final_output == "streamed structured"
+
+
+@pytest.mark.asyncio
+async def test_stop_on_first_tool_still_stringifies_non_structured_values() -> None:
+    @function_tool
+    def int_tool() -> int:
+        return 42
+
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("int_tool", "{}")])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[int_tool],
+        tool_use_behavior="stop_on_first_tool",
+    )
+
+    result = await Runner.run(agent, "hi")
+    assert result.final_output == "42"


### PR DESCRIPTION
### Summary

When `tool_use_behavior` is `stop_on_first_tool` or `stop_at_tool_names`, plain-text agents finalize through `_maybe_finalize_from_tool_results`, which previously called `str(...)` on the tool result. For structured returns such as `ToolOutputText` / `ToolOutputImage` (and TypedDict equivalents), that produced Pydantic or dict `__str__`/`__repr__` values like `type='text' text='hello structured'` instead of usable plain-text output.

This pull request fixes that by coercing structured tool outputs through the existing `ItemHelpers._convert_tool_output_as_structured` path:

- single `ToolOutputText` / text TypedDict → the text content string
- other structured outputs (image/file/lists) → stable JSON matching the Responses wire shape
- non-structured values (e.g. `int`) → unchanged `str(...)` behavior

**Affected component:** `src/agents/run_internal/turn_resolution.py` (`_maybe_finalize_from_tool_results`)

**Problem:** `stop_on_first_tool` / `stop_at_tool_names` turned structured tool returns into Pydantic/dict string representations for default plain-text agents.

**Minimal reproduction (FakeModel, no API key):**
```python
@function_tool
def text_tool():
    return ToolOutputText(text="hello structured")

agent = Agent(
    name="a",
    model=FakeModel(initial_output=[get_function_tool_call("text_tool", "{}")]),
    tools=[text_tool],
    tool_use_behavior="stop_on_first_tool",
)
result = await Runner.run(agent, "hi")
# before: "type='text' text='hello structured'"
# after:  "hello structured"
```

**Root cause:** Blind `str(final_output)` for plain-text agents does not use the structured tool-output conversion already used for tool wire payloads.

**Why minimal:** One shared helper in the finalization path used by both streamed and non-streamed runs. No public API changes. Does not change the rejected `None`-preservation behavior from #3943 (plain-text agents still stringify non-structured values, including `None` → `"None"`).

**Compatibility:** Corrects buggy released behavior for structured tool finals on plain-text agents (`v0.19.0`). Callers that depended on Pydantic/`dict` `__str__` text were relying on the bug.

**Non-goals:** No change to custom `output_type` agents, approval/sticky-reject behavior, session persistence, or intentional empty-string `as_tool` fallbacks.

### Test plan

- [x] Added regression tests in `tests/test_tool_use_behavior.py` covering:
  - `ToolOutputText` via `stop_on_first_tool`
  - `ToolOutputTextDict` via `stop_on_first_tool`
  - `ToolOutputText` via `stop_at_tool_names`
  - `ToolOutputImage` (JSON, not Pydantic repr)
  - streamed `Runner.run_streamed` path
  - non-structured `int` still stringified to `"42"`
- [x] Pre-fix: focused tests failed with Pydantic/dict string outputs
- [x] Post-fix: `uv run pytest tests/test_tool_use_behavior.py -q` → 15 passed (ran repeatedly)
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh`
  - `make format` passed
  - `make lint` passed
  - `make typecheck` passed
  - `make tests` passed
- [x] Confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR

### Issue number

N/A — focused correctness fix submitted directly (duplicate search found no open issue for this symptom).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
