### PR TITLE
fix(sandbox): honour attr_cache_timeout_sec=0 in generated blobfuse config

### DIFF
--- a/src/agents/sandbox/entries/mounts/patterns.py
+++ b/src/agents/sandbox/entries/mounts/patterns.py
@@ -271,7 +271,9 @@ class FuseMountPattern(MountPatternBase):
                     ]
                 )
 
-            attr_cache_timeout = self.attr_cache_timeout_sec or 7200
+            attr_cache_timeout = (
+                7200 if self.attr_cache_timeout_sec is None else self.attr_cache_timeout_sec
+            )
             lines.extend(
                 [
                     "attr_cache:",

--- a/tests/sandbox/test_mounts.py
+++ b/tests/sandbox/test_mounts.py
@@ -1250,6 +1250,58 @@ async def test_blobfuse_generated_config_is_written_owner_only() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("attr_cache_timeout_sec", [0, 5])
+async def test_blobfuse_config_preserves_explicit_attr_cache_timeout(
+    attr_cache_timeout_sec: int,
+) -> None:
+    session_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    session = _GeneratedConfigApplySession(session_id=session_id)
+    pattern = FuseMountPattern(attr_cache_timeout_sec=attr_cache_timeout_sec)
+
+    await pattern.apply(
+        session,
+        Path("/workspace/mnt"),
+        FuseMountConfig(
+            account="acct",
+            container="container",
+            endpoint=None,
+            identity_client_id=None,
+            account_key="secret",
+            mount_type="azure_blob_mount",
+            read_only=True,
+        ),
+    )
+
+    (_, generated_config) = session.write_calls[0]
+    assert b"attr_cache:\n  timeout-sec: %d\n" % attr_cache_timeout_sec in generated_config
+
+
+@pytest.mark.asyncio
+async def test_blobfuse_config_defaults_attr_cache_timeout_when_unset() -> None:
+    session_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    session = _GeneratedConfigApplySession(session_id=session_id)
+    pattern = FuseMountPattern()
+    assert pattern.attr_cache_timeout_sec is None
+
+    await pattern.apply(
+        session,
+        Path("/workspace/mnt"),
+        FuseMountConfig(
+            account="acct",
+            container="container",
+            endpoint=None,
+            identity_client_id=None,
+            account_key="secret",
+            mount_type="azure_blob_mount",
+            read_only=True,
+        ),
+    )
+
+    (_, generated_config) = session.write_calls[0]
+    assert b"attr_cache:\n  timeout-sec: 7200\n" in generated_config
+
+
+@pytest.mark.asyncio
 async def test_blobfuse_cache_path_must_be_relative_to_workspace() -> None:
     with pytest.raises(MountConfigError) as exc_info:
         FuseMountPattern(cache_path=Path("/tmp/blobfuse-cache"))


### PR DESCRIPTION
## Summary

`FuseMountPattern.attr_cache_timeout_sec` is declared `int | None` with a `None` default, so `0` is a value a user can legitimately set -- in blobfuse2, `attr_cache.timeout-sec: 0` disables the attribute cache. The generated config resolved it with `or`:

```python
attr_cache_timeout = self.attr_cache_timeout_sec or 7200
```

`0 or 7200` is `7200`, so asking for **no** attribute caching silently produced the **longest** caching interval instead. Blob metadata on the mount then stays stale for two hours -- the exact opposite of what was requested, with no error and nothing in the generated YAML to hint at it.

The three sibling cache fields on the same dataclass already distinguish "unset" from "falsy" correctly:

```python
if self.entry_cache_timeout_sec is not None:
    libfuse_lines.append(f"  entry-expiration-sec: {self.entry_cache_timeout_sec}")
if self.negative_entry_cache_timeout_sec is not None:
    libfuse_lines.append(
        f"  negative-entry-expiration-sec: {self.negative_entry_cache_timeout_sec}"
    )
```

so the same `0` behaves inconsistently depending on which of the four knobs you set.

## Reproduction

Rendering `BlobfuseConfig.to_text()` with each of the four cache timeouts set to `0`:

```
attr_cache_timeout_sec=0     -> ['  timeout-sec: 7200']      <- wrong, requested 0
attr_cache_timeout_sec=5     -> ['  timeout-sec: 5']         <- fine
attr_cache_timeout_sec=None  -> ['  timeout-sec: 7200']      <- fine, default

entry_cache_timeout_sec=0    -> ['  entry-expiration-sec: 0']            <- correct
negative_..._timeout_sec=0   -> ['  negative-entry-expiration-sec: 0']   <- correct
```

## Changes

`src/agents/sandbox/entries/mounts/patterns.py` -- one line, resolve the default on `is None` rather than on falsiness:

```python
attr_cache_timeout = (
    7200 if self.attr_cache_timeout_sec is None else self.attr_cache_timeout_sec
)
```

The `None` default stays at 7200; only the explicit-`0` case changes.

`tests/sandbox/test_mounts.py` -- added coverage for the explicit `0` and `5` cases (parametrized) and for the `None` default. They go through `pattern.apply()` and assert on the rendered config text, matching the style of the existing `test_blobfuse_generated_config_is_written_owner_only`.

## Verification

`tests/sandbox/` (excluding `test_docker.py`, which needs the optional `docker` package): **444 passed**, up from 441 on the unmodified tree. The 10 failures in `test_tar_utils.py` / `test_workspace_paths.py` are pre-existing on an unmodified checkout in this environment (Windows symlink creation privileges) and are unrelated to this change -- I confirmed by stashing the change and re-running.

`ruff format --check` and `ruff check` clean on both files; `mypy` on the changed module reports no issues.

Control experiment -- reverting only `patterns.py` and keeping the new tests:

```
FAILED tests/sandbox/test_mounts.py::test_blobfuse_config_preserves_explicit_attr_cache_timeout[0]
  AssertionError: assert (b'attr_cache:
  timeout-sec: %d
' % 0) in b'...timeout-sec: 7200...'
1 failed, 5 passed
```

Only the `0` case fails, so the new tests pin exactly the defect and nothing more -- the `5` case and the `None` default pass either way.
