### PR TITLE
fix(models): ignore a non-finite Retry-After instead of sleeping forever

### DIFF
--- a/src/agents/models/_retry_runtime.py
+++ b/src/agents/models/_retry_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import time
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
@@ -55,6 +56,17 @@ def get_error_header(error: Exception, key: str) -> str | None:
     return None
 
 
+def _usable_delay(parsed: float) -> float | None:
+    """Return the delay only when it is a wait a caller can actually finish.
+
+    `float()` accepts `inf`, `Infinity`, and overflowing literals such as `1e400`, none of
+    which RFC 9110 allows in `Retry-After`. An infinite delay reaches `asyncio.sleep()`
+    unchanged and parks the run permanently, so it is rejected here alongside the negative
+    and NaN values this module already refuses.
+    """
+    return parsed if math.isfinite(parsed) and parsed >= 0 else None
+
+
 def parse_retry_after_ms(value: str | None) -> float | None:
     if value is None:
         return None
@@ -62,7 +74,7 @@ def parse_retry_after_ms(value: str | None) -> float | None:
         parsed = float(value) / 1000.0
     except ValueError:
         return None
-    return parsed if parsed >= 0 else None
+    return _usable_delay(parsed)
 
 
 def parse_retry_after_value(value: str | None) -> float | None:
@@ -74,7 +86,7 @@ def parse_retry_after_value(value: str | None) -> float | None:
     except ValueError:
         parsed = None
     if parsed is not None:
