### PR TITLE
fix(voice): block audio dispatcher while idle

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -57,6 +57,7 @@ class StreamedAudioResult:
         self._ordered_tasks: deque[asyncio.Queue[VoiceStreamEvent | None]] = (
             deque()
         )  # New: deque to hold local queues for each text segment
+        self._dispatcher_event = asyncio.Event()
         self._dispatcher_task: asyncio.Task[Any] | None = (
             None  # Task to dispatch audio chunks in order
         )
@@ -86,6 +87,10 @@ class StreamedAudioResult:
 
     async def _add_error(self, error: Exception):
         await self._queue.put(VoiceStreamEventError(error))
+
+    def _enqueue_audio_segment(self, local_queue: asyncio.Queue[VoiceStreamEvent | None]) -> None:
+        self._ordered_tasks.append(local_queue)
+        self._dispatcher_event.set()
 
     def _transform_audio_buffer(
         self, buffer: list[bytes], output_dtype: npt.DTypeLike
@@ -209,7 +214,7 @@ class StreamedAudioResult:
 
         if combined_sentences:
             local_queue: asyncio.Queue[VoiceStreamEvent | None] = asyncio.Queue()
-            self._ordered_tasks.append(local_queue)
+            self._enqueue_audio_segment(local_queue)
             self._tasks.append(
                 asyncio.create_task(self._stream_audio(combined_sentences, local_queue))
             )
@@ -219,7 +224,7 @@ class StreamedAudioResult:
     async def _turn_done(self):
         if self._text_buffer:
             local_queue: asyncio.Queue[VoiceStreamEvent | None] = asyncio.Queue()
-            self._ordered_tasks.append(local_queue)  # Append the local queue for the final segment
+            self._enqueue_audio_segment(local_queue)
             self._tasks.append(
                 asyncio.create_task(
                     self._stream_audio(self._text_buffer, local_queue, finish_turn=True)
@@ -228,7 +233,7 @@ class StreamedAudioResult:
             self._text_buffer = ""
         elif self._started_processing_turn:
             local_queue = asyncio.Queue()
-            self._ordered_tasks.append(local_queue)
+            self._enqueue_audio_segment(local_queue)
             await local_queue.put(VoiceStreamEventLifecycle(event="turn_ended"))
         self._done_processing = True
         if self._dispatcher_task is None:
@@ -249,6 +254,7 @@ class StreamedAudioResult:
 
     async def _done(self):
         self._completed_session = True
+        self._dispatcher_event.set()
         await self._wait_for_completion()
 
     async def _dispatch_audio(self):
@@ -257,7 +263,10 @@ class StreamedAudioResult:
             if len(self._ordered_tasks) == 0:
                 if self._completed_session:
                     break
-                await asyncio.sleep(0)
+                self._dispatcher_event.clear()
+                # Recheck state after clearing so a notification cannot be lost before waiting.
+                if len(self._ordered_tasks) == 0 and not self._completed_session:
+                    await self._dispatcher_event.wait()
                 continue
             local_queue = self._ordered_tasks.popleft()
             while True:

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -286,6 +286,67 @@ async def test_streamed_audio_dispatcher_handles_stream_failure() -> None:
         if isinstance(event, VoiceStreamEventLifecycle) and event.event == "session_ended"
     ]
     assert len(terminal_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_dispatcher_blocks_until_work_is_available() -> None:
+    """The dispatcher must block while idle without losing a pre-wait notification."""
+
+    class PausingEvent(asyncio.Event):
+        def __init__(self) -> None:
+            super().__init__()
+            self.wait_calls = 0
+            self.wait_started = asyncio.Event()
+            self.second_wait_started = asyncio.Event()
+            self.allow_wait = asyncio.Event()
+
+        async def wait(self) -> Literal[True]:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                self.wait_started.set()
+                await self.allow_wait.wait()
+            elif self.wait_calls == 2:
+                self.second_wait_started.set()
+            return await super().wait()
+
+    def split_immediately(text: str) -> tuple[str, str]:
+        return text, ""
+
+    fake_tts = FakeTTS()
+    result = StreamedAudioResult(
+        fake_tts,
+        TTSModelSettings(buffer_size=1, text_splitter=split_immediately),
+        VoicePipelineConfig(),
+    )
+    dispatcher_event = PausingEvent()
+    result._dispatcher_event = dispatcher_event
+    dispatcher_task = asyncio.create_task(result._dispatch_audio())
+    result._dispatcher_task = dispatcher_task
+
+    try:
+        await asyncio.wait_for(dispatcher_event.wait_started.wait(), timeout=1.0)
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert dispatcher_event.wait_calls == 1
+        assert not dispatcher_task.done()
+
+        await result._add_text("ok")
+        assert dispatcher_event.is_set()
+        dispatcher_event.allow_wait.set()
+        await result._turn_done()
+        await asyncio.wait_for(dispatcher_event.second_wait_started.wait(), timeout=1.0)
+        await result._done()
+    finally:
+        dispatcher_event.allow_wait.set()
+        if not dispatcher_task.done():
+            dispatcher_task.cancel()
+        await asyncio.gather(dispatcher_task, return_exceptions=True)
+
+    events, audio_chunks = await extract_events(result)
+
+    assert events == ["turn_started", "audio", "turn_ended", "session_ended"]
+    assert len(audio_chunks) == 1
+    await fake_tts.verify_audio("ok", audio_chunks[0])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request fixes the multi-turn voice audio dispatcher continuously rescheduling itself while no ordered audio segments are available.

`StreamedAudioResult._dispatch_audio()` previously used `await asyncio.sleep(0)` whenever `_ordered_tasks` was empty and the session remained open. That yielded the current scheduling turn but kept the dispatcher runnable, causing idle voice sessions to consume CPU and event-loop capacity between turns.

The dispatcher now blocks on a private persistent `asyncio.Event` until either:

- a new ordered audio segment is appended, or
- session completion is signaled.

All segment appends go through `_enqueue_audio_segment()`, which preserves the existing deque as the sole FIFO ordering source and signals the dispatcher after enqueueing. `_done()` signals the same event after setting `_completed_session`.

Before waiting, the dispatcher clears the event and synchronously rechecks both the ordered deque and completion state. This prevents a notification delivered around the transition into the wait path from being lost. No timeout, polling interval, public configuration, event shape, or provider behavior is added.

### Test plan

Added `test_streamed_audio_dispatcher_blocks_until_work_is_available`, which uses a controlled event interleaving to verify that:

- the idle dispatcher enters one blocking wait and remains blocked across repeated event-loop turns;
- a work notification delivered before the underlying event wait begins remains observable;
- dispatch resumes and preserves `turn_started`, audio, `turn_ended`, and `session_ended` ordering;
- the dispatcher blocks again after the turn; and
- session completion wakes the idle dispatcher.

The regression times out on the original implementation because `_dispatch_audio()` never waits on the instrumented blocking primitive.

Validation completed successfully:

- Focused pipeline suite: 33 passed
- `make format`
- `make lint`
- `make typecheck`
- `make tests`

### Compatibility

This is an internal scheduling fix against the v0.19.1 behavior boundary. It does not change public APIs, constructor ordering, voice event formats, provider payloads, tracing behavior, or persisted state.

### Issue number

Closes #4052

### Checks

- [x] I have added new tests, if relevant
- [x] I have run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I have confirmed all verification steps pass
- [x] If using Codex, I have run `/review` before submitting this PR
