### PR TITLE
fix(chatcmpl): clear pending thinking blocks when flushing an assistant message

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -538,8 +538,8 @@ class Converter:
         pending_reasoning_content: str | None = None  # For DeepSeek reasoning_content
         normalized_base_url = base_url.rstrip("/") if base_url is not None else None
 
-        def flush_assistant_message(*, clear_pending_reasoning_content: bool = True) -> None:
-            nonlocal current_assistant_msg, pending_reasoning_content
+        def flush_assistant_message(*, clear_pending_reasoning: bool = True) -> None:
+            nonlocal current_assistant_msg, pending_reasoning_content, pending_thinking_blocks
             if current_assistant_msg is not None:
                 # The API doesn't support empty arrays for tool_calls
                 if not current_assistant_msg.get("tool_calls"):
@@ -548,8 +548,13 @@ class Converter:
                     pending_reasoning_content = None
                 result.append(current_assistant_msg)
                 current_assistant_msg = None
-            elif clear_pending_reasoning_content:
+            elif clear_pending_reasoning:
                 pending_reasoning_content = None
+            if clear_pending_reasoning:
+                # Thinking blocks belong to the assistant turn that produced them, so a
+                # reasoning item that is not directly followed by that turn's assistant
+                # message must not leak its signed blocks into a later one.
+                pending_thinking_blocks = None
 
         def apply_pending_reasoning_content(
             assistant_msg: ChatCompletionAssistantMessageParam,
@@ -637,8 +642,8 @@ class Converter:
             # 3) response output message => assistant
             elif resp_msg := cls.maybe_response_output_message(item):
                 # A reasoning item can be followed by an assistant message and then tool calls
-                # in the same turn, so preserve pending reasoning_content across this flush.
-                flush_assistant_message(clear_pending_reasoning_content=False)
+                # in the same turn, so preserve pending reasoning state across this flush.
+                flush_assistant_message(clear_pending_reasoning=False)
                 new_asst = ChatCompletionAssistantMessageParam(role="assistant")
                 contents = resp_msg["content"]
 

--- a/tests/models/test_anthropic_thinking_blocks.py
+++ b/tests/models/test_anthropic_thinking_blocks.py
@@ -416,3 +416,51 @@ def test_anthropic_thinking_blocks_without_tool_calls():
     assert (
         second_content.get("text") == "The weather in Paris is sunny with a temperature of 22°C."
     ), "Text content should be preserved"
+
+
+def test_thinking_blocks_do_not_leak_across_an_intervening_user_turn():
+    """A reasoning item not followed by its own assistant message must not leak.
+
+    When a turn produces extended thinking but no visible output, the only stored
+    output item is the reasoning item, so the next item in the history is the user's
+    next message. The signed thinking blocks belong to that earlier turn and must not
+    be prepended to a later assistant message.
+    """
+    silent_turn = InternalChatCompletionMessage(
+        role="assistant",
+        content="",
+        reasoning_content="Nothing to say yet.",
+        thinking_blocks=[
+            {
+                "type": "thinking",
+                "thinking": "Earlier private thinking.",
+                "signature": "EarlierTurnSignature",
+            }
+        ],
+        tool_calls=None,
+    )
+    output_items = Converter.message_to_output_items(silent_turn)
+    assert [item.type for item in output_items] == ["reasoning"]
+
+    history: list[dict[str, Any]] = [{"role": "user", "content": "first question"}]
+    history += [item.model_dump() for item in output_items]
+    history += [
+        {"role": "user", "content": "second question"},
+        {
+            "id": "msg_2",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "an answer", "annotations": []}],
+        },
+    ]
+
+    messages = Converter.items_to_messages(
+        history,  # type: ignore[arg-type]
+        model="anthropic/claude-4-opus",
+        preserve_thinking_blocks=True,
+    )
+
+    assistant_messages = [msg for msg in messages if msg.get("role") == "assistant"]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].get("content") == "an answer"


### PR DESCRIPTION
### Summary

`Converter.items_to_messages` keeps two pieces of cross-item reasoning state. `pending_reasoning_content` is cleared on flush, with a comment explaining why (`prevents stale reasoning_content from contaminating later turns`). Its sibling `pending_thinking_blocks` is not — it is only cleared where it is consumed, at the assistant-message and function-call branches.

So when a reasoning item is *not* directly followed by its own assistant message, its signed thinking blocks stay pending across an intervening user turn and are prepended to a later assistant message. Anthropic validates `signature` against the turn the block belongs to, so the next request either fails validation or replays a previous turn's private reasoning back to the model.

This is reachable without anything contrived: `message_to_output_items` drops the message item when the content is empty, so a Claude turn with extended thinking but no visible text produces *only* a reasoning item — the next history entry is the user's next message. It affects the paths that set `preserve_thinking_blocks=True` for Claude (`litellm_model.py`, `any_llm_model.py`).

Round-tripping a two-turn history through `message_to_output_items` → `items_to_messages` on `main`:

```
turn 1 output item types: ['reasoning']

{"role": "user", "content": "u1"},
{"role": "user", "content": "u2"},
{"role": "assistant", "content": [
   {"type": "thinking", "thinking": "TURN-1 PRIVATE THINKING", "signature": "SIG-TURN-1"},
   {"text": "a2", "type": "text"}]},
{"role": "user", "content": "u3"}
```

Turn 1's thinking block is attached to turn 2's assistant message. With this change the same history produces `{"role": "assistant", "content": "a2"}`.

### Fix

`flush_assistant_message` now clears `pending_thinking_blocks` alongside `pending_reasoning_content`. The single call site that deliberately preserves reasoning state across a flush — the `maybe_response_output_message` branch, where a reasoning item legitimately belongs to the assistant message that follows it — still passes the opt-out, so that case is unchanged. The keyword is renamed from `clear_pending_reasoning_content` to `clear_pending_reasoning` since it now covers both pieces of state; it is a parameter of a local closure, not public API.

### Test plan

Added `test_thinking_blocks_do_not_leak_across_an_intervening_user_turn` to the existing `tests/models/test_anthropic_thinking_blocks.py`, asserting the later assistant message carries no thinking block from the earlier turn. It fails on `main` (the assistant content is the thinking block plus the text instead of the text) and passes with this change.

- `tests/models/test_anthropic_thinking_blocks.py`: 6 passed with the fix; 1 failed / 5 passed without it.
- `tests/models`: 605 passed. Converter/litellm/reasoning-related selection: 341 passed.
- `ruff check` and `ruff format --check` clean on both files; `mypy` reports no errors in either changed file.

Verification-script note: `.agents/skills/code-change-verification/scripts/run.sh` could not run here because `make` is not installed on this machine, so I ran the underlying commands directly. The full parallel suite shows 38 pre-existing failures with the change and 39 on a stashed baseline — all xdist/tracing flakes in `testing_processor.py`, unrelated to this diff.

### Issue number

None — self-reported, found while reading the converter.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` — could not: `make` unavailable locally (see Test plan); ran the equivalent commands directly
- [x] I've confirmed all verification steps pass (format, lint, typecheck, affected tests; remaining failures verified pre-existing)
- [ ] If using Codex, I've run `/review` before submitting this PR — n/a

*AI assistance was used in preparing this change; I reviewed it, reproduced the leak and verified the fix locally.*
