### PR TITLE
fix(memory): enforce closed state in Redis and Dapr sessions

### DIFF
--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -105,6 +105,7 @@ class DaprSession(SessionABC):
         self._consistency = consistency
         self._lock = asyncio.Lock()
         self._owns_client = False  # Track if we own the Dapr client
+        self._closed = False
 
         # State keys
         self._messages_key = f"{self.session_id}:messages"
@@ -258,6 +259,11 @@ class DaprSession(SessionABC):
     # Session protocol implementation
     # ------------------------------------------------------------------
 
+    def _check_not_closed(self) -> None:
+        """Raise if the session has already been closed."""
+        if self._closed:
+            raise RuntimeError("DaprSession is closed")
+
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
@@ -271,6 +277,7 @@ class DaprSession(SessionABC):
         session_limit = resolve_session_limit(limit, self.session_settings)
 
         async with self._lock:
+            self._check_not_closed()
             # Get messages from state store with consistency level
             response = await self._dapr_client.get_state(
                 store_name=self._state_store_name,
@@ -319,10 +326,12 @@ class DaprSession(SessionABC):
         Args:
             items: List of input items to add to the history
         """
+        self._check_not_closed()
         if not items:
             return
 
         async with self._lock:
+            self._check_not_closed()
             serialized_items: list[str] = [await self._serialize_item(item) for item in items]
             attempt = 0
             while True:
@@ -373,6 +382,7 @@ class DaprSession(SessionABC):
             The most recent item if it exists, None if the session is empty
         """
         async with self._lock:
+            self._check_not_closed()
             while True:
                 attempt = 0
                 while True:
@@ -413,6 +423,7 @@ class DaprSession(SessionABC):
     async def clear_session(self) -> None:
         """Clear all items for this session."""
         async with self._lock:
+            self._check_not_closed()
             # Delete messages and metadata keys
             await self._dapr_client.delete_state(
                 store_name=self._state_store_name,
@@ -430,11 +441,19 @@ class DaprSession(SessionABC):
         """Close the Dapr client connection.
 
         Only closes the connection if this session owns the Dapr client
-        (i.e., created via from_address). If the client was injected externally,
-        the caller is responsible for managing its lifecycle.
+        (i.e., created via from_address). In that case the session becomes
+        terminal and subsequent operations raise RuntimeError. If the client was
+        injected externally, the caller is responsible for managing its lifecycle
+        and this is a no-op.
+
+        Repeated and concurrent calls are safe no-ops.
         """
-        if self._owns_client:
-            await self._dapr_client.close()
+        async with self._lock:
+            if self._closed:
+                return
+            if self._owns_client:
+                self._closed = True
+                await self._dapr_client.close()
 
     async def __aenter__(self) -> DaprSession:
         """Enter async context manager."""
@@ -449,33 +468,39 @@ class DaprSession(SessionABC):
 
         Returns:
             True if Dapr is reachable, False otherwise.
+
+        Raises:
+            RuntimeError: If the session owns its client and has been closed.
         """
-        try:
-            # First attempt a read; some stores may not be initialized yet.
-            await self._dapr_client.get_state(
-                store_name=self._state_store_name,
-                key="__ping__",
-                state_metadata=self._get_read_metadata(),
-            )
-            return True
-        except Exception as initial_error:
-            # If relation/table is missing or store isn't initialized,
-            # attempt a write to initialize it, then read again.
+        async with self._lock:
+            # Checked outside the try block; the except clause below would swallow it.
+            self._check_not_closed()
             try:
-                await self._dapr_client.save_state(
-                    store_name=self._state_store_name,
-                    key="__ping__",
-                    value="ok",
-                    state_metadata=self._get_metadata(),
-                    options=self._get_state_options(),
-                )
-                # Read again after write.
+                # First attempt a read; some stores may not be initialized yet.
                 await self._dapr_client.get_state(
                     store_name=self._state_store_name,
                     key="__ping__",
                     state_metadata=self._get_read_metadata(),
                 )
                 return True
-            except Exception:
-                log_model_and_tool_action_error(logger, "Dapr connection failed", initial_error)
-                return False
+            except Exception as initial_error:
+                # If relation/table is missing or store isn't initialized,
+                # attempt a write to initialize it, then read again.
+                try:
+                    await self._dapr_client.save_state(
+                        store_name=self._state_store_name,
+                        key="__ping__",
+                        value="ok",
+                        state_metadata=self._get_metadata(),
+                        options=self._get_state_options(),
+                    )
+                    # Read again after write.
+                    await self._dapr_client.get_state(
+                        store_name=self._state_store_name,
+                        key="__ping__",
+                        state_metadata=self._get_read_metadata(),
+                    )
+                    return True
+                except Exception:
+                    log_model_and_tool_action_error(logger, "Dapr connection failed", initial_error)
+                    return False

--- a/src/agents/extensions/memory/dapr_session.py
+++ b/src/agents/extensions/memory/dapr_session.py
@@ -106,6 +106,7 @@ class DaprSession(SessionABC):
         self._lock = asyncio.Lock()
         self._owns_client = False  # Track if we own the Dapr client
         self._closed = False
+        self._client_released = False
 
         # State keys
         self._messages_key = f"{self.session_id}:messages"
@@ -446,14 +447,18 @@ class DaprSession(SessionABC):
         injected externally, the caller is responsible for managing its lifecycle
         and this is a no-op.
 
-        Repeated and concurrent calls are safe no-ops.
+        The session is terminal from the first close attempt. If releasing the
+        client fails or is cancelled, operations still raise and a later close()
+        retries the unfinished cleanup. Once the client is released, repeated and
+        concurrent calls are safe no-ops.
         """
         async with self._lock:
-            if self._closed:
+            if not self._owns_client:
                 return
-            if self._owns_client:
-                self._closed = True
+            self._closed = True
+            if not self._client_released:
                 await self._dapr_client.close()
+                self._client_released = True
 
     async def __aenter__(self) -> DaprSession:
         """Enter async context manager."""

--- a/src/agents/extensions/memory/redis_session.py
+++ b/src/agents/extensions/memory/redis_session.py
@@ -85,6 +85,7 @@ class RedisSession(SessionABC):
         self._ttl = ttl
         self._lock = asyncio.Lock()
         self._owns_client = False  # Track if we own the Redis client
+        self._closed = False
 
         # Redis key patterns
         self._session_key = f"{self._key_prefix}:{self.session_id}"
@@ -153,6 +154,11 @@ class RedisSession(SessionABC):
     # Session protocol implementation
     # ------------------------------------------------------------------
 
+    def _check_not_closed(self) -> None:
+        """Raise if the session has already been closed."""
+        if self._closed:
+            raise RuntimeError("RedisSession is closed")
+
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
@@ -182,6 +188,7 @@ class RedisSession(SessionABC):
             return items
 
         async with self._lock:
+            self._check_not_closed()
             if session_limit is None:
                 # Get all messages in chronological order
                 raw_messages = await self._redis.lrange(self._messages_key, 0, -1)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
@@ -210,10 +217,12 @@ class RedisSession(SessionABC):
         Args:
             items: List of input items to add to the history
         """
+        self._check_not_closed()
         if not items:
             return
 
         async with self._lock:
+            self._check_not_closed()
             pipe = self._redis.pipeline()
             now = str(int(time.time()))
 
@@ -248,6 +257,7 @@ class RedisSession(SessionABC):
             The most recent item if it exists, None if the session is empty
         """
         async with self._lock:
+            self._check_not_closed()
             while True:
                 # Use RPOP to atomically remove and return the rightmost (most recent) item
                 raw_msg = await self._redis.rpop(self._messages_key)  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
@@ -269,6 +279,7 @@ class RedisSession(SessionABC):
     async def clear_session(self) -> None:
         """Clear all items for this session."""
         async with self._lock:
+            self._check_not_closed()
             # Delete all keys associated with this session
             await self._redis.delete(
                 self._session_key,
@@ -280,20 +291,34 @@ class RedisSession(SessionABC):
         """Close the Redis connection.
 
         Only closes the connection if this session owns the Redis client
-        (i.e., created via from_url). If the client was injected externally,
-        the caller is responsible for managing its lifecycle.
+        (i.e., created via from_url). In that case the session becomes terminal
+        and subsequent operations raise RuntimeError. If the client was injected
+        externally, the caller is responsible for managing its lifecycle and
+        this is a no-op.
+
+        Repeated and concurrent calls are safe no-ops.
         """
-        if self._owns_client:
-            await self._redis.aclose()
+        async with self._lock:
+            if self._closed:
+                return
+            if self._owns_client:
+                self._closed = True
+                await self._redis.aclose()
 
     async def ping(self) -> bool:
         """Test Redis connectivity.
 
         Returns:
             True if Redis is reachable, False otherwise.
+
+        Raises:
+            RuntimeError: If the session owns its client and has been closed.
         """
-        try:
-            await self._redis.ping()  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
-            return True
-        except Exception:
-            return False
+        async with self._lock:
+            # Checked outside the try block; the except clause below would swallow it.
+            self._check_not_closed()
+            try:
+                await self._redis.ping()  # type: ignore[misc]  # Redis library returns Union[Awaitable[T], T] in async context
+                return True
+            except Exception:
+                return False

--- a/src/agents/extensions/memory/redis_session.py
+++ b/src/agents/extensions/memory/redis_session.py
@@ -86,6 +86,7 @@ class RedisSession(SessionABC):
         self._lock = asyncio.Lock()
         self._owns_client = False  # Track if we own the Redis client
         self._closed = False
+        self._client_released = False
 
         # Redis key patterns
         self._session_key = f"{self._key_prefix}:{self.session_id}"
@@ -296,14 +297,18 @@ class RedisSession(SessionABC):
         externally, the caller is responsible for managing its lifecycle and
         this is a no-op.
 
-        Repeated and concurrent calls are safe no-ops.
+        The session is terminal from the first close attempt. If releasing the
+        client fails or is cancelled, operations still raise and a later close()
+        retries the unfinished cleanup. Once the client is released, repeated and
+        concurrent calls are safe no-ops.
         """
         async with self._lock:
-            if self._closed:
+            if not self._owns_client:
                 return
-            if self._owns_client:
-                self._closed = True
+            self._closed = True
+            if not self._client_released:
                 await self._redis.aclose()
+                self._client_released = True
 
     async def ping(self) -> bool:
         """Test Redis connectivity.

--- a/tests/extensions/memory/test_dapr_session.py
+++ b/tests/extensions/memory/test_dapr_session.py
@@ -1138,6 +1138,91 @@ async def test_dapr_session_close_is_idempotent():
         await session.get_items()
 
 
+async def test_dapr_session_failed_cleanup_is_terminal_and_retried():
+    """A failed cleanup keeps the session terminal, and the next close() retries it."""
+    import unittest.mock
+
+    session = _create_owned_dapr_session("failed_cleanup_test")
+    attempts = 0
+    real_close = session._dapr_client.close
+
+    async def failing_then_succeeding_close(*args: Any, **kwargs: Any) -> Any:
+        nonlocal attempts
+        attempts += 1
+        # Mirror a real client, which tears the channel down before surfacing the error.
+        await real_close(*args, **kwargs)
+        if attempts == 1:
+            raise OSError("channel shutdown error surfaced after teardown")
+
+    with unittest.mock.patch.object(session._dapr_client, "close", failing_then_succeeding_close):
+        with pytest.raises(OSError, match="channel shutdown error surfaced after teardown"):
+            await session.close()
+
+        assert session._closed is True
+        for operation in (
+            session.get_items(),
+            session.add_items([{"role": "user", "content": "after failed cleanup"}]),
+            session.pop_item(),
+            session.clear_session(),
+            session.ping(),
+        ):
+            with pytest.raises(RuntimeError, match="DaprSession is closed"):
+                await operation
+
+        await session.close()
+        assert attempts == 2
+        assert session._client_released is True
+
+        await session.close()
+        assert attempts == 2
+
+
+async def test_dapr_session_cancelled_cleanup_is_terminal_and_retried():
+    """A cancelled cleanup keeps the session terminal, and the next close() retries it."""
+    import asyncio
+    import unittest.mock
+    from contextlib import suppress
+
+    timeout = 5.0
+    session = _create_owned_dapr_session("cancelled_cleanup_test")
+    attempts = 0
+    entered_cleanup = asyncio.Event()
+    real_close = session._dapr_client.close
+
+    async def hanging_then_succeeding_close(*args: Any, **kwargs: Any) -> Any:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            entered_cleanup.set()
+            await asyncio.Event().wait()  # Hang until cancelled.
+        return await real_close(*args, **kwargs)
+
+    close_task: asyncio.Task[None] | None = None
+    try:
+        with unittest.mock.patch.object(
+            session._dapr_client, "close", hanging_then_succeeding_close
+        ):
+            close_task = asyncio.create_task(session.close())
+            await asyncio.wait_for(entered_cleanup.wait(), timeout)
+            close_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await close_task
+            close_task = None
+
+            assert session._closed is True
+            with pytest.raises(RuntimeError, match="DaprSession is closed"):
+                await session.get_items()
+
+            await asyncio.wait_for(session.close(), timeout)
+            assert attempts == 2
+            assert session._client_released is True
+    finally:
+        if close_task is not None:
+            close_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await close_task
+
+
 async def test_dapr_session_ping_raises_after_close():
     """ping() must not read or write through a client this session already closed."""
     session = _create_owned_dapr_session("ping_after_close_test")

--- a/tests/extensions/memory/test_dapr_session.py
+++ b/tests/extensions/memory/test_dapr_session.py
@@ -1072,3 +1072,173 @@ async def test_runner_with_session_settings_override(fake_dapr_client: FakeDaprC
         assert len(history_items) == 2
     finally:
         await session.close()
+
+
+def _create_owned_dapr_session(session_id: str) -> DaprSession:
+    """Create a session that owns its client, mirroring the from_address path."""
+    import unittest.mock
+
+    with unittest.mock.patch(
+        "agents.extensions.memory.dapr_session.DaprClient",
+        return_value=FakeDaprClient(),
+    ):
+        return DaprSession.from_address(session_id, state_store_name="statestore")
+
+
+async def test_dapr_session_closed_operations_raise_runtime_error():
+    """Operations on a closed owned-client session must fail instead of using a closed client."""
+    session = _create_owned_dapr_session("closed_state_test")
+    assert session._owns_client is True
+    await session.add_items([{"role": "user", "content": "before close"}])
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="DaprSession is closed"):
+        await session.get_items()
+
+    with pytest.raises(RuntimeError, match="DaprSession is closed"):
+        await session.add_items([{"role": "user", "content": "after close"}])
+
+    with pytest.raises(RuntimeError, match="DaprSession is closed"):
+        await session.pop_item()
+
+    with pytest.raises(RuntimeError, match="DaprSession is closed"):
+        await session.clear_session()
+
+
+async def test_dapr_session_closed_rejects_empty_add_items():
+    """add_items([]) must not bypass the closed check through the empty-list fast path."""
+    session = _create_owned_dapr_session("closed_empty_add_test")
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="DaprSession is closed"):
+        await session.add_items([])
+
+
+async def test_dapr_session_closed_after_context_manager_exit():
+    """Leaving the async context manager closes an owned session, so later use must fail."""
+    session = _create_owned_dapr_session("closed_context_manager_test")
+
+    async with session:
+        await session.add_items([{"role": "user", "content": "inside context"}])
+
+    with pytest.raises(RuntimeError, match="DaprSession is closed"):
+        await session.get_items()
+
+
+async def test_dapr_session_close_is_idempotent():
+    """Repeated and concurrent close() calls must remain safe no-ops."""
+    import asyncio
+
+    session = _create_owned_dapr_session("close_idempotent_test")
+
+    await asyncio.gather(session.close(), session.close())
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="DaprSession is closed"):
+        await session.get_items()
+
+
+async def test_dapr_session_ping_raises_after_close():
+    """ping() must not read or write through a client this session already closed."""
+    session = _create_owned_dapr_session("ping_after_close_test")
+    assert await session.ping() is True
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="DaprSession is closed"):
+        await session.ping()
+
+
+async def test_dapr_session_close_is_noop_for_injected_client():
+    """With an injected client, close() stays a no-op and the session remains usable."""
+    client = FakeDaprClient()
+    session = DaprSession(
+        session_id="injected_client_noop_test",
+        state_store_name="statestore",
+        dapr_client=client,  # type: ignore[arg-type]
+    )
+    assert session._owns_client is False
+
+    await session.add_items([{"role": "user", "content": "before close"}])
+    await session.close()
+
+    assert client._closed is False
+    await session.add_items([{"role": "user", "content": "after close"}])
+    items = await session.get_items()
+    assert [item.get("content") for item in items] == ["before close", "after close"]
+
+    assert await session.ping() is True
+
+    other = DaprSession(
+        session_id="injected_client_noop_test",
+        state_store_name="statestore",
+        dapr_client=client,  # type: ignore[arg-type]
+    )
+    assert len(await other.get_items()) == 2
+
+
+async def test_dapr_session_operation_waiting_behind_close_raises():
+    """An operation queued behind close() must fail rather than run after shutdown completes."""
+    import asyncio
+    import unittest.mock
+    from contextlib import suppress
+
+    from agents.memory.session_settings import resolve_session_limit
+
+    timeout = 5.0
+    blocked_probe = 0.1
+    fake_client = FakeDaprClient()
+    close_holds_lock = asyncio.Event()  # Set once close() is inside the session lock.
+    release_close = asyncio.Event()  # Test-owned gate that lets the paused close() finish.
+    op_entered = asyncio.Event()  # Set once the operation is past method entry.
+    real_close = fake_client.close
+    real_resolve = resolve_session_limit
+
+    async def paused_close(*args: Any, **kwargs: Any) -> Any:
+        close_holds_lock.set()
+        await asyncio.wait_for(release_close.wait(), timeout)
+        return await real_close(*args, **kwargs)
+
+    def entry_signalling_resolve(*args: Any, **kwargs: Any) -> Any:
+        # This runs immediately before the operation reaches the session lock.
+        op_entered.set()
+        return real_resolve(*args, **kwargs)
+
+    with unittest.mock.patch(
+        "agents.extensions.memory.dapr_session.DaprClient", return_value=fake_client
+    ):
+        session = DaprSession.from_address("close_interleave_test", state_store_name="statestore")
+    assert session._owns_client is True
+
+    close_task: asyncio.Task[None] | None = None
+    op_task: asyncio.Task[list[TResponseInputItem]] | None = None
+    try:
+        with unittest.mock.patch.object(fake_client, "close", paused_close):
+            close_task = asyncio.create_task(session.close())
+            await asyncio.wait_for(close_holds_lock.wait(), timeout)
+
+            # Start the operation while close() still holds the lock so it must queue behind it.
+            with unittest.mock.patch(
+                "agents.extensions.memory.dapr_session.resolve_session_limit",
+                entry_signalling_resolve,
+            ):
+                op_task = asyncio.create_task(session.get_items())
+                await asyncio.wait_for(op_entered.wait(), timeout)
+
+            # The operation is past method entry, so it can only be blocked on the session lock.
+            _, still_blocked = await asyncio.wait({op_task}, timeout=blocked_probe)
+            assert op_task in still_blocked
+
+            release_close.set()
+            await asyncio.wait_for(close_task, timeout)
+            close_task = None
+
+            with pytest.raises(RuntimeError, match="DaprSession is closed"):
+                await asyncio.wait_for(op_task, timeout)
+            op_task = None
+    finally:
+        release_close.set()
+        for task in (close_task, op_task):
+            if task is not None:
+                task.cancel()
+                with suppress(asyncio.CancelledError, RuntimeError):
+                    await task

