### PR TITLE
fix: preserve original exception traceback in MCP server retry re-raise

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1679,7 +1679,7 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                     if self.max_retry_attempts != -1 and retries_used >= self.max_retry_attempts:
                         if exc.__cause__ is not None:
                             raise exc.__cause__ from exc
-                        raise exc
+                        raise
                     backoff = self.retry_backoff_seconds_base * (2 ** (retries_used - 1))
                     await asyncio.sleep(backoff)
                 except Exception:


### PR DESCRIPTION
## Summary

Replace \aise exc\ with bare \aise\ inside \except\ block in \server.py\ to preserve the original exception traceback when re-raising after exhausting MCP retry attempts. In Python 3.10 (minimum supported version), \aise exc\ resets the traceback to the re-raise line, obscuring the original error location.

## Changes

\src/agents/mcp/server.py\: Changed 1 instance of \aise exc\ to bare \aise\.

## Test plan

- Existing tests pass (\make tests\)
- No behavior change: the same exception is re-raised, only the traceback is preserved unchanged