### PR TITLE
fix(sandbox): preserve tagged EnvValue subclasses

### DIFF
--- a/src/agents/sandbox/manifest.py
+++ b/src/agents/sandbox/manifest.py
@@ -1,10 +1,18 @@
 import abc
 import asyncio
+import inspect
 from collections.abc import Iterator, Mapping
 from pathlib import Path, PurePath, PurePosixPath
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializeAsAny,
+    field_serializer,
+    field_validator,
+)
+from pydantic_core import PydanticSerializationError
 from typing_extensions import assert_never
 
 from .._config_coercion import coerce_pydantic_config
@@ -41,27 +49,144 @@ DEFAULT_REMOTE_MOUNT_COMMAND_ALLOWLIST = [
 ]
 
 
+EnvValueClass = type["EnvValue"]
+
+
 # TODO (sdcoffey) env val from secret store
 class EnvValue(BaseModel, abc.ABC):
+    type: str = ""
+    _subclass_registry: ClassVar[dict[str, EnvValueClass]] = {}
+
     @abc.abstractmethod
     async def resolve(self) -> str: ...
 
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: object) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+
+        annotations = inspect.get_annotations(cls)
+        if "type" not in annotations:
+            return
+
+        type_field = cls.model_fields.get("type")
+        type_default = type_field.default if type_field is not None else None
+        if not isinstance(type_default, str) or type_default == "":
+            return
+
+        existing = EnvValue._subclass_registry.get(type_default)
+        if existing is not None and existing is not cls:
+            raise TypeError(
+                f"env value type `{type_default}` is already registered by {existing.__name__}"
+            )
+        EnvValue._subclass_registry[type_default] = cls
+
+    @classmethod
+    def parse(cls, payload: object) -> "EnvValue":
+        """Deserialize a mapping into the subclass registered under its `type` field.
+
+        An existing `EnvValue` instance is returned unchanged.
+        """
+        if isinstance(payload, EnvValue):
+            return payload
+        if not isinstance(payload, Mapping):
+            raise TypeError(
+                f"env value must be an EnvValue or mapping, got {type(payload).__name__}"
+            )
+
+        value = payload.get("value")
+        if set(payload) == {"value"} and isinstance(value, str):
+            return StrEnvValue(value=value)
+
+        env_value_type = payload.get("type")
+        if not isinstance(env_value_type, str):
+            raise ValueError("env value mapping must include a string `type` field")
+
+        env_value_class = EnvValue._subclass_registry.get(env_value_type)
+        if env_value_class is None:
+            known = ", ".join(sorted(EnvValue._subclass_registry)) or "<none>"
+            raise ValueError(
+                f"Unknown env value type `{env_value_type}`. Registered types: {known}"
+            )
+        return env_value_class.model_validate(dict(payload))
+
 
 class StrEnvValue(EnvValue):
+    type: Literal["str"] = "str"
     value: str
 
     async def resolve(self) -> str:
         return self.value
 
 
+def _serialize_env_value_with_type(value: EnvValue, serialized: object) -> dict[str, Any]:
+    if EnvValue._subclass_registry.get(value.type) is not type(value):
+        raise PydanticSerializationError(
+            f"{type(value).__name__} must explicitly declare its own non-empty `type` "
+            "to be serialized"
+        )
+    if not isinstance(serialized, Mapping):
+        raise PydanticSerializationError(
+            f"{type(value).__name__} serializer must return a mapping to preserve its `type`"
+        )
+
+    data = dict(serialized)
+    data["type"] = value.type
+    return data
+
+
 class EnvEntry(BaseModel):
     description: str | None = None
     ephemeral: bool = Field(default=False)
