### PR TITLE
fix: preserve original exception traceback in tool execution re-raise

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1690,7 +1690,7 @@ class _FunctionToolBatchExecutor:
                     )
                 )
                 if isinstance(e, AgentsException):
-                    raise e
+                    raise
                 raise UserError(f"Error running tool {func_tool.name}: {e}") from e
 
             if self.config.trace_include_sensitive_data:


### PR DESCRIPTION
## Summary

Replace \aise e\ with bare \aise\ inside \except\ block in \	ool_execution.py\ to preserve the original exception traceback when re-raising \AgentsException\. In Python 3.10 (minimum supported version), \aise e\ resets the traceback to the re-raise line, obscuring the original error location.

## Changes

\src/agents/run_internal/tool_execution.py\: Changed 1 instance of \aise e\ to bare \aise\.

## Test plan

- Existing tests pass (\make tests\)
- No behavior change: the same exception is re-raised, only the traceback is preserved unchanged