### PR TITLE
fix(mcp): redact URL credentials from tracing and tool metadata

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -342,7 +342,7 @@ class MCPUtil:
         run_context: RunContextWrapper[Any],
         agent: AgentBase,
     ) -> list[MCPTool]:
-        with mcp_tools_span(server=server.name) as span:
+        with mcp_tools_span(server=get_mcp_server_log_name(server.name)) as span:
             tools = await server.list_tools(run_context, agent)
             span.span_data.result = [tool.name for tool in tools]
             return tools
@@ -451,7 +451,7 @@ class MCPUtil:
         not depend on object identity or cross any serialization boundary.
         """
         base_names = [
-            cls._build_prefixed_tool_base_name(server.name, tool.name)
+            cls._build_prefixed_tool_base_name(get_mcp_server_log_name(server.name), tool.name)
             for _, server, tools in server_tool_batches
             for tool in tools
         ]
@@ -459,9 +459,10 @@ class MCPUtil:
 
         candidates: list[_PrefixedToolNameCandidate] = []
         for server_index, server, tools in server_tool_batches:
+            server_name = get_mcp_server_log_name(server.name)
             for tool_index, tool in enumerate(tools):
-                base_name = cls._build_prefixed_tool_base_name(server.name, tool.name)
-                seed = f"{server.name}\0{tool.name}"
+                base_name = cls._build_prefixed_tool_base_name(server_name, tool.name)
+                seed = f"{server_name}\0{tool.name}"
                 force_hash = base_name_counts[base_name] > 1 or base_name in reserved_names
                 initial_name = cls._shorten_tool_name(base_name, seed, force_hash=force_hash)
                 candidates.append(
@@ -571,7 +572,7 @@ class MCPUtil:
             mcp_title=resolve_mcp_tool_title(tool),
             tool_origin=ToolOrigin(
                 type=ToolOriginType.MCP,
-                mcp_server_name=server.name,
+                mcp_server_name=get_mcp_server_log_name(server.name),
             ),
         )
         return function_tool
@@ -803,7 +804,7 @@ class MCPUtil:
                 ):
                     current_span.span_data.output = tool_output
                 current_span.span_data.mcp_data = {
-                    "server": server.name,
+                    "server": get_mcp_server_log_name(server.name),
                 }
             else:
                 if _debug.DONT_LOG_MODEL_DATA or _debug.DONT_LOG_TOOL_DATA:

--- a/tests/mcp/test_mcp_tracing.py
+++ b/tests/mcp/test_mcp_tracing.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from inline_snapshot import snapshot
 
@@ -272,3 +274,37 @@ async def test_mcp_tracing_redacts_output_when_sensitive_data_disabled():
             }
         ]
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trace_include_sensitive_data", [True, False])
+async def test_mcp_tracing_always_hides_url_credentials(
+    trace_include_sensitive_data: bool,
+):
+    model = FakeModel()
+    server = FakeMCPServer(
+        server_name=(
+            "streamable_http: https://user:s3cr3t_pw@mcp.example.test:8443/mcp"
+            "?api_key=SECRET_QS_KEY#SECRET_FRAGMENT"
+        )
+    )
+    server.add_tool("search", {})
+    agent = Agent(name="test", model=model, mcp_servers=[server])
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("search", "")],
+            [get_text_message("done")],
+        ]
+    )
+
+    await Runner.run(
+        agent,
+        input="trace_url_credentials",
+        run_config=RunConfig(trace_include_sensitive_data=trace_include_sensitive_data),
+    )
+
+    serialized_spans = json.dumps(fetch_normalized_spans())
+    safe_server_name = "streamable_http: https://mcp.example.test:8443/mcp"
+    assert serialized_spans.count(safe_server_name) == 3
+    for secret in ("user", "s3cr3t_pw", "SECRET_QS_KEY", "SECRET_FRAGMENT"):
+        assert secret not in serialized_spans

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -43,6 +43,13 @@ class Bar(BaseModel):
 
 Baz = TypeAdapter(dict[str, str])
 
+_URL_DERIVED_SECRET_SERVER_NAME = (
+    "streamable_http: https://user:s3cr3t_pw@mcp.example.test:8443/mcp"
+    "?api_key=SECRET_QS_KEY#SECRET_FRAGMENT"
+)
+_SANITIZED_SERVER_NAME = "streamable_http: https://mcp.example.test:8443/mcp"
+_SERVER_URL_SECRETS = ("user", "s3cr3t_pw", "SECRET_QS_KEY", "SECRET_FRAGMENT")
+
 
 def _convertible_schema() -> dict[str, Any]:
     schema = Foo.model_json_schema()
@@ -208,6 +215,31 @@ async def test_get_all_function_tools_can_prefix_server_tool_names():
     assert server1.tool_calls == []
     assert server2.tool_calls == ["search"]
     assert captured_meta_context == {"server_name": "calendar", "tool_name": "search"}
+
+
+@pytest.mark.asyncio
+async def test_get_all_function_tools_hides_url_credentials_from_public_name_and_origin():
+    server = FakeMCPServer(server_name=_URL_DERIVED_SECRET_SERVER_NAME)
+    server.add_tool("search", {})
+
+    tools = await MCPUtil.get_all_function_tools(
+        [server],
+        False,
+        RunContextWrapper(context=None),
+        Agent(name="test_agent", instructions="Test agent"),
+        include_server_in_tool_names=True,
+    )
+
+    assert len(tools) == 1
+    function_tool = tools[0]
+    assert isinstance(function_tool, FunctionTool)
+    assert function_tool.name == ("mcp_streamable_http__https___mcp_example_test_8443_mcp__search")
+    assert function_tool._tool_origin is not None
+    assert function_tool._tool_origin.mcp_server_name == _SANITIZED_SERVER_NAME
+    assert server.name == _URL_DERIVED_SECRET_SERVER_NAME
+    for secret in _SERVER_URL_SECRETS:
+        assert secret not in function_tool.name
+        assert secret not in repr(function_tool._tool_origin)
 
 
 @pytest.mark.asyncio
@@ -1216,6 +1248,30 @@ async def test_mcp_tool_graceful_error_handling(caplog: pytest.LogCaptureFixture
     assert (
         "MCP tool crashing_tool failed" in caplog.text or "Error invoking MCP tool" in caplog.text
     )
+
+
+@pytest.mark.asyncio
+async def test_mcp_default_tool_error_hides_url_credentials():
+    server = SecretCrashingFakeMCPServer(server_name=_URL_DERIVED_SECRET_SERVER_NAME)
+    function_tool = MCPUtil.to_function_tool(
+        MCPTool(name="crashing_tool", inputSchema={}),
+        server,
+        convert_schemas_to_strict=False,
+        agent=Agent(name="test-agent"),
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="crashing_tool",
+        tool_call_id="test_call_url_credentials",
+        tool_arguments="{}",
+    )
+
+    result = await function_tool.on_invoke_tool(tool_context, "{}")
+
+    assert isinstance(result, str)
+    assert _SANITIZED_SERVER_NAME in result
+    for secret in _SERVER_URL_SECRETS:
+        assert secret not in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_origin.py
+++ b/tests/test_tool_origin.py
@@ -166,6 +166,38 @@ async def test_runner_attaches_local_mcp_tool_origin_to_call_and_output_items() 
 
 
 @pytest.mark.asyncio
+async def test_local_mcp_tool_origin_hides_url_credentials_in_run_state() -> None:
+    raw_server_name = (
+        "streamable_http: https://user:s3cr3t_pw@mcp.example.test:8443/mcp"
+        "?api_key=SECRET_QS_KEY#SECRET_FRAGMENT"
+    )
+    safe_server_name = "streamable_http: https://mcp.example.test:8443/mcp"
+    model = FakeModel()
+    server = FakeMCPServer(
+        server_name=raw_server_name,
+        tools=[MCPTool(name="search_docs", inputSchema={})],
+    )
+    agent = Agent(name="mcp-agent", model=model, mcp_servers=[server])
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("search_docs", json.dumps({}), call_id="call_search_docs")],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = await Runner.run(agent, input="hello")
+
+    expected = ToolOrigin(type=ToolOriginType.MCP, mcp_server_name=safe_server_name)
+    assert _first_item(result.new_items, ToolCallItem).tool_origin == expected
+    assert _first_item(result.new_items, ToolCallOutputItem).tool_origin == expected
+    serialized_state = json.dumps(result.to_state().to_json())
+    assert safe_server_name in serialized_state
+    for secret in ("user", "s3cr3t_pw", "SECRET_QS_KEY", "SECRET_FRAGMENT"):
+        assert secret not in serialized_state
+    assert server.name == raw_server_name
+
+
+@pytest.mark.asyncio
 async def test_streamed_tool_call_item_includes_local_mcp_origin() -> None:
     model = FakeModel()
     server = FakeMCPServer(


### PR DESCRIPTION
This pull request fixes #4016 the remaining MCP URL credential exposure paths by sanitizing URL-derived server names before they enter list/function spans, persisted `ToolOrigin` metadata, and server-prefixed function tool names.

It adds regression coverage for default model-visible errors, both sensitive tracing modes, and `RunState` serialization while preserving raw server names for runtime configuration and callback contexts.