### PR TITLE
fix(run): report output guardrail results when a tripwire aborts the run

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -20,6 +20,7 @@ from .exceptions import (
 )
 from .guardrail import (
     InputGuardrailResult,
+    OutputGuardrailResult,
 )
 from .items import (
     ItemHelpers,
@@ -723,6 +724,9 @@ class AgentRunner:
                 input_guardrail_results: list[InputGuardrailResult] = (
                     list(run_state._input_guardrail_results) if run_state is not None else []
                 )
+                # Output guardrails run once, at the end of the run. Accumulate their results
+                # here so the failure handler below can report them on the raised exception.
+                output_guardrail_results: list[OutputGuardrailResult] = []
                 tool_input_guardrail_results: list[ToolInputGuardrailResult] = (
                     list(getattr(run_state, "_tool_input_guardrail_results", []))
                     if run_state is not None
@@ -1002,12 +1006,13 @@ class AgentRunner:
                             )
 
                             if isinstance(turn_result.next_step, NextStepFinalOutput):
-                                output_guardrail_results = await run_output_guardrails(
+                                await run_output_guardrails(
                                     current_agent.output_guardrails
                                     + (run_config.output_guardrails or []),
                                     current_agent,
                                     turn_result.next_step.output,
                                     context_wrapper,
+                                    output_guardrail_results,
                                 )
                                 current_step = getattr(run_state, "_current_step", None)
                                 approvals_from_state = approvals_from_step(current_step)
@@ -1140,11 +1145,12 @@ class AgentRunner:
                             context_wrapper,
                             validated_output,
                         )
-                        output_guardrail_results = await run_output_guardrails(
+                        await run_output_guardrails(
                             current_agent.output_guardrails + (run_config.output_guardrails or []),
                             current_agent,
                             validated_output,
                             context_wrapper,
+                            output_guardrail_results,
                         )
                         current_step = getattr(run_state, "_current_step", None)
                         approvals_from_state = approvals_from_step(current_step)
@@ -1446,12 +1452,13 @@ class AgentRunner:
 
                     try:
                         if isinstance(turn_result.next_step, NextStepFinalOutput):
-                            output_guardrail_results = await run_output_guardrails(
+                            await run_output_guardrails(
                                 current_agent.output_guardrails
                                 + (run_config.output_guardrails or []),
                                 current_agent,
                                 turn_result.next_step.output,
                                 context_wrapper,
+                                output_guardrail_results,
                             )
 
                             # Ensure starting_input is not None and not RunState
@@ -1593,7 +1600,7 @@ class AgentRunner:
                         last_agent=current_agent,
                         context_wrapper=context_wrapper,
                         input_guardrail_results=input_guardrail_results,
-                        output_guardrail_results=[],
+                        output_guardrail_results=output_guardrail_results,
                     )
                 raise
             finally:

--- a/src/agents/run_internal/guardrails.py
+++ b/src/agents/run_internal/guardrails.py
@@ -177,8 +177,14 @@ async def run_output_guardrails(
     agent: Agent[TContext],
     agent_output: Any,
     context: RunContextWrapper[TContext],
+    results_sink: list[OutputGuardrailResult] | None = None,
 ) -> list[OutputGuardrailResult]:
-    """Run output guardrails in parallel and raise on tripwires."""
+    """Run output guardrails in parallel and raise on tripwires.
+
+    Results are recorded into ``results_sink`` as each guardrail completes, including the
+    tripping result, so callers can report them even when this function raises. This mirrors
+    `run_input_guardrails`.
+    """
     if not guardrails:
         return []
 
@@ -189,10 +195,16 @@ async def run_output_guardrails(
 
     guardrail_results: list[OutputGuardrailResult] = []
 
+    def record(result: OutputGuardrailResult) -> None:
+        guardrail_results.append(result)
+        if results_sink is not None:
+            results_sink.append(result)
+
     try:
         for done in asyncio.as_completed(guardrail_tasks):
             result = await done
             if result.output.tripwire_triggered:
+                record(result)
                 for t in guardrail_tasks:
                     t.cancel()
                 await asyncio.gather(*guardrail_tasks, return_exceptions=True)
@@ -203,7 +215,7 @@ async def run_output_guardrails(
                     )
                 )
                 raise OutputGuardrailTripwireTriggered(result)
-            guardrail_results.append(result)
+            record(result)
     except BaseException:
         # On any error (including a guardrail raising or the caller being cancelled),
         # cancel and await siblings so they don't leak past this function's return.

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -394,18 +394,25 @@ async def _run_output_guardrails_for_stream(
     context_wrapper: RunContextWrapper[TContext],
     streamed_result: RunResultStreaming,
 ) -> list[Any]:
+    # Recorded as each guardrail completes so a tripwire still publishes the results that
+    # already finished, mirroring the non-streamed path.
+    completed_results: list[Any] = []
     streamed_result._output_guardrails_task = asyncio.create_task(
         run_output_guardrails(
             agent.output_guardrails + (run_config.output_guardrails or []),
             agent,
             output,
             context_wrapper,
+            completed_results,
         )
     )
 
     try:
         return cast(list[Any], await streamed_result._output_guardrails_task)
     except OutputGuardrailTripwireTriggered:
+        streamed_result.output_guardrail_results = (
+            streamed_result.output_guardrail_results + completed_results
+        )
         raise
     except asyncio.CancelledError:
         raise

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -13,6 +13,7 @@ from agents import (
     InputGuardrail,
     InputGuardrailTripwireTriggered,
     OutputGuardrail,
+    OutputGuardrailTripwireTriggered,
     RunConfig,
     RunContextWrapper,
     Runner,
@@ -2129,6 +2130,119 @@ async def test_input_guardrail_exception_reports_completed_results():
             Agent(name="t"),
             _ordered_input_guardrails(second_triggers=False, second_raises=True),
             "test input",
+            RunContextWrapper(context=None),
+            collected,
+        )
+
+    assert _result_names(collected) == ["passes"]
+
+
+def _ordered_output_guardrails(
+    *, second_triggers: bool, second_raises: bool = False
+) -> list[OutputGuardrail[Any]]:
+    """Build two output guardrails whose completion order is fixed by an explicit barrier."""
+    first_done = asyncio.Event()
+
+    async def first_fn(
+        context: RunContextWrapper[Any], agent: Agent[Any], agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        first_done.set()
+        return GuardrailFunctionOutput(output_info="passes", tripwire_triggered=False)
+
+    async def second_fn(
+        context: RunContextWrapper[Any], agent: Agent[Any], agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        await first_done.wait()
+        if second_raises:
+            raise RuntimeError("guardrail exploded")
+        return GuardrailFunctionOutput(output_info="second", tripwire_triggered=second_triggers)
+
+    return [
+        OutputGuardrail(guardrail_function=first_fn, name="passes"),
+        OutputGuardrail(guardrail_function=second_fn, name="raises" if second_raises else "trips"),
+    ]
+
+
+def _output_tripwire_agent(model: FakeModel) -> Agent[Any]:
+    return Agent(
+        name="output_guardrail_results_agent",
+        model=model,
+        output_guardrails=_ordered_output_guardrails(second_triggers=True),
+    )
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_tripwire_reports_results():
+    """Runner.run() reports every completed output guardrail result on the raised tripwire."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+
+    with pytest.raises(OutputGuardrailTripwireTriggered) as exc_info:
+        await Runner.run(_output_tripwire_agent(model), "test input")
+
+    run_data = exc_info.value.run_data
+    assert run_data is not None
+    assert _result_names(run_data.output_guardrail_results) == ["passes", "trips"]
+    assert exc_info.value.guardrail_result.guardrail.get_name() == "trips"
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_tripwire_reports_results_streamed():
+    """The streamed path reports the same results, including on the streamed result object."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+
+    result = Runner.run_streamed(_output_tripwire_agent(model), "test input")
+    with pytest.raises(OutputGuardrailTripwireTriggered) as exc_info:
+        async for _ in result.stream_events():
+            pass
+
+    run_data = exc_info.value.run_data
+    assert run_data is not None
+    assert _result_names(run_data.output_guardrail_results) == ["passes", "trips"]
+    assert _result_names(result.output_guardrail_results) == ["passes", "trips"]
+
+
+def test_output_guardrail_tripwire_reports_results_sync():
+    """Runner.run_sync() matches the async entry points."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+
+    with pytest.raises(OutputGuardrailTripwireTriggered) as exc_info:
+        Runner.run_sync(_output_tripwire_agent(model), "test input")
+
+    run_data = exc_info.value.run_data
+    assert run_data is not None
+    assert _result_names(run_data.output_guardrail_results) == ["passes", "trips"]
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_results_reported_on_success():
+    """Passing output guardrails still land on the successful result exactly once."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+    agent = Agent(
+        name="output_guardrail_results_agent",
+        model=model,
+        output_guardrails=_ordered_output_guardrails(second_triggers=False),
+    )
+
+    result = await Runner.run(agent, "test input")
+
+    assert _result_names(result.output_guardrail_results) == ["passes", "trips"]
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_exception_reports_completed_results():
+    """A guardrail raising a non-tripwire error still preserves earlier results."""
+    from agents.run_internal.guardrails import run_output_guardrails
+
+    collected: list[Any] = []
+    with pytest.raises(RuntimeError, match="guardrail exploded"):
+        await run_output_guardrails(
+            _ordered_output_guardrails(second_triggers=False, second_raises=True),
+            Agent(name="t"),
+            "out",
             RunContextWrapper(context=None),
             collected,
         )


### PR DESCRIPTION
### Summary

#4071 made input guardrails report the results that had already completed when a tripwire aborts the run. The output-guardrail sibling, directly below it in the same file, was left as it was — so the two exception types still report asymmetrically.

On an output tripwire, `run_output_guardrails` raises immediately and discards the local `guardrail_results` it had accumulated, `run.py` hardcodes `output_guardrail_results=[]` when building `RunErrorDetails`, and the streamed path only assigns `streamed_result.output_guardrail_results` after the guardrail task returns — so a tripwire leaves it at its previous, empty value. Even the tripping result is absent from `run_data`; it is reachable only via `exc.guardrail_result`.

Reproduction with two output guardrails ordered by an `asyncio.Event` barrier (`passes`, then `trips`), on `main`:

```
run()           run_data.output_guardrail_results = []
run_streamed()  run_data.output_guardrail_results = []
run_streamed()  result.output_guardrail_results   = []
run_sync()      run_data.output_guardrail_results = []
```

With this change all four report `['passes', 'trips']`.

### Fix

Mirrors #4071: `run_output_guardrails` takes a `results_sink` and records each result as it completes; `run.py` keeps a run-level accumulator and passes it to the three call sites, using it for `RunErrorDetails`; the streamed path publishes the completed results onto `streamed_result` in its `except OutputGuardrailTripwireTriggered` branch. Behaviour on the success path is unchanged.

### Test plan

Five tests appended to `tests/test_guardrails.py` (the file #4071 used), reusing its `_result_names` helper and parameterised across `run` / `run_streamed` / `run_sync`: results reported on tripwire for each entry point, results still reported on success, and completed results reported when a guardrail raises a non-tripwire exception.

`pytest tests/test_guardrails.py`: 55 passed / 2 failed with the change; clean `main` baseline is 50 passed / **the same 2 failed** (`test_blocking_guardrail_cancels_remaining_on_trigger` and its `_streaming` variant — timing-sensitive, unrelated to this diff). `pytest tests/models`: 608 passed. `ruff check` / `ruff format --check` clean; `mypy` reports no issues on the changed files.

Verification-script note: `.agents/skills/code-change-verification/scripts/run.sh` could not run here because `make` is not installed on this machine, so I ran the underlying commands directly.

### Issue number

None — noticed while reading #4071.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` — could not: `make` unavailable locally (see Test plan); ran the equivalent commands directly
- [x] I've confirmed all verification steps pass (format, lint, typecheck, affected tests; the 2 remaining failures are present on clean `main`)
- [ ] If using Codex, I've run `/review` before submitting this PR — n/a

*AI assistance was used in preparing this change; I reviewed it, reproduced the behaviour and verified the fix locally.*
