### PR TITLE
fix(memory): count valid Redis and Dapr session items for positive limits

### DIFF
--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -284,7 +284,23 @@ class DaprSession(SessionABC):
             if session_limit is not None:
                 if session_limit <= 0:
                     return []
-                messages = messages[-session_limit:]
+                # Walk back from the newest entry so limit counts valid conversation items:
+                # a corrupt entry is skipped instead of spending the caller's budget, matching
+                # pop_item and the other session backends.
+                latest_first: list[TResponseInputItem] = []
+                for msg in reversed(messages):
+                    try:
+                        if isinstance(msg, str):
+                            item = await self._deserialize_item(msg)
+                        else:
+                            item = msg
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    latest_first.append(item)
+                    if len(latest_first) == session_limit:
+                        break
+                latest_first.reverse()
+                return latest_first
             items: list[TResponseInputItem] = []
             for msg in messages:
                 try:

--- a/src/agents/extensions/memory/redis_session.py
+++ b/src/agents/extensions/memory/redis_session.py
@@ -165,17 +165,7 @@ class RedisSession(SessionABC):
         """
         session_limit = resolve_session_limit(limit, self.session_settings)
 
-        async with self._lock:
-            if session_limit is None:
-                # Get all messages in chronological order
-                raw_messages = await self._redis.lrange(self._messages_key, 0, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
-            else:
-                if session_limit <= 0:
-                    return []
-                # Get the latest N messages (Redis list is ordered chronologically)
-                # Use negative indices to get from the end - Redis uses -N to -1 for last N items
-                raw_messages = await self._redis.lrange(self._messages_key, -session_limit, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
-
+        async def _decode_messages(raw_messages: list[Any]) -> list[TResponseInputItem]:
             items: list[TResponseInputItem] = []
             for raw_msg in raw_messages:
                 try:
@@ -189,8 +179,30 @@ class RedisSession(SessionABC):
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     # Skip corrupted messages
                     continue
-
             return items
+
+        async with self._lock:
+            if session_limit is None:
+                # Get all messages in chronological order
+                raw_messages = await self._redis.lrange(self._messages_key, 0, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
+                return await _decode_messages(raw_messages)
+
+            if session_limit <= 0:
+                return []
+
+            # Get the latest N messages (Redis list is ordered chronologically)
+            # Use negative indices to get from the end - Redis uses -N to -1 for last N items.
+            # Expand the fetch window when corrupt messages sit among the newest entries so
+            # limit counts valid conversation items, matching pop_item and the other backends.
+            window = session_limit
+            while True:
+                raw_messages = await self._redis.lrange(self._messages_key, -window, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
+                items = await _decode_messages(raw_messages)
+                if len(items) >= session_limit:
+                    return items[-session_limit:]
+                if len(raw_messages) < window:
+                    return items
+                window *= 2
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
         """Add new items to the conversation history.

--- a/tests/extensions/memory/test_dapr_session.py
+++ b/tests/extensions/memory/test_dapr_session.py
@@ -396,6 +396,42 @@ async def test_pop_from_empty_session(fake_dapr_client: FakeDaprClient):
         await session.close()
 
 
+async def test_get_items_limit_skips_corrupt_newest_entries(fake_dapr_client: FakeDaprClient):
+    """limit counts valid items, expanding past corrupt newest entries."""
+    session = await _create_test_session(fake_dapr_client, "limit_corrupt")
+
+    try:
+        serialized = [
+            await session._serialize_item({"role": "user", "content": "valid 0"}),
+            await session._serialize_item({"role": "assistant", "content": "valid 1"}),
+            await session._serialize_item({"role": "user", "content": "valid 2"}),
+            "not valid json {{{",
+        ]
+        fake_dapr_client._state[session._messages_key] = json.dumps(
+            serialized, separators=(",", ":")
+        ).encode("utf-8")
+
+        limited = await session.get_items(limit=2)
+        assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+    finally:
+        await session.close()
+
+
+async def test_get_items_limit_returns_fewer_when_history_exhausted(
+    fake_dapr_client: FakeDaprClient,
+):
+    """A limit larger than the stored history returns what exists."""
+    session = await _create_test_session(fake_dapr_client, "limit_exhausted")
+
+    try:
+        await session.add_items([{"role": "user", "content": "only valid"}])
+
+        retrieved = await session.get_items(limit=5)
+        assert [item.get("content") for item in retrieved] == ["only valid"]
+    finally:
+        await session.close()
+
+
 async def test_pop_item_skips_corrupt_most_recent(fake_dapr_client: FakeDaprClient):
     """pop_item skips corrupt newest entries and returns the next valid item."""
     session = await _create_test_session(fake_dapr_client, "pop_corrupt")

--- a/tests/extensions/memory/test_redis_session.py
+++ b/tests/extensions/memory/test_redis_session.py
@@ -706,6 +706,49 @@ async def test_add_items_preserves_created_at_metadata():
         await session.close()
 
 
