### PR TITLE
fix(mcp): redact URL credentials from SDK errors

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -103,7 +103,7 @@ T = TypeVar("T")
 
 
 def _safe_transport_cause(http_error: Exception) -> Exception | None:
-    """Keep a transport exception only when its request URLs need no sanitization."""
+    """Keep a transport exception only when its HTTPX URLs need no sanitization."""
     if not isinstance(http_error, httpx.HTTPStatusError | httpx.RequestError):
         return http_error
 
@@ -114,11 +114,19 @@ def _safe_transport_cause(http_error: Exception) -> Exception | None:
         pass
 
     if isinstance(http_error, httpx.HTTPStatusError):
-        for response in http_error.response.history:
+        for response in [*http_error.response.history, http_error.response]:
             try:
-                request_urls.append(str(response.request.url))
+                response_url = response.request.url
             except RuntimeError:
-                continue
+                return None
+
+            request_urls.append(str(response_url))
+            redirect_location = response.headers.get("location")
+            if redirect_location is not None:
+                try:
+                    request_urls.append(str(response_url.join(redirect_location)))
+                except (httpx.InvalidURL, ValueError):
+                    return None
 
     return http_error if all(get_mcp_server_log_name(url) == url for url in request_urls) else None
 
@@ -778,7 +786,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
     def _extract_http_error_from_exception(self, e: BaseException) -> Exception | None:
         """Extract HTTP error from exception or ExceptionGroup."""
-        if isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
+        if isinstance(e, httpx.HTTPStatusError | httpx.RequestError):
             return e
 
         # Recursively check ExceptionGroups for HTTP errors
@@ -801,6 +809,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
         elif isinstance(http_error, httpx.TimeoutException):
             error_message += "Connection timeout."
+
+        elif isinstance(http_error, httpx.RequestError):
+            error_message += "Request failed."
 
         return UserError(error_message)
 
@@ -854,23 +865,20 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         except Exception as e:
             # Try to extract HTTP error from exception or ExceptionGroup
             http_error = self._extract_http_error_from_exception(e)
-            if http_error:
-                connection_error = self._user_error_for_http_error(http_error)
-                connection_cause = _safe_transport_cause(http_error)
-
-            # For CancelledError, preserve cancellation semantics - don't wrap it.
-            # If it's masking an HTTP error, cleanup() will extract and raise UserError.
-            elif isinstance(e, asyncio.CancelledError):
+            if http_error is None:
                 raise
 
-            # For HTTP-related errors, wrap them
-            elif isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
-                connection_error = self._user_error_for_http_error(e)
-                connection_cause = _safe_transport_cause(e)
-
-            # For other errors, re-raise as-is (don't wrap non-HTTP errors)
-            else:
+            connection_cause = _safe_transport_cause(http_error)
+            maps_safe_error = isinstance(
+                http_error,
+                httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException,
+            )
+            if connection_cause is not None and not maps_safe_error:
                 raise
+
+            connection_error = self._user_error_for_http_error(http_error)
+            if connection_cause is None:
+                http_error = None
         finally:
             # Always attempt cleanup on error, but suppress cleanup errors that mask the original
             if not connection_succeeded:
@@ -943,19 +951,24 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 f"HTTP error {status_code}"
             )
             transport_cause = _safe_transport_cause(e)
-        except httpx.ConnectError as e:
-            transport_error = UserError(
-                f"Failed to list tools from MCP server '{self._error_name}': Connection lost. "
-                f"The server may have disconnected."
-            )
+        except httpx.RequestError as e:
             transport_cause = _safe_transport_cause(e)
-        except httpx.TimeoutException as e:
-            transport_cause = _safe_transport_cause(e)
-            if transport_cause is not None:
+            if transport_cause is not None and not isinstance(e, httpx.ConnectError):
                 raise
-            transport_error = UserError(
-                f"Failed to list tools from MCP server '{self._error_name}': Connection timeout."
-            )
+            if isinstance(e, httpx.ConnectError):
+                transport_error = UserError(
+                    f"Failed to list tools from MCP server '{self._error_name}': Connection lost. "
+                    f"The server may have disconnected."
+                )
+            elif isinstance(e, httpx.TimeoutException):
+                transport_error = UserError(
+                    f"Failed to list tools from MCP server '{self._error_name}': "
+                    "Connection timeout."
+                )
+            else:
+                transport_error = UserError(
+                    f"Failed to list tools from MCP server '{self._error_name}': Request failed."
+                )
 
         assert transport_error is not None
         self._raise_mapped_transport_error(transport_error, transport_cause)
@@ -994,20 +1007,25 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 f"HTTP error {status_code}"
             )
             transport_cause = _safe_transport_cause(e)
-        except httpx.ConnectError as e:
-            transport_error = UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
-                f"Connection lost. The server may have disconnected."
-            )
+        except httpx.RequestError as e:
             transport_cause = _safe_transport_cause(e)
-        except httpx.TimeoutException as e:
-            transport_cause = _safe_transport_cause(e)
-            if transport_cause is not None:
+            if transport_cause is not None and not isinstance(e, httpx.ConnectError):
                 raise
-            transport_error = UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
-                "Connection timeout."
-            )
+            if isinstance(e, httpx.ConnectError):
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                    "Connection lost. The server may have disconnected."
+                )
+            elif isinstance(e, httpx.TimeoutException):
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                    "Connection timeout."
+                )
+            else:
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                    "Request failed."
+                )
 
         assert transport_error is not None
         self._raise_mapped_transport_error(transport_error, transport_cause)
@@ -1132,6 +1150,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         connect_error = exc
                     elif isinstance(exc, httpx.TimeoutException):
                         timeout_error = exc
+                del exc
 
                 # Only raise HTTP errors if we're cleaning up after a failed connection.
                 # During normal teardown, log them instead.
@@ -1139,6 +1158,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                     if is_failed_connection_cleanup:
                         cleanup_error = self._user_error_for_http_error(http_error)
                         cleanup_cause = _safe_transport_cause(http_error)
