### PR TITLE
feat(tool): expose original callable through wrapped

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -393,6 +393,51 @@ class FunctionToolResult:
     """Nested agent run result (for agent-as-tool)."""
 
 
+class _FunctionToolWrappedCallableDescriptor:
+    """Expose decorator callable metadata on instances without affecting class inspection."""
+
+    @overload
+    def __get__(
+        self,
+        instance: None,
+        owner: type[FunctionTool],
+    ) -> _FunctionToolWrappedCallableDescriptor: ...
+
+    @overload
+    def __get__(
+        self,
+        instance: FunctionTool,
+        owner: type[FunctionTool] | None = None,
+    ) -> ToolFunction[...]: ...
+
+    def __get__(
+        self,
+        instance: FunctionTool | None,
+        owner: type[FunctionTool] | None = None,
+    ) -> ToolFunction[...] | _FunctionToolWrappedCallableDescriptor:
+        """Return the callable passed to `function_tool`.
+
+        Calling this callable directly bypasses the function-tool runtime pipeline, including JSON
+        schema validation, context injection, guardrails, timeouts, failure handling, and tracing.
+
+        Raises:
+            AttributeError: If accessed on the class, if the tool was not created by
+                `function_tool`, or if its invoker was replaced.
+        """
+        if instance is None:
+            raise AttributeError("FunctionTool classes have no wrapped Python callable")
+        if not isinstance(instance.on_invoke_tool, _FailureHandlingFunctionToolInvoker):
+            raise AttributeError("FunctionTool has no wrapped Python callable")
+        wrapped_callable = instance.on_invoke_tool._get_wrapped_callable()
+        if wrapped_callable is _MISSING_FUNCTION_TOOL_WRAPPED_CALLABLE:
+            raise AttributeError("FunctionTool has no wrapped Python callable")
+        return cast("ToolFunction[...]", wrapped_callable)
+
+    def __set__(self, instance: FunctionTool, value: object) -> None:
+        """Reject replacement so wrapper metadata cannot diverge from runtime invocation."""
+        raise AttributeError("FunctionTool.__wrapped__ is read-only")
+
+
 @dataclass
 class FunctionTool:
     """A tool that wraps a function. In most cases, you should use  the `function_tool` helpers to
@@ -529,23 +574,7 @@ class FunctionTool:
             tool_qualified_name(self.name, get_explicit_function_tool_namespace(self)) or self.name
         )
 
-    @property
-    def __wrapped__(self) -> ToolFunction[...]:
-        """Return the callable passed to `function_tool`.
-
-        Calling this callable directly bypasses the function-tool runtime pipeline, including JSON
-        schema validation, context injection, guardrails, timeouts, failure handling, and tracing.
-
-        Raises:
-            AttributeError: If this tool was not created by `function_tool`, or its invoker was
-                replaced.
-        """
-        if not isinstance(self.on_invoke_tool, _FailureHandlingFunctionToolInvoker):
-            raise AttributeError("FunctionTool has no wrapped Python callable")
-        wrapped_callable = self.on_invoke_tool._get_wrapped_callable()
-        if wrapped_callable is _MISSING_FUNCTION_TOOL_WRAPPED_CALLABLE:
-            raise AttributeError("FunctionTool has no wrapped Python callable")
-        return cast("ToolFunction[...]", wrapped_callable)
+    __wrapped__ = _FunctionToolWrappedCallableDescriptor()
 
     def __post_init__(self):
         self.allowed_callers = _normalize_tool_allowed_callers(

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -198,6 +198,8 @@ ToolErrorFunction = Callable[[RunContextWrapper[Any], Exception], MaybeAwaitable
 CustomToolExecutor = Callable[[ToolContext[Any], str], MaybeAwaitable[Any]]
 CustomToolApprovalFunction = Callable[[RunContextWrapper[Any], str, str], MaybeAwaitable[bool]]
 _SYNC_FUNCTION_TOOL_MARKER = "__agents_sync_function_tool__"
+_FUNCTION_TOOL_WRAPPED_CALLABLE_MARKER = "__agents_function_tool_wrapped_callable__"
+_MISSING_FUNCTION_TOOL_WRAPPED_CALLABLE = object()
 _UNSET_FAILURE_ERROR_FUNCTION = object()
 
 
@@ -527,6 +529,24 @@ class FunctionTool:
             tool_qualified_name(self.name, get_explicit_function_tool_namespace(self)) or self.name
         )
 
+    @property
+    def __wrapped__(self) -> ToolFunction[...]:
+        """Return the callable passed to `function_tool`.
+
+        Calling this callable directly bypasses the function-tool runtime pipeline, including JSON
+        schema validation, context injection, guardrails, timeouts, failure handling, and tracing.
+
+        Raises:
+            AttributeError: If this tool was not created by `function_tool`, or its invoker was
+                replaced.
+        """
+        if not isinstance(self.on_invoke_tool, _FailureHandlingFunctionToolInvoker):
+            raise AttributeError("FunctionTool has no wrapped Python callable")
+        wrapped_callable = self.on_invoke_tool._get_wrapped_callable()
+        if wrapped_callable is _MISSING_FUNCTION_TOOL_WRAPPED_CALLABLE:
+            raise AttributeError("FunctionTool has no wrapped Python callable")
+        return cast("ToolFunction[...]", wrapped_callable)
+
     def __post_init__(self):
         self.allowed_callers = _normalize_tool_allowed_callers(
             self.allowed_callers,
@@ -571,6 +591,14 @@ class _FailureHandlingFunctionToolInvoker:
         self._invoke_tool_impl = invoke_tool_impl
         self._on_handled_error = on_handled_error
         self._function_tool = function_tool
+
+    def _get_wrapped_callable(self) -> object:
+        """Return wrapped-callable metadata from the invocation implementation, if present."""
+        return getattr(
+            self._invoke_tool_impl,
+            _FUNCTION_TOOL_WRAPPED_CALLABLE_MARKER,
+            _MISSING_FUNCTION_TOOL_WRAPPED_CALLABLE,
+        )
 
     def __agents_bind_function_tool__(
         self, function_tool: FunctionTool
@@ -2507,6 +2535,7 @@ def function_tool(
     """
 
     def _create_function_tool(the_func: ToolFunction[...]) -> FunctionTool:
+        original_callable = the_func
         the_func, callable_description = _normalize_function_tool_callable(
             the_func,
             docstring_style,
@@ -2573,6 +2602,11 @@ def function_tool(
 
             return result
 
+        setattr(
+            _on_invoke_tool_impl,
+            _FUNCTION_TOOL_WRAPPED_CALLABLE_MARKER,
+            original_callable,
+        )
         function_tool = _build_wrapped_function_tool(
             name=schema.name,
             description=schema.description or "",

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -199,6 +199,15 @@ def test_tool_exposes_original_callable_without_mutating_it() -> None:
         cast(Any, wrapped_tool).__wrapped__ = original
 
 
+def test_wrapped_callable_descriptor_is_hidden_on_function_tool_classes() -> None:
+    @dataclasses.dataclass(init=False)
+    class FunctionToolSubclass(FunctionTool):
+        pass
+
+    assert not hasattr(FunctionTool, "__wrapped__")
+    assert not hasattr(FunctionToolSubclass, "__wrapped__")
+
+
 def test_configured_tool_exposes_original_callable() -> None:
     def original(value: int) -> int:
         return value + 1

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import copy
+import dataclasses
 import functools
 import inspect
 import json
@@ -15,7 +17,8 @@ from inline_snapshot import snapshot
 from pydantic import BaseModel
 from typing_extensions import Self
 
-from agents import UserError, function_tool
+from agents import Agent, FunctionTool, UserError, function_tool
+from agents.decorators import tool
 from agents.run_context import RunContextWrapper
 from agents.tool_context import ToolContext
 
@@ -168,6 +171,142 @@ def deferred_lookup(customer_id: str) -> str:
 
 def test_function_tool_defer_loading():
     assert deferred_lookup.defer_loading is True
+
+
+def test_tool_exposes_original_callable_without_mutating_it() -> None:
+    def original(value: int) -> int:
+        """Increment a value."""
+        return value + 1
+
+    original.__dict__["extra_metadata"] = "preserved"
+    original_dict = original.__dict__.copy()
+    original_name = original.__name__
+    original_doc = original.__doc__
+    original_signature = inspect.signature(original)
+
+    wrapped_tool = tool(original)
+
+    assert wrapped_tool.__wrapped__ is original
+    direct_callable = cast(Callable[[int], int], wrapped_tool.__wrapped__)
+    assert direct_callable(1) == 2
+    assert not callable(wrapped_tool)
+    assert original.__dict__ == original_dict
+    assert original.__name__ == original_name
+    assert original.__doc__ == original_doc
+    assert inspect.signature(wrapped_tool.__wrapped__) == original_signature
+
+    with pytest.raises(AttributeError):
+        cast(Any, wrapped_tool).__wrapped__ = original
+
+
+def test_configured_tool_exposes_original_callable() -> None:
+    def original(value: int) -> int:
+        return value + 1
+
+    configured_tool = tool(name_override="increment")
+    wrapped_tool = configured_tool(original)
+
+    assert wrapped_tool.__wrapped__ is original
+    assert wrapped_tool.name == "increment"
+
+
+def test_wrapped_callable_identity_for_supported_function_shapes() -> None:
+    def sync_function(value: int) -> int:
+        return value
+
+    async def async_function(value: int) -> int:
+        return value
+
+    def context_function(ctx: ToolContext[Any], value: int) -> int:
+        return value
+
+    class Handler:
+        def method(self, value: int) -> int:
+            return value
+
+    bound_method = Handler().method
+
+    for original in (sync_function, async_function, context_function, bound_method):
+        assert function_tool(original).__wrapped__ is original
+
+
+@pytest.mark.asyncio
+async def test_callable_instance_identity_survives_tool_clone_paths() -> None:
+    class Counter:
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        async def __call__(self, value: int) -> int:
+            self.calls.append(value)
+            return value
+
+    counter = Counter()
+    wrapped_tool = function_tool(counter)
+    copied_tool = copy.copy(wrapped_tool)
+    deep_copied_tool = copy.deepcopy(wrapped_tool)
+    replaced_tool = dataclasses.replace(wrapped_tool, name="renamed")
+
+    for cloned_tool in (wrapped_tool, copied_tool, deep_copied_tool, replaced_tool):
+        assert cloned_tool.__wrapped__ is counter
+
+    direct_callable = cast(Callable[[int], Any], wrapped_tool.__wrapped__)
+    assert await direct_callable(1) == 1
+    assert await copied_tool.on_invoke_tool(ctx_wrapper(), '{"value": 2}') == 2
+    assert await deep_copied_tool.on_invoke_tool(ctx_wrapper(), '{"value": 3}') == 3
+    assert await replaced_tool.on_invoke_tool(ctx_wrapper(), '{"value": 4}') == 4
+    assert counter.calls == [1, 2, 3, 4]
+
+
+def test_wrapped_callable_follows_standard_unwrap_chain() -> None:
+    def original(value: int) -> int:
+        return value
+
+    @functools.wraps(original)
+    def intermediate(value: int) -> int:
+        return original(value)
+
+    wrapped_tool = function_tool(intermediate)
+
+    assert wrapped_tool.__wrapped__ is intermediate
+    assert inspect.unwrap(wrapped_tool.__wrapped__) is original
+    assert inspect.unwrap(cast(Callable[..., Any], wrapped_tool)) is original
+
+
+def test_non_decorator_function_tools_have_no_wrapped_callable() -> None:
+    async def manual_invoker(ctx: ToolContext[Any], input_json: str) -> str:
+        return input_json
+
+    manual_tool = FunctionTool(
+        name="manual",
+        description="",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=manual_invoker,
+    )
+    agent_tool = Agent(name="Nested").as_tool(
+        tool_name="nested",
+        tool_description="Run the nested agent.",
+    )
+
+    for non_decorator_tool in (manual_tool, agent_tool):
+        assert not hasattr(non_decorator_tool, "__wrapped__")
+        with pytest.raises(AttributeError):
+            _ = non_decorator_tool.__wrapped__
+        assert inspect.unwrap(cast(Callable[..., Any], non_decorator_tool)) is non_decorator_tool
+
+
+def test_replacing_invoker_removes_wrapped_callable() -> None:
+    def original(value: int) -> int:
+        return value
+
+    async def replacement(ctx: ToolContext[Any], input_json: str) -> str:
+        return input_json
+
+    wrapped_tool = function_tool(original)
+    assert wrapped_tool.__wrapped__ is original
+
+    wrapped_tool.on_invoke_tool = replacement
+
+    assert not hasattr(wrapped_tool, "__wrapped__")
 
 
 @function_tool(strict_mode=False)


### PR DESCRIPTION
This pull request resolves #3381 by exposing the exact callable passed to `@tool` or `@function_tool` through the standard, read-only `FunctionTool.__wrapped__` protocol.

It intentionally does not add an `_func`/`.func` dataclass field or make `FunctionTool` callable, superseding the approaches proposed in #2146, #3396, and #4034. Instead, the callable is retained as private metadata on the generated invocation wrapper. This preserves callable identity across copy, deepcopy, and dataclass replacement without changing the public constructor, dataclass shape, serialization, or runtime invocation contract.

`FunctionTool` remains non-callable, avoiding the pytest collection regression previously caused by `__call__` and `functools.update_wrapper`. Manually constructed, agent-as-tool, and replaced-invoker tools continue to expose no wrapped callable.