### PR TITLE
fix(models): merge dictionary fields in ModelSettings.resolve

### DIFF
--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -249,16 +249,24 @@ class ModelSettings:
             and getattr(override, field.name, None) is not None
         }
 
-        # Handle extra_args merging specially - merge dictionaries instead of replacing.
-        if (override_fields is None or "extra_args" in override_fields) and (
-            self.extra_args is not None or override.extra_args is not None
+        # Handle dictionary fields merging - merge dictionaries instead of replacing.
+        for dict_field_name in (
+            "extra_args",
+            "extra_headers",
+            "extra_query",
+            "extra_body",
+            "metadata",
         ):
-            merged_args = {}
-            if self.extra_args:
-                merged_args.update(self.extra_args)
-            if override.extra_args:
-                merged_args.update(override.extra_args)
-            changes["extra_args"] = merged_args if merged_args else None
+            if override_fields is None or dict_field_name in override_fields:
+                self_val = getattr(self, dict_field_name, None)
+                override_val = getattr(override, dict_field_name, None)
+                if self_val is not None or override_val is not None:
+                    merged_dict = {}
+                    if self_val:
+                        merged_dict.update(self_val)
+                    if override_val:
+                        merged_dict.update(override_val)
+                    changes[dict_field_name] = merged_dict if merged_dict else None
 
         if (override_fields is None or "retry" in override_fields) and (
             self.retry is not None or override.retry is not None

--- a/tests/model_settings/test_serialization.py
+++ b/tests/model_settings/test_serialization.py
@@ -256,6 +256,31 @@ def test_extra_args_resolve_both_none() -> None:
     assert resolved.top_p == 0.9
 
 
+def test_dictionary_fields_resolve() -> None:
+    """Test that dictionary fields (metadata, extra_headers, extra_query, extra_body)
+    are merged in resolve.
+    """
+    base_settings = ModelSettings(
+        metadata={"k1": "v1", "k2": "v2_base"},
+        extra_headers={"h1": "v1", "h2": "v2_base"},
+        extra_query={"q1": "v1", "q2": "v2_base"},
+        extra_body={"b1": "v1", "b2": "v2_base"},
+    )
+    override_settings = ModelSettings(
+        metadata={"k2": "v2_override", "k3": "v3"},
+        extra_headers={"h2": "v2_override", "h3": "v3"},
+        extra_query={"q2": "v2_override", "q3": "v3"},
+        extra_body={"b2": "v2_override", "b3": "v3"},
+    )
+
+    resolved = base_settings.resolve(override_settings)
+
+    assert resolved.metadata == {"k1": "v1", "k2": "v2_override", "k3": "v3"}
+    assert resolved.extra_headers == {"h1": "v1", "h2": "v2_override", "h3": "v3"}
+    assert resolved.extra_query == {"q1": "v1", "q2": "v2_override", "q3": "v3"}
+    assert resolved.extra_body == {"b1": "v1", "b2": "v2_override", "b3": "v3"}
+
+
 def test_pydantic_serialization() -> None:
     """Tests whether ModelSettings can be serialized with Pydantic."""
 


### PR DESCRIPTION
### Summary

`ModelSettings.resolve()` overlays an override `ModelSettings` object or dictionary on top of a base `ModelSettings` instance. Previously, while `extra_args` was handled specially to merge dictionary keys, other dictionary configuration fields—`extra_headers`, `extra_query`, `extra_body`, and `metadata`—were replaced as atomic values.

As a result, when resolving model settings (for example, when `RunConfig.model_settings` overlays an `Agent.model_settings`), any dictionary keys specified on the base settings for `metadata`, `extra_headers`, `extra_query`, or `extra_body` were discarded if the override specified any value for that dictionary field.

This PR updates `ModelSettings.resolve()` so that all dictionary settings (`extra_args`, `extra_headers`, `extra_query`, `extra_body`, and `metadata`) are merged dictionary-wise, preserving non-conflicting base keys while allowing override keys to take precedence.

### Test plan

- Added focused unit tests in `tests/model_settings/test_serialization.py` verifying that dictionary fields (`metadata`, `extra_headers`, `extra_query`, `extra_body`) merge correctly during `ModelSettings.resolve()`.
- Verified the new test failed before the fix and passed after the fix.
- Ran formatting, linting, type checks, and tests:
  ```bash
  uv run ruff format --check .
  uv run ruff check .
  uv run pyright
  uv run pytest tests/model_settings/
  ```

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
