### PR TITLE
fix(models): close the LiteLLM provider stream on exit

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 import os
 import time
@@ -39,7 +41,7 @@ from ... import _debug
 from ...agent_output import AgentOutputSchemaBase
 from ...handoffs import Handoff
 from ...items import ModelResponse, TResponseInputItem, TResponseStreamEvent
-from ...logger import logger
+from ...logger import log_model_action_debug, logger
 from ...model_settings import ModelSettings
 from ...models._openai_retry import get_openai_retry_advice
 from ...models._retry_runtime import should_disable_provider_managed_retries
@@ -398,13 +400,22 @@ class LitellmModel(Model):
             )
 
             final_response: Response | None = None
-            async for chunk in ChatCmplStreamHandler.handle_stream(
-                response, stream, model=self.model
-            ):
-                yield chunk
+            close_stream_in_background = False
+            try:
+                async for chunk in ChatCmplStreamHandler.handle_stream(
+                    response, stream, model=self.model
+                ):
+                    yield chunk
 
-                if chunk.type == "response.completed":
-                    final_response = chunk.response
+                    if chunk.type == "response.completed":
+                        final_response = chunk.response
+            except asyncio.CancelledError:
+                close_stream_in_background = True
+                self._schedule_async_iterator_close(stream)
+                raise
+            finally:
+                if not close_stream_in_background:
+                    await self._maybe_aclose(stream)
 
             if tracing.include_data() and final_response:
                 span_generation.span_data.output = [final_response.model_dump()]
@@ -832,6 +843,34 @@ class LitellmModel(Model):
 
     def _merge_headers(self, model_settings: ModelSettings):
         return {**HEADERS, **(model_settings.extra_headers or {}), **(HEADERS_OVERRIDE.get() or {})}
