### PR TITLE
fix(trimmer): keep tool parameters named like schema keywords

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -289,6 +289,14 @@ class ToolOutputTrimmer:
         """Remove verbose prose from a JSON schema while preserving its structure."""
         trimmed_schema: dict[str, Any] = {}
         for key, value in schema.items():
+            # Keys of a "properties" mapping are parameter names, not schema keywords, so
+            # they must survive even when they collide with the prose keywords below.
+            if key == "properties" and isinstance(value, dict):
+                trimmed_schema[key] = {
+                    name: self._trim_json_schema(sub) if isinstance(sub, dict) else sub
+                    for name, sub in value.items()
+                }
+                continue
             if key in {"description", "title", "$comment", "examples"}:
                 continue
             if isinstance(value, dict):

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -365,6 +365,64 @@ class TestTrimming:
         assert trimmed_tools[0]["parameters"]["properties"]["customer_id"]["default"] == "cust_123"
         assert len(json.dumps(trimmed_tools, sort_keys=True)) < original_len
 
+    def test_keeps_tool_parameters_named_like_schema_keywords(self) -> None:
+        """Parameter names that collide with trimmed schema keywords must survive."""
+        parameters = {
+            "type": "object",
+            "description": "schema prose " * 200,
+            "properties": {
+                "description": {"type": "string"},
+                "title": {"type": "string"},
+                "$comment": {"type": "string"},
+                "examples": {"type": "string"},
+                "query": {"type": "string"},
+            },
+            "required": ["description", "title", "$comment", "examples", "query"],
+            "additionalProperties": False,
+        }
+        items = [
+            _user("q1"),
+            {"type": "tool_search_call", "call_id": "ts1", "arguments": {"query": "tickets"}},
+            {
+                "type": "tool_search_output",
+                "call_id": "ts1",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "create_ticket",
+                        "description": "tool description " * 200,
+                        "parameters": parameters,
+                    }
+                ],
+            },
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+
+        trimmer = ToolOutputTrimmer(max_output_chars=400, preview_chars=60)
+        result = trimmer(_make_data(items))
+        trimmed_item_dict = cast(dict[str, Any], result.input[2])
+        trimmed_parameters = trimmed_item_dict["tools"][0]["parameters"]
+
+        # Every declared parameter is still present, so `required` stays satisfiable.
+        assert sorted(trimmed_parameters["properties"]) == [
+            "$comment",
+            "description",
+            "examples",
+            "query",
+            "title",
+        ]
+        assert not [
+            name
+            for name in trimmed_parameters["required"]
+            if name not in trimmed_parameters["properties"]
+        ]
+        # Schema-level prose is still trimmed.
+        assert "description" not in trimmed_parameters
+
     def test_trims_legacy_tool_search_output_results(self) -> None:
         """Legacy tool_search_output snapshots with free-text results should still trim."""
         large = "x" * 2000


### PR DESCRIPTION
### Summary

`ToolOutputTrimmer` silently deletes tool parameters whose names collide with JSON Schema prose keywords.

`_trim_json_schema` strips `description`, `title`, `$comment` and `examples` to save tokens, but it recurses into every nested dict and applies that keyword filter uniformly — including to `properties`, whose keys are user-defined **parameter names**, not schema keywords. A tool declaring a parameter named `description` (e.g. `create_ticket(title, description)`) loses that parameter when its `tool_search_output` is replayed from an older turn.

The result is not just lossy, it is an invalid schema: the deleted names remain in `required` while `additionalProperties: false` still closes the object, so the model receives a schema whose required properties are undeclared. There is no error and no log line. Reproduced through the public filter API (`CallModelData`), no network or API key:

```
BEFORE properties: ['description', 'query', 'title']
AFTER  properties: ['query']
AFTER  required  : ['description', 'title', 'query']
required-but-absent params: ['description', 'title']
```

The fix handles `properties` before the keyword check, recursing into its values while keeping its keys verbatim. This only narrows what gets deleted — schema-level prose trimming is unchanged, and no public API, signature or field order is touched.

Haystack fixed the same bug class in its own schema walker (`_remove_title_from_schema` in `haystack/tools/from_function.py`, commented *"Keys of a 'properties' mapping are property names, not schema keywords."*).

**Knowingly out of scope:** `$defs`/`definitions` entries keyed by a lowercase keyword name are still dropped — I verified this happens (`$defs` keys `['Address', 'description']` → `['Address']`), which would also dangle a `$ref` pointing at it. I left it out because that path is much harder to reach in practice — `$defs` keys come from Pydantic class names, which are conventionally capitalised — and folding it in would add a second permutation to the same abstraction beyond the reported defect. It is a one-line follow-up (`if key in {"properties", "$defs", "definitions"}`) if you'd rather have it covered here.

### Test plan

Added one case to `tests/extensions/test_tool_output_trimmer.py`, going through the public trimmer call: parameters named `description`, `title`, `$comment` and `examples` all survive, no `required` name is missing from `properties`, and a genuine schema-level `description` is still stripped (so the trimming feature itself is still exercised).

- `tests/extensions/test_tool_output_trimmer.py`: **39 passed** with the fix; **1 failed, 38 passed** without it (the new test fails on the `properties` assertion).
- `tests/extensions/` (whole directory): **1158 passed, 6 skipped**.
- `ruff check`: all checks passed. `ruff format --check`: 842 files already formatted (no unrelated reformatting).
- `mypy` scoped to the two changed files: `Success: no issues found`.

Verification-script note, per the template: `.agents/skills/code-change-verification/scripts/run.sh` could not run here — `make` is not installed on this machine (both `run.sh` and `run.ps1` abort at the `make` availability check), so I ran the underlying Makefile targets directly via `uv run`. Unrelated pre-existing failures I confirmed also fail on an unmodified `main` (`ddc39d0`): 52 tracing-test failures (`KeyError: ('trace_…', 'span_…')` from `tests/testing_processor.py`), one pre-existing `pyright` error in `src/agents/sandbox/util/tar_utils.py:161`, and mypy errors confined to `sandbox/`, `examples/` and a Windows-only `SIGQUIT` reference.

### Issue number

None — self-reported; found while reading the trimmer.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` — could not: `make` unavailable locally (see Test plan); ran the equivalent Makefile targets directly instead
- [x] I've confirmed all verification steps pass (format, lint, typecheck and the affected tests; remaining failures verified pre-existing on `main`)
- [ ] If using Codex, I've run `/review` before submitting this PR — n/a

*AI assistance was used to draft this change; it was reviewed, reproduced and verified by me.*
