### PR TITLE
fix(sandbox): preserve EnvValue subclasses through manifest serialization

### DIFF
--- a/src/agents/sandbox/manifest.py
+++ b/src/agents/sandbox/manifest.py
@@ -149,7 +149,8 @@ class EnvEntry(BaseModel):
 def _parse_environment_value(payload: object) -> "str | EnvValue | EnvEntry":
     """Route one environment member to the shape it represents.
 
-    `EnvEntry` has no `type` field, so a mapping carrying one came from an `EnvValue`.
+    `EnvEntry` has no `type` field and its `value` is never a bare string, so a mapping
+    with either came from an `EnvValue`.
     """
     if isinstance(payload, str | EnvValue | EnvEntry):
         return payload
@@ -157,7 +158,7 @@ def _parse_environment_value(payload: object) -> "str | EnvValue | EnvEntry":
         raise TypeError(
             f"environment value must be a str, EnvValue, or EnvEntry, got {type(payload).__name__}"
         )
-    if "type" in payload:
+    if "type" in payload or isinstance(payload.get("value"), str):
         return EnvValue.parse(payload)
     return EnvEntry.model_validate(dict(payload))
 

--- a/src/agents/sandbox/manifest.py
+++ b/src/agents/sandbox/manifest.py
@@ -2,9 +2,16 @@ import abc
 import asyncio
 from collections.abc import Iterator, Mapping
 from pathlib import Path, PurePath, PurePosixPath
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal, cast
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializeAsAny,
+    field_serializer,
+    field_validator,
+    model_serializer,
+)
 from typing_extensions import assert_never
 
 from .._config_coercion import coerce_pydantic_config
@@ -41,13 +48,87 @@ DEFAULT_REMOTE_MOUNT_COMMAND_ALLOWLIST = [
 ]
 
 
+EnvValueClass = type["EnvValue"]
+
+
 # TODO (sdcoffey) env val from secret store
 class EnvValue(BaseModel, abc.ABC):
+    type: str = ""
+    _subclass_registry: ClassVar[dict[str, EnvValueClass]] = {}
+
     @abc.abstractmethod
     async def resolve(self) -> str: ...
 
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: object) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+
+        type_field = cls.model_fields.get("type")
+        type_default = type_field.default if type_field is not None else None
+        if not isinstance(type_default, str) or type_default == "":
+            if type_field is not None and (
+                type_field.is_required() or type_field.default_factory is not None
+            ):
+                # `type` is per-instance here, so the registry cannot learn a tag at
+                # class-definition time.
+                raise TypeError(
+                    f"{cls.__name__} must define a non-empty string default for `type`; "
+                    "`type` is the EnvValue discriminator and cannot be used as a general field"
+                )
+            # A subclass with no usable `type` default cannot be identified on the wire; skip
+            # registration instead of raising so existing subclasses keep importing.
+            return
+
+        existing = EnvValue._subclass_registry.get(type_default)
+        if existing is not None and existing is not cls:
+            if existing.__module__ == cls.__module__ and existing.__qualname__ == cls.__qualname__:
+                EnvValue._subclass_registry[type_default] = cls
+                return
+            raise TypeError(
+                f"env value type `{type_default}` is already registered by {existing.__name__}"
+            )
+        EnvValue._subclass_registry[type_default] = cls
+
+    @classmethod
+    def parse(cls, payload: object) -> "EnvValue":
+        """Deserialize a mapping into the subclass registered under its `type` field.
+
+        An existing `EnvValue` instance is returned unchanged.
+        """
+        if isinstance(payload, EnvValue):
+            return payload
+        if not isinstance(payload, Mapping):
+            raise TypeError(
+                f"env value must be an EnvValue or mapping, got {type(payload).__name__}"
+            )
+
+        env_value_type = payload.get("type")
+        if not isinstance(env_value_type, str):
+            raise ValueError("env value mapping must include a string `type` field")
+        if env_value_type == "":
+            raise ValueError(
+                "env value mapping has an empty `type` field; the EnvValue subclass it was "
+                "serialized from must declare a non-empty `type` default to be deserializable"
+            )
+
+        env_value_class = EnvValue._subclass_registry.get(env_value_type)
+        if env_value_class is None:
+            known = ", ".join(sorted(EnvValue._subclass_registry)) or "<none>"
+            raise ValueError(
+                f"Unknown env value type `{env_value_type}`. Registered types: {known}"
+            )
+        return env_value_class.model_validate(dict(payload))
+
+    @model_serializer(mode="wrap")
+    def _serialize_always_include_type(self, handler: Any) -> dict[str, Any]:
+        data = handler(self)
+        if isinstance(data, dict):
+            data["type"] = self.type
+        return cast(dict[str, Any], data)
+
 
 class StrEnvValue(EnvValue):
+    type: Literal["str"] = "str"
     value: str
 
     async def resolve(self) -> str:
@@ -57,11 +138,39 @@ class StrEnvValue(EnvValue):
 class EnvEntry(BaseModel):
     description: str | None = None
     ephemeral: bool = Field(default=False)
-    value: EnvValue
+    value: SerializeAsAny[EnvValue]
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_value(cls, value: object) -> EnvValue:
+        return EnvValue.parse(value)
+
+
+def _parse_environment_value(payload: object) -> "str | EnvValue | EnvEntry":
+    """Route one environment member to the shape it represents.
+
+    `EnvEntry` has no `type` field, so a mapping carrying one came from an `EnvValue`.
+    """
+    if isinstance(payload, str | EnvValue | EnvEntry):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise TypeError(
+            f"environment value must be a str, EnvValue, or EnvEntry, got {type(payload).__name__}"
+        )
+    if "type" in payload:
+        return EnvValue.parse(payload)
+    return EnvEntry.model_validate(dict(payload))
 
 
 class Environment(BaseModel):
-    value: dict[str, str | EnvValue | EnvEntry] = Field(default_factory=dict)
+    value: dict[str, str | SerializeAsAny[EnvValue] | EnvEntry] = Field(default_factory=dict)
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_value(cls, value: object) -> dict[str, "str | EnvValue | EnvEntry"]:
+        if not isinstance(value, Mapping):
+            raise ValueError(f"Environment mapping must be a mapping, got {type(value).__name__}")
+        return {key: _parse_environment_value(entry) for key, entry in value.items()}
 
     def normalized(self) -> dict[str, EnvEntry]:
         result: dict[str, EnvEntry] = {}

--- a/tests/extensions/sandbox/test_vercel.py
+++ b/tests/extensions/sandbox/test_vercel.py
@@ -1072,11 +1072,11 @@ async def test_vercel_s3_manifest_sanitization_preserves_typed_environment(
     )
     assert serialized_environment == {
         "value": {
-            "DIRECT": {"value": "direct-value"},
+            "DIRECT": {"type": "str", "value": "direct-value"},
             "ENTRY": {
                 "description": "typed entry",
                 "ephemeral": True,
-                "value": {"value": "entry-value"},
+                "value": {"type": "str", "value": "entry-value"},
             },
         }
     }

--- a/tests/sandbox/test_compatibility_guards.py
+++ b/tests/sandbox/test_compatibility_guards.py
@@ -40,6 +40,7 @@ from agents.sandbox.entries.mounts.patterns import (
     RcloneMountPattern,
     S3FilesMountPattern,
 )
+from agents.sandbox.manifest import EnvValue, StrEnvValue
 from agents.sandbox.session.sandbox_client import BaseSandboxClientOptions
 from agents.sandbox.session.sandbox_session_state import SandboxSessionState
 from agents.sandbox.snapshot import LocalSnapshot, NoopSnapshot, RemoteSnapshot, SnapshotBase
@@ -891,6 +892,7 @@ def test_core_discriminator_type_strings_are_stable() -> None:
         S3FilesMountPattern: "s3files",
         InContainerMountStrategy: "in_container",
         DockerVolumeMountStrategy: "docker_volume",
+        StrEnvValue: "str",
     }
 
     for cls, expected_type in expected_types.items():
@@ -1001,6 +1003,7 @@ def test_core_discriminator_registries_parse_released_payload_shapes() -> None:
         MountStrategyBase.parse({"type": "docker_volume", "driver": "rclone"}),
         DockerVolumeMountStrategy,
     )
+    assert isinstance(EnvValue.parse({"type": "str", "value": "env-value"}), StrEnvValue)
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_manifest.py
+++ b/tests/sandbox/test_manifest.py
@@ -415,6 +415,9 @@ def test_manifest_rejects_malformed_env_values() -> None:
     with pytest.raises(TypeError, match="env value must be an EnvValue or mapping"):
         Manifest.model_validate({"environment": {"value": {"TOKEN": {"value": 1}}}})
 
+    with pytest.raises(ValueError, match="must include a string `type` field"):
+        Manifest.model_validate({"environment": {"value": {"TOKEN": {"value": "untagged"}}}})
+
     with pytest.raises(ValidationError, match="Environment mapping must be a mapping"):
         Manifest.model_validate({"environment": {"value": None}})
 

--- a/tests/sandbox/test_manifest.py
+++ b/tests/sandbox/test_manifest.py
@@ -1,6 +1,11 @@
+import abc
+import json
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Literal
 
 import pytest
+from pydantic import Field, ValidationError
 
 from agents.sandbox.entries import (
     Dir,
@@ -10,8 +15,32 @@ from agents.sandbox.entries import (
     MountpointMountPattern,
 )
 from agents.sandbox.errors import InvalidManifestPathError
-from agents.sandbox.manifest import Manifest
+from agents.sandbox.manifest import EnvEntry, Environment, EnvValue, Manifest, StrEnvValue
 from agents.sandbox.manifest_render import _truncate_manifest_description
+
+
+class _ReferenceEnvValue(EnvValue):
+    type: Literal["test-reference"] = "test-reference"
+    secret_name: str
+
+    async def resolve(self) -> str:
+        return f"resolved-{self.secret_name}"
+
+
+class _JoinedEnvValue(EnvValue):
+    type: Literal["test-joined"] = "test-joined"
+    parts: list[str]
+
+    async def resolve(self) -> str:
+        return "-".join(self.parts)
+
+
+@pytest.fixture
+def restore_env_value_registry() -> Iterator[None]:
+    registered = dict(EnvValue._subclass_registry)
+    yield
+    EnvValue._subclass_registry.clear()
+    EnvValue._subclass_registry.update(registered)
 
 
 def test_manifest_rejects_nested_child_paths_that_escape_workspace() -> None:
@@ -212,3 +241,291 @@ def test_manifest_description_truncation_preserves_unbounded_description() -> No
     description = "short"
 
     assert _truncate_manifest_description(description, None) == description
+
+
+def test_manifest_roundtrips_custom_env_value_subclass() -> None:
+    manifest = Manifest(
+        environment=Environment(value={"TOKEN": _ReferenceEnvValue(secret_name="token")})
+    )
+
+    payload = manifest.model_dump(mode="json")
+
+    assert payload["environment"] == {
+        "value": {"TOKEN": {"type": "test-reference", "secret_name": "token"}}
+    }
+
+    parsed = Manifest.model_validate(payload)
+    parsed_value = parsed.environment.value["TOKEN"]
+
+    assert isinstance(parsed_value, _ReferenceEnvValue)
+    assert parsed_value.secret_name == "token"
+
+
+def test_manifest_roundtrips_custom_env_value_inside_env_entry() -> None:
+    manifest = Manifest(
+        environment=Environment(
+            value={
+                "TOKEN": EnvEntry(
+                    description="api token",
+                    ephemeral=True,
+                    value=_ReferenceEnvValue(secret_name="token"),
+                )
+            }
+        )
+    )
+
+    payload = manifest.model_dump(mode="json")
+
+    assert payload["environment"] == {
+        "value": {
+            "TOKEN": {
+                "description": "api token",
+                "ephemeral": True,
+                "value": {"type": "test-reference", "secret_name": "token"},
+            }
+        }
+    }
+
+    parsed = Manifest.model_validate(payload)
+    parsed_entry = parsed.environment.value["TOKEN"]
+
+    assert isinstance(parsed_entry, EnvEntry)
+    assert parsed_entry.description == "api token"
+    assert parsed_entry.ephemeral is True
+    assert isinstance(parsed_entry.value, _ReferenceEnvValue)
+    assert parsed_entry.value.secret_name == "token"
+
+
+def test_manifest_roundtrips_distinct_env_value_subclasses_together() -> None:
+    manifest = Manifest(
+        environment=Environment(
+            value={
+                "TOKEN": _ReferenceEnvValue(secret_name="token"),
+                "PATH_PARTS": _JoinedEnvValue(parts=["a", "b"]),
+                "ENTRY": EnvEntry(value=_JoinedEnvValue(parts=["c", "d"])),
+            }
+        )
+    )
+
+    parsed = Manifest.model_validate(manifest.model_dump(mode="json"))
+
+    assert parsed.environment.value == {
+        "TOKEN": _ReferenceEnvValue(secret_name="token"),
+        "PATH_PARTS": _JoinedEnvValue(parts=["a", "b"]),
+        "ENTRY": EnvEntry(value=_JoinedEnvValue(parts=["c", "d"])),
+    }
+
+
+def test_manifest_roundtrips_str_env_values() -> None:
+    manifest = Manifest(
+        environment=Environment(value={"PLAIN": "plain", "TYPED": StrEnvValue(value="typed")})
+    )
+
+    payload = manifest.model_dump(mode="json")
+
+    assert payload["environment"] == {
+        "value": {"PLAIN": "plain", "TYPED": {"type": "str", "value": "typed"}}
+    }
+
+    parsed = Manifest.model_validate(payload)
+
+    assert parsed.environment.value["PLAIN"] == "plain"
+    assert parsed.environment.value["TYPED"] == StrEnvValue(value="typed")
+
+
+@pytest.mark.parametrize(("exclude_unset", "exclude_defaults"), [(True, False), (False, True)])
+def test_manifest_env_value_type_survives_narrowed_dumps(
+    exclude_unset: bool,
+    exclude_defaults: bool,
+) -> None:
+    manifest = Manifest(
+        environment=Environment(
+            value={
+                "TOKEN": _ReferenceEnvValue(secret_name="token"),
+                "ENTRY": EnvEntry(value=StrEnvValue(value="typed")),
+            }
+        )
+    )
+
+    payload = manifest.model_dump(
+        mode="json",
+        exclude_unset=exclude_unset,
+        exclude_defaults=exclude_defaults,
+    )
+    environment = payload["environment"]["value"]
+
+    assert environment["TOKEN"]["type"] == "test-reference"
+    assert environment["ENTRY"]["value"]["type"] == "str"
+
+    parsed = Manifest.model_validate(payload)
+
+    assert parsed.environment.value == manifest.environment.value
+
+
+@pytest.mark.asyncio
+async def test_manifest_env_values_resolve_after_round_trip() -> None:
+    manifest = Manifest(
+        environment=Environment(
+            value={
+                "DIRECT": _ReferenceEnvValue(secret_name="direct"),
+                "ENTRY": EnvEntry(value=_ReferenceEnvValue(secret_name="entry")),
+            }
+        )
+    )
+
+    parsed = Manifest.model_validate(manifest.model_dump(mode="json"))
+
+    assert await parsed.environment.resolve() == {
+        "DIRECT": "resolved-direct",
+        "ENTRY": "resolved-entry",
+    }
+
+
+@pytest.mark.asyncio
+async def test_manifest_env_resolution_does_not_persist_resolved_values() -> None:
+    manifest = Manifest(
+        environment=Environment(value={"TOKEN": _ReferenceEnvValue(secret_name="token")})
+    )
+
+    assert await manifest.environment.resolve() == {"TOKEN": "resolved-token"}
+
+    assert manifest.environment.value == {"TOKEN": _ReferenceEnvValue(secret_name="token")}
+    assert "resolved-token" not in json.dumps(manifest.model_dump(mode="json"))
+
+
+def test_env_entry_has_no_type_field() -> None:
+    # Environment members are routed by the presence of `type`, so an EnvEntry never carries one.
+    assert "type" not in EnvEntry.model_fields
+
+
+def test_manifest_rejects_unknown_env_value_type() -> None:
+    payload = {"environment": {"value": {"TOKEN": {"type": "test-unregistered"}}}}
+
+    with pytest.raises(ValueError, match="Unknown env value type `test-unregistered`"):
+        Manifest.model_validate(payload)
+
+
+def test_manifest_rejects_malformed_env_values() -> None:
+    with pytest.raises(ValueError, match="must include a string `type` field"):
+        Manifest.model_validate({"environment": {"value": {"TOKEN": {"type": 1}}}})
+
+    with pytest.raises(TypeError, match="environment value must be a str, EnvValue, or EnvEntry"):
+        Manifest.model_validate({"environment": {"value": {"TOKEN": 1}}})
+
+    with pytest.raises(TypeError, match="env value must be an EnvValue or mapping"):
+        Manifest.model_validate({"environment": {"value": {"TOKEN": {"value": 1}}}})
+
+    with pytest.raises(ValidationError, match="Environment mapping must be a mapping"):
+        Manifest.model_validate({"environment": {"value": None}})
+
+
+@pytest.mark.asyncio
+async def test_untagged_env_value_subclasses_are_usable_but_not_deserializable(
+    restore_env_value_registry: None,
+) -> None:
+    class _UntaggedEnvValue(EnvValue):
+        async def resolve(self) -> str:
+            return "untagged"
+
+    class _UntaggedChildEnvValue(_UntaggedEnvValue):
+        note: str = "child"
+
+    registered = EnvValue._subclass_registry.values()
+    assert _UntaggedEnvValue not in registered
+    assert _UntaggedChildEnvValue not in registered
+
+    manifest = Manifest(
+        environment=Environment(
+            value={"TOKEN": _UntaggedEnvValue(), "CHILD": _UntaggedChildEnvValue()}
+        )
+    )
+
+    assert await manifest.environment.resolve() == {"TOKEN": "untagged", "CHILD": "untagged"}
+
+    with pytest.raises(ValueError, match="empty `type` field"):
+        Manifest.model_validate(manifest.model_dump(mode="json"))
+
+
+def test_subclassing_a_registered_env_value_without_a_new_type_raises(
+    restore_env_value_registry: None,
+) -> None:
+    with pytest.raises(TypeError, match="already registered by _ReferenceEnvValue"):
+
+        class _ReferenceEnvValueWithVersion(_ReferenceEnvValue):
+            version: str = "v1"
+
+
+def test_env_value_subclasses_cannot_declare_type_as_required_or_computed(
+    restore_env_value_registry: None,
+) -> None:
+    with pytest.raises(TypeError, match="must define a non-empty string default for `type`"):
+
+        class _NoDefaultEnvValue(EnvValue):
+            type: Literal["test-no-default"]
+
+            async def resolve(self) -> str:
+                return "no-default"
+
+    with pytest.raises(TypeError, match="must define a non-empty string default for `type`"):
+
+        class _FactoryDefaultEnvValue(EnvValue):
+            type: str = Field(default_factory=lambda: "test-factory-default")
+
+            async def resolve(self) -> str:
+                return "factory-default"
+
+
+def test_duplicate_env_value_type_registration_raises(
+    restore_env_value_registry: None,
+) -> None:
+    class _DuplicateEnvValueA(EnvValue):
+        type: Literal["test-duplicate"] = "test-duplicate"
+
+        async def resolve(self) -> str:
+            return "a"
+
+    with pytest.raises(TypeError, match="already registered"):
+
+        class _DuplicateEnvValueB(EnvValue):
+            type: Literal["test-duplicate"] = "test-duplicate"
+
+            async def resolve(self) -> str:
+                return "b"
+
+
+def test_re_registering_the_same_env_value_class_is_allowed(
+    restore_env_value_registry: None,
+) -> None:
+    def define() -> type[EnvValue]:
+        class _ReimportedEnvValue(EnvValue):
+            type: Literal["test-reimport"] = "test-reimport"
+
+            async def resolve(self) -> str:
+                return "reimported"
+
+        return _ReimportedEnvValue
+
+    first = define()
+    second = define()
+
+    assert first is not second
+    assert EnvValue._subclass_registry["test-reimport"] is second
+
+
+def test_env_value_parse_restores_subclass_of_abstract_intermediate_base(
+    restore_env_value_registry: None,
+) -> None:
+    class _AbstractLookupEnvValue(EnvValue, abc.ABC):
+        @abc.abstractmethod
+        async def lookup(self) -> str: ...
+
+        async def resolve(self) -> str:
+            return await self.lookup()
+
+    class _ConcreteLookupEnvValue(_AbstractLookupEnvValue):
+        type: Literal["test-concrete"] = "test-concrete"
+
+        async def lookup(self) -> str:
+            return "looked-up"
+
+    assert EnvValue.parse({"type": "test-concrete"}) == _ConcreteLookupEnvValue()

--- a/tests/sandbox/test_session_state_roundtrip.py
+++ b/tests/sandbox/test_session_state_roundtrip.py
@@ -17,6 +17,7 @@ import pytest
 from pydantic import ConfigDict, ValidationError, field_serializer, field_validator
 
 from agents.sandbox import Manifest, SandboxPathGrant
+from agents.sandbox.manifest import EnvEntry, Environment, EnvValue
 from agents.sandbox.session import (
     BaseSandboxClient,
     Dependencies,
@@ -78,6 +79,15 @@ class _RoundTripClient(BaseSandboxClient[None]):
 
     def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
         return self._deserialize_session_state_payload(payload, _SimpleSessionState)
+
+
+class _SecretRefEnvValue(EnvValue):
+    __test__ = False
+    type: Literal["secret-ref-roundtrip"] = "secret-ref-roundtrip"
+    secret_name: str
+
+    async def resolve(self) -> str:
+        return f"resolved-{self.secret_name}"
 
 
 class _NonCopyable:
@@ -175,6 +185,35 @@ class TestSandboxSessionStateRoundTrip:
 
         assert "type" in dumped
         assert dumped["type"] == "stub-roundtrip"
+
+    @pytest.mark.asyncio
+    async def test_parse_restores_manifest_env_value_subclasses(self) -> None:
+        """Custom EnvValue subclasses must survive the persisted session state round trip."""
+        original = _StubSessionState(
+            session_id=uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            snapshot=LocalSnapshot(id="snap-1", base_path=Path("/tmp/snapshots")),
+            manifest=Manifest(
+                environment=Environment(
+                    value={
+                        "DIRECT": _SecretRefEnvValue(secret_name="direct"),
+                        "ENTRY": EnvEntry(value=_SecretRefEnvValue(secret_name="entry")),
+                    }
+                )
+            ),
+            custom_field="my-value",
+        )
+
+        restored = SandboxSessionState.parse(original.model_dump(mode="json"))
+        restored_environment = restored.manifest.environment.value
+
+        assert type(restored_environment["DIRECT"]) is _SecretRefEnvValue
+        restored_entry = restored_environment["ENTRY"]
+        assert isinstance(restored_entry, EnvEntry)
+        assert type(restored_entry.value) is _SecretRefEnvValue
+        assert await restored.manifest.environment.resolve() == {
+            "DIRECT": "resolved-direct",
+            "ENTRY": "resolved-entry",
+        }
 
     def test_model_dump_preserves_snapshot_subclass_fields(self) -> None:
         """model_dump() must preserve snapshot subclass fields (e.g. LocalSnapshot.base_path).


### PR DESCRIPTION
This PR attempts to fix an issue where plaintext secrets were leaking into the serialized manifest.

`EnvEntry.value` and the `EnvValue` member of `Environment.value` are typed as the abstract base, so plain `model_dump` writes any concrete subclass as `{}`, and reading a mapping-shaped env value back raises `TypeError: Can't instantiate abstract class EnvValue`. This PR adds a `type` discriminator with an open subclass registry and `EnvValue.parse` (same pattern as `MountStrategyBase` and `SnapshotBase`), and `SerializeAsAny` at both sites. 

Note: this also makes the Vercel adapter's `serialize_as_any=True` redundant, which is why its fixture changed.

Serialized env values now carry an extra key `type: str = ""`. I think this would have been much cleaner without the `= ""`, but that would have been a breaking change for all users that are currently subclassing it. Adding an empty default, though messier, therefore keeps direct EnvValue subclasses importing and resolving as before. However, subclassing an already-tagged class like `StrEnvValue` would still need its own `type` field added.