### PR TITLE
fix(tracing): attach errors to non-streaming agent spans

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -84,6 +84,7 @@ from .run_internal.oai_conversation import OpenAIServerConversationTracker
 from .run_internal.prompt_cache_key import PromptCacheKeyResolver
 from .run_internal.run_grouping import resolve_run_grouping_id
 from .run_internal.run_loop import (
+    _should_attach_generic_agent_error,
     cleanup_models_after_run,
     get_all_tools,
     get_handoffs,
@@ -1587,6 +1588,26 @@ class AgentRunner:
                         turn_result.new_step_items.clear()
             except BaseException as exc:
                 run_exception = exc
+                if (
+                    current_span
+                    and isinstance(exc, Exception)
+                    and not isinstance(exc, MaxTurnsExceeded)
+                    and _should_attach_generic_agent_error(exc)
+                ):
+                    _error_tracing.attach_error_to_span(
+                        current_span,
+                        SpanError(
+                            message="Error in agent run",
+                            data={
+                                "error": _error_tracing.get_trace_error(
+                                    trace_include_sensitive_data=(
+                                        run_config.trace_include_sensitive_data
+                                    ),
+                                    error_message=str(exc),
+                                )
+                            },
+                        ),
+                    )
                 if isinstance(exc, AgentsException):
                     exc.run_data = RunErrorDetails(
                         input=original_input,

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -55,6 +55,47 @@ async def test_single_turn_model_error():
                             "tools": [],
                             "output_type": "str",
                         },
+                        "error": {"message": "Error in agent run", "data": {"error": "test error"}},
+                        "children": [
+                            {
+                                "type": "generation",
+                                "error": {
+                                    "message": "Error",
+                                    "data": {"name": "ValueError", "message": "test error"},
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+
+
+def test_run_sync_attaches_generic_error_to_agent_span():
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output(ValueError("test error"))
+
+    with pytest.raises(ValueError):
+        Runner.run_sync(Agent(name="test_agent", model=model), input="first_test")
+
+    assert fetch_normalized_spans() == snapshot(
+        [
+            {
+                "workflow_name": "Agent workflow",
+                "children": [
+                    {
+                        "type": "agent",
+                        "error": {
+                            "message": "Error in agent run",
+                            "data": {"error": "test error"},
+                        },
+                        "data": {
+                            "name": "test_agent",
+                            "handoffs": [],
+                            "tools": [],
+                            "output_type": "str",
+                        },
                         "children": [
                             {
                                 "type": "generation",
@@ -102,6 +143,10 @@ async def test_multi_turn_no_handoffs():
                 "children": [
                     {
                         "type": "agent",
+                        "error": {
+                            "message": "Error in agent run",
+                            "data": {"error": "test error"},
+                        },
                         "data": {
                             "name": "test_agent",
                             "handoffs": [],


### PR DESCRIPTION
## Summary
- attach generic run errors to the active agent span in non-streaming runs
- keep max-turn and guardrail-specific span behavior unchanged
- add async and sync regression coverage

Closes #4070

## Validation
- `uv run pytest tests/test_tracing_errors.py tests/test_tracing_errors_streamed.py -q` (20 passed)
- `make format`
- `make lint`
- `make typecheck` (blocked by existing optional-dependency/type issues in sandbox, LiteLLM, NumPy, SQLAlchemy, and AnyLLM modules)

## AI Usage
AI assistance was used to inspect the issue, propose the focused change, and review the patch. The final implementation and validation were performed in this checkout.
