### PR TITLE
fix(memory): count valid AdvancedSQLiteSession items for positive limits

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -206,49 +206,15 @@ class AdvancedSQLiteSession(SQLiteSession):
         if branch_id is None:
             branch_id = self._current_branch_id
 
-            # Get all items for this branch
-            def _get_all_items_sync():
-                """Synchronous helper to get all items for a branch."""
-                with self._locked_connection() as conn:
-                    with closing(conn.cursor()) as cursor:
-                        if session_limit is None:
-                            cursor.execute(
-                                f"""
-                                SELECT m.message_data
-                                FROM {self.messages_table} m
-                                JOIN message_structure s ON m.id = s.message_id
-                                WHERE m.session_id = ? AND s.branch_id = ?
-                                ORDER BY s.sequence_number ASC
-                            """,
-                                (self.session_id, branch_id),
-                            )
-                        else:
-                            cursor.execute(
-                                f"""
-                                SELECT m.message_data
-                                FROM {self.messages_table} m
-                                JOIN message_structure s ON m.id = s.message_id
-                                WHERE m.session_id = ? AND s.branch_id = ?
-                                ORDER BY s.sequence_number DESC
-                                LIMIT ?
-                            """,
-                                (self.session_id, branch_id, session_limit),
-                            )
-
-                        rows = cursor.fetchall()
-                        if session_limit is not None:
-                            rows = list(reversed(rows))
-
-                    items = []
-                    for (message_data,) in rows:
-                        try:
-                            item = json.loads(message_data)
-                            items.append(item)
-                        except json.JSONDecodeError:
-                            continue
-                    return items
-
-            return await asyncio.to_thread(_get_all_items_sync)
+        def _decode_rows(rows: list[Any]) -> list[TResponseInputItem]:
+            items: list[TResponseInputItem] = []
+            for (message_data,) in rows:
+                try:
+                    item = json.loads(message_data)
+                    items.append(item)
+                except json.JSONDecodeError:
+                    continue
+            return items
 
         def _get_items_sync():
             """Synchronous helper to get items for a specific branch."""