-    value: EnvValue
+    value: SerializeAsAny[EnvValue]
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_value(cls, value: object) -> EnvValue:
+        return EnvValue.parse(value)
+
+    @field_serializer("value", mode="wrap")
+    def _serialize_value(self, value: EnvValue, handler: Any) -> dict[str, Any]:
+        return _serialize_env_value_with_type(value, handler(value))
+
+
+def _parse_environment_value(payload: object) -> "str | EnvValue | EnvEntry":
+    """Route one environment member to the shape it represents."""
+    if isinstance(payload, str | EnvValue | EnvEntry):
+        return payload
+    if not isinstance(payload, Mapping):
+        raise TypeError(
+            f"environment value must be a str, EnvValue, or EnvEntry, got {type(payload).__name__}"
+        )
+    if "type" in payload or isinstance(payload.get("value"), str):
+        return EnvValue.parse(payload)
+    return EnvEntry.model_validate(dict(payload))
 
 
 class Environment(BaseModel):
-    value: dict[str, str | EnvValue | EnvEntry] = Field(default_factory=dict)
+    value: dict[str, str | SerializeAsAny[EnvValue] | EnvEntry] = Field(default_factory=dict)
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _parse_value(cls, value: object) -> dict[str, "str | EnvValue | EnvEntry"]:
+        if not isinstance(value, Mapping):
+            raise ValueError(f"Environment mapping must be a mapping, got {type(value).__name__}")
+        return {key: _parse_environment_value(entry) for key, entry in value.items()}
+
+    @field_serializer("value", mode="wrap")
+    def _serialize_value(
+        self,
+        values: dict[str, "str | EnvValue | EnvEntry"],
+        handler: Any,
+    ) -> dict[str, Any]:
+        serialized = handler(values)
+        if not isinstance(serialized, Mapping):
+            raise PydanticSerializationError("Environment serializer must return a mapping")
+
+        data = dict(serialized)
+        for key, value in values.items():
+            if isinstance(value, EnvValue) and key in data:
+                data[key] = _serialize_env_value_with_type(value, data[key])
+        return data
 
     def normalized(self) -> dict[str, EnvEntry]:
         result: dict[str, EnvEntry] = {}

--- a/tests/extensions/sandbox/test_vercel.py
+++ b/tests/extensions/sandbox/test_vercel.py
@@ -1072,11 +1072,11 @@ async def test_vercel_s3_manifest_sanitization_preserves_typed_environment(
     )
     assert serialized_environment == {
         "value": {
-            "DIRECT": {"value": "direct-value"},
+            "DIRECT": {"type": "str", "value": "direct-value"},
             "ENTRY": {
                 "description": "typed entry",
                 "ephemeral": True,
-                "value": {"value": "entry-value"},
+                "value": {"type": "str", "value": "entry-value"},
             },
         }
     }

--- a/tests/sandbox/test_compatibility_guards.py
+++ b/tests/sandbox/test_compatibility_guards.py
@@ -40,6 +40,7 @@ from agents.sandbox.entries.mounts.patterns import (
     RcloneMountPattern,
     S3FilesMountPattern,
 )
+from agents.sandbox.manifest import EnvValue, StrEnvValue
 from agents.sandbox.session.sandbox_client import BaseSandboxClientOptions
 from agents.sandbox.session.sandbox_session_state import SandboxSessionState
 from agents.sandbox.snapshot import LocalSnapshot, NoopSnapshot, RemoteSnapshot, SnapshotBase
@@ -891,6 +892,7 @@ def test_core_discriminator_type_strings_are_stable() -> None:
         S3FilesMountPattern: "s3files",
         InContainerMountStrategy: "in_container",
         DockerVolumeMountStrategy: "docker_volume",
+        StrEnvValue: "str",
     }
 
     for cls, expected_type in expected_types.items():
@@ -1001,6 +1003,7 @@ def test_core_discriminator_registries_parse_released_payload_shapes() -> None:
         MountStrategyBase.parse({"type": "docker_volume", "driver": "rclone"}),
         DockerVolumeMountStrategy,
     )
+    assert isinstance(EnvValue.parse({"type": "str", "value": "env-value"}), StrEnvValue)
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_manifest.py
+++ b/tests/sandbox/test_manifest.py
@@ -1,6 +1,10 @@
+import json
 from pathlib import Path
+from typing import Literal
 
 import pytest
