### PR TITLE
fix(memory): count valid SQLite session items for positive limits

### DIFF
--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -127,6 +127,16 @@ class AsyncSQLiteSession(SessionABC):
 
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        def _decode_rows(rows: list[Any]) -> list[TResponseInputItem]:
+            items: list[TResponseInputItem] = []
+            for (message_data,) in rows:
+                try:
+                    item = json.loads(message_data)
+                    items.append(item)
+                except json.JSONDecodeError:
+                    continue
+            return items
+
         async with self._locked_connection() as conn:
             if session_limit is None:
                 cursor = await conn.execute(
@@ -137,32 +147,47 @@ class AsyncSQLiteSession(SessionABC):
                 """,
                     (self.session_id,),
                 )
-            else:
-                cursor = await conn.execute(
-                    f"""
-                    SELECT message_data FROM {self.messages_table}
-                    WHERE session_id = ?
-                    ORDER BY id DESC
-                    LIMIT ?
-                    """,
-                    (self.session_id, session_limit),
-                )
+                rows = list(await cursor.fetchall())
+                await cursor.close()
+                return _decode_rows(rows)
 
+            if session_limit > 0:
+                # Expand the fetch window when corrupt rows sit among the newest entries so
+                # limit counts valid conversation items, matching EncryptedSession and pop_item.
+                window = session_limit
+                while True:
+                    cursor = await conn.execute(
+                        f"""
+                        SELECT message_data FROM {self.messages_table}
+                        WHERE session_id = ?
+                        ORDER BY id DESC
+                        LIMIT ?
+                        """,
+                        (self.session_id, window),
+                    )
+                    rows = list(await cursor.fetchall())
+                    await cursor.close()
+                    items = _decode_rows(rows[::-1])
+                    if len(items) >= session_limit:
+                        return items[-session_limit:]
+                    if len(rows) < window:
+                        return items
+                    window *= 2
+
+            # Preserve historical non-positive LIMIT semantics (including SQLite's
+            # unlimited behavior for negative values).
+            cursor = await conn.execute(
+                f"""
+                SELECT message_data FROM {self.messages_table}
+                WHERE session_id = ?
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (self.session_id, session_limit),
+            )
             rows = list(await cursor.fetchall())
             await cursor.close()
-
-        if session_limit is not None:
-            rows = rows[::-1]
-
-        items: list[TResponseInputItem] = []
-        for (message_data,) in rows:
-            try:
-                item = json.loads(message_data)
-                items.append(item)
-            except json.JSONDecodeError:
-                continue
-
-        return items
+            return _decode_rows(rows[::-1])
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
         """Add new items to the conversation history.

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -215,6 +215,17 @@ class SQLiteSession(SessionABC):
         """
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        def _decode_rows(rows: list[Any]) -> list[TResponseInputItem]:
+            items: list[TResponseInputItem] = []
+            for (message_data,) in rows:
+                try:
+                    item = json.loads(message_data)
+                    items.append(item)
+                except (json.JSONDecodeError, TypeError):
+                    # Skip invalid JSON entries
+                    continue
+            return items
+
         def _get_items_sync():
             with self._locked_connection() as conn:
                 if session_limit is None:
