### PR TITLE
fix(mcp): strip URL credentials from server names in raised errors

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeVar, Union, cast
 
 import anyio
 import httpx
@@ -234,6 +234,19 @@ MCPStreamTransport = (
         GetSessionIdCallback | None,
     ]
 )
+
+
+def _raise_mcp_transport_error(error: UserError, cause: Exception | None) -> NoReturn:
+    """Raise ``error`` for a failed MCP transport call, chaining ``cause`` only when allowed.
+
+    ``cause`` is typically an httpx error whose request URL can embed credentials, so the
+    chain is dropped while tool-data logging is disabled. Call this *outside* the ``except``
+    block: ``raise ... from None`` is not enough, because the original exception would stay
+    reachable through ``__context__``.
+    """
+    if _debug.DONT_LOG_TOOL_DATA or cause is None:
+        raise error
+    raise error from cause
 
 
 class MCPServer(abc.ABC):
@@ -762,8 +775,12 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
         return None
 
-    def _raise_user_error_for_http_error(self, http_error: Exception) -> None:
-        """Raise appropriate UserError for HTTP error."""
+    def _build_user_error_for_http_error(self, http_error: Exception) -> UserError:
+        """Build the UserError for an HTTP error, using only safe diagnostic fields.
+
+        Only the status code and reason phrase are copied out of the httpx error; its
+        request URL can embed credentials, so the exception itself is never chained here.
+        """
         error_message = f"Failed to connect to MCP server '{self._error_name}': "
         if isinstance(http_error, httpx.HTTPStatusError):
             error_message += f"HTTP error {http_error.response.status_code} ({http_error.response.reason_phrase})"  # noqa: E501
@@ -774,7 +791,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         elif isinstance(http_error, httpx.TimeoutException):
             error_message += "Connection timeout."
 
-        raise UserError(error_message) from http_error
+        return UserError(error_message)
 
     async def _run_with_retries(self, func: Callable[[], Awaitable[T]]) -> T:
         attempts = 0
@@ -791,6 +808,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
     async def connect(self):
         """Connect to the server."""
         connection_succeeded = False
+        connect_error: UserError | None = None
+        connect_cause: Exception | None = None
         try:
             transport = await self.exit_stack.enter_async_context(self.create_streams())
             # streamablehttp_client returns (read, write, get_session_id)
@@ -818,19 +837,24 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             # Try to extract HTTP error from exception or ExceptionGroup
             http_error = self._extract_http_error_from_exception(e)
             if http_error:
-                self._raise_user_error_for_http_error(http_error)
+                # Raised after the try statement so the credential-bearing httpx error is
+                # not retained through __cause__ or __context__.
+                connect_error = self._build_user_error_for_http_error(http_error)
+                connect_cause = http_error
 
             # For CancelledError, preserve cancellation semantics - don't wrap it.
             # If it's masking an HTTP error, cleanup() will extract and raise UserError.
-            if isinstance(e, asyncio.CancelledError):
+            elif isinstance(e, asyncio.CancelledError):
                 raise
 
             # For HTTP-related errors, wrap them
-            if isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
-                self._raise_user_error_for_http_error(e)
+            elif isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
+                connect_error = self._build_user_error_for_http_error(e)
+                connect_cause = e
 
             # For other errors, re-raise as-is (don't wrap non-HTTP errors)
-            raise
+            else:
+                raise
         finally:
             # Always attempt cleanup on error, but suppress cleanup errors that mask the original
             if not connection_succeeded:
@@ -861,6 +885,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                             get_mcp_server_log_message("Error during cleanup of MCP server", self),
                             cleanup_error,
                         )