-        return parsed if parsed >= 0 else None
+        return _usable_delay(parsed)
 
     try:
         retry_datetime = parsedate_to_datetime(value)

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -1298,6 +1299,62 @@ async def test_get_response_with_retry_prefers_retry_after_over_backoff(monkeypa
 
     assert rewinds == 1
     assert sleeps == [1.75]
+    assert result.usage.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_get_response_with_retry_falls_back_to_backoff_for_infinite_retry_after(
+    monkeypatch,
+) -> None:
+    """A `Retry-After: inf` header must not become the sleep the run waits on.
+
+    `float("inf")` reaches `asyncio.sleep()` unchanged, which never wakes up, so the retry
+    budget is never spent and the run parks forever. Ignoring the unusable hint and using the
+    configured backoff is the only outcome that still makes progress.
+    """
+    calls = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    async def rewind() -> None:
+        return None
+
+    def _rate_limit_error() -> APIStatusError:
+        request = httpx.Request("POST", "https://example.com")
+        response = httpx.Response(429, request=request, headers={"retry-after": "inf"})
+        return APIStatusError("rate limited", response=response, body=None)
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _rate_limit_error()
+        return ModelResponse(
+            output=[get_text_message("ok")],
+            usage=Usage(requests=1),
+            response_id="resp_inf_retry_after",
+        )
+
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=rewind,
+        retry_settings=ModelRetrySettings(
+            max_retries=1,
+            backoff=ModelRetryBackoffSettings(initial_delay=0.5, jitter=False),
+            policy=retry_policies.http_status([429]),
+        ),
+        get_retry_advice=lambda _request: None,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    assert calls == 2
+    assert sleeps == [0.5]
+    assert all(math.isfinite(delay) for delay in sleeps)
     assert result.usage.requests == 2
 
 

--- a/tests/models/test_openai_retry_helpers.py
+++ b/tests/models/test_openai_retry_helpers.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
 
 import httpx
+import pytest
 
 from agents.models._openai_retry import get_openai_retry_advice
 from agents.models._retry_runtime import (
@@ -75,6 +76,24 @@ def test_parse_retry_after_numeric_and_http_date() -> None:
     assert parsed is not None and parsed > 0
 
     assert _parse_retry_after("definitely not a date") is None
+
+
+@pytest.mark.parametrize("header", ["inf", "+inf", "INF", "Infinity", "infinity", "1e400"])
+def test_parse_retry_after_rejects_non_finite_delays(header: str) -> None:
+    """`float()` accepts these but they are not delays a run can ever wake up from.
+
+    An infinite delay is passed straight to ``asyncio.sleep()``, so accepting one parks the
+    run permanently instead of retrying. Falling back to the configured backoff is the only
+    recoverable behavior.
+    """
+    assert _parse_retry_after(header) is None
+    assert _parse_retry_after_ms(header) is None
+
+
+def test_parse_retry_after_keeps_large_finite_delays() -> None:
+    """Only non-finite values are rejected; a long-but-finite wait is still the provider's call."""
+    assert _parse_retry_after("86400") == 86400.0
+    assert _parse_retry_after_ms("86400000") == 86400.0
 
 
 def test_get_retry_after_preserves_outer_exception_precedence() -> None:


### PR DESCRIPTION
### Summary

A `Retry-After: inf` header currently parks a run forever instead of retrying it.

`parse_retry_after_value` and `parse_retry_after_ms` build the delay with `float()` and then accept anything `>= 0`. `float()` accepts `inf`, `+inf`, `INF`, `Infinity`, `infinity`, and overflowing literals such as `1e400` — none of which RFC 9110 permits in `Retry-After` — and `inf >= 0` is true, so each is returned as a usable delay. The negative and NaN forms of the same problem are already rejected by that guard (`-inf >= 0` and `nan >= 0` are both false); only `inf` slips through.

Nothing downstream bounds it. The value flows `get_retry_after` → `ModelRetryNormalizedError.retry_after` → `RetryDecision.delay` → `_sleep_for_retry`, which calls `asyncio.sleep(delay)` and only short-circuits on `delay <= 0`. `backoff.max_delay` is applied solely inside `_default_retry_delay`, and `_evaluate_retry` uses the retry-after hint *instead of* calling that — which is deliberate and documented (`docs/models/index.md`: "`backoff.max_delay` caps this computed backoff delay only. It does not cap explicit delays returned by a policy or retry-after hints"). That makes the parser the only place an unusable value can be rejected, so this fix stays there and leaves the documented `max_delay` semantics untouched.

The fix adds `math.isfinite()` alongside the existing `>= 0` check, via a small shared `_usable_delay()` helper so both parsers keep identical behavior. Long-but-finite waits are unchanged — a 24-hour `Retry-After` is still honored, because that remains the provider's call. Only values a run could never wake up from are dropped, and the caller then falls back to the configured backoff.

For reference, the `openai` SDK this repo wraps bounds the header before using it in `_base_client._calculate_retry_timeout` (`if retry_after is not None and 0 < retry_after <= 60`), falling back to exponential backoff otherwise.

### Test plan

Three regression tests, at both levels:

- `tests/models/test_openai_retry_helpers.py::test_parse_retry_after_rejects_non_finite_delays` — parametrized over `inf`, `+inf`, `INF`, `Infinity`, `infinity`, `1e400` for both parsers.
- `tests/models/test_openai_retry_helpers.py::test_parse_retry_after_keeps_large_finite_delays` — pins that `86400` is still accepted, so the change is not a general clamp.
- `tests/models/test_model_retry.py::test_get_response_with_retry_falls_back_to_backoff_for_infinite_retry_after` — end-to-end: a 429 carrying `Retry-After: inf` with `initial_delay=0.5, jitter=False` must sleep `0.5`, retry, and succeed.

Verified:

- The three new tests plus the existing retry suites: **81 passed**.
- **Control:** reverting only `_retry_runtime.py` and rerunning the same set gives **7 failed / 74 passed**, with the end-to-end case failing as `assert [inf] == [0.5]` — confirming the run really does sleep on infinity today.
- `tests/models/`: **602 passed, 4 skipped**.
- Lint/format: `ruff format --check` clean, `ruff check` "All checks passed!".
- Typecheck: `mypy` "Success: no issues found", `pyright` "0 errors, 0 warnings".
- `pytest -n auto --dist loadfile -m "not serial"`: failing-file set byte-identical before and after the change (5 pre-existing tracing files).
- `pytest -m serial`: 3 failed / 4 passed / 27 skipped, identical on a clean tree — all three are `ConnectionError` in `tests/extensions/` and need network access.

`.agents/skills/code-change-verification/scripts/run.sh` itself could not run here: this is a Windows checkout with no `make` on `PATH`, and the script drives every step through `make`. I ran each of its steps directly instead — `format`, `lint`, `mypy`, `pyright`, `tests-parallel`, `tests-serial` — with the results above. Happy to rerun anything under CI.

### Issue number

Closes #4021

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (no `make` available on this Windows checkout; ran each step it invokes directly — see test plan)
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
