### PR TITLE
fix: consolidate same-exception re-raises into bare raise across all modules

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1679,7 +1679,7 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                     if self.max_retry_attempts != -1 and retries_used >= self.max_retry_attempts:
                         if exc.__cause__ is not None:
                             raise exc.__cause__ from exc
-                        raise exc
+                        raise
                     backoff = self.retry_backoff_seconds_base * (2 ** (retries_used - 1))
                     await asyncio.sleep(backoff)
                 except Exception:

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1690,7 +1690,7 @@ class _FunctionToolBatchExecutor:
                     )
                 )
                 if isinstance(e, AgentsException):
-                    raise e
+                    raise
                 raise UserError(f"Error running tool {func_tool.name}: {e}") from e
 
             if self.config.trace_include_sensitive_data:

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -202,7 +202,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             raise wrapped_err from e
         except Exception as e:
             await self._output_queue.put(ErrorSentinel(e))
-            raise e
+            raise
 
         await self._configure_session()
 
@@ -252,7 +252,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                 break
             except Exception as e:
                 await self._output_queue.put(ErrorSentinel(e))
-                raise e
+                raise
         await self._output_queue.put(SessionCompleteSentinel())
 
     async def _stream_audio(
@@ -279,7 +279,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                 break
             except Exception as e:
                 await self._output_queue.put(ErrorSentinel(e))
-                raise e
+                raise
 
             await asyncio.sleep(0)  # yield control
 
@@ -303,7 +303,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                     raise AgentsException("Listener task not initialized")
         except Exception as e:
             await self._output_queue.put(ErrorSentinel(e))
-            raise e
+            raise
 
     def _check_errors(self) -> None:
         if self._connection_task and self._connection_task.done():
@@ -447,7 +447,7 @@ class OpenAISTTModel(STTModel):
                         data={},
                     )
                 )
-                raise e
+                raise
 
     async def create_session(
         self,

--- a/src/agents/voice/pipeline.py
+++ b/src/agents/voice/pipeline.py
@@ -115,7 +115,7 @@ class VoicePipeline:
                 except Exception as e:
                     log_model_and_tool_action_error(logger, "Error processing single voice turn", e)
                     await output._add_error(e)
-                    raise e
+                    raise
 
         output._set_task(asyncio.create_task(stream_events()))
         return output
@@ -158,7 +158,7 @@ class VoicePipeline:
                 except Exception as e:
                     log_model_and_tool_action_error(logger, "Error processing voice turns", e)
                     await output._add_error(e)
-                    raise e
+                    raise
                 finally:
                     if transcription_session is not None:
                         await transcription_session.close()

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -196,7 +196,7 @@ class StreamedAudioResult:
 
                 # Signal completion for whole session because of error
                 await local_queue.put(VoiceStreamEventLifecycle(event="session_ended"))
-                raise e
+                raise
 
     async def _add_text(self, text: str):
         await self._start_turn()


### PR DESCRIPTION
## Summary

Replace `raise e` / `raise exc` with bare `raise` inside `except` blocks to avoid adding an artificial re-raise frame to the traceback. While the original failure frame is preserved with either form, bare `raise` keeps the traceback clean without an extra re-raise frame.

## Changes

All changes follow the same pattern: inside an `except` handler, replace `raise e` (or `raise exc`) with bare `raise` to re-raise the currently handled exception without adding an extra traceback frame.

- **src/agents/voice/models/openai_stt.py** (5 instances) — `except Exception as e: ... raise e` → `raise`
- **src/agents/voice/pipeline.py** (2 instances) — `except Exception as e: ... raise e` → `raise`
- **src/agents/voice/result.py** (1 instance) — `except Exception as e: ... raise e` → `raise`
- **src/agents/run_internal/tool_execution.py** (1 instance) — `except Exception as e: ... raise e` → `raise`
- **src/agents/mcp/server.py** (1 instance) — `except IsolatedSessionRetryFailed as exc: ... raise exc` → `raise`

No behavior change: the same exception object is re-raised in all cases. The only difference is the traceback will not include an artificial re-raise frame.

## Test plan

- Existing tests pass
- Mechanical Python-language cleanup — no runtime behavior change