### PR TITLE
fix: cancel sibling enablement checks on failure

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -55,6 +55,7 @@ from .tool import (
 )
 from .tool_context import ToolContext
 from .util import _transforms
+from .util._asyncio_tasks import gather_with_cancel
 from .util._types import MaybeAwaitable
 
 if TYPE_CHECKING:
@@ -259,7 +260,7 @@ class AgentBase(Generic[TContext]):
                 return bool(await res)
             return bool(res)
 
-        results = await asyncio.gather(*(_check_tool_enabled(t) for t in self.tools))
+        results = await gather_with_cancel(*(_check_tool_enabled(t) for t in self.tools))
         enabled: list[Tool] = [t for t, ok in zip(self.tools, results, strict=False) if ok]
         all_tools: list[Tool] = prune_orphaned_tool_search_tools([*mcp_tools, *enabled])
         _validate_codex_tool_name_collisions(all_tools)

--- a/src/agents/realtime/_tool_filtering.py
+++ b/src/agents/realtime/_tool_filtering.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 from collections.abc import Iterable
 from typing import Any
@@ -8,6 +7,7 @@ from typing import Any
 from ..agent import AgentBase
 from ..run_context import RunContextWrapper
 from ..tool import FunctionTool, Tool
+from ..util._asyncio_tasks import gather_with_cancel
 
 
 async def filter_enabled_tools(
@@ -29,7 +29,7 @@ async def filter_enabled_tools(
             return bool(await result)
         return bool(result)
 
-    results = await asyncio.gather(*(_check_tool_enabled(tool) for tool in tools_list))
+    results = await gather_with_cancel(*(_check_tool_enabled(tool) for tool in tools_list))
     return [tool for tool, ok in zip(tools_list, results, strict=False) if ok]
 
 

--- a/src/agents/realtime/handoffs.py
+++ b/src/agents/realtime/handoffs.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, cast, overload
@@ -14,6 +13,7 @@ from ..run_context import RunContextWrapper, TContext
 from ..strict_schema import ensure_strict_json_schema
 from ..tracing.spans import SpanError
 from ..util import _error_tracing, _json
+from ..util._asyncio_tasks import gather_with_cancel
 from ..util._types import MaybeAwaitable
 from . import RealtimeAgent
 
@@ -44,7 +44,7 @@ async def filter_enabled_handoffs(
             return await result
         return result
 
-    results = await asyncio.gather(*(_check_handoff_enabled(h) for h in handoffs_list))
+    results = await gather_with_cancel(*(_check_handoff_enabled(h) for h in handoffs_list))
     return [h for h, ok in zip(handoffs_list, results, strict=False) if ok]
 
 

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -95,6 +95,7 @@ from agents.tool import (
     ensure_function_tool_supports_responses_only_features,
     ensure_tool_choice_supports_backend,
 )
+from agents.util._asyncio_tasks import gather_with_cancel
 from agents.util._types import MaybeAwaitable
 
 from .. import _debug
@@ -445,7 +446,7 @@ async def _build_model_settings_from_agent(
     if agent.prompt is not None:
         updated_settings["prompt"] = agent.prompt
 
-    instructions, tools, handoffs = await asyncio.gather(
+    instructions, tools, handoffs = await gather_with_cancel(
         agent.get_system_prompt(context_wrapper),
         agent.get_all_tools(context_wrapper),
         _collect_enabled_handoffs(agent, context_wrapper),

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -33,6 +33,7 @@ from ..tool import DEFAULT_APPROVAL_REJECTION_MESSAGE, FunctionTool, Tool, invok
 from ..tool_context import ToolContext
 from ..tool_guardrails import ToolInputGuardrailData
 from ..util._approvals import evaluate_needs_approval_setting, parse_function_tool_arguments
+from ..util._asyncio_tasks import gather_with_cancel
 from ._tool_filtering import filter_enabled_tools
 from ._tool_validation import validate_realtime_tool_names
 from .agent import RealtimeAgent
@@ -1576,7 +1577,7 @@ class RealtimeSession(RealtimeModelListener):
         ):
             return self._current_dispatch_snapshot
 
-        tools, handoffs = await asyncio.gather(
+        tools, handoffs = await gather_with_cancel(
             agent.get_all_tools(self._context_wrapper),
             self._get_handoffs(agent, self._context_wrapper),
         )
@@ -1586,7 +1587,7 @@ class RealtimeSession(RealtimeModelListener):
         self,
         snapshot: _RealtimeDispatchSnapshot,
     ) -> _RealtimeDispatchSnapshot:
-        tools, handoffs = await asyncio.gather(
+        tools, handoffs = await gather_with_cancel(
             filter_enabled_tools(snapshot.tools, self._context_wrapper, snapshot.agent),
             filter_enabled_handoffs(snapshot.handoffs, self._context_wrapper, snapshot.agent),
         )
@@ -1607,7 +1608,7 @@ class RealtimeSession(RealtimeModelListener):
         if agent.prompt is not None:
             updated_settings["prompt"] = agent.prompt
 
-        instructions, tools, handoffs = await asyncio.gather(
+        instructions, tools, handoffs = await gather_with_cancel(
             agent.get_system_prompt(self._context_wrapper),
             agent.get_all_tools(self._context_wrapper),
             self._get_handoffs(agent, self._context_wrapper),

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -93,6 +93,7 @@ from ..tool_guardrails import (
 from ..tracing import Span, SpanError, function_span, get_current_trace
 from ..util import _coro, _error_tracing
 from ..util._approvals import evaluate_needs_approval_setting, parse_function_tool_arguments
+from ..util._asyncio_tasks import gather_with_cancel
 from ..util._custom_data import maybe_extract_custom_data, merge_custom_data
 from ..util._tool_errors import get_trace_tool_error
 from ..util._types import MaybeAwaitable
@@ -581,7 +582,9 @@ async def resolve_enabled_function_tools(
     if not function_tools:
         return []
 
-    enabled_results = await asyncio.gather(*(_check_tool_enabled(tool) for tool in function_tools))
+    enabled_results = await gather_with_cancel(
+        *(_check_tool_enabled(tool) for tool in function_tools)
+    )
     return [tool for tool, enabled in zip(function_tools, enabled_results, strict=False) if enabled]
 
 

--- a/src/agents/run_internal/turn_preparation.py
+++ b/src/agents/run_internal/turn_preparation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 from typing import Any
 
@@ -18,6 +17,7 @@ from ..run_context import RunContextWrapper, TContext
 from ..tool import Tool
 from ..tracing import SpanError
 from ..util import _error_tracing
+from ..util._asyncio_tasks import gather_with_cancel
 
 __all__ = [
     "validate_run_hooks",
@@ -111,7 +111,7 @@ async def get_handoffs(agent: Agent[Any], context_wrapper: RunContextWrapper[Any
             return bool(await res)
         return bool(res)
 
-    results = await asyncio.gather(*(check_handoff_enabled(h) for h in handoffs))
+    results = await gather_with_cancel(*(check_handoff_enabled(h) for h in handoffs))
     enabled: list[Handoff] = [h for h, ok in zip(handoffs, results, strict=False) if ok]
     return enabled
 

--- a/src/agents/util/_asyncio_tasks.py
+++ b/src/agents/util/_asyncio_tasks.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+async def gather_with_cancel(*awaitables: Awaitable[T]) -> list[T]:
+    """Gather awaitables, cancelling and draining siblings when one raises."""
+    tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
+    try:
+        return list(await asyncio.gather(*tasks))
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise

--- a/src/agents/util/_asyncio_tasks.py
+++ b/src/agents/util/_asyncio_tasks.py
@@ -2,16 +2,40 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable
-from typing import TypeVar
+from typing import Any, TypeVar, overload
 
 T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
 
 
-async def gather_with_cancel(*awaitables: Awaitable[T]) -> list[T]:
+@overload
+async def gather_with_cancel(
+    awaitable_1: Awaitable[T1],
+    awaitable_2: Awaitable[T2],
+    /,
+) -> tuple[T1, T2]: ...
+
+
+@overload
+async def gather_with_cancel(
+    awaitable_1: Awaitable[T1],
+    awaitable_2: Awaitable[T2],
+    awaitable_3: Awaitable[T3],
+    /,
+) -> tuple[T1, T2, T3]: ...
+
+
+@overload
+async def gather_with_cancel(*awaitables: Awaitable[T]) -> tuple[T, ...]: ...
+
+
+async def gather_with_cancel(*awaitables: Awaitable[Any]) -> tuple[Any, ...]:
     """Gather awaitables, cancelling and draining siblings when one raises."""
     tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
     try:
-        return list(await asyncio.gather(*tasks))
+        return tuple(await asyncio.gather(*tasks))
     except BaseException:
         for task in tasks:
             if not task.done():

--- a/tests/realtime/test_realtime_handoffs.py
+++ b/tests/realtime/test_realtime_handoffs.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from agents import Agent
 from agents.exceptions import ModelBehaviorError, UserError
 from agents.realtime import RealtimeAgent, realtime_handoff
+from agents.realtime.handoffs import collect_enabled_handoffs
 from agents.run_context import RunContextWrapper
 
 
@@ -44,6 +45,42 @@ def test_realtime_handoff_with_custom_params():
     assert handoff_obj.tool_name == "custom_handoff"
     assert handoff_obj.tool_description == "Custom handoff description"
     assert handoff_obj.is_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_collect_enabled_handoffs_cancels_sibling_checks_on_error() -> None:
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_enabled(_ctx: RunContextWrapper[Any], _agent: RealtimeAgent[Any]) -> bool:
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return True
+
+    async def failing_enabled(_ctx: RunContextWrapper[Any], _agent: RealtimeAgent[Any]) -> bool:
+        await slow_started.wait()
+        raise RuntimeError("enablement failed")
+
+    parent = RealtimeAgent(
+        name="parent",
+        handoffs=[
+            realtime_handoff(RealtimeAgent(name="slow"), is_enabled=slow_enabled),
+            realtime_handoff(RealtimeAgent(name="failing"), is_enabled=failing_enabled),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="enablement failed"):
+        await collect_enabled_handoffs(parent, RunContextWrapper(None))
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/realtime/test_realtime_model_settings.py
+++ b/tests/realtime/test_realtime_model_settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 from unittest.mock import AsyncMock
 
@@ -9,7 +10,9 @@ from openai.types.realtime.realtime_session_create_request import (
 )
 from openai.types.realtime.session_update_event import SessionUpdateEvent
 
+from agents.agent import AgentBase
 from agents.handoffs import Handoff
+from agents.realtime._tool_filtering import filter_enabled_tools
 from agents.realtime.agent import RealtimeAgent
 from agents.realtime.config import RealtimeRunConfig, RealtimeSessionModelSettings
 from agents.realtime.handoffs import realtime_handoff
@@ -54,6 +57,42 @@ async def test_collect_enabled_handoffs_filters_disabled() -> None:
     assert len(enabled) == 1
     assert isinstance(enabled[0], Handoff)
     assert enabled[0].agent_name == "child_enabled"
+
+
+@pytest.mark.asyncio
+async def test_filter_enabled_tools_cancels_sibling_checks_on_error() -> None:
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase[Any]) -> bool:
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return True
+
+    async def failing_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase[Any]) -> bool:
+        await slow_started.wait()
+        raise RuntimeError("enablement failed")
+
+    slow_tool = function_tool(lambda: "slow", is_enabled=slow_enabled)
+    failing_tool = function_tool(lambda: "failing", is_enabled=failing_enabled)
+    agent = RealtimeAgent(name="parent")
+
+    with pytest.raises(RuntimeError, match="enablement failed"):
+        await filter_enabled_tools(
+            [slow_tool, failing_tool],
+            RunContextWrapper(None),
+            agent,
+        )
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/realtime/test_realtime_model_settings.py
+++ b/tests/realtime/test_realtime_model_settings.py
@@ -43,6 +43,52 @@ def _disabled_billing_realtime_tool(*, is_enabled: Any = False) -> FunctionTool:
     )
 
 
+def _agent_with_cross_group_enablement_failure() -> tuple[
+    RealtimeAgent[Any], asyncio.Event, asyncio.Event
+]:
+    handoff_started = asyncio.Event()
+    handoff_cancelled = asyncio.Event()
+    handoff_finished = asyncio.Event()
+
+    async def failing_tool_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase[Any]) -> bool:
+        await handoff_started.wait()
+        raise RuntimeError("tool enablement failed")
+
+    async def blocking_handoff_enabled(
+        _ctx: RunContextWrapper[Any], _agent: RealtimeAgent[Any]
+    ) -> bool:
+        handoff_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            handoff_cancelled.set()
+            raise
+        finally:
+            handoff_finished.set()
+        return True
+
+    return (
+        RealtimeAgent(
+            name="parent",
+            tools=[
+                function_tool(
+                    lambda: "failing",
+                    name_override="failing_tool",
+                    is_enabled=failing_tool_enabled,
+                )
+            ],
+            handoffs=[
+                realtime_handoff(
+                    RealtimeAgent(name="blocking"),
+                    is_enabled=blocking_handoff_enabled,
+                )
+            ],
+        ),
+        handoff_cancelled,
+        handoff_finished,
+    )
+
+
 @pytest.mark.asyncio
 async def test_collect_enabled_handoffs_filters_disabled() -> None:
     parent = RealtimeAgent(name="parent")
@@ -93,6 +139,23 @@ async def test_filter_enabled_tools_cancels_sibling_checks_on_error() -> None:
 
     assert slow_cancelled.is_set()
     assert slow_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_build_model_settings_cancels_cross_group_enablement_on_error() -> None:
+    agent, handoff_cancelled, handoff_finished = _agent_with_cross_group_enablement_failure()
+
+    with pytest.raises(RuntimeError, match="tool enablement failed"):
+        await _build_model_settings_from_agent(
+            agent=agent,
+            context_wrapper=RunContextWrapper(None),
+            base_settings={},
+            starting_settings=None,
+            run_config=None,
+        )
+
+    assert handoff_cancelled.is_set()
+    assert handoff_finished.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/realtime/test_session.py
+++ b/tests/realtime/test_session.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import BaseModel, ConfigDict
 
 import agents._debug as _debug
+from agents.agent import AgentBase
 from agents.exceptions import ToolTimeoutError, UserError
 from agents.guardrail import GuardrailFunctionOutput, OutputGuardrail
 from agents.handoffs import Handoff
@@ -148,6 +149,47 @@ def _disabled_billing_tool(*, is_enabled: Any = False) -> FunctionTool:
         lambda: "ok",
         name_override="transfer_to_billing",
         is_enabled=is_enabled,
+    )
+
+
+def _agent_with_cross_group_enablement_failure() -> tuple[
+    RealtimeAgent[Any], asyncio.Event, asyncio.Event
+]:
+    handoff_started = asyncio.Event()
+    handoff_cancelled = asyncio.Event()
+    handoff_finished = asyncio.Event()
+
+    async def failing_tool_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase[Any]) -> bool:
+        await handoff_started.wait()
+        raise RuntimeError("tool enablement failed")
+
+    async def blocking_handoff_enabled(
+        _ctx: RunContextWrapper[Any], _agent: RealtimeAgent[Any]
+    ) -> bool:
+        handoff_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            handoff_cancelled.set()
+            raise
+        finally:
+            handoff_finished.set()
+        return True
+
+    return (
+        RealtimeAgent(
+            name="parent",
+            tools=[
+                function_tool(
+                    lambda: "failing",
+                    name_override="failing_tool",
+                    is_enabled=failing_tool_enabled,
+                )
+            ],
+            handoffs=[_disabled_billing_handoff(is_enabled=blocking_handoff_enabled)],
+        ),
+        handoff_cancelled,
+        handoff_finished,
     )
 
 
@@ -742,6 +784,38 @@ async def test_get_handoffs_async_is_enabled(monkeypatch):
     enabled = await RealtimeSession._get_handoffs(a, session._context_wrapper)
     # Both should be enabled
     assert len(enabled) == 2
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "resolve_dispatch_snapshot",
+        "filter_enabled_dispatch_snapshot",
+        "get_updated_model_settings",
+    ],
+)
+@pytest.mark.asyncio
+async def test_realtime_session_boundaries_cancel_cross_group_enablement_on_error(
+    boundary: str,
+) -> None:
+    agent, handoff_cancelled, handoff_finished = _agent_with_cross_group_enablement_failure()
+    session = RealtimeSession(_DummyModel(), agent, None)
+
+    with pytest.raises(RuntimeError, match="tool enablement failed"):
+        if boundary == "resolve_dispatch_snapshot":
+            await session._resolve_dispatch_snapshot(agent, None)
+        elif boundary == "filter_enabled_dispatch_snapshot":
+            settings = cast(
+                RealtimeSessionModelSettings,
+                {"tools": agent.tools, "handoffs": agent.handoffs},
+            )
+            snapshot = session._dispatch_snapshot_from_settings(agent, settings)
+            await session._filter_enabled_dispatch_snapshot(snapshot)
+        else:
+            await session._get_updated_model_settings_from_agent(None, agent)
+
+    assert handoff_cancelled.is_set()
+    assert handoff_finished.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -499,6 +499,44 @@ async def test_is_enabled_bool_and_callable():
 
 
 @pytest.mark.asyncio
+async def test_get_all_tools_cancels_sibling_enablement_checks_on_error() -> None:
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase) -> bool:
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return True
+
+    async def failing_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase) -> bool:
+        await slow_started.wait()
+        raise RuntimeError("enablement failed")
+
+    @function_tool(is_enabled=slow_enabled)
+    def slow_tool() -> str:
+        return "slow"
+
+    @function_tool(is_enabled=failing_enabled)
+    def failing_tool() -> str:
+        return "failing"
+
+    agent = Agent(name="t", tools=[slow_tool, failing_tool])
+
+    with pytest.raises(RuntimeError, match="enablement failed"):
+        await agent.get_all_tools(RunContextWrapper(None))
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()
+
+
+@pytest.mark.asyncio
 async def test_get_all_tools_preserves_explicit_tool_search_when_deferred_tools_are_disabled():
     async def deferred_enabled(ctx: RunContextWrapper[BoolCtx], agent: AgentBase) -> bool:
         return ctx.context.enable_tools

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import json
 import logging
@@ -468,6 +469,42 @@ async def test_handoff_is_enabled_filtering_integration():
     agent_names = {h.agent_name for h in filtered_handoffs}
     assert agent_names == {"agent_1", "agent_3"}
     assert "agent_2" not in agent_names
+
+
+@pytest.mark.asyncio
+async def test_get_handoffs_cancels_sibling_enablement_checks_on_error() -> None:
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_enabled(_ctx: RunContextWrapper[Any], _agent: Agent[Any]) -> bool:
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return True
+
+    async def failing_enabled(_ctx: RunContextWrapper[Any], _agent: Agent[Any]) -> bool:
+        await slow_started.wait()
+        raise RuntimeError("enablement failed")
+
+    parent = Agent(
+        name="parent",
+        handoffs=[
+            handoff(Agent(name="slow"), is_enabled=slow_enabled),
+            handoff(Agent(name="failing"), is_enabled=failing_enabled),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="enablement failed"):
+        await get_handoffs(parent, RunContextWrapper(None))
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -1528,6 +1528,57 @@ async def test_function_tool_disabled_before_execution_fails_before_starting_sib
 
 
 @pytest.mark.asyncio
+async def test_function_tool_enablement_error_cancels_sibling_checks_before_execution() -> None:
+    slow_check_count = 0
+    failing_check_count = 0
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase[Any]) -> bool:
+        nonlocal slow_check_count
+        slow_check_count += 1
+        if slow_check_count == 1:
+            return True
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return True
+
+    async def failing_enabled(_ctx: RunContextWrapper[Any], _agent: AgentBase[Any]) -> bool:
+        nonlocal failing_check_count
+        failing_check_count += 1
+        if failing_check_count == 1:
+            return True
+        await slow_started.wait()
+        raise RuntimeError("enablement failed")
+
+    slow_tool = function_tool(lambda: "slow", name_override="slow_tool", is_enabled=slow_enabled)
+    failing_tool = function_tool(
+        lambda: "failing",
+        name_override="failing_tool",
+        is_enabled=failing_enabled,
+    )
+    agent = Agent(name="test", tools=[slow_tool, failing_tool])
+    response = ModelResponse(
+        output=[get_function_tool_call("slow_tool", "{}", call_id="call-1")],
+        usage=Usage(),
+        response_id=None,
+    )
+
+    with pytest.raises(RuntimeError, match="enablement failed"):
+        await get_execute_result(agent, response)
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()
+
+
+@pytest.mark.asyncio
 async def test_execute_function_tool_calls_allows_non_agent_function_tool() -> None:
     @function_tool(name_override="synthetic_tool")
     def synthetic_tool() -> str:


### PR DESCRIPTION
### Summary

Dynamic `FunctionTool.is_enabled` and `Handoff.is_enabled` callbacks are evaluated concurrently. If one callback raised, `asyncio.gather()` propagated its exception while sibling callbacks kept running after the SDK call returned.

This change adds a private cancel-and-drain gather helper and uses it for regular-agent, execution-time, and Realtime tool/handoff enablement checks. The original exception is preserved, while unfinished sibling callbacks are cancelled and awaited before control returns.

### Test plan

- `UV_PYTHON=3.12 uv run pytest tests/test_function_tool.py::test_get_all_tools_cancels_sibling_enablement_checks_on_error tests/test_handoff_tool.py::test_get_handoffs_cancels_sibling_enablement_checks_on_error tests/test_run_step_execution.py::test_function_tool_enablement_error_cancels_sibling_checks_before_execution tests/realtime/test_realtime_model_settings.py::test_filter_enabled_tools_cancels_sibling_checks_on_error tests/realtime/test_realtime_handoffs.py::test_collect_enabled_handoffs_cancels_sibling_checks_on_error -q` — 5 passed
- `UV_PYTHON=3.12 uv run pytest tests/test_function_tool.py tests/test_handoff_tool.py tests/realtime/test_realtime_handoffs.py tests/realtime/test_realtime_model_settings.py -q` — 109 passed
- `UV_PYTHON=3.12 uv run pytest tests/test_run_step_execution.py -q` — 89 passed
- `UV_PYTHON=3.12 make format` — passed
- `UV_PYTHON=3.12 make lint` — passed
- `UV_PYTHON=3.12 make typecheck` — mypy and pyright passed; mypy checked 833 source files
- `UV_PYTHON=3.12 make tests` — non-serial: 5,782 passed, 3 skipped; serial: 28 passed, 5 skipped
- `UV_PYTHON=3.12 bash .agents/skills/code-change-verification/scripts/run.sh` — all commands passed

The regression tests coordinate callbacks with `asyncio.Event`, assert the original error, and verify that sibling cancellation and finalization complete before the caller regains control.

This changes no public API or successful-result ordering. Error paths now wait for cancelled callback cleanup, matching the existing concurrent guardrail cleanup behavior.

### Issue number

N/A — no matching open or closed issue/PR was found. #3115 / #3118 concern execution-time authorization rechecks rather than cleanup after an enablement callback fails.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
