### PR TITLE
fix: use isinstance instead of type() for int checks in run_state deserialization

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -2864,7 +2864,7 @@ async def _build_run_state_from_json(
                 if session_index_value is None:
                     continue
                 if (
-                    type(session_index_value) is not int
+                    not isinstance(session_index_value, int)
                     or session_index_value < 0
                     or session_index_value >= len(serialized_session_items)
                     or session_index_value in used_session_indexes
@@ -2906,11 +2906,11 @@ async def _build_run_state_from_json(
     for item_ref in nested_history_refs_json:
         if (
             not isinstance(item_ref, Mapping)
-            or type(item_ref.get("index")) is not int
+            or not isinstance(item_ref.get("index"), int)
             or cast(int, item_ref["index"]) < 0
             or not isinstance(item_ref.get("digest"), str)
             or len(cast(str, item_ref["digest"])) != 64
-            or type(item_ref.get("input_index")) is not int
+            or not isinstance(item_ref.get("input_index"), int)
             or cast(int, item_ref["input_index"]) < 0
         ):
             raise UserError(


### PR DESCRIPTION
## Summary

Replace `type(x) is not int` with `not isinstance(x, int)` in three places during RunState deserialization validation.

`type()` rejects bool, which is a subclass of int — `type(True) is not int` evaluates to `True` (since `type(True)` is `bool`, not `int`). Using `isinstance` ensures bool values (`True` = 1, `False` = 0) are accepted as valid integer indexes.

## Changes

`src/agents/run_state.py`:
- Line 2867: `type(session_index_value) is not int` → `not isinstance(session_index_value, int)`
- Line 2909: `type(item_ref.get("index")) is not int` → `not isinstance(item_ref.get("index"), int)`
- Line 2913: `type(item_ref.get("input_index")) is not int` → `not isinstance(item_ref.get("input_index"), int)`

## Test plan

- Existing tests pass
