### PR TITLE
fix: preserve original exception traceback in voice pipeline re-raises

### DIFF
--- a/src/agents/voice/pipeline.py
+++ b/src/agents/voice/pipeline.py
@@ -115,7 +115,7 @@ class VoicePipeline:
                 except Exception as e:
                     log_model_and_tool_action_error(logger, "Error processing single voice turn", e)
                     await output._add_error(e)
-                    raise e
+                    raise
 
         output._set_task(asyncio.create_task(stream_events()))
         return output
@@ -158,7 +158,7 @@ class VoicePipeline:
                 except Exception as e:
                     log_model_and_tool_action_error(logger, "Error processing voice turns", e)
                     await output._add_error(e)
-                    raise e
+                    raise
                 finally:
                     if transcription_session is not None:
                         await transcription_session.close()


### PR DESCRIPTION
## Summary

Replace \aise e\ with bare \aise\ inside \except\ blocks in \pipeline.py\ to preserve the original exception traceback when re-raising. In Python 3.10 (the minimum supported version), \aise e\ resets the traceback to the re-raise line, obscuring the original error location.

## Changes

\src/agents/voice/pipeline.py\: Changed 2 instances of \aise e\ to bare \aise\ inside \except\ handlers.

## Test plan

- Existing tests pass (\make tests\)
- No behavior change: the same exception is re-raised, only the traceback is preserved unchanged