+async def test_get_items_limit_skips_corrupt_newest_messages():
+    """limit counts valid items, expanding past corrupt newest messages."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for direct data manipulation")
+
+    session = await _create_test_session("limit_corrupt_test")
+
+    try:
+        await session.clear_session()
+        await session.add_items(
+            [
+                {"role": "user", "content": "valid 0"},
+                {"role": "assistant", "content": "valid 1"},
+                {"role": "user", "content": "valid 2"},
+            ]
+        )
+
+        # Append a corrupt newest message.
+        await _safe_rpush(fake_redis, session._messages_key, "not valid json {{{")
+
+        limited = await session.get_items(limit=2)
+        assert [item.get("content") for item in limited] == ["valid 1", "valid 2"]
+    finally:
+        await session.close()
+
+
+async def test_get_items_limit_returns_fewer_when_history_exhausted():
+    """Window expansion stops at the end of history instead of looping."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for direct data manipulation")
+
+    session = await _create_test_session("limit_exhausted_test")
+
+    try:
+        await session.clear_session()
+        await session.add_items([{"role": "user", "content": "only valid"}])
+
+        retrieved = await session.get_items(limit=5)
+        assert [item.get("content") for item in retrieved] == ["only valid"]
+    finally:
+        await session.close()
+
+
 async def test_corrupted_data_handling():
     """Test that corrupted JSON data is handled gracefully."""
     if not USE_FAKE_REDIS:
@@ -720,7 +763,7 @@ async def test_corrupted_data_handling():
         await session.add_items([{"role": "user", "content": "valid message"}])
 
         # Inject corrupted data directly into Redis
-        messages_key = "test:corruption_test:messages"
+        messages_key = session._messages_key
 
         # Add invalid JSON directly using the typed Redis client
         await _safe_rpush(fake_redis, messages_key, "invalid json data")


### PR DESCRIPTION
### Summary

`RedisSession.get_items(limit=N)` and `DaprSession.get_items(limit=N)` select the newest N records
and *then* drop the ones that fail to decode, so a caller asking for N items gets fewer than N
whenever corrupt records sit among the newest entries — even though older valid history is still
there to return.

This completes the class fixed in #4001 (`SQLiteSession`, `AsyncSQLiteSession`), #4031
(`AdvancedSQLiteSession`) and #4032 (`SQLAlchemySession`, `MongoDBSession`). These are the last two
of the seven session backends. As in every earlier case, each class's own `pop_item` already
skips corrupt records and keeps looking, so the two read paths disagree within a single class.

- `RedisSession` calls `lrange(key, -N, -1)`, so corrupt entries spend the caller's budget.
- `DaprSession` slices `messages[-N:]` from the already-loaded list before decoding.

Reproduction (fakeredis / the repo's fake Dapr client, no network):

```python
await session.add_items([
    {"role": "user", "content": "valid 0"},
    {"role": "assistant", "content": "valid 1"},
    {"role": "user", "content": "valid 2"},
])
# a corrupt newest record is appended directly to the store

await session.get_items(limit=2)
# before: ["valid 2"]
# after:  ["valid 1", "valid 2"]
```

Fix: Redis expands its `lrange` window until enough valid items decode or the list is exhausted,
matching the SQLite and SQLAlchemy backends. Dapr already holds the whole message list in memory,
so it needs no second round trip — it walks back from the newest entry and stops once `limit`
valid items are collected, which is the same rule expressed without a re-fetch.

**One test-only change beyond the fix, called out rather than buried.** The existing
`test_corrupted_data_handling` injects corruption into `"test:corruption_test:messages"`, but the
session reads `test::corruption_test:messages` — `key_prefix="test:"` already carries its colon, so
`_messages_key` has two. The corruption was going to a key nobody reads, and every assertion in
that test passed whether or not corrupt handling worked. It now uses `session._messages_key`.
**I verified this is a vacuous test and not a masked bug**: with the corrected key every one of its
existing assertions still passes unchanged, so `RedisSession`'s corrupt handling was always
correct. My first draft of the new test hardcoded the key the same way and passed against
unpatched code, which is how this surfaced.

Deliberately unchanged: both backends keep their existing `session_limit <= 0 → []` behaviour, the
unlimited path is untouched in both, and `pop_item`, serialization and TTL/state-store handling are
not modified.

### Test plan

Four tests added, two per backend, following each file's existing corrupt-record pattern:

- `tests/extensions/memory/test_redis_session.py::test_get_items_limit_skips_corrupt_newest_messages`
- `tests/extensions/memory/test_dapr_session.py::test_get_items_limit_skips_corrupt_newest_entries`

  Each stores three valid items plus a corrupt newest record and asserts `get_items(limit=2)`
  returns `["valid 1", "valid 2"]`. **Both fail on `main`** with
  `assert ['valid 2'] == ['valid 1', 'valid 2']`.

- `test_get_items_limit_returns_fewer_when_history_exhausted` in both files — a single valid item
  with `limit=5` returns that one item, covering termination when history runs out.

`.agents/skills/code-change-verification/scripts/run.sh` reports **all commands passed**
(`make format`, `make lint`, `make typecheck`, `make tests`). Redis and Dapr file suites: 65 passed,
4 skipped.

### Issue number

None — found by reading the seven session backends side by side after #4001.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
