### PR TITLE
fix: avoid deadlock when agent-as-tool on_stream callback raises CancelledError

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -855,6 +855,20 @@ class Agent(AgentBase, Generic[TContext]):
                             maybe_result = stream_handler(payload)
                             if inspect.isawaitable(maybe_result):
                                 await maybe_result
+                        except asyncio.CancelledError as exc:
+                            current_task = asyncio.current_task()
+                            if current_task is not None and current_task.cancelling():
+                                raise
+
+                            def diagnostic_extra() -> dict[str, object]:
+                                return {"agent_name": self.name}
+
+                            log_model_and_tool_action_error(
+                                logger,
+                                "Error while handling an agent tool on_stream event",
+                                exc,
+                                diagnostic_extra=diagnostic_extra,
+                            )
                         except Exception as exc:
 
                             def diagnostic_extra() -> dict[str, object]:

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -2251,6 +2251,59 @@ async def test_agent_as_tool_streaming_reraises_parent_cancellation_without_wait
 
 
 @pytest.mark.asyncio
+async def test_agent_as_tool_streaming_callback_cancelled_error_does_not_deadlock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = Agent(name="streamer")
+
+    class DummyStreamingResult:
+        def __init__(self) -> None:
+            self.final_output = "ok"
+            self.current_agent = agent
+
+        async def stream_events(self):
+            yield RawResponsesStreamEvent(data=cast(Any, {"type": "response_started"}))
+
+    monkeypatch.setattr(
+        Runner, "run_streamed", classmethod(lambda *args, **kwargs: DummyStreamingResult())
+    )
+    monkeypatch.setattr(
+        Runner,
+        "run",
+        classmethod(lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("no run"))),
+    )
+
+    async def on_stream(_: AgentToolStreamEvent) -> None:
+        raise asyncio.CancelledError("synthetic callback cancellation")
+
+    tool_call = ResponseFunctionToolCall(
+        id="call_callback_cancel",
+        arguments='{"input": "go"}',
+        call_id="call-callback-cancel",
+        name="stream_tool",
+        type="function_call",
+    )
+
+    tool = agent.as_tool(
+        tool_name="stream_tool",
+        tool_description="Streams events",
+        on_stream=on_stream,
+    )
+
+    tool_context = ToolContext(
+        context=None,
+        tool_name="stream_tool",
+        tool_call_id=tool_call.call_id,
+        tool_arguments=tool_call.arguments,
+        tool_call=tool_call,
+    )
+
+    output = await asyncio.wait_for(tool.on_invoke_tool(tool_context, '{"input": "go"}'), timeout=1.0)
+
+    assert output == "ok"
+
+
+@pytest.mark.asyncio
 async def test_agent_as_tool_streaming_extractor_can_access_agent_tool_invocation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Title

fix: avoid deadlock when agent-as-tool on_stream callback raises CancelledError

## Description

This pull request fixes a deadlock risk in the agent-as-tool streaming path when the on_stream callback raises CancelledError from user callback code.

### Background

In the streaming callback dispatcher, a callback-level CancelledError could prematurely terminate the dispatcher task and leave the queue completion flow waiting on join, which may block tool completion in cancellation-adjacent scenarios.

### What changed

1. Updated callback handling logic in the streaming dispatcher to distinguish two cancellation sources:
   - Real task cancellation (dispatcher task is actively being cancelled): re-raise CancelledError to preserve expected cancellation semantics.
   - Callback-raised CancelledError from user handler code: treat it as callback failure, log it, and continue draining the queue.
2. Added a regression test to ensure callback-raised CancelledError does not deadlock the tool invocation path.
3. Preserved existing parent-cancellation behavior.

### Why this is safe

- The change is narrow and localized to callback dispatch behavior.
- It preserves true cancellation propagation for task-level cancellation.
- It only converts callback-originated CancelledError into non-fatal callback failure handling, consistent with existing exception-tolerant callback behavior.

Thank you very much for reviewing this change. I sincerely appreciate your time and feedback, and I am very happy to iterate quickly if you prefer a different handling strategy.

### Files changed

- agent.py
- test_agent_as_tool.py

## Test commands (Linux)

### Focused tests for this fix

```bash
cd /path/to/openai-agents-python_woo
uv run pytest -q tests/test_agent_as_tool.py -k "streaming_callback_cancelled_error_does_not_deadlock or streaming_reraises_parent_cancellation_without_waiting_for_handler"
```

### New regression test only

```bash
cd /path/to/openai-agents-python_woo
uv run pytest -q tests/test_agent_as_tool.py -k "streaming_callback_cancelled_error_does_not_deadlock"
```

### Full verification (repo standard order)

```bash
cd /path/to/openai-agents-python_woo
make format
make lint
make typecheck
make tests
```

### If `uv` is unavailable on Linux

```bash
cd /path/to/openai-agents-python_woo
python -m pytest -q tests/test_agent_as_tool.py -k "streaming_callback_cancelled_error_does_not_deadlock or streaming_reraises_parent_cancellation_without_waiting_for_handler"
```