+                        if cleanup_cause is None:
+                            http_error = None
                     else:
                         # Normal teardown - log but don't raise
                         _log_transport_warning(
@@ -1151,6 +1172,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                     if is_failed_connection_cleanup:
                         cleanup_error = self._user_error_for_http_error(connect_error)
                         cleanup_cause = _safe_transport_cause(connect_error)
+                        if cleanup_cause is None:
+                            connect_error = None
                     else:
                         _log_transport_warning(
                             get_mcp_server_log_message(
@@ -1162,6 +1185,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                     if is_failed_connection_cleanup:
                         cleanup_error = self._user_error_for_http_error(timeout_error)
                         cleanup_cause = _safe_transport_cause(timeout_error)
+                        if cleanup_cause is None:
+                            timeout_error = None
                     else:
                         _log_transport_warning(
                             get_mcp_server_log_message(
@@ -1782,22 +1807,28 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 f"HTTP error {status_code}"
             )
             transport_cause = _safe_transport_cause(e)
-        except httpx.ConnectError as e:
-            transport_error = UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
-                f"Connection lost. The server may have disconnected."
-            )
+        except httpx.RequestError as e:
             transport_cause = _safe_transport_cause(e)
-        except httpx.TimeoutException as e:
-            transport_cause = _safe_transport_cause(e)
-            if transport_cause is not None:
+            if transport_cause is not None and not isinstance(e, httpx.ConnectError):
                 raise
-            transport_error = UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
-                "Connection timeout."
-            )
+            if isinstance(e, httpx.ConnectError):
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                    "Connection lost. The server may have disconnected."
+                )
+            elif isinstance(e, httpx.TimeoutException):
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                    "Connection timeout."
+                )
+            else:
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                    "Request failed."
+                )
         except BaseExceptionGroup as e:
             http_error = self._extract_http_error_from_exception(e)
+            transport_cause = _safe_transport_cause(http_error) if http_error is not None else None
             if isinstance(http_error, httpx.HTTPStatusError):
                 status_code = http_error.response.status_code
                 transport_error = UserError(
@@ -1814,9 +1845,17 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                     f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     "Connection timeout."
                 )
+            elif isinstance(http_error, httpx.RequestError):
+                if transport_cause is not None:
+                    raise
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                    "Request failed."
+                )
             else:
                 raise
-            transport_cause = _safe_transport_cause(http_error)
+            if transport_cause is None:
+                http_error = None
 
         assert transport_error is not None
         self._raise_mapped_transport_error(transport_error, transport_cause)

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -131,6 +131,11 @@ def _safe_transport_cause(http_error: Exception) -> Exception | None:
     return http_error if all(get_mcp_server_log_name(url) == url for url in request_urls) else None
 
 
+def _first_unsafe_transport_error(http_errors: list[Exception]) -> Exception | None:
+    """Return the first transport error whose HTTPX URLs require sanitization."""
+    return next((error for error in http_errors if _safe_transport_cause(error) is None), None)
+
+
 def _log_transport_warning(message: str, http_error: Exception) -> None:
     """Log a transport failure without attaching credential-bearing request URLs."""
     if _debug.DONT_LOG_TOOL_DATA:
@@ -784,19 +789,18 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         """Invalidate the tools cache."""
         self._cache_dirty = True
 
-    def _extract_http_error_from_exception(self, e: BaseException) -> Exception | None:
-        """Extract HTTP error from exception or ExceptionGroup."""
+    def _extract_http_errors_from_exception(self, e: BaseException) -> list[Exception]:
+        """Extract all HTTP errors from an exception or nested ExceptionGroup."""
         if isinstance(e, httpx.HTTPStatusError | httpx.RequestError):
-            return e
+            return [e]
 
-        # Recursively check ExceptionGroups for HTTP errors
         if isinstance(e, BaseExceptionGroup):
+            http_errors: list[Exception] = []
             for exc in e.exceptions:
-                result = self._extract_http_error_from_exception(exc)
-                if result is not None:
-                    return result
+                http_errors.extend(self._extract_http_errors_from_exception(exc))
+            return http_errors
 
-        return None
+        return []
 
     def _user_error_for_http_error(self, http_error: Exception) -> UserError:
         """Build a UserError from safe HTTP diagnostics."""
@@ -863,12 +867,13 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             self.session = session
             connection_succeeded = True
         except Exception as e:
-            # Try to extract HTTP error from exception or ExceptionGroup
-            http_error = self._extract_http_error_from_exception(e)
-            if http_error is None:
+            http_errors = self._extract_http_errors_from_exception(e)
+            if not http_errors:
                 raise
 
-            connection_cause = _safe_transport_cause(http_error)
+            unsafe_http_error = _first_unsafe_transport_error(http_errors)
+            http_error = unsafe_http_error or http_errors[0]
+            connection_cause = None if unsafe_http_error is not None else http_error
             maps_safe_error = isinstance(
                 http_error,
                 httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException,
@@ -878,7 +883,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
             connection_error = self._user_error_for_http_error(http_error)
             if connection_cause is None:
+                http_errors.clear()
                 http_error = None
+                unsafe_http_error = None
         finally:
             # Always attempt cleanup on error, but suppress cleanup errors that mask the original
             if not connection_succeeded:
@@ -1827,8 +1834,13 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                     "Request failed."
                 )
         except BaseExceptionGroup as e:
-            http_error = self._extract_http_error_from_exception(e)
-            transport_cause = _safe_transport_cause(http_error) if http_error is not None else None
+            http_errors = self._extract_http_errors_from_exception(e)
+            if not http_errors:
+                raise
+
+            unsafe_http_error = _first_unsafe_transport_error(http_errors)
+            http_error = unsafe_http_error or http_errors[0]
+            transport_cause = None if unsafe_http_error is not None else http_error
             if isinstance(http_error, httpx.HTTPStatusError):
                 status_code = http_error.response.status_code
                 transport_error = UserError(
@@ -1855,7 +1867,9 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
             else:
                 raise
             if transport_cause is None:
+                http_errors.clear()
                 http_error = None
+                unsafe_http_error = None
 
         assert transport_error is not None
         self._raise_mapped_transport_error(transport_error, transport_cause)

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -884,8 +884,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             connection_error = self._user_error_for_http_error(http_error)
             if connection_cause is None:
                 http_errors.clear()
-                http_error = None
-                unsafe_http_error = None
+                del http_error
+                del unsafe_http_error
         finally:
             # Always attempt cleanup on error, but suppress cleanup errors that mask the original
             if not connection_succeeded:
@@ -1868,8 +1868,8 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 raise
             if transport_cause is None:
                 http_errors.clear()
-                http_error = None
-                unsafe_http_error = None
+                del http_error
+                del unsafe_http_error
 
         assert transport_error is not None
         self._raise_mapped_transport_error(transport_error, transport_cause)

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeVar, Union, cast
 
 import anyio
 import httpx
@@ -102,6 +102,41 @@ else:
 T = TypeVar("T")
 
 
+def _safe_transport_cause(http_error: Exception) -> Exception | None:
+    """Keep a transport exception only when its request URLs need no sanitization."""
+    if not isinstance(http_error, httpx.HTTPStatusError | httpx.RequestError):
+        return http_error
+
+    request_urls: list[str] = []
+    try:
+        request_urls.append(str(http_error.request.url))
+    except RuntimeError:
+        pass
+
+    if isinstance(http_error, httpx.HTTPStatusError):
+        for response in http_error.response.history:
+            try:
+                request_urls.append(str(response.request.url))
+            except RuntimeError:
+                continue
+
+    return http_error if all(get_mcp_server_log_name(url) == url for url in request_urls) else None
+
+
+def _log_transport_warning(message: str, http_error: Exception) -> None:
+    """Log a transport failure without attaching credential-bearing request URLs."""
+    if _debug.DONT_LOG_TOOL_DATA:
+        log_tool_action_warning(logger, message, http_error)
+        return
+
+    safe_error = _safe_transport_cause(http_error)
+    if safe_error is None:
+        logger.warning("%s", message, stacklevel=3)
+        return
+
+    log_tool_action_warning(logger, message, safe_error)
+
+
 def _create_default_streamable_http_client(
     headers: dict[str, str] | None = None,
     timeout: httpx.Timeout | None = None,
@@ -127,8 +162,7 @@ class _InitializedNotificationTolerantStreamableHTTPTransport(StreamableHTTPTran
         try:
             await super()._handle_post_request(ctx)
         except httpx.HTTPError as exc:
-            log_tool_action_warning(
-                logger,
+            _log_transport_warning(
                 "Ignoring initialized notification HTTP failure",
                 exc,
             )
@@ -290,6 +324,11 @@ class MCPServer(abc.ABC):
         """A readable name for the server."""
         pass
 
+    @property
+    def _error_name(self) -> str:
+        """Return a diagnostic server name with URL credentials removed."""
+        return get_mcp_server_log_name(self.name)
+
     @abc.abstractmethod
     async def cleanup(self):
         """Cleanup the server. For example, this might mean closing a subprocess or
@@ -355,7 +394,7 @@ class MCPServer(abc.ABC):
         unimplemented; it will raise :exc:`NotImplementedError` at call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support list_resources. "
+            f"MCP server '{self._error_name}' does not support list_resources. "
             "Override this method in your server implementation."
         )
 
@@ -377,7 +416,7 @@ class MCPServer(abc.ABC):
         call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support list_resource_templates. "
+            f"MCP server '{self._error_name}' does not support list_resource_templates. "
             "Override this method in your server implementation."
         )
 
@@ -393,7 +432,7 @@ class MCPServer(abc.ABC):
         :exc:`NotImplementedError` at call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support read_resource. "
+            f"MCP server '{self._error_name}' does not support read_resource. "
             "Override this method in your server implementation."
         )
 
@@ -751,9 +790,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
         return None
 
-    def _raise_user_error_for_http_error(self, http_error: Exception) -> None:
-        """Raise appropriate UserError for HTTP error."""
-        error_message = f"Failed to connect to MCP server '{self.name}': "
+    def _user_error_for_http_error(self, http_error: Exception) -> UserError:
+        """Build a UserError from safe HTTP diagnostics."""
+        error_message = f"Failed to connect to MCP server '{self._error_name}': "
         if isinstance(http_error, httpx.HTTPStatusError):
             error_message += f"HTTP error {http_error.response.status_code} ({http_error.response.reason_phrase})"  # noqa: E501
 
@@ -763,7 +802,14 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         elif isinstance(http_error, httpx.TimeoutException):
             error_message += "Connection timeout."
 
-        raise UserError(error_message) from http_error
+        return UserError(error_message)
+
+    @staticmethod
+    def _raise_mapped_transport_error(error: UserError, cause: Exception | None) -> NoReturn:
+        """Raise a mapped transport error without retaining unsafe URL data."""
+        if cause is None:
+            raise error from None
+        raise error from cause
 
     async def _run_with_retries(self, func: Callable[[], Awaitable[T]]) -> T:
         attempts = 0
@@ -780,6 +826,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
     async def connect(self):
         """Connect to the server."""
         connection_succeeded = False
+        connection_error: UserError | None = None
+        connection_cause: Exception | None = None
         try:
             transport = await self.exit_stack.enter_async_context(self.create_streams())
             # streamablehttp_client returns (read, write, get_session_id)
@@ -807,19 +855,22 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             # Try to extract HTTP error from exception or ExceptionGroup
             http_error = self._extract_http_error_from_exception(e)
             if http_error:
-                self._raise_user_error_for_http_error(http_error)
+                connection_error = self._user_error_for_http_error(http_error)
+                connection_cause = _safe_transport_cause(http_error)
 
             # For CancelledError, preserve cancellation semantics - don't wrap it.
             # If it's masking an HTTP error, cleanup() will extract and raise UserError.
-            if isinstance(e, asyncio.CancelledError):
+            elif isinstance(e, asyncio.CancelledError):
                 raise
 
             # For HTTP-related errors, wrap them
-            if isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
-                self._raise_user_error_for_http_error(e)
+            elif isinstance(e, httpx.HTTPStatusError | httpx.ConnectError | httpx.TimeoutException):
+                connection_error = self._user_error_for_http_error(e)
+                connection_cause = _safe_transport_cause(e)
 
             # For other errors, re-raise as-is (don't wrap non-HTTP errors)
-            raise
+            else:
+                raise
         finally:
             # Always attempt cleanup on error, but suppress cleanup errors that mask the original
             if not connection_succeeded:
@@ -851,6 +902,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                             cleanup_error,
                         )
 
+        if connection_error is not None:
+            self._raise_mapped_transport_error(connection_error, connection_cause)
+
     async def list_tools(
         self,
         run_context: RunContextWrapper[Any] | None = None,
@@ -862,6 +916,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         session = self.session
         assert session is not None
 
+        transport_error: UserError | None = None
+        transport_cause: Exception | None = None
         try:
             # Return from cache if caching is enabled, we have tools, and the cache is not dirty
             if self.cache_tools_list and not self._cache_dirty and self._tools_list:
@@ -882,14 +938,27 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             return filtered_tools
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
-            raise UserError(
-                f"Failed to list tools from MCP server '{self.name}': HTTP error {status_code}"
-            ) from e
+            transport_error = UserError(
+                f"Failed to list tools from MCP server '{self._error_name}': "
+                f"HTTP error {status_code}"
+            )
+            transport_cause = _safe_transport_cause(e)
         except httpx.ConnectError as e:
-            raise UserError(
-                f"Failed to list tools from MCP server '{self.name}': Connection lost. "
+            transport_error = UserError(
+                f"Failed to list tools from MCP server '{self._error_name}': Connection lost. "
                 f"The server may have disconnected."
-            ) from e
+            )
+            transport_cause = _safe_transport_cause(e)
+        except httpx.TimeoutException as e:
+            transport_cause = _safe_transport_cause(e)
+            if transport_cause is not None:
+                raise
+            transport_error = UserError(
+                f"Failed to list tools from MCP server '{self._error_name}': Connection timeout."
+            )
+
+        assert transport_error is not None
+        self._raise_mapped_transport_error(transport_error, transport_cause)
 
     async def call_tool(
         self,
@@ -903,6 +972,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         session = self.session
         assert session is not None
 
+        transport_error: UserError | None = None
+        transport_cause: Exception | None = None
         try:
             self._validate_required_parameters(tool_name=tool_name, arguments=arguments)
             if meta is None:
@@ -918,15 +989,28 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             )
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
-            raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+            transport_error = UserError(
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
-            ) from e
+            )
+            transport_cause = _safe_transport_cause(e)
         except httpx.ConnectError as e:
-            raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': Connection lost. "
-                f"The server may have disconnected."
-            ) from e
+            transport_error = UserError(
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                f"Connection lost. The server may have disconnected."
+            )
+            transport_cause = _safe_transport_cause(e)
+        except httpx.TimeoutException as e:
+            transport_cause = _safe_transport_cause(e)
+            if transport_cause is not None:
+                raise
+            transport_error = UserError(
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                "Connection timeout."
+            )
+
+        assert transport_error is not None
+        self._raise_mapped_transport_error(transport_error, transport_cause)
 
     def _validate_required_parameters(
         self, tool_name: str, arguments: dict[str, Any] | None
@@ -949,7 +1033,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             arguments_to_validate = arguments
         else:
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 "arguments must be an object."
             )
 
@@ -958,7 +1042,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         if missing:
             missing_text = ", ".join(sorted(missing))
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"missing required parameters: {missing_text}"
             )
 
@@ -1022,6 +1106,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             # During normal teardown (via __aexit__), log but don't raise to avoid
             # masking the original exception.
             is_failed_connection_cleanup = self.session is None
+            cleanup_error: UserError | None = None
+            cleanup_cause: Exception | None = None
 
             try:
                 await self.exit_stack.aclose()
@@ -1038,7 +1124,6 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 http_error = None
                 connect_error = None
                 timeout_error = None
-                error_message = f"Failed to connect to MCP server '{self.name}': "
 
                 for exc in eg.exceptions:
                     if isinstance(exc, httpx.HTTPStatusError):
@@ -1052,12 +1137,11 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 # During normal teardown, log them instead.
                 if http_error:
                     if is_failed_connection_cleanup:
-                        error_message += f"HTTP error {http_error.response.status_code} ({http_error.response.reason_phrase})"  # noqa: E501
-                        raise UserError(error_message) from http_error
+                        cleanup_error = self._user_error_for_http_error(http_error)
+                        cleanup_cause = _safe_transport_cause(http_error)
                     else:
                         # Normal teardown - log but don't raise
-                        log_tool_action_warning(
-                            logger,
+                        _log_transport_warning(
                             get_mcp_server_log_message(
                                 "HTTP error during cleanup of MCP server", self
                             ),
@@ -1065,11 +1149,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         )
                 elif connect_error:
                     if is_failed_connection_cleanup:
-                        error_message += "Could not reach the server."
-                        raise UserError(error_message) from connect_error
+                        cleanup_error = self._user_error_for_http_error(connect_error)
+                        cleanup_cause = _safe_transport_cause(connect_error)
                     else:
-                        log_tool_action_warning(
-                            logger,
+                        _log_transport_warning(
                             get_mcp_server_log_message(
                                 "Connection error during cleanup of MCP server", self
                             ),
@@ -1077,11 +1160,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         )
                 elif timeout_error:
                     if is_failed_connection_cleanup:
-                        error_message += "Connection timeout."
-                        raise UserError(error_message) from timeout_error
+                        cleanup_error = self._user_error_for_http_error(timeout_error)
+                        cleanup_cause = _safe_transport_cause(timeout_error)
                     else:
-                        log_tool_action_warning(
-                            logger,
+                        _log_transport_warning(
                             get_mcp_server_log_message(
                                 "Timeout error during cleanup of MCP server", self
                             ),
@@ -1127,6 +1209,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             finally:
                 self.session = None
                 self._get_session_id = None
+
+            if cleanup_error is not None:
+                self._raise_mapped_transport_error(cleanup_error, cleanup_cause)
 
 
 class MCPServerStdioParams(TypedDict):
@@ -1654,6 +1739,8 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
         if not self.session:
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
 
+        transport_error: UserError | None = None
+        transport_cause: Exception | None = None
         try:
             self._validate_required_parameters(tool_name=tool_name, arguments=arguments)
             retries_used = 0
@@ -1690,34 +1777,49 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                 first_attempt = False
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
-            raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+            transport_error = UserError(
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                 f"HTTP error {status_code}"
-            ) from e
+            )
+            transport_cause = _safe_transport_cause(e)
         except httpx.ConnectError as e:
-            raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': Connection lost. "
-                f"The server may have disconnected."
-            ) from e
+            transport_error = UserError(
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                f"Connection lost. The server may have disconnected."
+            )
+            transport_cause = _safe_transport_cause(e)
+        except httpx.TimeoutException as e:
+            transport_cause = _safe_transport_cause(e)
+            if transport_cause is not None:
+                raise
+            transport_error = UserError(
+                f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
+                "Connection timeout."
+            )
         except BaseExceptionGroup as e:
             http_error = self._extract_http_error_from_exception(e)
             if isinstance(http_error, httpx.HTTPStatusError):
                 status_code = http_error.response.status_code
-                raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     f"HTTP error {status_code}"
-                ) from http_error
-            if isinstance(http_error, httpx.ConnectError):
-                raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                )
+            elif isinstance(http_error, httpx.ConnectError):
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     "Connection lost. The server may have disconnected."
-                ) from http_error
-            if isinstance(http_error, httpx.TimeoutException):
-                raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                )
+            elif isinstance(http_error, httpx.TimeoutException):
+                transport_error = UserError(
+                    f"Failed to call tool '{tool_name}' on MCP server '{self._error_name}': "
                     "Connection timeout."
-                ) from http_error
-            raise
+                )
+            else:
+                raise
+            transport_cause = _safe_transport_cause(http_error)
+
+        assert transport_error is not None
+        self._raise_mapped_transport_error(transport_error, transport_cause)
 
     @property
     def name(self) -> str:

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -705,7 +705,8 @@ class MCPUtil:
                 finished_task = done.pop()
                 if finished_task.cancelled():
                     raise MCPToolCancellationError(
-                        f"Failed to call tool '{tool.name}' on MCP server '{server.name}': "
+                        f"Failed to call tool '{tool.name}' on MCP server "
+                        f"'{get_mcp_server_log_name(server.name)}': "
                         "tool execution was cancelled."
                     )
                 result = finished_task.result()
@@ -748,7 +749,8 @@ class MCPUtil:
                 )
             log_tool_action_error(logger, log_message, e)
             raise AgentsException(
-                f"Error invoking MCP tool {tool_name_for_display} on server '{server.name}': {e}"
+                f"Error invoking MCP tool {tool_name_for_display} on server "
+                f"'{get_mcp_server_log_name(server.name)}': {e}"
             ) from e
 
         if _debug.DONT_LOG_TOOL_DATA:

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -774,6 +774,11 @@ class SlowFakeMCPServer(FakeMCPServer):
         return await super().call_tool(tool_name, arguments, meta=meta)
 
 
+_CREDENTIALED_SERVER_NAME = (
+    "sse: https://user:s3cr3t_pw@mcp.example.com/sse?api_key=SECRET_QS_KEY#SECRET_FRAGMENT"
+)
+
+
 class CleanupOnCancelFakeMCPServer(FakeMCPServer):
     def __init__(self, cleanup_finished: asyncio.Event):
         super().__init__()
@@ -941,6 +946,45 @@ async def test_mcp_tool_inner_cancellation_becomes_tool_error():
     result = await function_tool.on_invoke_tool(tool_context, "{}")
     assert isinstance(result, str)
     assert "tool execution was cancelled" in result
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_inner_cancellation_sanitizes_url_derived_server_name():
+    server = CancelledFakeMCPServer(server_name=_CREDENTIALED_SERVER_NAME)
+    server.add_tool("cancel_tool", {})
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="cancel_tool", inputSchema={})
+
+    with pytest.raises(MCPToolCancellationError) as exc_info:
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
+
+    message = str(exc_info.value)
+    assert "cancel_tool" in message
+    assert "mcp.example.com/sse" in message
+    assert "s3cr3t_pw" not in message
+    assert "SECRET_QS_KEY" not in message
+    assert "SECRET_FRAGMENT" not in message
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_generic_error_sanitizes_only_url_derived_server_name():
+    server = CrashingFakeMCPServer(server_name=_CREDENTIALED_SERVER_NAME)
+    server.add_tool("crashing_tool", {})
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="crashing_tool", inputSchema={})
+
+    with pytest.raises(AgentsException) as exc_info:
+        await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
+
+    message = str(exc_info.value)
+    assert "crashing_tool" in message
+    assert "mcp.example.com/sse" in message
+    assert "Crash!" in message
+    assert "s3cr3t_pw" not in message
+    assert "SECRET_QS_KEY" not in message
+    assert "SECRET_FRAGMENT" not in message
+    assert isinstance(exc_info.value.__cause__, Exception)
+    assert str(exc_info.value.__cause__) == "Crash!"
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -1,13 +1,19 @@
 import builtins
+import logging
 import sys
-from unittest.mock import MagicMock, patch
+import traceback
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from agents import Agent
+from agents import Agent, _debug
 from agents.exceptions import UserError
-from agents.mcp.server import MCPServerStreamableHttp, _MCPServerWithClientSession
+from agents.mcp.server import (
+    MCPServerSse,
+    MCPServerStreamableHttp,
+    _MCPServerWithClientSession,
+)
 from agents.run_context import RunContextWrapper
 
 # Handle Python version compatibility for ExceptionGroups
@@ -15,6 +21,38 @@ if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
 else:
     BaseExceptionGroup = builtins.BaseExceptionGroup
+
+
+_CREDENTIALED_URL = (
+    "https://user:s3cr3t_pw@mcp.example.com/sse?api_key=SECRET_QS_KEY#SECRET_FRAGMENT"
+)
+_URL_SECRETS = ("user", "s3cr3t_pw", "SECRET_QS_KEY", "SECRET_FRAGMENT")
+_SAFE_URL = "https://mcp.example.com/sse"
+
+
+def _assert_url_credentials_hidden(error: BaseException) -> None:
+    rendered = "".join(traceback.format_exception(error))
+    for secret in _URL_SECRETS:
+        assert secret not in str(error)
+        assert secret not in rendered
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
+def _assert_url_credentials_hidden_from_log_record(record: logging.LogRecord) -> None:
+    rendered = logging.Formatter("%(levelname)s %(message)s").format(record)
+    attached_values = repr(
+        {
+            "msg": record.msg,
+            "args": record.args,
+            "exc_info": record.exc_info,
+            "exc_text": record.exc_text,
+            "extra": record.__dict__,
+        }
+    )
+    for secret in _URL_SECRETS:
+        assert secret not in rendered
+        assert secret not in attached_values
 
 
 class CrashingClientSessionServer(_MCPServerWithClientSession):
@@ -59,19 +97,27 @@ async def test_not_calling_connect_causes_error():
 
 
 @pytest.mark.asyncio
-async def test_call_tool_nested_exception_group_mapping():
+@pytest.mark.parametrize(
+    ("url", "retains_cause"),
+    [
+        ("http://fake-mcp-server", True),
+        (_CREDENTIALED_URL, False),
+    ],
+)
+async def test_call_tool_nested_exception_group_mapping(url: str, retains_cause: bool):
     """
     Regression test ensuring that nested ExceptionGroups containing HTTP errors
     are recursively extracted and mapped to a UserError in call_tool().
     """
     # 1. Initialize the server with mock streamable parameters
-    server = MCPServerStreamableHttp(params={"url": "http://fake-mcp-server"})
+    server = MCPServerStreamableHttp(params={"url": url})
 
     # 2. Simulate an active connection by mocking the session object
     server.session = MagicMock()
 
     # 3. Construct a nested ExceptionGroup hierarchy containing a connection error
-    http_error = httpx.ConnectError("Network unreachable")
+    request = httpx.Request("POST", url)
+    http_error = httpx.ConnectError("Network unreachable", request=request)
     inner_group = BaseExceptionGroup("inner_failures", [http_error])
     outer_group = BaseExceptionGroup("outer_failures", [inner_group])
 
@@ -82,4 +128,234 @@ async def test_call_tool_nested_exception_group_mapping():
 
     # 6. Verify that the user-facing message is mapped correctly based on the root cause
     assert "Connection lost" in str(exc_info.value)
-    assert exc_info.value.__cause__ is http_error
+    if retains_cause:
+        assert exc_info.value.__cause__ is http_error
+    else:
+        assert "mcp.example.com/sse" in str(exc_info.value)
+        _assert_url_credentials_hidden(exc_info.value)
+
+
+@pytest.mark.parametrize("server_type", [MCPServerSse, MCPServerStreamableHttp])
+def test_error_name_sanitizes_url_derived_names_without_changing_runtime_name(server_type):
+    server = server_type(params={"url": _CREDENTIALED_URL})
+
+    assert server.name.endswith(_CREDENTIALED_URL)
+    assert server._error_name.endswith("https://mcp.example.com/sse")
+
+    explicitly_named = server_type(params={"url": _CREDENTIALED_URL}, name="safe server")
+    assert explicitly_named._error_name == "safe server"
+
+
+@pytest.mark.asyncio
+async def test_connect_http_error_hides_url_credentials_from_exception_graph():
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    request = httpx.Request("GET", _CREDENTIALED_URL)
+    http_error = httpx.HTTPStatusError(
+        "boom",
+        request=request,
+        response=httpx.Response(503, request=request),
+    )
+
+    with patch.object(server, "create_streams", side_effect=http_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.connect()
+
+    assert "mcp.example.com/sse" in str(exc_info.value)
+    assert "HTTP error 503 (Service Unavailable)" in str(exc_info.value)
+    _assert_url_credentials_hidden(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_list_tools_http_error_hides_url_credentials_from_exception_graph():
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    server.session = MagicMock()
+    request = httpx.Request("GET", _CREDENTIALED_URL)
+    http_error = httpx.HTTPStatusError(
+        "boom", request=request, response=httpx.Response(500, request=request)
+    )
+
+    with patch.object(server, "_run_with_retries", side_effect=http_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.list_tools(None, None)
+
+    assert "mcp.example.com/sse" in str(exc_info.value)
+    assert "HTTP error 500" in str(exc_info.value)
+    _assert_url_credentials_hidden(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_list_tools_http_error_hides_redirect_history_url_credentials():
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    server.session = MagicMock()
+    final_request = httpx.Request("GET", "https://mcp.example.com/final")
+    redirect_response = httpx.Response(
+        302,
+        request=httpx.Request("GET", _CREDENTIALED_URL),
+    )
+    response = httpx.Response(
+        500,
+        request=final_request,
+        history=[redirect_response],
+    )
+    http_error = httpx.HTTPStatusError(
+        "boom",
+        request=final_request,
+        response=response,
+    )
+
+    with patch.object(server, "_run_with_retries", side_effect=http_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.list_tools(None, None)
+
+    assert "mcp.example.com/sse" in str(exc_info.value)
+    assert "HTTP error 500" in str(exc_info.value)
+    _assert_url_credentials_hidden(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_connect_error_hides_url_credentials_from_exception_graph():
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    server.session = MagicMock()
+    request = httpx.Request("POST", _CREDENTIALED_URL)
+    connect_error = httpx.ConnectError("down", request=request)
+
+    with patch.object(server, "_run_with_retries", side_effect=connect_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.call_tool("safe_tool", {})
+
+    assert "safe_tool" in str(exc_info.value)
+    assert "mcp.example.com/sse" in str(exc_info.value)
+    assert "Connection lost" in str(exc_info.value)
+    _assert_url_credentials_hidden(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("server_type", [MCPServerSse, MCPServerStreamableHttp])
+@pytest.mark.parametrize(
+    ("url", "maps_to_user_error"),
+    [
+        (_SAFE_URL, False),
+        (_CREDENTIALED_URL, True),
+    ],
+)
+async def test_list_tools_direct_timeout_only_maps_credentialed_urls(
+    server_type, url: str, maps_to_user_error: bool
+):
+    server = server_type(params={"url": url})
+    server.session = MagicMock()
+    timeout_error = httpx.ReadTimeout(
+        "timed out",
+        request=httpx.Request("GET", url),
+    )
+
+    with patch.object(server, "_run_with_retries", side_effect=timeout_error):
+        if maps_to_user_error:
+            with pytest.raises(UserError) as user_error_info:
+                await server.list_tools(None, None)
+
+            assert "Connection timeout" in str(user_error_info.value)
+            _assert_url_credentials_hidden(user_error_info.value)
+        else:
+            with pytest.raises(httpx.ReadTimeout) as timeout_info:
+                await server.list_tools(None, None)
+
+            assert timeout_info.value is timeout_error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("server_type", [MCPServerSse, MCPServerStreamableHttp])
+@pytest.mark.parametrize(
+    ("url", "maps_to_user_error"),
+    [
+        (_SAFE_URL, False),
+        (_CREDENTIALED_URL, True),
+    ],
+)
+async def test_call_tool_direct_timeout_only_maps_credentialed_urls(
+    server_type, url: str, maps_to_user_error: bool
+):
+    server = server_type(params={"url": url})
+    server.session = MagicMock()
+    server.max_retry_attempts = 0
+    timeout_error = httpx.ReadTimeout(
+        "timed out",
+        request=httpx.Request("POST", url),
+    )
+    retry_method = (
+        "_call_tool_with_isolated_retry"
+        if server_type is MCPServerStreamableHttp
+        else "_run_with_retries"
+    )
+
+    with patch.object(server, retry_method, side_effect=timeout_error):
+        if maps_to_user_error:
+            with pytest.raises(UserError) as user_error_info:
+                await server.call_tool("safe_tool", {})
+
+            assert "Connection timeout" in str(user_error_info.value)
+            _assert_url_credentials_hidden(user_error_info.value)
+        else:
+            with pytest.raises(httpx.ReadTimeout) as timeout_info:
+                await server.call_tool("safe_tool", {})
+
+            assert timeout_info.value is timeout_error
+
+
+@pytest.mark.asyncio
+async def test_failed_connection_cleanup_hides_url_credentials_from_exception_graph():
+    server = MCPServerSse(params={"url": _CREDENTIALED_URL})
+    request = httpx.Request("GET", _CREDENTIALED_URL)
+    http_error = httpx.HTTPStatusError(
+        "boom", request=request, response=httpx.Response(502, request=request)
+    )
+    cleanup_group = BaseExceptionGroup("cleanup failed", [http_error])
+
+    with patch.object(server.exit_stack, "aclose", AsyncMock(side_effect=cleanup_group)):
+        with pytest.raises(UserError) as exc_info:
+            await server.cleanup()
+
+    assert "mcp.example.com/sse" in str(exc_info.value)
+    assert "HTTP error 502" in str(exc_info.value)
+    _assert_url_credentials_hidden(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("redacted", [True, False])
+@pytest.mark.parametrize(
+    ("url", "safe_to_attach"),
+    [
+        (_SAFE_URL, True),
+        (_CREDENTIALED_URL, False),
+    ],
+)
+async def test_normal_cleanup_only_logs_safe_transport_exceptions(
+    monkeypatch,
+    caplog,
+    redacted: bool,
+    url: str,
+    safe_to_attach: bool,
+):
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", redacted)
+    server = MCPServerSse(params={"url": url})
+    server.session = MagicMock()
+    timeout_error = httpx.ReadTimeout(
+        "timed out",
+        request=httpx.Request("GET", url),
+    )
+    cleanup_group = BaseExceptionGroup("cleanup failed", [timeout_error])
+
+    with (
+        patch.object(server.exit_stack, "aclose", AsyncMock(side_effect=cleanup_group)),
+        caplog.at_level(logging.WARNING, logger="openai.agents"),
+    ):
+        await server.cleanup()
+
+    record = caplog.records[-1]
+    if not redacted and safe_to_attach:
+        assert record.exc_info is not None
+        assert record.exc_info[1] is timeout_error
+    else:
+        assert record.exc_info is None
+
+    if not safe_to_attach:
+        _assert_url_credentials_hidden_from_log_record(record)

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -144,6 +144,65 @@ async def test_call_tool_nested_exception_group_mapping(url: str, retains_cause:
         _assert_not_retained_in_traceback_locals(exc_info.value, http_error)
 
 
+def _mixed_request_error_group(
+    later_url: str,
+) -> tuple[BaseExceptionGroup, httpx.ReadError, httpx.ConnectError]:
+    safe_error = httpx.ReadError(
+        "safe read failed",
+        request=httpx.Request("GET", _SAFE_URL),
+    )
+    later_error = httpx.ConnectError(
+        "later connection failed",
+        request=httpx.Request("GET", later_url),
+    )
+    nested_group = BaseExceptionGroup("later failures", [later_error])
+    return BaseExceptionGroup("mixed failures", [safe_error, nested_group]), safe_error, later_error
+
+
+@pytest.mark.asyncio
+async def test_connect_checks_every_request_error_before_preserving_exception_group():
+    server = MCPServerSse(params={"url": _SAFE_URL})
+    error_group, _, unsafe_error = _mixed_request_error_group(_CREDENTIALED_URL)
+
+    with patch.object(server, "create_streams", side_effect=error_group):
+        with pytest.raises(UserError) as exc_info:
+            await server.connect()
+
+    assert "Could not reach the server" in str(exc_info.value)
+    _assert_url_credentials_hidden(exc_info.value)
+    _assert_not_retained_in_traceback_locals(exc_info.value, error_group)
+    _assert_not_retained_in_traceback_locals(exc_info.value, unsafe_error)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_checks_every_request_error_before_preserving_exception_group():
+    server = MCPServerStreamableHttp(params={"url": _SAFE_URL})
+    server.session = MagicMock()
+    server.max_retry_attempts = 0
+    error_group, _, unsafe_error = _mixed_request_error_group(_CREDENTIALED_URL)
+
+    with patch.object(server, "_call_tool_with_isolated_retry", side_effect=error_group):
+        with pytest.raises(UserError) as exc_info:
+            await server.call_tool("test_tool", {})
+
+    assert "Connection lost" in str(exc_info.value)
+    _assert_url_credentials_hidden(exc_info.value)
+    _assert_not_retained_in_traceback_locals(exc_info.value, error_group)
+    _assert_not_retained_in_traceback_locals(exc_info.value, unsafe_error)
+
+
+@pytest.mark.asyncio
+async def test_connect_preserves_exception_group_when_every_request_error_is_safe():
+    server = MCPServerSse(params={"url": _SAFE_URL})
+    error_group, _, _ = _mixed_request_error_group(_SAFE_URL)
+
+    with patch.object(server, "create_streams", side_effect=error_group):
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await server.connect()
+
+    assert exc_info.value is error_group
+
+
 @pytest.mark.parametrize("server_type", [MCPServerSse, MCPServerStreamableHttp])
 def test_error_name_sanitizes_url_derived_names_without_changing_runtime_name(server_type):
     server = server_type(params={"url": _CREDENTIALED_URL})

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -39,6 +39,14 @@ def _assert_url_credentials_hidden(error: BaseException) -> None:
     assert error.__context__ is None
 
 
+def _assert_not_retained_in_traceback_locals(error: BaseException, sensitive_value: object) -> None:
+    current = error.__traceback__
+    while current is not None:
+        if current.tb_frame.f_code.co_filename.endswith("/src/agents/mcp/server.py"):
+            assert all(value is not sensitive_value for value in current.tb_frame.f_locals.values())
+        current = current.tb_next
+
+
 def _assert_url_credentials_hidden_from_log_record(record: logging.LogRecord) -> None:
     rendered = logging.Formatter("%(levelname)s %(message)s").format(record)
     attached_values = repr(
@@ -133,6 +141,7 @@ async def test_call_tool_nested_exception_group_mapping(url: str, retains_cause:
     else:
         assert "mcp.example.com/sse" in str(exc_info.value)
         _assert_url_credentials_hidden(exc_info.value)
+        _assert_not_retained_in_traceback_locals(exc_info.value, http_error)
 
 
 @pytest.mark.parametrize("server_type", [MCPServerSse, MCPServerStreamableHttp])
@@ -163,6 +172,7 @@ async def test_connect_http_error_hides_url_credentials_from_exception_graph():
     assert "mcp.example.com/sse" in str(exc_info.value)
     assert "HTTP error 503 (Service Unavailable)" in str(exc_info.value)
     _assert_url_credentials_hidden(exc_info.value)
+    _assert_not_retained_in_traceback_locals(exc_info.value, http_error)
 
 
 @pytest.mark.asyncio
@@ -210,6 +220,29 @@ async def test_list_tools_http_error_hides_redirect_history_url_credentials():
     assert "mcp.example.com/sse" in str(exc_info.value)
     assert "HTTP error 500" in str(exc_info.value)
     _assert_url_credentials_hidden(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_list_tools_http_error_hides_current_redirect_location_credentials():
+    server = MCPServerSse(params={"url": _SAFE_URL})
+    server.session = MagicMock()
+    request = httpx.Request("GET", _SAFE_URL)
+    response = httpx.Response(
+        302,
+        request=request,
+        headers={"location": _CREDENTIALED_URL},
+    )
+    with pytest.raises(httpx.HTTPStatusError) as http_error_info:
+        response.raise_for_status()
+    http_error = http_error_info.value
+
+    with patch.object(server, "_run_with_retries", side_effect=http_error):
+        with pytest.raises(UserError) as exc_info:
+            await server.list_tools(None, None)
+
+    assert "HTTP error 302" in str(exc_info.value)
+    _assert_url_credentials_hidden(exc_info.value)
+    _assert_not_retained_in_traceback_locals(exc_info.value, http_error)
 
 
 @pytest.mark.asyncio
@@ -302,6 +335,94 @@ async def test_call_tool_direct_timeout_only_maps_credentialed_urls(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_type",
+    [
+        httpx.ReadError,
+        httpx.WriteError,
+        httpx.RemoteProtocolError,
+        httpx.ProxyError,
+    ],
+)
+@pytest.mark.parametrize(
+    ("url", "maps_to_user_error"),
+    [
+        (_SAFE_URL, False),
+        (_CREDENTIALED_URL, True),
+    ],
+)
+async def test_list_tools_request_errors_only_map_credentialed_urls(
+    error_type, url: str, maps_to_user_error: bool
+):
+    server = MCPServerSse(params={"url": url})
+    server.session = MagicMock()
+    request_error = error_type(
+        "request failed",
+        request=httpx.Request("GET", url),
+    )
+
+    with patch.object(server, "_run_with_retries", side_effect=request_error):
+        if maps_to_user_error:
+            with pytest.raises(UserError) as user_error_info:
+                await server.list_tools(None, None)
+
+            assert "Request failed" in str(user_error_info.value)
+            _assert_url_credentials_hidden(user_error_info.value)
+            _assert_not_retained_in_traceback_locals(
+                user_error_info.value,
+                request_error,
+            )
+        else:
+            with pytest.raises(error_type) as request_error_info:
+                await server.list_tools(None, None)
+
+            assert request_error_info.value is request_error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("server_type", [MCPServerSse, MCPServerStreamableHttp])
+@pytest.mark.parametrize(
+    ("url", "maps_to_user_error"),
+    [
+        (_SAFE_URL, False),
+        (_CREDENTIALED_URL, True),
+    ],
+)
+async def test_call_tool_request_error_only_maps_credentialed_urls(
+    server_type, url: str, maps_to_user_error: bool
+):
+    server = server_type(params={"url": url})
+    server.session = MagicMock()
+    server.max_retry_attempts = 0
+    request_error = httpx.ReadError(
+        "request failed",
+        request=httpx.Request("POST", url),
+    )
+    retry_method = (
+        "_call_tool_with_isolated_retry"
+        if server_type is MCPServerStreamableHttp
+        else "_run_with_retries"
+    )
+
+    with patch.object(server, retry_method, side_effect=request_error):
+        if maps_to_user_error:
+            with pytest.raises(UserError) as user_error_info:
+                await server.call_tool("safe_tool", {})
+
+            assert "Request failed" in str(user_error_info.value)
+            _assert_url_credentials_hidden(user_error_info.value)
+            _assert_not_retained_in_traceback_locals(
+                user_error_info.value,
+                request_error,
+            )
+        else:
+            with pytest.raises(httpx.ReadError) as request_error_info:
+                await server.call_tool("safe_tool", {})
+
+            assert request_error_info.value is request_error
+
+
+@pytest.mark.asyncio
 async def test_failed_connection_cleanup_hides_url_credentials_from_exception_graph():
     server = MCPServerSse(params={"url": _CREDENTIALED_URL})
     request = httpx.Request("GET", _CREDENTIALED_URL)
@@ -317,6 +438,7 @@ async def test_failed_connection_cleanup_hides_url_credentials_from_exception_gr
     assert "mcp.example.com/sse" in str(exc_info.value)
     assert "HTTP error 502" in str(exc_info.value)
     _assert_url_credentials_hidden(exc_info.value)
+    _assert_not_retained_in_traceback_locals(exc_info.value, http_error)
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_streamable_http_client_factory.py
+++ b/tests/mcp/test_streamable_http_client_factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import logging
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -11,6 +12,7 @@ from anyio import create_memory_object_stream
 from mcp.shared.message import SessionMessage
 from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCRequest
 
+from agents import _debug
 from agents.mcp import MCPServerStreamableHttp
 from agents.mcp.server import (
     _create_default_streamable_http_client,
@@ -311,6 +313,52 @@ async def test_initialized_notification_transport_exception_returns_synthetic_su
     finally:
         await client.aclose()
         await read_stream_writer.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("redacted", [True, False])
+async def test_initialized_notification_transport_exception_hides_url_credentials_in_log(
+    monkeypatch,
+    caplog,
+    redacted: bool,
+):
+    url = "https://user:s3cr3t_pw@example.test/mcp?api_key=SECRET_QS_KEY#SECRET_FRAGMENT"
+    secrets = ("user", "s3cr3t_pw", "SECRET_QS_KEY", "SECRET_FRAGMENT")
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", redacted)
+    transport = _InitializedNotificationTolerantStreamableHTTPTransport(url)
+    read_stream_writer, _ = create_memory_object_stream[SessionMessage | Exception](0)
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        ctx = MagicMock()
+        ctx.client = client
+        ctx.read_stream_writer = read_stream_writer
+        ctx.session_message = SessionMessage(
+            JSONRPCMessage(
+                JSONRPCNotification(
+                    jsonrpc="2.0",
+                    method="notifications/initialized",
+                    params={},
+                )
+            )
+        )
+
+        with caplog.at_level(logging.WARNING, logger="openai.agents"):
+            await transport._handle_post_request(ctx)
+    finally:
+        await client.aclose()
+        await read_stream_writer.aclose()
+
+    record = caplog.records[-1]
+    rendered = logging.Formatter("%(levelname)s %(message)s").format(record)
+    attached_values = repr(record.__dict__)
+    assert record.exc_info is None
+    for secret in secrets:
+        assert secret not in rendered
+        assert secret not in attached_values
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes credential disclosure from URL-derived MCP server names and chained HTTP transport errors.

It sanitizes SDK-generated error diagnostics without changing the runtime server name, public constructors, logging flags, or tool identity. Credential-bearing direct and redirect-history request URLs are removed from the mapped exception graph, while safe transport causes remain available for debugging.