### PR TITLE
fix(realtime): preserve raw server event payloads

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -1113,11 +1113,13 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
 
         try:
             if "previous_item_id" in event and event["previous_item_id"] is None:
-                event["previous_item_id"] = ""  # TODO (rm) remove
+                validation_event = {**event, "previous_item_id": ""}  # TODO (rm) remove
+            else:
+                validation_event = event
             validation_event = (
-                _normalize_custom_voice_for_server_event_validation(event)
-                if _should_normalize_custom_voice_for_server_event(event)
-                else event
+                _normalize_custom_voice_for_server_event_validation(validation_event)
+                if _should_normalize_custom_voice_for_server_event(validation_event)
+                else validation_event
             )
             parsed: AllRealtimeServerEvents = self._server_event_type_adapter.validate_python(
                 validation_event

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -17,6 +17,7 @@ from agents.realtime.model import RealtimeModelConfig
 from agents.realtime.model_events import (
     RealtimeModelAudioEvent,
     RealtimeModelErrorEvent,
+    RealtimeModelRawServerEvent,
     RealtimeModelToolCallEvent,
     RealtimeModelUsageEvent,
 )
@@ -418,6 +419,35 @@ class TestConnectionLifecycle(TestOpenAIRealtimeWebSocketModel):
 
 class TestEventHandlingRobustness(TestOpenAIRealtimeWebSocketModel):
     """Test event parsing, validation, and error handling robustness."""
+
+    @pytest.mark.asyncio
+    async def test_raw_event_preserves_null_previous_item_id(self, model):
+        """Validation compatibility must not mutate the retained raw server payload."""
+        mock_listener = AsyncMock()
+        model.add_listener(mock_listener)
+        server_event = {
+            "type": "conversation.item.created",
+            "event_id": "event_1",
+            "previous_item_id": None,
+            "item": {
+                "id": "item_1",
+                "type": "message",
+                "status": "completed",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            },
+        }
+
+        await model._handle_ws_event(server_event)
+
+        assert mock_listener.on_event.call_count == 2
+        raw_event = mock_listener.on_event.call_args_list[0][0][0]
+        assert isinstance(raw_event, RealtimeModelRawServerEvent)
+        assert raw_event.data is server_event
+        assert raw_event.data["previous_item_id"] is None
+
+        item_updated_event = mock_listener.on_event.call_args_list[1][0][0]
+        assert item_updated_event.item.previous_item_id == ""
 
     @pytest.mark.asyncio
     async def test_handle_malformed_json_logs_error_continues(self, model):


### PR DESCRIPTION
### Summary

This pull request prevents typed Realtime server-event validation from mutating the dictionary already emitted through `RealtimeModelRawServerEvent`.

`OpenAIRealtimeWebSocketModel._handle_ws_event()` emits the incoming dictionary to raw-event listeners before generated-model validation. When a top-level `previous_item_id` was present with a JSON null value, the validation compatibility path then changed that same dictionary in place from `None` to `""`. Because the raw event intentionally retains the original dictionary object, listeners that stored it observed a payload different from what the server sent.

The compatibility rewrite now operates on a shallow validation copy only when `previous_item_id` is `None`. Events that do not need this normalization continue to use the original validation payload without an unconditional copy. If custom-voice normalization is also needed, the copied validation payload flows through the existing normalization pipeline.

This preserves both sides of the current contract:

- raw listeners retain the exact input dictionary and its original null value; and
- generated typed validation continues to receive the empty-string compatibility value.

No deep copy, new validation path, public API change, or Realtime protocol reinterpretation is introduced.

### Test plan

Added `test_raw_event_preserves_null_previous_item_id` using a real valid `conversation.item.created` server event and the generated event adapter. It asserts that:

- the first emitted event is `RealtimeModelRawServerEvent`;
- its `data` remains the identical input dictionary;
- `previous_item_id` remains `None` after `_handle_ws_event()` completes; and
- the emitted typed item still receives `previous_item_id == ""` through compatibility validation.

The regression fails against the original implementation because the retained raw dictionary contains `""` after handling.

Validation completed successfully:

- Focused Realtime model suite: 77 passed
- `make format`
- `make lint`
- `make typecheck`
- `make tests`

### Compatibility

This is an internal ownership fix against the v0.19.1 behavior boundary. It preserves raw-event object identity and existing typed-event compatibility while changing no public signatures, event formats, provider payloads, configuration, tracing behavior, or persisted state.

### Issue number

Closes #4056

### Checks

- [x] I have added new tests, if relevant
- [x] I have run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I have confirmed all verification steps pass
- [ ] If using Codex, I have run `/review` before submitting this PR