+
+        if connect_error is not None:
+            _raise_mcp_transport_error(connect_error, connect_cause)
 
     async def list_tools(
         self,
@@ -893,15 +920,19 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             return filtered_tools
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
-            raise UserError(
+            transport_error = UserError(
                 f"Failed to list tools from MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
-            ) from e
+            )
+            transport_cause: Exception = e
         except httpx.ConnectError as e:
-            raise UserError(
+            transport_error = UserError(
                 f"Failed to list tools from MCP server '{self._error_name}': Connection lost. "
                 f"The server may have disconnected."
-            ) from e
+            )
+            transport_cause = e
+
+        _raise_mcp_transport_error(transport_error, transport_cause)
 
     async def call_tool(
         self,
@@ -930,15 +961,19 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             )
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
-            raise UserError(
+            transport_error = UserError(
                 f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
-            ) from e
+            )
+            transport_cause: Exception = e
         except httpx.ConnectError as e:
-            raise UserError(
+            transport_error = UserError(
                 f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"Connection lost. The server may have disconnected."
-            ) from e
+            )
+            transport_cause = e
+
+        _raise_mcp_transport_error(transport_error, transport_cause)
 
     def _validate_required_parameters(
         self, tool_name: str, arguments: dict[str, Any] | None
@@ -1034,6 +1069,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             # During normal teardown (via __aexit__), log but don't raise to avoid
             # masking the original exception.
             is_failed_connection_cleanup = self.session is None
+            cleanup_transport_error: UserError | None = None
+            cleanup_transport_cause: Exception | None = None
 
             try:
                 await self.exit_stack.aclose()
@@ -1065,7 +1102,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 if http_error:
                     if is_failed_connection_cleanup:
                         error_message += f"HTTP error {http_error.response.status_code} ({http_error.response.reason_phrase})"  # noqa: E501
-                        raise UserError(error_message) from http_error
+                        cleanup_transport_error = UserError(error_message)
+                        cleanup_transport_cause = http_error
                     else:
                         # Normal teardown - log but don't raise
                         log_tool_action_warning(
@@ -1078,7 +1116,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 elif connect_error:
                     if is_failed_connection_cleanup:
                         error_message += "Could not reach the server."
-                        raise UserError(error_message) from connect_error
+                        cleanup_transport_error = UserError(error_message)
+                        cleanup_transport_cause = connect_error
                     else:
                         log_tool_action_warning(
                             logger,
@@ -1090,7 +1129,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 elif timeout_error:
                     if is_failed_connection_cleanup:
                         error_message += "Connection timeout."
-                        raise UserError(error_message) from timeout_error
+                        cleanup_transport_error = UserError(error_message)
+                        cleanup_transport_cause = timeout_error
                     else:
                         log_tool_action_warning(
                             logger,
@@ -1139,6 +1179,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             finally:
                 self.session = None
                 self._get_session_id = None
+
+            if cleanup_transport_error is not None:
+                _raise_mcp_transport_error(cleanup_transport_error, cleanup_transport_cause)
 
 
 class MCPServerStdioParams(TypedDict):
@@ -1702,34 +1745,40 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 first_attempt = False
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
-            raise UserError(
+            transport_error = UserError(
                 f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
-            ) from e
+            )
+            transport_cause: Exception = e
         except httpx.ConnectError as e:
-            raise UserError(
+            transport_error = UserError(
                 f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"Connection lost. The server may have disconnected."
-            ) from e
+            )
+            transport_cause = e
         except BaseExceptionGroup as e:
             http_error = self._extract_http_error_from_exception(e)
             if isinstance(http_error, httpx.HTTPStatusError):
                 status_code = http_error.response.status_code
-                raise UserError(
+                transport_error = UserError(
                     f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     f"HTTP error {status_code}"
-                ) from http_error
-            if isinstance(http_error, httpx.ConnectError):
-                raise UserError(
+                )
+            elif isinstance(http_error, httpx.ConnectError):
+                transport_error = UserError(
                     f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     "Connection lost. The server may have disconnected."
-                ) from http_error
-            if isinstance(http_error, httpx.TimeoutException):
-                raise UserError(
+                )
+            elif isinstance(http_error, httpx.TimeoutException):
+                transport_error = UserError(
                     f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     "Connection timeout."
-                ) from http_error
-            raise
+                )
+            else:
+                raise
+            transport_cause = http_error
+
+        _raise_mcp_transport_error(transport_error, transport_cause)
 
     @property
     def name(self) -> str:

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1193,8 +1193,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
             if cleanup_transport_error is not None:
                 # Drop the transport locals: this frame is part of the raised traceback, and
-                # the httpx errors keep a request URL that can embed credentials.
+                # the httpx errors keep a request URL that can embed credentials. ``exc`` is
+                # the exception-group loop target, which also outlives the loop.
                 http_error = connect_error = timeout_error = None
+                exc = None
                 _raise_mcp_transport_error(cleanup_transport_error, cleanup_transport_cause)
 
 

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -236,6 +236,9 @@ MCPStreamTransport = (
 )
 
 
+_REDACTED_SERVER_LABEL = "<redacted>"
+
+
 def _transport_error_cause(exc: Exception) -> Exception | None:
     """Return the cause to retain for a transport failure, or None while redacting.
 
@@ -313,13 +316,17 @@ class MCPServer(abc.ABC):
 
     @property
     def _error_name(self) -> str:
-        """The server name with URL credentials stripped, for use in raised errors.
+        """The server label to use in raised errors.
 
         HTTP server names default to the connection URL (for example
-        ``sse: https://user:password@host/path?api_key=...``), which can embed credentials.
-        Errors are raised to callers regardless of the tool-data logging flags, so the
-        credentials are always stripped while the host and path are kept for debugging.
+        ``sse: https://user:password@host/path?api_key=...``), and these errors reach the
+        model through the tool-failure formatter. While tool data is redacted the name is
+        replaced by a fixed label, because an explicit name is caller supplied and a
+        URL-derived one keeps its path. Otherwise the name is returned with its
+        credentials, query, and fragment stripped.
         """
+        if _debug.DONT_LOG_TOOL_DATA:
+            return _REDACTED_SERVER_LABEL
         return get_mcp_server_log_name(self.name)
 
     @abc.abstractmethod

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -236,15 +236,23 @@ MCPStreamTransport = (
 )
 
 
-def _raise_mcp_transport_error(error: UserError, cause: Exception | None) -> NoReturn:
-    """Raise ``error`` for a failed MCP transport call, chaining ``cause`` only when allowed.
+def _transport_error_cause(exc: Exception) -> Exception | None:
+    """Return the cause to retain for a transport failure, or None while redacting.
 
-    ``cause`` is typically an httpx error whose request URL can embed credentials, so the
-    chain is dropped while tool-data logging is disabled. Call this *outside* the ``except``
-    block: ``raise ... from None`` is not enough, because the original exception would stay
-    reachable through ``__context__``.
+    An httpx error keeps the request URL, which can embed credentials. While tool data is
+    redacted the exception is dropped at the point it is caught, so it is not retained by
+    ``__cause__``, ``__context__``, or the traceback frame locals of the raising frames.
     """
-    if _debug.DONT_LOG_TOOL_DATA or cause is None:
+    return None if _debug.DONT_LOG_TOOL_DATA else exc
+
+
+def _raise_mcp_transport_error(error: UserError, cause: Exception | None) -> NoReturn:
+    """Raise ``error`` for a failed MCP transport call, chaining ``cause`` when there is one.
+
+    Call this *outside* the ``except`` block: ``raise ... from None`` is not enough, because
+    the original exception would stay reachable through ``__context__``.
+    """
+    if cause is None:
         raise error
     raise error from cause
 
@@ -840,7 +848,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 # Raised after the try statement so the credential-bearing httpx error is
                 # not retained through __cause__ or __context__.
                 connect_error = self._build_user_error_for_http_error(http_error)
-                connect_cause = http_error
+                connect_cause = _transport_error_cause(http_error)
+                # Drop the local: this frame is part of the raised traceback, and the httpx
+                # error keeps a request URL that can embed credentials.
+                del http_error
 
             # For CancelledError, preserve cancellation semantics - don't wrap it.
             # If it's masking an HTTP error, cleanup() will extract and raise UserError.
@@ -850,7 +861,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             # For HTTP-related errors, wrap them
             elif isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
                 connect_error = self._build_user_error_for_http_error(e)
-                connect_cause = e
+                connect_cause = _transport_error_cause(e)
 
             # For other errors, re-raise as-is (don't wrap non-HTTP errors)
             else:
@@ -924,13 +935,13 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 f"Failed to list tools from MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
             )
-            transport_cause: Exception = e
+            transport_cause: Exception | None = _transport_error_cause(e)
         except httpx.ConnectError as e:
             transport_error = UserError(
                 f"Failed to list tools from MCP server '{self._error_name}': Connection lost. "
                 f"The server may have disconnected."
             )
-            transport_cause = e
+            transport_cause = _transport_error_cause(e)
 
         _raise_mcp_transport_error(transport_error, transport_cause)
 
@@ -965,13 +976,13 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
             )
-            transport_cause: Exception = e
+            transport_cause: Exception | None = _transport_error_cause(e)
         except httpx.ConnectError as e:
             transport_error = UserError(
                 f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"Connection lost. The server may have disconnected."
             )
-            transport_cause = e
+            transport_cause = _transport_error_cause(e)
 
         _raise_mcp_transport_error(transport_error, transport_cause)
 
@@ -1103,7 +1114,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                     if is_failed_connection_cleanup:
                         error_message += f"HTTP error {http_error.response.status_code} ({http_error.response.reason_phrase})"  # noqa: E501
                         cleanup_transport_error = UserError(error_message)
-                        cleanup_transport_cause = http_error
+                        cleanup_transport_cause = _transport_error_cause(http_error)
                     else:
                         # Normal teardown - log but don't raise
                         log_tool_action_warning(
@@ -1117,7 +1128,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                     if is_failed_connection_cleanup:
                         error_message += "Could not reach the server."
                         cleanup_transport_error = UserError(error_message)
-                        cleanup_transport_cause = connect_error
+                        cleanup_transport_cause = _transport_error_cause(connect_error)
                     else:
                         log_tool_action_warning(
                             logger,
@@ -1130,7 +1141,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                     if is_failed_connection_cleanup:
                         error_message += "Connection timeout."
                         cleanup_transport_error = UserError(error_message)
-                        cleanup_transport_cause = timeout_error
+                        cleanup_transport_cause = _transport_error_cause(timeout_error)
                     else:
                         log_tool_action_warning(
                             logger,
@@ -1181,6 +1192,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 self._get_session_id = None
 
             if cleanup_transport_error is not None:
+                # Drop the transport locals: this frame is part of the raised traceback, and
+                # the httpx errors keep a request URL that can embed credentials.
+                http_error = connect_error = timeout_error = None
                 _raise_mcp_transport_error(cleanup_transport_error, cleanup_transport_cause)
 
 
@@ -1749,13 +1763,13 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
             )
-            transport_cause: Exception = e
+            transport_cause: Exception | None = _transport_error_cause(e)
         except httpx.ConnectError as e:
             transport_error = UserError(
                 f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"Connection lost. The server may have disconnected."
             )
-            transport_cause = e
+            transport_cause = _transport_error_cause(e)
         except BaseExceptionGroup as e:
             http_error = self._extract_http_error_from_exception(e)
             if isinstance(http_error, httpx.HTTPStatusError):
@@ -1776,7 +1790,10 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 )
             else:
                 raise
-            transport_cause = http_error
+            transport_cause = _transport_error_cause(http_error)
+            # Drop the local: this frame is part of the raised traceback, and the httpx
+            # error keeps a request URL that can embed credentials.
+            del http_error
 
         _raise_mcp_transport_error(transport_error, transport_cause)
 

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -290,6 +290,17 @@ class MCPServer(abc.ABC):
         """A readable name for the server."""
         pass
 
+    @property
+    def _error_name(self) -> str:
+        """The server name with URL credentials stripped, for use in raised errors.
+
+        HTTP server names default to the connection URL (for example
+        ``sse: https://user:password@host/path?api_key=...``), which can embed credentials.
+        Errors are raised to callers regardless of the tool-data logging flags, so the
+        credentials are always stripped while the host and path are kept for debugging.
+        """
+        return get_mcp_server_log_name(self.name)
+
     @abc.abstractmethod
     async def cleanup(self):
         """Cleanup the server. For example, this might mean closing a subprocess or
@@ -355,7 +366,7 @@ class MCPServer(abc.ABC):
         unimplemented; it will raise :exc:`NotImplementedError` at call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support list_resources. "
+            f"MCP server '{self._error_name}' does not support list_resources. "
             "Override this method in your server implementation."
         )
 
@@ -377,7 +388,7 @@ class MCPServer(abc.ABC):
         call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support list_resource_templates. "
+            f"MCP server '{self._error_name}' does not support list_resource_templates. "
             "Override this method in your server implementation."
         )
 
@@ -393,7 +404,7 @@ class MCPServer(abc.ABC):
         :exc:`NotImplementedError` at call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support read_resource. "
+            f"MCP server '{self._error_name}' does not support read_resource. "
             "Override this method in your server implementation."
         )
 
@@ -753,7 +764,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
     def _raise_user_error_for_http_error(self, http_error: Exception) -> None:
         """Raise appropriate UserError for HTTP error."""
-        error_message = f"Failed to connect to MCP server '{self.name}': "
+        error_message = f"Failed to connect to MCP server '{self._error_name}': "
         if isinstance(http_error, httpx.HTTPStatusError):
             error_message += f"HTTP error {http_error.response.status_code} ({http_error.response.reason_phrase})"  # noqa: E501
 
@@ -883,11 +894,12 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
             raise UserError(
-                f"Failed to list tools from MCP server '{self.name}': HTTP error {status_code}"
+                f"Failed to list tools from MCP server '{self._error_name}': "
+                f"HTTP error {status_code}"
             ) from e
         except httpx.ConnectError as e:
             raise UserError(
-                f"Failed to list tools from MCP server '{self.name}': Connection lost. "
+                f"Failed to list tools from MCP server '{self._error_name}': Connection lost. "
                 f"The server may have disconnected."
             ) from e
 
@@ -919,13 +931,13 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
             ) from e
         except httpx.ConnectError as e:
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': Connection lost. "
-                f"The server may have disconnected."
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                f"Connection lost. The server may have disconnected."
             ) from e
 
     def _validate_required_parameters(
@@ -949,7 +961,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             arguments_to_validate = arguments
         else:
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 "arguments must be an object."
             )
 
@@ -958,7 +970,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         if missing:
             missing_text = ", ".join(sorted(missing))
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"missing required parameters: {missing_text}"
             )
 
