### PR TITLE
fix: strip stale Responses item ids and rebuild once on 404

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -758,7 +758,9 @@ def strip_stale_response_item_ids(
         # Always strip reasoning ids; also strip other server-ref ids when present
         should_strip = item_type == "reasoning" or (
             isinstance(item_id, str)
-            and (item_id.startswith("rs_") or item_id.startswith("fc_") or item_id.startswith("msg_"))
+            and (
+                item_id.startswith("rs_") or item_id.startswith("fc_") or item_id.startswith("msg_")
+            )
         )
         if should_strip:
             cleaned = dict(item)

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -62,6 +62,8 @@ __all__ = [
     "prepare_model_input_items",
     "run_item_to_input_item",
     "run_items_to_input_items",
+    "is_stale_response_item_not_found_error",
+    "strip_stale_response_item_ids",
     "normalize_input_items_for_api",
     "normalize_resumed_input",
     "fingerprint_input_item",
@@ -153,13 +155,20 @@ def run_items_to_input_items(
     run_items: Sequence[RunItem],
     reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
 ) -> list[TResponseInputItem]:
-    """Convert run items to model input items while skipping approvals."""
+    """Convert run items to model input items while skipping approvals.
+
+    Always strips server-side Responses item ``id`` fields (``rs_``/``fc_``/``msg_``)
+    from the converted list so multi-turn replays do not 404 when the API no longer
+    stores those items (#2020). Content is preserved. Per-item reasoning omit policy
+    is still applied during conversion before the shared strip pass.
+    """
     converted: list[TResponseInputItem] = []
     for run_item in run_items:
         item = run_item_to_input_item(run_item, reasoning_item_id_policy)
         if item is not None:
             converted.append(item)
-    return converted
+    # Default and omit both strip server item ids — replaying dead IDs is the #2020 failure mode.
+    return strip_stale_response_item_ids(converted)
 
 
 def drop_orphan_function_calls(
@@ -707,6 +716,57 @@ def _without_reasoning_item_id(item: TResponseInputItem) -> TResponseInputItem:
     sanitized = dict(item)
     sanitized.pop("id", None)
     return cast(TResponseInputItem, sanitized)
+
+
+def is_stale_response_item_not_found_error(error: BaseException) -> bool:
+    """True when the API reports a missing Responses item id (``rs_``/``fc_``/etc.).
+
+    Used to decide whether to rebuild model input without server item IDs and retry.
+    See https://github.com/openai/openai-agents-python/issues/2020
+    """
+    text = str(error)
+    if "Item with id" not in text and "item with id" not in text.lower():
+        # Also match common SDK wrapping of the same message
+        if "not found" not in text.lower():
+            return False
+    lowered = text.lower()
+    if "not found" not in lowered:
+        return False
+    # Server item ids typically look like rs_… / fc_… / msg_…
+    return any(marker in text for marker in ("rs_", "fc_", "msg_")) or "Item with id" in text
+
+
+def strip_stale_response_item_ids(
+    items: Sequence[TResponseInputItem],
+) -> list[TResponseInputItem]:
+    """Strip server-side item ``id`` fields from next-turn model input.
+
+    Replaying ``rs_``/``fc_`` IDs that the Responses API no longer stores causes
+    HTTP 404 ``Item with id 'rs_…' not found`` on multi-turn runs (#2020).
+    Content is preserved; only the ``id`` key is removed from dict items.
+    """
+    sanitized: list[TResponseInputItem] = []
+    for item in items:
+        if not isinstance(item, dict):
+            sanitized.append(item)
+            continue
+        if "id" not in item:
+            sanitized.append(item)
+            continue
+        item_id = item.get("id")
+        item_type = item.get("type")
+        # Always strip reasoning ids; also strip other server-ref ids when present
+        should_strip = item_type == "reasoning" or (
+            isinstance(item_id, str)
+            and (item_id.startswith("rs_") or item_id.startswith("fc_") or item_id.startswith("msg_"))
+        )
+        if should_strip:
+            cleaned = dict(item)
+            cleaned.pop("id", None)
+            sanitized.append(cast(TResponseInputItem, cleaned))
+        else:
+            sanitized.append(item)
+    return sanitized
 
 
 def deduplicate_input_items(items: Sequence[TResponseInputItem]) -> list[TResponseInputItem]:

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -20,7 +20,6 @@ from ..models._retry_runtime import (
     provider_managed_retries_disabled,
     websocket_pre_event_retries_disabled,
 )
-from .items import is_stale_response_item_not_found_error
 from ..retry import (
     ModelRetryAdvice,
     ModelRetryAdviceRequest,
@@ -34,6 +33,7 @@ from ..retry import (
     retry_policy_retries_safe_transport_errors,
 )
 from ..usage import RequestUsage, Usage
+from .items import is_stale_response_item_not_found_error
 
 GetResponseCallable = Callable[[], Awaitable[ModelResponse]]
 GetStreamCallable = Callable[[], AsyncIterator[TResponseStreamEvent]]

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -20,6 +20,7 @@ from ..models._retry_runtime import (
     provider_managed_retries_disabled,
     websocket_pre_event_retries_disabled,
 )
+from .items import is_stale_response_item_not_found_error
 from ..retry import (
     ModelRetryAdvice,
     ModelRetryAdviceRequest,
@@ -44,7 +45,11 @@ DEFAULT_MAX_DELAY_SECONDS = 2.0
 DEFAULT_BACKOFF_MULTIPLIER = 2.0
 DEFAULT_BACKOFF_JITTER = True
 COMPATIBILITY_CONVERSATION_LOCKED_RETRIES = 3
+# One rebuild after Responses "Item with id 'rs_/fc_/msg_…' not found" (#2020).
+COMPATIBILITY_STALE_RESPONSE_ITEM_RETRIES = 1
 _RETRY_SAFE_STREAM_EVENT_TYPES = frozenset({"response.created", "response.in_progress"})
+
+SanitizeStaleResponseItemIdsCallable = Callable[[], Awaitable[None] | None]
 
 
 def _is_conversation_locked_error(error: Exception) -> bool:
@@ -415,11 +420,13 @@ async def get_response_with_retry(
     previous_response_id: str | None,
     conversation_id: str | None,
     replay_unsafe_request: bool = False,
+    sanitize_stale_response_item_ids: SanitizeStaleResponseItemIdsCallable | None = None,
 ) -> ModelResponse:
     request_attempt = 1
     policy_attempt = 1
     failed_policy_attempts = 0
     compatibility_retries_taken = 0
+    stale_item_retries_taken = 0
     disable_websocket_pre_event_retry = replay_unsafe_request or (
         _should_disable_websocket_pre_event_retry(retry_settings)
     )
@@ -446,7 +453,7 @@ async def get_response_with_retry(
                 response = await get_response()
             response.usage = apply_retry_attempt_usage(
                 response.usage,
-                failed_policy_attempts + compatibility_retries_taken,
+                failed_policy_attempts + compatibility_retries_taken + stale_item_retries_taken,
             )
             return response
         except Exception as error:
@@ -472,6 +479,28 @@ async def get_response_with_retry(
                     await _sleep_for_retry(delay)
                     request_attempt += 1
                     continue
+
+            # Responses API 404: Item with id 'rs_/fc_/msg_…' not found — strip server ids once
+            # and rebuild the request (#2020). Does not require a user retry policy.
+            if (
+                not replay_unsafe_request
+                and sanitize_stale_response_item_ids is not None
+                and stale_item_retries_taken < COMPATIBILITY_STALE_RESPONSE_ITEM_RETRIES
+                and is_stale_response_item_not_found_error(error)
+            ):
+                stale_item_retries_taken += 1
+                logger.debug(
+                    "Stale Responses item id not found; stripping server item ids and "
+                    "retrying once (attempt %s/%s).",
+                    stale_item_retries_taken,
+                    COMPATIBILITY_STALE_RESPONSE_ITEM_RETRIES,
+                )
+                maybe_awaitable = sanitize_stale_response_item_ids()
+                if isawaitable(maybe_awaitable):
+                    await maybe_awaitable
+                await rewind()
+                request_attempt += 1
+                continue
 
             provider_advice = get_retry_advice(
                 ModelRetryAdviceRequest(
@@ -521,11 +550,13 @@ async def stream_response_with_retry(
     conversation_id: str | None,
     failed_retry_attempts_out: list[int] | None = None,
     replay_unsafe_request: bool = False,
+    sanitize_stale_response_item_ids: SanitizeStaleResponseItemIdsCallable | None = None,
 ) -> AsyncIterator[TResponseStreamEvent]:
     request_attempt = 1
     policy_attempt = 1
     failed_policy_attempts = 0
     compatibility_retries_taken = 0
+    stale_item_retries_taken = 0
     disable_websocket_pre_event_retry = replay_unsafe_request or (
         _should_disable_websocket_pre_event_retry(retry_settings)
     )
@@ -565,7 +596,9 @@ async def stream_response_with_retry(
                     emitted_retry_unsafe_event = True
                 if failed_retry_attempts_out is not None:
                     failed_retry_attempts_out[:] = [
-                        failed_policy_attempts + compatibility_retries_taken
+                        failed_policy_attempts
+                        + compatibility_retries_taken
+                        + stale_item_retries_taken
                     ]
                 yield event
             return
@@ -596,6 +629,25 @@ async def stream_response_with_retry(
                     await _sleep_for_retry(delay)
                     request_attempt += 1
                     continue
+            if (
+                not replay_unsafe_request
+                and sanitize_stale_response_item_ids is not None
+                and stale_item_retries_taken < COMPATIBILITY_STALE_RESPONSE_ITEM_RETRIES
+                and is_stale_response_item_not_found_error(error)
+            ):
+                stale_item_retries_taken += 1
+                logger.debug(
+                    "Stale Responses item id not found during stream; stripping server "
+                    "item ids and retrying once (attempt %s/%s).",
+                    stale_item_retries_taken,
+                    COMPATIBILITY_STALE_RESPONSE_ITEM_RETRIES,
+                )
+                maybe_awaitable = sanitize_stale_response_item_ids()
+                if isawaitable(maybe_awaitable):
+                    await maybe_awaitable
+                await rewind()
+                request_attempt += 1
+                continue
             provider_advice = get_retry_advice(
                 ModelRetryAdviceRequest(
                     error=error,

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -129,6 +129,7 @@ from .items import (
     prepare_model_input_items,
     reconcile_nested_history_owned_input_after_rewrite,
     run_items_to_input_items,
+    strip_stale_response_item_ids,
 )
 from .model_retry import (
     apply_retry_attempt_usage,
@@ -310,7 +311,9 @@ def _prepare_turn_input_items(
 ) -> list[TResponseInputItem]:
     caller_items = ItemHelpers.input_to_new_input_list(caller_input)
     continuation_items = run_items_to_input_items(generated_items, reasoning_item_id_policy)
-    return prepare_model_input_items(caller_items, continuation_items)
+    # Strip server item ids from caller history too (session / to_input_list replays) (#2020).
+    prepared = prepare_model_input_items(caller_items, continuation_items)
+    return strip_stale_response_item_ids(prepared)
 
 
 def _complete_stream_interruption(
@@ -1551,6 +1554,10 @@ async def run_single_turn_streamed(
         if server_conversation_tracker is not None:
             server_conversation_tracker.rewind_input(filtered.input)
 
+    async def sanitize_stale_response_item_ids() -> None:
+        if isinstance(filtered.input, list):
+            filtered.input = strip_stale_response_item_ids(filtered.input)
+
     stream_failed_retry_attempts: list[int] = [0]
 
     retry_stream = stream_response_with_retry(
@@ -1577,6 +1584,7 @@ async def run_single_turn_streamed(
         replay_unsafe_request=any(
             isinstance(tool, ProgrammaticToolCallingTool) for tool in all_tools
         ),
+        sanitize_stale_response_item_ids=sanitize_stale_response_item_ids,
     )
 
     async for event in model_run_context_stream(retry_stream, tool_use_tracker):
@@ -1976,6 +1984,11 @@ async def get_new_response(
             await rewind_session_items(session, items_to_rewind, server_conversation_tracker)
             server_conversation_tracker.rewind_input(filtered.input)
 
+    async def sanitize_stale_response_item_ids() -> None:
+        # Rebuild model input without server item ids after a Responses 404 (#2020).
+        if isinstance(filtered.input, list):
+            filtered.input = strip_stale_response_item_ids(filtered.input)
+
     with model_run_context(tool_use_tracker):
         new_response = await get_response_with_retry(
             get_response=lambda: model.get_response(
@@ -2000,6 +2013,7 @@ async def get_new_response(
             replay_unsafe_request=any(
                 isinstance(tool, ProgrammaticToolCallingTool) for tool in all_tools
             ),
+            sanitize_stale_response_item_ids=sanitize_stale_response_item_ids,
         )
     if server_conversation_tracker is not None:
         # Retry helpers rewind sent-input tracking before replaying a failed request. Mark the

--- a/tests/test_stale_response_item_ids.py
+++ b/tests/test_stale_response_item_ids.py
@@ -2,37 +2,78 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+from agents.items import TResponseInputItem
 from agents.run_internal.items import (
     is_stale_response_item_not_found_error,
     run_items_to_input_items,
     strip_stale_response_item_ids,
 )
 from agents.run_internal.model_retry import get_response_with_retry
+from agents.usage import Usage
 
 
-def test_strip_stale_response_item_ids_removes_reasoning_and_rs_ids():
-    items = [
-        {"type": "message", "role": "user", "content": "hi"},
-        {"type": "reasoning", "id": "rs_deadbeef123", "summary": [{"text": "think"}]},
-        {"type": "function_call", "id": "fc_abc", "name": "f", "arguments": "{}"},
-        {"type": "message", "role": "assistant", "content": "ok", "id": "msg_xyz"},
-        {"type": "message", "role": "user", "content": "again", "id": "local-keep-me"},
+def test_strip_stale_response_item_ids_removes_reasoning_and_rs_ids() -> None:
+    items: list[TResponseInputItem] = [
+        cast(
+            TResponseInputItem,
+            {"type": "message", "role": "user", "content": "hi"},
+        ),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "reasoning",
+                "id": "rs_deadbeef123",
+                "summary": [{"text": "think"}],
+            },
+        ),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "function_call",
+                "id": "fc_abc",
+                "name": "f",
+                "arguments": "{}",
+                "call_id": "call_abc",
+            },
+        ),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": "ok",
+                "id": "msg_xyz",
+            },
+        ),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "message",
+                "role": "user",
+                "content": "again",
+                "id": "local-keep-me",
+            },
+        ),
     ]
     out = strip_stale_response_item_ids(items)
     assert out[0] == items[0]
+    assert isinstance(out[1], dict)
     assert "id" not in out[1]
-    assert out[1]["type"] == "reasoning"
+    assert out[1].get("type") == "reasoning"
+    assert isinstance(out[2], dict)
     assert "id" not in out[2]
-    assert out[2]["name"] == "f"
+    assert out[2].get("name") == "f"
+    assert isinstance(out[3], dict)
     assert "id" not in out[3]
-    assert out[4]["id"] == "local-keep-me"
+    assert isinstance(out[4], dict)
+    assert out[4].get("id") == "local-keep-me"
 
 
-def test_is_stale_response_item_not_found_error_detects_rs_404():
+def test_is_stale_response_item_not_found_error_detects_rs_404() -> None:
     err = Exception(
         "Error code: 404 - {'error': {'message': \"Item with id "
         "'rs_3c4caff36e34c099006900f0e3c66481909c15ac262a15b060' not found.\"}}"
@@ -48,11 +89,11 @@ class _FakeRunItem:
         self.type = item_type
         self.raw_item = raw
 
-    def to_input_item(self) -> dict[str, Any]:
-        return dict(self.raw_item)
+    def to_input_item(self) -> TResponseInputItem:
+        return cast(TResponseInputItem, dict(self.raw_item))
 
 
-def test_run_items_to_input_items_strips_under_default_policy():
+def test_run_items_to_input_items_strips_under_default_policy() -> None:
     """Default policy (None) must strip server ids — not only omit (#2020)."""
     run_items = [
         _FakeRunItem(
@@ -73,34 +114,39 @@ def test_run_items_to_input_items_strips_under_default_policy():
     # Default policy (preserve / None) — still strip server ids for multi-turn safety
     out = run_items_to_input_items(run_items, None)  # type: ignore[arg-type]
     assert len(out) == 2
-    assert out[0]["type"] == "reasoning"
+    assert isinstance(out[0], dict)
+    assert out[0].get("type") == "reasoning"
     assert "id" not in out[0]
-    assert out[0]["summary"] == [{"text": "t"}]
+    assert out[0].get("summary") == [{"text": "t"}]
+    assert isinstance(out[1], dict)
     assert "id" not in out[1]
-    assert out[1]["call_id"] == "call_1"
+    assert out[1].get("call_id") == "call_1"
 
 
 @pytest.mark.asyncio
-async def test_get_response_with_retry_rebuilds_on_stale_item_404():
+async def test_get_response_with_retry_rebuilds_on_stale_item_404() -> None:
     """404 Item-with-id-not-found must sanitize input once and retry (live path)."""
-    input_box: list[list[dict[str, Any]]] = [
+    input_box: list[list[TResponseInputItem]] = [
         [
-            {"type": "reasoning", "id": "rs_dead", "summary": []},
-            {"type": "message", "role": "user", "content": "hi", "id": "msg_1"},
+            cast(
+                TResponseInputItem,
+                {"type": "reasoning", "id": "rs_dead", "summary": []},
+            ),
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "user", "content": "hi", "id": "msg_1"},
+            ),
         ]
     ]
     attempts: list[list[Any]] = []
 
-    class FakeUsage:
-        def __init__(self) -> None:
-            self.requests = 1
-
     class FakeResp:
         def __init__(self) -> None:
-            self.usage = FakeUsage()
+            # Real Usage so apply_retry_attempt_usage can attach failed-attempt accounting.
+            self.usage = Usage()
 
-    async def get_response():
-        ids = [it.get("id") for it in input_box[0]]
+    async def get_response() -> FakeResp:
+        ids = [item.get("id") if isinstance(item, dict) else None for item in input_box[0]]
         attempts.append(list(ids))
         if any(isinstance(i, str) and i.startswith(("rs_", "fc_", "msg_")) for i in ids):
             raise Exception(
@@ -108,10 +154,10 @@ async def test_get_response_with_retry_rebuilds_on_stale_item_404():
             )
         return FakeResp()
 
-    async def sanitize():
+    async def sanitize() -> None:
         input_box[0] = strip_stale_response_item_ids(input_box[0])
 
-    async def rewind():
+    async def rewind() -> None:
         return None
 
     resp = await get_response_with_retry(
@@ -127,4 +173,5 @@ async def test_get_response_with_retry_rebuilds_on_stale_item_404():
     assert len(attempts) == 2
     assert attempts[0] == ["rs_dead", "msg_1"]
     assert attempts[1] == [None, None]
+    assert isinstance(input_box[0][0], dict)
     assert "id" not in input_box[0][0]

--- a/tests/test_stale_response_item_ids.py
+++ b/tests/test_stale_response_item_ids.py
@@ -1,0 +1,130 @@
+"""Tests for #2020: strip stale Responses item ids + 404 rebuild retry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agents.run_internal.items import (
+    is_stale_response_item_not_found_error,
+    run_items_to_input_items,
+    strip_stale_response_item_ids,
+)
+from agents.run_internal.model_retry import get_response_with_retry
+
+
+def test_strip_stale_response_item_ids_removes_reasoning_and_rs_ids():
+    items = [
+        {"type": "message", "role": "user", "content": "hi"},
+        {"type": "reasoning", "id": "rs_deadbeef123", "summary": [{"text": "think"}]},
+        {"type": "function_call", "id": "fc_abc", "name": "f", "arguments": "{}"},
+        {"type": "message", "role": "assistant", "content": "ok", "id": "msg_xyz"},
+        {"type": "message", "role": "user", "content": "again", "id": "local-keep-me"},
+    ]
+    out = strip_stale_response_item_ids(items)
+    assert out[0] == items[0]
+    assert "id" not in out[1]
+    assert out[1]["type"] == "reasoning"
+    assert "id" not in out[2]
+    assert out[2]["name"] == "f"
+    assert "id" not in out[3]
+    assert out[4]["id"] == "local-keep-me"
+
+
+def test_is_stale_response_item_not_found_error_detects_rs_404():
+    err = Exception(
+        "Error code: 404 - {'error': {'message': \"Item with id "
+        "'rs_3c4caff36e34c099006900f0e3c66481909c15ac262a15b060' not found.\"}}"
+    )
+    assert is_stale_response_item_not_found_error(err) is True
+    assert is_stale_response_item_not_found_error(ValueError("unrelated")) is False
+
+
+class _FakeRunItem:
+    """Minimal RunItem-like object for conversion tests."""
+
+    def __init__(self, item_type: str, raw: dict[str, Any]):
+        self.type = item_type
+        self.raw_item = raw
+
+    def to_input_item(self) -> dict[str, Any]:
+        return dict(self.raw_item)
+
+
+def test_run_items_to_input_items_strips_under_default_policy():
+    """Default policy (None) must strip server ids — not only omit (#2020)."""
+    run_items = [
+        _FakeRunItem(
+            "reasoning_item",
+            {"type": "reasoning", "id": "rs_default_path", "summary": [{"text": "t"}]},
+        ),
+        _FakeRunItem(
+            "tool_call_item",
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "tool",
+                "arguments": "{}",
+            },
+        ),
+    ]
+    # Default policy (preserve / None) — still strip server ids for multi-turn safety
+    out = run_items_to_input_items(run_items, None)  # type: ignore[arg-type]
+    assert len(out) == 2
+    assert out[0]["type"] == "reasoning"
+    assert "id" not in out[0]
+    assert out[0]["summary"] == [{"text": "t"}]
+    assert "id" not in out[1]
+    assert out[1]["call_id"] == "call_1"
+
+
+@pytest.mark.asyncio
+async def test_get_response_with_retry_rebuilds_on_stale_item_404():
+    """404 Item-with-id-not-found must sanitize input once and retry (live path)."""
+    input_box: list[list[dict[str, Any]]] = [
+        [
+            {"type": "reasoning", "id": "rs_dead", "summary": []},
+            {"type": "message", "role": "user", "content": "hi", "id": "msg_1"},
+        ]
+    ]
+    attempts: list[list[Any]] = []
+
+    class FakeUsage:
+        def __init__(self) -> None:
+            self.requests = 1
+
+    class FakeResp:
+        def __init__(self) -> None:
+            self.usage = FakeUsage()
+
+    async def get_response():
+        ids = [it.get("id") for it in input_box[0]]
+        attempts.append(list(ids))
+        if any(isinstance(i, str) and i.startswith(("rs_", "fc_", "msg_")) for i in ids):
+            raise Exception(
+                "Error code: 404 - {'error': {'message': \"Item with id 'rs_dead' not found.\"}}"
+            )
+        return FakeResp()
+
+    async def sanitize():
+        input_box[0] = strip_stale_response_item_ids(input_box[0])
+
+    async def rewind():
+        return None
+
+    resp = await get_response_with_retry(
+        get_response=get_response,
+        rewind=rewind,
+        retry_settings=None,
+        get_retry_advice=lambda req: None,
+        previous_response_id=None,
+        conversation_id=None,
+        sanitize_stale_response_item_ids=sanitize,
+    )
+    assert isinstance(resp, FakeResp)
+    assert len(attempts) == 2
+    assert attempts[0] == ["rs_dead", "msg_1"]
+    assert attempts[1] == [None, None]
+    assert "id" not in input_box[0][0]


### PR DESCRIPTION
## Summary
- Always strip server-side Responses item `id`s (`rs_` / `fc_` / `msg_`) when converting run history to next-turn model input (not only when `reasoning_item_id_policy="omit"`)
- Also strip ids from caller/session history in `_prepare_turn_input_items`
- On Responses 404 `Item with id '…' not found`, sanitize input and **retry once** in both non-stream and stream paths (`get_response_with_retry` / `stream_response_with_retry`)
- Content is preserved; only the `id` field is removed

Fixes #2020

## Problem
Multi-turn / session runs can re-send dead Responses item IDs that the API no longer stores, causing production 404s. Framing this as SDK resilience for stale ids (not a server-side “fix”).

## Test plan
- [x] `tests/test_stale_response_item_ids.py` — strip helpers, default `run_items_to_input_items` strip, live `get_response_with_retry` 404 rebuild
- [ ] Full package CI on this PR

## Residual risk
- Always-strip is fail-soft for id chaining when `store=true`; the one-shot 404 rebuild remains a backstop if a filter reintroduces ids.