### PR TITLE
fix(memory): count valid SQLAlchemy and MongoDB session items for positive limits

### DIFF
--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -277,25 +277,34 @@ class MongoDBSession(SessionABC):
 
         query = {"session_id": self.session_id}
 
+        async def _decode_docs(docs: list[Any]) -> list[TResponseInputItem]:
+            items: list[TResponseInputItem] = []
+            for doc in docs:
+                try:
+                    items.append(await self._deserialize_item(doc["message_data"]))
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    # Skip corrupted or malformed documents (including non-string BSON values).
+                    continue
+            return items
+
         if session_limit is None:
             cursor = self._messages.find(query).sort("seq", 1)
-            docs = await cursor.to_list()
-        else:
-            # Fetch the latest N documents in reverse order, then reverse the
-            # list to restore chronological order.
-            cursor = self._messages.find(query).sort("seq", -1).limit(session_limit)
-            docs = await cursor.to_list()
-            docs.reverse()
+            return await _decode_docs(await cursor.to_list())
 
-        items: list[TResponseInputItem] = []
-        for doc in docs:
-            try:
-                items.append(await self._deserialize_item(doc["message_data"]))
-            except (json.JSONDecodeError, KeyError, TypeError):
-                # Skip corrupted or malformed documents (including non-string BSON values).
-                continue
-
-        return items
+        # Fetch the latest N documents in reverse order, then reverse the
+        # list to restore chronological order. Expand the fetch window when corrupt
+        # documents sit among the newest entries so limit counts valid conversation
+        # items, matching pop_item and the SQLite backends.
+        window = session_limit
+        while True:
+            cursor = self._messages.find(query).sort("seq", -1).limit(window)
+            docs = await cursor.to_list()
+            items = await _decode_docs(docs[::-1])
+            if len(items) >= session_limit:
+                return items[-session_limit:]
+            if len(docs) < window:
+                return items
+            window *= 2
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
         """Add new items to the conversation history.

--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
     Index,
     Integer,
     MetaData,
+    Select,
     String,
     Table,
     Text,
@@ -300,6 +301,29 @@ class SQLAlchemySession(SessionABC):
 
         session_limit = resolve_session_limit(limit, self.session_settings)
 
+        async def _decode_rows(rows: list[str]) -> list[TResponseInputItem]:
+            items: list[TResponseInputItem] = []
+            for raw in rows:
+                try:
+                    items.append(await self._deserialize_item(raw))
+                except json.JSONDecodeError:
+                    # Skip corrupted rows
+                    continue
+            return items
+
+        def _latest_first_stmt(row_limit: int) -> Select[tuple[str]]:
+            # Use DESC + LIMIT to get the latest N
+            # then reverse later for chronological order.
+            return (
+                select(self._messages.c.message_data)
+                .where(self._messages.c.session_id == self.session_id)
+                .order_by(
+                    self._messages.c.created_at.desc(),
+                    self._messages.c.id.desc(),
+                )
+                .limit(row_limit)
+            )
+
         async with self._session_factory() as sess:
             if session_limit is None:
                 stmt = (
@@ -310,33 +334,27 @@ class SQLAlchemySession(SessionABC):
                         self._messages.c.id.asc(),
                     )
                 )
-            else:
-                stmt = (
-                    select(self._messages.c.message_data)
-                    .where(self._messages.c.session_id == self.session_id)
-                    # Use DESC + LIMIT to get the latest N
-                    # then reverse later for chronological order.
-                    .order_by(
-                        self._messages.c.created_at.desc(),
-                        self._messages.c.id.desc(),
-                    )
-                    .limit(session_limit)
-                )
+                result = await sess.execute(stmt)
+                return await _decode_rows([row[0] for row in result.all()])
 
-            result = await sess.execute(stmt)
-            rows: list[str] = [row[0] for row in result.all()]
+            if session_limit > 0:
+                # Expand the fetch window when corrupt rows sit among the newest entries so
+                # limit counts valid conversation items, matching pop_item and the SQLite
+                # backends.
+                window = session_limit
+                while True:
+                    result = await sess.execute(_latest_first_stmt(window))
+                    rows: list[str] = [row[0] for row in result.all()]
+                    items = await _decode_rows(rows[::-1])
+                    if len(items) >= session_limit:
+                        return items[-session_limit:]
+                    if len(rows) < window:
+                        return items
+                    window *= 2
 
-            if session_limit is not None:
-                rows.reverse()
-
-            items: list[TResponseInputItem] = []
-            for raw in rows:
-                try:
-                    items.append(await self._deserialize_item(raw))
-                except json.JSONDecodeError:
-                    # Skip corrupted rows
-                    continue
-            return items
+            # Preserve existing non-positive LIMIT semantics, which are dialect-defined.
+            result = await sess.execute(_latest_first_stmt(session_limit))
+            return await _decode_rows([row[0] for row in result.all()][::-1])
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
         """Add new items to the conversation history.

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -541,6 +541,39 @@ async def test_non_string_message_data_is_skipped(session: MongoDBSession) -> No
     assert items[0].get("content") == "valid"
 
 
