### PR TITLE
feat(sandbox): support native host paths in path grants

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -1145,6 +1145,7 @@ class BlaxelSandboxClient(BaseSandboxClient["BlaxelSandboxClientOptions"]):
         """
         if not isinstance(state, BlaxelSandboxSessionState):
             raise TypeError("BlaxelSandboxClient.resume expects a BlaxelSandboxSessionState")
+        state.assert_path_grants_rebound()
 
         SandboxInstance = _import_blaxel_sdk()
         blaxel_sandbox = None
@@ -1179,7 +1180,7 @@ class BlaxelSandboxClient(BaseSandboxClient["BlaxelSandboxClientOptions"]):
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return BlaxelSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, BlaxelSandboxSessionState)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agents/extensions/sandbox/cloudflare/sandbox.py
+++ b/src/agents/extensions/sandbox/cloudflare/sandbox.py
@@ -1491,6 +1491,7 @@ class CloudflareSandboxClient(BaseSandboxClient[CloudflareSandboxClientOptions])
             raise TypeError(
                 "CloudflareSandboxClient.resume expects a CloudflareSandboxSessionState"
             )
+        state.assert_path_grants_rebound()
         inner = CloudflareSandboxSession.from_state(
             state,
             exec_timeout_s=self._exec_timeout_s,
@@ -1503,7 +1504,7 @@ class CloudflareSandboxClient(BaseSandboxClient[CloudflareSandboxClientOptions])
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return CloudflareSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, CloudflareSandboxSessionState)
 
     async def _request_sandbox_id(
         self,

--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -1326,6 +1326,7 @@ class DaytonaSandboxClient(BaseSandboxClient[DaytonaSandboxClientOptions]):
     ) -> SandboxSession:
         if not isinstance(state, DaytonaSandboxSessionState):
             raise TypeError("DaytonaSandboxClient.resume expects a DaytonaSandboxSessionState")
+        state.assert_path_grants_rebound()
 
         daytona_sandbox = None
         reconnected = False
@@ -1357,7 +1358,7 @@ class DaytonaSandboxClient(BaseSandboxClient[DaytonaSandboxClientOptions]):
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return DaytonaSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, DaytonaSandboxSessionState)
 
 
 __all__ = [

--- a/src/agents/extensions/sandbox/e2b/sandbox.py
+++ b/src/agents/extensions/sandbox/e2b/sandbox.py
@@ -1770,6 +1770,7 @@ class E2BSandboxClient(BaseSandboxClient[E2BSandboxClientOptions]):
     ) -> SandboxSession:
         if not isinstance(state, E2BSandboxSessionState):
             raise TypeError("E2BSandboxClient.resume expects an E2BSandboxSessionState")
+        state.assert_path_grants_rebound()
 
         sandbox_type = _coerce_sandbox_type(state.sandbox_type)
         SandboxClass = _import_sandbox_class(sandbox_type)
@@ -1817,7 +1818,7 @@ class E2BSandboxClient(BaseSandboxClient[E2BSandboxClientOptions]):
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return E2BSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, E2BSandboxSessionState)
 
 
 __all__ = [

--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -2171,6 +2171,7 @@ class ModalSandboxClient(BaseSandboxClient[ModalSandboxClientOptions]):
     ) -> SandboxSession:
         if not isinstance(state, ModalSandboxSessionState):
             raise TypeError("ModalSandboxClient.resume expects a ModalSandboxSessionState")
+        state.assert_path_grants_rebound()
         inner = ModalSandboxSession.from_state(state)
         reconnected = await inner._ensure_sandbox()
         if reconnected:
@@ -2178,4 +2179,4 @@ class ModalSandboxClient(BaseSandboxClient[ModalSandboxClientOptions]):
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return ModalSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, ModalSandboxSessionState)

--- a/src/agents/extensions/sandbox/runloop/sandbox.py
+++ b/src/agents/extensions/sandbox/runloop/sandbox.py
@@ -1673,6 +1673,7 @@ class RunloopSandboxClient(BaseSandboxClient[RunloopSandboxClientOptions | None]
         """
         if not isinstance(state, RunloopSandboxSessionState):
             raise TypeError("RunloopSandboxClient.resume expects a RunloopSandboxSessionState")
+        state.assert_path_grants_rebound()
 
         devbox = None
         reconnected = False
@@ -1717,4 +1718,4 @@ class RunloopSandboxClient(BaseSandboxClient[RunloopSandboxClientOptions | None]
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return RunloopSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, RunloopSandboxSessionState)

--- a/src/agents/extensions/sandbox/vercel/sandbox.py
+++ b/src/agents/extensions/sandbox/vercel/sandbox.py
@@ -1414,6 +1414,7 @@ class VercelSandboxClient(BaseSandboxClient[VercelSandboxClientOptions]):
     async def resume(self, state: SandboxSessionState) -> SandboxSession:
         if not isinstance(state, VercelSandboxSessionState):
             raise TypeError("VercelSandboxClient.resume expects a VercelSandboxSessionState")
