### PR TITLE
fix(mcp): sanitize URL credentials in error messages and tracing metadata

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -355,7 +355,7 @@ class MCPServer(abc.ABC):
         unimplemented; it will raise :exc:`NotImplementedError` at call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support list_resources. "
+            f"MCP server '{get_mcp_server_log_name(self.name)}' does not support list_resources. "
             "Override this method in your server implementation."
         )
 
@@ -377,7 +377,7 @@ class MCPServer(abc.ABC):
         call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support list_resource_templates. "
+            f"MCP server '{get_mcp_server_log_name(self.name)}' does not support list_resource_templates. "
             "Override this method in your server implementation."
         )
 
@@ -393,7 +393,7 @@ class MCPServer(abc.ABC):
         :exc:`NotImplementedError` at call time.
         """
         raise NotImplementedError(
-            f"MCP server '{self.name}' does not support read_resource. "
+            f"MCP server '{get_mcp_server_log_name(self.name)}' does not support read_resource. "
             "Override this method in your server implementation."
         )
 
@@ -688,7 +688,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         filter_context = ToolFilterContext(
             run_context=run_context,
             agent=agent,
-            server_name=self.name,
+            server_name=get_mcp_server_log_name(self.name),
         )
 
         filtered_tools = []
@@ -753,7 +753,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
     def _raise_user_error_for_http_error(self, http_error: Exception) -> None:
         """Raise appropriate UserError for HTTP error."""
-        error_message = f"Failed to connect to MCP server '{self.name}': "
+        error_message = f"Failed to connect to MCP server '{get_mcp_server_log_name(self.name)}': "
         if isinstance(http_error, httpx.HTTPStatusError):
             error_message += f"HTTP error {http_error.response.status_code} ({http_error.response.reason_phrase})"  # noqa: E501
 
@@ -883,11 +883,11 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
             raise UserError(
-                f"Failed to list tools from MCP server '{self.name}': HTTP error {status_code}"
+                f"Failed to list tools from MCP server '{get_mcp_server_log_name(self.name)}': HTTP error {status_code}"
             ) from e
         except httpx.ConnectError as e:
             raise UserError(
-                f"Failed to list tools from MCP server '{self.name}': Connection lost. "
+                f"Failed to list tools from MCP server '{get_mcp_server_log_name(self.name)}': Connection lost. "
                 f"The server may have disconnected."
             ) from e
 
@@ -919,12 +919,12 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': "
                 f"HTTP error {status_code}"
             ) from e
         except httpx.ConnectError as e:
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': Connection lost. "
+                f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': Connection lost. "
                 f"The server may have disconnected."
             ) from e
 
@@ -949,7 +949,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             arguments_to_validate = arguments
         else:
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': "
                 "arguments must be an object."
             )
 
@@ -958,7 +958,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         if missing:
             missing_text = ", ".join(sorted(missing))
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': "
                 f"missing required parameters: {missing_text}"
             )
 
@@ -1052,6 +1052,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 # During normal teardown, log them instead.
                 if http_error:
                     if is_failed_connection_cleanup:
+                        error_message = f"Failed to connect to MCP server '{get_mcp_server_log_name(self.name)}': "
                         error_message += f"HTTP error {http_error.response.status_code} ({http_error.response.reason_phrase})"  # noqa: E501
                         raise UserError(error_message) from http_error
                     else:
@@ -1065,6 +1066,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         )
                 elif connect_error:
                     if is_failed_connection_cleanup:
+                        error_message = f"Failed to connect to MCP server '{get_mcp_server_log_name(self.name)}': "
                         error_message += "Could not reach the server."
                         raise UserError(error_message) from connect_error
                     else:
@@ -1077,6 +1079,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         )
                 elif timeout_error:
                     if is_failed_connection_cleanup:
+                        error_message = f"Failed to connect to MCP server '{get_mcp_server_log_name(self.name)}': "
                         error_message += "Connection timeout."
                         raise UserError(error_message) from timeout_error
                     else:
@@ -1691,12 +1694,12 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
         except httpx.HTTPStatusError as e:
             status_code = e.response.status_code
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': "
                 f"HTTP error {status_code}"
             ) from e
         except httpx.ConnectError as e:
             raise UserError(
-                f"Failed to call tool '{tool_name}' on MCP server '{self.name}': Connection lost. "
+                f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': Connection lost. "
                 f"The server may have disconnected."
             ) from e
         except BaseExceptionGroup as e:
@@ -1704,17 +1707,17 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
             if isinstance(http_error, httpx.HTTPStatusError):
                 status_code = http_error.response.status_code
                 raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                    f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': "
                     f"HTTP error {status_code}"
                 ) from http_error
             if isinstance(http_error, httpx.ConnectError):
                 raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                    f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': "
                     "Connection lost. The server may have disconnected."
                 ) from http_error
             if isinstance(http_error, httpx.TimeoutException):
                 raise UserError(
-                    f"Failed to call tool '{tool_name}' on MCP server '{self.name}': "
+                    f"Failed to call tool '{tool_name}' on MCP server '{get_mcp_server_log_name(self.name)}': "
                     "Connection timeout."
                 ) from http_error
             raise

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -342,7 +342,7 @@ class MCPUtil:
         run_context: RunContextWrapper[Any],
         agent: AgentBase,
     ) -> list[MCPTool]:
-        with mcp_tools_span(server=server.name) as span:
+        with mcp_tools_span(server=get_mcp_server_log_name(server.name)) as span:
             tools = await server.list_tools(run_context, agent)
             span.span_data.result = [tool.name for tool in tools]
             return tools
@@ -571,7 +571,7 @@ class MCPUtil:
             mcp_title=resolve_mcp_tool_title(tool),
             tool_origin=ToolOrigin(
                 type=ToolOriginType.MCP,
-                mcp_server_name=server.name,
+                mcp_server_name=get_mcp_server_log_name(server.name),
             ),
         )
         return function_tool
@@ -614,7 +614,7 @@ class MCPUtil:
 
         extractor_context = MCPToolCustomDataContext(
             run_context=context,
-            server_name=server.name,
+            server_name=get_mcp_server_log_name(server.name),
             tool_name=tool_name,
             tool_display_name=tool_display_name,
             arguments=MappingProxyType(copy.deepcopy(arguments)),
@@ -640,7 +640,7 @@ class MCPUtil:
         arguments_copy = copy.deepcopy(arguments) if arguments is not None else None
         resolver_context = MCPToolMetaContext(
             run_context=context,
-            server_name=server.name,
+            server_name=get_mcp_server_log_name(server.name),
             tool_name=tool_name,
             arguments=arguments_copy,
         )
@@ -705,7 +705,7 @@ class MCPUtil:
                 finished_task = done.pop()
                 if finished_task.cancelled():
                     raise MCPToolCancellationError(
-                        f"Failed to call tool '{tool.name}' on MCP server '{server.name}': "
+                        f"Failed to call tool '{tool.name}' on MCP server '{get_mcp_server_log_name(server.name)}': "
                         "tool execution was cancelled."
                     )
                 result = finished_task.result()
@@ -748,7 +748,7 @@ class MCPUtil:
                 )
             log_tool_action_error(logger, log_message, e)
             raise AgentsException(
-                f"Error invoking MCP tool {tool_name_for_display} on server '{server.name}': {e}"
+                f"Error invoking MCP tool {tool_name_for_display} on server '{get_mcp_server_log_name(server.name)}': {e}"
             ) from e
 
         if _debug.DONT_LOG_TOOL_DATA:
@@ -801,7 +801,7 @@ class MCPUtil:
                 ):
                     current_span.span_data.output = tool_output
                 current_span.span_data.mcp_data = {
-                    "server": server.name,
+                    "server": get_mcp_server_log_name(server.name),
                 }
             else:
                 if _debug.DONT_LOG_MODEL_DATA or _debug.DONT_LOG_TOOL_DATA:


### PR DESCRIPTION
MCP server URLs containing HTTP user-info, query parameters, or fragments can leak credentials through error messages, tracing spans, and tool metadata. The SDK includes `get_mcp_server_log_name()` to strip these values for diagnostic logs, but error paths in `src/agents/mcp/server.py` and metadata assignments in `src/agents/mcp/util.py` interpolated the raw `server.name` directly.

This fix applies the existing sanitizer to all UserError and AgentsException messages, tracing span metadata (mcp_tools_span, FunctionSpanData.mcp_data), ToolOrigin metadata, and context objects passed to user callbacks (ToolFilterContext, MCPToolMetaContext, MCPToolCustomDataContext). Only the scheme, host, optional port, and path are retained in these paths, preventing credentials or signed tokens from reaching LLMs, trace exporters, or persisted run state.

Fixes #4016