+async def test_get_items_limit_skips_corrupt_newest_docs(session: MongoDBSession) -> None:
+    """limit counts valid items, expanding past corrupt newest documents."""
+    await session.add_items(
+        [
+            {"role": "user", "content": "valid 0"},
+            {"role": "assistant", "content": "valid 1"},
+            {"role": "user", "content": "valid 2"},
+        ]
+    )
+
+    # Inject a corrupt document with a higher seq so it sorts as "most recent".
+    bad_doc = {
+        "_id": FakeObjectId(),
+        "session_id": session.session_id,
+        "seq": 999,
+        "message_data": "not valid json {{{",
+    }
+    session._messages._docs[id(bad_doc["_id"])] = bad_doc
+
+    limited = await session.get_items(limit=2)
+    assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+
+
+async def test_get_items_limit_returns_fewer_when_history_exhausted(
+    session: MongoDBSession,
+) -> None:
+    """Window expansion stops at the end of history instead of looping."""
+    await session.add_items([{"role": "user", "content": "only valid"}])
+
+    retrieved = await session.get_items(limit=5)
+    assert [item.get("content") for item in retrieved] == ["only valid"]
+
+
 async def test_pop_item_skips_corrupt_most_recent(session: MongoDBSession) -> None:
     """pop_item must skip a corrupt most-recent document and return the next valid one."""
     await session.add_items([{"role": "user", "content": "valid"}])

--- a/tests/extensions/memory/test_sqlalchemy_session.py
+++ b/tests/extensions/memory/test_sqlalchemy_session.py
@@ -256,6 +256,41 @@ async def test_pop_item_skips_corrupt_most_recent():
     assert await session.get_items() == []
 
 
+async def test_get_items_limit_skips_corrupt_newest_rows():
+    """limit counts valid items, expanding past corrupt newest rows."""
+    session = SQLAlchemySession.from_url("limit_corrupt", url=DB_URL, create_tables=True)
+
+    await session.add_items(
+        [
+            {"role": "user", "content": "valid 0"},
+            {"role": "assistant", "content": "valid 1"},
+            {"role": "user", "content": "valid 2"},
+        ]
+    )
+
+    await session._ensure_tables()
+    async with session._session_factory() as sess:
+        async with sess.begin():
+            await sess.execute(
+                insert(session._messages).values(
+                    {"session_id": session.session_id, "message_data": "not valid json {{{"}
+                )
+            )
+
+    limited = await session.get_items(limit=2)
+    assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+
+
+async def test_get_items_limit_returns_fewer_when_history_exhausted():
+    """Window expansion stops at the end of history instead of looping."""
+    session = SQLAlchemySession.from_url("limit_exhausted", url=DB_URL, create_tables=True)
+
+    await session.add_items([{"role": "user", "content": "only valid"}])
+
+    retrieved = await session.get_items(limit=5)
+    assert [item.get("content") for item in retrieved] == ["only valid"]
+
+
 async def test_pop_item_returns_none_after_dropping_only_corrupt_rows():
     """pop_item removes corrupt rows and returns None when no valid items remain."""
     session = SQLAlchemySession.from_url("pop_only_corrupt", url=DB_URL, create_tables=True)


### PR DESCRIPTION
### Summary

`SQLAlchemySession.get_items(limit=N)` and `MongoDBSession.get_items(limit=N)` apply the limit at
the query layer (`.limit(N)`) and then drop rows/documents that fail to decode, so a caller asking
for N items gets fewer than N whenever corrupt records sit among the newest entries — even though
older valid history is still there to return.

#4001 fixed this in `SQLiteSession` and `AsyncSQLiteSession`, establishing that a positive limit
counts valid conversation items rather than raw rows. Both backends here already agree with that
contract in `pop_item`, which loops past corrupt records and keeps looking. `MongoDBSession`'s
`pop_item` docstring even states the invariant:

> This matches :meth:`get_items`, which also skips corrupt documents, so a single bad row cannot
> make a non-empty session look empty to callers.

The limited path is where that stops being true.

Reproduction (in-memory SQLite / the repo's fake pymongo, no network):

```python
await session.add_items([
    {"role": "user", "content": "valid 0"},
    {"role": "assistant", "content": "valid 1"},
    {"role": "user", "content": "valid 2"},
])
# a corrupt newest record is inserted directly

await session.get_items(limit=2)
# before: ["valid 2"]
# after:  ["valid 1", "valid 2"]
```

Fix: for positive limits, expand the fetch window until enough valid items decode or history is
exhausted, then return the latest N in chronological order — the same window-expansion the SQLite
backends and `EncryptedSession` use. In `sqlalchemy_session.py` the latest-first query is factored
into `_latest_first_stmt(row_limit)` so the window loop and the non-positive path build the same
statement rather than repeating the `select`.

Deliberately unchanged: `SQLAlchemySession` keeps its existing dialect-defined semantics for
non-positive limits, and `MongoDBSession` keeps its `session_limit <= 0 → []` early return — this
PR does not reconcile that difference, which is a separate behaviour question. The unlimited path
still fetches ascending in one query in both. `pop_item`, serialization hooks and schema are
untouched. `RedisSession`, `DaprSession` and `AdvancedSQLiteSession` share this defect and are
left for separate PRs rather than widened into this one.

### Test plan

Four tests added, two per backend, following each file's existing corrupt-record pattern:

- `tests/extensions/memory/test_sqlalchemy_session.py::test_get_items_limit_skips_corrupt_newest_rows`
- `tests/extensions/memory/test_mongodb_session.py::test_get_items_limit_skips_corrupt_newest_docs`

  Each inserts three valid items plus a corrupt newest record and asserts `get_items(limit=2)`
  returns `["valid 1", "valid 2"]`. **Both fail on `main`** with
  `assert ['valid 2'] == ['valid 1', 'valid 2']`.

- `test_get_items_limit_returns_fewer_when_history_exhausted` in both files — a single valid item
  with `limit=5` returns that one item, covering the new loop's termination when history runs out.

`.agents/skills/code-change-verification/scripts/run.sh` reports **all commands passed**
(`make format`, `make lint`, `make typecheck`, `make tests`). Full suite: 5867 passed, 8 skipped,
plus 28 passed serial — 5863 on `main` and the 4 tests added here. Both file suites: 71 passed.

### Issue number

None — found by reading the session backends side by side after #4001.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
