### PR TITLE
fix(agent-tools): honor falsey input builders

### DIFF
--- a/src/agents/agent_tool_input.py
+++ b/src/agents/agent_tool_input.py
@@ -83,11 +83,11 @@ async def resolve_agent_tool_input(
     input_builder: StructuredToolInputBuilder | None = None,
 ) -> str | list[TResponseInputItem]:
     """Resolve structured tool input into a string or list of input items."""
-    should_build_structured_input = bool(
-        input_builder or (schema_info and (schema_info.summary or schema_info.json_schema))
+    should_build_structured_input = input_builder is not None or bool(
+        schema_info and (schema_info.summary or schema_info.json_schema)
     )
     if should_build_structured_input:
-        builder = input_builder or default_tool_input_builder
+        builder = input_builder if input_builder is not None else default_tool_input_builder
         result = builder(
             {
                 "params": params,

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -1053,6 +1053,66 @@ async def test_agent_as_tool_supports_custom_input_builder(
 
 
 @pytest.mark.asyncio
+async def test_agent_as_tool_supports_falsey_callable_input_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class TranslationInput(BaseModel):
+        text: str
+
+    custom_items = [{"role": "user", "content": "custom input"}]
+
+    class FalseyInputBuilder:
+        def __bool__(self) -> bool:
+            return False
+
+        def __call__(self, _options: StructuredToolInputBuilderOptions):
+            return custom_items
+
+    agent = Agent(name="builder_agent")
+    tool = agent.as_tool(
+        tool_name="builder_tool",
+        tool_description="Builder tool",
+        parameters=TranslationInput,
+        input_builder=FalseyInputBuilder(),
+    )
+    captured: dict[str, Any] = {}
+
+    class DummyResult:
+        def __init__(self) -> None:
+            self.final_output = "ok"
+
+    async def fake_run(
+        cls,
+        starting_agent,
+        input,
+        *,
+        context,
+        max_turns,
+        hooks,
+        run_config,
+        previous_response_id,
+        conversation_id,
+        session,
+    ):
+        captured["input"] = input
+        return DummyResult()
+
+    monkeypatch.setattr(Runner, "run", classmethod(fake_run))
+
+    args = {"text": "hola"}
+    tool_context = ToolContext(
+        context=None,
+        tool_name="builder_tool",
+        tool_call_id="call_builder",
+        tool_arguments=json.dumps(args),
+    )
+
+    await tool.on_invoke_tool(tool_context, json.dumps(args))
+
+    assert captured["input"] == custom_items
+
+
+@pytest.mark.asyncio
 async def test_agent_as_tool_rejects_invalid_builder_output() -> None:
     """Invalid builder output should surface as a tool error."""
 


### PR DESCRIPTION
### Summary

`Agent.as_tool(input_builder=...)` currently checks the builder by truthiness in `resolve_agent_tool_input`. A callable object whose `__bool__` returns `False` is therefore accepted at the public API boundary but never invoked, and the nested agent receives fallback JSON instead of the caller's custom input.

This changes the two builder-selection checks to use explicit `is not None` comparisons. `None` keeps the existing default behavior; no public API changes.

The regression test reproduces the bug through `Agent.as_tool`: before the production change it failed three times with the nested input equal to `'{"text": "hola"}'`; after the change it passed three times with the custom input items.

### Test plan

- `uv run pytest -q tests/test_agent_tool_input.py tests/test_agent_as_tool.py` — 57 passed
- `bash .agents/skills/code-change-verification/scripts/run.sh` — format, lint, typecheck, and full tests passed
- `make tests-asyncio-stability` — 5 repetitions passed (7 + 32 tests per repetition)
- `make coverage` — 5,808 passed, 7 skipped; 90% total coverage
- `make format-check` — 841 files already formatted
- `git diff --check` — passed
- Python 3.10 focused tests — 11 passed
- Python 3.14 focused tests — 11 passed

### Issue number

N/A — repository policy does not require an issue for this focused fix, and searches across open/closed issues and PRs found no duplicate.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
