### PR TITLE
Report completed input guardrail results when a tripwire aborts a run

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -807,8 +807,10 @@ class AgentRunner:
                                 sequential_guardrails,
                                 copy_input_items(original_input),
                                 context_wrapper,
+                                results_out=sequential_results,
                             )
                         except InputGuardrailTripwireTriggered:
+                            input_guardrail_results.extend(sequential_results)
                             session_input_items_for_persistence = (
                                 await persist_session_items_for_guardrail_trip(
                                     session,
@@ -1226,8 +1228,10 @@ class AgentRunner:
                                         sequential_guardrails,
                                         copy_input_items(original_input),
                                         context_wrapper,
+                                        results_out=sequential_results,
                                     )
                             except InputGuardrailTripwireTriggered:
+                                input_guardrail_results.extend(sequential_results)
                                 session_input_items_for_persistence = (
                                     await persist_session_items_for_guardrail_trip(
                                         session,
@@ -1272,6 +1276,7 @@ class AgentRunner:
                                         parallel_guardrails,
                                         copy_input_items(original_input),
                                         context_wrapper,
+                                        results_out=parallel_results,
                                     )
                                 )
                                 try:
@@ -1280,6 +1285,8 @@ class AgentRunner:
                                         model_task,
                                     )
                                 except InputGuardrailTripwireTriggered:
+                                    input_guardrail_results.extend(sequential_results)
+                                    input_guardrail_results.extend(parallel_results)
                                     if should_cancel_parallel_model_task_on_input_guardrail_trip():
                                         if not model_task.done():
                                             model_task.cancel()

--- a/src/agents/run_internal/guardrails.py
+++ b/src/agents/run_internal/guardrails.py
@@ -121,21 +121,31 @@ async def run_input_guardrails(
     guardrails: list[InputGuardrail[TContext]],
     input: str | list[TResponseInputItem],
     context: RunContextWrapper[TContext],
+    results_out: list[InputGuardrailResult] | None = None,
 ) -> list[InputGuardrailResult]:
-    """Run input guardrails concurrently and raise on tripwires."""
+    """Run input guardrails concurrently and raise on tripwires.
+
+    A tripwire aborts the run before this function returns, so the return value is only
+    available on the success path. Callers that also need the results on the error path
+    pass ``results_out``, which records every result as its guardrail completes,
+    including the one that trips.
+    """
+    guardrail_results: list[InputGuardrailResult] = results_out if results_out is not None else []
+
     if not guardrails:
-        return []
+        return guardrail_results
 
     guardrail_tasks = [
         asyncio.create_task(run_single_input_guardrail(agent, guardrail, input, context))
         for guardrail in guardrails
     ]
 
-    guardrail_results: list[InputGuardrailResult] = []
-
     try:
         for done in asyncio.as_completed(guardrail_tasks):
             result = await done
+            # Record before the tripwire check so a trip still reports every guardrail that
+            # completed, matching what run_input_guardrails_with_queue exposes to streamed runs.
+            guardrail_results.append(result)
             if result.output.tripwire_triggered:
                 for t in guardrail_tasks:
                     t.cancel()
@@ -147,7 +157,6 @@ async def run_input_guardrails(
                     )
                 )
                 raise InputGuardrailTripwireTriggered(result)
-            guardrail_results.append(result)
     except BaseException:
         # On any error (including a guardrail raising or the caller being cancelled),
         # cancel and await siblings so they don't leak past this function's return.

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1886,6 +1886,88 @@ async def test_input_guardrail_tripwire_triggered_causes_exception():
         await Runner.run(agent, input="user_message")
 
 
