### PR TITLE
fix(voice): cancel producer tasks when the stream consumer stops early

### DIFF
--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -319,28 +319,31 @@ class StreamedAudioResult:
     async def stream(self) -> AsyncIterator[VoiceStreamEvent]:
         """Stream the events and audio data as they're generated."""
         saw_session_end = False
-        while True:
-            try:
-                event = await self._queue.get()
-            except asyncio.CancelledError:
-                await self._cleanup_tasks()
-                raise
-            if isinstance(event, VoiceStreamEventError):
-                self._stored_exception = event.error
-                log_model_and_tool_action_error(
-                    logger, "Error processing voice output", event.error
-                )
-                break
-            if event is None:
-                break
-            yield event
-            if event.type == "voice_stream_event_lifecycle" and event.event == "session_ended":
-                saw_session_end = True
-                break
-
-        # On the normal completion path, let the producer task finish gracefully so any active
-        # trace context can emit `trace_end` before we run cleanup.
+        # The whole body sits under `finally` so a consumer that stops early -- `break` out of
+        # the `async for`, or an explicit `aclose()` -- still gets the producer tasks
+        # cancelled. Without it `GeneratorExit` arrives at the `yield` below and unwinds past
+        # the cleanup, leaving those tasks running.
         try:
+            while True:
+                try:
+                    event = await self._queue.get()
+                except asyncio.CancelledError:
+                    raise
+                if isinstance(event, VoiceStreamEventError):
+                    self._stored_exception = event.error
+                    log_model_and_tool_action_error(
+                        logger, "Error processing voice output", event.error
+                    )
+                    break
+                if event is None:
+                    break
+                yield event
+                if event.type == "voice_stream_event_lifecycle" and event.event == "session_ended":
+                    saw_session_end = True
+                    break
+
+            # On the normal completion path, let the producer task finish gracefully so any
+            # active trace context can emit `trace_end` before we run cleanup.
             if (
                 saw_session_end
                 and self.text_generation_task is not None

--- a/tests/voice/test_result_cleanup.py
+++ b/tests/voice/test_result_cleanup.py
@@ -1,0 +1,70 @@
+"""A consumer that stops early must still get the producer tasks cancelled."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agents.voice.result import StreamedAudioResult
+
+
+def _make_result() -> StreamedAudioResult:
+    result = StreamedAudioResult.__new__(StreamedAudioResult)
+    result._queue = asyncio.Queue()  # type: ignore[attr-defined]
+    result._tasks = []  # type: ignore[attr-defined]
+    result._dispatcher_task = None  # type: ignore[attr-defined]
+    result.text_generation_task = None  # type: ignore[attr-defined]
+    result._stored_exception = None  # type: ignore[attr-defined]
+    result._done_processing = False  # type: ignore[attr-defined]
+    result._buffer = []  # type: ignore[attr-defined]
+    result._playing = False  # type: ignore[attr-defined]
+    result._tracing_span = None  # type: ignore[attr-defined]
+    result._ordered_done = False  # type: ignore[attr-defined]
+    return result
+
+
+@pytest.mark.asyncio
+async def test_early_break_cancels_producer_tasks() -> None:
+    """`break` out of the stream leaves nothing running."""
+    result = _make_result()
+    started = asyncio.Event()
+
+    async def producer() -> None:
+        started.set()
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(producer())
+    result._tasks.append(task)  # type: ignore[attr-defined]
+    await started.wait()
+
+    from agents.voice.events import VoiceStreamEventLifecycle
+
+    await result._queue.put(VoiceStreamEventLifecycle(event="turn_started"))  # type: ignore[attr-defined]
+
+    stream = result.stream()
+    async for _event in stream:
+        break
+    await stream.aclose()
+
+    await asyncio.sleep(0)
+    assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_normal_exhaustion_still_cleans_up() -> None:
+    """The existing path is unchanged: `None` ends the stream and cleanup runs."""
+    result = _make_result()
+
+    async def producer() -> None:
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(producer())
+    result._tasks.append(task)  # type: ignore[attr-defined]
+
+    await result._queue.put(None)  # type: ignore[attr-defined]
+
+    events = [event async for event in result.stream()]
+
+    assert events == []
+    assert task.cancelled() or task.done()


### PR DESCRIPTION
Addresses the `StreamedAudioResult.stream()` half of #4051.

## What

`stream()` calls `_cleanup_tasks()` only after the yield loop has finished. When a consumer stops early — `break` out of the `async for`, or an explicit `aclose()` — `GeneratorExit` is delivered at the `yield` and unwinds straight past that block, so the producer tasks are never cancelled.

The pattern in isolation:

```
try/finally YOK    -> ['temizlik KOSMADI']
try/finally VAR    -> ['temizlik KOSTU']
```

The existing `try/except asyncio.CancelledError` only wraps `await self._queue.get()`, so it covers cancellation that lands while waiting on the queue, not finalization that lands at the yield.

## How

The body is wrapped in `try/finally` with `await self._cleanup_tasks()` in the `finally`. The `CancelledError` branch no longer calls `_cleanup_tasks()` itself — the `finally` covers that path now, so cleanup runs exactly once either way. No behaviour changes on the normal path: the `session_ended` shield and `_check_errors()` still run before cleanup, and `_stored_exception` is still raised after it.

## Tests

`tests/voice/test_result_cleanup.py`, two cases:

- `test_early_break_cancels_producer_tasks` — one long-running producer task registered, one event queued, consumer breaks after the first event and calls `aclose()`. Asserts the task ends up cancelled. **Fails on `main`, passes with this change.**
- `test_normal_exhaustion_still_cleans_up` — the pre-existing path, `None` ends the stream, cleanup still runs. Passes both ways; it's there so the normal path can't regress.

`tests/voice/` is at 64 passed with the change. `test_workflow.py` doesn't collect in my environment because `inline_snapshot` isn't installed, which is unrelated and identical on a clean checkout. `ruff check` and `ruff format --check` are clean on both files.

## Not covered here

#4051 also lists `OpenAIRealtimeTranscriptionSession.transcribe_turns()` in `openai_stt.py`, which has the same shape — cleanup after the loop, `yield turn` unguarded. I left it out to keep this reviewable; happy to do it in the same PR or a follow-up, whichever you prefer.

The issue's second point — that cleanup calls `task.cancel()` without awaiting the tasks — is already handled here for `result.py`: `_cleanup_tasks()` does `await asyncio.gather(*tasks, return_exceptions=True)` after cancelling.
