### PR TITLE
fix: preserve original exception traceback in voice result re-raise

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -196,7 +196,7 @@ class StreamedAudioResult:
 
                 # Signal completion for whole session because of error
                 await local_queue.put(VoiceStreamEventLifecycle(event="session_ended"))
-                raise e
+                raise
 
     async def _add_text(self, text: str):
         await self._start_turn()


### PR DESCRIPTION
## Summary

Replace \aise e\ with bare \aise\ inside \except\ block in \esult.py\ to preserve the original exception traceback when re-raising. In Python 3.10 (minimum supported version), \aise e\ resets the traceback to the re-raise line, obscuring the original error location.

## Changes

\src/agents/voice/result.py\: Changed 1 instance of \aise e\ to bare \aise\.

## Test plan

- Existing tests pass (\make tests\)
- No behavior change: the same exception is re-raised, only the traceback is preserved unchanged