+def _named_input_guardrail(
+    name: str, triggered: bool, run_in_parallel: bool, delay: float = 0.0
+) -> InputGuardrail[Any]:
+    async def guardrail_function(
+        context: RunContextWrapper[Any], agent: Agent[Any], input: Any
+    ) -> GuardrailFunctionOutput:
+        if delay:
+            await asyncio.sleep(delay)
+        return GuardrailFunctionOutput(output_info=name, tripwire_triggered=triggered)
+
+    return InputGuardrail(
+        guardrail_function=guardrail_function, name=name, run_in_parallel=run_in_parallel
+    )
+
+
+def _tripping_agent(model: FakeModel, run_in_parallel: bool) -> Agent[Any]:
+    return Agent(
+        name="test",
+        model=model,
+        input_guardrails=[
+            _named_input_guardrail("passes", triggered=False, run_in_parallel=run_in_parallel),
+            # Delay the tripwire so the passing guardrail is guaranteed to complete first.
+            _named_input_guardrail(
+                "trips", triggered=True, run_in_parallel=run_in_parallel, delay=0.01
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_in_parallel", [True, False])
+async def test_input_guardrail_tripwire_reports_completed_results(run_in_parallel: bool):
+    """A tripwire must still report every input guardrail that already completed.
+
+    The guardrail results are observable run state, so aborting the run must not discard the
+    results of the guardrails that finished before the tripwire fired.
+    """
+    model = FakeModel()
+    model.set_next_output([get_text_message("user_message")])
+
+    with pytest.raises(InputGuardrailTripwireTriggered) as exc_info:
+        await Runner.run(_tripping_agent(model, run_in_parallel), input="user_message")
+
+    run_data = exc_info.value.run_data
+    assert run_data is not None
+    assert [result.guardrail.get_name() for result in run_data.input_guardrail_results] == [
+        "passes",
+        "trips",
+    ]
+    assert [result.output.output_info for result in run_data.input_guardrail_results] == [
+        "passes",
+        "trips",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_in_parallel", [True, False])
+async def test_input_guardrail_tripwire_results_match_streamed_run(run_in_parallel: bool):
+    """Runner.run() and Runner.run_streamed() must report the same guardrail results."""
+    non_streamed_model = FakeModel()
+    non_streamed_model.set_next_output([get_text_message("user_message")])
+    with pytest.raises(InputGuardrailTripwireTriggered) as non_streamed_exc:
+        await Runner.run(_tripping_agent(non_streamed_model, run_in_parallel), input="user_message")
+
+    streamed_model = FakeModel()
+    streamed_model.set_next_output([get_text_message("user_message")])
+    streamed = Runner.run_streamed(
+        _tripping_agent(streamed_model, run_in_parallel), input="user_message"
+    )
+    with pytest.raises(InputGuardrailTripwireTriggered) as streamed_exc:
+        async for _ in streamed.stream_events():
+            pass
+
+    non_streamed_data = non_streamed_exc.value.run_data
+    streamed_data = streamed_exc.value.run_data
+    assert non_streamed_data is not None
+    assert streamed_data is not None
+    assert [
+        result.guardrail.get_name() for result in non_streamed_data.input_guardrail_results
+    ] == [result.guardrail.get_name() for result in streamed_data.input_guardrail_results]
+
+
 @pytest.mark.asyncio
 async def test_input_guardrail_tripwire_does_not_save_assistant_message_to_session():
     async def guardrail_function(


### PR DESCRIPTION
### Summary

When an input guardrail tripwire fires, `InputGuardrailTripwireTriggered.run_data.input_guardrail_results` is empty for `Runner.run()` / `Runner.run_sync()`, while `Runner.run_streamed()` correctly reports every guardrail that completed.

`run_input_guardrails()` accumulated its results in a local list and raised `InputGuardrailTripwireTriggered` as soon as a tripwire fired, discarding that list. `run.py` only merged the results into the run-level `input_guardrail_results` on the success path (`input_guardrail_results.extend(sequential_results)`), so the `RunErrorDetails` attached to the exception was built from an empty list. The streamed path uses `run_input_guardrails_with_queue()`, which assigns `streamed_result.input_guardrail_results` before propagating the tripwire, hence the asymmetry.

Callers could therefore not read the `output_info` of the guardrails that ran — including the ones that passed — from the raised exception. `exc.guardrail_result` still exposed the single tripping result, so what was lost is specifically the full run-state view.

This contradicts two rules in `.agents/references/runner-lifecycle.md`: *"Guardrail results are observable run state. Preserve them across handoffs, error handlers, streamed completion, and `RunState` round-trips"* and *"Streaming and non-streaming paths must produce equivalent final output, generated items, current agent, usage, guardrail results, session history, and interruption state for the same model behavior."*

**Change:** `run_input_guardrails()` takes an optional `results_out` accumulator and records each result as its guardrail completes — before the tripwire check, mirroring what `run_input_guardrails_with_queue()` already does — so the tripping result and every earlier one survive the raise. The three call sites in `run.py` pass their existing staging lists and merge them into `input_guardrail_results` on the tripwire paths.

Scope notes:

- The success path is unchanged: results are still merged by the existing `extend` calls, in the same order.
- No public API change. `results_out` is an optional keyword-only-by-convention parameter appended to the end of an internal `run_internal` helper; the exception type and its fields are untouched.
- Only the `InputGuardrailTripwireTriggered` paths merge early. Non-tripwire failures are left as they are, since they are outside the reported problem.

### Test plan

Four new tests in `tests/test_agent_runner.py`, parametrized over `run_in_parallel=True` and `run_in_parallel=False` so both the parallel and sequential guardrail paths are covered, per *"Test guardrail tripwires and exceptions in sequential and parallel modes when relevant."*

- `test_input_guardrail_tripwire_reports_completed_results` — asserts the raised exception reports both the passing and the tripping guardrail, by name and by `output_info`.
- `test_input_guardrail_tripwire_results_match_streamed_run` — asserts `Runner.run()` and `Runner.run_streamed()` report the identical set, locking in the streaming/non-streaming parity rule.

Both use the existing `FakeModel`, so no API key, network access or model call is involved. I confirmed the tests are not vacuous: with the `src/` changes stashed, all four fail (`assert [] == ['passes', 'trips']`); with the fix applied, all four pass.

Full verification stack via `.agents/skills/code-change-verification/scripts/run.sh`:

- `make lint` — all checks passed
- `make typecheck` — mypy: no issues in 833 source files; pyright: 0 errors, 0 warnings
- `make tests` — 5961 passed, 4 skipped

### Issue number

Closes #4068

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