@@ -227,34 +238,42 @@ class SQLiteSession(SessionABC):
                     """,
                         (self.session_id,),
                     )
-                else:
-                    # Fetch the latest N items in chronological order
-                    cursor = conn.execute(
-                        f"""
-                        SELECT message_data FROM {self.messages_table}
-                        WHERE session_id = ?
-                        ORDER BY id DESC
-                        LIMIT ?
-                        """,
-                        (self.session_id, session_limit),
-                    )
+                    return _decode_rows(cursor.fetchall())
 
-                rows = cursor.fetchall()
+                if session_limit > 0:
+                    # Expand the fetch window when corrupt rows sit among the newest entries so
+                    # limit counts valid conversation items, matching EncryptedSession and pop_item.
+                    window = session_limit
+                    while True:
+                        cursor = conn.execute(
+                            f"""
+                            SELECT message_data FROM {self.messages_table}
+                            WHERE session_id = ?
+                            ORDER BY id DESC
+                            LIMIT ?
+                            """,
+                            (self.session_id, window),
+                        )
+                        rows = cursor.fetchall()
+                        items = _decode_rows(list(reversed(rows)))
+                        if len(items) >= session_limit:
+                            return items[-session_limit:]
+                        if len(rows) < window:
+                            return items
+                        window *= 2
 
-                # Reverse to get chronological order when using DESC
-                if session_limit is not None:
-                    rows = list(reversed(rows))
-
-                items = []
-                for (message_data,) in rows:
-                    try:
-                        item = json.loads(message_data)
-                        items.append(item)
-                    except (json.JSONDecodeError, TypeError):
-                        # Skip invalid JSON entries
-                        continue
-
-                return items
+                # Preserve historical non-positive LIMIT semantics (including SQLite's
+                # unlimited behavior for negative values).
+                cursor = conn.execute(
+                    f"""
+                    SELECT message_data FROM {self.messages_table}
+                    WHERE session_id = ?
+                    ORDER BY id DESC
+                    LIMIT ?
+                    """,
+                    (self.session_id, session_limit),
+                )
+                return _decode_rows(list(reversed(cursor.fetchall())))
 
         return await asyncio.to_thread(_get_items_sync)
 

--- a/tests/extensions/memory/test_async_sqlite_session.py
+++ b/tests/extensions/memory/test_async_sqlite_session.py
@@ -141,6 +141,33 @@ async def test_async_sqlite_session_get_items_limit():
         await session.close()
 
 
+async def test_async_sqlite_session_get_items_limit_skips_corrupt_newest_rows():
+    """limit counts valid items, expanding past corrupt newest rows."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "async_limit_corrupt.db"
+        session = AsyncSQLiteSession("async_limit_corrupt", db_path)
+
+        await session.add_items(
+            [
+                {"role": "user", "content": "valid 0"},
+                {"role": "assistant", "content": "valid 1"},
+                {"role": "user", "content": "valid 2"},
+            ]
+        )
+
+        conn = await session._get_connection()
+        await conn.execute(
+            f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
+            (session.session_id, "not valid json {{{"),
+        )
+        await conn.commit()
+
+        limited = await session.get_items(limit=2)
+        assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+
+        await session.close()
+
+
 async def test_async_sqlite_session_session_settings_default():
     """Test that session_settings defaults to empty SessionSettings."""
     session = AsyncSQLiteSession("async_default_settings")

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -430,6 +430,67 @@ async def test_sqlite_session_get_items_with_limit():
         session.close()
 
 
+@pytest.mark.asyncio
+async def test_sqlite_session_get_items_limit_skips_corrupt_newest_rows():
+    """limit counts valid items, expanding past corrupt newest rows."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_limit_corrupt.db"
+        session = SQLiteSession("limit_corrupt", db_path)
+
+        await session.add_items(
+            [
+                {"role": "user", "content": "valid 0"},
+                {"role": "assistant", "content": "valid 1"},
+                {"role": "user", "content": "valid 2"},
+            ]
+        )
+
+        with session._locked_connection() as conn:
+            conn.execute(
+                f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
+                (session.session_id, "not valid json {{{"),
+            )
+            conn.commit()
+
+        # Newest row is corrupt; limit=2 should still return the two latest valid items.
+        limited = await session.get_items(limit=2)
+        assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+
+        session.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_session_get_items_session_settings_limit_skips_corrupt_rows():
+    """session_settings.limit also counts valid items when newest rows are corrupt."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_settings_limit_corrupt.db"
+        session = SQLiteSession(
+            "settings_limit_corrupt",
+            db_path,
+            session_settings=SessionSettings(limit=2),
+        )
+
+        await session.add_items(
+            [
+                {"role": "user", "content": "valid 0"},
+                {"role": "assistant", "content": "valid 1"},
+                {"role": "user", "content": "valid 2"},
+            ]
+        )
+
+        with session._locked_connection() as conn:
+            conn.execute(
+                f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
+                (session.session_id, "not valid json {{{"),
+            )
+            conn.commit()
+
+        limited = await session.get_items()
+        assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+
+        session.close()
+
+
 @pytest.mark.parametrize("runner_method", ["run", "run_sync", "run_streamed"])
 @pytest.mark.asyncio
 async def test_session_memory_appends_list_input_by_default(runner_method):