+
+    @staticmethod
+    async def _maybe_aclose(value: Any) -> None:
+        aclose = getattr(value, "aclose", None)
+        if callable(aclose):
+            await aclose()
+            return
+
+        close = getattr(value, "close", None)
+        if callable(close):
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+
+    def _schedule_async_iterator_close(self, iterator: Any) -> None:
+        task = asyncio.create_task(self._maybe_aclose(iterator))
+        task.add_done_callback(self._consume_background_cleanup_task_result)
+
+    @staticmethod
+    def _consume_background_cleanup_task_result(task: asyncio.Task[Any]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            log_model_action_debug(
+                logger, "Background stream cleanup failed after cancellation", exc
+            )
 
 
 class LitellmConverter:

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -1,4 +1,6 @@
+import asyncio
 from collections.abc import AsyncIterator
+from typing import Any, cast
 
 import pytest
 from openai.types.chat.chat_completion_chunk import (
@@ -27,8 +29,9 @@ from openai.types.responses import (
 
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.extensions.models.litellm_provider import LitellmProvider
+from agents.items import TResponseStreamEvent
 from agents.model_settings import ModelSettings
-from agents.models.interface import ModelTracing
+from agents.models.interface import Model, ModelTracing
 
 
 @pytest.mark.allow_call_model_methods
@@ -695,3 +698,208 @@ async def test_stream_response_content_filter_refusal_after_reasoning(monkeypatc
     assert deltas and all(d.content_index == 0 and d.output_index == 1 for d in deltas)
     # The empty "" delta still opens no text part.
     assert "response.output_text.delta" not in [e.type for e in output_events]
+
+
+class _ClosableChatStream:
+    """A provider stream that records closes.
+
+    This mirrors litellm's `CustomStreamWrapper`, which exposes `aclose` and no `close`.
+    """
+
+    def __init__(self, chunks: list[ChatCompletionChunk]) -> None:
+        self._chunks = list(chunks)
+        self.aclose_calls = 0
+
+    def __aiter__(self) -> "_ClosableChatStream":
+        return self
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+class _BlockingChatStream(_ClosableChatStream):
+    """Yields its chunks and then blocks so the consumer can be cancelled mid-stream."""
+
+    def __init__(self, chunks: list[ChatCompletionChunk], blocked: asyncio.Event) -> None:
+        super().__init__(chunks)
+        self._blocked = blocked
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        if self._chunks:
+            return self._chunks.pop(0)
+        self._blocked.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+class _SlowCloseChatStream(_ClosableChatStream):
+    """Blocks in `aclose` until released, mirroring a provider close that waits on transport I/O."""
+
+    def __init__(
+        self,
+        chunks: list[ChatCompletionChunk],
+        blocked: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        super().__init__(chunks)
+        self._blocked = blocked
+        self._release = release
+        self.aclose_completed = 0
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        if self._chunks:
+            return self._chunks.pop(0)
+        self._blocked.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+        await self._release.wait()
+        self.aclose_completed += 1
+
+
+def _text_chunk(text: str) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content=text))],
+    )
+
+
+def _patch_fetch_response(monkeypatch, provider_stream: _ClosableChatStream) -> None:
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, provider_stream
+
+    monkeypatch.setattr(LitellmModel, "_fetch_response", patched_fetch_response)
+
+
+def _stream_response(model: Model) -> AsyncIterator[TResponseStreamEvent]:
+    return model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_closes_provider_stream_on_explicit_aclose(monkeypatch) -> None:
+    """Closing the returned generator early must release the provider stream."""
+    provider_stream = _ClosableChatStream([_text_chunk("He"), _text_chunk("llo")])
+    _patch_fetch_response(monkeypatch, provider_stream)
+    model = LitellmProvider().get_model("gpt-4")
+
+    stream_agen = cast(Any, _stream_response(model))
+    async for _event in stream_agen:
+        break
+    await stream_agen.aclose()
+
+    assert provider_stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_closes_provider_stream_on_normal_exhaustion(monkeypatch) -> None:
+    """Consuming the stream to completion must also release the provider stream."""
+    provider_stream = _ClosableChatStream([_text_chunk("He"), _text_chunk("llo")])
+    _patch_fetch_response(monkeypatch, provider_stream)
+    model = LitellmProvider().get_model("gpt-4")
+
+    async for _event in _stream_response(model):
+        pass
+
+    assert provider_stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_closes_provider_stream_after_cancellation(monkeypatch) -> None:
+    """Cancelling the consumer unwinds into the `finally` and releases the provider stream.
+
+    Closing the already-finished generator afterwards is a no-op, so the stream is closed once.
+    """
+    blocked = asyncio.Event()
+    provider_stream = _BlockingChatStream([_text_chunk("He")], blocked)
+    _patch_fetch_response(monkeypatch, provider_stream)
+    model = LitellmProvider().get_model("gpt-4")
+
+    stream_agen = cast(Any, _stream_response(model))
+
+    async def consume() -> None:
+        async for _event in stream_agen:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(blocked.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        task.cancel()
+
+    await stream_agen.aclose()
+
+    assert provider_stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_does_not_block_cancellation_on_slow_close(monkeypatch) -> None:
+    """A provider close that waits on transport I/O must not delay cancellation."""
+    blocked = asyncio.Event()
+    release = asyncio.Event()
+    provider_stream = _SlowCloseChatStream([_text_chunk("He")], blocked, release)
+    _patch_fetch_response(monkeypatch, provider_stream)
+    model = LitellmProvider().get_model("gpt-4")
+
+    stream_agen = cast(Any, _stream_response(model))
+
+    async def consume() -> None:
+        async for _event in stream_agen:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(blocked.wait(), timeout=5)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 0
+
+        release.set()
+        for _ in range(200):
+            if provider_stream.aclose_completed == 1:
+                break
+            await asyncio.sleep(0.01)
+        assert provider_stream.aclose_completed == 1
+    finally:
+        release.set()
+        task.cancel()


### PR DESCRIPTION
### Summary

`LitellmModel.stream_response()` iterates the `litellm.acompletion(..., stream=True)` result with no `try/finally`, so `CustomStreamWrapper.aclose()` is never called on any path that finalizes the generator, including normal completion.

LiteLLM is the only Chat Completions adapter with this gap:

| adapter | closes the provider stream? |
|---|---|
| `models/openai_chatcompletions.py:370-398` | yes, added by #3689 |
| `extensions/models/any_llm_model.py:603-604` | yes, `finally: await self._maybe_aclose(stream)` |
| `extensions/models/litellm_model.py:400-404` | no |

#3689 touched two files and does not mention LiteLLM. Generator finalization does not cover it either: `ChatCmplStreamHandler.handle_stream` contains no cleanup, which is why #3689 closed the stream in the adapter itself.

Impact: after a cancelled or completed streamed run the provider connection stays checked out of the pool until the next gen-2 collection, while the upstream provider keeps generating and transmitting billed tokens.

The fix mirrors the cleanup block `openai_chatcompletions.py:370-398` already uses, rather than inventing a narrower variant:

- close the provider stream in a `finally`;
- on `CancelledError`, schedule the close in the background and re-raise, so a provider close that waits on transport I/O cannot delay cancellation (`.agents/references/runner-lifecycle.md`);
- once `response.completed` has been yielded, log and ignore a cleanup failure; before any terminal event, still raise it. This keeps equivalent streaming paths aligned on errors (`.agents/references/model-provider-boundaries.md`).

`_maybe_aclose` matches `any_llm_model.py:1091-1101` so the adapters share one idiom. Scoped to LiteLLM: `any_llm_model.py` closes its stream but has neither guard, which is a separate gap and I did not widen this PR to cover it. A direct `await stream.aclose()` is not available anyway: the declared type `openai.AsyncStream` exposes `close`, not `aclose`, so it fails `mypy --strict`.

### Test plan

Six tests in `tests/models/test_litellm_chatcompletions_stream.py`. Three pin the close itself, scoped to explicit `aclose()`, normal exhaustion, and cancellation; one pins that a slow provider close does not delay cancellation; two pin the terminal-error semantics. The cancellation test uses a test-owned `asyncio.Event` barrier with a bounded `wait_for`, not `sleep(0)`.

All six fail on `main`:

```
$ uv run pytest tests/models/test_litellm_chatcompletions_stream.py -q
6 failed, 7 passed in 1.17s

$ uv run pytest tests/models/test_litellm_chatcompletions_stream.py -q -k "closes_provider_stream"
3 failed, 10 deselected in 1.52s       (assert 0 == 1)
```

Each guard is mutation-tested:

```
drop the terminal guard       -> ignores_close_error_after_terminal_event    FAILED
always swallow (if True)      -> surfaces_close_error_before_terminal_event  FAILED
drop the CancelledError branch-> does_not_block_cancellation_on_slow_close   FAILED (TimeoutError)
restored                      -> all pass
```

Replacing the `finally` body with `pass` fails all six, so the cleanup itself is load-bearing too.

Through the public `Runner.run_streamed(...)` plus `result.cancel()` API, with only the network boundary faked: `LITELLM aclose_calls=0`, `OPENAI-CC aclose_calls=1`.

```
$ ./.agents/skills/code-change-verification/scripts/run.sh
code-change-verification: all commands passed.

uv run pytest tests/models -q      604 passed
make tests                         5929 passed, 4 skipped  |  38 passed, 5 skipped (serial)
```

Codex `/review` on this head reports no actionable issues, focused regressions 62/62. Its two earlier `[P1]`s on this block are what produced the cancellation branch and the terminal-event guard above.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR