### PR TITLE
fix(run): report input guardrail results when a tripwire aborts the run

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -797,16 +797,16 @@ class AgentRunner:
                         g for g in all_input_guardrails if not g.run_in_parallel
                     ]
                     parallel_guardrails = [g for g in all_input_guardrails if g.run_in_parallel]
-                    sequential_results: list[InputGuardrailResult] = []
                     if sandbox_runtime.enabled and sequential_guardrails:
                         # Blocking first-turn guardrails must run before sandbox prep so a tripwire
                         # can prevent session creation, startup, or live-session mutation.
                         try:
-                            sequential_results = await run_input_guardrails(
+                            await run_input_guardrails(
                                 starting_agent,
                                 sequential_guardrails,
                                 copy_input_items(original_input),
                                 context_wrapper,
+                                input_guardrail_results,
                             )
                         except InputGuardrailTripwireTriggered:
                             session_input_items_for_persistence = (
@@ -1221,11 +1221,12 @@ class AgentRunner:
                         if current_turn <= 1:
                             try:
                                 if sequential_guardrails:
-                                    sequential_results = await run_input_guardrails(
+                                    await run_input_guardrails(
                                         starting_agent,
                                         sequential_guardrails,
                                         copy_input_items(original_input),
                                         context_wrapper,
+                                        input_guardrail_results,
                                     )
                             except InputGuardrailTripwireTriggered:
                                 session_input_items_for_persistence = (
@@ -1240,7 +1241,6 @@ class AgentRunner:
                                 )
                                 raise
 
-                            parallel_results: list[InputGuardrailResult] = []
                             model_task = asyncio.create_task(
                                 run_single_turn(
                                     bindings=current_bindings,
@@ -1272,10 +1272,11 @@ class AgentRunner:
                                         parallel_guardrails,
                                         copy_input_items(original_input),
                                         context_wrapper,
+                                        input_guardrail_results,
                                     )
                                 )
                                 try:
-                                    parallel_results, turn_result = await asyncio.gather(
+                                    _, turn_result = await asyncio.gather(
                                         guardrail_task,
                                         model_task,
                                     )
@@ -1310,9 +1311,6 @@ class AgentRunner:
                                     raise
                             else:
                                 turn_result = await model_task
-
-                            input_guardrail_results.extend(sequential_results)
-                            input_guardrail_results.extend(parallel_results)
                         else:
                             turn_result = await run_single_turn(
                                 bindings=current_bindings,

--- a/src/agents/run_internal/guardrails.py
+++ b/src/agents/run_internal/guardrails.py
@@ -121,8 +121,14 @@ async def run_input_guardrails(
     guardrails: list[InputGuardrail[TContext]],
     input: str | list[TResponseInputItem],
     context: RunContextWrapper[TContext],
+    results_sink: list[InputGuardrailResult] | None = None,
 ) -> list[InputGuardrailResult]:
-    """Run input guardrails concurrently and raise on tripwires."""
+    """Run input guardrails concurrently and raise on tripwires.
+
+    Results are recorded into ``results_sink`` as each guardrail completes, including the
+    tripping result, so callers can report them even when this function raises. The streamed
+    path publishes the same results through `RunResultStreaming.input_guardrail_results`.
+    """
     if not guardrails:
         return []
 
@@ -133,10 +139,16 @@ async def run_input_guardrails(
 
     guardrail_results: list[InputGuardrailResult] = []
 
+    def record(result: InputGuardrailResult) -> None:
+        guardrail_results.append(result)
+        if results_sink is not None:
+            results_sink.append(result)
+
     try:
         for done in asyncio.as_completed(guardrail_tasks):
             result = await done
             if result.output.tripwire_triggered:
+                record(result)
                 for t in guardrail_tasks:
                     t.cancel()
                 await asyncio.gather(*guardrail_tasks, return_exceptions=True)
@@ -147,7 +159,7 @@ async def run_input_guardrails(
                     )
                 )
                 raise InputGuardrailTripwireTriggered(result)
-            guardrail_results.append(result)
+            record(result)
     except BaseException:
         # On any error (including a guardrail raising or the caller being cancelled),
         # cancel and await siblings so they don't leak past this function's return.

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1997,3 +1997,140 @@ async def test_output_guardrail_raise_cancels_siblings():
 
     assert sibling_cancelled.is_set(), "Sibling task should have been cancelled"
     assert not sibling_completed.is_set(), "Sibling task should not have completed"
+
+
+def _ordered_input_guardrails(
+    *, second_triggers: bool, second_raises: bool = False, run_in_parallel: bool = False
+) -> list[InputGuardrail[Any]]:
+    """Build two guardrails whose completion order is fixed by an explicit barrier."""
+    first_done = asyncio.Event()
+
+    async def first_fn(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        first_done.set()
+        return GuardrailFunctionOutput(output_info="passes", tripwire_triggered=False)
+
+    async def second_fn(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
+    ) -> GuardrailFunctionOutput:
+        await first_done.wait()
+        if second_raises:
+            raise RuntimeError("guardrail exploded")
+        return GuardrailFunctionOutput(output_info="second", tripwire_triggered=second_triggers)
+
+    return [
+        InputGuardrail(guardrail_function=first_fn, name="passes", run_in_parallel=run_in_parallel),
+        InputGuardrail(
+            guardrail_function=second_fn,
+            name="raises" if second_raises else "trips",
+            run_in_parallel=run_in_parallel,
+        ),
+    ]
+
+
+def _tripwire_agent(model: FakeModel, *, run_in_parallel: bool) -> Agent[Any]:
+    return Agent(
+        name="guardrail_results_agent",
+        model=model,
+        input_guardrails=_ordered_input_guardrails(
+            second_triggers=True, run_in_parallel=run_in_parallel
+        ),
+    )
+
+
+def _result_names(results: list[Any]) -> list[str]:
+    return [result.guardrail.get_name() for result in results]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_in_parallel", [False, True])
+async def test_input_guardrail_tripwire_reports_results(run_in_parallel: bool):
+    """Runner.run() reports every completed guardrail result on the raised tripwire."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+
+    with pytest.raises(InputGuardrailTripwireTriggered) as exc_info:
+        await Runner.run(_tripwire_agent(model, run_in_parallel=run_in_parallel), "test input")
+
+    run_data = exc_info.value.run_data
+    assert run_data is not None
+    assert _result_names(run_data.input_guardrail_results) == ["passes", "trips"]
+    assert exc_info.value.guardrail_result.guardrail.get_name() == "trips"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_in_parallel", [False, True])
+async def test_input_guardrail_tripwire_reports_results_streamed(run_in_parallel: bool):
+    """The streamed path reports the same results, including on the streamed result object."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+
+    result = Runner.run_streamed(
+        _tripwire_agent(model, run_in_parallel=run_in_parallel), "test input"
+    )
+    with pytest.raises(InputGuardrailTripwireTriggered) as exc_info:
+        async for _ in result.stream_events():
+            pass
+
+    run_data = exc_info.value.run_data
+    assert run_data is not None
+    assert _result_names(run_data.input_guardrail_results) == ["passes", "trips"]
+    assert _result_names(result.input_guardrail_results) == ["passes", "trips"]
+
+
+def test_input_guardrail_tripwire_reports_results_sync():
+    """Runner.run_sync() matches the async entry points."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+
+    with pytest.raises(InputGuardrailTripwireTriggered) as exc_info:
+        Runner.run_sync(_tripwire_agent(model, run_in_parallel=False), "test input")
+
+    run_data = exc_info.value.run_data
+    assert run_data is not None
+    assert _result_names(run_data.input_guardrail_results) == ["passes", "trips"]
+
+
+@pytest.mark.asyncio
+async def test_input_guardrail_results_reported_on_success():
+    """Passing guardrails still land on the successful result exactly once."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+    agent = Agent(
+        name="guardrail_results_agent",
+        model=model,
+        input_guardrails=[
+            InputGuardrail(
+                guardrail_function=get_sync_guardrail(triggers=False),
+                name="blocking",
+                run_in_parallel=False,
+            ),
+            InputGuardrail(
+                guardrail_function=get_sync_guardrail(triggers=False),
+                name="parallel",
+                run_in_parallel=True,
+            ),
+        ],
+    )
+
+    result = await Runner.run(agent, "test input")
+
+    assert _result_names(result.input_guardrail_results) == ["blocking", "parallel"]
+
+
+@pytest.mark.asyncio
+async def test_input_guardrail_exception_reports_completed_results():
+    """A guardrail raising a non-tripwire error still preserves earlier results."""
+
+    collected: list[Any] = []
+    with pytest.raises(RuntimeError, match="guardrail exploded"):
+        await run_input_guardrails(
+            Agent(name="t"),
+            _ordered_input_guardrails(second_triggers=False, second_raises=True),
+            "test input",
+            RunContextWrapper(context=None),
+            collected,
+        )
+
+    assert _result_names(collected) == ["passes"]


### PR DESCRIPTION
### Summary

When an input guardrail tripwire aborts a run, `InputGuardrailTripwireTriggered.run_data.input_guardrail_results` was empty for `Runner.run()` and `Runner.run_sync()`, while `Runner.run_streamed()` reported every completed result. This makes the same error handler observe different run state depending on which entry point was used.

**Affected component:** `src/agents/run_internal/guardrails.py::run_input_guardrails` and its three call sites in `src/agents/run.py` (non-streaming input-guardrail path). The streamed path uses `run_input_guardrails_with_queue` and is unchanged.

**Problem.** `run_input_guardrails()` accumulated results in a local list and raised `InputGuardrailTripwireTriggered(result)` as soon as a tripwire fired, discarding the accumulation. `run.py` merged those results into the run-level `input_guardrail_results` only on the success path (`input_guardrail_results.extend(sequential_results)`), so the `RunErrorDetails` built by the outer failure handler saw an empty list. `run_input_guardrails_with_queue()` assigns `streamed_result.input_guardrail_results` before propagating, which is why streaming was already correct.

**Minimal reproduction** (no API key, no network, no paid model call):

```python
def _guardrail(name: str, trip: bool, delay: float = 0.0) -> InputGuardrail[Any]:
    async def fn(ctx, agent, inp) -> GuardrailFunctionOutput:
        if delay:
            await asyncio.sleep(delay)
        return GuardrailFunctionOutput(output_info=name, tripwire_triggered=trip)

    return InputGuardrail(guardrail_function=fn, name=name)


agent = Agent(
    name="A",
    model=FakeModel(),
    input_guardrails=[
        _guardrail("passes", trip=False),
        _guardrail("trips", trip=True, delay=0.02),
    ],
)

with pytest.raises(InputGuardrailTripwireTriggered) as exc_info:
    await Runner.run(agent, input="hi")

# streamed reports ["passes", "trips"]; non-streamed reports []
[r.guardrail.get_name() for r in exc_info.value.run_data.input_guardrail_results]
```

**Current behavior.** `Runner.run` / `Runner.run_sync` → `[]`. `Runner.run_streamed` → `["passes", "trips"]`.

**Corrected behavior.** All three entry points report `["passes", "trips"]` — the guardrails that completed before the run was aborted, including the tripping one. `exc.guardrail_result` is unchanged.

**Root cause.** Results were owned by the callee and only published on a normal return, so the failure path had nothing to attach.

**Implementation.** `run_input_guardrails()` takes an optional `results_sink` list and records each result into it as the guardrail completes — including the tripping result, immediately before raising. `run.py` passes its existing `input_guardrail_results` list at all three call sites (sandbox pre-run sequential, normal sequential, and the parallel guardrail task) and the two now-redundant `extend()` calls are removed.

**Why this is minimal.** The change publishes results the runner already collected, at the point they become known. It reuses the run-level accumulator that was already the destination on the success path rather than adding new state, and it removes two lines rather than adding a parallel bookkeeping path. There is no public API change: `run_input_guardrails` lives in `run_internal`, the new parameter is optional and appended last, and `InputGuardrailTripwireTriggered`, `RunErrorDetails`, and `RunResult.input_guardrail_results` keep their existing shapes. Success-path content and ordering (sequential results before parallel results) are unchanged.

**Regression tests** (all in `tests/test_guardrails.py`):

- `test_input_guardrail_tripwire_reports_results[False|True]` — `Runner.run`, blocking and parallel guardrails.
- `test_input_guardrail_tripwire_reports_results_streamed[False|True]` — streamed parity, asserting both `run_data` and `RunResultStreaming.input_guardrail_results`.
- `test_input_guardrail_tripwire_reports_results_sync` — `Runner.run_sync`.
- `test_input_guardrail_results_reported_on_success` — passing guardrails still land on the successful result exactly once, in sequential-then-parallel order (guards against double-counting from the removed `extend()` calls).
- `test_input_guardrail_exception_reports_completed_results` — a guardrail raising a non-tripwire error still preserves earlier results.

Completion order is fixed with an `asyncio.Event` barrier rather than sleeps, so the assertions are deterministic. The four tests covering `Runner.run`, `Runner.run_sync`, and the direct helper fail on `upstream/main` (`assert [] == ['passes', 'trips']`); the streamed and success tests pass before and after and act as the no-regression baseline.

**Execution modes covered:** `Runner.run`, `Runner.run_sync`, `Runner.run_streamed`; blocking (`run_in_parallel=False`) and parallel input guardrails; tripwire and non-tripwire guardrail failures; the success path.

**Cleanup and lifecycle.** Sibling-task cancellation and draining in `run_input_guardrails` are untouched: the tripwire branch still cancels and `gather`s siblings, and the `except BaseException` cleanup block is unchanged. Recording the tripping result happens before cancellation and does not alter which tasks are awaited. `make tests-asyncio-stability` was run to confirm no teardown regressions.

### Test plan

Run from the repository root on `fix/4068-input-guardrail-results-non-streamed` (Python 3.12.13, macOS 15.7.3):

| Command | Result |
|---|---|
| `make format` | `842 files left unchanged`; `ruff check --fix` → `All checks passed!` |
| `make lint` | `All checks passed!` |
| `make typecheck` | mypy `Success: no issues found in 833 source files`; pyright `0 errors, 0 warnings, 0 informations` |
| `make tests` | `5965 passed, 3 skipped, 2 warnings` (parallel) and `45 passed, 4 skipped, 5968 deselected` (serial) |
| `make tests-asyncio-stability` | 5/5 runs passed |
| `git diff --check` | clean |
| `uv run pytest tests/test_guardrails.py -q` | `52 passed` (run 5× consecutively, no flakes) |
| `uv run pytest tests/test_guardrails.py tests/test_agent_runner.py tests/test_agent_runner_streamed.py tests/test_run_state.py tests/test_tracing_errors.py tests/test_tracing_errors_streamed.py -q` | `522 passed` (run 5× consecutively) |
| `UV_PROJECT_ENVIRONMENT=.venv_310 uv run --python 3.10 -m pytest tests/test_guardrails.py -q` | `52 passed` |

Pre-fix baseline on the same branch with only `src/agents/run.py` and `src/agents/run_internal/guardrails.py` reverted: `4 failed, 3 passed` — the `Runner.run`, `Runner.run_sync`, and direct-helper tests fail, the streamed and success tests pass.

No OpenAI API key, network access, or paid model call was used; the tests rely on `tests/fake_model.py::FakeModel`.

**Not run:** `make integration-tests*` (requires live provider credentials and external services) and `make build-docs` (no documentation files changed). No inline snapshots were added or modified. No lockfile or dependency changes.

**Compatibility.** No public API, exception type, or serialized-state change. Behavior changes only on the failure path, where the reported list goes from empty to populated; the success path is byte-identical in content and order. Callers that assumed `run_data.input_guardrail_results` was always empty on a tripwire would see the populated list, which is the documented intent.

**Non-goals.** Output-guardrail tripwire results (empty on both paths today — consistent, so out of scope here), guardrail cancellation semantics, and the `run_input_guardrails_with_queue` streamed implementation.

### Issue number

Closes #4068

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

> Note on the unchecked boxes: I ran the documented verification stack directly (`make format`, `make lint`, `make typecheck`, `make tests`, plus `make tests-asyncio-stability` and a Python 3.10 run) rather than invoking the skill script wrapper, and I did not use Codex, so `/review` does not apply.