### PR DESCRIPTION
### Summary

This pull request fixes `SQLiteSession.get_items(limit=N)` and `AsyncSQLiteSession.get_items(limit=N)` so positive limits count **valid** conversation items rather than raw SQLite rows.

**Affected component:** `src/agents/memory/sqlite_session.py`, `src/agents/extensions/memory/async_sqlite_session.py`

**Problem:** Both backends fetch `LIMIT N` newest rows and then skip corrupt/unparseable `message_data`. When corrupt rows sit among the newest entries, callers receive fewer than N valid items even though earlier valid history exists. The same backends’ `pop_item()` already skips corrupt newest rows and keeps looking, and `EncryptedSession` already expands its fetch window so limits count valid decrypted items (#3175).

**Minimal reproduction (no API key):**

```python
await session.add_items([
    {"role": "user", "content": "valid 0"},
    {"role": "assistant", "content": "valid 1"},
    {"role": "user", "content": "valid 2"},
])
# insert corrupt newest message_data = "not valid json {{{"
assert [i["content"] for i in await session.get_items(limit=2)] == ["valid 1", "valid 2"]
# before: ["valid 2"]
```

**Corrected behavior:** For positive limits (explicit or via `SessionSettings.limit`), expand the SQL fetch window until enough valid items are decoded or history is exhausted, then return the latest N valid items in chronological order.

**Root cause:** Limit was applied to raw rows before JSON decoding.

**Implementation:** Mirror the EncryptedSession window-expansion pattern inside the two SQLite backends. Non-positive `LIMIT` semantics are intentionally unchanged (including SQLite’s historical unlimited behavior for negative values).

**Why minimal:** Only the positive-limit path changes; clean-data limit behavior, `limit=None`, and non-positive limits are preserved. No public API changes.

**Regression tests:**
- corrupt newest row + explicit `limit=2`
- corrupt newest row + `SessionSettings(limit=2)`
- AsyncSQLite equivalent
- existing clean-data limit tests remain green

**Non-goals:** SQLAlchemy/Mongo/Redis/AdvancedSQLite backends; negative-limit policy changes; EncryptedSession (already fixed).

### Test plan

- [x] Pre-fix repro failed with `assert ['valid 2'] == ['valid 1', 'valid 2']` on `upstream/main` (`bb3d64e7`)
- [x] `uv run pytest tests/memory/test_session.py::test_sqlite_session_get_items_limit_skips_corrupt_newest_rows tests/memory/test_session.py::test_sqlite_session_get_items_session_settings_limit_skips_corrupt_rows tests/memory/test_session.py::test_sqlite_session_get_items_with_limit tests/extensions/memory/test_async_sqlite_session.py::test_async_sqlite_session_get_items_limit_skips_corrupt_newest_rows tests/extensions/memory/test_async_sqlite_session.py::test_async_sqlite_session_get_items_limit -q` → 5 passed
- [x] Focused corrupt-limit tests repeated 3× → passed
- [x] `uv run pytest tests/memory/test_session.py tests/extensions/memory/test_async_sqlite_session.py tests/extensions/memory/test_encrypt_session.py -q` → 78 passed
- [x] `bash .agents/skills/code-change-verification/scripts/run.sh` → format, lint, typecheck, and tests all passed
- [x] `git diff --check` → clean
- [x] No OpenAI API key or live model calls used

### Issue number

N/A — small correctness fix submitted directly per common repository practice. Analogous prior fix: #3175 / #3174 (EncryptedSession).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
