### PR TITLE
fix: validate streamed cancel mode and reject invalid values

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -753,6 +753,11 @@ class RunResultStreaming(RunResultBase):
         Note: After calling cancel(), you should continue consuming stream_events()
         to allow the cancellation to complete properly.
         """
+        if mode not in ("immediate", "after_turn"):
+            raise ValueError(
+                f"Invalid cancel mode: {mode!r}. Expected one of: 'immediate', 'after_turn'."
+            )
+
         # Store the cancel mode for the background task to check
         self._cancel_mode = mode
 

--- a/tests/test_soft_cancel.py
+++ b/tests/test_soft_cancel.py
@@ -1,6 +1,7 @@
 """Tests for soft cancel (after_turn mode) functionality."""
 
 import json
+from typing import cast
 
 import pytest
 
@@ -189,6 +190,20 @@ async def test_cancel_mode_backward_compatibility():
     assert result.is_complete
     assert result._event_queue.empty()
     assert result._cancel_mode == "immediate", "Should default to immediate mode"
+
+
+@pytest.mark.asyncio
+async def test_cancel_mode_invalid_value_raises():
+    """Verify invalid cancel mode is rejected and does not mutate state."""
+    model = FakeModel()
+    agent = Agent(name="Assistant", model=model)
+
+    result = Runner.run_streamed(agent, input="Hello")
+
+    with pytest.raises(ValueError, match="Invalid cancel mode"):
+        result.cancel(mode=cast(str, "later"))
+
+    assert result._cancel_mode == "none"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Title

fix: validate streamed cancel mode and reject invalid values

## Description

This PR addresses a bug where an invalid stream cancel mode could be accepted silently, which could cause cancellation to be skipped and leave the stream in an inconsistent state.

- Adds runtime validation in `result.py` so `RunResultStreaming.cancel` only accepts `immediate` and `after_turn`.
- Raises a `ValueError` for unsupported cancel mode input instead of proceeding silently.
- Adds a regression test in `test_soft_cancel.py` to verify invalid mode rejection and confirm that internal cancel state is not mutated on failure.

This change preserves existing behavior for valid modes while making invalid usage fail fast with a clear error.