### PR TITLE
fix(sandbox): harden default snapshot resolution

### DIFF
--- a/src/agents/sandbox/snapshot_defaults.py
+++ b/src/agents/sandbox/snapshot_defaults.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import os
 import sys
-import time
 from collections.abc import Mapping
 from pathlib import Path, PureWindowsPath
 
 from .snapshot import LocalSnapshotSpec
 
-_DEFAULT_LOCAL_SNAPSHOT_TTL_SECONDS = 60 * 60 * 24 * 30
 _DEFAULT_LOCAL_SNAPSHOT_SUBDIR = Path("openai-agents-python") / "sandbox" / "snapshots"
 
 
@@ -30,7 +28,7 @@ def default_local_snapshot_base_dir(
     os_name: str | None = None,
 ) -> Path:
     resolved_home = home or Path.home()
-    resolved_env = env or os.environ
+    resolved_env = os.environ if env is None else env
     resolved_platform = platform or sys.platform
     resolved_os_name = os_name or os.name
 
@@ -45,39 +43,14 @@ def default_local_snapshot_base_dir(
         base = env_base if env_base is not None else resolved_home / "AppData" / "Local"
     else:
         xdg_state_home = resolved_env.get("XDG_STATE_HOME")
-        base = Path(xdg_state_home) if xdg_state_home else resolved_home / ".local" / "state"
+        xdg_base = Path(xdg_state_home) if xdg_state_home else None
+        base = (
+            xdg_base
+            if xdg_base is not None and xdg_base.is_absolute()
+            else resolved_home / ".local" / "state"
+        )
 
     return base / _DEFAULT_LOCAL_SNAPSHOT_SUBDIR
-
-
-def cleanup_stale_default_local_snapshots(
-    base_path: Path,
-    *,
-    now: float | None = None,
-    max_age_seconds: int = _DEFAULT_LOCAL_SNAPSHOT_TTL_SECONDS,
-) -> None:
-    # This is intentionally limited to stale files in the SDK-managed default directory.
-    # We do not delete snapshots during normal session teardown because pause/resume may still
-    # need them. If we add explicit artifact cleanup later, it should be a separate opt-in path
-    # that can also account for backend-specific remote artifacts.
-    if max_age_seconds < 0 or not base_path.exists():
-        return
-
-    cutoff = (time.time() if now is None else now) - max_age_seconds
-    try:
-        candidates = list(base_path.glob("*.tar"))
-    except OSError:
-        return
-
-    for candidate in candidates:
-        try:
-            if not candidate.is_file():
-                continue
-            if candidate.stat().st_mtime >= cutoff:
-                continue
-            candidate.unlink(missing_ok=True)
-        except OSError:
-            continue
 
 
 def resolve_default_local_snapshot_spec(
@@ -86,7 +59,6 @@ def resolve_default_local_snapshot_spec(
     env: Mapping[str, str] | None = None,
     platform: str | None = None,
     os_name: str | None = None,
-    now: float | None = None,
 ) -> LocalSnapshotSpec:
     base_path = default_local_snapshot_base_dir(
         home=home,
@@ -94,6 +66,7 @@ def resolve_default_local_snapshot_spec(
         platform=platform,
         os_name=os_name,
     )
+    # Existing archives may still back paused or serialized resume state.
     base_path.mkdir(parents=True, exist_ok=True, mode=0o700)
     if (os_name or os.name) != "nt":
         try:

--- a/tests/sandbox/test_snapshot_defaults.py
+++ b/tests/sandbox/test_snapshot_defaults.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
+
 from agents.sandbox.snapshot import LocalSnapshotSpec
 from agents.sandbox.snapshot_defaults import (
-    _DEFAULT_LOCAL_SNAPSHOT_TTL_SECONDS,
-    cleanup_stale_default_local_snapshots,
     default_local_snapshot_base_dir,
     resolve_default_local_snapshot_spec,
 )
@@ -22,6 +22,38 @@ def test_default_local_snapshot_base_dir_uses_xdg_state_home(tmp_path: Path) -> 
     )
 
     assert result == state_home / "openai-agents-python" / "sandbox" / "snapshots"
+
+
+def test_default_local_snapshot_base_dir_honors_explicit_empty_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "host-state"))
+
+    result = default_local_snapshot_base_dir(
+        home=home,
+        env={},
+        platform="linux",
+        os_name="posix",
+    )
+
+    assert result == home / ".local" / "state" / "openai-agents-python" / "sandbox" / "snapshots"
+
+
+def test_default_local_snapshot_base_dir_ignores_relative_xdg_state_home(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+
+    result = default_local_snapshot_base_dir(
+        home=home,
+        env={"XDG_STATE_HOME": "relative-state"},
+        platform="linux",
+        os_name="posix",
+    )
+
+    assert result == home / ".local" / "state" / "openai-agents-python" / "sandbox" / "snapshots"
 
 
 def test_default_local_snapshot_base_dir_uses_macos_application_support(tmp_path: Path) -> None:
@@ -98,29 +130,6 @@ def test_default_local_snapshot_base_dir_ignores_posix_absolute_localappdata_on_
     assert result == home / "AppData" / "Local" / "openai-agents-python" / "sandbox" / "snapshots"
 
 
-def test_cleanup_stale_default_local_snapshots_removes_only_old_tar_files(tmp_path: Path) -> None:
-    managed_dir = tmp_path / "snapshots"
-    managed_dir.mkdir()
-    stale = managed_dir / "stale.tar"
-    fresh = managed_dir / "fresh.tar"
-    keep = managed_dir / "keep.txt"
-    stale.write_bytes(b"stale")
-    fresh.write_bytes(b"fresh")
-    keep.write_text("keep")
-
-    now = 2_000_000_000.0
-    stale_mtime = now - (_DEFAULT_LOCAL_SNAPSHOT_TTL_SECONDS + 60)
-    fresh_mtime = now - 60
-    os.utime(stale, (stale_mtime, stale_mtime))
-    os.utime(fresh, (fresh_mtime, fresh_mtime))
-
-    cleanup_stale_default_local_snapshots(managed_dir, now=now)
-
-    assert not stale.exists()
-    assert fresh.exists()
-    assert keep.exists()
-
-
 def test_resolve_default_local_snapshot_spec_keeps_existing_stale_files(
     tmp_path: Path,
 ) -> None:
@@ -129,16 +138,13 @@ def test_resolve_default_local_snapshot_spec_keeps_existing_stale_files(
     managed_dir.mkdir(parents=True)
     stale = managed_dir / "stale.tar"
     stale.write_bytes(b"stale")
-    now = 2_000_000_000.0
-    stale_mtime = now - (_DEFAULT_LOCAL_SNAPSHOT_TTL_SECONDS + 60)
-    os.utime(stale, (stale_mtime, stale_mtime))
+    os.utime(stale, (0, 0))
 
     spec = resolve_default_local_snapshot_spec(
         home=tmp_path / "home",
         env={"XDG_STATE_HOME": str(state_home)},
         platform="linux",
         os_name="posix",
-        now=now,
     )
 
     assert isinstance(spec, LocalSnapshotSpec)


### PR DESCRIPTION
### Summary

This pull request fixes two default local snapshot path-resolution bugs and removes an unsupported stale-deletion path.

#### Deterministic environment injection

`default_local_snapshot_base_dir()` previously selected `env or os.environ`. An explicitly supplied empty mapping therefore fell back to ambient process state, which made embedded callers and tests depend on host variables such as `XDG_STATE_HOME`.

The resolver now uses `os.environ` only when `env is None`, so `env={}` is honored as an isolated environment.

#### Absolute XDG state paths

The POSIX branch previously accepted any non-empty `XDG_STATE_HOME`, including relative paths. That could place SDK-managed archives below the process working directory. The resolver now accepts the override only when `Path(value).is_absolute()` and otherwise uses `<home>/.local/state`, matching the XDG Base Directory requirement and the existing Windows override hardening.

#### Snapshot retention ownership

The module contained a 30-day stale-archive helper and a resolver `now` parameter, but production never invoked the helper. Current behavior and regression coverage intentionally retain existing archives during default resolution because an old archive may still back paused or serialized resume state.

This PR takes the non-destructive lifecycle option described in #4059: it removes the unused TTL, deletion helper, `time` dependency, and dead `now` argument instead of making an unrelated path-resolution call delete durable resume artifacts. Automatic deletion should only be introduced later through an explicit artifact-cleanup API that can prove ownership and account for backend-specific state.

Explicit caller-provided snapshot specs, archive formats, directory permissions, macOS behavior, and Windows path resolution are unchanged.

### Test plan

- Added a regression proving `env={}` ignores an ambient host `XDG_STATE_HOME`.
- Added a regression proving relative `XDG_STATE_HOME` falls back to `<home>/.local/state`.
- Retained coverage that an absolute XDG path is accepted.
- Retained coverage that resolving the managed directory does not delete an existing stale archive.
- `uv run pytest -q tests/sandbox/test_snapshot_defaults.py tests/sandbox/test_session_manager.py` (`18 passed`)
- `bash .agents/skills/code-change-verification/scripts/run.sh`
  - `make format`
  - `make lint`
  - `make typecheck`
  - `make tests`

### Issue number

Closes #4059

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