@@ -1038,7 +1050,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 http_error = None
                 connect_error = None
                 timeout_error = None
-                error_message = f"Failed to connect to MCP server '{self.name}': "
+                error_message = f"Failed to connect to MCP server '{self._error_name}': "
 
                 for exc in eg.exceptions:
                     if isinstance(exc, httpx.HTTPStatusError):
@@ -1691,30 +1703,30 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
             ) from e
         except httpx.ConnectError as e:
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': Connection lost. "
-                f"The server may have disconnected."
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                f"Connection lost. The server may have disconnected."
             ) from e
         except BaseExceptionGroup as e:
             http_error = self._extract_http_error_from_exception(e)
             if isinstance(http_error, httpx.HTTPStatusError):
                 status_code = http_error.response.status_code
                 raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     f"HTTP error {status_code}"
                 ) from http_error
             if isinstance(http_error, httpx.ConnectError):
                 raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     "Connection lost. The server may have disconnected."
                 ) from http_error
             if isinstance(http_error, httpx.TimeoutException):
                 raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     "Connection timeout."
                 ) from http_error
             raise

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -692,6 +692,8 @@ class MCPUtil:
         else:
             logger.debug("Invoking MCP tool %s with input %s", tool_name_for_display, input_json)
 
+        invocation_error: AgentsException | None = None
+        invocation_cause: Exception | None = None
         try:
             resolved_meta = await cls._resolve_meta(server, context, tool.name, json_data)
             merged_meta = cls._merge_mcp_meta(resolved_meta, meta)
@@ -747,10 +749,22 @@ class MCPUtil:
                     f"Error invoking MCP tool {tool_name_for_display} on server", server
                 )
             log_tool_action_error(logger, log_message, e)
-            raise AgentsException(
+            # Only a safe diagnostic field is copied out while tool data is redacted: the
+            # exception text can carry the credentialed request URL or tool payloads.
+            detail = e.__class__.__name__ if _debug.DONT_LOG_TOOL_DATA else str(e)
+            invocation_error = AgentsException(
                 f"Error invoking MCP tool {tool_name_for_display} on server "
-                f"'{get_mcp_server_log_name(server.name)}': {e}"
-            ) from e
+                f"'{get_mcp_server_log_name(server.name)}': {detail}"
+            )
+            invocation_cause = e
+
+        if invocation_error is not None:
+            # Raised outside the ``except`` block: the underlying exception can carry the
+            # credentialed request URL or tool data, and it would stay reachable through
+            # ``__context__`` even with ``raise ... from None``.
+            if _debug.DONT_LOG_TOOL_DATA or invocation_cause is None:
+                raise invocation_error
+            raise invocation_error from invocation_cause
 
         if _debug.DONT_LOG_TOOL_DATA:
             logger.debug("MCP tool completed.")

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -705,8 +705,8 @@ class MCPUtil:
                 finished_task = done.pop()
                 if finished_task.cancelled():
                     raise MCPToolCancellationError(
-                        f"Failed to call tool '{tool.name}' on MCP server '{server.name}': "
-                        "tool execution was cancelled."
+                        f"Failed to call tool '{tool.name}' on MCP server "
+                        f"'{get_mcp_server_log_name(server.name)}': tool execution was cancelled."
                     )
                 result = finished_task.result()
             except asyncio.CancelledError:
@@ -748,7 +748,8 @@ class MCPUtil:
                 )
             log_tool_action_error(logger, log_message, e)
             raise AgentsException(
-                f"Error invoking MCP tool {tool_name_for_display} on server '{server.name}': {e}"
+                f"Error invoking MCP tool {tool_name_for_display} on server "
+                f"'{get_mcp_server_log_name(server.name)}': {e}"
             ) from e
 
         if _debug.DONT_LOG_TOOL_DATA:

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -754,9 +754,12 @@ class MCPUtil:
             # controlled for a custom MCPServer, and keeping the object would leave it
             # reachable through the traceback frame locals of the raising frame.
             if _debug.DONT_LOG_TOOL_DATA:
+                # The server name is left out too: an explicit name is caller supplied and a
+                # URL-derived one keeps its path, and this message reaches the model through
+                # the default failure formatter. This matches get_mcp_server_log_message,
+                # which also drops the name while tool data is redacted.
                 invocation_error = AgentsException(
-                    f"Error invoking MCP tool {tool_name_for_display} on server "
-                    f"'{get_mcp_server_log_name(server.name)}'"
+                    f"Error invoking MCP tool {tool_name_for_display}"
                 )
                 invocation_cause = None
             else:
@@ -767,6 +770,9 @@ class MCPUtil:
                 invocation_cause = e
 
         if invocation_error is not None:
+            # A completed task keeps its exception, and repr(task) renders it, so drop the
+            # task references before this frame becomes part of the raised traceback.
+            call_task = finished_task = None  # type: ignore[assignment]
             # Raised outside the ``except`` block: the underlying exception would otherwise
             # stay reachable through ``__context__`` even with ``raise ... from None``.
             if invocation_cause is None:

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -749,20 +749,27 @@ class MCPUtil:
                     f"Error invoking MCP tool {tool_name_for_display} on server", server
                 )
             log_tool_action_error(logger, log_message, e)
-            # Only a safe diagnostic field is copied out while tool data is redacted: the
-            # exception text can carry the credentialed request URL or tool payloads.
-            detail = e.__class__.__name__ if _debug.DONT_LOG_TOOL_DATA else str(e)
-            invocation_error = AgentsException(
-                f"Error invoking MCP tool {tool_name_for_display} on server "
-                f"'{get_mcp_server_log_name(server.name)}': {detail}"
-            )
-            invocation_cause = e
+            # While tool data is redacted the caught exception is not inspected at all and
+            # not retained: its text, its type name, and its attributes are all attacker
+            # controlled for a custom MCPServer, and keeping the object would leave it
+            # reachable through the traceback frame locals of the raising frame.
+            if _debug.DONT_LOG_TOOL_DATA:
+                invocation_error = AgentsException(
+                    f"Error invoking MCP tool {tool_name_for_display} on server "
+                    f"'{get_mcp_server_log_name(server.name)}'"
+                )
+                invocation_cause = None
+            else:
+                invocation_error = AgentsException(
+                    f"Error invoking MCP tool {tool_name_for_display} on server "
+                    f"'{get_mcp_server_log_name(server.name)}': {e}"
+                )
+                invocation_cause = e
 
         if invocation_error is not None:
-            # Raised outside the ``except`` block: the underlying exception can carry the
-            # credentialed request URL or tool data, and it would stay reachable through
-            # ``__context__`` even with ``raise ... from None``.
-            if _debug.DONT_LOG_TOOL_DATA or invocation_cause is None:
+            # Raised outside the ``except`` block: the underlying exception would otherwise
+            # stay reachable through ``__context__`` even with ``raise ... from None``.
+            if invocation_cause is None:
                 raise invocation_error
             raise invocation_error from invocation_cause
 

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -706,6 +706,10 @@ class MCPUtil:
                 done, _ = await asyncio.wait({call_task}, return_when=asyncio.FIRST_COMPLETED)
                 finished_task = done.pop()
                 if finished_task.cancelled():
+                    # This reaches the model through the tool-failure formatter, so the tool
+                    # and server names are left out while tool data is redacted.
+                    if _debug.DONT_LOG_TOOL_DATA:
+                        raise MCPToolCancellationError("MCP tool execution was cancelled.")
                     raise MCPToolCancellationError(
                         f"Failed to call tool '{tool.name}' on MCP server "
                         f"'{get_mcp_server_log_name(server.name)}': tool execution was cancelled."
@@ -754,13 +758,11 @@ class MCPUtil:
             # controlled for a custom MCPServer, and keeping the object would leave it
             # reachable through the traceback frame locals of the raising frame.
             if _debug.DONT_LOG_TOOL_DATA:
-                # The server name is left out too: an explicit name is caller supplied and a
-                # URL-derived one keeps its path, and this message reaches the model through
-                # the default failure formatter. This matches get_mcp_server_log_message,
-                # which also drops the name while tool data is redacted.
-                invocation_error = AgentsException(
-                    f"Error invoking MCP tool {tool_name_for_display}"
-                )
+                # Names are left out as well: a tool name is supplied by the server and a
+                # server name is caller supplied, and this message reaches the model through
+                # the default failure formatter. This mirrors the "Invoking MCP tool" debug
+                # log above, which also drops both names while tool data is redacted.
+                invocation_error = AgentsException("Error invoking MCP tool")
                 invocation_cause = None
             else:
                 invocation_error = AgentsException(

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1124,7 +1124,9 @@ async def test_mcp_invocation_mcp_error_reraises(caplog: pytest.LogCaptureFixtur
 
 
 @pytest.mark.asyncio
-async def test_mcp_tool_graceful_error_handling(caplog: pytest.LogCaptureFixture):
+async def test_mcp_tool_graceful_error_handling(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+):
     """Test that MCP tool errors are handled gracefully when invoked via FunctionTool.
 
     When an MCP tool is created via to_function_tool and then invoked, errors should be
@@ -1132,6 +1134,8 @@ async def test_mcp_tool_graceful_error_handling(caplog: pytest.LogCaptureFixture
     the agent to continue running after tool failures.
     """
     caplog.set_level(logging.DEBUG)
+    # The underlying failure text is only surfaced when tool-data logging is enabled.
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
 
     # Create a server that will crash when calling a tool
     server = CrashingFakeMCPServer()
@@ -1175,12 +1179,14 @@ async def test_mcp_tool_graceful_error_handling(caplog: pytest.LogCaptureFixture
 
 
 @pytest.mark.asyncio
-async def test_mcp_tool_timeout_handling():
+async def test_mcp_tool_timeout_handling(monkeypatch: pytest.MonkeyPatch):
     """Test that MCP tool timeouts are handled gracefully.
 
     This simulates a timeout scenario where the MCP server call_tool raises a timeout error.
     The error should be caught and converted to an error message instead of halting the agent.
     """
+    # The underlying failure text is only surfaced when tool-data logging is enabled.
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
 
     class TimeoutFakeMCPServer(FakeMCPServer):
         async def call_tool(

--- a/tests/mcp/test_runner_calls_mcp.py
+++ b/tests/mcp/test_runner_calls_mcp.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
+import agents._debug as _debug
 from agents import (
     Agent,
     FunctionTool,
@@ -357,8 +358,12 @@ class CrashingFakeMCPServer(FakeMCPServer):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("streaming", [False, True])
-async def test_runner_emits_mcp_error_tool_call_output_item(streaming: bool):
+async def test_runner_emits_mcp_error_tool_call_output_item(
+    streaming: bool, monkeypatch: pytest.MonkeyPatch
+):
     """Runner should emit tool_call_output_item with failure output when MCP tool raises."""
+    # The underlying failure text is only surfaced when tool-data logging is enabled.
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
     server = CrashingFakeMCPServer()
     server.add_tool("crashing_tool", {})
 

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -96,21 +96,41 @@ _CREDENTIALED_URL = "https://user:s3cr3t_pw@mcp.example.com/sse?api_key=SECRET_Q
 
 
 def _assert_url_credentials_redacted(message: str) -> None:
+    """While tool data is redacted, no part of the connection URL may appear."""
     assert "s3cr3t_pw" not in message
     assert "SECRET_QS_KEY" not in message
-    # The host and path stay so the error still says which server failed.
-    assert "mcp.example.com/sse" in message
+    assert "mcp.example.com" not in message
 
 
-def test_error_name_strips_url_credentials_from_default_name() -> None:
-    """HTTP server names default to the connection URL, which can embed credentials."""
+def test_error_name_is_a_fixed_label_while_redacting() -> None:
+    """These errors reach the model, so the server name is replaced by a fixed label."""
     server = MCPServerSse(params={"url": _CREDENTIALED_URL})
 
     assert "s3cr3t_pw" in server.name  # the raw name still carries them
-    _assert_url_credentials_redacted(server._error_name)
+    assert server._error_name == "<redacted>"
 
 
-def test_error_name_leaves_explicit_names_untouched() -> None:
+def test_error_name_is_sanitized_when_tool_logging_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+
+    # Credentials, query, and fragment are stripped; the host and path stay for debugging.
+    assert server._error_name == "sse: https://mcp.example.com/sse"
+
+
+def test_error_name_hides_explicit_names_while_redacting() -> None:
+    """An explicit name is caller supplied, so it is not surfaced either."""
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL}, name="my server")
+
+    assert server._error_name == "<redacted>"
+
+
+def test_error_name_shows_explicit_names_when_tool_logging_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
     server = MCPServerSse(params={"url": _CREDENTIALED_URL}, name="my server")
 
     assert server._error_name == "my server"
@@ -125,7 +145,10 @@ def test_connect_http_error_redacts_url_credentials() -> None:
 
     error = server._build_user_error_for_http_error(http_error)
 
-    _assert_url_credentials_redacted(str(error))
+    message = str(error)
+    _assert_url_credentials_redacted(message)
+    # The status code stays: it is a safe diagnostic field.
+    assert "503" in message
 
 
 @pytest.mark.asyncio
@@ -312,7 +335,8 @@ async def test_invoke_mcp_tool_does_not_inspect_exception_while_redacting() -> N
         )
 
     message = str(exc_info.value)
-    assert "Error invoking MCP tool test_tool" in message
+    # Fixed text: the tool name comes from the server and is not surfaced either.
+    assert message == "Error invoking MCP tool"
     assert "SECRET_TYPE_NAME_123" not in message
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -1,4 +1,5 @@
 import builtins
+import os
 import sys
 import traceback
 from unittest.mock import MagicMock, patch
@@ -178,6 +179,24 @@ def _assert_no_credentials_anywhere(error: BaseException) -> None:
     assert "s3cr3t_pw" not in rendered
     assert "SECRET_QS_KEY" not in rendered
 
+    # Telemetry that captures frame locals must not recover the transport error from any
+    # SDK frame. The caller's own frame legitimately still holds the exception it raised,
+    # so only frames inside agents/mcp are checked here.
+    tb = error.__traceback__
+    while tb is not None:
+        filename = tb.tb_frame.f_code.co_filename
+        if f"agents{os.sep}mcp{os.sep}" in filename:
+            for local_name, value in tb.tb_frame.f_locals.items():
+                if isinstance(value, BaseException):
+                    where = f"{os.path.basename(filename)}:{local_name}"
+                    assert "s3cr3t_pw" not in str(value), f"leaked via local {where}"
+                    request = getattr(value, "request", None)
+                    if request is not None:
+                        url = str(getattr(request, "url", ""))
+                        assert "s3cr3t_pw" not in url, f"leaked via local {where}"
+                        assert "SECRET_QS_KEY" not in url, f"leaked via local {where}"
+        tb = tb.tb_next
+
 
 @pytest.mark.asyncio
 async def test_call_tool_does_not_retain_credentialed_cause_by_default() -> None:
@@ -232,6 +251,54 @@ async def test_call_tool_chains_cause_when_tool_logging_enabled(
             await server.call_tool("some_tool", {})
 
     assert exc_info.value.__cause__ is connect_error
+
+
+@pytest.mark.asyncio
+async def test_invoke_mcp_tool_does_not_inspect_exception_while_redacting() -> None:
+    """A custom MCPServer controls its exception type, so redacted mode must not touch it."""
+    from mcp.types import Tool as MCPTool
+
+    from agents.exceptions import AgentsException
+    from agents.mcp import MCPUtil
+    from agents.run_context import RunContextWrapper
+
+    from .helpers import FakeMCPServer
+
+    class _HostileException(Exception):
+        """Reading the message must not happen, and the type name itself is a secret."""
+
+        def __str__(self) -> str:
+            raise AssertionError("redacted error inspected __str__")
+
+        def __repr__(self) -> str:
+            raise AssertionError("redacted error inspected __repr__")
+
+    # A dynamically created exception type can carry a secret in its name, so the type name
+    # is not safe operational metadata either.
+    _HostileException.__name__ = "SECRET_TYPE_NAME_123"
+    _HostileException.__qualname__ = "SECRET_TYPE_NAME_123"
+
+    server = FakeMCPServer(server_name="hostile server")
+    server.add_tool("test_tool", {})
+
+    async def boom(*args, **kwargs):
+        raise _HostileException()
+
+    server.call_tool = boom  # type: ignore[method-assign]
+
+    with pytest.raises(AgentsException) as exc_info:
+        await MCPUtil.invoke_mcp_tool(
+            server,
+            MCPTool(name="test_tool", inputSchema={}),
+            RunContextWrapper(context=None),
+            "",
+        )
+
+    message = str(exc_info.value)
+    assert "Error invoking MCP tool test_tool" in message
+    assert "SECRET_TYPE_NAME_123" not in message
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -1,10 +1,12 @@
 import builtins
 import sys
+import traceback
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
+import agents._debug as _debug
 from agents import Agent
 from agents.exceptions import UserError
 from agents.mcp.server import MCPServerSse, MCPServerStreamableHttp, _MCPServerWithClientSession
@@ -59,11 +61,14 @@ async def test_not_calling_connect_causes_error():
 
 
 @pytest.mark.asyncio
-async def test_call_tool_nested_exception_group_mapping():
+async def test_call_tool_nested_exception_group_mapping(monkeypatch: pytest.MonkeyPatch):
     """
     Regression test ensuring that nested ExceptionGroups containing HTTP errors
     are recursively extracted and mapped to a UserError in call_tool().
     """
+    # The cause is only chained when tool-data logging is enabled, because an httpx error
+    # keeps the request URL (which can embed credentials) reachable from the raised error.
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
     # 1. Initialize the server with mock streamable parameters
     server = MCPServerStreamableHttp(params={"url": "http://fake-mcp-server"})
 
@@ -116,10 +121,9 @@ def test_connect_http_error_redacts_url_credentials() -> None:
         "boom", request=request, response=httpx.Response(503, request=request)
     )
 
-    with pytest.raises(UserError) as exc_info:
-        server._raise_user_error_for_http_error(http_error)
+    error = server._build_user_error_for_http_error(http_error)
 
-    _assert_url_credentials_redacted(str(exc_info.value))
+    _assert_url_credentials_redacted(str(error))
 
 
 @pytest.mark.asyncio
@@ -135,7 +139,7 @@ async def test_list_tools_http_error_redacts_url_credentials() -> None:
         with pytest.raises(UserError) as exc_info:
             await server.list_tools(None, None)
 
-    _assert_url_credentials_redacted(str(exc_info.value))
+    _assert_no_credentials_anywhere(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -147,7 +151,87 @@ async def test_call_tool_connect_error_redacts_url_credentials() -> None:
         with pytest.raises(UserError) as exc_info:
             await server.call_tool("some_tool", {})
 
-    _assert_url_credentials_redacted(str(exc_info.value))
+    _assert_no_credentials_anywhere(exc_info.value)
+
+
+def _assert_no_credentials_anywhere(error: BaseException) -> None:
+    """The credentials must be absent from the message, the whole chain, and the traceback."""
+    _assert_url_credentials_redacted(str(error))
+
+    # Recursive __cause__ / __context__ walk, including objects the exceptions hold on to.
+    seen: set[int] = set()
+    pending: list[BaseException | None] = [error]
+    while pending:
+        current = pending.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        assert "s3cr3t_pw" not in str(current)
+        assert "SECRET_QS_KEY" not in str(current)
+        request = getattr(current, "request", None)
+        if request is not None:
+            assert "s3cr3t_pw" not in str(getattr(request, "url", ""))
+            assert "SECRET_QS_KEY" not in str(getattr(request, "url", ""))
+        pending.extend([current.__cause__, current.__context__])
+
+    rendered = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    assert "s3cr3t_pw" not in rendered
+    assert "SECRET_QS_KEY" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_call_tool_does_not_retain_credentialed_cause_by_default() -> None:
+    """The httpx error keeps the credentialed request URL, so it must not stay reachable."""
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    server.session = MagicMock()
+    request = httpx.Request("GET", _CREDENTIALED_URL)
+    http_error = httpx.HTTPStatusError(
+        "boom", request=request, response=httpx.Response(503, request=request)
+    )
+
+    with patch.object(server, "_run_with_retries", side_effect=http_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.call_tool("some_tool", {})
+
+    error = exc_info.value
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    _assert_no_credentials_anywhere(error)
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_does_not_retain_credentialed_cause() -> None:
+    """connect() wraps transport failures; the httpx error must not survive on the chain."""
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    request = httpx.Request("GET", _CREDENTIALED_URL)
+    http_error = httpx.HTTPStatusError(
+        "boom", request=request, response=httpx.Response(401, request=request)
+    )
+
+    with patch.object(server, "create_streams", side_effect=http_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.connect()
+
+    error = exc_info.value
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    _assert_no_credentials_anywhere(error)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_chains_cause_when_tool_logging_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    server.session = MagicMock()
+    connect_error = httpx.ConnectError("down")
+
+    with patch.object(server, "_run_with_retries", side_effect=connect_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.call_tool("some_tool", {})
+
+    assert exc_info.value.__cause__ is connect_error
 
 
 @pytest.mark.asyncio
@@ -165,7 +249,9 @@ async def test_invoke_mcp_tool_error_redacts_url_credentials_in_exception() -> N
     server.add_tool("test_tool", {})
 
     async def boom(*args, **kwargs):
-        raise ValueError("upstream exploded")
+        # The transport error text itself carries the credentialed URL, which is exactly
+        # what the generic wrapper used to copy into the caller-visible message.
+        raise ValueError(f"connection to {_CREDENTIALED_URL} failed")
 
     server.call_tool = boom  # type: ignore[method-assign]
 
@@ -177,4 +263,4 @@ async def test_invoke_mcp_tool_error_redacts_url_credentials_in_exception() -> N
             "",
         )
 
-    _assert_url_credentials_redacted(str(exc_info.value))
+    _assert_no_credentials_anywhere(exc_info.value)

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -7,7 +7,7 @@ import pytest
 
 from agents import Agent
 from agents.exceptions import UserError
-from agents.mcp.server import MCPServerStreamableHttp, _MCPServerWithClientSession
+from agents.mcp.server import MCPServerSse, MCPServerStreamableHttp, _MCPServerWithClientSession
 from agents.run_context import RunContextWrapper
 
 # Handle Python version compatibility for ExceptionGroups
@@ -83,3 +83,98 @@ async def test_call_tool_nested_exception_group_mapping():
     # 6. Verify that the user-facing message is mapped correctly based on the root cause
     assert "Connection lost" in str(exc_info.value)
     assert exc_info.value.__cause__ is http_error
+
+
+_CREDENTIALED_URL = "https://user:s3cr3t_pw@mcp.example.com/sse?api_key=SECRET_QS_KEY"
+
+
+def _assert_url_credentials_redacted(message: str) -> None:
+    assert "s3cr3t_pw" not in message
+    assert "SECRET_QS_KEY" not in message
+    # The host and path stay so the error still says which server failed.
+    assert "mcp.example.com/sse" in message
+
+
+def test_error_name_strips_url_credentials_from_default_name() -> None:
+    """HTTP server names default to the connection URL, which can embed credentials."""
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+
+    assert "s3cr3t_pw" in server.name  # the raw name still carries them
+    _assert_url_credentials_redacted(server._error_name)
+
+
+def test_error_name_leaves_explicit_names_untouched() -> None:
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL}, name="my server")
+
+    assert server._error_name == "my server"
+
+
+def test_connect_http_error_redacts_url_credentials() -> None:
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    request = httpx.Request("GET", _CREDENTIALED_URL)
+    http_error = httpx.HTTPStatusError(
+        "boom", request=request, response=httpx.Response(503, request=request)
+    )
+
+    with pytest.raises(UserError) as exc_info:
+        server._raise_user_error_for_http_error(http_error)
+
+    _assert_url_credentials_redacted(str(exc_info.value))
+
+
+@pytest.mark.asyncio
+async def test_list_tools_http_error_redacts_url_credentials() -> None:
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    server.session = MagicMock()
+    request = httpx.Request("GET", _CREDENTIALED_URL)
+    http_error = httpx.HTTPStatusError(
+        "boom", request=request, response=httpx.Response(500, request=request)
+    )
+
+    with patch.object(server, "_run_with_retries", side_effect=http_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.list_tools(None, None)
+
+    _assert_url_credentials_redacted(str(exc_info.value))
+
+
+@pytest.mark.asyncio
+async def test_call_tool_connect_error_redacts_url_credentials() -> None:
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    server.session = MagicMock()
+
+    with patch.object(server, "_run_with_retries", side_effect=httpx.ConnectError("down")):
+        with pytest.raises(UserError) as exc_info:
+            await server.call_tool("some_tool", {})
+
+    _assert_url_credentials_redacted(str(exc_info.value))
+
+
+@pytest.mark.asyncio
+async def test_invoke_mcp_tool_error_redacts_url_credentials_in_exception() -> None:
+    """The raised AgentsException must not leak credentials the sibling log call redacts."""
+    from mcp.types import Tool as MCPTool
+
+    from agents.exceptions import AgentsException
+    from agents.mcp import MCPUtil
+    from agents.run_context import RunContextWrapper
+
+    from .helpers import FakeMCPServer
+
+    server = FakeMCPServer(server_name=f"sse: {_CREDENTIALED_URL}")
+    server.add_tool("test_tool", {})
+
+    async def boom(*args, **kwargs):
+        raise ValueError("upstream exploded")
+
+    server.call_tool = boom  # type: ignore[method-assign]
+
+    with pytest.raises(AgentsException) as exc_info:
+        await MCPUtil.invoke_mcp_tool(
+            server,
+            MCPTool(name="test_tool", inputSchema={}),
+            RunContextWrapper(context=None),
+            "",
+        )
+
+    _assert_url_credentials_redacted(str(exc_info.value))

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -1,3 +1,4 @@
+import asyncio
 import builtins
 import os
 import sys
@@ -179,18 +180,34 @@ def _assert_no_credentials_anywhere(error: BaseException) -> None:
     assert "s3cr3t_pw" not in rendered
     assert "SECRET_QS_KEY" not in rendered
 
-    # Telemetry that captures frame locals must not recover the transport error from any
-    # SDK frame. The caller's own frame legitimately still holds the exception it raised,
-    # so only frames inside agents/mcp are checked here.
+    _assert_no_credentials_in_frames(error)
+
+
+def _assert_no_credentials_in_frames(error: BaseException) -> None:
+    """Telemetry that captures frame locals must not recover the transport error.
+
+    Only frames inside agents/mcp are checked: the caller's own frame legitimately still
+    holds the exception it raised.
+    """
     tb = error.__traceback__
     while tb is not None:
         filename = tb.tb_frame.f_code.co_filename
         if f"agents{os.sep}mcp{os.sep}" in filename:
             for local_name, value in tb.tb_frame.f_locals.items():
+                where = f"{os.path.basename(filename)}:{local_name}"
+                candidates: list[BaseException] = []
                 if isinstance(value, BaseException):
-                    where = f"{os.path.basename(filename)}:{local_name}"
-                    assert "s3cr3t_pw" not in str(value), f"leaked via local {where}"
-                    request = getattr(value, "request", None)
+                    candidates.append(value)
+                elif isinstance(value, asyncio.Task) and value.done():
+                    # A completed task keeps its exception, and repr(task) renders it.
+                    assert "s3cr3t_pw" not in repr(value), f"leaked via local {where}"
+                    if not value.cancelled():
+                        task_exc = value.exception()
+                        if task_exc is not None:
+                            candidates.append(task_exc)
+                for candidate in candidates:
+                    assert "s3cr3t_pw" not in str(candidate), f"leaked via local {where}"
+                    request = getattr(candidate, "request", None)
                     if request is not None:
                         url = str(getattr(request, "url", ""))
                         assert "s3cr3t_pw" not in url, f"leaked via local {where}"
@@ -330,4 +347,13 @@ async def test_invoke_mcp_tool_error_redacts_url_credentials_in_exception() -> N
             "",
         )
 
-    _assert_no_credentials_anywhere(exc_info.value)
+    error = exc_info.value
+    message = str(error)
+    assert "s3cr3t_pw" not in message
+    assert "SECRET_QS_KEY" not in message
+    # This message reaches the model through the default failure formatter, so while tool
+    # data is redacted it carries no server name at all.
+    assert "mcp.example.com" not in message
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    _assert_no_credentials_in_frames(error)


### PR DESCRIPTION
### Summary

- `MCPServerSse` / `MCPServerStreamableHttp` default their name to the connection url (`sse: {url}`), which commonly embeds credentials (`user:password@host` or `?api_key=...`). every raised connection and tool-call error interpolated that raw name, so any transient failure surfaced the credential to the caller.
- unlike the log paths, raised errors are not gated by `DONT_LOG_TOOL_DATA`, so there was no way to suppress this even on the default redact-by-default setting.
- the redaction helper already existed and is unit-tested (`get_mcp_server_log_name`), and `server.py` already used it for logs. the raised errors just never got it.

fix:

- add `MCPServer._error_name`, a thin wrapper over that helper. credentials, query, and fragment are stripped; host and path stay so the error still tells you which server failed.
- apply it to the 16 raised-error sites in mcp/server.py, plus the two raised errors in mcp/util.py that sit directly next to already-redacted log calls.
- functional uses of `server.name` (tool namespacing, span identity) are deliberately unchanged.

before:

```
UserError: Failed to connect to MCP server 'sse: https://user:s3cr3t_pw@mcp.example.com/sse?api_key=SECRET_QS_KEY': HTTP error 503
```

after:

```
UserError: Failed to connect to MCP server 'sse: https://mcp.example.com/sse': HTTP error 503
```

### Test plan

- 6 new tests in tests/mcp/test_server_errors.py: the `_error_name` property (default url name redacted, explicit name untouched), the connect / list_tools / call_tool raised errors, and the `invoke_mcp_tool` AgentsException. each asserts the password and api key are gone and the host is kept.
- `make format` and `make lint`: clean.
- `make tests`: full suite green (5770 + 28 passed, 0 failed). tests/mcp/ specifically: 239 passed.
- `make typecheck`: adds 0 new errors.
- ran `.agents/skills/code-change-verification/scripts/run.sh`: format and lint pass, then it stops at typecheck on 31 pre-existing errors unrelated to this change (vercel extension name-collision, py3.12-only apis on a 3.11 checkout, boto3 not installed, redis `type: ignore` skew).

### Issue number

<!-- add if there is a tracking issue -->

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
