### PR TITLE
fix(run): count streamed retries when terminal usage is missing

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1603,13 +1603,17 @@ async def run_single_turn_streamed(
                 # the terminal response output empty. Preserve those items so the runner can
                 # resolve the completed step correctly.
                 terminal_response.output = list(streamed_response_output)
-            usage = (
-                apply_retry_attempt_usage(
-                    _response_usage_to_usage(terminal_response.usage),
-                    stream_failed_retry_attempts[0],
-                )
-                if terminal_response.usage
-                else Usage()
+            # Always fold retry attempts into usage, even when the terminal response omits
+            # provider usage (common for some Chat Completions / LiteLLM streams). Skipping
+            # apply_retry_attempt_usage here would drop failed-attempt accounting and diverge
+            # from the non-streaming get_response_with_retry path.
+            usage = apply_retry_attempt_usage(
+                (
+                    _response_usage_to_usage(terminal_response.usage)
+                    if terminal_response.usage
+                    else Usage()
+                ),
+                stream_failed_retry_attempts[0],
             )
             final_response = ModelResponse(
                 output=terminal_response.output,

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import AsyncIterator
 from typing import Any, cast
 
 import httpx
@@ -40,12 +41,20 @@ from agents import (
     handoff,
     retry_policies,
 )
-from agents.items import RunItem, ToolApprovalItem, TResponseInputItem
+from agents.items import (
+    ModelResponse,
+    RunItem,
+    ToolApprovalItem,
+    TResponseInputItem,
+    TResponseStreamEvent,
+)
 from agents.memory.openai_conversations_session import OpenAIConversationsSession
+from agents.models.interface import Model, ModelTracing
 from agents.run import RunConfig
 from agents.run_internal import run_loop
 from agents.run_internal.run_loop import QueueCompleteSentinel
 from agents.stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent, StreamEvent
+from agents.tool import Tool
 from agents.usage import Usage
 
 from .fake_model import FakeModel, get_response_obj
@@ -383,6 +392,100 @@ async def test_streamed_run_preserves_request_usage_entries_after_retry() -> Non
     assert usage.request_usage_entries[1].input_tokens == 10
     assert usage.request_usage_entries[1].output_tokens == 5
     assert usage.request_usage_entries[1].total_tokens == 15
+
+
+class _RetryThenMissingUsageModel(Model):
+    """Stream a successful retry whose terminal Response omits usage data."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: Any,
+        handoffs: list[Handoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: Any | None,
+    ) -> ModelResponse:
+        self.calls += 1
+        if self.calls == 1:
+            raise APIConnectionError(
+                message="connection error",
+                request=httpx.Request("POST", "https://example.com"),
+            )
+        return ModelResponse(
+            output=[get_text_message("done")],
+            usage=Usage(requests=1),
+            response_id="resp-missing-usage",
+        )
+
+    async def stream_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: Any,
+        handoffs: list[Handoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: Any | None,
+    ) -> AsyncIterator[TResponseStreamEvent]:
+        self.calls += 1
+        if self.calls == 1:
+            raise APIConnectionError(
+                message="connection error",
+                request=httpx.Request("POST", "https://example.com"),
+            )
+        response = get_response_obj([get_text_message("done")])
+        response.usage = None
+        yield ResponseCompletedEvent(
+            type="response.completed",
+            response=response,
+            sequence_number=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_counts_retry_attempts_when_terminal_usage_missing() -> None:
+    """Retry accounting must survive successful streams that omit Response.usage.
+
+    Non-OpenAI chat-completions adapters (e.g. LiteLLM) can complete a stream without a usage
+    chunk, leaving ``Response.usage`` as ``None``. Failed retry attempts must still be counted,
+    matching the non-streaming ``apply_retry_attempt_usage`` path.
+    """
+
+    model = _RetryThenMissingUsageModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        model_settings=ModelSettings(
+            retry=ModelRetrySettings(
+                max_retries=1,
+                policy=retry_policies.network_error(),
+            )
+        ),
+    )
+
+    result = Runner.run_streamed(agent, input="test")
+    async for _ in result.stream_events():
+        pass
+
+    usage = result.context_wrapper.usage
+    assert model.calls == 2
+    assert usage.requests == 2
+    assert len(usage.request_usage_entries) == 2
+    assert usage.request_usage_entries[0].total_tokens == 0
+    assert usage.request_usage_entries[1].total_tokens == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request fixes streamed model-retry usage accounting when the successful terminal `Response` omits provider usage data.

When `Runner.run_streamed` retries a failed model stream and the eventual `response.completed` event has `Response.usage = None` (common for some Chat Completions / LiteLLM adapters that never emit a usage chunk), the run loop previously skipped `apply_retry_attempt_usage` and replaced usage with an empty `Usage()`. That dropped failed-attempt request counts and zeroed `request_usage_entries`, even though the requests happened. Non-streaming `get_response_with_retry` already always folds retry attempts into usage, so streamed and non-streamed accounting diverged.

The fix always routes through `apply_retry_attempt_usage`, using `Usage()` as the base when terminal provider usage is missing.

**Affected component:** `src/agents/run_internal/run_loop.py` (`run_single_turn_streamed`)

**Root cause:** `if terminal_response.usage` treated missing usage as “no retry accounting needed,” instead of “zero token usage, still count requests.”

**Non-goals:** changing token totals when usage is present; changing retry policy behavior; FakeModel defaults; non-streaming paths (already correct).

### Test plan

- [x] Added `test_streamed_run_counts_retry_attempts_when_terminal_usage_missing` (custom model: first stream raises `APIConnectionError`, second completes with `usage=None`)
- [x] Pre-fix failure: `usage.requests == 0` (expected `2`)
- [x] Post-fix: focused test passes (also repeated 3×)
- [x] Related tests: `test_streamed_run_preserves_request_usage_entries_after_retry`, `test_streamed_run_preserves_request_usage_entries_after_conversation_locked_retry`
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh` (`make format`, `make lint`, `make typecheck`, `make tests`) — all passed
- [x] `git diff --check` — clean
- [x] No OpenAI API key or live provider calls used

### Issue number

N/A — small focused correctness fix submitted directly as a PR.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
