### PR TITLE
docs: add Pisama to the external tracing processors list

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -231,3 +231,4 @@ The following community and vendor integrations support the OpenAI Agents SDK tr
 -   [Datadog](https://docs.datadoghq.com/llm_observability/instrumentation/auto_instrumentation/?tab=python#openai-agents)
 -   [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
 -   [DProvenanceKit](https://dprovenance.dev/openai-agents/)
+-   [Pisama](https://docs.pisama.ai/guides/integrations/openai-agents-sdk/)


### PR DESCRIPTION
### Summary

Adds Pisama to the external tracing processors list in `docs/tracing.md`.

[Pisama](https://pisama.ai) is a failure-detection layer for agent systems. It consumes the Agents SDK's exported tracing payload through a `TracingProcessor` and runs structural detectors over the resulting trace, with handoff transitions mapped as first-class edges so coordination failures across a handoff boundary stay visible.

Integration guide: https://docs.pisama.ai/guides/integrations/openai-agents-sdk/

The adapter reads the exported dicts rather than importing `openai-agents`, so it adds no dependency to user projects and is not pinned to an SDK version. It is registered with `add_trace_processor`, so the OpenAI tracing backend keeps receiving the same spans.

Docs-only change: one line appended to the list, matching the existing `-   [Name](url)` formatting.

### Test plan

Not applicable to a docs-only list entry, but the integration behind it was verified before submitting:

- `pip install pisama-core==1.9.0` from PyPI into a clean venv, then ran the exact snippet from the linked guide against `openai-agents` 0.19.0. A `trace()` containing `agent_span` and `handoff_span` was captured and parsed, with the handoff edge preserved.
- The adapter ships with 29 tests whose fixture is real SDK output, captured by driving the SDK's own span context managers through a capturing `TracingProcessor` (verbatim `TraceImpl.export()` / `SpanImpl.export()` payloads). No model call is needed to run them.
- The linked docs page is live and serves real content.

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

Docs-only change touching no code paths, so the verification-script and test checkboxes are left unchecked rather than claimed.