@@ -266,31 +232,47 @@ class AdvancedSQLiteSession(SQLiteSession):
                         """,
                             (self.session_id, branch_id),
                         )
-                    else:
-                        cursor.execute(
-                            f"""
-                            SELECT m.message_data
-                            FROM {self.messages_table} m
-                            JOIN message_structure s ON m.id = s.message_id
-                            WHERE m.session_id = ? AND s.branch_id = ?
-                            ORDER BY s.sequence_number DESC
-                            LIMIT ?
-                        """,
-                            (self.session_id, branch_id, session_limit),
-                        )
+                        return _decode_rows(cursor.fetchall())
 
-                    rows = cursor.fetchall()
-                    if session_limit is not None:
-                        rows = list(reversed(rows))
+                    if session_limit > 0:
+                        # Expand the fetch window when corrupt rows sit among the newest
+                        # entries so limit counts valid conversation items, matching
+                        # SQLiteSession.get_items and the inherited pop_item.
+                        window = session_limit
+                        while True:
+                            cursor.execute(
+                                f"""
+                                SELECT m.message_data
+                                FROM {self.messages_table} m
+                                JOIN message_structure s ON m.id = s.message_id
+                                WHERE m.session_id = ? AND s.branch_id = ?
+                                ORDER BY s.sequence_number DESC
+                                LIMIT ?
+                            """,
+                                (self.session_id, branch_id, window),
+                            )
+                            rows = cursor.fetchall()
+                            items = _decode_rows(list(reversed(rows)))
+                            if len(items) >= session_limit:
+                                return items[-session_limit:]
+                            if len(rows) < window:
+                                return items
+                            window *= 2
 
-                items = []
-                for (message_data,) in rows:
-                    try:
-                        item = json.loads(message_data)
-                        items.append(item)
-                    except json.JSONDecodeError:
-                        continue
-                return items
+                    # Preserve historical non-positive LIMIT semantics (including SQLite's
+                    # unlimited behavior for negative values).
+                    cursor.execute(
+                        f"""
+                        SELECT m.message_data
+                        FROM {self.messages_table} m
+                        JOIN message_structure s ON m.id = s.message_id
+                        WHERE m.session_id = ? AND s.branch_id = ?
+                        ORDER BY s.sequence_number DESC
+                        LIMIT ?
+                    """,
+                        (self.session_id, branch_id, session_limit),
+                    )
+                    return _decode_rows(list(reversed(cursor.fetchall())))
 
         return await asyncio.to_thread(_get_items_sync)
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -1782,6 +1782,59 @@ async def test_get_items_explicit_limit_overrides_session_settings():
     session.close()
 
 
+async def test_get_items_limit_skips_corrupt_newest_rows():
+    """limit counts valid items, expanding past corrupt newest rows."""
+    session = AdvancedSQLiteSession(session_id="limit_corrupt_test", create_tables=True)
+
+    await session.add_items(
+        [
+            {"role": "user", "content": "valid 0"},
+            {"role": "assistant", "content": "valid 1"},
+            {"role": "user", "content": "valid 2"},
+        ]
+    )
+
+    # Append a corrupt newest row, with the branch structure the JOIN needs.
+    conn = session._get_connection()
+    cursor = conn.execute(
+        f"INSERT INTO {session.messages_table} (session_id, message_data) VALUES (?, ?)",
+        (session.session_id, "not valid json {{{"),
+    )
+    next_sequence = conn.execute(
+        "SELECT COALESCE(MAX(sequence_number), 0) + 1 FROM message_structure "
+        "WHERE session_id = ? AND branch_id = ?",
+        (session.session_id, "main"),
+    ).fetchone()[0]
+    conn.execute(
+        "INSERT INTO message_structure "
+        "(session_id, message_id, branch_id, sequence_number, message_type, "
+        "user_turn_number, branch_turn_number) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (session.session_id, cursor.lastrowid, "main", next_sequence, "user", 1, 1),
+    )
+    conn.commit()
+
+    limited = await session.get_items(limit=2)
+    assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+
+    # The explicit-branch call resolves to the same rows.
+    limited_explicit = await session.get_items(limit=2, branch_id="main")
+    assert [item.get("content") for item in limited_explicit] == ["valid 1", "valid 2"]
+
+    session.close()
+
+
+async def test_get_items_limit_returns_fewer_when_history_exhausted():
+    """Window expansion stops at the end of history instead of looping."""
+    session = AdvancedSQLiteSession(session_id="limit_exhausted_test", create_tables=True)
+
+    await session.add_items([{"role": "user", "content": "only valid"}])
+
+    retrieved = await session.get_items(limit=5)
+    assert [item.get("content") for item in retrieved] == ["only valid"]
+
+    session.close()
+
+
 async def test_session_settings_resolve():
     """Test SessionSettings.resolve() method."""
     from agents.memory import SessionSettings


### PR DESCRIPTION
### Summary

`AdvancedSQLiteSession.get_items(limit=N)` applies `LIMIT N` in SQL and then drops rows whose
`message_data` fails to decode, so a caller asking for N items gets fewer than N whenever corrupt
rows sit among the newest entries — even though older valid history is still there to return.

#4001 fixed this in `SQLiteSession` and `AsyncSQLiteSession`, establishing that a positive limit
counts valid conversation items rather than raw rows. `AdvancedSQLiteSession` overrides
`get_items`, so it never received that fix. It also inherits `pop_item` from `SQLiteSession`,
which skips corrupt rows and keeps looking — so a single class currently treats a corrupt row as
"keep looking" on one read path and "counts against your limit" on the other.

Reproduction (no API key, no network):

```python
session = AdvancedSQLiteSession(session_id="s", create_tables=True)
await session.add_items([
    {"role": "user", "content": "valid 0"},
    {"role": "assistant", "content": "valid 1"},
    {"role": "user", "content": "valid 2"},
])
# a corrupt newest row lands in agent_messages (+ its message_structure entry)

await session.get_items(limit=2)
# before: ["valid 2"]
# after:  ["valid 1", "valid 2"]
```

Fix: for positive limits, expand the fetch window until enough valid items decode or the branch's
history is exhausted, then return the latest N in chronological order — the same window-expansion
`SQLiteSession` and `EncryptedSession` use.

**Scope.** `get_items` held two inner helpers: `_get_all_items_sync`, taken when `branch_id is
None`, and `_get_items_sync`. Once the `branch_id is None` case resolves the default branch into
`branch_id`, the two were identical — same SQL, same ordering, same decode loop. Keeping both
would mean writing the window loop twice in one file, so the default-branch copy is removed and
both call shapes now run a single implementation. That removal is not a behaviour change, and the
test exercises both `get_items(limit=2)` and `get_items(limit=2, branch_id="main")` to hold it.

Deliberately unchanged: non-positive limits keep their existing pass-through semantics (including
SQLite's unlimited behaviour for negative values), matching `SQLiteSession`; the unlimited path
still fetches ascending in one query; `pop_item` and the branching/usage APIs are untouched. The
remaining backends that share this defect (`RedisSession`, `DaprSession`) are left for separate
PRs rather than widened into this one.

### Test plan

Two tests added to `tests/extensions/memory/test_advanced_sqlite_session.py`:

- `test_get_items_limit_skips_corrupt_newest_rows` — inserts three valid items plus a corrupt
  newest row with its `message_structure` entry, asserts `get_items(limit=2)` returns
  `["valid 1", "valid 2"]` on both the default-branch and explicit-`branch_id` paths. **Fails on
  `main`** with `assert ['valid 2'] == ['valid 1', 'valid 2']`.
- `test_get_items_limit_returns_fewer_when_history_exhausted` — a single valid item with
  `limit=5` returns that one item, covering the new loop's termination when history runs out.

`.agents/skills/code-change-verification/scripts/run.sh` reports **all commands passed**
(`make format`, `make lint`, `make typecheck`, `make tests`). Full suite: 5865 passed, 8 skipped,
plus 28 passed serial — 5863 on `main` and the 2 tests added here. File suite: 67 passed.

### Issue number

None — found by reading the session backends side by side after #4001.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
