### PR TITLE
fix(voice): propagate iterator cancellation

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -346,7 +346,11 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             try:
                 turn = await self._output_queue.get()
             except asyncio.CancelledError:
-                break
+                if self._tracing_span:
+                    self._end_turn("")
+                if self._websocket:
+                    await self._websocket.close()
+                raise
 
             if (
                 turn is None

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -305,7 +305,8 @@ class StreamedAudioResult:
             try:
                 event = await self._queue.get()
             except asyncio.CancelledError:
-                break
+                self._cleanup_tasks()
+                raise
             if isinstance(event, VoiceStreamEventError):
                 self._stored_exception = event.error
                 log_model_and_tool_action_error(

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -58,6 +58,44 @@ def fake_time(increment: int):
 
 # ===== Tests =====
 @pytest.mark.asyncio
+async def test_transcribe_turns_propagates_consumer_cancellation(monkeypatch) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    session._websocket = AsyncMock()
+    get_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+
+    async def wait_for_turn() -> str:
+        get_started.set()
+        await never_finishes.wait()
+        raise AssertionError("Unreachable")
+
+    async def hold_connection_open() -> None:
+        await never_finishes.wait()
+
+    monkeypatch.setattr(session._output_queue, "get", wait_for_turn)
+    monkeypatch.setattr(session, "_process_websocket_connection", hold_connection_open)
+    consumer = asyncio.ensure_future(anext(session.transcribe_turns()))
+    await get_started.wait()
+    consumer.cancel()
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+        session._websocket.close.assert_awaited_once()
+    finally:
+        await session.close()
+        if session._connection_task is not None:
+            await asyncio.gather(session._connection_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("trace_include_sensitive_data", "expected_error"),
     [

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -61,6 +61,43 @@ def test_streamed_audio_result_odd_length_buffer_int16() -> None:
     assert transformed.tolist() == [1]
 
 
+@pytest.mark.asyncio
+async def test_streamed_audio_result_propagates_consumer_cancellation(monkeypatch) -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    get_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+    producer_started = asyncio.Event()
+    producer_stopped = asyncio.Event()
+
+    async def wait_for_event() -> VoiceStreamEvent:
+        get_started.set()
+        await never_finishes.wait()
+        raise AssertionError("Unreachable")
+
+    async def produce_events() -> None:
+        producer_started.set()
+        try:
+            await never_finishes.wait()
+        finally:
+            producer_stopped.set()
+
+    producer = asyncio.create_task(produce_events())
+    result._tasks.append(producer)
+    monkeypatch.setattr(result._queue, "get", wait_for_event)
+    consumer = asyncio.ensure_future(anext(result.stream()))
+    await asyncio.gather(get_started.wait(), producer_started.wait())
+    consumer.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+    await producer_stopped.wait()
+    assert producer.cancelled()
+
+
 def test_voice_pipeline_config_normalizes_dictionary_settings() -> None:
     config = VoicePipelineConfig(
         stt_settings={"language": "ja", "temperature": 0.0},


### PR DESCRIPTION
### Summary

`StreamedAudioResult.stream()` and `OpenAISTTTranscriptionSession.transcribe_turns()` treated caller task cancellation as normal iterator completion by catching `asyncio.CancelledError` and breaking their queue-consumption loops. Callers therefore observed `StopAsyncIteration`, which hides cancellation from parent orchestration, timeouts, and shutdown logic.

This change re-raises the original cancellation after preserving each iterator's existing cleanup behavior:

- `StreamedAudioResult` still cancels its owned producer tasks.
- The streamed STT session still ends its active turn and closes its websocket.

The public API and normal completion paths are unchanged.

### Test plan

- Added event-coordinated regression tests for both iterators. They wait until `queue.get()` has started before cancelling, without arbitrary sleeps or live API calls.
- Pre-fix control: both new tests failed because the consumer raised `StopAsyncIteration` instead of `CancelledError`.
- `UV_PYTHON=3.12 uv run pytest tests/voice -q` — 60 passed.
- Repeated both async regressions 10 consecutive times — 20 passed.
- `UV_PYTHON=3.12 .agents/skills/code-change-verification/scripts/run.sh` — format, lint, mypy, pyright, and the full test matrix all passed.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
