### PR TITLE
fix: preserve zero shell timeouts

### DIFF
--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -664,11 +664,11 @@ def coerce_shell_call(tool_call: Any) -> ShellCallData:
     if not commands:
         raise ModelBehaviorError("Shell call action must include at least one command.")
 
-    timeout_value = (
-        get_mapping_or_attr(action_payload, "timeout_ms")
-        or get_mapping_or_attr(action_payload, "timeoutMs")
-        or get_mapping_or_attr(action_payload, "timeout")
-    )
+    timeout_value = get_mapping_or_attr(action_payload, "timeout_ms")
+    if timeout_value is None:
+        timeout_value = get_mapping_or_attr(action_payload, "timeoutMs")
+    if timeout_value is None:
+        timeout_value = get_mapping_or_attr(action_payload, "timeout")
     timeout_ms = int(timeout_value) if isinstance(timeout_value, int | float) else None
 
     max_length_value = get_mapping_or_attr(action_payload, "max_output_length")

--- a/tests/test_shell_call_serialization.py
+++ b/tests/test_shell_call_serialization.py
@@ -23,6 +23,18 @@ def test_coerce_shell_call_reads_max_output_length() -> None:
     assert result.action.max_output_length == 512
 
 
+@pytest.mark.parametrize("timeout_key", ["timeout_ms", "timeoutMs", "timeout"])
+def test_coerce_shell_call_preserves_zero_timeout(timeout_key: str) -> None:
+    tool_call = {
+        "call_id": "shell-zero-timeout",
+        "action": {"commands": ["ls"], timeout_key: 0},
+    }
+
+    result = run_loop.coerce_shell_call(tool_call)
+
+    assert result.action.timeout_ms == 0
+
+
 def test_coerce_shell_call_requires_commands() -> None:
     tool_call = {"call_id": "shell-2", "action": {"commands": []}}
     with pytest.raises(ModelBehaviorError):


### PR DESCRIPTION
### Summary

Preserve an explicit zero timeout while normalizing next-generation shell call payloads. The previous truthiness-based alias fallback converted `timeout_ms=0` and `timeoutMs=0` to `None`, so executors could receive a default timeout instead of the caller-provided value.

This keeps the existing `timeout_ms`, `timeoutMs`, and `timeout` precedence while falling back only when a field is absent.

### Test plan

- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`
- Verified the regression test fails on the previous implementation for `timeout_ms` and `timeoutMs`, then passes with this change.

### Issue number

Fixes #4092

### Checks

- [x] I have added new tests, if relevant
- [x] I have run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I have confirmed all verification steps pass
- [x] If using Codex, I have run `/review` before submitting this PR