+from pydantic import model_serializer
+from pydantic_core import PydanticSerializationError
 
 from agents.sandbox.entries import (
     Dir,
@@ -10,8 +14,29 @@ from agents.sandbox.entries import (
     MountpointMountPattern,
 )
 from agents.sandbox.errors import InvalidManifestPathError
-from agents.sandbox.manifest import Manifest
+from agents.sandbox.manifest import EnvEntry, Environment, EnvValue, Manifest, StrEnvValue
 from agents.sandbox.manifest_render import _truncate_manifest_description
+
+
+class _SecretReferenceEnvValue(EnvValue):
+    type: Literal["test.secret_reference"] = "test.secret_reference"
+    key: str
+
+    async def resolve(self) -> str:
+        return f"resolved-secret-for-{self.key}"
+
+
+class _CustomSerializedEnvValue(EnvValue):
+    type: Literal["test.custom_serializer"] = "test.custom_serializer"
+    key: str
+    internal_value: str = ""
+
+    async def resolve(self) -> str:
+        return self.internal_value
+
+    @model_serializer
+    def _serialize_reference(self) -> dict[str, str]:
+        return {"key": self.key}
 
 
 def test_manifest_rejects_nested_child_paths_that_escape_workspace() -> None:
@@ -212,3 +237,213 @@ def test_manifest_description_truncation_preserves_unbounded_description() -> No
     description = "short"
 
     assert _truncate_manifest_description(description, None) == description
+
+
+@pytest.mark.asyncio
+async def test_manifest_round_trips_tagged_env_values_without_resolved_secrets() -> None:
+    manifest = Manifest(
+        environment=Environment(
+            value={
+                "DIRECT": _SecretReferenceEnvValue(key="direct"),
+                "ENTRY": EnvEntry(
+                    description="secret reference",
+                    ephemeral=True,
+                    value=_SecretReferenceEnvValue(key="entry"),
+                ),
+            }
+        )
+    )
+
+    payload_json = manifest.model_dump_json()
+    payload = json.loads(payload_json)
+
+    assert payload["environment"] == {
+        "value": {
+            "DIRECT": {"type": "test.secret_reference", "key": "direct"},
+            "ENTRY": {
+                "description": "secret reference",
+                "ephemeral": True,
+                "value": {"type": "test.secret_reference", "key": "entry"},
+            },
+        }
+    }
+    assert "resolved-secret" not in payload_json
+
+    restored = Manifest.model_validate_json(payload_json)
+
+    assert type(restored.environment.value["DIRECT"]) is _SecretReferenceEnvValue
+    restored_entry = restored.environment.value["ENTRY"]
+    assert isinstance(restored_entry, EnvEntry)
+    assert type(restored_entry.value) is _SecretReferenceEnvValue
+    assert await restored.environment.resolve() == {
+        "DIRECT": "resolved-secret-for-direct",
+        "ENTRY": "resolved-secret-for-entry",
+    }
+
+
+def test_manifest_preserves_type_from_env_value_custom_serializer() -> None:
+    manifest = Manifest(
+        environment=Environment(
+            value={
+                "DIRECT": _CustomSerializedEnvValue(
+                    key="direct",
+                    internal_value="direct-secret",
+                ),
+                "ENTRY": EnvEntry(
+                    value=_CustomSerializedEnvValue(
+                        key="entry",
+                        internal_value="entry-secret",
+                    )
+                ),
+            }
+        )
+    )
+
+    payload = manifest.model_dump(mode="json")
+    serialized = json.dumps(payload)
+
+    assert payload["environment"]["value"] == {
+        "DIRECT": {"type": "test.custom_serializer", "key": "direct"},
+        "ENTRY": {
+            "description": None,
+            "ephemeral": False,
+            "value": {"type": "test.custom_serializer", "key": "entry"},
+        },
+    }
+    assert "direct-secret" not in serialized
+    assert "entry-secret" not in serialized
+
+    restored = Manifest.model_validate(payload)
+
+    assert type(restored.environment.value["DIRECT"]) is _CustomSerializedEnvValue
+    restored_entry = restored.environment.value["ENTRY"]
+    assert isinstance(restored_entry, EnvEntry)
+    assert type(restored_entry.value) is _CustomSerializedEnvValue
+
+
+def test_manifest_round_trips_str_env_value() -> None:
+    manifest = Manifest(
+        environment=Environment(value={"PLAIN": "plain", "TYPED": StrEnvValue(value="typed")})
+    )
+
+    payload = manifest.model_dump(mode="json")
+    restored = Manifest.model_validate(payload)
+
+    assert payload["environment"] == {
+        "value": {"PLAIN": "plain", "TYPED": {"type": "str", "value": "typed"}}
+    }
+    assert restored.environment.value == {
+        "PLAIN": "plain",
+        "TYPED": StrEnvValue(value="typed"),
+    }
+
+
+def test_manifest_reads_legacy_discriminator_free_str_env_values() -> None:
+    payload = {
+        "environment": {
+            "value": {
+                "DIRECT": {"value": "direct-value"},
+                "ENTRY": {
+                    "description": "typed entry",
+                    "ephemeral": True,
+                    "value": {"value": "entry-value"},
+                },
+            }
+        }
+    }
+
+    restored = Manifest.model_validate(payload)
+
+    assert restored.environment.value == {
+        "DIRECT": StrEnvValue(value="direct-value"),
+        "ENTRY": EnvEntry(
+            description="typed entry",
+            ephemeral=True,
+            value=StrEnvValue(value="entry-value"),
+        ),
+    }
+
+
+def test_manifest_rejects_ambiguous_discriminator_free_env_values() -> None:
+    payload = {
+        "environment": {
+            "value": {
+                "AMBIGUOUS": {"value": "plain", "description": "not a legacy StrEnvValue"},
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="must include a string `type` field"):
+        Manifest.model_validate(payload)
+
+
+@pytest.mark.parametrize(("exclude_unset", "exclude_defaults"), [(True, False), (False, True)])
+def test_manifest_env_value_type_survives_narrowed_dumps(
+    exclude_unset: bool,
+    exclude_defaults: bool,
+) -> None:
+    manifest = Manifest(
+        environment=Environment(value={"TOKEN": _SecretReferenceEnvValue(key="token")})
+    )
+
+    payload = manifest.model_dump(
+        mode="json",
+        exclude_unset=exclude_unset,
+        exclude_defaults=exclude_defaults,
+    )
+
+    assert payload["environment"]["value"]["TOKEN"]["type"] == "test.secret_reference"
+    assert Manifest.model_validate(payload).environment == manifest.environment
+
+
+def test_manifest_rejects_unknown_env_value_type() -> None:
+    payload = {"environment": {"value": {"TOKEN": {"type": "unknown.env.value"}}}}
+
+    with pytest.raises(ValueError, match="Unknown env value type `unknown.env.value`"):
+        Manifest.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_untagged_env_value_imports_and_resolves_but_does_not_serialize() -> None:
+    class _UntaggedEnvValue(EnvValue):
+        key: str
+
+        async def resolve(self) -> str:
+            return f"resolved-secret-for-{self.key}"
+
+    value = _UntaggedEnvValue(key="token")
+
+    assert await value.resolve() == "resolved-secret-for-token"
+    with pytest.raises(
+        PydanticSerializationError,
+        match="_UntaggedEnvValue must explicitly declare its own non-empty `type`",
+    ):
+        Manifest(environment=Environment(value={"TOKEN": value})).model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_inherited_env_value_tag_imports_and_resolves_but_does_not_serialize() -> None:
+    class _LabeledStrEnvValue(StrEnvValue):
+        label: str
+
+    value = _LabeledStrEnvValue(value="plain", label="example")
+
+    assert await value.resolve() == "plain"
+    with pytest.raises(
+        PydanticSerializationError,
+        match="_LabeledStrEnvValue must explicitly declare its own non-empty `type`",
+    ):
+        Manifest(environment=Environment(value={"VALUE": value})).model_dump_json()
+
+
+def test_duplicate_env_value_type_registration_raises() -> None:
+    with pytest.raises(
+        TypeError,
+        match="already registered by _SecretReferenceEnvValue",
+    ):
+
+        class _DuplicateSecretReferenceEnvValue(EnvValue):
+            type: Literal["test.secret_reference"] = "test.secret_reference"
+
+            async def resolve(self) -> str:
+                return "unused"

--- a/tests/sandbox/test_session_state_roundtrip.py
+++ b/tests/sandbox/test_session_state_roundtrip.py
@@ -17,6 +17,7 @@ import pytest
 from pydantic import ConfigDict, ValidationError, field_serializer, field_validator
 
 from agents.sandbox import Manifest, SandboxPathGrant
+from agents.sandbox.manifest import EnvEntry, Environment, EnvValue, StrEnvValue
 from agents.sandbox.session import (
     BaseSandboxClient,
     Dependencies,
@@ -49,6 +50,15 @@ class _EmptyDefaultSessionState(SandboxSessionState):
 class _SimpleSessionState(SandboxSessionState):
     __test__ = False
     type: Literal["simple-roundtrip"] = "simple-roundtrip"
+
+
+class _SecretReferenceEnvValue(EnvValue):
+    __test__ = False
+    type: Literal["test.session-secret-reference"] = "test.session-secret-reference"
+    key: str
+
+    async def resolve(self) -> str:
+        return f"resolved-secret-for-{self.key}"
 
 
 class _RoundTripClient(BaseSandboxClient[None]):
@@ -175,6 +185,63 @@ class TestSandboxSessionStateRoundTrip:
 
         assert "type" in dumped
         assert dumped["type"] == "stub-roundtrip"
+
+    @pytest.mark.asyncio
+    async def test_parse_restores_manifest_env_value_subclasses(self) -> None:
+        original = _StubSessionState(
+            session_id=uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            snapshot=LocalSnapshot(id="snap-1", base_path=Path("/tmp/snapshots")),
+            manifest=Manifest(
+                environment=Environment(
+                    value={
+                        "DIRECT": _SecretReferenceEnvValue(key="direct"),
+                        "ENTRY": EnvEntry(value=_SecretReferenceEnvValue(key="entry")),
+                    }
+                )
+            ),
+            custom_field="my-value",
+        )
+
+        payload = original.model_dump(mode="json")
+        serialized = json.dumps(payload)
+
+        assert "resolved-secret" not in serialized
+
+        restored = SandboxSessionState.parse(payload)
+        restored_environment = restored.manifest.environment.value
+
+        assert type(restored_environment["DIRECT"]) is _SecretReferenceEnvValue
+        restored_entry = restored_environment["ENTRY"]
+        assert isinstance(restored_entry, EnvEntry)
+        assert type(restored_entry.value) is _SecretReferenceEnvValue
+        assert await restored.manifest.environment.resolve() == {
+            "DIRECT": "resolved-secret-for-direct",
+            "ENTRY": "resolved-secret-for-entry",
+        }
+
+    def test_parse_reads_legacy_discriminator_free_str_env_values(self) -> None:
+        payload = _make_session_state().model_dump(mode="json")
+        payload["manifest"]["environment"] = {
+            "value": {
+                "DIRECT": {"value": "direct-value"},
+                "ENTRY": {
+                    "description": "typed entry",
+                    "ephemeral": True,
+                    "value": {"value": "entry-value"},
+                },
+            }
+        }
+
+        restored = SandboxSessionState.parse(payload)
+
+        assert restored.manifest.environment.value == {
+            "DIRECT": StrEnvValue(value="direct-value"),
+            "ENTRY": EnvEntry(
+                description="typed entry",
+                ephemeral=True,
+                value=StrEnvValue(value="entry-value"),
+            ),
+        }
 
     def test_model_dump_preserves_snapshot_subclass_fields(self) -> None:
         """model_dump() must preserve snapshot subclass fields (e.g. LocalSnapshot.base_path).


### PR DESCRIPTION
This pull request fixes polymorphic `EnvValue` persistence by serializing explicitly tagged subclasses and reconstructing them from manifest and sandbox session-state payloads.

Untagged subclasses and subclasses that only inherit a parent's tag remain usable at runtime but now fail serialization clearly instead of producing ambiguous or unsafe payloads. The change also adds focused coverage for tagged reference round trips, resolved-value exclusion, discriminator compatibility, and invalid subtype registration.

ref: https://github.com/openai/openai-agents-python/pull/4037