### PR TITLE
Preserve zero Blobfuse attribute cache timeout

### DIFF
--- a/src/agents/sandbox/entries/mounts/patterns.py
+++ b/src/agents/sandbox/entries/mounts/patterns.py
@@ -271,7 +271,9 @@ class FuseMountPattern(MountPatternBase):
                     ]
                 )
 
-            attr_cache_timeout = self.attr_cache_timeout_sec or 7200
+            attr_cache_timeout = (
+                self.attr_cache_timeout_sec if self.attr_cache_timeout_sec is not None else 7200
+            )
             lines.extend(
                 [
                     "attr_cache:",

--- a/tests/sandbox/test_mounts.py
+++ b/tests/sandbox/test_mounts.py
@@ -1250,6 +1250,29 @@ async def test_blobfuse_generated_config_is_written_owner_only() -> None:
 
 
 @pytest.mark.asyncio
+async def test_blobfuse_generated_config_preserves_zero_attr_cache_timeout() -> None:
+    session_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    session = _GeneratedConfigApplySession(session_id=session_id)
+    pattern = FuseMountPattern(attr_cache_timeout_sec=0)
+
+    await pattern.apply(
+        session,
+        Path("/workspace/mnt"),
+        FuseMountConfig(
+            account="acct",
+            container="container",
+            endpoint=None,
+            identity_client_id=None,
+            account_key="secret",
+            mount_type="azure_blob_mount",
+            read_only=True,
+        ),
+    )
+
+    assert b"attr_cache:\n  timeout-sec: 0\n" in session.write_calls[0][1]
+
+
+@pytest.mark.asyncio
 async def test_blobfuse_cache_path_must_be_relative_to_workspace() -> None:
     with pytest.raises(MountConfigError) as exc_info:
         FuseMountPattern(cache_path=Path("/tmp/blobfuse-cache"))


### PR DESCRIPTION
### Summary

- Preserve an explicit `attr_cache_timeout_sec=0` when generating Blobfuse configuration.
- Continue using `7200` only when the timeout is unset (`None`).
- Add a regression test through `FuseMountPattern.apply()` that verifies the generated YAML.

Blobfuse supports zero-valued cache timeouts to disable caching, but the existing truthiness fallback replaced `0` with `7200`. The fix uses an explicit `None` check, matching the neighboring entry-cache timeout handling without changing the public API or nonzero behavior.

I searched open and closed issues and pull requests for `attr_cache_timeout_sec`, Blobfuse zero-timeout behavior, the `7200` fallback, and `FuseMountPattern`; no overlapping report or change was found.

### Test plan

- `UV_PYTHON=3.12 uv run pytest tests/sandbox/test_mounts.py::test_blobfuse_generated_config_preserves_zero_attr_cache_timeout -q`
  - Before the runtime change: failed because the generated YAML did not contain `timeout-sec: 0`.
  - After the runtime change: `1 passed`.
- `UV_PYTHON=3.12 uv run pytest tests/sandbox/test_mounts.py -q`
  - `31 passed`.
- `UV_PYTHON=3.12 bash .agents/skills/code-change-verification/scripts/run.sh`
  - `make format`, `make lint`, `make typecheck`, and `make tests` all passed.
- `UV_PYTHON=3.12 make tests`
  - Parallel phase: `5780 passed, 3 skipped`.
  - Serial phase: `28 passed, 5 skipped`.
- `UV_PYTHON=3.12 make format-check`
  - `841 files already formatted`.
- `git diff --check`
  - Passed.

### Issue number

N/A — no corresponding issue was found.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR