### PR TITLE
fix(mcp): auto-paginate tool and prompt listings

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -1193,6 +1193,9 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                         "listing tools."
                     ) from None
 
+                cursor = None
+                seen_cursors.clear()
+                del fetch_pages
                 self._tools_list = tools
                 self._cache_dirty = False
 

--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -34,6 +34,8 @@ from mcp.types import (
     ListPromptsResult,
     ListResourcesResult,
     ListResourceTemplatesResult,
+    ListToolsResult,
+    PaginatedRequestParams,
     ReadResourceResult,
 )
 from typing_extensions import NotRequired, TypedDict
@@ -764,6 +766,27 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         async with self._request_lock:
             return await func()
 
+    async def _list_tools_page(
+        self, session: ClientSession, cursor: str | None = None
+    ) -> ListToolsResult:
+        return await self._maybe_serialize_request(
+            lambda: session.list_tools()
+            if cursor is None
+            else session.list_tools(params=PaginatedRequestParams(cursor=cursor))
+        )
+
+    async def _list_prompts_page(
+        self, session: ClientSession, cursor: str | None = None
+    ) -> ListPromptsResult:
+        return await self._run_request_with_transport_error_redaction(
+            "list prompts",
+            lambda: self._maybe_serialize_request(
+                lambda: session.list_prompts()
+                if cursor is None
+                else session.list_prompts(params=PaginatedRequestParams(cursor=cursor))
+            ),
+        )
+
     async def _apply_tool_filter(
         self,
         tools: list[MCPTool],
@@ -1120,17 +1143,58 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         transport_error: UserError | None = None
         transport_cause: Exception | None = None
         try:
+            tools: list[MCPTool]
             # Return from cache if caching is enabled, we have tools, and the cache is not dirty
             if self.cache_tools_list and not self._cache_dirty and self._tools_list:
                 tools = self._tools_list
             else:
-                # Fetch the tools from the server
-                result = await self._run_with_retries(
-                    lambda: self._maybe_serialize_request(lambda: session.list_tools())
-                )
-                self._tools_list = result.tools
+                tools = []
+                cursor: str | None = None
+                seen_cursors: set[str | None] = set()
+
+                async def fetch_pages() -> bool:
+                    nonlocal cursor
+                    while True:
+                        result = await self._list_tools_page(session, cursor)
+                        tools.extend(result.tools)
+                        seen_cursors.add(cursor)
+                        next_cursor = result.nextCursor
+                        if next_cursor is None:
+                            return True
+                        if next_cursor in seen_cursors:
+                            return False
+                        cursor = next_cursor
+
+                pagination_complete = False
+                pagination_failure: BaseException | None = None
+                try:
+                    pagination_complete = await self._run_with_retries(fetch_pages)
+                except BaseException as error:
+                    if cursor is None:
+                        raise
+                    if isinstance(error, BaseExceptionGroup):
+                        pagination_failure = _credential_safe_exception_group(error)
+                    elif isinstance(error, Exception):
+                        pagination_failure = self._user_error_for_request_operation(
+                            "list tools", error
+                        )
+                    else:
+                        pagination_failure = _credential_safe_exception_leaf(error)
+
+                if pagination_failure is not None or not pagination_complete:
+                    cursor = None
+                    seen_cursors.clear()
+                    tools.clear()
+                    del fetch_pages
+                    if pagination_failure is not None:
+                        raise pagination_failure from None
+                    raise UserError(
+                        f"MCP server '{self._error_name}' returned a repeated cursor while "
+                        "listing tools."
+                    ) from None
+
+                self._tools_list = tools
                 self._cache_dirty = False
-                tools = self._tools_list
 
             # Filter tools based on tool_filter
             filtered_tools = tools
@@ -1265,10 +1329,52 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             raise UserError("Server not initialized. Make sure you call `connect()` first.")
         session = self.session
         assert session is not None
-        return await self._run_request_with_transport_error_redaction(
-            "list prompts",
-            lambda: self._maybe_serialize_request(lambda: session.list_prompts()),
-        )
+        result = await self._list_prompts_page(session)
+        if result.nextCursor is None:
+            return result
+
+        prompts = list(result.prompts)
+        cursor: str | None = result.nextCursor
+        seen_cursors: set[str | None] = {None}
+        pagination_failure: BaseException | None = None
+        repeated_cursor = False
+        page: ListPromptsResult | None = None
+        next_cursor: str | None = None
+        while cursor is not None:
+            try:
+                page = await self._list_prompts_page(session, cursor)
+            except BaseException as error:
+                if isinstance(error, BaseExceptionGroup):
+                    pagination_failure = _credential_safe_exception_group(error)
+                elif isinstance(error, Exception):
+                    pagination_failure = self._user_error_for_request_operation(
+                        "list prompts", error
+                    )
+                else:
+                    pagination_failure = _credential_safe_exception_leaf(error)
+                break
+            prompts.extend(page.prompts)
+            seen_cursors.add(cursor)
+            next_cursor = page.nextCursor
+            if next_cursor is not None and next_cursor in seen_cursors:
+                repeated_cursor = True
+                break
+            cursor = next_cursor
+
+        if pagination_failure is not None or repeated_cursor:
+            cursor = None
+            seen_cursors.clear()
+            prompts.clear()
+            page = None
+            next_cursor = None
+            del result
+            if pagination_failure is not None:
+                raise pagination_failure from None
+            raise UserError(
+                f"MCP server '{self._error_name}' returned a repeated cursor while listing prompts."
+            ) from None
+
+        return result.model_copy(update={"prompts": prompts, "nextCursor": None})
 
     async def get_prompt(
         self, name: str, arguments: dict[str, Any] | None = None

--- a/tests/mcp/servers/paginated.py
+++ b/tests/mcp/servers/paginated.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import anyio
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import (
+    ListPromptsRequest,
+    ListPromptsResult,
+    ListToolsRequest,
+    ListToolsResult,
+    Prompt,
+    TextContent,
+    Tool,
+)
+
+server = Server("paginated-test-server")
+
+
+@server.list_tools()  # type: ignore[misc]
+async def list_tools(request: ListToolsRequest) -> ListToolsResult:
+    cursor = request.params.cursor if request.params is not None else None
+    if cursor is None:
+        return ListToolsResult(
+            tools=[
+                Tool(
+                    name="first_page_tool",
+                    inputSchema={"type": "object", "properties": {}},
+                )
+            ],
+            nextCursor="",
+        )
+    if cursor == "":
+        return ListToolsResult(
+            tools=[
+                Tool(
+                    name="second_page_tool",
+                    inputSchema={"type": "object", "properties": {}},
+                )
+            ],
+        )
+    raise ValueError(f"Unexpected tools cursor: {cursor}")
+
+
+@server.list_prompts()  # type: ignore[misc]
+async def list_prompts(request: ListPromptsRequest) -> ListPromptsResult:
+    cursor = request.params.cursor if request.params is not None else None
+    if cursor is None:
+        return ListPromptsResult(
+            prompts=[Prompt(name="first_page_prompt")],
+            nextCursor="",
+            _meta={"page": "first"},
+        )
+    if cursor == "":
+        return ListPromptsResult(
+            prompts=[Prompt(name="second_page_prompt")],
+            _meta={"page": "second"},
+        )
+    raise ValueError(f"Unexpected prompts cursor: {cursor}")
+
+
+@server.call_tool()  # type: ignore[misc]
+async def call_tool(name: str, arguments: dict[str, object] | None) -> list[TextContent]:
+    if name not in {"first_page_tool", "second_page_tool"}:
+        raise ValueError(f"Unexpected tool: {name}")
+    return [TextContent(type="text", text=f"called:{name}")]
+
+
+async def main() -> None:
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -1,7 +1,7 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
-from mcp.types import ListToolsResult, Tool as MCPTool
+from mcp.types import ListToolsResult, PaginatedRequestParams, Tool as MCPTool
 
 from agents import Agent
 from agents.mcp import MCPServerStdio
@@ -61,3 +61,36 @@ async def test_server_caching_works(
         # Without invalidating the cache, calling list_tools() again should return the cached value
         result_tools = await server.list_tools(run_context, agent)
         assert result_tools == tools
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_paginated_tools_are_cached_before_filtering(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    first_page_tool = MCPTool(name="first_page_tool", inputSchema={})
+    second_page_tool = MCPTool(name="second_page_tool", inputSchema={})
+    mock_list_tools.side_effect = [
+        ListToolsResult(tools=[first_page_tool], nextCursor=""),
+        ListToolsResult(tools=[second_page_tool]),
+    ]
+    server = MCPServerStdio(
+        params={"command": tee},
+        cache_tools_list=True,
+        tool_filter={"allowed_tool_names": ["second_page_tool"]},
+    )
+
+    async with server:
+        filtered_tools = await server.list_tools()
+        cached_tools = server.cached_tools
+        filtered_tools_again = await server.list_tools()
+
+    assert filtered_tools == [second_page_tool]
+    assert filtered_tools_again == [second_page_tool]
+    assert cached_tools == [first_page_tool, second_page_tool]
+    assert mock_list_tools.await_args_list == [
+        call(),
+        call(params=PaginatedRequestParams(cursor="")),
+    ]

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -8,7 +8,15 @@ import pytest
 from anyio import ClosedResourceError
 from mcp import ClientSession, Tool as MCPTool
 from mcp.shared.exceptions import McpError
-from mcp.types import CallToolResult, ErrorData, GetPromptResult, ListPromptsResult, ListToolsResult
+from mcp.types import (
+    CallToolResult,
+    ErrorData,
+    GetPromptResult,
+    ListPromptsResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    Prompt,
+)
 
 from agents.exceptions import UserError
 from agents.mcp.server import MCPServerStreamableHttp, _MCPServerWithClientSession
@@ -30,7 +38,7 @@ class DummySession:
             raise RuntimeError("call_tool failure")
         return CallToolResult(content=[])
 
-    async def list_tools(self):
+    async def list_tools(self, *, params: PaginatedRequestParams | None = None):
         self.list_tools_attempts += 1
         if self.list_tools_attempts <= self.fail_list_tools:
             raise RuntimeError("list_tools failure")
@@ -73,6 +81,121 @@ async def test_list_tools_unlimited_retries():
     assert len(tools) == 1
     assert tools[0].name == "tool"
     assert session.list_tools_attempts == 4
+
+
+class PaginatedRetrySession(DummySession):
+    def __init__(self):
+        super().__init__()
+        self.cursors: list[str | None] = []
+        self.second_page_attempts = 0
+
+    async def list_tools(self, *, params: PaginatedRequestParams | None = None):
+        cursor = params.cursor if params is not None else None
+        self.cursors.append(cursor)
+        if cursor is None:
+            return ListToolsResult(
+                tools=[MCPTool(name="first_page_tool", inputSchema={})],
+                nextCursor="second-page",
+            )
+
+        self.second_page_attempts += 1
+        if self.second_page_attempts == 1:
+            raise RuntimeError("second page failure")
+        return ListToolsResult(tools=[MCPTool(name="second_page_tool", inputSchema={})])
+
+
+@pytest.mark.asyncio
+async def test_list_tools_retries_only_the_failed_page():
+    session = PaginatedRetrySession()
+    server = DummyServer(session=session, retries=1)
+
+    tools = await server.list_tools()
+
+    assert [tool.name for tool in tools] == ["first_page_tool", "second_page_tool"]
+    assert session.cursors == [None, "second-page", "second-page"]
+
+
+class SharedRetryBudgetSession(DummySession):
+    def __init__(self):
+        super().__init__()
+        self.cursors: list[str | None] = []
+
+    async def list_tools(self, *, params: PaginatedRequestParams | None = None):
+        cursor = params.cursor if params is not None else None
+        self.cursors.append(cursor)
+        if self.cursors == [None]:
+            raise RuntimeError("first page failure")
+        if cursor is None:
+            return ListToolsResult(
+                tools=[MCPTool(name="first_page_tool", inputSchema={})],
+                nextCursor="second-page",
+            )
+        raise RuntimeError("second page failure")
+
+
+@pytest.mark.asyncio
+async def test_list_tools_shares_retry_budget_across_pages():
+    session = SharedRetryBudgetSession()
+    server = DummyServer(session=session, retries=1)
+
+    with pytest.raises(UserError, match="Failed to list tools.*Request failed"):
+        await server.list_tools()
+
+    assert session.cursors == [None, None, "second-page"]
+
+
+class RepeatedCursorSession(DummySession):
+    def __init__(self):
+        super().__init__()
+        self.tool_cursors: list[str | None] = []
+        self.prompt_cursors: list[str | None] = []
+
+    async def list_tools(self, *, params: PaginatedRequestParams | None = None):
+        cursor = params.cursor if params is not None else None
+        self.tool_cursors.append(cursor)
+        if cursor is None:
+            return ListToolsResult(
+                tools=[MCPTool(name="first_page_tool", inputSchema={})],
+                nextCursor="tenant-secret-cursor",
+            )
+        return ListToolsResult(
+            tools=[MCPTool(name="second_page_tool", inputSchema={})],
+            nextCursor="tenant-secret-cursor",
+        )
+
+    async def list_prompts(
+        self, *, params: PaginatedRequestParams | None = None
+    ) -> ListPromptsResult:
+        cursor = params.cursor if params is not None else None
+        self.prompt_cursors.append(cursor)
+        if cursor is None:
+            return ListPromptsResult(
+                prompts=[Prompt(name="first_page_prompt")],
+                nextCursor="tenant-secret-cursor",
+                _meta={"page": "first"},
+            )
+        return ListPromptsResult(
+            prompts=[Prompt(name="second_page_prompt")],
+            nextCursor="tenant-secret-cursor",
+            _meta={"page": "second"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_paginated_lists_reject_a_repeated_cursor_without_caching_partial_tools():
+    session = RepeatedCursorSession()
+    server = DummyServer(session=session, retries=1)
+
+    with pytest.raises(UserError, match="repeated cursor while listing tools") as tools_error:
+        await server.list_tools()
+    with pytest.raises(UserError, match="repeated cursor while listing prompts") as prompts_error:
+        await server.list_prompts()
+
+    assert server.cached_tools is None
+    assert session.tool_cursors == [None, "tenant-secret-cursor"]
+    assert session.prompt_cursors == [None, "tenant-secret-cursor"]
+    assert "tenant-secret-cursor" not in str(tools_error.value)
+    assert "tenant-secret-cursor" not in str(prompts_error.value)
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_mcp_pagination_integration.py
+++ b/tests/mcp/test_mcp_pagination_integration.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from agents import Agent, Runner
+from agents.mcp import MCPServerStdio
+
+from ..fake_model import FakeModel
+from ..test_responses import get_function_tool_call, get_text_message
+
+PAGINATED_SERVER_PATH = Path(__file__).parent / "servers" / "paginated.py"
+
+
+def create_paginated_server() -> MCPServerStdio:
+    return MCPServerStdio(
+        name="paginated-test-server",
+        params={
+            "command": sys.executable,
+            "args": [str(PAGINATED_SERVER_PATH)],
+        },
+        cache_tools_list=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_auto_paginates_tools_and_prompts():
+    async with create_paginated_server() as server:
+        tools = await server.list_tools()
+        prompts = await server.list_prompts()
+
+    assert [tool.name for tool in tools] == ["first_page_tool", "second_page_tool"]
+    assert [prompt.name for prompt in prompts.prompts] == [
+        "first_page_prompt",
+        "second_page_prompt",
+    ]
+    assert prompts.nextCursor is None
+    assert prompts.meta == {"page": "first"}
+
+
+@pytest.mark.asyncio
+async def test_agent_calls_tool_from_second_stdio_page():
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("second_page_tool", "{}")],
+            [get_text_message("done")],
+        ]
+    )
+
+    async with create_paginated_server() as server:
+        result = await Runner.run(
+            Agent(name="test", model=model, mcp_servers=[server]),
+            input="Call the second-page tool.",
+        )
+
+    tool_outputs = [
+        item.output for item in result.new_items if item.type == "tool_call_output_item"
+    ]
+    assert result.final_output == "done"
+    assert tool_outputs == [{"type": "text", "text": "called:second_page_tool"}]

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -445,6 +445,29 @@ async def test_paginated_list_cancellation_preserves_control_flow_without_cursor
 
 
 @pytest.mark.asyncio
+async def test_paginated_tools_clear_cursor_before_filter_failure():
+    cursor = "SECRET_OPAQUE_CURSOR"
+    server = MCPServerStreamableHttp(
+        params={"url": _SAFE_URL},
+        tool_filter=lambda context, tool: True,
+    )
+    session = MagicMock()
+    session.list_tools = AsyncMock(
+        side_effect=[
+            ListToolsResult(tools=[], nextCursor=cursor),
+            ListToolsResult(tools=[]),
+        ]
+    )
+    server.session = session
+
+    with pytest.raises(UserError, match="run_context and agent are required") as error_info:
+        await server.list_tools()
+
+    assert cursor not in "".join(traceback.format_exception(error_info.value))
+    _assert_text_hidden_from_server_traceback_locals(error_info.value, cursor)
+
+
+@pytest.mark.asyncio
 async def test_resource_request_nested_group_replaces_ordinary_siblings_safely():
     server = MCPServerStreamableHttp(params={"url": _CREDENTIALED_URL})
     request_error = httpx.ConnectError(

--- a/tests/mcp/test_server_errors.py
+++ b/tests/mcp/test_server_errors.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from mcp.types import ListPromptsResult, ListToolsResult
 
 from agents import Agent, _debug
 from agents.exceptions import UserError
@@ -93,6 +94,18 @@ def _assert_url_credentials_hidden_from_traceback_locals(error: BaseException) -
             attached_values = repr(tuple(current.tb_frame.f_locals.values()))
             for secret in _URL_SECRETS:
                 assert secret not in attached_values
+        current = current.tb_next
+
+
+def _assert_text_hidden_from_server_traceback_locals(
+    error: BaseException,
+    sensitive_text: str,
+) -> None:
+    current = error.__traceback__
+    while current is not None:
+        if current.tb_frame.f_code.co_filename.endswith("/src/agents/mcp/server.py"):
+            attached_values = repr(tuple(current.tb_frame.f_locals.values()))
+            assert sensitive_text not in attached_values
         current = current.tb_next
 
 
@@ -324,6 +337,111 @@ async def test_prompt_request_http_status_hides_url_credentials():
     _assert_url_credentials_hidden(user_error_info.value)
     _assert_not_retained_in_traceback_locals(user_error_info.value, http_error)
     _assert_url_credentials_hidden_from_traceback_locals(user_error_info.value)
+
+
+def _paginated_list_result(
+    method_name: str,
+    next_cursor: str,
+) -> ListToolsResult | ListPromptsResult:
+    if method_name == "list_tools":
+        return ListToolsResult(tools=[], nextCursor=next_cursor)
+    return ListPromptsResult(prompts=[], nextCursor=next_cursor)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["list_tools", "list_prompts"])
+async def test_paginated_list_failure_does_not_retain_opaque_cursor(method_name: str):
+    cursor = "SECRET_OPAQUE_CURSOR"
+    failure_message = "SECRET_CONTINUATION_FAILURE"
+    continuation_error = RuntimeError(failure_message)
+    server = MCPServerStreamableHttp(params={"url": _SAFE_URL})
+    session = MagicMock()
+    setattr(
+        session,
+        method_name,
+        AsyncMock(
+            side_effect=[
+                _paginated_list_result(method_name, cursor),
+                continuation_error,
+            ]
+        ),
+    )
+    server.session = session
+    server.max_retry_attempts = 0
+
+    with pytest.raises(UserError) as user_error_info:
+        await getattr(server, method_name)()
+
+    rendered = "".join(traceback.format_exception(user_error_info.value))
+    assert "Request failed" in str(user_error_info.value)
+    assert cursor not in rendered
+    assert failure_message not in rendered
+    assert user_error_info.value.__cause__ is None
+    assert user_error_info.value.__context__ is None
+    _assert_not_retained_in_exception_graph(user_error_info.value, continuation_error)
+    _assert_text_hidden_from_server_traceback_locals(user_error_info.value, cursor)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["list_tools", "list_prompts"])
+async def test_paginated_list_cycle_does_not_retain_opaque_cursor(method_name: str):
+    cursor = "SECRET_OPAQUE_CURSOR"
+    server = MCPServerStreamableHttp(params={"url": _SAFE_URL})
+    session = MagicMock()
+    setattr(
+        session,
+        method_name,
+        AsyncMock(
+            side_effect=[
+                _paginated_list_result(method_name, cursor),
+                _paginated_list_result(method_name, cursor),
+            ]
+        ),
+    )
+    server.session = session
+    server.max_retry_attempts = 0
+
+    with pytest.raises(UserError, match=f"repeated cursor while listing {method_name[5:]}") as info:
+        await getattr(server, method_name)()
+
+    assert cursor not in "".join(traceback.format_exception(info.value))
+    assert info.value.__cause__ is None
+    assert info.value.__context__ is None
+    _assert_text_hidden_from_server_traceback_locals(info.value, cursor)
+    if method_name == "list_tools":
+        assert server.cached_tools is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["list_tools", "list_prompts"])
+async def test_paginated_list_cancellation_preserves_control_flow_without_cursor(
+    method_name: str,
+):
+    cursor = "SECRET_OPAQUE_CURSOR"
+    cancellation = asyncio.CancelledError(cursor)
+    server = MCPServerStreamableHttp(params={"url": _SAFE_URL})
+    session = MagicMock()
+    setattr(
+        session,
+        method_name,
+        AsyncMock(
+            side_effect=[
+                _paginated_list_result(method_name, cursor),
+                cancellation,
+            ]
+        ),
+    )
+    server.session = session
+    server.max_retry_attempts = 0
+
+    with pytest.raises(asyncio.CancelledError) as cancellation_info:
+        await getattr(server, method_name)()
+
+    assert str(cancellation_info.value) == ""
+    assert cancellation_info.value.__cause__ is None
+    assert cancellation_info.value.__context__ is None
+    _assert_not_retained_in_exception_graph(cancellation_info.value, cancellation)
+    _assert_text_hidden_from_server_traceback_locals(cancellation_info.value, cursor)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes MCP list pagination by following `nextCursor` until exhaustion for tools and prompts while leaving resource and resource-template pagination page-scoped. It preserves first-page prompt metadata, cache/filter and shared retry behavior, rejects cursor cycles without exposing opaque cursors, and adds official MCP stdio integration coverage including second-page Agent tool calls.

This pull request resolves #4085 and incorporates the relevant review feedback from #4086.