### PR TITLE
feat: implement auto-pagination for MCP server list operations and address review feedback

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1127,27 +1127,36 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 # Fetch the tools from the server
                 all_tools = []
                 cursor = None
-                seen_cursors = set()
+                seen_cursors: set[str | None] = set()
                 while True:
                     if cursor in seen_cursors:
                         logger.warning(
-                            "MCP server %s returned repeated cursor %s during list_tools. "
+                            "MCP server %s returned repeated cursor during list_tools. "
                             "Breaking to prevent infinite loop.",
                             self._error_name,
-                            cursor,
                         )
                         break
                     seen_cursors.add(cursor)
-                    _cursor = cursor
-                    result = await self._run_with_retries(
-                        lambda c=_cursor: self._maybe_serialize_request(
-                            lambda: session.list_tools(cursor=c)
+                    _cursor: str | None = cursor
+
+                    async def fetch_tools_page(page_cursor: str | None = _cursor) -> Any:
+                        return await self._maybe_serialize_request(
+                            lambda: session.list_tools(cursor=page_cursor)
                         )
-                    )
-                    all_tools.extend(result.tools)
-                    if not result.nextCursor:
+
+                    result = await self._run_with_retries(fetch_tools_page)
+                    next_cursor = result.nextCursor
+                    if next_cursor is not None and next_cursor in seen_cursors:
+                        logger.warning(
+                            "MCP server %s returned repeated cursor during list_tools. "
+                            "Breaking to prevent infinite loop.",
+                            self._error_name,
+                        )
                         break
-                    cursor = result.nextCursor
+                    all_tools.extend(result.tools)
+                    if next_cursor is None:
+                        break
+                    cursor = next_cursor
                 self._tools_list = all_tools
                 self._cache_dirty = False
                 tools = self._tools_list
@@ -1287,29 +1296,52 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         assert session is not None
         all_prompts = []
         cursor = None
-        seen_cursors = set()
+        seen_cursors: set[str | None] = set()
+        first_result: ListPromptsResult | None = None
+        combined_meta: dict[str, Any] = {}
         while True:
             if cursor in seen_cursors:
                 logger.warning(
-                    "MCP server %s returned repeated cursor %s during list_prompts. "
+                    "MCP server %s returned repeated cursor during list_prompts. "
                     "Breaking to prevent infinite loop.",
                     self._error_name,
-                    cursor,
                 )
                 break
             seen_cursors.add(cursor)
-            _cursor = cursor
+            _cursor: str | None = cursor
+
+            async def fetch_prompts_page(page_cursor: str | None = _cursor) -> ListPromptsResult:
+                return await self._maybe_serialize_request(
+                    lambda: session.list_prompts(cursor=page_cursor)
+                )
+
             result = await self._run_request_with_transport_error_redaction(
-                "list prompts",
-                lambda c=_cursor: self._maybe_serialize_request(
-                    lambda: session.list_prompts(cursor=c)
-                ),
+                "list prompts", fetch_prompts_page
             )
-            all_prompts.extend(result.prompts)
-            if not result.nextCursor:
+            next_cursor = result.nextCursor
+            if next_cursor is not None and next_cursor in seen_cursors:
+                logger.warning(
+                    "MCP server %s returned repeated cursor during list_prompts. "
+                    "Breaking to prevent infinite loop.",
+                    self._error_name,
+                )
                 break
-            cursor = result.nextCursor
-        return ListPromptsResult(prompts=all_prompts, nextCursor=None)
+            if first_result is None:
+                first_result = result
+            all_prompts.extend(result.prompts)
+            if result.meta:
+                combined_meta.update(result.meta)
+            if next_cursor is None:
+                break
+            cursor = next_cursor
+        assert first_result is not None
+        return first_result.model_copy(
+            update={
+                "prompts": all_prompts,
+                "nextCursor": None,
+                "meta": combined_meta or None,
+            }
+        )
 
     async def get_prompt(
         self, name: str, arguments: dict[str, Any] | None = None
@@ -1330,31 +1362,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
         session = self.session
         assert session is not None
-        all_resources = []
-        current_cursor = cursor
-        seen_cursors = set()
-        while True:
-            if current_cursor in seen_cursors:
-                logger.warning(
-                    "MCP server %s returned repeated cursor %s during list_resources. "
-                    "Breaking to prevent infinite loop.",
-                    self._error_name,
-                    current_cursor,
-                )
-                break
-            seen_cursors.add(current_cursor)
-            _cursor = current_cursor
-            result = await self._run_request_with_transport_error_redaction(
-                "list resources",
-                lambda c=_cursor: self._maybe_serialize_request(
-                    lambda: session.list_resources(cursor=c)
-                ),
-            )
-            all_resources.extend(result.resources)
-            if not result.nextCursor:
-                break
-            current_cursor = result.nextCursor
-        return ListResourcesResult(resources=all_resources, nextCursor=None)
+        return await self._run_request_with_transport_error_redaction(
+            "list resources",
+            lambda: self._maybe_serialize_request(lambda: session.list_resources(cursor)),
+        )
 
     async def list_resource_templates(
         self, cursor: str | None = None
@@ -1364,31 +1375,10 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
         session = self.session
         assert session is not None
-        all_templates = []
-        current_cursor = cursor
-        seen_cursors = set()
-        while True:
-            if current_cursor in seen_cursors:
-                logger.warning(
-                    "MCP server %s returned repeated cursor %s during list_resource_templates. "
-                    "Breaking to prevent infinite loop.",
-                    self._error_name,
-                    current_cursor,
-                )
-                break
-            seen_cursors.add(current_cursor)
-            _cursor = current_cursor
-            result = await self._run_request_with_transport_error_redaction(
-                "list resource templates",
-                lambda c=_cursor: self._maybe_serialize_request(
-                    lambda: session.list_resource_templates(cursor=c)
-                ),
-            )
-            all_templates.extend(result.resourceTemplates)
-            if not result.nextCursor:
-                break
-            current_cursor = result.nextCursor
-        return ListResourceTemplatesResult(resourceTemplates=all_templates, nextCursor=None)
+        return await self._run_request_with_transport_error_redaction(
+            "list resource templates",
+            lambda: self._maybe_serialize_request(lambda: session.list_resource_templates(cursor)),
+        )
 
     async def read_resource(self, uri: str) -> ReadResourceResult:
         """Read the contents of a specific resource by URI.

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1125,10 +1125,30 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 tools = self._tools_list
             else:
                 # Fetch the tools from the server
-                result = await self._run_with_retries(
-                    lambda: self._maybe_serialize_request(lambda: session.list_tools())
-                )
-                self._tools_list = result.tools
+                all_tools = []
+                cursor = None
+                seen_cursors = set()
+                while True:
+                    if cursor in seen_cursors:
+                        logger.warning(
+                            "MCP server %s returned repeated cursor %s during list_tools. "
+                            "Breaking to prevent infinite loop.",
+                            self._error_name,
+                            cursor,
+                        )
+                        break
+                    seen_cursors.add(cursor)
+                    _cursor = cursor
+                    result = await self._run_with_retries(
+                        lambda c=_cursor: self._maybe_serialize_request(
+                            lambda: session.list_tools(cursor=c)
+                        )
+                    )
+                    all_tools.extend(result.tools)
+                    if not result.nextCursor:
+                        break
+                    cursor = result.nextCursor
+                self._tools_list = all_tools
                 self._cache_dirty = False
                 tools = self._tools_list
 
@@ -1265,10 +1285,31 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
         session = self.session
         assert session is not None
-        return await self._run_request_with_transport_error_redaction(
-            "list prompts",
-            lambda: self._maybe_serialize_request(lambda: session.list_prompts()),
-        )
+        all_prompts = []
+        cursor = None
+        seen_cursors = set()
+        while True:
+            if cursor in seen_cursors:
+                logger.warning(
+                    "MCP server %s returned repeated cursor %s during list_prompts. "
+                    "Breaking to prevent infinite loop.",
+                    self._error_name,
+                    cursor,
+                )
+                break
+            seen_cursors.add(cursor)
+            _cursor = cursor
+            result = await self._run_request_with_transport_error_redaction(
+                "list prompts",
+                lambda c=_cursor: self._maybe_serialize_request(
+                    lambda: session.list_prompts(cursor=c)
+                ),
+            )
+            all_prompts.extend(result.prompts)
+            if not result.nextCursor:
+                break
+            cursor = result.nextCursor
+        return ListPromptsResult(prompts=all_prompts, nextCursor=None)
 
     async def get_prompt(
         self, name: str, arguments: dict[str, Any] | None = None
@@ -1289,10 +1330,31 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
         session = self.session
         assert session is not None
-        return await self._run_request_with_transport_error_redaction(
-            "list resources",
-            lambda: self._maybe_serialize_request(lambda: session.list_resources(cursor)),
-        )
+        all_resources = []
+        current_cursor = cursor
+        seen_cursors = set()
+        while True:
+            if current_cursor in seen_cursors:
+                logger.warning(
+                    "MCP server %s returned repeated cursor %s during list_resources. "
+                    "Breaking to prevent infinite loop.",
+                    self._error_name,
+                    current_cursor,
+                )
+                break
+            seen_cursors.add(current_cursor)
+            _cursor = current_cursor
+            result = await self._run_request_with_transport_error_redaction(
+                "list resources",
+                lambda c=_cursor: self._maybe_serialize_request(
+                    lambda: session.list_resources(cursor=c)
+                ),
+            )
+            all_resources.extend(result.resources)
+            if not result.nextCursor:
+                break
+            current_cursor = result.nextCursor
+        return ListResourcesResult(resources=all_resources, nextCursor=None)
 
     async def list_resource_templates(
         self, cursor: str | None = None
@@ -1302,10 +1364,31 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
         session = self.session
         assert session is not None
-        return await self._run_request_with_transport_error_redaction(
-            "list resource templates",
-            lambda: self._maybe_serialize_request(lambda: session.list_resource_templates(cursor)),
-        )
+        all_templates = []
+        current_cursor = cursor
+        seen_cursors = set()
+        while True:
+            if current_cursor in seen_cursors:
+                logger.warning(
+                    "MCP server %s returned repeated cursor %s during list_resource_templates. "
+                    "Breaking to prevent infinite loop.",
+                    self._error_name,
+                    current_cursor,
+                )
+                break
+            seen_cursors.add(current_cursor)
+            _cursor = current_cursor
+            result = await self._run_request_with_transport_error_redaction(
+                "list resource templates",
+                lambda c=_cursor: self._maybe_serialize_request(
+                    lambda: session.list_resource_templates(cursor=c)
+                ),
+            )
+            all_templates.extend(result.resourceTemplates)
+            if not result.nextCursor:
+                break
+            current_cursor = result.nextCursor
+        return ListResourceTemplatesResult(resourceTemplates=all_templates, nextCursor=None)
 
     async def read_resource(self, uri: str) -> ReadResourceResult:
         """Read the contents of a specific resource by URI.

--- a/tests/mcp/test_mcp_resources.py
+++ b/tests/mcp/test_mcp_resources.py
@@ -62,8 +62,8 @@ async def test_list_resources_returns_result(server: MCPServerStreamableHttp):
 
     result = await server.list_resources()
 
-    assert result.resources == expected.resources
-    mock_session.list_resources.assert_awaited_once_with(cursor=None)
+    assert result is expected
+    mock_session.list_resources.assert_awaited_once_with(None)
 
 
 @pytest.mark.asyncio
@@ -76,8 +76,8 @@ async def test_list_resources_forwards_cursor(server: MCPServerStreamableHttp):
 
     result = await server.list_resources(cursor="tok_abc")
 
-    assert result.resources == page2.resources
-    mock_session.list_resources.assert_awaited_once_with(cursor="tok_abc")
+    assert result is page2
+    mock_session.list_resources.assert_awaited_once_with("tok_abc")
 
 
 @pytest.mark.asyncio
@@ -94,8 +94,8 @@ async def test_list_resource_templates_returns_result(server: MCPServerStreamabl
 
     result = await server.list_resource_templates()
 
-    assert result.resourceTemplates == expected.resourceTemplates
-    mock_session.list_resource_templates.assert_awaited_once_with(cursor=None)
+    assert result is expected
+    mock_session.list_resource_templates.assert_awaited_once_with(None)
 
 
 @pytest.mark.asyncio
@@ -108,8 +108,8 @@ async def test_list_resource_templates_forwards_cursor(server: MCPServerStreamab
 
     result = await server.list_resource_templates(cursor="tok_xyz")
 
-    assert result.resourceTemplates == page2.resourceTemplates
-    mock_session.list_resource_templates.assert_awaited_once_with(cursor="tok_xyz")
+    assert result is page2
+    mock_session.list_resource_templates.assert_awaited_once_with("tok_xyz")
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_mcp_resources.py
+++ b/tests/mcp/test_mcp_resources.py
@@ -62,8 +62,8 @@ async def test_list_resources_returns_result(server: MCPServerStreamableHttp):
 
     result = await server.list_resources()
 
-    assert result is expected
-    mock_session.list_resources.assert_awaited_once_with(None)
+    assert result.resources == expected.resources
+    mock_session.list_resources.assert_awaited_once_with(cursor=None)
 
 
 @pytest.mark.asyncio
@@ -76,8 +76,8 @@ async def test_list_resources_forwards_cursor(server: MCPServerStreamableHttp):
 
     result = await server.list_resources(cursor="tok_abc")
 
-    assert result is page2
-    mock_session.list_resources.assert_awaited_once_with("tok_abc")
+    assert result.resources == page2.resources
+    mock_session.list_resources.assert_awaited_once_with(cursor="tok_abc")
 
 
 @pytest.mark.asyncio
@@ -94,8 +94,8 @@ async def test_list_resource_templates_returns_result(server: MCPServerStreamabl
 
     result = await server.list_resource_templates()
 
-    assert result is expected
-    mock_session.list_resource_templates.assert_awaited_once_with(None)
+    assert result.resourceTemplates == expected.resourceTemplates
+    mock_session.list_resource_templates.assert_awaited_once_with(cursor=None)
 
 
 @pytest.mark.asyncio
@@ -108,8 +108,8 @@ async def test_list_resource_templates_forwards_cursor(server: MCPServerStreamab
 
     result = await server.list_resource_templates(cursor="tok_xyz")
 
-    assert result is page2
-    mock_session.list_resource_templates.assert_awaited_once_with("tok_xyz")
+    assert result.resourceTemplates == page2.resourceTemplates
+    mock_session.list_resource_templates.assert_awaited_once_with(cursor="tok_xyz")
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_pagination.py
+++ b/tests/mcp/test_pagination.py
@@ -1,0 +1,88 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.types import (
+    AnyUrl,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListResourceTemplatesResult,
+    ListToolsResult,
+    Prompt,
+    Resource,
+    ResourceTemplate,
+    Tool,
+)
+
+from agents.mcp.server import MCPServerStreamableHttp
+
+
+@pytest.fixture
+def server():
+    return MCPServerStreamableHttp({"url": "http://localhost"})
+
+
+@pytest.mark.asyncio
+async def test_list_tools_pagination_and_loop_guard(server: MCPServerStreamableHttp):
+    mock_session = MagicMock()
+    page1 = ListToolsResult(
+        tools=[
+            Tool(name="tool_1", description="", inputSchema={"type": "object", "properties": {}})
+        ],
+        nextCursor="tok_loop",
+    )
+    # The session repeatedly returns the same cursor
+    mock_session.list_tools = AsyncMock(return_value=page1)
+    server.session = mock_session
+
+    result = await server.list_tools()
+
+    # The result should contain the tool twice because the loop breaks on the second identical fetch
+    assert len(result) == 2
+    assert result[0].name == "tool_1"
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_pagination_and_loop_guard(server: MCPServerStreamableHttp):
+    mock_session = MagicMock()
+    page1 = ListPromptsResult(
+        prompts=[Prompt(name="prompt_1", description="")], nextCursor="tok_loop"
+    )
+    mock_session.list_prompts = AsyncMock(return_value=page1)
+    server.session = mock_session
+
+    result = await server.list_prompts()
+
+    assert len(result.prompts) == 2
+    assert result.prompts[0].name == "prompt_1"
+
+
+@pytest.mark.asyncio
+async def test_list_resources_pagination_and_loop_guard(server: MCPServerStreamableHttp):
+    mock_session = MagicMock()
+    page1 = ListResourcesResult(
+        resources=[Resource(uri=AnyUrl("file:///1"), name="res_1", mimeType="text/plain")],
+        nextCursor="tok_loop",
+    )
+    mock_session.list_resources = AsyncMock(return_value=page1)
+    server.session = mock_session
+
+    result = await server.list_resources()
+
+    assert len(result.resources) == 2
+    assert result.resources[0].name == "res_1"
+
+
+@pytest.mark.asyncio
+async def test_list_resource_templates_pagination_and_loop_guard(server: MCPServerStreamableHttp):
+    mock_session = MagicMock()
+    page1 = ListResourceTemplatesResult(
+        resourceTemplates=[ResourceTemplate(uriTemplate="file:///{path}", name="temp_1")],
+        nextCursor="tok_loop",
+    )
+    mock_session.list_resource_templates = AsyncMock(return_value=page1)
+    server.session = mock_session
+
+    result = await server.list_resource_templates()
+
+    assert len(result.resourceTemplates) == 2
+    assert result.resourceTemplates[0].name == "temp_1"

--- a/tests/mcp/test_pagination.py
+++ b/tests/mcp/test_pagination.py
@@ -1,17 +1,7 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
-from mcp.types import (
-    AnyUrl,
-    ListPromptsResult,
-    ListResourcesResult,
-    ListResourceTemplatesResult,
-    ListToolsResult,
-    Prompt,
-    Resource,
-    ResourceTemplate,
-    Tool,
-)
+from mcp.types import ListPromptsResult, ListToolsResult, Prompt, Tool
 
 from agents.mcp.server import MCPServerStreamableHttp
 
@@ -21,68 +11,136 @@ def server():
     return MCPServerStreamableHttp({"url": "http://localhost"})
 
 
+def _tool(name: str) -> Tool:
+    return Tool(name=name, description="", inputSchema={"type": "object", "properties": {}})
+
+
 @pytest.mark.asyncio
-async def test_list_tools_pagination_and_loop_guard(server: MCPServerStreamableHttp):
+async def test_list_tools_accumulates_pages(server: MCPServerStreamableHttp):
     mock_session = MagicMock()
-    page1 = ListToolsResult(
-        tools=[
-            Tool(name="tool_1", description="", inputSchema={"type": "object", "properties": {}})
-        ],
-        nextCursor="tok_loop",
+    mock_session.list_tools = AsyncMock(
+        side_effect=[
+            ListToolsResult(tools=[_tool("tool_1")], nextCursor="page_2"),
+            ListToolsResult(tools=[_tool("tool_2")]),
+        ]
     )
-    # The session repeatedly returns the same cursor
-    mock_session.list_tools = AsyncMock(return_value=page1)
     server.session = mock_session
 
     result = await server.list_tools()
 
-    # The result should contain the tool twice because the loop breaks on the second identical fetch
-    assert len(result) == 2
-    assert result[0].name == "tool_1"
+    assert [tool.name for tool in result] == ["tool_1", "tool_2"]
+    assert mock_session.list_tools.await_args_list == [
+        call(cursor=None),
+        call(cursor="page_2"),
+    ]
 
 
 @pytest.mark.asyncio
-async def test_list_prompts_pagination_and_loop_guard(server: MCPServerStreamableHttp):
+async def test_list_tools_does_not_append_repeated_cursor_page(server: MCPServerStreamableHttp):
     mock_session = MagicMock()
-    page1 = ListPromptsResult(
-        prompts=[Prompt(name="prompt_1", description="")], nextCursor="tok_loop"
+    mock_session.list_tools = AsyncMock(
+        side_effect=[
+            ListToolsResult(tools=[_tool("tool_1")], nextCursor="tok_loop"),
+            ListToolsResult(tools=[_tool("duplicate")], nextCursor="tok_loop"),
+        ]
     )
-    mock_session.list_prompts = AsyncMock(return_value=page1)
+    server.session = mock_session
+
+    result = await server.list_tools()
+
+    assert [tool.name for tool in result] == ["tool_1"]
+    assert mock_session.list_tools.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_accumulates_pages_and_merges_metadata(
+    server: MCPServerStreamableHttp,
+):
+    mock_session = MagicMock()
+    mock_session.list_prompts = AsyncMock(
+        side_effect=[
+            ListPromptsResult(
+                prompts=[Prompt(name="prompt_1", description="")],
+                nextCursor="page_2",
+                _meta={"page_1": True, "shared": "first"},
+            ),
+            ListPromptsResult(
+                prompts=[Prompt(name="prompt_2", description="")],
+                _meta={"page_2": True, "shared": "second"},
+            ),
+        ]
+    )
     server.session = mock_session
 
     result = await server.list_prompts()
 
-    assert len(result.prompts) == 2
-    assert result.prompts[0].name == "prompt_1"
+    assert [prompt.name for prompt in result.prompts] == ["prompt_1", "prompt_2"]
+    assert result.nextCursor is None
+    assert result.meta == {"page_1": True, "page_2": True, "shared": "second"}
+    assert mock_session.list_prompts.await_args_list == [
+        call(cursor=None),
+        call(cursor="page_2"),
+    ]
 
 
 @pytest.mark.asyncio
-async def test_list_resources_pagination_and_loop_guard(server: MCPServerStreamableHttp):
+async def test_list_prompts_does_not_append_repeated_cursor_page(
+    server: MCPServerStreamableHttp,
+):
     mock_session = MagicMock()
-    page1 = ListResourcesResult(
-        resources=[Resource(uri=AnyUrl("file:///1"), name="res_1", mimeType="text/plain")],
-        nextCursor="tok_loop",
+    mock_session.list_prompts = AsyncMock(
+        side_effect=[
+            ListPromptsResult(
+                prompts=[Prompt(name="prompt_1", description="")],
+                nextCursor="tok_loop",
+                _meta={"page": 1},
+            ),
+            ListPromptsResult(
+                prompts=[Prompt(name="duplicate", description="")],
+                nextCursor="tok_loop",
+                _meta={"page": 2},
+            ),
+        ]
     )
-    mock_session.list_resources = AsyncMock(return_value=page1)
     server.session = mock_session
 
-    result = await server.list_resources()
+    result = await server.list_prompts()
 
-    assert len(result.resources) == 2
-    assert result.resources[0].name == "res_1"
+    assert [prompt.name for prompt in result.prompts] == ["prompt_1"]
+    assert result.meta == {"page": 1}
+    assert mock_session.list_prompts.await_count == 2
 
 
 @pytest.mark.asyncio
-async def test_list_resource_templates_pagination_and_loop_guard(server: MCPServerStreamableHttp):
+async def test_list_prompts_returns_none_metadata_when_pages_have_none(
+    server: MCPServerStreamableHttp,
+):
     mock_session = MagicMock()
-    page1 = ListResourceTemplatesResult(
-        resourceTemplates=[ResourceTemplate(uriTemplate="file:///{path}", name="temp_1")],
-        nextCursor="tok_loop",
+    mock_session.list_prompts = AsyncMock(
+        return_value=ListPromptsResult(prompts=[Prompt(name="prompt", description="")])
     )
-    mock_session.list_resource_templates = AsyncMock(return_value=page1)
     server.session = mock_session
 
-    result = await server.list_resource_templates()
+    result = await server.list_prompts()
 
-    assert len(result.resourceTemplates) == 2
-    assert result.resourceTemplates[0].name == "temp_1"
+    assert result.meta is None
+
+
+@pytest.mark.asyncio
+async def test_list_tools_supports_empty_string_next_cursor(server: MCPServerStreamableHttp):
+    mock_session = MagicMock()
+    mock_session.list_tools = AsyncMock(
+        side_effect=[
+            ListToolsResult(tools=[_tool("tool_1")], nextCursor=""),
+            ListToolsResult(tools=[_tool("tool_2")]),
+        ]
+    )
+    server.session = mock_session
+
+    result = await server.list_tools()
+
+    assert [tool.name for tool in result] == ["tool_1", "tool_2"]
+    assert mock_session.list_tools.await_args_list == [
+        call(cursor=None),
+        call(cursor=""),
+    ]


### PR DESCRIPTION
This pull request implements automatic pagination for MCP server list operations (`list_tools` and `list_prompts`) in `src/agents/mcp/server.py` and resolves review feedback regarding cursor evaluation and log redaction.
#4085 

### Background & Context
When interacting with MCP servers that return paginated tool or prompt lists, the SDK previously fetched only the first page. For large servers, subsequent tools and prompts were omitted. Additionally, review feedback identified two key considerations in the pagination loop:
1. **Opaque Empty String Cursors**: Valid pagination cursors represented as empty strings (`""`) were improperly treated as exhaustion when evaluated with truthiness (`if not next_cursor:`).
2. **Sensitive Log Exposure**: Raw `cursor` and `next_cursor` values were written to `logger.warning(...)` calls during loop detection, potentially exposing opaque server tokens or tenant state in logs.

### Key Changes
- **Auto-Pagination**: Updated `list_tools` and `list_prompts` in `src/agents/mcp/server.py` to transparently accumulate all pages until `nextCursor` is `None`.
- **Strict `None` Exhaustion Check**: Replaced truthiness checks with `next_cursor is None` and `if next_cursor is not None and next_cursor in seen_cursors:` to safely support empty string cursor tokens (`""`).
- **Sensitive Log Redaction**: Omitted raw `cursor` / `next_cursor` payload values from `logger.warning(...)` messages in both `list_tools` and `list_prompts`.
- **Test Coverage & Verification**:
  - Updated unit tests in `tests/mcp/test_pagination.py` verifying multi-page tool/prompt accumulation, metadata merging, repeated-cursor loop termination, and empty string cursor handling.
  - Included a local integration probe (`local_mcp_pagination_probe.py`) to verify real Streamable HTTP transport pagination.