+        state.assert_path_grants_rebound()
         if state.s3_mounts_non_resumable or _vercel_s3_mounts(state.manifest):
             raise MountConfigError(
                 message=(
@@ -1482,7 +1483,7 @@ class VercelSandboxClient(BaseSandboxClient[VercelSandboxClientOptions]):
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return VercelSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, VercelSandboxSessionState)
 
 
 __all__ = [

--- a/src/agents/sandbox/capabilities/skills.py
+++ b/src/agents/sandbox/capabilities/skills.py
@@ -509,7 +509,9 @@ class Skills(Capability):
     skills_path: str = Field(default=".agents")
 
     _skills_metadata: list[SkillMetadata] | None = PrivateAttr(default=None)
-    _skills_metadata_cache_key: tuple[tuple[str, bool], ...] | None = PrivateAttr(default=None)
+    _skills_metadata_cache_key: tuple[tuple[str, bool, str | None], ...] | None = PrivateAttr(
+        default=None
+    )
 
     @field_validator("skills", mode="before")
     @classmethod
@@ -762,10 +764,15 @@ class Skills(Capability):
         self._skills_metadata_cache_key = cache_key
         return self._skills_metadata
 
-    def _metadata_cache_key(self, manifest: Manifest) -> tuple[tuple[str, bool], ...]:
+    def _metadata_cache_key(
+        self,
+        manifest: Manifest,
+    ) -> tuple[tuple[str, bool, str | None], ...]:
         if self.lazy_from is None:
             return ()
-        return tuple((grant.path, grant.read_only) for grant in manifest.extra_path_grants)
+        return tuple(
+            (grant.path, grant.read_only, grant.host_path) for grant in manifest.extra_path_grants
+        )
 
     async def instructions(self, manifest: Manifest) -> str | None:
         skills = await self._skill_metadata(manifest)

--- a/src/agents/sandbox/entries/artifacts.py
+++ b/src/agents/sandbox/entries/artifacts.py
@@ -24,7 +24,7 @@ from ..errors import (
 )
 from ..materialization import MaterializedFile, gather_in_order
 from ..types import ExecResult, User
-from ..workspace_paths import SandboxPathGrant
+from ..workspace_paths import SandboxPathGrant, sandbox_path_grant_host_path
 from .base import BaseEntry
 
 if TYPE_CHECKING:
@@ -276,7 +276,7 @@ class LocalDir(BaseEntry):
         source_grants: tuple[SandboxPathGrant, ...],
     ) -> SandboxPathGrant | None:
         for grant in source_grants:
-            grant_root = _absolute_without_symlink_resolution(Path(grant.path))
+            grant_root = _absolute_without_symlink_resolution(sandbox_path_grant_host_path(grant))
             try:
                 src_input.relative_to(grant_root)
                 return grant

--- a/src/agents/sandbox/runtime_session_manager.py
+++ b/src/agents/sandbox/runtime_session_manager.py
@@ -337,7 +337,6 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
             explicit_state = explicit_state.rebind_persisted_path_grants(
                 self._resolve_trusted_resume_manifest(
                     agent=agent,
-                    capabilities=capabilities,
                 )
             )
             explicit_state = self._process_resumed_state_manifest(
@@ -533,15 +532,9 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
         self,
         *,
         agent: SandboxAgent[TContext],
-        capabilities: list[Capability],
     ) -> Manifest | None:
         sandbox_config = self._require_sandbox_config()
-        configured_manifest = sandbox_config.manifest or agent.default_manifest
-        return self._process_manifest(
-            capabilities,
-            configured_manifest,
-            run_as_user=self._agent_run_as_user(agent),
-        )
+        return sandbox_config.manifest or agent.default_manifest
 
     @staticmethod
     def _process_manifest(

--- a/src/agents/sandbox/runtime_session_manager.py
+++ b/src/agents/sandbox/runtime_session_manager.py
@@ -334,15 +334,11 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
             resume_from_run_state = True
 
         if explicit_state is not None:
-            explicit_state = explicit_state.rebind_persisted_path_grants(
-                self._resolve_trusted_resume_manifest(
-                    agent=agent,
-                )
-            )
             explicit_state = self._process_resumed_state_manifest(
                 agent=agent,
                 capabilities=capabilities,
                 session_state=explicit_state,
+                trusted_manifest=self._resolve_trusted_resume_manifest(agent=agent),
             )
             span_cm = (
                 custom_span(
@@ -774,15 +770,26 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
         agent: SandboxAgent[TContext],
         capabilities: list[Capability],
         session_state: SandboxSessionState,
+        trusted_manifest: Manifest | None,
     ) -> SandboxSessionState:
+        resume_manifest = session_state.manifest
+        if session_state.path_grants_require_rebind and trusted_manifest is not None:
+            resume_manifest = resume_manifest.model_copy(
+                update={
+                    "extra_path_grants": tuple(
+                        grant.model_copy() for grant in trusted_manifest.extra_path_grants
+                    )
+                },
+            )
         processed_manifest = cls._process_manifest(
             capabilities,
-            session_state.manifest,
+            resume_manifest,
             run_as_user=cls._agent_run_as_user(agent),
         )
         if processed_manifest is None:
             return session_state
-        return session_state.model_copy(update={"manifest": processed_manifest})
+        processed_state = session_state.model_copy(update={"manifest": processed_manifest})
+        return processed_state.rebind_persisted_path_grants(processed_manifest)
 
     @staticmethod
     def _agent_run_as_user(agent: SandboxAgent[Any]) -> User | None:

--- a/src/agents/sandbox/runtime_session_manager.py
+++ b/src/agents/sandbox/runtime_session_manager.py
@@ -327,9 +327,19 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
         )
         if resumed_payload is not None:
             explicit_state = client.deserialize_session_state(resumed_payload)
+            explicit_state = SandboxSessionState._mark_persisted_path_grants(
+                explicit_state,
+                payload=resumed_payload,
+            )
             resume_from_run_state = True
 
         if explicit_state is not None:
+            explicit_state = explicit_state.rebind_persisted_path_grants(
+                self._resolve_trusted_resume_manifest(
+                    agent=agent,
+                    capabilities=capabilities,
+                )
+            )
             explicit_state = self._process_resumed_state_manifest(
                 agent=agent,
                 capabilities=capabilities,
@@ -519,6 +529,20 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
             return sandbox_config.manifest
         return agent.default_manifest
 
+    def _resolve_trusted_resume_manifest(
+        self,
+        *,
+        agent: SandboxAgent[TContext],
+        capabilities: list[Capability],
+    ) -> Manifest | None:
+        sandbox_config = self._require_sandbox_config()
+        configured_manifest = sandbox_config.manifest or agent.default_manifest
+        return self._process_manifest(
+            capabilities,
+            configured_manifest,
+            run_as_user=self._agent_run_as_user(agent),
+        )
+
     @staticmethod
     def _process_manifest(
         capabilities: list[Capability],
@@ -554,6 +578,11 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
         if processed_manifest is None or processed_manifest == current_manifest:
             return _LiveSessionManifestUpdate(processed_manifest=None, entries_to_apply=[])
 
+        cls._validate_live_session_host_path_grants(
+            current_manifest=current_manifest,
+            processed_manifest=processed_manifest,
+        )
+
         entries_to_apply: list[tuple[Path, BaseEntry]] = []
         if running:
             cls._validate_running_live_session_manifest_update(
@@ -576,6 +605,34 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
             processed_manifest=processed_manifest,
             entries_to_apply=entries_to_apply,
         )
+
+    @staticmethod
+    def _host_path_grant_topology(
+        manifest: Manifest,
+    ) -> tuple[tuple[str, bool, str | None], ...]:
+        mounted_targets = {
+            grant.path for grant in manifest.extra_path_grants if grant.host_path is not None
+        }
+        return tuple(
+            (grant.path, grant.read_only, grant.host_path)
+            for grant in manifest.extra_path_grants
+            if grant.path in mounted_targets
+        )
+
+    @classmethod
+    def _validate_live_session_host_path_grants(
+        cls,
+        *,
+        current_manifest: Manifest,
+        processed_manifest: Manifest,
+    ) -> None:
+        if cls._host_path_grant_topology(current_manifest) != cls._host_path_grant_topology(
+            processed_manifest
+        ):
+            raise ValueError(
+                "Injected sandbox sessions do not support capability changes to host-backed "
+                "`manifest.extra_path_grants`; use a fresh session or a session_state resume flow."
+            )
 
     @classmethod
     def _validate_running_live_session_manifest_update(

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -1718,7 +1718,7 @@ def _validate_docker_path_grants(manifest: Manifest) -> None:
             continue
         explicit_targets.add(target_str)
         sandbox_path_grant_host_path(grant)
-        if target == root or root in target.parents:
+        if target == root or root in target.parents or target in root.parents:
             raise ValueError(
                 "Docker sandbox path grant host_path target must be outside "
                 f"the workspace root: {grant.path}"

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -3,6 +3,7 @@ import errno
 import hashlib
 import io
 import logging
+import os
 import re
 import socket
 import tarfile
@@ -74,6 +75,7 @@ from ..workspace_paths import (
     coerce_posix_path,
     posix_path_as_path,
     posix_path_for_error,
+    sandbox_path_grant_host_path,
     sandbox_path_str,
 )
 
@@ -1468,6 +1470,7 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
         image = options.image
         session_id = uuid.uuid4()
         manifest = manifest or Manifest()
+        _validate_docker_path_grants(manifest)
 
         container = await self._create_container(
             image,
@@ -1534,8 +1537,12 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
     ) -> SandboxSession:
         if not isinstance(state, DockerSandboxSessionState):
             raise TypeError("DockerSandboxClient.resume expects a DockerSandboxSessionState")
+        state.assert_path_grants_rebound()
+        _validate_docker_path_grants(state.manifest)
         container = self.get_container(state.container_id)
         reused_existing_container = container is not None
+        if container is not None:
+            _assert_existing_container_path_grants_match(container, state.manifest)
         if container is None:
             container = await self._create_container(
                 state.image,
@@ -1557,7 +1564,7 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return DockerSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, DockerSandboxSessionState)
 
     async def _create_container(
         self,
@@ -1567,6 +1574,8 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
         exposed_ports: tuple[int, ...] = (),
         session_id: uuid.UUID | None = None,
     ) -> Container:
+        if manifest is not None:
+            _validate_docker_path_grants(manifest)
         # create image if it does not exist
         if not self.image_exists(image):
             repo, tag = parse_repository_tag(image)
@@ -1660,6 +1669,18 @@ def _build_docker_volume_mounts(
 ) -> list[DockerSDKMount]:
     mounts: list[DockerSDKMount] = []
 
+    for grant in manifest.extra_path_grants:
+        if grant.host_path is None:
+            continue
+        mounts.append(
+            DockerSDKMount(
+                target=grant.path,
+                source=str(sandbox_path_grant_host_path(grant)),
+                type="bind",
+                read_only=grant.read_only,
+            )
+        )
+
     for artifact, mount_path in _docker_volume_mounts_for_manifest(manifest):
         driver_config = artifact.mount_strategy.build_docker_volume_driver_config(artifact)
         assert driver_config is not None
@@ -1675,6 +1696,89 @@ def _build_docker_volume_mounts(
         )
 
     return mounts
+
+
+def _validate_docker_path_grants(manifest: Manifest) -> None:
+    root = coerce_posix_path(manifest.root)
+    seen_targets: set[str] = set()
+    explicit_targets: set[str] = set()
+    volume_targets = {
+        coerce_posix_path(mount_path).as_posix()
+        for _artifact, mount_path in _docker_volume_mounts_for_manifest(manifest)
+    }
+    for grant in manifest.extra_path_grants:
+        target = coerce_posix_path(grant.path)
+        target_str = target.as_posix()
+        if target_str in seen_targets and (
+            grant.host_path is not None or target_str in explicit_targets
+        ):
+            raise ValueError(f"duplicate Docker sandbox path grant target: {grant.path}")
+        seen_targets.add(target_str)
+        if grant.host_path is None:
+            continue
+        explicit_targets.add(target_str)
+        sandbox_path_grant_host_path(grant)
+        if target == root or root in target.parents:
+            raise ValueError(
+                "Docker sandbox path grant host_path target must be outside "
+                f"the workspace root: {grant.path}"
+            )
+        if target_str in volume_targets:
+            raise ValueError(
+                f"Docker sandbox path grant target conflicts with a manifest mount: {grant.path}"
+            )
+
+
+def _assert_existing_container_path_grants_match(
+    container: Container,
+    manifest: Manifest,
+) -> None:
+    container.reload()
+    raw_mounts = container.attrs.get("Mounts")
+    mounts = raw_mounts if isinstance(raw_mounts, list) else []
+    expected_grants = {
+        grant.path: grant for grant in manifest.extra_path_grants if grant.host_path is not None
+    }
+    actual_bind_mounts: dict[str, list[dict[object, object]]] = {}
+    for mount in mounts:
+        if not isinstance(mount, dict) or mount.get("Type") != "bind":
+            continue
+        destination = mount.get("Destination")
+        if not isinstance(destination, str):
+            raise ValueError(
+                "Existing Docker sandbox has a bind mount without a valid destination; "
+                "create a fresh sandbox session"
+            )
+        actual_bind_mounts.setdefault(destination, []).append(mount)
+
+    unexpected_targets = sorted(set(actual_bind_mounts) - set(expected_grants))
+    if unexpected_targets:
+        raise ValueError(
+            "Existing Docker sandbox has bind mounts that are not present in the current "
+            f"trusted manifest: {', '.join(unexpected_targets)}; create a fresh sandbox session"
+        )
+
+    for grant in expected_grants.values():
+        target_mounts = actual_bind_mounts.get(grant.path, [])
+        if len(target_mounts) != 1:
+            raise ValueError(
+                "Existing Docker sandbox path grant mount does not match the current trusted "
+                f"manifest for {grant.path!r}; create a fresh sandbox session"
+            )
+        expected_source = os.path.normcase(
+            os.path.normpath(str(sandbox_path_grant_host_path(grant)))
+        )
+        mount = target_mounts[0]
+        raw_source = mount.get("Source")
+        source = (
+            os.path.normcase(os.path.normpath(raw_source)) if isinstance(raw_source, str) else None
+        )
+        read_only = mount.get("RW") is False
+        if source != expected_source or read_only != grant.read_only:
+            raise ValueError(
+                "Existing Docker sandbox path grant mount does not match the current trusted "
+                f"manifest for {grant.path!r}; create a fresh sandbox session"
+            )
 
 
 def _docker_volume_names_for_manifest(

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -177,6 +177,7 @@ class UnixLocalSandboxSession(BaseSandboxSession):
         only_ephemeral: bool = False,
         provision_accounts: bool = True,
     ) -> MaterializationResult:
+        _assert_unix_local_host_path_grants_unsupported(self.state.manifest)
         if self.state.manifest.users or self.state.manifest.groups:
             raise ValueError(
                 "UnixLocalSandboxSession does not support manifest users or groups because "
@@ -1100,6 +1101,8 @@ class UnixLocalSandboxClient(BaseSandboxClient[UnixLocalSandboxClientOptions | N
         options: UnixLocalSandboxClientOptions | None = None,
     ) -> SandboxSession:
         resolved_options = options or UnixLocalSandboxClientOptions()
+        if manifest is not None:
+            _assert_unix_local_host_path_grants_unsupported(manifest)
         # For local execution, runner-created sessions should always get an isolated temp root
         # unless the caller explicitly chose a custom host path.
         workspace_root_owned = False
@@ -1159,8 +1162,24 @@ class UnixLocalSandboxClient(BaseSandboxClient[UnixLocalSandboxClientOptions | N
     ) -> SandboxSession:
         if not isinstance(state, UnixLocalSandboxSessionState):
             raise TypeError("UnixLocalSandboxClient.resume expects a UnixLocalSandboxSessionState")
+        state.assert_path_grants_rebound()
+        _assert_unix_local_host_path_grants_unsupported(state.manifest)
         inner = UnixLocalSandboxSession.from_state(state)
         return self._wrap_session(inner, instrumentation=self._instrumentation)
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
-        return UnixLocalSandboxSessionState.model_validate(payload)
+        return self._deserialize_session_state_payload(payload, UnixLocalSandboxSessionState)
+
+
+def _assert_unix_local_host_path_grants_unsupported(manifest: Manifest) -> None:
+    grant = next(
+        (grant for grant in manifest.extra_path_grants if grant.host_path is not None),
+        None,
+    )
+    if grant is None:
+        return
+    raise ValueError(
+        "UnixLocalSandboxClient does not support sandbox path grant host_path "
+        f"for {grant.path!r}; omit host_path when both paths are the same or use "
+        "DockerSandboxClient"
+    )

--- a/src/agents/sandbox/session/base_sandbox_session.py
+++ b/src/agents/sandbox/session/base_sandbox_session.py
@@ -204,7 +204,7 @@ class BaseSandboxSession(abc.ABC):
     _runtime_helpers_installed: set[PurePath] | None = None
     _runtime_helper_cache_key: object = _RUNTIME_HELPER_CACHE_KEY_UNSET
     _workspace_path_policy_cache: (
-        tuple[str, tuple[tuple[str, bool], ...], WorkspacePathPolicy] | None
+        tuple[str, tuple[tuple[str, bool, str | None], ...], WorkspacePathPolicy] | None
     ) = None
     # True when start() is reusing a backend whose workspace files may still be present.
     # This controls whether start() can avoid a full manifest apply for non-snapshot resumes.
@@ -742,7 +742,8 @@ class BaseSandboxSession(abc.ABC):
     def _workspace_path_policy(self) -> WorkspacePathPolicy:
         root = self.state.manifest.root
         grants_key = tuple(
-            (grant.path, grant.read_only) for grant in self.state.manifest.extra_path_grants
+            (grant.path, grant.read_only, grant.host_path)
+            for grant in self.state.manifest.extra_path_grants
         )
         cached = self._workspace_path_policy_cache
         if cached is not None and cached[0] == root and cached[1] == grants_key:

--- a/src/agents/sandbox/session/sandbox_client.py
+++ b/src/agents/sandbox/session/sandbox_client.py
@@ -11,7 +11,10 @@ from .base_sandbox_session import BaseSandboxSession
 from .dependencies import Dependencies
 from .manager import Instrumentation
 from .sandbox_session import SandboxSession
-from .sandbox_session_state import SandboxSessionState
+from .sandbox_session_state import (
+    REDACTED_HOST_PATH_GRANT_PATHS_KEY,
+    SandboxSessionState,
+)
 
 SandboxClientOptionsClass = type["BaseSandboxClientOptions"]
 ClientOptionsT = TypeVar("ClientOptionsT")
@@ -172,7 +175,36 @@ class BaseSandboxClient(abc.ABC, Generic[ClientOptionsT]):
 
     def serialize_session_state(self, state: SandboxSessionState) -> dict[str, object]:
         """Serialize backend-specific sandbox state into a JSON-compatible payload."""
-        return state.model_dump(mode="json")
+        redacted_paths = set(state.redacted_host_path_grant_paths)
+        persistent_grants = []
+        for grant in state.manifest.extra_path_grants:
+            if grant.host_path is not None:
+                redacted_paths.add(grant.path)
+            persistent_grants.append(grant.model_copy(update={"host_path": None}))
+
+        persistent_manifest = state.manifest.model_copy(
+            update={"extra_path_grants": tuple(persistent_grants)},
+        )
+        persistent_state = state.model_copy(update={"manifest": persistent_manifest})
+        payload = cast(dict[str, object], persistent_state.model_dump(mode="json"))
+        manifest_payload = payload.get("manifest")
+        if isinstance(manifest_payload, dict):
+            grant_payloads = manifest_payload.get("extra_path_grants")
+            if isinstance(grant_payloads, list):
+                for grant_payload in grant_payloads:
+                    if isinstance(grant_payload, dict):
+                        grant_payload.pop("host_path", None)
+        if redacted_paths:
+            payload[REDACTED_HOST_PATH_GRANT_PATHS_KEY] = sorted(redacted_paths)
+        return payload
+
+    @staticmethod
+    def _deserialize_session_state_payload(
+        payload: dict[str, object],
+        state_class: type[SandboxSessionState],
+    ) -> SandboxSessionState:
+        state = state_class.model_validate(payload)
+        return SandboxSessionState._mark_persisted_path_grants(state, payload=payload)
 
     @abc.abstractmethod
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:

--- a/src/agents/sandbox/session/sandbox_client.py
+++ b/src/agents/sandbox/session/sandbox_client.py
@@ -175,25 +175,19 @@ class BaseSandboxClient(abc.ABC, Generic[ClientOptionsT]):
 
     def serialize_session_state(self, state: SandboxSessionState) -> dict[str, object]:
         """Serialize backend-specific sandbox state into a JSON-compatible payload."""
-        redacted_paths = set(state.redacted_host_path_grant_paths)
+        redacted_paths = set(state.path_grants_require_rebind)
         persistent_grants = []
         for grant in state.manifest.extra_path_grants:
             if grant.host_path is not None:
                 redacted_paths.add(grant.path)
-            persistent_grants.append(grant.model_copy(update={"host_path": None}))
+                continue
+            persistent_grants.append(grant)
 
         persistent_manifest = state.manifest.model_copy(
             update={"extra_path_grants": tuple(persistent_grants)},
         )
         persistent_state = state.model_copy(update={"manifest": persistent_manifest})
         payload = cast(dict[str, object], persistent_state.model_dump(mode="json"))
-        manifest_payload = payload.get("manifest")
-        if isinstance(manifest_payload, dict):
-            grant_payloads = manifest_payload.get("extra_path_grants")
-            if isinstance(grant_payloads, list):
-                for grant_payload in grant_payloads:
-                    if isinstance(grant_payload, dict):
-                        grant_payload.pop("host_path", None)
         if redacted_paths:
             payload[REDACTED_HOST_PATH_GRANT_PATHS_KEY] = sorted(redacted_paths)
         return payload

--- a/src/agents/sandbox/session/sandbox_session_state.py
+++ b/src/agents/sandbox/session/sandbox_session_state.py
@@ -16,7 +16,6 @@ from pydantic import (
 
 from ..manifest import Manifest
 from ..snapshot import SnapshotBase
-from ..workspace_paths import SandboxPathGrant
 
 SessionStateClass = type["SandboxSessionState"]
 REDACTED_HOST_PATH_GRANT_PATHS_KEY = "__openai_agents_redacted_host_path_grant_paths"
@@ -35,15 +34,10 @@ class SandboxSessionState(BaseModel):
 
     _subclass_registry: ClassVar[dict[str, SessionStateClass]] = {}
     _path_grants_require_rebind: tuple[str, ...] = PrivateAttr(default=())
-    _redacted_host_path_grant_paths: tuple[str, ...] = PrivateAttr(default=())
 
     @property
     def path_grants_require_rebind(self) -> tuple[str, ...]:
         return self._path_grants_require_rebind
-
-    @property
-    def redacted_host_path_grant_paths(self) -> tuple[str, ...]:
-        return self._redacted_host_path_grant_paths
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
@@ -111,10 +105,7 @@ class SandboxSessionState(BaseModel):
             else ()
         )
         marked = state.model_copy()
-        marked._path_grants_require_rebind = tuple(
-            grant.path for grant in state.manifest.extra_path_grants
-        )
-        marked._redacted_host_path_grant_paths = redacted_paths
+        marked._path_grants_require_rebind = redacted_paths
         return marked
 
     def rebind_persisted_path_grants(
@@ -131,35 +122,15 @@ class SandboxSessionState(BaseModel):
                 "manifest before resume"
             )
 
-        trusted_grants: dict[str, list[SandboxPathGrant]] = {}
-        for grant in trusted_manifest.extra_path_grants:
-            trusted_grants.setdefault(grant.path, []).append(grant)
-
-        matched_grant_counts: dict[str, int] = {}
-        rebound_grants: list[SandboxPathGrant] = []
-        missing_paths: list[str] = []
-        for persisted_grant in self.manifest.extra_path_grants:
-            candidates = trusted_grants.get(persisted_grant.path, [])
-            candidate_index = matched_grant_counts.get(persisted_grant.path, 0)
-            if candidate_index >= len(candidates):
-                missing_paths.append(persisted_grant.path)
-                continue
-            rebound_grants.append(candidates[candidate_index].model_copy())
-            matched_grant_counts[persisted_grant.path] = candidate_index + 1
-
-        if missing_paths:
-            raise ValueError(
-                "Sandbox session state contains path grants that are not present in the "
-                f"current trusted manifest: {', '.join(missing_paths)}"
-            )
-
-        rebound_host_path_grant_paths = {
-            grant.path for grant in rebound_grants if grant.host_path is not None
+        trusted_host_path_grant_paths = {
+            grant.path
+            for grant in trusted_manifest.extra_path_grants
+            if grant.host_path is not None
         }
         missing_host_paths = [
             path
-            for path in self.redacted_host_path_grant_paths
-            if path in self.path_grants_require_rebind and path not in rebound_host_path_grant_paths
+            for path in self.path_grants_require_rebind
+            if path not in trusted_host_path_grant_paths
         ]
         if missing_host_paths:
             raise ValueError(
@@ -168,11 +139,14 @@ class SandboxSessionState(BaseModel):
             )
 
         rebound_manifest = self.manifest.model_copy(
-            update={"extra_path_grants": tuple(rebound_grants)},
+            update={
+                "extra_path_grants": tuple(
+                    grant.model_copy() for grant in trusted_manifest.extra_path_grants
+                )
+            },
         )
         rebound = self.model_copy(update={"manifest": rebound_manifest})
         rebound._path_grants_require_rebind = ()
-        rebound._redacted_host_path_grant_paths = ()
         return rebound
 
     def assert_path_grants_rebound(self) -> None:

--- a/src/agents/sandbox/session/sandbox_session_state.py
+++ b/src/agents/sandbox/session/sandbox_session_state.py
@@ -99,13 +99,30 @@ class SandboxSessionState(BaseModel):
         payload: dict[str, object],
     ) -> SandboxSessionState:
         redacted_value = payload.get(REDACTED_HOST_PATH_GRANT_PATHS_KEY)
-        redacted_paths = (
+        marker_paths = (
             tuple(path for path in redacted_value if isinstance(path, str))
             if isinstance(redacted_value, list | tuple)
             else ()
         )
-        marked = state.model_copy()
-        marked._path_grants_require_rebind = redacted_paths
+        serialized_host_path_grant_paths = tuple(
+            grant.path for grant in state.manifest.extra_path_grants if grant.host_path is not None
+        )
+        persistent_grants = tuple(
+            grant for grant in state.manifest.extra_path_grants if grant.host_path is None
+        )
+        sanitized_manifest = state.manifest.model_copy(
+            update={"extra_path_grants": persistent_grants},
+        )
+        marked = state.model_copy(update={"manifest": sanitized_manifest})
+        marked._path_grants_require_rebind = tuple(
+            dict.fromkeys(
+                (
+                    *state.path_grants_require_rebind,
+                    *marker_paths,
+                    *serialized_host_path_grant_paths,
+                )
+            )
+        )
         return marked
 
     def rebind_persisted_path_grants(

--- a/src/agents/sandbox/session/sandbox_session_state.py
+++ b/src/agents/sandbox/session/sandbox_session_state.py
@@ -4,12 +4,22 @@ import uuid
 from collections.abc import Iterable
 from typing import Any, ClassVar, Literal, get_args, get_origin
 
-from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, field_validator, model_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    SerializeAsAny,
+    field_validator,
+    model_serializer,
+)
 
 from ..manifest import Manifest
 from ..snapshot import SnapshotBase
+from ..workspace_paths import SandboxPathGrant
 
 SessionStateClass = type["SandboxSessionState"]
+REDACTED_HOST_PATH_GRANT_PATHS_KEY = "__openai_agents_redacted_host_path_grant_paths"
 
 
 class SandboxSessionState(BaseModel):
@@ -24,6 +34,16 @@ class SandboxSessionState(BaseModel):
     workspace_root_ready: bool = False
 
     _subclass_registry: ClassVar[dict[str, SessionStateClass]] = {}
+    _path_grants_require_rebind: tuple[str, ...] = PrivateAttr(default=())
+    _redacted_host_path_grant_paths: tuple[str, ...] = PrivateAttr(default=())
+
+    @property
+    def path_grants_require_rebind(self) -> tuple[str, ...]:
+        return self._path_grants_require_rebind
+
+    @property
+    def redacted_host_path_grant_paths(self) -> tuple[str, ...]:
+        return self._redacted_host_path_grant_paths
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
@@ -70,9 +90,98 @@ class SandboxSessionState(BaseModel):
             if subclass is None:
                 raise ValueError(f"unknown sandbox session state type `{state_type}`")
 
-            return subclass.model_validate(payload)
+            return cls._mark_persisted_path_grants(
+                subclass.model_validate(payload),
+                payload=payload,
+            )
 
         raise TypeError("session state payload must be a SandboxSessionState or dict")
+
+    @classmethod
+    def _mark_persisted_path_grants(
+        cls,
+        state: SandboxSessionState,
+        *,
+        payload: dict[str, object],
+    ) -> SandboxSessionState:
+        redacted_value = payload.get(REDACTED_HOST_PATH_GRANT_PATHS_KEY)
+        redacted_paths = (
+            tuple(path for path in redacted_value if isinstance(path, str))
+            if isinstance(redacted_value, list | tuple)
+            else ()
+        )
+        marked = state.model_copy()
+        marked._path_grants_require_rebind = tuple(
+            grant.path for grant in state.manifest.extra_path_grants
+        )
+        marked._redacted_host_path_grant_paths = redacted_paths
+        return marked
+
+    def rebind_persisted_path_grants(
+        self,
+        trusted_manifest: Manifest | None,
+    ) -> SandboxSessionState:
+        """Replace persisted path grants with grants from current trusted configuration."""
+
+        if not self.path_grants_require_rebind:
+            return self
+        if trusted_manifest is None:
+            raise ValueError(
+                "Sandbox session state contains path grants that require a current trusted "
+                "manifest before resume"
+            )
+
+        trusted_grants: dict[str, list[SandboxPathGrant]] = {}
+        for grant in trusted_manifest.extra_path_grants:
+            trusted_grants.setdefault(grant.path, []).append(grant)
+
+        matched_grant_counts: dict[str, int] = {}
+        rebound_grants: list[SandboxPathGrant] = []
+        missing_paths: list[str] = []
+        for persisted_grant in self.manifest.extra_path_grants:
+            candidates = trusted_grants.get(persisted_grant.path, [])
+            candidate_index = matched_grant_counts.get(persisted_grant.path, 0)
+            if candidate_index >= len(candidates):
+                missing_paths.append(persisted_grant.path)
+                continue
+            rebound_grants.append(candidates[candidate_index].model_copy())
+            matched_grant_counts[persisted_grant.path] = candidate_index + 1
+
+        if missing_paths:
+            raise ValueError(
+                "Sandbox session state contains path grants that are not present in the "
+                f"current trusted manifest: {', '.join(missing_paths)}"
+            )
+
+        rebound_host_path_grant_paths = {
+            grant.path for grant in rebound_grants if grant.host_path is not None
+        }
+        missing_host_paths = [
+            path
+            for path in self.redacted_host_path_grant_paths
+            if path in self.path_grants_require_rebind and path not in rebound_host_path_grant_paths
+        ]
+        if missing_host_paths:
+            raise ValueError(
+                "Sandbox session state requires current trusted host_path values for these "
+                f"path grants: {', '.join(missing_host_paths)}"
+            )
+
+        rebound_manifest = self.manifest.model_copy(
+            update={"extra_path_grants": tuple(rebound_grants)},
+        )
+        rebound = self.model_copy(update={"manifest": rebound_manifest})
+        rebound._path_grants_require_rebind = ()
+        rebound._redacted_host_path_grant_paths = ()
+        return rebound
+
+    def assert_path_grants_rebound(self) -> None:
+        if not self.path_grants_require_rebind:
+            return
+        raise ValueError(
+            "Sandbox session state path grants must be rebound from a current trusted manifest "
+            "before resume; resume through Runner with SandboxRunConfig.manifest"
+        )
 
     @model_serializer(mode="wrap")
     def _serialize_always_include_defaults(self, handler: Any) -> dict[str, Any]:

--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -173,6 +173,7 @@ def sandbox_path_grant_host_path(grant: SandboxPathGrant) -> Path:
             f"sandbox path grant host_path must be drive-qualified on Windows: {raw_path}"
         )
     _raise_if_filesystem_root(native_path)
+    _raise_if_filesystem_root(native_path.resolve(strict=False), resolved=True)
     return native_path
 
 

--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -173,8 +173,9 @@ def sandbox_path_grant_host_path(grant: SandboxPathGrant) -> Path:
             f"sandbox path grant host_path must be drive-qualified on Windows: {raw_path}"
         )
     _raise_if_filesystem_root(native_path)
-    _raise_if_filesystem_root(native_path.resolve(strict=False), resolved=True)
-    return native_path
+    resolved_path = native_path.resolve(strict=False)
+    _raise_if_filesystem_root(resolved_path, resolved=True)
+    return resolved_path
 
 
 class WorkspacePathPolicy:

--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import os
 import posixpath
+import re
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import Literal, cast
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .errors import InvalidManifestPathError, WorkspaceArchiveWriteError
 
@@ -70,11 +72,16 @@ def _native_path_from_windows_absolute(path: PureWindowsPath) -> Path | None:
 
 
 class SandboxPathGrant(BaseModel):
-    """Extra absolute path access outside the sandbox workspace."""
+    """Extra absolute path access outside the sandbox workspace.
+
+    ``path`` is the POSIX path visible inside the sandbox. ``host_path`` is an optional
+    native host source used for local materialization and Docker bind mounts.
+    """
 
     path: str
     read_only: bool = False
     description: str | None = None
+    host_path: str | None = Field(default=None, exclude_if=lambda value: value is None)
 
     @field_validator("path", mode="before")
     @classmethod
@@ -100,7 +107,73 @@ class SandboxPathGrant(BaseModel):
             _raise_if_filesystem_root(path)
             return path.as_posix()
 
-        raise ValueError("sandbox path grant path must be absolute")
+        raise ValueError("sandbox path grant path must be POSIX absolute")
+
+    @field_validator("host_path", mode="before")
+    @classmethod
+    def _coerce_host_path(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, PurePath):
+            return str(value)
+        if isinstance(value, str):
+            return value
+        raise ValueError("sandbox path grant host_path must be a string or Path")
+
+    @field_validator("host_path")
+    @classmethod
+    def _validate_host_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if value.startswith(("\\\\", "//")):
+            raise ValueError("sandbox path grant host_path does not support UNC or device paths")
+        if any(part == ".." for part in re.split(r"[\\/]", value)):
+            raise ValueError("sandbox path grant host_path must not contain parent segments")
+
+        windows_path = PureWindowsPath(value)
+        if windows_path.is_absolute():
+            if not re.fullmatch(r"[A-Za-z]:", windows_path.drive):
+                raise ValueError(
+                    "sandbox path grant host_path does not support UNC or device paths"
+                )
+            _raise_if_filesystem_root(windows_path)
+            return str(windows_path)
+
+        posix_path = PurePosixPath(posixpath.normpath(value))
+        if posix_path.is_absolute():
+            _raise_if_filesystem_root(posix_path)
+            return posix_path.as_posix()
+
+        raise ValueError("sandbox path grant host_path must be an absolute host path")
+
+    @model_validator(mode="after")
+    def _validate_split_path_grant(self) -> SandboxPathGrant:
+        if self.host_path is not None and windows_absolute_path(self.path) is not None:
+            raise ValueError(
+                "sandbox path grant path must be POSIX absolute when host_path is configured"
+            )
+        return self
+
+
+def sandbox_path_grant_host_path(grant: SandboxPathGrant) -> Path:
+    """Return and validate the native host path used by a sandbox path grant."""
+
+    raw_path = grant.host_path if grant.host_path is not None else grant.path
+    native_path = Path(raw_path)
+    if grant.host_path is not None and not native_path.is_absolute():
+        raise ValueError(
+            f"sandbox path grant host_path must be absolute on the current host: {raw_path}"
+        )
+    if (
+        grant.host_path is not None
+        and os.name == "nt"
+        and not re.fullmatch(r"[A-Za-z]:", PureWindowsPath(raw_path).drive)
+    ):
+        raise ValueError(
+            f"sandbox path grant host_path must be drive-qualified on Windows: {raw_path}"
+        )
+    _raise_if_filesystem_root(native_path)
+    return native_path
 
 
 class WorkspacePathPolicy:
@@ -319,7 +392,7 @@ class WorkspacePathPolicy:
         matches: list[tuple[SandboxPathGrant, PurePath]] = []
         for grant in self._extra_path_grants:
             grant_root: PurePath = (
-                Path(grant.path).resolve(strict=False)
+                sandbox_path_grant_host_path(grant).resolve(strict=False)
                 if resolve_roots
                 else coerce_posix_path(grant.path)
             )

--- a/tests/sandbox/capabilities/test_shell_capability.py
+++ b/tests/sandbox/capabilities/test_shell_capability.py
@@ -512,7 +512,7 @@ class TestShellCapability:
         )
 
     @pytest.mark.asyncio
-    async def test_exec_command_tool_allows_extra_path_grant_workdir(
+    async def test_exec_command_tool_allows_split_path_grant_workdir(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -520,7 +520,13 @@ class TestShellCapability:
         session = _ShellSession(
             Manifest(
                 root="/workspace",
-                extra_path_grants=(SandboxPathGrant(path="/tmp", read_only=True),),
+                extra_path_grants=(
+                    SandboxPathGrant(
+                        path="/mnt/shared-data",
+                        host_path="/native/shared-data",
+                        read_only=True,
+                    ),
+                ),
             )
         )
         capability.bind(session)
@@ -536,20 +542,20 @@ class TestShellCapability:
             cast(ToolContext[object], None),
             ExecCommandArgs(
                 cmd="pwd",
-                workdir="/tmp",
+                workdir="/mnt/shared-data",
                 shell="/bin/bash",
                 login=False,
             ).model_dump_json(),
         )
 
-        assert session.exec_calls == [("cd /tmp && pwd", 10.0, ["/bin/bash", "-c"])]
+        assert session.exec_calls == [("cd /mnt/shared-data && pwd", 10.0, ["/bin/bash", "-c"])]
         assert (
             output == "Chunk ID: 111111\n"
             "Wall time: 0.2500 seconds\n"
             "Process exited with code 7\n"
             "Output:\n"
-            "stdout: cd /tmp && pwd\n"
-            "stderr: cd /tmp && pwd"
+            "stdout: cd /mnt/shared-data && pwd\n"
+            "stderr: cd /mnt/shared-data && pwd"
         )
 
     @pytest.mark.asyncio

--- a/tests/sandbox/capabilities/test_skills_capability.py
+++ b/tests/sandbox/capabilities/test_skills_capability.py
@@ -776,3 +776,48 @@ class TestSkillsLazyLoading:
             "- cached-skill: old description (file: .agents/dynamic-skill)" in second_instructions
         )
         assert "- cached-skill: new description (file: .agents/dynamic-skill)" in third_instructions
+
+    @pytest.mark.asyncio
+    async def test_lazy_metadata_cache_is_invalidated_when_host_path_changes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        src_root = tmp_path / "skills"
+        skill_dir = src_root / "dynamic-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: cached-skill\ndescription: cached description\n---\n# Skill\n",
+            encoding="utf-8",
+        )
+        other_root = tmp_path / "other-skills"
+        other_root.mkdir()
+        capability = Skills(lazy_from=LocalDirLazySkillSource(source=LocalDir(src=src_root)))
+
+        first_instructions = await capability.instructions(
+            Manifest(
+                root="/workspace",
+                extra_path_grants=(
+                    SandboxPathGrant(
+                        path="/mnt/skills",
+                        host_path=str(src_root),
+                    ),
+                ),
+            )
+        )
+        second_instructions = await capability.instructions(
+            Manifest(
+                root="/workspace",
+                extra_path_grants=(
+                    SandboxPathGrant(
+                        path="/mnt/skills",
+                        host_path=str(other_root),
+                    ),
+                ),
+            )
+        )
+
+        assert first_instructions is not None
+        assert (
+            "- cached-skill: cached description (file: .agents/dynamic-skill)" in first_instructions
+        )
+        assert second_instructions is None

--- a/tests/sandbox/test_docker.py
+++ b/tests/sandbox/test_docker.py
@@ -1404,19 +1404,21 @@ async def test_docker_normalize_path_preserves_safe_leaf_symlink_path(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_docker_read_allows_extra_path_grant(tmp_path: Path) -> None:
+async def test_docker_read_uses_sandbox_target_for_split_path_grant(tmp_path: Path) -> None:
     host_root = tmp_path / "container"
     workspace = host_root / "workspace"
     extra_root = host_root / "tmp"
+    native_source = tmp_path / "native-source"
     workspace.mkdir(parents=True)
     extra_root.mkdir(parents=True)
+    native_source.mkdir()
     (extra_root / "result.txt").write_text("scratch output", encoding="utf-8")
 
     session = _HostBackedDockerSession(
         host_root=host_root,
         manifest=Manifest(
             root="/workspace",
-            extra_path_grants=(SandboxPathGrant(path="/tmp"),),
+            extra_path_grants=(SandboxPathGrant(path="/tmp", host_path=str(native_source)),),
         ),
     )
 
@@ -1734,6 +1736,130 @@ async def test_docker_create_container_publishes_exposed_ports(
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_docker_create_container_mounts_explicit_host_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host_path = tmp_path / "shared-data"
+    host_path.mkdir()
+    container = _ResumeContainer(status="created")
+    docker_client = _FakeCreateDockerClient(container)
+    client = DockerSandboxClient(docker_client=cast(object, docker_client))
+    manifest = Manifest(
+        extra_path_grants=(
+            SandboxPathGrant(
+                path="/mnt/shared-data",
+                host_path=str(host_path),
+                read_only=True,
+            ),
+        )
+    )
+
+    monkeypatch.setattr(client, "image_exists", lambda _image: True)
+
+    created = await client._create_container(
+        DEFAULT_PYTHON_SANDBOX_IMAGE,
+        manifest=manifest,
+    )
+
+    assert created is container
+    mounts = cast(list[dict[str, object]], docker_client.containers.calls[0]["mounts"])
+    assert mounts == [
+        {
+            "Target": "/mnt/shared-data",
+            "Source": str(host_path),
+            "Type": "bind",
+            "ReadOnly": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_docker_create_container_keeps_path_only_grant_unmounted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    container = _ResumeContainer(status="created")
+    docker_client = _FakeCreateDockerClient(container)
+    client = DockerSandboxClient(docker_client=cast(object, docker_client))
+    manifest = Manifest(extra_path_grants=(SandboxPathGrant(path="/tmp", read_only=True),))
+
+    monkeypatch.setattr(client, "image_exists", lambda _image: True)
+
+    await client._create_container(
+        DEFAULT_PYTHON_SANDBOX_IMAGE,
+        manifest=manifest,
+    )
+
+    assert "mounts" not in docker_client.containers.calls[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit_first", [False, True])
+async def test_docker_rejects_duplicate_target_shared_by_split_and_path_only_grants(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    explicit_first: bool,
+) -> None:
+    path_only = SandboxPathGrant(path="/mnt/shared-data")
+    explicit = SandboxPathGrant(
+        path="/mnt/shared-data",
+        host_path=str(tmp_path),
+    )
+    grants = (explicit, path_only) if explicit_first else (path_only, explicit)
+    client = DockerSandboxClient(docker_client=cast(object, _FakeDockerClient()))
+    image_lookups = 0
+
+    def _image_exists(_image: str) -> bool:
+        nonlocal image_lookups
+        image_lookups += 1
+        return True
+
+    monkeypatch.setattr(client, "image_exists", _image_exists)
+
+    with pytest.raises(ValueError, match="duplicate Docker sandbox path grant target"):
+        await client._create_container(
+            DEFAULT_PYTHON_SANDBOX_IMAGE,
+            manifest=Manifest(extra_path_grants=grants),
+        )
+
+    assert image_lookups == 0
+
+
+@pytest.mark.asyncio
+async def test_docker_rejects_host_path_target_inside_workspace_before_image_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = DockerSandboxClient(docker_client=cast(object, _FakeDockerClient()))
+    image_lookups = 0
+
+    def _image_exists(_image: str) -> bool:
+        nonlocal image_lookups
+        image_lookups += 1
+        return True
+
+    monkeypatch.setattr(client, "image_exists", _image_exists)
+
+    with pytest.raises(
+        ValueError,
+        match="host_path target must be outside the workspace root",
+    ):
+        await client._create_container(
+            DEFAULT_PYTHON_SANDBOX_IMAGE,
+            manifest=Manifest(
+                extra_path_grants=(
+                    SandboxPathGrant(
+                        path="/workspace/shared-data",
+                        host_path=str(tmp_path),
+                    ),
+                )
+            ),
+        )
+
+    assert image_lookups == 0
 
 
 @pytest.mark.asyncio
@@ -2395,12 +2521,16 @@ class _ResumeContainer:
         container_id: str = "container",
         workspace_exists: bool = False,
         published_ports: dict[str, list[dict[str, str]] | None] | None = None,
+        mounts: list[dict[str, object]] | None = None,
     ) -> None:
         self.status = status
         self.id = container_id
         self.exec_calls: list[dict[str, object]] = []
         self._workspace_exists = workspace_exists
-        self.attrs = {"NetworkSettings": {"Ports": published_ports or {}}}
+        self.attrs = {
+            "NetworkSettings": {"Ports": published_ports or {}},
+            "Mounts": mounts or [],
+        }
 
     def reload(self) -> None:
         return
@@ -2840,6 +2970,118 @@ async def test_docker_resume_preserves_workspace_readiness_from_state() -> None:
     assert isinstance(not_ready_session._inner, DockerSandboxSession)
     assert not_ready_session._inner._workspace_root_ready is False
     assert not_ready_session._inner.should_provision_manifest_accounts_on_resume() is False
+
+
+@pytest.mark.asyncio
+async def test_docker_resume_requires_existing_host_mount_to_match_trusted_state(
+    tmp_path: Path,
+) -> None:
+    host_path = tmp_path / "shared-data"
+    host_path.mkdir()
+    manifest = Manifest(
+        extra_path_grants=(
+            SandboxPathGrant(
+                path="/mnt/shared-data",
+                host_path=str(host_path),
+                read_only=True,
+            ),
+        )
+    )
+    matching_client = DockerSandboxClient(
+        docker_client=_ResumeDockerClient(
+            _ResumeContainer(
+                status="running",
+                mounts=[
+                    {
+                        "Type": "bind",
+                        "Source": str(host_path),
+                        "Destination": "/mnt/shared-data",
+                        "RW": False,
+                    }
+                ],
+            )
+        )
+    )
+    state = DockerSandboxSessionState(
+        manifest=manifest,
+        snapshot=NoopSnapshot(id="snapshot"),
+        image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+        container_id="container",
+    )
+
+    await matching_client.resume(state)
+
+    mismatched_client = DockerSandboxClient(
+        docker_client=_ResumeDockerClient(_ResumeContainer(status="running"))
+    )
+    with pytest.raises(ValueError, match="does not match the current trusted manifest"):
+        await mismatched_client.resume(state)
+
+
+@pytest.mark.asyncio
+async def test_docker_resume_rejects_stale_bind_mount_for_path_only_grant(
+    tmp_path: Path,
+) -> None:
+    host_path = tmp_path / "shared-data"
+    host_path.mkdir()
+    client = DockerSandboxClient(
+        docker_client=_ResumeDockerClient(
+            _ResumeContainer(
+                status="running",
+                mounts=[
+                    {
+                        "Type": "bind",
+                        "Source": str(host_path),
+                        "Destination": "/mnt/shared-data",
+                        "RW": True,
+                    }
+                ],
+            )
+        )
+    )
+    state = DockerSandboxSessionState(
+        manifest=Manifest(
+            extra_path_grants=(SandboxPathGrant(path="/mnt/shared-data"),),
+        ),
+        snapshot=NoopSnapshot(id="snapshot"),
+        image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+        container_id="container",
+    )
+
+    with pytest.raises(ValueError, match="not present in the current trusted manifest"):
+        await client.resume(state)
+
+
+@pytest.mark.asyncio
+async def test_docker_resume_rejects_bind_mount_when_persisted_grants_are_removed(
+    tmp_path: Path,
+) -> None:
+    host_path = tmp_path / "shared-data"
+    host_path.mkdir()
+    client = DockerSandboxClient(
+        docker_client=_ResumeDockerClient(
+            _ResumeContainer(
+                status="running",
+                mounts=[
+                    {
+                        "Type": "bind",
+                        "Source": str(host_path),
+                        "Destination": "/mnt/shared-data",
+                        "RW": True,
+                    }
+                ],
+            )
+        )
+    )
+    state = DockerSandboxSessionState(
+        manifest=Manifest(),
+        snapshot=NoopSnapshot(id="snapshot"),
+        image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+        container_id="container",
+    )
+
+    with pytest.raises(ValueError, match="not present in the current trusted manifest"):
+        await client.resume(state)
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_docker.py
+++ b/tests/sandbox/test_docker.py
@@ -1829,9 +1829,19 @@ async def test_docker_rejects_duplicate_target_shared_by_split_and_path_only_gra
 
 
 @pytest.mark.asyncio
-async def test_docker_rejects_host_path_target_inside_workspace_before_image_lookup(
+@pytest.mark.parametrize(
+    ("root", "target"),
+    [
+        ("/workspace", "/workspace/shared-data"),
+        ("/workspace/project", "/workspace"),
+    ],
+    ids=["target-inside-workspace", "target-contains-workspace"],
+)
+async def test_docker_rejects_host_path_target_overlapping_workspace_before_image_lookup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    root: str,
+    target: str,
 ) -> None:
     client = DockerSandboxClient(docker_client=cast(object, _FakeDockerClient()))
     image_lookups = 0
@@ -1850,12 +1860,13 @@ async def test_docker_rejects_host_path_target_inside_workspace_before_image_loo
         await client._create_container(
             DEFAULT_PYTHON_SANDBOX_IMAGE,
             manifest=Manifest(
+                root=root,
                 extra_path_grants=(
                     SandboxPathGrant(
-                        path="/workspace/shared-data",
+                        path=target,
                         host_path=str(tmp_path),
                     ),
-                )
+                ),
             ),
         )
 

--- a/tests/sandbox/test_entries.py
+++ b/tests/sandbox/test_entries.py
@@ -282,6 +282,35 @@ async def test_local_file_allows_extra_path_granted_source_outside_base_dir(
 
 
 @pytest.mark.asyncio
+async def test_local_file_uses_host_path_for_source_grant(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    outside = tmp_path / "outside"
+    base.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    session = _RecordingSession(
+        Manifest(
+            extra_path_grants=(
+                SandboxPathGrant(
+                    path="/mnt/shared-data",
+                    host_path=str(outside),
+                    read_only=True,
+                ),
+            )
+        ),
+    )
+
+    result = await LocalFile(src=outside / "secret.txt").apply(
+        session,
+        Path("/workspace/copied.txt"),
+        base,
+    )
+
+    assert result[0].path == Path("/workspace/copied.txt")
+    assert session.writes[Path("/workspace/copied.txt")] == b"secret"
+
+
+@pytest.mark.asyncio
 async def test_local_file_rejects_source_outside_extra_path_grants(tmp_path: Path) -> None:
     base = tmp_path / "base"
     outside = tmp_path / "outside"

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -767,14 +767,16 @@ class _ManifestUsersCapability(Capability):
 class _ManifestPathGrantsCapability(Capability):
     type: str = "manifest-path-grants"
     grants: tuple[SandboxPathGrant, ...]
+    process_calls: int
 
     def __init__(self, grants: tuple[SandboxPathGrant, ...]) -> None:
         super().__init__(
             type="manifest-path-grants",
-            **cast(Any, {"grants": grants}),
+            **cast(Any, {"grants": grants, "process_calls": 0}),
         )
 
     def process_manifest(self, manifest: Manifest) -> Manifest:
+        self.process_calls += 1
         manifest.extra_path_grants = self.grants
         return manifest
 
@@ -3331,6 +3333,123 @@ async def test_session_manager_rebinds_persisted_path_grants_from_current_manife
     assert client.resume_state is not None
     assert client.resume_state.manifest.extra_path_grants == trusted_manifest.extra_path_grants
     assert client.resume_state.path_grants_require_rebind == ()
+
+
+@pytest.mark.asyncio
+async def test_session_manager_rebinds_capability_host_path_grant_once(
+    tmp_path: Path,
+) -> None:
+    host_grant = SandboxPathGrant(
+        path="/mnt/shared-data",
+        host_path=str(tmp_path),
+        read_only=True,
+    )
+    capability = _ManifestPathGrantsCapability((host_grant,))
+    client = _FakeClient(_FakeSession(Manifest()))
+    agent = SandboxAgent(
+        name="worker",
+        model=FakeModel(),
+        instructions="Worker.",
+        default_manifest=Manifest(),
+    )
+    session_state = TestSessionState(
+        manifest=Manifest(extra_path_grants=(host_grant,)),
+        snapshot=NoopSnapshot(id="resume"),
+    )
+    serialized_state = client.serialize_session_state(session_state)
+    run_state = cast(
+        RunState[Any, Agent[Any]],
+        RunState(
+            context=RunContextWrapper(context={}),
+            original_input="hello",
+            starting_agent=agent,
+        ),
+    )
+    run_state._current_agent = agent
+    run_state._sandbox = {
+        "backend_id": client.backend_id,
+        "current_agent_key": agent.name,
+        "current_agent_name": agent.name,
+        "session_state": serialized_state,
+        "sessions_by_agent": {
+            agent.name: {
+                "agent_name": agent.name,
+                "session_state": serialized_state,
+            }
+        },
+    }
+    manager = SandboxRuntimeSessionManager(
+        starting_agent=agent,
+        sandbox_config=SandboxRunConfig(client=client, options={"image": "sandbox"}),
+        run_state=run_state,
+    )
+
+    manager.acquire_agent(agent)
+    await manager.ensure_session(
+        agent=agent,
+        capabilities=[capability],
+        is_resumed_state=True,
+    )
+
+    assert capability.process_calls == 1
+    assert client.resume_state is not None
+    assert client.resume_state.manifest.extra_path_grants == (host_grant,)
+    assert client.resume_state.path_grants_require_rebind == ()
+
+
+@pytest.mark.asyncio
+async def test_session_manager_rejects_unmarked_serialized_host_path(
+    tmp_path: Path,
+) -> None:
+    client = _FakeClient(_FakeSession(Manifest()))
+    agent = SandboxAgent(name="worker", model=FakeModel(), instructions="Worker.")
+    serialized_state = TestSessionState(
+        manifest=Manifest(
+            extra_path_grants=(
+                SandboxPathGrant(
+                    path="/mnt/shared-data",
+                    host_path=str(tmp_path),
+                ),
+            )
+        ),
+        snapshot=NoopSnapshot(id="resume"),
+    ).model_dump(mode="json")
+    run_state = cast(
+        RunState[Any, Agent[Any]],
+        RunState(
+            context=RunContextWrapper(context={}),
+            original_input="hello",
+            starting_agent=agent,
+        ),
+    )
+    run_state._current_agent = agent
+    run_state._sandbox = {
+        "backend_id": client.backend_id,
+        "current_agent_key": agent.name,
+        "current_agent_name": agent.name,
+        "session_state": serialized_state,
+        "sessions_by_agent": {
+            agent.name: {
+                "agent_name": agent.name,
+                "session_state": serialized_state,
+            }
+        },
+    }
+    manager = SandboxRuntimeSessionManager(
+        starting_agent=agent,
+        sandbox_config=SandboxRunConfig(client=client, options={"image": "sandbox"}),
+        run_state=run_state,
+    )
+
+    manager.acquire_agent(agent)
+    with pytest.raises(ValueError, match="requires current trusted host_path"):
+        await manager.ensure_session(
+            agent=agent,
+            capabilities=[],
+            is_resumed_state=True,
+        )
+
+    assert client.resume_state is None
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -761,6 +761,21 @@ class _ManifestUsersCapability(Capability):
         return manifest
 
 
+class _ManifestPathGrantsCapability(Capability):
+    type: str = "manifest-path-grants"
+    grants: tuple[SandboxPathGrant, ...]
+
+    def __init__(self, grants: tuple[SandboxPathGrant, ...]) -> None:
+        super().__init__(
+            type="manifest-path-grants",
+            **cast(Any, {"grants": grants}),
+        )
+
+    def process_manifest(self, manifest: Manifest) -> Manifest:
+        manifest.extra_path_grants = self.grants
+        return manifest
+
+
 class _ProcessContextSessionCapability(Capability):
     type: str = "process-context-session"
     bound_session: BaseSandboxSession | None = None
@@ -3246,6 +3261,71 @@ async def test_session_manager_reapplies_capability_manifest_mutations_on_resume
 
 
 @pytest.mark.asyncio
+async def test_session_manager_rebinds_persisted_path_grants_from_current_manifest(
+    tmp_path: Path,
+) -> None:
+    trusted_manifest = Manifest(
+        extra_path_grants=(
+            SandboxPathGrant(
+                path="/mnt/shared-data",
+                host_path=str(tmp_path),
+                read_only=True,
+            ),
+        )
+    )
+    client = _FakeClient(_FakeSession(Manifest()))
+    agent = SandboxAgent(
+        name="worker",
+        model=FakeModel(),
+        instructions="Worker.",
+        default_manifest=trusted_manifest,
+    )
+    session_state = TestSessionState(
+        manifest=trusted_manifest,
+        snapshot=NoopSnapshot(id="resume"),
+    )
+    serialized_state = client.serialize_session_state(session_state)
+    serialized_state.pop("__openai_agents_redacted_host_path_grant_paths", None)
+    run_state = cast(
+        RunState[Any, Agent[Any]],
+        RunState(
+            context=RunContextWrapper(context={}),
+            original_input="hello",
+            starting_agent=agent,
+        ),
+    )
+    run_state._current_agent = agent
+    run_state._sandbox = {
+        "backend_id": client.backend_id,
+        "current_agent_key": agent.name,
+        "current_agent_name": agent.name,
+        "session_state": serialized_state,
+        "sessions_by_agent": {
+            agent.name: {
+                "agent_name": agent.name,
+                "session_state": serialized_state,
+            }
+        },
+    }
+    manager = SandboxRuntimeSessionManager(
+        starting_agent=agent,
+        sandbox_config=SandboxRunConfig(client=client, options={"image": "sandbox"}),
+        run_state=run_state,
+    )
+
+    manager.acquire_agent(agent)
+    await manager.ensure_session(
+        agent=agent,
+        capabilities=[],
+        is_resumed_state=True,
+    )
+
+    assert client.resume_state is not None
+    assert client.resume_state.manifest.extra_path_grants == trusted_manifest.extra_path_grants
+    assert client.resume_state.path_grants_require_rebind == ()
+
+
+@pytest.mark.asyncio
 async def test_session_manager_adds_run_as_user_on_resume() -> None:
     client = _FakeClient(_FakeSession(Manifest()))
     run_as = User(name="sandbox-user")
@@ -3371,6 +3451,61 @@ async def test_session_manager_starts_stopped_injected_session_with_manifest_mut
     assert live_session.shutdown_calls == 0
     assert session.state.manifest.entries["cap.txt"] == File(content=b"capability")
     assert payload is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "processed_grants",
+    [
+        (
+            SandboxPathGrant(
+                path="/mnt/shared-data",
+                host_path="/native/new",
+                read_only=True,
+            ),
+        ),
+        (
+            SandboxPathGrant(path="/mnt/shared-data"),
+            SandboxPathGrant(
+                path="/mnt/shared-data",
+                host_path="/native/old",
+                read_only=True,
+            ),
+        ),
+    ],
+    ids=["changed-host-source", "mixed-duplicate-target"],
+)
+async def test_session_manager_rejects_stopped_injected_session_host_mount_changes(
+    processed_grants: tuple[SandboxPathGrant, ...],
+) -> None:
+    current_grants = (
+        SandboxPathGrant(
+            path="/mnt/shared-data",
+            host_path="/native/old",
+            read_only=True,
+        ),
+    )
+    live_session = _LiveSessionDeltaRecorder(
+        Manifest(extra_path_grants=current_grants),
+    )
+    capability = _ManifestPathGrantsCapability(processed_grants)
+    agent = SandboxAgent(name="worker", model=FakeModel(), instructions="Worker.")
+    manager = SandboxRuntimeSessionManager(
+        starting_agent=agent,
+        sandbox_config=SandboxRunConfig(session=live_session),
+        run_state=None,
+    )
+
+    manager.acquire_agent(agent)
+    with pytest.raises(ValueError, match="host-backed `manifest.extra_path_grants`"):
+        await manager.ensure_session(
+            agent=agent,
+            capabilities=[capability],
+            is_resumed_state=False,
+        )
+
+    assert live_session.start_calls == 0
+    assert live_session.state.manifest.extra_path_grants == current_grants
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -732,6 +732,7 @@ class _ManifestMutationCapability(Capability):
     type: str = "manifest-mutation"
     rel_path: str
     content: bytes
+    process_calls: int
 
     def __init__(self, *, rel_path: str = "cap.txt", content: bytes = b"capability") -> None:
         super().__init__(
@@ -741,11 +742,13 @@ class _ManifestMutationCapability(Capability):
                 {
                     "rel_path": rel_path,
                     "content": content,
+                    "process_calls": 0,
                 },
             ),
         )
 
     def process_manifest(self, manifest: Manifest) -> Manifest:
+        self.process_calls += 1
         manifest.entries[self.rel_path] = File(content=self.content)
         return manifest
 
@@ -3204,7 +3207,12 @@ async def test_session_manager_reapplies_capability_manifest_mutations_on_resume
 ) -> None:
     client = _FakeClient(_FakeSession(Manifest()))
     capability = _ManifestMutationCapability()
-    agent = SandboxAgent(name="worker", model=FakeModel(), instructions="Worker.")
+    agent = SandboxAgent(
+        name="worker",
+        model=FakeModel(),
+        instructions="Worker.",
+        default_manifest=Manifest(),
+    )
     session_state = TestSessionState(
         manifest=Manifest(),
         snapshot=NoopSnapshot(id="resume"),
@@ -3258,6 +3266,7 @@ async def test_session_manager_reapplies_capability_manifest_mutations_on_resume
     assert session.state.manifest.entries["cap.txt"] == File(content=b"capability")
     assert client.resume_state is not None
     assert client.resume_state.manifest.entries["cap.txt"] == File(content=b"capability")
+    assert capability.process_calls == 1
 
 
 @pytest.mark.asyncio
@@ -3285,7 +3294,6 @@ async def test_session_manager_rebinds_persisted_path_grants_from_current_manife
         snapshot=NoopSnapshot(id="resume"),
     )
     serialized_state = client.serialize_session_state(session_state)
-    serialized_state.pop("__openai_agents_redacted_host_path_grant_paths", None)
     run_state = cast(
         RunState[Any, Agent[Any]],
         RunState(

--- a/tests/sandbox/test_session_state_roundtrip.py
+++ b/tests/sandbox/test_session_state_roundtrip.py
@@ -381,3 +381,36 @@ class TestSandboxSessionStateRoundTrip:
         assert restored.path_grants_require_rebind == ()
         assert client.resume_state is not None
         assert client.resume_state.manifest.extra_path_grants == ()
+
+    @pytest.mark.asyncio
+    async def test_deserialization_discards_unmarked_serialized_host_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        client = _RoundTripClient()
+        trusted_manifest = Manifest(
+            extra_path_grants=(
+                SandboxPathGrant(
+                    path="/mnt/shared-data",
+                    host_path=str(tmp_path),
+                ),
+            )
+        )
+        state = _SimpleSessionState(
+            manifest=trusted_manifest,
+            snapshot=NoopSnapshot(id="snapshot"),
+        )
+        payload = cast(dict[str, object], state.model_dump(mode="json"))
+
+        restored = client.deserialize_session_state(payload)
+
+        assert restored.manifest.extra_path_grants == ()
+        assert restored.path_grants_require_rebind == ("/mnt/shared-data",)
+        with pytest.raises(ValueError, match="must be rebound"):
+            await client.resume(restored)
+
+        rebound = restored.rebind_persisted_path_grants(trusted_manifest)
+        await client.resume(rebound)
+
+        assert client.resume_state is rebound
+        assert rebound.manifest.extra_path_grants == trusted_manifest.extra_path_grants

--- a/tests/sandbox/test_session_state_roundtrip.py
+++ b/tests/sandbox/test_session_state_roundtrip.py
@@ -11,17 +11,18 @@ import io
 import json
 import uuid
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, cast
 
 import pytest
 from pydantic import ConfigDict, ValidationError, field_serializer, field_validator
 
 from agents.sandbox import Manifest, SandboxPathGrant
-from agents.sandbox.sandboxes.unix_local import (
-    UnixLocalSandboxClient,
-    UnixLocalSandboxSessionState,
+from agents.sandbox.session import (
+    BaseSandboxClient,
+    Dependencies,
+    SandboxSession,
+    SandboxSessionState,
 )
-from agents.sandbox.session import Dependencies, SandboxSessionState
 from agents.sandbox.snapshot import LocalSnapshot, NoopSnapshot, SnapshotBase
 
 # ---------------------------------------------------------------------------
@@ -48,6 +49,35 @@ class _EmptyDefaultSessionState(SandboxSessionState):
 class _SimpleSessionState(SandboxSessionState):
     __test__ = False
     type: Literal["simple-roundtrip"] = "simple-roundtrip"
+
+
+class _RoundTripClient(BaseSandboxClient[None]):
+    backend_id = "roundtrip"
+    supports_default_options = True
+
+    def __init__(self) -> None:
+        self.resume_state: SandboxSessionState | None = None
+
+    async def create(
+        self,
+        *,
+        snapshot: object | None = None,
+        manifest: Manifest | None = None,
+        options: None = None,
+    ) -> SandboxSession:
+        _ = (snapshot, manifest, options)
+        raise AssertionError("create() is not used by round-trip tests")
+
+    async def delete(self, session: SandboxSession) -> SandboxSession:
+        raise AssertionError("delete() is not used by round-trip tests")
+
+    async def resume(self, state: SandboxSessionState) -> SandboxSession:
+        state.assert_path_grants_rebound()
+        self.resume_state = state
+        return cast(SandboxSession, object())
+
+    def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
+        return self._deserialize_session_state_payload(payload, _SimpleSessionState)
 
 
 class _NonCopyable:
@@ -245,7 +275,7 @@ class TestSandboxSessionStateRoundTrip:
         self,
         tmp_path: Path,
     ) -> None:
-        client = UnixLocalSandboxClient()
+        client = _RoundTripClient()
         trusted_manifest = Manifest(
             extra_path_grants=(
                 SandboxPathGrant(
@@ -255,10 +285,9 @@ class TestSandboxSessionStateRoundTrip:
                 ),
             )
         )
-        state = UnixLocalSandboxSessionState(
+        state = _SimpleSessionState(
             manifest=trusted_manifest,
             snapshot=NoopSnapshot(id="snapshot"),
-            workspace_root_owned=False,
         )
 
         payload = client.serialize_session_state(state)
@@ -266,47 +295,51 @@ class TestSandboxSessionStateRoundTrip:
 
         assert str(tmp_path) not in encoded
         assert payload["__openai_agents_redacted_host_path_grant_paths"] == ["/mnt/shared-data"]
+        manifest_payload = payload["manifest"]
+        assert isinstance(manifest_payload, dict)
+        assert manifest_payload["extra_path_grants"] == []
         restored = client.deserialize_session_state(payload)
-        assert restored.manifest.extra_path_grants[0].host_path is None
+        assert restored.manifest.extra_path_grants == ()
         assert restored.path_grants_require_rebind == ("/mnt/shared-data",)
 
         rebound = restored.rebind_persisted_path_grants(trusted_manifest)
 
         assert rebound.manifest.extra_path_grants == trusted_manifest.extra_path_grants
         assert rebound.path_grants_require_rebind == ()
-        assert restored.manifest.extra_path_grants[0].host_path is None
+        assert restored.manifest.extra_path_grants == ()
 
-    def test_rebind_preserves_duplicate_path_grant_order_and_permissions(self) -> None:
-        client = UnixLocalSandboxClient()
-        trusted_manifest = Manifest(
+    @pytest.mark.asyncio
+    async def test_path_only_grants_preserve_direct_client_resume_roundtrip(self) -> None:
+        client = _RoundTripClient()
+        manifest = Manifest(
             extra_path_grants=(
                 SandboxPathGrant(path="/mnt/shared-data", read_only=True),
                 SandboxPathGrant(path="/mnt/shared-data", read_only=False),
             )
         )
-        state = UnixLocalSandboxSessionState(
-            manifest=trusted_manifest,
+        state = _SimpleSessionState(
+            manifest=manifest,
             snapshot=NoopSnapshot(id="snapshot"),
-            workspace_root_owned=False,
         )
 
         restored = client.deserialize_session_state(client.serialize_session_state(state))
-        rebound = restored.rebind_persisted_path_grants(trusted_manifest)
+        await client.resume(restored)
 
-        assert rebound.manifest.extra_path_grants == trusted_manifest.extra_path_grants
+        assert restored.path_grants_require_rebind == ()
+        assert client.resume_state is not None
+        assert client.resume_state.manifest.extra_path_grants == manifest.extra_path_grants
 
     def test_client_state_roundtrip_does_not_deepcopy_extension_state(self) -> None:
-        client = UnixLocalSandboxClient()
+        client = _RoundTripClient()
         trusted_manifest = Manifest(
             extra_path_grants=(SandboxPathGrant(path="/mnt/shared-data"),),
         )
-        state = UnixLocalSandboxSessionState(
+        state = _SimpleSessionState(
             manifest=trusted_manifest,
             snapshot=_SerializableNonCopyableSnapshot(
                 id="snapshot",
                 token=_NonCopyable(),
             ),
-            workspace_root_owned=False,
         )
 
         payload = client.serialize_session_state(state)
@@ -322,21 +355,29 @@ class TestSandboxSessionStateRoundTrip:
         assert isinstance(snapshot, _SerializableNonCopyableSnapshot)
         assert isinstance(snapshot.token, _NonCopyable)
 
-    def test_deserialized_grants_require_rebind_even_if_redaction_marker_is_removed(
+    @pytest.mark.asyncio
+    async def test_removed_redaction_marker_does_not_restore_host_backed_grant(
         self,
+        tmp_path: Path,
     ) -> None:
-        client = UnixLocalSandboxClient()
-        state = UnixLocalSandboxSessionState(
-            manifest=Manifest(extra_path_grants=(SandboxPathGrant(path="/mnt/shared-data"),)),
+        client = _RoundTripClient()
+        state = _SimpleSessionState(
+            manifest=Manifest(
+                extra_path_grants=(
+                    SandboxPathGrant(
+                        path="/mnt/shared-data",
+                        host_path=str(tmp_path),
+                    ),
+                )
+            ),
             snapshot=NoopSnapshot(id="snapshot"),
-            workspace_root_owned=False,
         )
         payload = client.serialize_session_state(state)
         payload.pop("__openai_agents_redacted_host_path_grant_paths", None)
 
         restored = client.deserialize_session_state(payload)
+        await client.resume(restored)
 
-        with pytest.raises(ValueError, match="current trusted manifest"):
-            restored.assert_path_grants_rebound()
-        with pytest.raises(ValueError, match="not present"):
-            restored.rebind_persisted_path_grants(Manifest())
+        assert restored.path_grants_require_rebind == ()
+        assert client.resume_state is not None
+        assert client.resume_state.manifest.extra_path_grants == ()

--- a/tests/sandbox/test_session_state_roundtrip.py
+++ b/tests/sandbox/test_session_state_roundtrip.py
@@ -7,17 +7,22 @@ fields, or the ``type`` discriminator under ``exclude_unset``.
 
 from __future__ import annotations
 
+import io
 import json
 import uuid
 from pathlib import Path
 from typing import ClassVar, Literal
 
 import pytest
-from pydantic import ValidationError
+from pydantic import ConfigDict, ValidationError, field_serializer, field_validator
 
-from agents.sandbox import Manifest
-from agents.sandbox.session import SandboxSessionState
-from agents.sandbox.snapshot import LocalSnapshot
+from agents.sandbox import Manifest, SandboxPathGrant
+from agents.sandbox.sandboxes.unix_local import (
+    UnixLocalSandboxClient,
+    UnixLocalSandboxSessionState,
+)
+from agents.sandbox.session import Dependencies, SandboxSessionState
+from agents.sandbox.snapshot import LocalSnapshot, NoopSnapshot, SnapshotBase
 
 # ---------------------------------------------------------------------------
 # Test-only stubs
@@ -43,6 +48,46 @@ class _EmptyDefaultSessionState(SandboxSessionState):
 class _SimpleSessionState(SandboxSessionState):
     __test__ = False
     type: Literal["simple-roundtrip"] = "simple-roundtrip"
+
+
+class _NonCopyable:
+    def __deepcopy__(self, memo: dict[int, object]) -> object:
+        _ = memo
+        raise RuntimeError("not copyable")
+
+
+class _SerializableNonCopyableSnapshot(SnapshotBase):
+    __test__ = False
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    type: Literal["serializable-noncopyable-roundtrip"] = "serializable-noncopyable-roundtrip"
+    token: _NonCopyable
+
+    @field_serializer("token")
+    def _serialize_token(self, value: _NonCopyable) -> str:
+        _ = value
+        return "token"
+
+    @field_validator("token", mode="before")
+    @classmethod
+    def _parse_token(cls, value: object) -> object:
+        return _NonCopyable() if value == "token" else value
+
+    async def persist(
+        self,
+        data: io.IOBase,
+        *,
+        dependencies: Dependencies | None = None,
+    ) -> None:
+        _ = (data, dependencies)
+
+    async def restore(self, *, dependencies: Dependencies | None = None) -> io.IOBase:
+        _ = dependencies
+        raise FileNotFoundError(Path("<serializable-noncopyable>"))
+
+    async def restorable(self, *, dependencies: Dependencies | None = None) -> bool:
+        _ = dependencies
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -195,3 +240,103 @@ class TestSandboxSessionStateRoundTrip:
                 custom_field="my-value",
                 exposed_ports=raw_ports,  # type: ignore[arg-type]
             )
+
+    def test_client_serialization_redacts_host_paths_and_rebinds_from_trusted_manifest(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        client = UnixLocalSandboxClient()
+        trusted_manifest = Manifest(
+            extra_path_grants=(
+                SandboxPathGrant(
+                    path="/mnt/shared-data",
+                    host_path=str(tmp_path),
+                    read_only=True,
+                ),
+            )
+        )
+        state = UnixLocalSandboxSessionState(
+            manifest=trusted_manifest,
+            snapshot=NoopSnapshot(id="snapshot"),
+            workspace_root_owned=False,
+        )
+
+        payload = client.serialize_session_state(state)
+        encoded = json.dumps(payload)
+
+        assert str(tmp_path) not in encoded
+        assert payload["__openai_agents_redacted_host_path_grant_paths"] == ["/mnt/shared-data"]
+        restored = client.deserialize_session_state(payload)
+        assert restored.manifest.extra_path_grants[0].host_path is None
+        assert restored.path_grants_require_rebind == ("/mnt/shared-data",)
+
+        rebound = restored.rebind_persisted_path_grants(trusted_manifest)
+
+        assert rebound.manifest.extra_path_grants == trusted_manifest.extra_path_grants
+        assert rebound.path_grants_require_rebind == ()
+        assert restored.manifest.extra_path_grants[0].host_path is None
+
+    def test_rebind_preserves_duplicate_path_grant_order_and_permissions(self) -> None:
+        client = UnixLocalSandboxClient()
+        trusted_manifest = Manifest(
+            extra_path_grants=(
+                SandboxPathGrant(path="/mnt/shared-data", read_only=True),
+                SandboxPathGrant(path="/mnt/shared-data", read_only=False),
+            )
+        )
+        state = UnixLocalSandboxSessionState(
+            manifest=trusted_manifest,
+            snapshot=NoopSnapshot(id="snapshot"),
+            workspace_root_owned=False,
+        )
+
+        restored = client.deserialize_session_state(client.serialize_session_state(state))
+        rebound = restored.rebind_persisted_path_grants(trusted_manifest)
+
+        assert rebound.manifest.extra_path_grants == trusted_manifest.extra_path_grants
+
+    def test_client_state_roundtrip_does_not_deepcopy_extension_state(self) -> None:
+        client = UnixLocalSandboxClient()
+        trusted_manifest = Manifest(
+            extra_path_grants=(SandboxPathGrant(path="/mnt/shared-data"),),
+        )
+        state = UnixLocalSandboxSessionState(
+            manifest=trusted_manifest,
+            snapshot=_SerializableNonCopyableSnapshot(
+                id="snapshot",
+                token=_NonCopyable(),
+            ),
+            workspace_root_owned=False,
+        )
+
+        payload = client.serialize_session_state(state)
+
+        assert payload["snapshot"] == {
+            "type": "serializable-noncopyable-roundtrip",
+            "id": "snapshot",
+            "token": "token",
+        }
+        restored = client.deserialize_session_state(payload)
+        rebound = restored.rebind_persisted_path_grants(trusted_manifest)
+        snapshot = rebound.snapshot
+        assert isinstance(snapshot, _SerializableNonCopyableSnapshot)
+        assert isinstance(snapshot.token, _NonCopyable)
+
+    def test_deserialized_grants_require_rebind_even_if_redaction_marker_is_removed(
+        self,
+    ) -> None:
+        client = UnixLocalSandboxClient()
+        state = UnixLocalSandboxSessionState(
+            manifest=Manifest(extra_path_grants=(SandboxPathGrant(path="/mnt/shared-data"),)),
+            snapshot=NoopSnapshot(id="snapshot"),
+            workspace_root_owned=False,
+        )
+        payload = client.serialize_session_state(state)
+        payload.pop("__openai_agents_redacted_host_path_grant_paths", None)
+
+        restored = client.deserialize_session_state(payload)
+
+        with pytest.raises(ValueError, match="current trusted manifest"):
+            restored.assert_path_grants_rebound()
+        with pytest.raises(ValueError, match="not present"):
+            restored.rebind_persisted_path_grants(Manifest())

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import pytest
 
+from agents.sandbox import SandboxPathGrant
 from agents.sandbox.errors import PtySessionNotFoundError
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.sandboxes.unix_local import (
@@ -38,6 +39,38 @@ class _RecordingUnixLocalSession(UnixLocalSandboxSession):
         _ = timeout
         self.exec_commands.append(tuple(str(part) for part in command))
         return ExecResult(stdout=b"", stderr=b"", exit_code=0)
+
+
+@pytest.mark.asyncio
+async def test_unix_local_rejects_host_path_before_creating_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _unexpected_mkdtemp(*args: object, **kwargs: object) -> str:
+        raise AssertionError(f"unexpected mkdtemp call: {args!r} {kwargs!r}")
+
+    monkeypatch.setattr(
+        "agents.sandbox.sandboxes.unix_local.tempfile.mkdtemp",
+        _unexpected_mkdtemp,
+    )
+    client = UnixLocalSandboxClient()
+
+    with pytest.raises(
+        ValueError,
+        match="UnixLocalSandboxClient does not support sandbox path grant host_path",
+    ):
+        await client.create(
+            manifest=Manifest(
+                extra_path_grants=(
+                    SandboxPathGrant(
+                        path="/mnt/shared-data",
+                        host_path=str(tmp_path),
+                    ),
+                )
+            ),
+            snapshot=None,
+            options=None,
+        )
 
 
 class TestUnixLocalPty:

--- a/tests/sandbox/test_workspace_paths.py
+++ b/tests/sandbox/test_workspace_paths.py
@@ -653,3 +653,17 @@ def test_host_path_grant_rejects_symlink_to_root(tmp_path: Path) -> None:
         match="sandbox path grant path must not resolve to filesystem root",
     ):
         sandbox_path_grant_host_path(grant)
+
+
+def test_host_path_grant_returns_validated_resolved_source(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    source_alias = tmp_path / "source-alias"
+    os.symlink(source, source_alias, target_is_directory=True)
+    grant = SandboxPathGrant(path="/mnt/shared-data", host_path=str(source_alias))
+
+    resolved_source = sandbox_path_grant_host_path(grant)
+    source_alias.unlink()
+    os.symlink(Path("/"), source_alias, target_is_directory=True)
+
+    assert resolved_source == source.resolve()

--- a/tests/sandbox/test_workspace_paths.py
+++ b/tests/sandbox/test_workspace_paths.py
@@ -403,7 +403,55 @@ def test_extra_path_grant_accepts_native_windows_drive_absolute_path(
 
     grant = SandboxPathGrant(path=str(tmp_path))
 
-    assert Path(grant.path).is_absolute()
+    assert grant.path == str(tmp_path)
+
+
+def test_split_path_grant_rejects_native_windows_sandbox_path(tmp_path: Path) -> None:
+    if not Path(PureWindowsPath("C:/tmp")).is_absolute():
+        pytest.skip("Windows drive paths are not native absolute paths on this host")
+
+    with pytest.raises(
+        ValidationError,
+        match="sandbox path grant path must be POSIX absolute when host_path is configured",
+    ):
+        SandboxPathGrant(path=str(tmp_path), host_path=str(tmp_path / "source"))
+
+
+def test_extra_path_grant_normalizes_distinct_host_path() -> None:
+    grant = SandboxPathGrant(
+        path="/mnt/shared-data",
+        host_path="C:/Users/example/shared-data",
+        read_only=True,
+    )
+
+    assert grant.path == "/mnt/shared-data"
+    assert grant.host_path == "C:\\Users\\example\\shared-data"
+    assert grant.read_only is True
+
+
+@pytest.mark.parametrize(
+    ("host_path", "message"),
+    [
+        ("relative/path", "must be an absolute host path"),
+        ("/", "must not be filesystem root"),
+        ("/srv/../secret", "must not contain parent segments"),
+        ("//server/share", "does not support UNC or device paths"),
+        ("\\\\server\\share", "does not support UNC or device paths"),
+        ("C:\\", "must not be filesystem root"),
+    ],
+)
+def test_extra_path_grant_rejects_unsupported_host_paths(
+    host_path: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        SandboxPathGrant(path="/mnt/shared-data", host_path=host_path)
+
+
+def test_extra_path_grant_preserves_host_path_whitespace() -> None:
+    grant = SandboxPathGrant(path="/mnt/shared-data", host_path="/srv/shared ")
+
+    assert grant.host_path == "/srv/shared "
 
 
 def test_extra_path_grant_rules_reject_windows_drive_absolute_path() -> None:
@@ -536,9 +584,9 @@ def test_extra_path_grant_rejects_relative_path() -> None:
     assert error == {
         "type": "value_error",
         "loc": ("path",),
-        "msg": "Value error, sandbox path grant path must be absolute",
+        "msg": "Value error, sandbox path grant path must be POSIX absolute",
         "input": "tmp",
-        "ctx": {"error": "sandbox path grant path must be absolute"},
+        "ctx": {"error": "sandbox path grant path must be POSIX absolute"},
     }
 
 

--- a/tests/sandbox/test_workspace_paths.py
+++ b/tests/sandbox/test_workspace_paths.py
@@ -15,6 +15,7 @@ from agents.sandbox.workspace_paths import (
     WorkspacePathPolicy,
     coerce_posix_path,
     posix_path_as_path,
+    sandbox_path_grant_host_path,
 )
 
 PathInput = str | PurePath
@@ -640,3 +641,15 @@ def test_host_io_rejects_extra_path_grant_symlink_to_root(tmp_path: Path) -> Non
         policy.normalize_path(root_alias / "etc" / "passwd", resolve_symlinks=True)
 
     assert str(exc_info.value) == "sandbox path grant path must not resolve to filesystem root"
+
+
+def test_host_path_grant_rejects_symlink_to_root(tmp_path: Path) -> None:
+    root_alias = tmp_path / "root-alias"
+    os.symlink(Path("/"), root_alias, target_is_directory=True)
+    grant = SandboxPathGrant(path="/mnt/shared-data", host_path=str(root_alias))
+
+    with pytest.raises(
+        ValueError,
+        match="sandbox path grant path must not resolve to filesystem root",
+    ):
+        sandbox_path_grant_host_path(grant)


### PR DESCRIPTION
This pull request adds native `host_path` support to sandbox path grants while preserving portable POSIX paths inside Docker sandboxes.

It creates and validates Docker bind mounts, rejects unsupported or ambiguous grant configurations before side effects, redacts native paths from persisted session state, and rebinds them from current trusted configuration during resume. It also prevents stopped or running injected sessions from adopting host-backed grant topology that does not match the existing container.

Docker command workdirs already use Python's shared workspace path policy, so granted split paths work without a separate Docker-specific resolver. Published documentation is intentionally unchanged.

see also: https://github.com/openai/openai-agents-js/pull/1538