### PR TITLE
docs: correct the documented Chat Completions store default

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -143,7 +143,8 @@ class ModelSettings:
     store: bool | None = None
     """Whether to store the generated model response for later retrieval.
     For Responses API: automatically enabled when not specified.
-    For Chat Completions API: disabled when not specified."""
+    For Chat Completions API: enabled when not specified for the official OpenAI API, and
+    omitted for other providers so their own default applies."""
 
     prompt_cache_retention: Literal["in_memory", "24h"] | None = None
     """The retention policy for the prompt cache. Set to `24h` to enable extended


### PR DESCRIPTION
### Summary

`ModelSettings.store` documents that Chat Completions leaves storage disabled when the setting is
not specified. It does the opposite: `ChatCmplHelpers.get_store_param` defaults to `True` for the
official OpenAI client, so the request sends `store=True`, and for other providers it leaves the
parameter unset rather than disabling it.

- `src/agents/models/chatcmpl_helpers.py`: `default_store = True if cls.is_openai(client) else None`
- `src/agents/models/openai_chatcompletions.py`: the resolved value is passed straight through as
  `"store"` on the create call
- `tests/models/test_openai_chatcompletions.py`: the existing assertions expect `True` for the
  official client and `None` for a custom `base_url`

#3103 reported the same mismatch and the Chat Completions behavior was confirmed correct there, so
the docstring is the part that is out of date. This updates the docstring to match; no behavior
changes.

### Test plan

Docstring-only change, no code paths touched. The new wording matches what `get_store_param`
returns and what the existing `store` assertions in `tests/models/test_openai_chatcompletions.py`
already cover.

### Issue number

N/A (related: #3103)
