### PR TITLE
fix(memory): keep repeated session_input_callback history items out of session input

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -217,6 +217,15 @@ async def prepare_input_with_session(
             )
         history_for_callback = copy.deepcopy(converted_history)
         new_items_for_callback = copy.deepcopy(new_input_list)
+        # The callback may mutate the lists it receives, so capture history provenance before it
+        # runs. This snapshot also keeps every copied history item alive for the rest of this
+        # function, so an item the callback removes from `history_for_callback` still counts as
+        # history and its recorded id cannot be reused by an unrelated object.
+        history_objects = list(history_for_callback)
+        # Object identity with a copied history item proves the item came from history, and it
+        # stays true however many times the callback emits that same object. The reference maps
+        # below are consumed per occurrence, so they alone cannot classify a repeat.
+        history_object_ids = {id(history_item) for history_item in history_objects}
         combined = session_input_callback(history_for_callback, new_items_for_callback)
         if inspect.isawaitable(combined):
             combined = await combined
@@ -227,16 +236,12 @@ async def prepare_input_with_session(
         # the copied history and copied new-input lists so we can reconstruct which output items
         # belong to the new turn and therefore still need to be persisted.
         history_refs = _build_reference_map(
-            history_for_callback,
+            history_objects,
             ignore_openai_conversation_item_ids=is_openai_conversation_session,
         )
-        # Object identity with a copied history item proves the item came from history, and it
-        # stays true however many times the callback emits that same object. The reference maps
-        # below are consumed per occurrence, so they alone cannot classify a repeat.
-        history_object_ids = {id(history_item) for history_item in history_for_callback}
         new_refs = _build_reference_map(new_items_for_callback)
         history_counts = _build_frequency_map(
-            history_for_callback,
+            history_objects,
             ignore_openai_conversation_item_ids=is_openai_conversation_session,
         )
         new_counts = _build_frequency_map(new_items_for_callback)

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -230,6 +230,10 @@ async def prepare_input_with_session(
             history_for_callback,
             ignore_openai_conversation_item_ids=is_openai_conversation_session,
         )
+        # Object identity with a copied history item proves the item came from history, and it
+        # stays true however many times the callback emits that same object. The reference maps
+        # below are consumed per occurrence, so they alone cannot classify a repeat.
+        history_object_ids = {id(history_item) for history_item in history_for_callback}
         new_refs = _build_reference_map(new_items_for_callback)
         history_counts = _build_frequency_map(
             history_for_callback,
@@ -250,6 +254,11 @@ async def prepare_input_with_session(
                 continue
             if _consume_reference(history_refs, history_key, item):
                 history_counts[history_key] = max(history_counts.get(history_key, 0) - 1, 0)
+                prune_history_indexes.add(combined_index)
+                continue
+            if id(item) in history_object_ids:
+                # A repeat of a history object the callback already emitted. The content budget
+                # was spent on the first occurrence, so leave it for reconstructed items.
                 prune_history_indexes.add(combined_index)
                 continue
             if history_counts.get(history_key, 0) > 0:

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -568,6 +568,45 @@ async def test_session_callback_prepared_input(runner_method):
             session.close()
 
 
+@pytest.mark.parametrize("runner_method", ["run", "run_sync", "run_streamed"])
+@pytest.mark.asyncio
+async def test_session_callback_repeating_history_does_not_grow_session(runner_method):
+    """A callback that repeats a history item must not re-persist it on every turn."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_memory.db"
+        model = FakeModel()
+        agent = Agent(name="test", model=model)
+        session = SQLiteSession("session_repeat", db_path)
+
+        def repeat_first(history, new_input):
+            # Re-emphasize the original request at the end of the model context.
+            if not history:
+                return new_input
+            return history + [history[0]] + new_input
+
+        try:
+            for turn in range(3):
+                model.set_next_output([get_text_message(f"assistant {turn}")])
+                await run_agent_async(
+                    runner_method,
+                    agent,
+                    f"user {turn}",
+                    session=session,
+                    run_config=RunConfig(session_input_callback=repeat_first),
+                )
+
+            stored = await session.get_items()
+            user_messages = [item for item in stored if item.get("role") == "user"]
+            assert [item.get("content") for item in user_messages] == [
+                "user 0",
+                "user 1",
+                "user 2",
+            ]
+            assert len(stored) == 6
+        finally:
+            session.close()
+
+
 @pytest.mark.asyncio
 async def test_sqlite_session_unicode_content():
     """Test that session correctly stores and retrieves unicode/non-ASCII content."""

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2274,6 +2274,104 @@ async def test_prepare_input_with_session_matches_copied_items_by_content() -> N
 
 
 @pytest.mark.asyncio
+async def test_prepare_input_with_session_callback_repeats_history_item() -> None:
+    """Repeating the same history object must not persist it as new turn input."""
+    history_item = cast(TResponseInputItem, {"role": "user", "content": "history"})
+    session = SimpleListSession(history=[history_item])
+
+    def callback(
+        history: list[TResponseInputItem], new_input: list[TResponseInputItem]
+    ) -> list[TResponseInputItem]:
+        # Re-emphasize the original request at the end of the model context.
+        return [history[0], new_input[0], history[0]]
+
+    prepared, session_items = await prepare_input_with_session("new", session, callback)
+
+    assert [cast(dict[str, Any], item).get("content") for item in prepared] == [
+        "history",
+        "new",
+        "history",
+    ]
+    assert [cast(dict[str, Any], item).get("content") for item in session_items] == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_callback_repeats_equal_history_items() -> None:
+    """Distinct history entries with equal content stay classified as history when repeated."""
+    first = cast(TResponseInputItem, {"role": "user", "content": "same"})
+    second = cast(TResponseInputItem, {"role": "user", "content": "same"})
+    session = SimpleListSession(history=[first, second])
+
+    def callback(
+        history: list[TResponseInputItem], new_input: list[TResponseInputItem]
+    ) -> list[TResponseInputItem]:
+        return [history[0], history[1], history[0], history[1], new_input[0]]
+
+    prepared, session_items = await prepare_input_with_session("new", session, callback)
+
+    assert [cast(dict[str, Any], item).get("content") for item in prepared] == [
+        "same",
+        "same",
+        "same",
+        "same",
+        "new",
+    ]
+    assert [cast(dict[str, Any], item).get("content") for item in session_items] == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_repeated_history_keeps_equal_new_item() -> None:
+    """A new item equal in content to a repeated history item is still persisted once."""
+    history_item = cast(TResponseInputItem, {"role": "user", "content": "same"})
+    session = SimpleListSession(history=[history_item])
+
+    def callback(
+        history: list[TResponseInputItem], new_input: list[TResponseInputItem]
+    ) -> list[TResponseInputItem]:
+        return [history[0], history[0], new_input[0]]
+
+    prepared, session_items = await prepare_input_with_session("same", session, callback)
+
+    assert [cast(dict[str, Any], item).get("content") for item in prepared] == [
+        "same",
+        "same",
+        "same",
+    ]
+    assert [cast(dict[str, Any], item).get("content") for item in session_items] == ["same"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_extra_reconstructed_item_stays_new_input() -> None:
+    """Content matching stays budget-limited: only object identity proves history origin.
+
+    The first rebuilt copy is attributed to history by content, but a further copy beyond the
+    item's multiplicity in history carries no evidence that it came from history, so it is
+    persisted. Attributing it to history would require unbounded value equality, which would
+    silently drop genuinely new items that happen to match stored content.
+    """
+    history_item = cast(TResponseInputItem, {"role": "user", "content": "history"})
+    session = SimpleListSession(history=[history_item])
+
+    def callback(
+        history: list[TResponseInputItem], new_input: list[TResponseInputItem]
+    ) -> list[TResponseInputItem]:
+        rebuilt = cast(TResponseInputItem, dict(cast(dict[str, Any], history[0])))
+        return [history[0], rebuilt, new_input[0]]
+
+    prepared, session_items = await prepare_input_with_session("new", session, callback)
+
+    assert [cast(dict[str, Any], item).get("content") for item in prepared] == [
+        "history",
+        "history",
+        "new",
+    ]
+    assert [cast(dict[str, Any], item).get("content") for item in session_items] == [
+        "history",
+        "new",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_prepare_input_with_openai_conversation_strips_assistant_history_ids() -> None:
     class DummyOpenAIConversationsSession(OpenAIConversationsSession):
         def __init__(self, history: list[TResponseInputItem]) -> None:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2296,6 +2296,52 @@ async def test_prepare_input_with_session_callback_repeats_history_item() -> Non
 
 
 @pytest.mark.asyncio
+async def test_prepare_input_with_session_callback_pops_and_repeats_history_item() -> None:
+    """Removing an item from the history list does not make it new input when re-emitted."""
+    history_item = cast(TResponseInputItem, {"role": "user", "content": "history"})
+    session = SimpleListSession(history=[history_item])
+
+    def callback(
+        history: list[TResponseInputItem], new_input: list[TResponseInputItem]
+    ) -> list[TResponseInputItem]:
+        # The callback owns the lists it receives, so moving an item out of `history` is allowed.
+        moved = history.pop(0)
+        return history + [moved, new_input[0], moved]
+
+    prepared, session_items = await prepare_input_with_session("new", session, callback)
+
+    assert [cast(dict[str, Any], item).get("content") for item in prepared] == [
+        "history",
+        "new",
+        "history",
+    ]
+    assert [cast(dict[str, Any], item).get("content") for item in session_items] == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_async_callback_pops_and_repeats_history_item() -> None:
+    """An async callback that pops history while awaiting keeps the item out of session input."""
+    history_item = cast(TResponseInputItem, {"role": "user", "content": "history"})
+    session = SimpleListSession(history=[history_item])
+
+    async def callback(
+        history: list[TResponseInputItem], new_input: list[TResponseInputItem]
+    ) -> list[TResponseInputItem]:
+        await asyncio.sleep(0)
+        moved = history.pop(0)
+        return history + [moved, new_input[0], moved]
+
+    prepared, session_items = await prepare_input_with_session("new", session, callback)
+
+    assert [cast(dict[str, Any], item).get("content") for item in prepared] == [
+        "history",
+        "new",
+        "history",
+    ]
+    assert [cast(dict[str, Any], item).get("content") for item in session_items] == ["new"]
+
+
+@pytest.mark.asyncio
 async def test_prepare_input_with_session_callback_repeats_equal_history_items() -> None:
     """Distinct history entries with equal content stay classified as history when repeated."""
     first = cast(TResponseInputItem, {"role": "user", "content": "same"})


### PR DESCRIPTION
### Summary

A `session_input_callback` that emits the same history object more than once had every repeat persisted into the session store as new turn input. Because the re-persisted copy becomes part of the next turn's history, the duplication compounds on every turn and permanently corrupts the stored conversation.

**Affected component:** `src/agents/run_internal/session_persistence.py::prepare_input_with_session`.

#### Root cause

`prepare_input_with_session()` classifies each item the callback returns by consuming an object-identity reference from `new_refs` / `history_refs`, then falling back to content-frequency budgets:

1. identity match against a new-input object → persist
2. identity match against a history object → prune
3. content budget remaining in history → prune
4. content budget remaining in new input → persist
5. otherwise → persist

`_consume_reference()` **pops** the matched object out of the reference list, so identity evidence is available only once per object. When the callback emits the same history object a second time, step 2 no longer matches; step 3 has already had that key's budget decremented by the step-2 match, so it is exhausted too, and the repeat falls through to step 5 and is persisted.

The same evidence is lost in a second way: every reference and frequency map was built **after** the callback returned. The callback owns the lists it receives, so a callback that pops an item out of `history` and still returns that object leaves nothing in those maps to attribute it to history, and it is persisted as new input on the first occurrence too.

#### Behavioral change

A callback may now include the same existing history item as many times as it likes, and may move it out of the `history` list it was handed, without that item being classified or persisted as new input. With `history + [history[0]] + new` over four turns, the SQLite session used to hold 11 items (`u0` stored three extra times); it now holds 8. The model input is unchanged — the repeat is still forwarded to the model, since the callback deliberately put it there.

#### Why this fix is safe

The fix snapshots the copied history objects **before** the callback is invoked or awaited, records their ids once, and treats an id match as permanent proof of origin:

```python
history_for_callback = copy.deepcopy(converted_history)
new_items_for_callback = copy.deepcopy(new_input_list)
history_objects = list(history_for_callback)
history_object_ids = {id(history_item) for history_item in history_objects}
combined = session_input_callback(history_for_callback, new_items_for_callback)
if inspect.isawaitable(combined):
    combined = await combined
...
if id(item) in history_object_ids:
    prune_history_indexes.add(combined_index)
    continue
```

It is deliberately **not** a value-equality relaxation. Broad content matching would let a genuinely new item that happens to serialize identically to a stored item be silently dropped from persistence. The distinction used here is the real semantic one: the callback receives deep copies of history and of the new input as two disjoint object graphs, so `id(item)` being one of the history copies is conclusive, while equal content is only a hint.

Everything else is untouched:

- The snapshot is taken before the callback runs, so provenance survives a callback that mutates the list it was given. `history_objects` also keeps a strong reference to every copied history item for the rest of the function, so an id recorded there cannot be recycled by an unrelated object.
- `history_refs` and `history_counts` are built from that same snapshot, for the same reason. For a callback that does not mutate `history`, the snapshot is element-for-element identical to the list those maps were previously built from, so classification is unchanged.
- The new identity branch is placed **after** the existing `history_refs` consumption, so the first occurrence still consumes its reference and decrements the content budget exactly as before. Only surplus occurrences take the new branch, and they intentionally do not decrement the budget again — that budget stays reserved for reconstructed items.
- History and new-input copies never share objects, so the new check cannot steal an item from the new-input branch.
- The check is independent of the `OpenAIConversationsSession` key sanitization, so it behaves identically for both session kinds.

Steps 1, 3, 4 and 5 are byte-for-byte unchanged, which is what keeps genuinely new items, reconstructed items, reordering, filtering, and empty callback results behaving exactly as they did.

#### Tests added

Unit tests in `tests/test_agent_runner.py`, alongside the existing `prepare_input_with_session` cases:

- `test_prepare_input_with_session_callback_repeats_history_item` — the same history object emitted twice is persisted zero times; ordering of the prepared model input is asserted.
- `test_prepare_input_with_session_callback_pops_and_repeats_history_item` — the callback pops an existing history item out of the `history` list and repeats it in the returned model input; it is still persisted zero times.
- `test_prepare_input_with_session_async_callback_pops_and_repeats_history_item` — the same case through an async callback that pops after an `await`. This pins the "before invoking **or** awaiting" requirement: a snapshot taken between the call and the await would pass the sync test and fail this one.
- `test_prepare_input_with_session_callback_repeats_equal_history_items` — two **distinct** history entries with equal content, each repeated, all still classify as history.
- `test_prepare_input_with_session_repeated_history_keeps_equal_new_item` — a genuinely new item whose content equals the repeated history item is still persisted exactly once. This is the guard against a value-equality-based fix.
- `test_prepare_input_with_session_extra_reconstructed_item_stays_new_input` — documents the intentional boundary: a rebuilt copy beyond the item's multiplicity in history carries no proof of origin and is still persisted. This behavior is unchanged by the PR and is asserted so any future move to unbounded content matching is a conscious decision.

Runner-level test in `tests/memory/test_session.py`:

- `test_session_callback_repeating_history_does_not_grow_session[run|run_sync|run_streamed]` — three turns against a temporary `SQLiteSession` with a `history + [history[0]] + new` callback, asserting the stored user messages are exactly `["user 0", "user 1", "user 2"]` and the session holds 6 items. This covers the sync, async, and streamed entry points, which share this code path.

No sleeps and no concurrency are involved in these tests; the callbacks are deterministic and the assertions are on stored state. Existing coverage for empty callback results (`test_prepare_input_with_session_callback_drops_new_items`, `..._ignores_callback_without_history`), append-after-history ordering (`..._uses_sync_callback`, `..._awaits_async_callback`), reordering (`..._callback_reorders_new_items`), and content-matched rebuilds (`..._matches_copied_items_by_content`) all still pass unchanged.

**Pre-fix proof.** With only `src/agents/run_internal/session_persistence.py` at upstream `main` and the new tests in place:

```
FAILED tests/test_agent_runner.py::test_prepare_input_with_session_callback_repeats_history_item
  AssertionError: assert ['new', 'history'] == ['new']
FAILED tests/test_agent_runner.py::test_prepare_input_with_session_callback_pops_and_repeats_history_item
FAILED tests/test_agent_runner.py::test_prepare_input_with_session_async_callback_pops_and_repeats_history_item
  AssertionError: assert ['history', 'new', 'history'] == ['new']
FAILED tests/test_agent_runner.py::test_prepare_input_with_session_callback_repeats_equal_history_items
  AssertionError: assert ['same', 'same', 'new'] == ['new']
FAILED tests/test_agent_runner.py::test_prepare_input_with_session_repeated_history_keeps_equal_new_item
  AssertionError: assert ['same', 'same'] == ['same']
FAILED tests/memory/test_session.py::test_session_callback_repeating_history_does_not_grow_session[run]
FAILED tests/memory/test_session.py::test_session_callback_repeating_history_does_not_grow_session[run_sync]
FAILED tests/memory/test_session.py::test_session_callback_repeating_history_does_not_grow_session[run_streamed]
  AssertionError: assert ['user 0', 'user 0', 'user 1', 'user 0', 'user 2'] == ['user 0', 'user 1', 'user 2']
```

The two pop cases also fail against the previous revision of this PR, which built the id set after the callback returned. All pass with the current fix.

#### Compatibility

No public API, exception type, or persisted-schema change. Behavior changes only for callbacks that repeat or relocate a history object, where an item that used to be written to the session store no longer is — the documented intent in `.agents/references/session-persistence.md` ("Existing history must not be re-appended as new input, even when `session_input_callback` deep-copies, reorders, filters, duplicates, or reconstructs items"). Model input is unaffected.

**Non-goals.** Callbacks that repeat a *new-input* object (still persisted per occurrence), unbounded content-based history attribution, and any change to handoff or compaction persistence paths.

### Test plan

Run from the repository root on `fix/4069-session-callback-history-repetition` (Python 3.12.13, macOS 15.7.3):

| Command | Result |
|---|---|
| `make format` | `842 files left unchanged`; `ruff check --fix` → `All checks passed!` |
| `make lint` | `All checks passed!` |
| `make typecheck` | mypy `Success: no issues found in 833 source files`; pyright `0 errors, 0 warnings, 0 informations` |
| `make tests` | `5967 passed, 3 skipped, 2 warnings` (parallel) and `45 passed, 4 skipped, 5970 deselected` (serial) |
| `make tests-asyncio-stability` | 5/5 runs passed |
| `git diff --check` | clean |
| `uv run pytest tests/memory/test_session.py -k repeating_history -q` | `3 passed` |
| `uv run pytest tests/test_agent_runner.py -k prepare_input_with_session -q` | `21 passed` |
| `uv run pytest tests/memory/ tests/test_agent_runner.py tests/test_agent_runner_streamed.py tests/test_agent_runner_sync.py -q` | `378 passed` (run 5× consecutively, no flakes) |
| `UV_PROJECT_ENVIRONMENT=.venv_310 uv run --python 3.10 -m pytest tests/memory/ tests/test_agent_runner.py -q` | `318 passed` |

No OpenAI API key, network access, or paid model call was used; the tests rely on `tests/fake_model.py::FakeModel`, `tests/utils/simple_session.py::SimpleListSession`, and a temporary `SQLiteSession`.

**Not run:** `make integration-tests*` (requires live provider credentials and external services) and `make build-docs` (no documentation files changed). No inline snapshots were added or modified. No lockfile or dependency changes.

### Issue number

Fixes #4069

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

> Note on the unchecked boxes: I ran the documented verification stack directly (`make format`, `make lint`, `make typecheck`, `make tests`, plus `make tests-asyncio-stability` and a Python 3.10 run) rather than through the skill script wrapper, and I did not use Codex, so `/review` does not apply.