--- a/tests/extensions/memory/test_redis_session.py
+++ b/tests/extensions/memory/test_redis_session.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -1065,3 +1065,187 @@ async def test_runner_with_session_settings_override():
         assert len(history_items) == 2
     finally:
         await session.close()
+
+
+def _create_owned_redis_session(session_id: str) -> RedisSession:
+    """Create a session that owns its client, mirroring the from_url path."""
+    import unittest.mock
+
+    import fakeredis.aioredis
+
+    with unittest.mock.patch(
+        "agents.extensions.memory.redis_session.redis.from_url",
+        return_value=fakeredis.aioredis.FakeRedis(),
+    ):
+        return RedisSession.from_url(session_id, url="redis://localhost:6379/15")
+
+
+async def test_redis_session_closed_operations_raise_runtime_error():
+    """Operations on a closed owned-client session must fail instead of reconnecting."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for isolated close-state verification")
+
+    session = _create_owned_redis_session("closed_state_test")
+    assert session._owns_client is True
+    await session.add_items([{"role": "user", "content": "before close"}])
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="RedisSession is closed"):
+        await session.get_items()
+
+    with pytest.raises(RuntimeError, match="RedisSession is closed"):
+        await session.add_items([{"role": "user", "content": "after close"}])
+
+    with pytest.raises(RuntimeError, match="RedisSession is closed"):
+        await session.pop_item()
+
+    with pytest.raises(RuntimeError, match="RedisSession is closed"):
+        await session.clear_session()
+
+
+async def test_redis_session_closed_rejects_empty_add_items():
+    """add_items([]) must not bypass the closed check through the empty-list fast path."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for isolated close-state verification")
+
+    session = _create_owned_redis_session("closed_empty_add_test")
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="RedisSession is closed"):
+        await session.add_items([])
+
+
+async def test_redis_session_close_is_idempotent():
+    """Repeated and concurrent close() calls must remain safe no-ops."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for isolated close-state verification")
+
+    import asyncio
+
+    session = _create_owned_redis_session("close_idempotent_test")
+
+    await asyncio.gather(session.close(), session.close())
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="RedisSession is closed"):
+        await session.get_items()
+
+
+async def test_redis_session_ping_raises_after_close():
+    """ping() must not reopen a connection on a client this session already closed."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for isolated close-state verification")
+
+    session = _create_owned_redis_session("ping_after_close_test")
+    assert await session.ping() is True
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="RedisSession is closed"):
+        await session.ping()
+
+
+async def test_redis_session_close_is_noop_for_injected_client():
+    """With an injected client, close() stays a no-op and the session remains usable."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for isolated close-state verification")
+
+    import fakeredis.aioredis
+
+    client = fakeredis.aioredis.FakeRedis()
+    session = RedisSession(
+        session_id="injected_client_noop_test",
+        redis_client=cast("Redis", client),
+        key_prefix="test:",
+    )
+    assert session._owns_client is False
+
+    await session.add_items([{"role": "user", "content": "before close"}])
+    await session.close()
+
+    await session.add_items([{"role": "user", "content": "after close"}])
+    items = await session.get_items()
+    assert [item.get("content") for item in items] == ["before close", "after close"]
+
+    assert await session.ping() is True
+
+    other = RedisSession(
+        session_id="injected_client_noop_test",
+        redis_client=cast("Redis", client),
+        key_prefix="test:",
+    )
+    assert len(await other.get_items()) == 2
+
+    await session.clear_session()
+
+
+async def test_redis_session_operation_waiting_behind_close_raises():
+    """An operation queued behind close() must fail rather than run after shutdown completes."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for controlled close interleaving")
+
+    import asyncio
+    import unittest.mock
+    from contextlib import suppress
+
+    import fakeredis.aioredis
+
+    from agents.memory.session_settings import resolve_session_limit
+
+    timeout = 5.0
+    blocked_probe = 0.1
+    fake_client = fakeredis.aioredis.FakeRedis()
+    close_holds_lock = asyncio.Event()  # Set once close() is inside the session lock.
+    release_close = asyncio.Event()  # Test-owned gate that lets the paused close() finish.
+    op_entered = asyncio.Event()  # Set once the operation is past method entry.
+    real_aclose = fake_client.aclose
+    real_resolve = resolve_session_limit
+
+    async def paused_aclose(*args: Any, **kwargs: Any) -> Any:
+        close_holds_lock.set()
+        await asyncio.wait_for(release_close.wait(), timeout)
+        return await real_aclose(*args, **kwargs)
+
+    def entry_signalling_resolve(*args: Any, **kwargs: Any) -> Any:
+        # This runs immediately before the operation reaches the session lock.
+        op_entered.set()
+        return real_resolve(*args, **kwargs)
+
+    with unittest.mock.patch(
+        "agents.extensions.memory.redis_session.redis.from_url", return_value=fake_client
+    ):
+        session = RedisSession.from_url("close_interleave_test", url="redis://localhost:6379/15")
+    assert session._owns_client is True
+
+    close_task: asyncio.Task[None] | None = None
+    op_task: asyncio.Task[list[TResponseInputItem]] | None = None
+    try:
+        with unittest.mock.patch.object(fake_client, "aclose", paused_aclose):
+            close_task = asyncio.create_task(session.close())
+            await asyncio.wait_for(close_holds_lock.wait(), timeout)
+
+            # Start the operation while close() still holds the lock so it must queue behind it.
+            with unittest.mock.patch(
+                "agents.extensions.memory.redis_session.resolve_session_limit",
+                entry_signalling_resolve,
+            ):
+                op_task = asyncio.create_task(session.get_items())
+                await asyncio.wait_for(op_entered.wait(), timeout)
+
+            # The operation is past method entry, so it can only be blocked on the session lock.
+            _, still_blocked = await asyncio.wait({op_task}, timeout=blocked_probe)
+            assert op_task in still_blocked
+
+            release_close.set()
+            await asyncio.wait_for(close_task, timeout)
+            close_task = None
+
+            with pytest.raises(RuntimeError, match="RedisSession is closed"):
+                await asyncio.wait_for(op_task, timeout)
+            op_task = None
+    finally:
+        release_close.set()
+        for task in (close_task, op_task):
+            if task is not None:
+                task.cancel()
+                with suppress(asyncio.CancelledError, RuntimeError):
+                    await task

