### PR TITLE
fix(items): support iterable structured tool outputs

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import json
 import weakref
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, TypeVar, cast
 
@@ -905,9 +905,15 @@ class ItemHelpers:
     ) -> ResponseFunctionCallOutputItemListParam | None:
         """Convert known structured tool outputs without stringifying other values."""
 
-        # If the output is either a single or list of the known structured output types, convert to
-        # ResponseFunctionCallOutputItemListParam.
-        if isinstance(output, list | tuple):
+        maybe_converted_output = cls._maybe_get_output_as_structured_function_output(output)
+        if maybe_converted_output is not None:
+            return [cls._convert_single_tool_output_pydantic_model(maybe_converted_output)]
+
+        # Convert iterables of known structured output types without treating strings, mappings,
+        # or unrelated Pydantic models as collections of output items.
+        if isinstance(output, Iterable) and not isinstance(
+            output, str | bytes | bytearray | Mapping | BaseModel
+        ):
             maybe_converted_output_list = [
                 cls._maybe_get_output_as_structured_function_output(item) for item in output
             ]
@@ -922,9 +928,6 @@ class ItemHelpers:
                 ]
             return None
 
-        maybe_converted_output = cls._maybe_get_output_as_structured_function_output(output)
-        if maybe_converted_output:
-            return [cls._convert_single_tool_output_pydantic_model(maybe_converted_output)]
         return None
 
     @classmethod

--- a/tests/test_tool_output_conversion.py
+++ b/tests/test_tool_output_conversion.py
@@ -76,6 +76,24 @@ def test_tool_call_output_item_mixed_list() -> None:
     assert items[2]["type"] == "input_file" and items[2]["file_data"] == "ZmlsZS1kYXRh"
 
 
+def test_tool_call_output_item_generator() -> None:
+    call = _make_tool_call()
+    outputs = (
+        item
+        for item in (
+            ToolOutputText(text="a"),
+            {"type": "image", "image_url": "http://example/img.png"},
+        )
+    )
+
+    payload = ItemHelpers.tool_call_output_item(call, outputs)
+
+    assert payload["output"] == [
+        {"type": "input_text", "text": "a"},
+        {"type": "input_image", "image_url": "http://example/img.png"},
+    ]
+
+
 def test_tool_call_output_item_image_forwards_file_id_and_detail() -> None:
     """Ensure image outputs forward provided file_id and detail fields."""
     call = _make_tool_call()


### PR DESCRIPTION
### Summary

- Fix `ItemHelpers.tool_call_output_item()` stringifying generator-backed structured tool outputs even though its public contract accepts an iterable of structured items.
- Recognize non-string, non-mapping iterables after checking single structured models and dictionaries, preserving the existing behavior for lists, tuples, invalid mixtures, and empty collections.
- Add a regression test covering a one-shot generator with both Pydantic and dictionary structured output forms.

### Test plan

- `.venv/bin/python -m pytest tests/test_tool_output_conversion.py::test_tool_call_output_item_generator -q`
- `.venv/bin/python -m pytest tests/test_tool_output_conversion.py -q` (27 passed)
- `make format`, `make lint`, and `make typecheck`
- `make tests` (6,016 parallel tests and 45 serial tests passed, with 7 total skips)
- `.agents/skills/code-change-verification/scripts/run.sh` (all commands passed)

### Issue number

N/A — no linked issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
