### PR TITLE
fix(run): cancel streamed models when input guardrails fail

### DIFF
--- a/src/agents/run_internal/guardrails.py
+++ b/src/agents/run_internal/guardrails.py
@@ -16,6 +16,7 @@ from ..result import RunResultStreaming
 from ..run_context import RunContextWrapper, TContext
 from ..tracing import Span, SpanError, guardrail_span
 from ..util import _error_tracing
+from .run_steps import QueueCompleteSentinel
 
 __all__ = [
     "run_single_input_guardrail",
@@ -95,11 +96,18 @@ async def run_input_guardrails_with_queue(
                     _error_tracing.attach_error_to_current_span(span_error)
                 break
             queue.put_nowait(result)
-    except BaseException:
+    except BaseException as error:
         for t in guardrail_tasks:
             if not t.done():
                 t.cancel()
         await asyncio.gather(*guardrail_tasks, return_exceptions=True)
+        if (
+            isinstance(error, Exception)
+            and asyncio.current_task() is streamed_result._input_guardrails_task
+        ):
+            if streamed_result.run_loop_task and not streamed_result.run_loop_task.done():
+                streamed_result.run_loop_task.cancel()
+            streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
         raise
 
     streamed_result.input_guardrail_results = (

--- a/src/agents/run_internal/guardrails.py
+++ b/src/agents/run_internal/guardrails.py
@@ -104,6 +104,7 @@ async def run_input_guardrails_with_queue(
         if (
             isinstance(error, Exception)
             and asyncio.current_task() is streamed_result._input_guardrails_task
+            and not streamed_result.is_complete
         ):
             if streamed_result.run_loop_task and not streamed_result.run_loop_task.done():
                 streamed_result.run_loop_task.cancel()

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -726,6 +726,52 @@ async def test_parallel_guardrail_non_tripwire_error_not_swallowed():
 
 
 @pytest.mark.asyncio
+async def test_parallel_guardrail_error_cancels_streaming_model():
+    model_started = asyncio.Event()
+    model_cancelled = asyncio.Event()
+    model_finished = asyncio.Event()
+
+    @input_guardrail(run_in_parallel=True)
+    async def raising_parallel_check(
+        ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        await asyncio.wait_for(model_started.wait(), timeout=1)
+        raise ValueError("guardrail boom")
+
+    model = FakeModel()
+
+    async def blocking_stream_response(*args, **kwargs):
+        model_started.set()
+        try:
+            await asyncio.Event().wait()
+            yield
+        except asyncio.CancelledError:
+            model_cancelled.set()
+            raise
+        finally:
+            model_finished.set()
+
+    agent = Agent(
+        name="streaming_guardrail_error_agent",
+        input_guardrails=[raising_parallel_check],
+        model=model,
+    )
+
+    async def consume_stream() -> None:
+        async for _event in result.stream_events():
+            pass
+
+    with patch.object(model, "stream_response", side_effect=blocking_stream_response):
+        result = Runner.run_streamed(agent, "trigger guardrail")
+        with pytest.raises(ValueError, match="guardrail boom"):
+            await asyncio.wait_for(consume_stream(), timeout=1)
+
+    await asyncio.wait_for(model_finished.wait(), timeout=1)
+    assert model_started.is_set() is True
+    assert model_cancelled.is_set() is True
+
+
+@pytest.mark.asyncio
 async def test_parallel_guardrail_may_not_prevent_tool_execution_streaming():
     tool_was_executed = False
     guardrail_executed = False

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -26,6 +26,7 @@ from agents.run_internal.guardrails import run_input_guardrails, run_input_guard
 
 from .fake_model import FakeModel
 from .test_responses import get_function_tool_call, get_text_message
+from .testing_processor import fetch_events
 
 SHORT_DELAY = 0.01
 MEDIUM_DELAY = 0.03
@@ -769,6 +770,71 @@ async def test_parallel_guardrail_error_cancels_streaming_model():
     await asyncio.wait_for(model_finished.wait(), timeout=1)
     assert model_started.is_set() is True
     assert model_cancelled.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_model_error_before_guardrail_error_preserves_stream_finalization():
+    model_cleanup_started = asyncio.Event()
+    allow_model_cleanup = asyncio.Event()
+    model_cleanup_finished = asyncio.Event()
+    model_cleanup_cancelled = asyncio.Event()
+    raise_guardrail_error = asyncio.Event()
+
+    @input_guardrail(run_in_parallel=True)
+    async def raising_parallel_check(
+        ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        await asyncio.wait_for(model_cleanup_started.wait(), timeout=1)
+        await asyncio.wait_for(raise_guardrail_error.wait(), timeout=1)
+        raise ValueError("guardrail boom")
+
+    class BlockingCleanupFakeModel(FakeModel):
+        async def _cleanup_on_run_end(self, owner: object) -> None:
+            model_cleanup_started.set()
+            try:
+                await allow_model_cleanup.wait()
+                model_cleanup_finished.set()
+            except asyncio.CancelledError:
+                model_cleanup_cancelled.set()
+                raise
+
+    model = BlockingCleanupFakeModel(tracing_enabled=True)
+    model.set_next_output(RuntimeError("model boom"))
+
+    agent = Agent(
+        name="streaming_model_error_agent",
+        input_guardrails=[raising_parallel_check],
+        model=model,
+    )
+
+    result = Runner.run_streamed(agent, "trigger model error")
+
+    await asyncio.wait_for(model_cleanup_started.wait(), timeout=1)
+    assert result.is_complete is True
+    raise_guardrail_error.set()
+
+    guardrail_task = result._input_guardrails_task
+    assert guardrail_task is not None
+
+    async def wait_until_guardrail_task_finishes() -> None:
+        while not guardrail_task.done():
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_until_guardrail_task_finishes(), timeout=1)
+    allow_model_cleanup.set()
+
+    with pytest.raises(ValueError, match="guardrail boom"):
+        async for _event in result.stream_events():
+            pass
+
+    assert model_cleanup_finished.is_set() is True
+    assert model_cleanup_cancelled.is_set() is False
+    assert result.run_loop_task is not None
+    assert result.run_loop_task.done() is True
+    assert result.run_loop_task.cancelled() is False
+    assert isinstance(result.run_loop_exception, RuntimeError)
+    assert str(result.run_loop_exception) == "model boom"
+    assert fetch_events()[-1] == "trace_end"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request fixes a streamed-run deadlock when a parallel input guardrail raises an ordinary exception before the model emits an event.

The streamed guardrail task now cancels the in-flight run loop and wakes the event consumer after draining sibling guardrails. This lets `stream_events()` propagate the original guardrail exception and await model cancellation instead of hanging on an empty queue and leaving an unretrieved task exception.

### Test plan

- Confirmed the new regression test fails three consecutive times on `upstream/main` with a one-second timeout in `stream_events()` and an unretrieved `ValueError`.
- `uv run pytest -q tests/test_guardrails.py::test_parallel_guardrail_error_cancels_streaming_model` (5 consecutive passes)
- `uv run pytest -q tests/test_guardrails.py` (44 passed)
- `uv run pytest -q tests/test_agent_runner_streamed.py` (55 passed)
- `uv run pytest -q tests/test_cancel_streaming.py` (11 passed)
- `bash .agents/skills/code-change-verification/scripts/run.sh`
- `make format-check`
- `make tests-asyncio-stability`
- `make coverage` (5,806 passed, 7 skipped; 90% coverage)
- Focused regression test on Python 3.10.20 and Python 3.14.6

### Issue number

N/A — no pre-filed issue is required for this focused bug fix.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