--- a/tests/extensions/memory/test_redis_session.py
+++ b/tests/extensions/memory/test_redis_session.py
@@ -1131,6 +1131,95 @@ async def test_redis_session_close_is_idempotent():
         await session.get_items()
 
 
+async def test_redis_session_failed_cleanup_is_terminal_and_retried():
+    """A failed cleanup keeps the session terminal, and the next close() retries it."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for isolated close-state verification")
+
+    import unittest.mock
+
+    session = _create_owned_redis_session("failed_cleanup_test")
+    attempts = 0
+    real_aclose = session._redis.aclose
+
+    async def failing_then_succeeding_aclose(*args: Any, **kwargs: Any) -> Any:
+        nonlocal attempts
+        attempts += 1
+        # Mirror redis-py, which tears the pool down before surfacing the error.
+        await real_aclose(*args, **kwargs)
+        if attempts == 1:
+            raise OSError("disconnect error surfaced after pool teardown")
+
+    with unittest.mock.patch.object(session._redis, "aclose", failing_then_succeeding_aclose):
+        with pytest.raises(OSError, match="disconnect error surfaced after pool teardown"):
+            await session.close()
+
+        assert session._closed is True
+        for operation in (
+            session.get_items(),
+            session.add_items([{"role": "user", "content": "after failed cleanup"}]),
+            session.pop_item(),
+            session.clear_session(),
+            session.ping(),
+        ):
+            with pytest.raises(RuntimeError, match="RedisSession is closed"):
+                await operation
+
+        await session.close()
+        assert attempts == 2
+        assert session._client_released is True
+
+        await session.close()
+        assert attempts == 2
+
+
+async def test_redis_session_cancelled_cleanup_is_terminal_and_retried():
+    """A cancelled cleanup keeps the session terminal, and the next close() retries it."""
+    if not USE_FAKE_REDIS:
+        pytest.skip("This test requires fakeredis for isolated close-state verification")
+
+    import asyncio
+    import unittest.mock
+    from contextlib import suppress
+
+    timeout = 5.0
+    session = _create_owned_redis_session("cancelled_cleanup_test")
+    attempts = 0
+    entered_cleanup = asyncio.Event()
+    real_aclose = session._redis.aclose
+
+    async def hanging_then_succeeding_aclose(*args: Any, **kwargs: Any) -> Any:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            entered_cleanup.set()
+            await asyncio.Event().wait()  # Hang until cancelled.
+        return await real_aclose(*args, **kwargs)
+
+    close_task: asyncio.Task[None] | None = None
+    try:
+        with unittest.mock.patch.object(session._redis, "aclose", hanging_then_succeeding_aclose):
+            close_task = asyncio.create_task(session.close())
+            await asyncio.wait_for(entered_cleanup.wait(), timeout)
+            close_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await close_task
+            close_task = None
+
+            assert session._closed is True
+            with pytest.raises(RuntimeError, match="RedisSession is closed"):
+                await session.get_items()
+
+            await asyncio.wait_for(session.close(), timeout)
+            assert attempts == 2
+            assert session._client_released is True
+    finally:
+        if close_task is not None:
+            close_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await close_task
+
+
 async def test_redis_session_ping_raises_after_close():
     """ping() must not reopen a connection on a client this session already closed."""
     if not USE_FAKE_REDIS:


### PR DESCRIPTION
### Summary

`SQLiteSession` makes `close()` terminal: it sets `_closed` under the session lock, and every operation re-checks that flag inside the same lock.

`RedisSession` and `DaprSession` do not. Both hold an `asyncio.Lock` in every operation, but `close()` never acquires it and records no closed state, so a `from_url()` / `from_address()` session closes its client and keeps using it:

```python
session = RedisSession.from_url("s", url="redis://localhost:6379/0")  # session owns the client
await session.add_items([{"role": "user", "content": "hi"}])
await session.close()

await session.get_items()      # returns history instead of raising
await session.add_items([...]) # silently writes
await session.pop_item()       # silently mutates
```

They succeed silently. `Redis.aclose()` only calls `connection_pool.disconnect()`, leaving the pool usable, so later operations reconnect and leak connections (redis-py 7.0.1). Dapr surfaces opaque gRPC errors. `add_items([])` slips through its empty-list fast path.

**Fix:** mirror `SQLiteSession`. `close()` takes the existing lock, returns early if closed, and marks the session terminal before releasing a client it owns. Every operation re-checks inside its existing `async with self._lock:`; `add_items()` checks before the empty-list return, and `ping()` now takes the lock too, so it cannot reopen a connection on a released client. With an injected client `close()` closes nothing and stays a no-op.

### Test plan

Thirteen tests, six Redis and seven Dapr, covering post-close raises for all four operations and `ping()`, the empty-list path, idempotent close, the injected-client no-op contract, and a controlled interleaving case where an operation queued behind `close()` still raises. Eleven fail on `main`; the two injected-client tests pass by design.

Verified locally:

- `make format-check` : `842 files already formatted` (exit 0)
- `make lint` : `All checks passed!` (exit 0)
- `make typecheck` : mypy `Success: no issues found in 833 source files`; pyright `0 errors, 0 warnings, 0 informations` (exit 0)
- `make tests-parallel` : `5886 passed, 4 skipped` (exit 0)
- `make tests-serial` : `36 passed, 5 skipped` (exit 0)
- `make tests-asyncio-stability` : 5/5 runs passed (exit 0)
- `.agents/skills/code-change-verification/scripts/run.sh` : `all commands passed` (exit 0)

### Issue number

N/A. Found while following the #3984 review.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
