### PR TITLE
fix: validate RunConfig literal options for reasoning and tool-not-found behavior

### DIFF
--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Generic, Literal
+from typing import TYPE_CHECKING, Any, Generic, Literal, get_args
 
 from pydantic import TypeAdapter
 from typing_extensions import NotRequired, TypedDict
@@ -52,6 +52,25 @@ def _default_trace_include_sensitive_data() -> bool:
     """Return the default for trace_include_sensitive_data based on environment."""
     val = os.getenv("OPENAI_AGENTS_TRACE_INCLUDE_SENSITIVE_DATA", "true")
     return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _validate_literal_setting(
+    *,
+    value: str | None,
+    setting_name: str,
+    allowed_values: tuple[str, ...],
+    allow_none: bool = False,
+) -> None:
+    if value is None:
+        if allow_none:
+            return
+        raise ValueError(
+            f"run_config.{setting_name} must be one of {allowed_values}; got None"
+        )
+    if value not in allowed_values:
+        raise ValueError(
+            f"run_config.{setting_name} must be one of {allowed_values}; got {value!r}"
+        )
 
 
 @dataclass
@@ -459,6 +478,17 @@ class RunConfig:
         ) -> None: ...
 
     def __post_init__(self) -> None:
+        _validate_literal_setting(
+            value=self.reasoning_item_id_policy,
+            setting_name="reasoning_item_id_policy",
+            allowed_values=get_args(ReasoningItemIdPolicy),
+            allow_none=True,
+        )
+        _validate_literal_setting(
+            value=self.tool_not_found_behavior,
+            setting_name="tool_not_found_behavior",
+            allowed_values=get_args(ToolNotFoundBehavior),
+        )
         if self.model_settings is not None:
             self.model_settings = _coerce_model_settings(
                 self.model_settings,

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -322,3 +322,25 @@ def test_tool_not_found_behavior_is_public_from_agents_package() -> None:
     config = RunConfig(tool_not_found_behavior=behavior)
 
     assert config.tool_not_found_behavior == "return_error_to_model"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_message"),
+    [
+        (
+            "reasoning_item_id_policy",
+            "preserve_ids",
+            r"run_config.reasoning_item_id_policy must be one of \('preserve', 'omit'\)",
+        ),
+        (
+            "tool_not_found_behavior",
+            "return_error",
+            r"run_config.tool_not_found_behavior must be one of \('raise_error', 'return_error_to_model'\)",
+        ),
+    ],
+)
+def test_run_config_rejects_invalid_literal_values(
+    field: str, value: str, expected_message: str
+) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        RunConfig(**{field: value})  # type: ignore[arg-type]


### PR DESCRIPTION
This pull request fixes missing runtime validation for `RunConfig` literal configuration fields so invalid spellings no longer silently fall back to unintended behavior.

### Background
`RunConfig` previously did not validate:
- `reasoning_item_id_policy`
- `tool_not_found_behavior`

Because these are `Literal`-typed options, typos (for example misspelled strings) could be accepted at runtime and lead to unexpected behavior rather than a clear error.

### What changed
- Added explicit validation in `RunConfig.__post_init__` for:
  - `reasoning_item_id_policy` (allows `None`, `"preserve"`, `"omit"`)
  - `tool_not_found_behavior` (allows `"raise_error"`, `"return_error_to_model"`)
- Validation now raises `ValueError` with actionable messages when a value is invalid.
- Added tests in `tests/test_run_config.py` to cover invalid values for both fields and assert clear failure messages.

### Behavior impact
- Before: invalid literal strings could pass silently.
- After: invalid literal strings fail fast at `RunConfig` construction time with explicit `ValueError`.

### Compatibility
- No change for valid existing values.
- Only invalid/misspelled inputs are now rejected earlier and explicitly.

### Test commands
> Not executed in this task per request.  
> The following commands can be run to verify the change:

```bash
uv run pytest -q test_run_config.py -k "literal or tool_not_found_behavior or reasoning_item_id_policy"
uv run pytest -q test_run_config.py
make format
make lint
make typecheck
make tests