### PR TITLE
fix(voice): clean up tasks when streams close early

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -12,7 +12,7 @@ from openai import AsyncOpenAI
 
 from ... import _debug
 from ...exceptions import AgentsException, UserError
-from ...logger import logger
+from ...logger import log_model_action_warning, logger
 from ...tracing import Span, SpanError, TranscriptionSpanData, transcription_span
 from ...util._error_tracing import get_trace_error
 from ..exceptions import STTWebsocketConnectionError
@@ -374,7 +374,21 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                     yield turn
                 finally:
                     self._output_queue.task_done()
-        finally:
+        except BaseException:
+            try:
+                await self.close()
+            except BaseException as cleanup_error:
+                try:
+                    log_model_action_warning(
+                        logger,
+                        "STT session cleanup failed while preserving the consumer exception",
+                        cleanup_error,
+                    )
+                except Exception:
+                    # Logging must not replace the original consumer exception.
+                    pass
+            raise
+        else:
             await self.close()
 
         self._check_errors()
@@ -382,12 +396,14 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             raise self._stored_exception
 
     async def close(self) -> None:
-        self._end_turn("")
         try:
             if self._websocket:
                 await self._websocket.close()
         finally:
-            await self._cleanup_tasks()
+            try:
+                await self._cleanup_tasks()
+            finally:
+                self._end_turn("")
 
 
 class OpenAISTTModel(STTModel):

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -381,8 +381,13 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
         finally:
             try:
                 await self.close()
-            except BaseException:
-                if not primary_exception_active:
+            except BaseException as cleanup_exception:
+                # Cancellation must always propagate, even while preserving a primary consumer
+                # exception, so callers that cancel or time out STT cleanup observe the
+                # cancellation instead of a successful close.
+                if isinstance(cleanup_exception, asyncio.CancelledError) or (
+                    not primary_exception_active
+                ):
                     raise
                 try:
                     logger.warning(

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -12,7 +12,7 @@ from openai import AsyncOpenAI
 
 from ... import _debug
 from ...exceptions import AgentsException, UserError
-from ...logger import log_model_action_warning, logger
+from ...logger import logger
 from ...tracing import Span, SpanError, TranscriptionSpanData, transcription_span
 from ...util._error_tracing import get_trace_error
 from ..exceptions import STTWebsocketConnectionError
@@ -360,6 +360,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
     async def transcribe_turns(self) -> AsyncIterator[str]:
         self._connection_task = asyncio.create_task(self._process_websocket_connection())
 
+        primary_exception_active = False
         try:
             while True:
                 turn = await self._output_queue.get()
@@ -375,21 +376,21 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
                 finally:
                     self._output_queue.task_done()
         except BaseException:
+            primary_exception_active = True
+            raise
+        finally:
             try:
                 await self.close()
-            except BaseException as cleanup_error:
+            except BaseException:
+                if not primary_exception_active:
+                    raise
                 try:
-                    log_model_action_warning(
-                        logger,
-                        "STT session cleanup failed while preserving the consumer exception",
-                        cleanup_error,
+                    logger.warning(
+                        "STT session cleanup failed while preserving the consumer exception"
                     )
                 except Exception:
                     # Logging must not replace the original consumer exception.
                     pass
-            raise
-        else:
-            await self.close()
 
         self._check_errors()
         if self._stored_exception:

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -123,9 +123,6 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
         self._tracing_span.start()
 
     def _end_turn(self, _transcript: str) -> None:
-        if len(_transcript) < 1:
-            return
-
         if self._tracing_span:
             # Only encode audio if tracing is enabled AND buffer is not empty
             if self._trace_include_sensitive_audio_data and self._turn_audio_buffer:
@@ -306,77 +303,91 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             raise
 
     def _check_errors(self) -> None:
-        if self._connection_task and self._connection_task.done():
+        if (
+            self._connection_task
+            and self._connection_task.done()
+            and not self._connection_task.cancelled()
+        ):
             exc = self._connection_task.exception()
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-        if self._process_events_task and self._process_events_task.done():
+        if (
+            self._process_events_task
+            and self._process_events_task.done()
+            and not self._process_events_task.cancelled()
+        ):
             exc = self._process_events_task.exception()
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-        if self._stream_audio_task and self._stream_audio_task.done():
+        if (
+            self._stream_audio_task
+            and self._stream_audio_task.done()
+            and not self._stream_audio_task.cancelled()
+        ):
             exc = self._stream_audio_task.exception()
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-        if self._listener_task and self._listener_task.done():
+        if (
+            self._listener_task
+            and self._listener_task.done()
+            and not self._listener_task.cancelled()
+        ):
             exc = self._listener_task.exception()
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-    def _cleanup_tasks(self) -> None:
-        if self._listener_task and not self._listener_task.done():
-            self._listener_task.cancel()
+    async def _cleanup_tasks(self) -> None:
+        owned_tasks = [
+            task
+            for task in (
+                self._listener_task,
+                self._process_events_task,
+                self._stream_audio_task,
+                self._connection_task,
+            )
+            if task is not None and task is not asyncio.current_task()
+        ]
+        for task in owned_tasks:
+            if not task.done():
+                task.cancel()
 
-        if self._process_events_task and not self._process_events_task.done():
-            self._process_events_task.cancel()
-
-        if self._stream_audio_task and not self._stream_audio_task.done():
-            self._stream_audio_task.cancel()
-
-        if self._connection_task and not self._connection_task.done():
-            self._connection_task.cancel()
+        if owned_tasks:
+            await asyncio.gather(*owned_tasks, return_exceptions=True)
 
     async def transcribe_turns(self) -> AsyncIterator[str]:
         self._connection_task = asyncio.create_task(self._process_websocket_connection())
 
-        while True:
-            try:
+        try:
+            while True:
                 turn = await self._output_queue.get()
-            except asyncio.CancelledError:
-                if self._tracing_span:
-                    self._end_turn("")
-                if self._websocket:
-                    await self._websocket.close()
-                raise
-
-            if (
-                turn is None
-                or isinstance(turn, ErrorSentinel)
-                or isinstance(turn, SessionCompleteSentinel)
-            ):
-                self._output_queue.task_done()
-                break
-            yield turn
-            self._output_queue.task_done()
-
-        if self._tracing_span:
-            self._end_turn("")
-
-        if self._websocket:
-            await self._websocket.close()
+                if (
+                    turn is None
+                    or isinstance(turn, ErrorSentinel)
+                    or isinstance(turn, SessionCompleteSentinel)
+                ):
+                    self._output_queue.task_done()
+                    break
+                try:
+                    yield turn
+                finally:
+                    self._output_queue.task_done()
+        finally:
+            await self.close()
 
         self._check_errors()
         if self._stored_exception:
             raise self._stored_exception
 
     async def close(self) -> None:
-        if self._websocket:
-            await self._websocket.close()
-
-        self._cleanup_tasks()
+        self._end_turn("")
+        try:
+            if self._websocket:
+                await self._websocket.close()
+        finally:
+            await self._cleanup_tasks()
 
 
 class OpenAISTTModel(STTModel):

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -363,8 +363,13 @@ class StreamedAudioResult:
                         await asyncio.shield(self.text_generation_task)
                 finally:
                     await self._cleanup_tasks()
-            except BaseException:
-                if not primary_exception_active:
+            except BaseException as cleanup_exception:
+                # Cancellation must always propagate, even while preserving a primary consumer
+                # exception, so callers that cancel or time out stream cleanup observe the
+                # cancellation instead of a successful close.
+                if isinstance(cleanup_exception, asyncio.CancelledError) or (
+                    not primary_exception_active
+                ):
                     raise
                 try:
                     logger.warning(

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -7,7 +7,12 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from ..exceptions import UserError
-from ..logger import log_model_action_error, log_model_and_tool_action_error, logger
+from ..logger import (
+    log_model_action_error,
+    log_model_action_warning,
+    log_model_and_tool_action_error,
+    logger,
+)
 from ..tracing import Span, SpeechGroupSpanData, speech_group_span, speech_span
 from ..tracing.util import time_iso
 from ..util._error_tracing import get_trace_error
@@ -338,5 +343,19 @@ class StreamedAudioResult:
             self._check_errors()
             if self._stored_exception:
                 raise self._stored_exception
-        finally:
+        except BaseException:
+            try:
+                await self._cleanup_tasks()
+            except BaseException as cleanup_error:
+                try:
+                    log_model_action_warning(
+                        logger,
+                        "Voice stream cleanup failed while preserving the consumer exception",
+                        cleanup_error,
+                    )
+                except Exception:
+                    # Logging must not replace the original consumer exception.
+                    pass
+            raise
+        else:
             await self._cleanup_tasks()

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -9,7 +9,6 @@ from typing import Any
 from ..exceptions import UserError
 from ..logger import (
     log_model_action_error,
-    log_model_action_warning,
     log_model_and_tool_action_error,
     logger,
 )
@@ -315,6 +314,7 @@ class StreamedAudioResult:
     async def stream(self) -> AsyncIterator[VoiceStreamEvent]:
         """Stream the events and audio data as they're generated."""
         saw_session_end = False
+        primary_exception_active = False
         try:
             while True:
                 event = await self._queue.get()
@@ -326,36 +326,45 @@ class StreamedAudioResult:
                     break
                 if event is None:
                     break
-                yield event
-                if event.type == "voice_stream_event_lifecycle" and event.event == "session_ended":
+                is_session_end = (
+                    event.type == "voice_stream_event_lifecycle" and event.event == "session_ended"
+                )
+                if is_session_end:
                     saw_session_end = True
+                yield event
+                if is_session_end:
                     break
-
-            # On the normal completion path, let the producer task finish gracefully so any active
-            # trace context can emit `trace_end` before we run cleanup.
-            if (
-                saw_session_end
-                and self.text_generation_task is not None
-                and not self.text_generation_task.done()
-            ):
-                await asyncio.shield(self.text_generation_task)
 
             self._check_errors()
             if self._stored_exception:
                 raise self._stored_exception
         except BaseException:
+            primary_exception_active = True
+            raise
+        finally:
             try:
-                await self._cleanup_tasks()
-            except BaseException as cleanup_error:
                 try:
-                    log_model_action_warning(
-                        logger,
-                        "Voice stream cleanup failed while preserving the consumer exception",
-                        cleanup_error,
+                    # Let the producer finish gracefully after terminal event delivery so any
+                    # active trace context can emit `trace_end` before cleanup.
+                    if (
+                        saw_session_end
+                        and self.text_generation_task is not None
+                        and not self.text_generation_task.done()
+                    ):
+                        await asyncio.shield(self.text_generation_task)
+                finally:
+                    await self._cleanup_tasks()
+            except BaseException:
+                if not primary_exception_active:
+                    raise
+                try:
+                    logger.warning(
+                        "Voice stream cleanup failed while preserving the consumer exception"
                     )
                 except Exception:
                     # Logging must not replace the original consumer exception.
                     pass
-            raise
-        else:
-            await self._cleanup_tasks()
+
+        self._check_errors()
+        if self._stored_exception:
+            raise self._stored_exception

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -280,22 +280,29 @@ class StreamedAudioResult:
             tasks.append(self._dispatcher_task)
         await asyncio.gather(*tasks)
 
-    def _cleanup_tasks(self):
+    async def _cleanup_tasks(self) -> None:
         self._finish_turn()
 
-        for task in self._tasks:
+        owned_tasks = list(self._tasks)
+        if self._dispatcher_task is not None:
+            owned_tasks.append(self._dispatcher_task)
+        if self.text_generation_task is not None:
+            owned_tasks.append(self.text_generation_task)
+
+        current_task = asyncio.current_task()
+        tasks_to_drain = list(
+            dict.fromkeys(task for task in owned_tasks if task is not current_task)
+        )
+        for task in tasks_to_drain:
             if not task.done():
                 task.cancel()
 
-        if self._dispatcher_task and not self._dispatcher_task.done():
-            self._dispatcher_task.cancel()
-
-        if self.text_generation_task and not self.text_generation_task.done():
-            self.text_generation_task.cancel()
+        if tasks_to_drain:
+            await asyncio.gather(*tasks_to_drain, return_exceptions=True)
 
     def _check_errors(self):
         for task in self._tasks:
-            if task.done():
+            if task.done() and not task.cancelled():
                 if task.exception():
                     self._stored_exception = task.exception()
                     break
@@ -303,36 +310,33 @@ class StreamedAudioResult:
     async def stream(self) -> AsyncIterator[VoiceStreamEvent]:
         """Stream the events and audio data as they're generated."""
         saw_session_end = False
-        while True:
-            try:
+        try:
+            while True:
                 event = await self._queue.get()
-            except asyncio.CancelledError:
-                self._cleanup_tasks()
-                raise
-            if isinstance(event, VoiceStreamEventError):
-                self._stored_exception = event.error
-                log_model_and_tool_action_error(
-                    logger, "Error processing voice output", event.error
-                )
-                break
-            if event is None:
-                break
-            yield event
-            if event.type == "voice_stream_event_lifecycle" and event.event == "session_ended":
-                saw_session_end = True
-                break
+                if isinstance(event, VoiceStreamEventError):
+                    self._stored_exception = event.error
+                    log_model_and_tool_action_error(
+                        logger, "Error processing voice output", event.error
+                    )
+                    break
+                if event is None:
+                    break
+                yield event
+                if event.type == "voice_stream_event_lifecycle" and event.event == "session_ended":
+                    saw_session_end = True
+                    break
 
-        # On the normal completion path, let the producer task finish gracefully so any active
-        # trace context can emit `trace_end` before we run cleanup.
-        if (
-            saw_session_end
-            and self.text_generation_task is not None
-            and not self.text_generation_task.done()
-        ):
-            await asyncio.shield(self.text_generation_task)
+            # On the normal completion path, let the producer task finish gracefully so any active
+            # trace context can emit `trace_end` before we run cleanup.
+            if (
+                saw_session_end
+                and self.text_generation_task is not None
+                and not self.text_generation_task.done()
+            ):
+                await asyncio.shield(self.text_generation_task)
 
-        self._check_errors()
-        self._cleanup_tasks()
-
-        if self._stored_exception:
-            raise self._stored_exception
+            self._check_errors()
+            if self._stored_exception:
+                raise self._stored_exception
+        finally:
+            await self._cleanup_tasks()

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+import logging
 import time
 from collections.abc import AsyncGenerator
 from typing import cast
@@ -12,6 +13,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+import agents._debug as _debug
 from agents import trace
 from agents.exceptions import UserError
 from tests.testing_processor import fetch_span_errors
@@ -155,6 +157,134 @@ async def test_transcribe_turns_closes_owned_tasks_after_yield(monkeypatch) -> N
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_close_finishes_span_started_while_websocket_close_is_pending() -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    old_span = MagicMock()
+    replacement_span = MagicMock()
+    session._tracing_span = old_span
+    websocket_close_started = asyncio.Event()
+    allow_websocket_close = asyncio.Event()
+
+    async def close_websocket() -> None:
+        websocket_close_started.set()
+        await allow_websocket_close.wait()
+
+    session._websocket = AsyncMock()
+    session._websocket.close.side_effect = close_websocket
+    session._process_events_task = asyncio.create_task(session._handle_events())
+
+    with patch(
+        "agents.voice.models.openai_stt.transcription_span",
+        return_value=replacement_span,
+    ):
+        close_task = asyncio.create_task(session.close())
+        try:
+            await websocket_close_started.wait()
+            await session._event_queue.put(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "transcript": "late transcript",
+                }
+            )
+            assert await session._output_queue.get() == "late transcript"
+            session._output_queue.task_done()
+
+            allow_websocket_close.set()
+            await close_task
+        finally:
+            allow_websocket_close.set()
+            if not close_task.done():
+                close_task.cancel()
+            await asyncio.gather(close_task, return_exceptions=True)
+
+    old_span.finish.assert_called_once_with()
+    replacement_span.start.assert_called_once_with()
+    replacement_span.finish.assert_called_once_with()
+    assert session._tracing_span is None
+    assert session._process_events_task.cancelled()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("redact_model_data", "logging_fails"),
+    [(True, False), (False, False), (True, True)],
+)
+async def test_transcribe_turns_preserves_consumer_exception_when_cleanup_fails(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+    redact_model_data: bool,
+    logging_fails: bool,
+) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    never_finishes = asyncio.Event()
+
+    async def hold_connection_open() -> None:
+        await never_finishes.wait()
+
+    async def fail_cleanup() -> None:
+        raise RuntimeError("sensitive cleanup detail")
+
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", redact_model_data)
+    monkeypatch.setattr(session, "_process_websocket_connection", hold_connection_open)
+    monkeypatch.setattr(session, "_cleanup_tasks", fail_cleanup)
+    if logging_fails:
+        monkeypatch.setattr(
+            "agents.voice.models.openai_stt.log_model_action_warning",
+            MagicMock(side_effect=RuntimeError("logging failed")),
+        )
+    await session._output_queue.put("hello")
+    turns = cast(AsyncGenerator[str, None], session.transcribe_turns())
+    assert await anext(turns) == "hello"
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="openai.agents"):
+            with pytest.raises(ValueError, match="sensitive consumer detail"):
+                await turns.athrow(ValueError("sensitive consumer detail"))
+    finally:
+        if session._connection_task is not None:
+            session._connection_task.cancel()
+            await asyncio.gather(session._connection_task, return_exceptions=True)
+
+    if logging_fails:
+        assert caplog.records == []
+        return
+
+    message = "STT session cleanup failed while preserving the consumer exception"
+    record = caplog.records[-1]
+    assert (record.exc_info is None) is redact_model_data
+    if redact_model_data:
+        assert record.msg == "%s"
+        assert record.args == (message,)
+        assert record.exc_text is None
+        assert record.getMessage() == message
+        formatted = logging.Formatter().format(record)
+        assert "sensitive cleanup detail" not in formatted
+        assert "sensitive consumer detail" not in formatted
+        assert all(
+            value not in {"sensitive cleanup detail", "sensitive consumer detail"}
+            and not isinstance(value, RuntimeError | ValueError)
+            for value in record.__dict__.values()
+        )
+    else:
+        assert record.msg == "%s: %s"
+        assert "sensitive cleanup detail" in logging.Formatter().format(record)
 
 
 @pytest.mark.asyncio

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -265,6 +265,41 @@ async def test_transcribe_turns_preserves_consumer_exception_when_cleanup_fails(
 
 
 @pytest.mark.asyncio
+async def test_transcribe_turns_propagates_cancellation_during_cleanup(monkeypatch) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    never_finishes = asyncio.Event()
+
+    async def hold_connection_open() -> None:
+        await never_finishes.wait()
+
+    async def cancelled_cleanup() -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(session, "_process_websocket_connection", hold_connection_open)
+    monkeypatch.setattr(session, "_cleanup_tasks", cancelled_cleanup)
+    await session._output_queue.put("hello")
+    turns = cast(AsyncGenerator[str, None], session.transcribe_turns())
+    assert await anext(turns) == "hello"
+
+    try:
+        # A primary consumer exception is active, but a cancellation raised while the STT
+        # session is closing must still propagate rather than be swallowed as secondary.
+        with pytest.raises(asyncio.CancelledError):
+            await turns.athrow(ValueError("consumer detail"))
+    finally:
+        if session._connection_task is not None:
+            session._connection_task.cancel()
+            await asyncio.gather(session._connection_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("trace_include_sensitive_data", "expected_error"),
     [

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -4,7 +4,9 @@ import asyncio
 import base64
 import json
 import time
-from unittest.mock import AsyncMock, patch
+from collections.abc import AsyncGenerator
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import numpy.typing as npt
@@ -93,6 +95,66 @@ async def test_transcribe_turns_propagates_consumer_cancellation(monkeypatch) ->
         await session.close()
         if session._connection_task is not None:
             await asyncio.gather(session._connection_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_transcribe_turns_closes_owned_tasks_after_yield(monkeypatch) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    session._websocket = AsyncMock()
+    tracing_span = MagicMock()
+    session._tracing_span = tracing_span
+    never_finishes = asyncio.Event()
+    started = [asyncio.Event() for _ in range(4)]
+    stopped = [asyncio.Event() for _ in range(4)]
+
+    async def hold_open(index: int) -> None:
+        started[index].set()
+        try:
+            await never_finishes.wait()
+        finally:
+            stopped[index].set()
+
+    async def hold_connection_open() -> None:
+        await hold_open(0)
+
+    monkeypatch.setattr(session, "_process_websocket_connection", hold_connection_open)
+    session._listener_task = asyncio.create_task(hold_open(1))
+    session._process_events_task = asyncio.create_task(hold_open(2))
+    session._stream_audio_task = asyncio.create_task(hold_open(3))
+    await session._output_queue.put("hello")
+
+    turns = cast(AsyncGenerator[str, None], session.transcribe_turns())
+    assert await anext(turns) == "hello"
+    await asyncio.gather(*(event.wait() for event in started))
+
+    owned_tasks = (
+        session._connection_task,
+        session._listener_task,
+        session._process_events_task,
+        session._stream_audio_task,
+    )
+    try:
+        await turns.aclose()
+        await asyncio.wait_for(
+            asyncio.gather(*(event.wait() for event in stopped)),
+            timeout=1,
+        )
+        assert all(task is not None and task.cancelled() for task in owned_tasks)
+        session._websocket.close.assert_awaited_once()
+        tracing_span.finish.assert_called_once_with()
+        assert session._tracing_span is None
+    finally:
+        tasks = [task for task in owned_tasks if task is not None]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -215,15 +215,9 @@ async def test_close_finishes_span_started_while_websocket_close_is_pending() ->
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("redact_model_data", "logging_fails"),
-    [(True, False), (False, False), (True, True)],
-)
 async def test_transcribe_turns_preserves_consumer_exception_when_cleanup_fails(
     monkeypatch,
     caplog: pytest.LogCaptureFixture,
-    redact_model_data: bool,
-    logging_fails: bool,
 ) -> None:
     session = OpenAISTTTranscriptionSession(
         input=StreamedAudioInput(),
@@ -241,14 +235,9 @@ async def test_transcribe_turns_preserves_consumer_exception_when_cleanup_fails(
     async def fail_cleanup() -> None:
         raise RuntimeError("sensitive cleanup detail")
 
-    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", redact_model_data)
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
     monkeypatch.setattr(session, "_process_websocket_connection", hold_connection_open)
     monkeypatch.setattr(session, "_cleanup_tasks", fail_cleanup)
-    if logging_fails:
-        monkeypatch.setattr(
-            "agents.voice.models.openai_stt.log_model_action_warning",
-            MagicMock(side_effect=RuntimeError("logging failed")),
-        )
     await session._output_queue.put("hello")
     turns = cast(AsyncGenerator[str, None], session.transcribe_turns())
     assert await anext(turns) == "hello"
@@ -262,29 +251,17 @@ async def test_transcribe_turns_preserves_consumer_exception_when_cleanup_fails(
             session._connection_task.cancel()
             await asyncio.gather(session._connection_task, return_exceptions=True)
 
-    if logging_fails:
-        assert caplog.records == []
-        return
-
     message = "STT session cleanup failed while preserving the consumer exception"
     record = caplog.records[-1]
-    assert (record.exc_info is None) is redact_model_data
-    if redact_model_data:
-        assert record.msg == "%s"
-        assert record.args == (message,)
-        assert record.exc_text is None
-        assert record.getMessage() == message
-        formatted = logging.Formatter().format(record)
-        assert "sensitive cleanup detail" not in formatted
-        assert "sensitive consumer detail" not in formatted
-        assert all(
-            value not in {"sensitive cleanup detail", "sensitive consumer detail"}
-            and not isinstance(value, RuntimeError | ValueError)
-            for value in record.__dict__.values()
-        )
-    else:
-        assert record.msg == "%s: %s"
-        assert "sensitive cleanup detail" in logging.Formatter().format(record)
+    assert record.msg == message
+    assert record.args == ()
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert record.getMessage() == message
+    assert logging.Formatter().format(record) == message
+    assert all(
+        not isinstance(value, RuntimeError | ValueError) for value in record.__dict__.values()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -96,6 +97,52 @@ async def test_streamed_audio_result_propagates_consumer_cancellation(monkeypatc
         await consumer
     await producer_stopped.wait()
     assert producer.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_closes_owned_tasks_after_yield() -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    never_finishes = asyncio.Event()
+    started = [asyncio.Event() for _ in range(3)]
+    stopped = [asyncio.Event() for _ in range(3)]
+
+    async def hold_open(index: int) -> None:
+        started[index].set()
+        try:
+            await never_finishes.wait()
+        finally:
+            stopped[index].set()
+
+    synthesis_task = asyncio.create_task(hold_open(0))
+    dispatcher_task = asyncio.create_task(hold_open(1))
+    producer_task = asyncio.create_task(hold_open(2))
+    result._tasks.append(synthesis_task)
+    result._dispatcher_task = dispatcher_task
+    result._set_task(producer_task)
+    await asyncio.gather(*(event.wait() for event in started))
+    await result._queue.put(VoiceStreamEventLifecycle(event="turn_started"))
+
+    stream = cast(AsyncGenerator[VoiceStreamEvent, None], result.stream())
+    event = await anext(stream)
+    assert isinstance(event, VoiceStreamEventLifecycle)
+    assert event.event == "turn_started"
+
+    owned_tasks = (synthesis_task, dispatcher_task, producer_task)
+    try:
+        await stream.aclose()
+        await asyncio.wait_for(
+            asyncio.gather(*(event.wait() for event in stopped)),
+            timeout=1,
+        )
+        assert all(task.cancelled() for task in owned_tasks)
+    finally:
+        for task in owned_tasks:
+            task.cancel()
+        await asyncio.gather(*owned_tasks, return_exceptions=True)
 
 
 def test_voice_pipeline_config_normalizes_dictionary_settings() -> None:

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -242,6 +242,47 @@ async def test_streamed_audio_result_closes_gracefully_after_session_end_yield()
         await asyncio.gather(close_task, producer_task, return_exceptions=True)
 
 
+@pytest.mark.asyncio
+async def test_streamed_audio_result_propagates_cancellation_during_session_end_cleanup() -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    producer_started = asyncio.Event()
+    producer_release = asyncio.Event()
+
+    async def produce_session() -> None:
+        producer_started.set()
+        await producer_release.wait()
+
+    producer_task = asyncio.create_task(produce_session())
+    result._set_task(producer_task)
+    await producer_started.wait()
+    await result._queue.put(VoiceStreamEventLifecycle(event="session_ended"))
+
+    stream = cast(AsyncGenerator[VoiceStreamEvent, None], result.stream())
+    event = await anext(stream)
+    assert isinstance(event, VoiceStreamEventLifecycle)
+    assert event.event == "session_ended"
+
+    # aclose() blocks in the finally awaiting asyncio.shield(text_generation_task). Cancelling
+    # that cleanup (as asyncio.wait_for would on timeout) must surface the cancellation instead
+    # of reporting a successful close.
+    close_task = asyncio.create_task(stream.aclose())
+    try:
+        await asyncio.sleep(0)
+        assert not close_task.done()
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+    finally:
+        producer_release.set()
+        if not producer_task.done():
+            producer_task.cancel()
+        await asyncio.gather(producer_task, return_exceptions=True)
+
+
 def test_voice_pipeline_config_normalizes_dictionary_settings() -> None:
     config = VoicePipelineConfig(
         stt_settings={"language": "ja", "temperature": 0.0},

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -5,7 +5,6 @@ import logging
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from typing import Any, cast
-from unittest.mock import MagicMock
 
 import numpy as np
 import numpy.typing as npt
@@ -101,15 +100,9 @@ async def test_streamed_audio_result_propagates_consumer_cancellation(monkeypatc
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("redact_model_data", "logging_fails"),
-    [(True, False), (False, False), (True, True)],
-)
 async def test_streamed_audio_result_preserves_cancellation_when_cleanup_fails(
     monkeypatch,
     caplog: pytest.LogCaptureFixture,
-    redact_model_data: bool,
-    logging_fails: bool,
 ) -> None:
     result = StreamedAudioResult(
         FakeTTS(),
@@ -127,14 +120,9 @@ async def test_streamed_audio_result_preserves_cancellation_when_cleanup_fails(
     async def fail_cleanup() -> None:
         raise RuntimeError("sensitive cleanup detail")
 
-    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", redact_model_data)
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
     monkeypatch.setattr(result._queue, "get", wait_for_event)
     monkeypatch.setattr(result, "_cleanup_tasks", fail_cleanup)
-    if logging_fails:
-        monkeypatch.setattr(
-            "agents.voice.result.log_model_action_warning",
-            MagicMock(side_effect=RuntimeError("logging failed")),
-        )
     with caplog.at_level(logging.WARNING, logger="openai.agents"):
         consumer = asyncio.ensure_future(anext(result.stream()))
         await get_started.wait()
@@ -143,26 +131,18 @@ async def test_streamed_audio_result_preserves_cancellation_when_cleanup_fails(
         with pytest.raises(asyncio.CancelledError):
             await consumer
 
-    if logging_fails:
-        assert caplog.records == []
-        return
-
     message = "Voice stream cleanup failed while preserving the consumer exception"
     record = caplog.records[-1]
-    assert (record.exc_info is None) is redact_model_data
-    if redact_model_data:
-        assert record.msg == "%s"
-        assert record.args == (message,)
-        assert record.exc_text is None
-        assert record.getMessage() == message
-        assert "sensitive cleanup detail" not in logging.Formatter().format(record)
-        assert all(
-            value != "sensitive cleanup detail" and not isinstance(value, RuntimeError)
-            for value in record.__dict__.values()
-        )
-    else:
-        assert record.msg == "%s: %s"
-        assert "sensitive cleanup detail" in logging.Formatter().format(record)
+    assert record.msg == message
+    assert record.args == ()
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert record.getMessage() == message
+    assert logging.Formatter().format(record) == message
+    assert all(
+        not isinstance(value, RuntimeError | asyncio.CancelledError)
+        for value in record.__dict__.values()
+    )
 
 
 @pytest.mark.asyncio
@@ -209,6 +189,57 @@ async def test_streamed_audio_result_closes_owned_tasks_after_yield() -> None:
         for task in owned_tasks:
             task.cancel()
         await asyncio.gather(*owned_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_closes_gracefully_after_session_end_yield() -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    producer_started = asyncio.Event()
+    allow_producer_finish = asyncio.Event()
+    producer_completed = asyncio.Event()
+    producer_cancelled = asyncio.Event()
+
+    async def produce_session() -> None:
+        producer_started.set()
+        try:
+            await allow_producer_finish.wait()
+        except asyncio.CancelledError:
+            producer_cancelled.set()
+            raise
+        else:
+            producer_completed.set()
+
+    producer_task = asyncio.create_task(produce_session())
+    result._set_task(producer_task)
+    await producer_started.wait()
+    await result._queue.put(VoiceStreamEventLifecycle(event="session_ended"))
+
+    stream = cast(AsyncGenerator[VoiceStreamEvent, None], result.stream())
+    event = await anext(stream)
+    assert isinstance(event, VoiceStreamEventLifecycle)
+    assert event.event == "session_ended"
+
+    close_task = asyncio.create_task(stream.aclose())
+    try:
+        await asyncio.sleep(0)
+        assert not close_task.done()
+        assert not producer_cancelled.is_set()
+        allow_producer_finish.set()
+        await asyncio.wait_for(close_task, timeout=1)
+        assert producer_completed.is_set()
+        assert not producer_cancelled.is_set()
+        assert not producer_task.cancelled()
+    finally:
+        allow_producer_finish.set()
+        if not close_task.done():
+            close_task.cancel()
+        if not producer_task.done():
+            producer_task.cancel()
+        await asyncio.gather(close_task, producer_task, return_exceptions=True)
 
 
 def test_voice_pipeline_config_normalizes_dictionary_settings() -> None:

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import numpy as np
 import numpy.typing as npt
@@ -97,6 +98,71 @@ async def test_streamed_audio_result_propagates_consumer_cancellation(monkeypatc
         await consumer
     await producer_stopped.wait()
     assert producer.cancelled()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("redact_model_data", "logging_fails"),
+    [(True, False), (False, False), (True, True)],
+)
+async def test_streamed_audio_result_preserves_cancellation_when_cleanup_fails(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+    redact_model_data: bool,
+    logging_fails: bool,
+) -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    get_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+
+    async def wait_for_event() -> VoiceStreamEvent:
+        get_started.set()
+        await never_finishes.wait()
+        raise AssertionError("Unreachable")
+
+    async def fail_cleanup() -> None:
+        raise RuntimeError("sensitive cleanup detail")
+
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", redact_model_data)
+    monkeypatch.setattr(result._queue, "get", wait_for_event)
+    monkeypatch.setattr(result, "_cleanup_tasks", fail_cleanup)
+    if logging_fails:
+        monkeypatch.setattr(
+            "agents.voice.result.log_model_action_warning",
+            MagicMock(side_effect=RuntimeError("logging failed")),
+        )
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        consumer = asyncio.ensure_future(anext(result.stream()))
+        await get_started.wait()
+        consumer.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+
+    if logging_fails:
+        assert caplog.records == []
+        return
+
+    message = "Voice stream cleanup failed while preserving the consumer exception"
+    record = caplog.records[-1]
+    assert (record.exc_info is None) is redact_model_data
+    if redact_model_data:
+        assert record.msg == "%s"
+        assert record.args == (message,)
+        assert record.exc_text is None
+        assert record.getMessage() == message
+        assert "sensitive cleanup detail" not in logging.Formatter().format(record)
+        assert all(
+            value != "sensitive cleanup detail" and not isinstance(value, RuntimeError)
+            for value in record.__dict__.values()
+        )
+    else:
+        assert record.msg == "%s: %s"
+        assert "sensitive cleanup detail" in logging.Formatter().format(record)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes voice background-task and tracing cleanup when a consumer explicitly closes or cancels a voice async iterator.

Closes #4051.

## Problem

`StreamedAudioResult.stream()` and `OpenAISTTTranscriptionSession.transcribe_turns()` previously ran cleanup only after normal iterator exhaustion or from cancellation handling around a queue read. Calling `aclose()` while either concrete async generator was suspended at a successful `yield` skipped trailing cleanup.

The cleanup helpers also requested task cancellation without draining owned work. Callers could therefore return before producer, dispatcher, synthesis, websocket, listener, or STT processing tasks had run their finalizers.

Two additional ordering hazards existed:

- STT cleanup finished the active span before awaiting WebSocket close, allowing event processing to start a replacement span during that await.
- `StreamedAudioResult.stream()` recorded `session_ended` only after yielding it. Immediate `aclose()` injected `GeneratorExit` before the flag changed, so cleanup cancelled the producer rather than allowing normal trace and session finalization.

Finally, attaching a secondary cleanup exception to a warning could render its implicit context, including the primary consumer traceback, when diagnostic logging was enabled.

## Changes

- Run iterator cleanup from one finalization boundary for normal exhaustion, consumer cancellation, and explicit `aclose()`.
- Record terminal `session_ended` delivery before yielding the event.
- During finalization after terminal delivery, shield the pipeline producer until it completes normally, then drain remaining owned tasks.
- Convert cleanup helpers to async cancel-and-drain operations and exclude the current cleanup task.
- Close the STT transport, cancel and drain session-owned work, and only then finish the final active transcription span.
- Preserve output-queue `task_done()` accounting when the STT iterator closes at a yield.
- Preserve an active consumer cancellation or exception when finalization fails.
- Emit only a fixed operational warning for secondary cleanup failure, without attaching the cleanup exception, arguments, traceback, or implicit consumer context.

## Regression coverage

Controlled `asyncio.Event` interleavings assert that:

- explicit close after a regular yielded event cancels and settles all owned tasks;
- explicit close immediately after receiving `session_ended` remains pending until the producer completes normally and does not cancel it;
- a transcription completion processed while WebSocket close is suspended cannot leave a replacement span unfinished;
- cleanup failure cannot replace `CancelledError` or an exception injected at a successful yield;
- cleanup-failure warnings remain fixed static records even with diagnostic model logging enabled; and
- STT websocket, task, tracing, and output-queue ownership remains deterministic.

## Scope

The deterministic cleanup guarantee covers normal exhaustion, cancellation, and explicit `aclose()`. A bare `async for` `break` does not synchronously await async-generator close, so this pull request does not claim synchronous cleanup at the point of a bare break.

## Compatibility

This is an internal lifecycle fix against the v0.19.1 behavior boundary. It does not change public signatures, event formats, provider payloads, configuration, or persisted state.

## Validation

- `make format`
- `make lint`
- `make typecheck`
- `make tests`
- Focused voice and STT suite: 53 passed
- Sensitive-logging collector tests: 10 passed
