### PR TITLE
fix(agent-tools): honor falsey custom output extractors

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -939,7 +939,7 @@ class Agent(AgentBase, Generic[TContext]):
                         scope_id=tool_state_scope_id,
                     )
 
-            if custom_output_extractor:
+            if custom_output_extractor is not None:
                 return await custom_output_extractor(run_result)
 
             if run_result.final_output is not None and (

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -410,6 +410,55 @@ async def test_agent_as_tool_custom_output_extractor(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
+async def test_agent_as_tool_honors_falsey_custom_output_extractor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = Agent(name="summarizer")
+
+    class DummyResult:
+        final_output = "default output"
+        new_items: list[Any] = []
+        interruptions: list[Any] = []
+
+    run_result = DummyResult()
+
+    async def fake_run(cls, *args, **kwargs):
+        return run_result
+
+    monkeypatch.setattr(Runner, "run", classmethod(fake_run))
+
+    class FalseyExtractor:
+        def __init__(self) -> None:
+            self.call_count = 0
+
+        def __bool__(self) -> bool:
+            return False
+
+        async def __call__(self, result: Any) -> str:
+            assert result is run_result
+            self.call_count += 1
+            return "custom output"
+
+    extractor = FalseyExtractor()
+    tool = agent.as_tool(
+        tool_name="summary_tool",
+        tool_description="Summarize input",
+        custom_output_extractor=extractor,
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="summary_tool",
+        tool_call_id="call_2",
+        tool_arguments='{"input": "summarize this"}',
+    )
+
+    output = await tool.on_invoke_tool(tool_context, '{"input": "summarize this"}')
+
+    assert output == "custom output"
+    assert extractor.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_agent_as_tool_fallback_uses_current_run_items_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Summary

`Agent.as_tool(custom_output_extractor=...)` currently checks the configured extractor by truthiness. A callable object whose `__bool__` returns `False` is accepted by the public API but silently skipped, so the nested agent returns its default output instead of the custom result.

This changes the guard to an explicit `is not None` check. `None` keeps the existing fallback behavior; ordinary async functions and the public API are unchanged.

### Test plan

- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` - format, lint, typecheck, and full tests passed
- `make coverage` - 6,034 passed, 8 skipped; 91% total coverage
- `make tests-asyncio-stability` - 5 repetitions passed (7 + 33 tests per repetition)
- Python 3.10 focused tests - 2 passed
- Python 3.14 focused tests - 2 passed

E2E top-hat using the public `Agent.as_tool` invocation path:

- `v0.19.2` returned `default-output` and skipped the falsey extractor
- This branch returned `custom-output` and invoked the extractor once

### Issue number

N/A - searches across open and closed issues and pull requests found no duplicate.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass