### PR TITLE
fix: add cycle detection to _extract_json_decode_error exception chain walk

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -1685,7 +1685,9 @@ def prune_orphaned_tool_search_tools(tools: list[Tool]) -> list[Tool]:
 
 def _extract_json_decode_error(error: BaseException) -> json.JSONDecodeError | None:
     current: BaseException | None = error
-    while current is not None:
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
         if isinstance(current, json.JSONDecodeError):
             return current
         current = current.__cause__ or current.__context__


### PR DESCRIPTION
## Summary

Add cycle detection to `_extract_json_decode_error()` in `tool.py`. The while loop walks the exception chain via `__cause__` / `__context__` without any cycle detection. If the exception chain contains a cycle, this would loop infinitely.

This function is called from the default tool error handler (`default_tool_error_function`), which executes on every tool invocation error. An infinite loop here would hang a tool call indefinitely.

## Change

`src/agents/tool.py`: Added `seen: set[int]` tracking `id(current)` before following the chain, matching the same pattern used by `iter_error_chain()` in `_retry_runtime.py` and other chain walkers in the codebase.

## Test plan

- Existing tests pass
- Safe no-op for non-cyclic chains (the common case): the id check adds trivial overhead
- Prevents infinite loop on cyclic chains