### PR TITLE
fix(tracing): mark the agent span when a non-streaming run fails

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -73,6 +73,7 @@ from .run_internal.error_handlers import (
     create_message_output_item,
     format_final_output_text,
     resolve_run_error_handler_result,
+    should_attach_generic_agent_error,
     validate_handler_final_output,
 )
 from .run_internal.items import (
@@ -1587,6 +1588,29 @@ class AgentRunner:
                         turn_result.new_step_items.clear()
             except BaseException as exc:
                 run_exception = exc
+                if (
+                    current_span is not None
+                    and current_span.error is None
+                    and isinstance(exc, Exception)
+                    and should_attach_generic_agent_error(exc)
+                ):
+                    # Mirror the streamed run loop so both paths report the failing agent. A span
+                    # that already carries a more specific error keeps it, and cancellation is
+                    # excluded because it is not an agent failure.
+                    _error_tracing.attach_error_to_span(
+                        current_span,
+                        SpanError(
+                            message="Error in agent run",
+                            data={
+                                "error": _error_tracing.get_trace_error(
+                                    trace_include_sensitive_data=(
+                                        run_config.trace_include_sensitive_data
+                                    ),
+                                    error_message=str(exc),
+                                )
+                            },
+                        ),
+                    )
                 if isinstance(exc, AgentsException):
                     exc.run_data = RunErrorDetails(
                         input=original_input,

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -69,11 +69,11 @@ from .run_internal.agent_runner_helpers import (
 )
 from .run_internal.approvals import approvals_from_step
 from .run_internal.error_handlers import (
+    attach_generic_agent_error,
     build_run_error_data,
     create_message_output_item,
     format_final_output_text,
     resolve_run_error_handler_result,
-    should_attach_generic_agent_error,
     validate_handler_final_output,
 )
 from .run_internal.items import (
@@ -1588,29 +1588,11 @@ class AgentRunner:
                         turn_result.new_step_items.clear()
             except BaseException as exc:
                 run_exception = exc
-                if (
-                    current_span is not None
-                    and current_span.error is None
-                    and isinstance(exc, Exception)
-                    and should_attach_generic_agent_error(exc)
-                ):
-                    # Mirror the streamed run loop so both paths report the failing agent. A span
-                    # that already carries a more specific error keeps it, and cancellation is
-                    # excluded because it is not an agent failure.
-                    _error_tracing.attach_error_to_span(
-                        current_span,
-                        SpanError(
-                            message="Error in agent run",
-                            data={
-                                "error": _error_tracing.get_trace_error(
-                                    trace_include_sensitive_data=(
-                                        run_config.trace_include_sensitive_data
-                                    ),
-                                    error_message=str(exc),
-                                )
-                            },
-                        ),
-                    )
+                attach_generic_agent_error(
+                    current_span,
+                    exc,
+                    trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+                )
                 if isinstance(exc, AgentsException):
                     exc.run_data = RunErrorDetails(
                         input=original_input,

--- a/src/agents/run_internal/error_handlers.py
+++ b/src/agents/run_internal/error_handlers.py
@@ -8,7 +8,14 @@ from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 
 from ..agent import Agent
 from ..agent_output import _WRAPPER_DICT_KEY, AgentOutputSchema
-from ..exceptions import MaxTurnsExceeded, ModelBehaviorError, ModelRefusalError, UserError
+from ..exceptions import (
+    InputGuardrailTripwireTriggered,
+    MaxTurnsExceeded,
+    ModelBehaviorError,
+    ModelRefusalError,
+    OutputGuardrailTripwireTriggered,
+    UserError,
+)
 from ..items import (
     ItemHelpers,
     MessageOutputItem,
@@ -28,6 +35,18 @@ from .items import ReasoningItemIdPolicy, run_item_to_input_item
 from .turn_preparation import get_output_schema
 
 RunErrorHandlerKind = Literal["max_turns", "model_refusal", "invalid_final_output"]
+
+
+def should_attach_generic_agent_error(exc: Exception) -> bool:
+    """Return whether a failed run still needs the generic agent-span error.
+
+    Failures that already write their own agent-span error, or that a dedicated child span
+    reports, are excluded so the span keeps the more specific diagnosis.
+    """
+    return not isinstance(
+        exc,
+        ModelBehaviorError | InputGuardrailTripwireTriggered | OutputGuardrailTripwireTriggered,
+    )
 
 
 def build_run_error_data(

--- a/src/agents/run_internal/error_handlers.py
+++ b/src/agents/run_internal/error_handlers.py
@@ -23,6 +23,7 @@ from ..items import (
     RunItem,
     TResponseInputItem,
 )
+from ..logger import logger
 from ..models.fake_id import FAKE_RESPONSES_ID
 from ..run_context import RunContextWrapper, TContext
 from ..run_error_handlers import (
@@ -31,21 +32,74 @@ from ..run_error_handlers import (
     RunErrorHandlerResult,
     RunErrorHandlers,
 )
+from ..tracing import Span, SpanError
+from ..util import _error_tracing
+from ..util._error_tracing import REDACTED_TRACE_ERROR_MESSAGE
 from .items import ReasoningItemIdPolicy, run_item_to_input_item
 from .turn_preparation import get_output_schema
 
 RunErrorHandlerKind = Literal["max_turns", "model_refusal", "invalid_final_output"]
 
+GENERIC_AGENT_ERROR_MESSAGE = "Error in agent run"
+UNFORMATTABLE_TRACE_ERROR_MESSAGE = "Error details are unavailable."
 
-def should_attach_generic_agent_error(exc: Exception) -> bool:
+
+def _is_generic_agent_error(exc: BaseException) -> bool:
     """Return whether a failed run still needs the generic agent-span error.
 
-    Failures that already write their own agent-span error, or that a dedicated child span
-    reports, are excluded so the span keeps the more specific diagnosis.
+    Only ``Exception`` is eligible: the non-streaming handler also catches ``BaseException``, but
+    cancellation is not an agent failure and the streamed path never marks it. Failures that
+    already write their own agent-span error, or that a dedicated child span reports, are excluded
+    so the span keeps the more specific diagnosis.
     """
+    if not isinstance(exc, Exception):
+        return False
     return not isinstance(
         exc,
         ModelBehaviorError | InputGuardrailTripwireTriggered | OutputGuardrailTripwireTriggered,
+    )
+
+
+def _format_agent_error_detail(exc: BaseException) -> str:
+    """Stringify an exception for tracing without ever raising.
+
+    A custom exception whose ``__str__`` raises must not replace the exception the run is
+    propagating, so the formatting failure is swallowed and reported as a placeholder.
+    """
+    try:
+        return str(exc)
+    except Exception:
+        logger.warning(
+            "Failed to format %s for tracing; recording a placeholder instead",
+            type(exc).__name__,
+        )
+        return UNFORMATTABLE_TRACE_ERROR_MESSAGE
+
+
+def attach_generic_agent_error(
+    span: Span[Any] | None,
+    exc: BaseException,
+    *,
+    trace_include_sensitive_data: bool,
+) -> None:
+    """Mark the agent span of a failed run with the generic ``Error in agent run`` error.
+
+    This owns the whole policy shared by the streaming and non-streaming paths: eligibility,
+    preserving a more specific error already on the span, redaction, the span error payload, and
+    the attachment itself. Tracing never changes what the run raises: the exception is stringified
+    only when sensitive data is traced, and a formatting failure cannot propagate.
+    """
+    if span is None or span.error is not None or not _is_generic_agent_error(exc):
+        return
+
+    detail = (
+        _format_agent_error_detail(exc)
+        if trace_include_sensitive_data
+        else REDACTED_TRACE_ERROR_MESSAGE
+    )
+    _error_tracing.attach_error_to_span(
+        span,
+        SpanError(message=GENERIC_AGENT_ERROR_MESSAGE, data={"error": detail}),
     )
 
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -106,11 +106,11 @@ from .agent_runner_helpers import (
 )
 from .approvals import approvals_from_step
 from .error_handlers import (
+    attach_generic_agent_error,
     build_run_error_data,
     create_message_output_item,
     format_final_output_text,
     resolve_run_error_handler_result,
-    should_attach_generic_agent_error,
     validate_handler_final_output,
 )
 from .guardrails import (
@@ -1241,21 +1241,11 @@ async def start_streaming(
                         streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
                         break
             except Exception as e:
-                if current_span and should_attach_generic_agent_error(e):
-                    _error_tracing.attach_error_to_span(
-                        current_span,
-                        SpanError(
-                            message="Error in agent run",
-                            data={
-                                "error": _error_tracing.get_trace_error(
-                                    trace_include_sensitive_data=(
-                                        run_config.trace_include_sensitive_data
-                                    ),
-                                    error_message=str(e),
-                                )
-                            },
-                        ),
-                    )
+                attach_generic_agent_error(
+                    current_span,
+                    e,
+                    trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+                )
                 raise
     except AgentsException as exc:
         streamed_result.is_complete = True
@@ -1271,19 +1261,11 @@ async def start_streaming(
         )
         raise
     except Exception as e:
-        if current_span and should_attach_generic_agent_error(e):
-            _error_tracing.attach_error_to_span(
-                current_span,
-                SpanError(
-                    message="Error in agent run",
-                    data={
-                        "error": _error_tracing.get_trace_error(
-                            trace_include_sensitive_data=run_config.trace_include_sensitive_data,
-                            error_message=str(e),
-                        )
-                    },
-                ),
-            )
+        attach_generic_agent_error(
+            current_span,
+            e,
+            trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+        )
         streamed_result.is_complete = True
         streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
         raise

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -110,6 +110,7 @@ from .error_handlers import (
     create_message_output_item,
     format_final_output_text,
     resolve_run_error_handler_result,
+    should_attach_generic_agent_error,
     validate_handler_final_output,
 )
 from .guardrails import (
@@ -282,13 +283,6 @@ async def cleanup_models_after_run(tool_use_tracker: AgentToolUseTracker) -> Non
 
 def _agent_diagnostic_extra(agent: Agent[Any]) -> dict[str, object]:
     return {"agent_name": agent.name}
-
-
-def _should_attach_generic_agent_error(exc: Exception) -> bool:
-    return not isinstance(
-        exc,
-        ModelBehaviorError | InputGuardrailTripwireTriggered | OutputGuardrailTripwireTriggered,
-    )
 
 
 async def _should_persist_stream_items(
@@ -1247,7 +1241,7 @@ async def start_streaming(
                         streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
                         break
             except Exception as e:
-                if current_span and _should_attach_generic_agent_error(e):
+                if current_span and should_attach_generic_agent_error(e):
                     _error_tracing.attach_error_to_span(
                         current_span,
                         SpanError(
@@ -1277,7 +1271,7 @@ async def start_streaming(
         )
         raise
     except Exception as e:
-        if current_span and _should_attach_generic_agent_error(e):
+        if current_span and should_attach_generic_agent_error(e):
             _error_tracing.attach_error_to_span(
                 current_span,
                 SpanError(

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -13,11 +13,17 @@ from agents import (
     InputGuardrail,
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
+    ModelBehaviorError,
+    ModelRefusalError,
+    RunConfig,
     RunContextWrapper,
     Runner,
     TResponseInputItem,
+    UserError,
     _debug,
 )
+from agents.tracing.span_data import AgentSpanData
+from agents.tracing.spans import SpanImpl
 
 from .fake_model import FakeModel
 from .test_responses import (
@@ -27,7 +33,7 @@ from .test_responses import (
     get_handoff_tool_call,
     get_text_message,
 )
-from .testing_processor import fetch_normalized_spans
+from .testing_processor import SPAN_PROCESSOR_TESTING, fetch_normalized_spans, fetch_span_errors
 
 
 @pytest.mark.asyncio
@@ -49,6 +55,7 @@ async def test_single_turn_model_error():
                 "children": [
                     {
                         "type": "agent",
+                        "error": {"message": "Error in agent run", "data": {"error": "test error"}},
                         "data": {
                             "name": "test_agent",
                             "handoffs": [],
@@ -102,6 +109,7 @@ async def test_multi_turn_no_handoffs():
                 "children": [
                     {
                         "type": "agent",
+                        "error": {"message": "Error in agent run", "data": {"error": "test error"}},
                         "data": {
                             "name": "test_agent",
                             "handoffs": [],
@@ -558,3 +566,167 @@ async def test_guardrail_error():
             }
         ]
     )
+
+
+SENSITIVE_ERROR_MESSAGE = "sensitive-error-detail"
+
+
+@pytest.mark.asyncio
+async def test_run_marks_agent_span_with_generic_error():
+    """A generic run failure marks the agent span, matching the streamed path."""
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output(ValueError("test error"))
+
+    with pytest.raises(ValueError, match="test error"):
+        await Runner.run(Agent(name="test_agent", model=model), input="first_test")
+
+    assert fetch_span_errors("agent") == [
+        {"message": "Error in agent run", "data": {"error": "test error"}}
+    ]
+
+
+def test_run_sync_marks_agent_span_with_generic_error():
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output(ValueError("test error"))
+
+    with pytest.raises(ValueError, match="test error"):
+        Runner.run_sync(Agent(name="test_agent", model=model), input="first_test")
+
+    assert fetch_span_errors("agent") == [
+        {"message": "Error in agent run", "data": {"error": "test error"}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_span_error_matches_streamed_path():
+    """The non-streamed and streamed paths record the same agent span error."""
+    non_streamed_model = FakeModel(tracing_enabled=True)
+    non_streamed_model.set_next_output(ValueError("test error"))
+    with pytest.raises(ValueError):
+        await Runner.run(Agent(name="test_agent", model=non_streamed_model), input="first_test")
+    non_streamed_errors = fetch_span_errors("agent")
+
+    SPAN_PROCESSOR_TESTING.clear()
+
+    streamed_model = FakeModel(tracing_enabled=True)
+    streamed_model.set_next_output(ValueError("test error"))
+    result = Runner.run_streamed(Agent(name="test_agent", model=streamed_model), input="first_test")
+    with pytest.raises(ValueError):
+        async for _ in result.stream_events():
+            pass
+
+    assert non_streamed_errors == fetch_span_errors("agent")
+
+
+@pytest.mark.asyncio
+async def test_run_agent_span_error_redacts_sensitive_data():
+    model = FakeModel(tracing_enabled=False)
+    model.set_next_output(ValueError(SENSITIVE_ERROR_MESSAGE))
+
+    with pytest.raises(ValueError):
+        await Runner.run(
+            Agent(name="test_agent", model=model),
+            input="first_test",
+            run_config=RunConfig(trace_include_sensitive_data=False),
+        )
+
+    assert fetch_span_errors("agent") == [
+        {
+            "message": "Error in agent run",
+            "data": {"error": "Error details are redacted."},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_mark_agent_span_for_model_behavior_error():
+    """ModelBehaviorError is reported by the generation span, so the agent span stays clean."""
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output(ModelBehaviorError("bad model output"))
+
+    with pytest.raises(ModelBehaviorError):
+        await Runner.run(Agent(name="test_agent", model=model), input="first_test")
+
+    assert fetch_span_errors("agent") == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_detail"),
+    [
+        pytest.param(
+            ModelRefusalError("refused"),
+            "Model refused to produce output: refused",
+            id="model-refusal-error",
+        ),
+        pytest.param(UserError("user problem"), "user problem", id="user-error"),
+    ],
+)
+async def test_run_marks_agent_span_for_other_agents_exceptions(
+    error: Exception, expected_detail: str
+):
+    """Agents exceptions without a dedicated agent-span error match the streamed path."""
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output(error)
+
+    with pytest.raises(type(error)):
+        await Runner.run(Agent(name="test_agent", model=model), input="first_test")
+
+    assert fetch_span_errors("agent") == [
+        {"message": "Error in agent run", "data": {"error": expected_detail}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_keeps_specific_max_turns_agent_span_error():
+    """A more specific span error already on the agent span is not overwritten."""
+    model = FakeModel(tracing_enabled=True)
+    agent = Agent(name="test_agent", model=model, tools=[get_function_tool("foo", "res")])
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("foo", json.dumps({"a": "b"}), call_id="c1")],
+            [get_function_tool_call("foo", json.dumps({"a": "b"}), call_id="c2")],
+            [get_function_tool_call("foo", json.dumps({"a": "b"}), call_id="c3")],
+        ]
+    )
+
+    with pytest.raises(MaxTurnsExceeded):
+        await Runner.run(agent, input="first_test", max_turns=2)
+
+    assert fetch_span_errors("agent") == [
+        {"message": "Max turns exceeded", "data": {"max_turns": 2}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_attaches_agent_span_error_exactly_once(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The generic error is recorded once, not re-applied by nested handlers."""
+    recorded: list[Any] = []
+    original_set_error = SpanImpl.set_error
+
+    def counting_set_error(self: Any, error: Any) -> None:
+        if isinstance(self.span_data, AgentSpanData):
+            recorded.append(error)
+        original_set_error(self, error)
+
+    monkeypatch.setattr(SpanImpl, "set_error", counting_set_error)
+
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output(ValueError("test error"))
+    with pytest.raises(ValueError):
+        await Runner.run(Agent(name="test_agent", model=model), input="first_test")
+
+    assert recorded == [{"message": "Error in agent run", "data": {"error": "test error"}}]
+
+
+@pytest.mark.asyncio
+async def test_successful_run_leaves_agent_span_without_error():
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output([get_text_message("done")])
+
+    result = await Runner.run(Agent(name="test_agent", model=model), input="first_test")
+
+    assert result.final_output == "done"
+    assert fetch_span_errors("agent") == []

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from inline_snapshot import snapshot
@@ -17,11 +17,13 @@ from agents import (
     ModelRefusalError,
     RunConfig,
     RunContextWrapper,
+    RunHooks,
     Runner,
     TResponseInputItem,
     UserError,
     _debug,
 )
+from agents.run_internal.error_handlers import attach_generic_agent_error
 from agents.tracing.span_data import AgentSpanData
 from agents.tracing.spans import SpanImpl
 
@@ -730,3 +732,87 @@ async def test_successful_run_leaves_agent_span_without_error():
 
     assert result.final_output == "done"
     assert fetch_span_errors("agent") == []
+
+
+class UnformattableError(Exception):
+    """An exception whose ``__str__`` raises, like an error with a broken custom formatter."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.str_calls = 0
+
+    def __str__(self) -> str:
+        self.str_calls += 1
+        raise RuntimeError("__str__ is broken")
+
+
+class RaisingHooks(RunHooks[Any]):
+    """Raises the given error from a run hook, i.e. from user code inside the agent span."""
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def on_agent_start(self, context: RunContextWrapper[Any], agent: Agent[Any]) -> None:
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_run_propagates_exception_whose_str_raises():
+    """Tracing must not replace the run exception when formatting it fails."""
+    error = UnformattableError()
+
+    with pytest.raises(UnformattableError) as exc_info:
+        await Runner.run(
+            Agent(name="test_agent", model=FakeModel(tracing_enabled=True)),
+            input="first_test",
+            hooks=RaisingHooks(error),
+        )
+
+    assert exc_info.value is error
+    assert fetch_span_errors("agent") == [
+        {"message": "Error in agent run", "data": {"error": "Error details are unavailable."}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_propagates_exception_whose_str_raises():
+    """The streamed path shares the helper, so it keeps the same guarantee."""
+    error = UnformattableError()
+
+    result = Runner.run_streamed(
+        Agent(name="test_agent", model=FakeModel(tracing_enabled=True)),
+        input="first_test",
+        hooks=RaisingHooks(error),
+    )
+    with pytest.raises(UnformattableError) as exc_info:
+        async for _ in result.stream_events():
+            pass
+
+    assert exc_info.value is error
+    assert fetch_span_errors("agent") == [
+        {"message": "Error in agent run", "data": {"error": "Error details are unavailable."}}
+    ]
+
+
+class RecordingSpan:
+    """The subset of the span API the generic agent-error helper uses."""
+
+    def __init__(self) -> None:
+        self.error: Any = None
+
+    def set_error(self, error: Any) -> None:
+        self.error = error
+
+
+def test_redacted_tracing_never_stringifies_the_exception():
+    """With redaction on, the detail is fixed, so the exception is never formatted at all."""
+    span = RecordingSpan()
+    error = UnformattableError()
+
+    attach_generic_agent_error(cast(Any, span), error, trace_include_sensitive_data=False)
+
+    assert error.str_calls == 0
+    assert span.error == {
+        "message": "Error in agent run",
+        "data": {"error": "Error details are redacted."},
+    }


### PR DESCRIPTION
### Summary

`Runner.run()` and `Runner.run_sync()` left the active agent span unmarked when a run failed, while `Runner.run_streamed()` attached an `Error in agent run` `SpanError`. Exported traces from non-streaming runs therefore under-reported failures, and failures raised outside a generation or function span produced a trace with no error marker anywhere.

**Affected component:** `src/agents/run.py` (non-streaming failure handler), with the shared exclusion predicate moved into `src/agents/run_internal/error_handlers.py` and reused by `src/agents/run_internal/run_loop.py`.

#### Root cause

`start_streaming()` in `run_loop.py` wraps its turn loop and outer body in `except Exception as e:` handlers that call:

```python
if current_span and _should_attach_generic_agent_error(e):
    _error_tracing.attach_error_to_span(
        current_span,
        SpanError(message="Error in agent run", data={"error": _error_tracing.get_trace_error(...)}),
    )
```

The corresponding block in `run.py` is `except BaseException as exc:`, which assigns `run_exception`, attaches `RunErrorDetails` to `AgentsException`s, and re-raises. It never touches `current_span`; the `finally` block then calls `current_span.finish(reset_current=True)` with no error recorded.

#### Parity gap between execution paths

The gap was already visible in the committed snapshots — `tests/test_tracing_errors.py::test_single_turn_model_error` had an agent span with no `error` key, while `tests/test_tracing_errors_streamed.py::test_single_turn_model_error` had `"error": {"message": "Error in agent run", "data": {"error": "test error"}}`.

I mapped the behavior of the streamed path per exception type and used it as the reference for the fix:

| Exception raised by the model | Streamed agent-span error | Non-streamed before | Non-streamed after |
|---|---|---|---|
| `ValueError` | `Error in agent run` | *(none)* | `Error in agent run` |
| `ModelRefusalError` | `Error in agent run` | *(none)* | `Error in agent run` |
| `UserError` | `Error in agent run` | *(none)* | `Error in agent run` |
| `AgentsException` | `Error in agent run` | *(none)* | `Error in agent run` |
| `ModelBehaviorError` | *(none — generation span reports it)* | *(none)* | *(none)* |
| Input/output guardrail tripwire | `Guardrail tripwire triggered` | `Guardrail tripwire triggered` | unchanged |
| `MaxTurnsExceeded` | `Max turns exceeded` | `Max turns exceeded` | unchanged |

`Runner.run_sync()` delegates to the same `AgentRunner.run()` code path, so it is fixed by the same change and is covered by its own test.

#### Behavioral change

A non-streaming run that fails now marks the active agent span with the same `SpanError` message and data shape the streamed path uses, honouring `RunConfig.trace_include_sensitive_data` through the existing `_error_tracing.get_trace_error()` helper. No new error schema is introduced.

The attach is guarded by three conditions:

```python
if (
    current_span is not None
    and current_span.error is None
    and isinstance(exc, Exception)
    and should_attach_generic_agent_error(exc)
):
```

- `current_span.error is None` — a more specific error already on the span (`Max turns exceeded`, `Guardrail tripwire triggered`) is never overwritten, and the generic error can never be applied twice. `SpanImpl.set_error()` overwrites unconditionally, so this guard is what makes both properties hold.
- `isinstance(exc, Exception)` — the handler catches `BaseException`, but `asyncio.CancelledError` is not an agent failure and the streamed path (which catches only `Exception`) never marks it.
- `should_attach_generic_agent_error(exc)` — the existing exclusion list, so `ModelBehaviorError` and guardrail tripwires keep their more specific reporting.

Everything else is untouched: the exception still propagates unchanged, `run_exception` assignment and `RunErrorDetails` attachment are unchanged, and successful runs never enter this branch.

`_should_attach_generic_agent_error` moved from `run_loop.py` into `error_handlers.py` as `should_attach_generic_agent_error` so both paths share one definition of the exclusion list rather than duplicating it. `run_loop.py` now imports it; its two call sites are otherwise unchanged.

#### Tests added

In `tests/test_tracing_errors.py`, using the repository's existing `FakeModel` and `SPAN_PROCESSOR_TESTING` / `fetch_span_errors` utilities:

- `test_run_marks_agent_span_with_generic_error` — `Runner.run()` marks the agent span, and the original `ValueError` still propagates (`pytest.raises(ValueError, match="test error")`).
- `test_run_sync_marks_agent_span_with_generic_error` — same through `Runner.run_sync()`.
- `test_run_agent_span_error_matches_streamed_path` — runs the identical failure through `Runner.run()` and `Runner.run_streamed()` and asserts both produce the same agent-span error.
- `test_run_agent_span_error_redacts_sensitive_data` — mirrors the streamed `test_streamed_agent_error_redacts_sensitive_data`; with `trace_include_sensitive_data=False` the detail is `"Error details are redacted."`.
- `test_run_does_not_mark_agent_span_for_model_behavior_error` — the excluded case stays clean.
- `test_run_marks_agent_span_for_other_agents_exceptions[model-refusal-error|user-error]` — non-excluded `AgentsException` subclasses match the streamed path.
- `test_run_keeps_specific_max_turns_agent_span_error` — a pre-existing, more specific `Max turns exceeded` error is preserved rather than overwritten.
- `test_run_attaches_agent_span_error_exactly_once` — wraps `SpanImpl.set_error` via `monkeypatch` and asserts exactly one error is recorded on the agent span.
- `test_successful_run_leaves_agent_span_without_error` — successful runs are unchanged.

All tests are deterministic: no sleeps, no concurrency, no network, and no API key.

**Snapshot changes.** Two committed inline snapshots change, both by exactly one added line on the agent span:

```python
"error": {"message": "Error in agent run", "data": {"error": "test error"}},
```

in `test_single_turn_model_error` and `test_multi_turn_no_handoffs`. Nothing else in those snapshots moves — the generation span error, agent data, tools and children are byte-identical, and the added line makes each snapshot match its streamed counterpart. I inspected both diffs and hand-applied the line in the repo's existing formatting rather than accepting the tool's rewrite, because `--inline-snapshot=fix` also reflowed several unrelated lines to a narrower width.

**Pre-fix proof.** With only the three `src/agents/` files reverted to upstream `main` and the tests in place:

```
FAILED tests/test_tracing_errors.py::test_single_turn_model_error
FAILED tests/test_tracing_errors.py::test_multi_turn_no_handoffs
FAILED tests/test_tracing_errors.py::test_run_marks_agent_span_with_generic_error
FAILED tests/test_tracing_errors.py::test_run_sync_marks_agent_span_with_generic_error
FAILED tests/test_tracing_errors.py::test_run_agent_span_error_matches_streamed_path
FAILED tests/test_tracing_errors.py::test_run_agent_span_error_redacts_sensitive_data
FAILED tests/test_tracing_errors.py::test_run_marks_agent_span_for_other_agents_exceptions[model-refusal-error]
FAILED tests/test_tracing_errors.py::test_run_marks_agent_span_for_other_agents_exceptions[user-error]
FAILED tests/test_tracing_errors.py::test_run_attaches_agent_span_error_exactly_once
9 failed, 9 passed, 2 errors
```

The three no-regression guards (`..._model_behavior_error`, `..._max_turns_agent_span_error`, `..._successful_run_...`) pass both before and after. All 18 pass with the fix.

#### Compatibility

No public API, exception type, or serialized-state change. Exported traces for failing non-streaming runs gain an agent-span error they previously lacked; consumers that assert the absence of that field would see the new value, which is the documented parity intent in `.agents/references/runner-lifecycle.md` ("Streaming and non-streaming paths must produce equivalent … guardrail results, session history, and interruption state for the same model behavior"). Successful runs are byte-identical.

**Non-goals.** The streamed path's own double-attach across its nested handlers, guardrail-span error wording, and any change to `run_exception` or `RunErrorDetails` semantics.

### Test plan

Run from the repository root on `fix/4070-nonstreaming-agent-span-error` (Python 3.12.13, macOS 15.7.3):

| Command | Result |
|---|---|
| `make format` | `842 files left unchanged`; `ruff check --fix` → `All checks passed!` |
| `make lint` | `All checks passed!` |
| `make typecheck` | mypy `Success: no issues found in 833 source files`; pyright `0 errors, 0 warnings, 0 informations` |
| `make tests` | `5968 passed, 3 skipped, 2 warnings` (parallel) and `45 passed, 4 skipped, 5971 deselected` (serial) |
| `make tests-asyncio-stability` | 5/5 runs passed |
| `git diff --check` | clean |
| `uv run pytest tests/test_tracing_errors.py tests/test_tracing_errors_streamed.py -q` | `29 passed` |
| `uv run pytest tests/test_tracing_errors.py tests/test_tracing_errors_streamed.py tests/test_agent_tracing.py tests/test_trace_processor.py tests/test_agent_runner.py tests/test_agent_runner_sync.py -q` | `274 passed` (run 5× consecutively, no flakes) |
| `UV_PROJECT_ENVIRONMENT=.venv_310 uv run --python 3.10 -m pytest tests/test_tracing_errors.py tests/test_tracing_errors_streamed.py tests/test_agent_tracing.py -q` | `55 passed` |

No OpenAI API key, network access, or paid model call was used; the tests rely on `tests/fake_model.py::FakeModel` and the in-repo `SpanProcessorForTests`.

**Not run:** `make integration-tests*` (requires live provider credentials and external services) and `make build-docs` (no documentation files changed). No lockfile or dependency changes.

### Issue number

Fixes #4070

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

> Note on the unchecked boxes: I ran the documented verification stack directly (`make format`, `make lint`, `make typecheck`, `make tests`, plus `make tests-asyncio-stability` and a Python 3.10 run) rather than through the skill script wrapper, and I did not use Codex, so `/review` does not apply.
