### PR TITLE
fix(tracing): use monotonic export deadlines

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -573,7 +573,7 @@ class BatchTraceProcessor(TracingProcessor):
         self._export_trigger_size = max(1, int(max_queue_size * export_trigger_ratio))
 
         # Track when we next *must* perform a scheduled export
-        self._next_export_time = time.time() + self._schedule_delay
+        self._next_export_time = time.monotonic() + self._schedule_delay
 
         # We lazily start the background worker thread the first time a span/trace is queued.
         self._worker_thread: threading.Thread | None = None
@@ -652,14 +652,14 @@ class BatchTraceProcessor(TracingProcessor):
 
     def _run(self):
         while not self._shutdown_event.is_set():
-            current_time = time.time()
+            current_time = time.monotonic()
             queue_size = self._queue.qsize()
 
             # If it's time for a scheduled flush or queue is above the trigger threshold
             if current_time >= self._next_export_time or queue_size >= self._export_trigger_size:
                 self._export_batches()
                 # Reset the next scheduled flush time
-                self._next_export_time = time.time() + self._schedule_delay
+                self._next_export_time = time.monotonic() + self._schedule_delay
             else:
                 # Sleep a short interval so we don't busy-wait.
                 time.sleep(0.2)

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -283,34 +283,65 @@ def test_batch_trace_processor_survives_exporter_exception():
     assert exporter.call_count >= 3
 
 
-def test_batch_trace_processor_scheduled_export(mocked_exporter):
-    """
-    Tests that items are automatically exported when the schedule_delay expires.
-    We mock time.time() so we can trigger the condition without waiting in real time.
-    """
-    with patch("time.time") as mock_time:
-        base_time = 1000.0
-        mock_time.return_value = base_time
+@pytest.mark.parametrize(
+    ("adjusted_wall_time", "adjusted_monotonic_time", "expected_scheduled_exports"),
+    [
+        (2000.0, 100.5, 0),
+        (0.0, 101.5, 1),
+    ],
+)
+def test_batch_trace_processor_schedule_uses_monotonic_clock(
+    mocked_exporter,
+    monkeypatch,
+    adjusted_wall_time: float,
+    adjusted_monotonic_time: float,
+    expected_scheduled_exports: int,
+) -> None:
+    class ControlledTime:
+        def __init__(self) -> None:
+            self.wall_time = 1000.0
+            self.monotonic_time = 100.0
+            self.sleep_calls = 0
 
-        processor = BatchTraceProcessor(exporter=mocked_exporter, schedule_delay=1.0)
+        def time(self) -> float:
+            return self.wall_time
 
-        processor.on_span_end(get_span(processor))  # queue size = 1
+        def monotonic(self) -> float:
+            return self.monotonic_time
 
-        # Now artificially advance time beyond the next export time
-        mock_time.return_value = base_time + 2.0  # > base_time + schedule_delay
-        # Let the background thread run a bit
-        time.sleep(0.3)
+        def sleep(self, _seconds: float) -> None:
+            self.sleep_calls += 1
+            if self.sleep_calls == 1:
+                self.wall_time = adjusted_wall_time
+                self.monotonic_time = adjusted_monotonic_time
+            else:
+                processor._shutdown_event.set()
 
-        # Check that exporter.export was eventually called
-        # Because the background thread runs, we might need a small sleep
-        processor.shutdown()
+    controlled_time = ControlledTime()
+    monkeypatch.setattr("agents.tracing.processors.time", controlled_time)
+    processor = BatchTraceProcessor(
+        exporter=mocked_exporter,
+        max_queue_size=100,
+        schedule_delay=1.0,
+        export_trigger_ratio=1.0,
+    )
+    processor._queue.put_nowait(get_span(processor))
+    scheduled_export = object()
+    export_deadlines: list[float | None | object] = []
 
-    total_exported = 0
-    for call_args in mocked_exporter.export.call_args_list:
-        batch = call_args[0][0]
-        total_exported += len(batch)
+    def record_export(deadline: float | None | object = scheduled_export) -> None:
+        export_deadlines.append(deadline)
+        if sum(item is scheduled_export for item in export_deadlines) > 1:
+            processor._shutdown_event.set()
 
-    assert total_exported == 1, "Item should be exported after scheduled delay"
+    monkeypatch.setattr(processor, "_export_batches", record_export)
+
+    processor._run()
+
+    assert sum(deadline is scheduled_export for deadline in export_deadlines) == (
+        expected_scheduled_exports
+    )
+    assert export_deadlines[-1] is None
 
 
 def test_flush_traces_delegates_to_default_trace_provider():


### PR DESCRIPTION
### Summary

This pull request makes `BatchTraceProcessor` scheduled exports use a monotonic clock consistently.

The processor represents `schedule_delay` as a relative deadline, but previously initialized, compared, and reset `_next_export_time` with `time.time()`. Wall time can move because of NTP corrections, host synchronization, timezone configuration, or manual changes:

- a backward jump could keep queued telemetry buffered much longer than configured; and
- a forward jump could trigger a premature export and reduce batching efficiency.

Scheduled-export initialization, comparison, and reset now use `time.monotonic()`, matching the existing monotonic shutdown deadlines. Queue-size triggers, the worker polling cadence, force flush, shutdown draining, retries, trace timestamps, and exporter payloads are unchanged.

No clock abstraction, public configuration, or alternate scheduling path is introduced.

### Test plan

Replaced the previous scheduled-export test with a deterministic controlled-clock regression.

The previous test patched wall time and then called `shutdown()` before counting exported items. Because shutdown always performs a final drain, it could pass even when the scheduled-export branch never executed.

The replacement runs the worker decision loop without real sleeping, distinguishes no-argument scheduled exports from the final shutdown drain, and covers both directions:

- wall time jumps forward while monotonic time remains before the deadline: no scheduled export occurs;
- wall time jumps backward while monotonic time passes the deadline: one scheduled export occurs.

Both cases fail against the original wall-clock implementation.

Validation completed successfully:

- Focused trace-processor suite: 56 passed
- `make format`
- `make lint`
- `make typecheck`
- `make tests`

### Compatibility

This is an internal scheduling correction against the v0.19.1 behavior boundary. It changes no public signatures, configuration meaning, trace or span data, exporter payloads, persisted state, or backend protocol behavior.

### Issue number

Closes #4057

### Checks

- [x] I have added new tests, if relevant
- [x] I have run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I have confirmed all verification steps pass
- [ ] If using Codex, I have run `/review` before submitting this PR
