### PR TITLE
fix(run): report tool guardrail results for streamed runs

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1140,6 +1140,16 @@ async def start_streaming(
                 streamed_result.raw_responses = streamed_result.raw_responses + [
                     turn_result.model_response
                 ]
+                # Mirror the non-streaming loop, which extends the run-wide tool guardrail lists
+                # from every turn result so the run result reports the guardrails that ran.
+                streamed_result.tool_input_guardrail_results = (
+                    streamed_result.tool_input_guardrail_results
+                    + turn_result.tool_input_guardrail_results
+                )
+                streamed_result.tool_output_guardrail_results = (
+                    streamed_result.tool_output_guardrail_results
+                    + turn_result.tool_output_guardrail_results
+                )
                 input_before_turn_rewrite = streamed_result.input
                 streamed_result.input = turn_result.original_input
                 if isinstance(turn_result.next_step, NextStepHandoff):

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -449,6 +449,23 @@ async def _finalize_streamed_final_output(
     streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
 
 
+def _accumulate_tool_guardrail_results(
+    streamed_result: RunResultStreaming,
+    turn_result: SingleStepResult,
+) -> None:
+    """Carry a turn's tool guardrail results onto the streamed result.
+
+    The non-streaming loop extends its run-wide lists from every turn result, so the streaming
+    loop has to do the same for `RunResultStreaming` to report the guardrails that ran.
+    """
+    streamed_result.tool_input_guardrail_results = (
+        streamed_result.tool_input_guardrail_results + turn_result.tool_input_guardrail_results
+    )
+    streamed_result.tool_output_guardrail_results = (
+        streamed_result.tool_output_guardrail_results + turn_result.tool_output_guardrail_results
+    )
+
+
 async def _finalize_streamed_interruption(
     *,
     streamed_result: RunResultStreaming,
@@ -858,6 +875,12 @@ async def start_streaming(
                         run_config.model_settings
                     ).store
 
+                    # The non-streaming resume path extends its run-wide lists before finalizing
+                    # but skips a resumed turn that loops back to the model, so a guardrail that
+                    # re-runs for the same tool call on resume is not counted twice.
+                    if not isinstance(turn_result.next_step, NextStepRunAgain):
+                        _accumulate_tool_guardrail_results(streamed_result, turn_result)
+
                     if isinstance(turn_result.next_step, NextStepInterruption):
                         await _finalize_streamed_interruption(
                             streamed_result=streamed_result,
@@ -1140,16 +1163,7 @@ async def start_streaming(
                 streamed_result.raw_responses = streamed_result.raw_responses + [
                     turn_result.model_response
                 ]
-                # Mirror the non-streaming loop, which extends the run-wide tool guardrail lists
-                # from every turn result so the run result reports the guardrails that ran.
-                streamed_result.tool_input_guardrail_results = (
-                    streamed_result.tool_input_guardrail_results
-                    + turn_result.tool_input_guardrail_results
-                )
-                streamed_result.tool_output_guardrail_results = (
-                    streamed_result.tool_output_guardrail_results
-                    + turn_result.tool_output_guardrail_results
-                )
+                _accumulate_tool_guardrail_results(streamed_result, turn_result)
                 input_before_turn_rewrite = streamed_result.input
                 streamed_result.input = turn_result.original_input
                 if isinstance(turn_result.next_step, NextStepHandoff):

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -36,6 +36,9 @@ from agents import (
     OutputGuardrailTripwireTriggered,
     RunContextWrapper,
     Runner,
+    ToolGuardrailFunctionOutput,
+    ToolInputGuardrailData,
+    ToolOutputGuardrailData,
     UserError,
     function_tool,
     handoff,
@@ -54,7 +57,8 @@ from agents.run import RunConfig
 from agents.run_internal import run_loop
 from agents.run_internal.run_loop import QueueCompleteSentinel
 from agents.stream_events import AgentUpdatedStreamEvent, RawResponsesStreamEvent, StreamEvent
-from agents.tool import Tool
+from agents.tool import FunctionTool, Tool
+from agents.tool_guardrails import tool_input_guardrail, tool_output_guardrail
 from agents.usage import Usage
 
 from .fake_model import FakeModel, get_response_obj
@@ -2259,3 +2263,217 @@ async def test_streaming_hitl_server_conversation_tracker_priming():
     # Should complete successfully without message duplication
     assert result2.final_output == "Second response"
     assert len(result2.new_items) >= 1
+
+
+def _tool_with_guardrails() -> FunctionTool:
+    """Build a function tool guarded by one input and one output tool guardrail."""
+
+    @tool_input_guardrail
+    def record_input(_data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info="input-checked")
+
+    @tool_output_guardrail
+    def record_output(_data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info="output-checked")
+
+    @function_tool(
+        name_override="guarded_tool",
+        tool_input_guardrails=[record_input],
+        tool_output_guardrails=[record_output],
+    )
+    def guarded_tool() -> str:
+        return "tool-result"
+
+    return guarded_tool
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_reports_tool_guardrail_results():
+    """Streamed runs must expose tool guardrail results like non-streamed runs do."""
+    model, agent = make_model_and_agent(tools=[_tool_with_guardrails()])
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("guarded_tool", "{}", call_id="call_1")],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="hello")
+    await consume_stream(result)
+
+    assert result.final_output == "done"
+    assert len(result.tool_input_guardrail_results) == 1
+    assert result.tool_input_guardrail_results[0].output.output_info == "input-checked"
+    assert len(result.tool_output_guardrail_results) == 1
+    assert result.tool_output_guardrail_results[0].output.output_info == "output-checked"
+
+
+@pytest.mark.asyncio
+async def test_streamed_tool_guardrail_results_match_non_streamed():
+    """The same run reports the same tool guardrail results in both execution modes."""
+
+    def _build() -> tuple[FakeModel, Agent[Any]]:
+        model, agent = make_model_and_agent(tools=[_tool_with_guardrails()])
+        model.add_multiple_turn_outputs(
+            [
+                [get_function_tool_call("guarded_tool", "{}", call_id="call_1")],
+                [get_function_tool_call("guarded_tool", "{}", call_id="call_2")],
+                [get_text_message("done")],
+            ]
+        )
+        return model, agent
+
+    _, non_streamed_agent = _build()
+    non_streamed = await Runner.run(non_streamed_agent, input="hello")
+
+    _, streamed_agent = _build()
+    streamed = Runner.run_streamed(streamed_agent, input="hello")
+    await consume_stream(streamed)
+
+    assert len(non_streamed.tool_input_guardrail_results) == 2
+    assert len(non_streamed.tool_output_guardrail_results) == 2
+    assert len(streamed.tool_input_guardrail_results) == len(
+        non_streamed.tool_input_guardrail_results
+    )
+    assert len(streamed.tool_output_guardrail_results) == len(
+        non_streamed.tool_output_guardrail_results
+    )
+
+
+@pytest.mark.asyncio
+async def test_streamed_tool_guardrail_results_survive_handoff():
+    """Tool guardrail results from a handoff turn reach the streamed result."""
+    model = FakeModel()
+    target = Agent(name="target", model=model)
+    agent = Agent(
+        name="source",
+        model=model,
+        tools=[_tool_with_guardrails()],
+        handoffs=[target],
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [
+                get_function_tool_call("guarded_tool", "{}", call_id="call_1"),
+                get_handoff_tool_call(target),
+            ],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="hello")
+    await consume_stream(result)
+
+    assert result.final_output == "done"
+    assert len(result.tool_input_guardrail_results) == 1
+    assert len(result.tool_output_guardrail_results) == 1
+
+
+@pytest.mark.asyncio
+async def test_streamed_interruption_reports_tool_guardrail_results():
+    """An interrupted streamed turn reports the tool guardrail results it produced."""
+
+    @tool_input_guardrail
+    def record_input(_data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info="input-checked")
+
+    @function_tool(name_override="plain_tool", tool_input_guardrails=[record_input])
+    def plain_tool() -> str:
+        return "plain-result"
+
+    @function_tool(name_override="approval_tool", needs_approval=True)
+    def approval_tool() -> str:
+        return "approved-result"
+
+    model, agent = make_model_and_agent(tools=[plain_tool, approval_tool])
+    model.set_next_output(
+        [
+            get_function_tool_call("plain_tool", "{}", call_id="call_plain"),
+            get_function_tool_call("approval_tool", "{}", call_id="call_approval"),
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="hello")
+    await consume_stream(result)
+
+    assert len(result.interruptions) == 1
+    assert len(result.tool_input_guardrail_results) == 1
+    assert result.tool_input_guardrail_results[0].output.output_info == "input-checked"
+
+
+@pytest.mark.asyncio
+async def test_streamed_tool_guardrail_results_persist_into_run_state():
+    """Tool guardrail results from a streamed run round-trip through RunState."""
+    model, agent = make_model_and_agent(tools=[_tool_with_guardrails()])
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("guarded_tool", "{}", call_id="call_1")],
+            [get_text_message("done")],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="hello")
+    await consume_stream(result)
+
+    state = result.to_state()
+    assert len(state._tool_input_guardrail_results) == 1
+    assert len(state._tool_output_guardrail_results) == 1
+
+
+@pytest.mark.asyncio
+async def test_streamed_resume_tool_guardrail_results_match_non_streamed():
+    """Resumed-turn accounting stays identical across execution modes.
+
+    Accumulating tool guardrail results for streamed runs must not change how a resumed turn
+    reports them, so this pins streamed and non-streamed resumes to the same value rather than
+    to a specific count.
+    """
+
+    def _build() -> tuple[FakeModel, Agent[Any]]:
+        @tool_input_guardrail
+        def record_input(_data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+            return ToolGuardrailFunctionOutput.allow(output_info="input-checked")
+
+        @tool_output_guardrail
+        def record_output(_data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+            return ToolGuardrailFunctionOutput.allow(output_info="output-checked")
+
+        @function_tool(
+            name_override="approval_tool",
+            needs_approval=True,
+            tool_input_guardrails=[record_input],
+            tool_output_guardrails=[record_output],
+        )
+        def approval_tool() -> str:
+            return "approved-result"
+
+        model, agent = make_model_and_agent(tools=[approval_tool])
+        model.add_multiple_turn_outputs(
+            [
+                [get_function_tool_call("approval_tool", "{}", call_id="call_approval")],
+                [get_text_message("done")],
+            ]
+        )
+        return model, agent
+
+    _, non_streamed_agent = _build()
+    non_streamed_first = await Runner.run(non_streamed_agent, "hello")
+    assert len(non_streamed_first.interruptions) == 1
+    non_streamed_state = non_streamed_first.to_state()
+    non_streamed_state.approve(non_streamed_first.interruptions[0])
+    non_streamed = await Runner.run(non_streamed_agent, non_streamed_state)
+
+    _, streamed_agent = _build()
+    streamed_first = Runner.run_streamed(streamed_agent, input="hello")
+    await consume_stream(streamed_first)
+    assert len(streamed_first.interruptions) == 1
+    streamed = await resume_streamed_after_first_approval(streamed_agent, streamed_first)
+
+    assert non_streamed.final_output == "done"
+    assert streamed.final_output == "done"
+    assert len(streamed.tool_input_guardrail_results) == len(
+        non_streamed.tool_input_guardrail_results
+    )
+    assert len(streamed.tool_output_guardrail_results) == len(
+        non_streamed.tool_output_guardrail_results
+    )

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -2477,3 +2477,134 @@ async def test_streamed_resume_tool_guardrail_results_match_non_streamed():
     assert len(streamed.tool_output_guardrail_results) == len(
         non_streamed.tool_output_guardrail_results
     )
+
+
+@pytest.mark.asyncio
+async def test_streamed_resume_terminal_turn_reports_tool_guardrail_results():
+    """A resumed streamed turn that ends the run reports its tool guardrail results.
+
+    With `tool_use_behavior="stop_on_first_tool"` the approved tool produces the final output
+    inside the resumed turn, so the run finalizes from the resume branch rather than from the
+    regular turn loop.
+    """
+
+    def _build() -> tuple[FakeModel, Agent[Any]]:
+        @tool_input_guardrail
+        def record_input(_data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+            return ToolGuardrailFunctionOutput.allow(output_info="input-checked")
+
+        @tool_output_guardrail
+        def record_output(_data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+            return ToolGuardrailFunctionOutput.allow(output_info="output-checked")
+
+        @function_tool(
+            name_override="approval_tool",
+            needs_approval=True,
+            tool_input_guardrails=[record_input],
+            tool_output_guardrails=[record_output],
+        )
+        def approval_tool() -> str:
+            return "approved-result"
+
+        model = FakeModel()
+        agent = Agent(
+            name="TestAgent",
+            model=model,
+            tools=[approval_tool],
+            tool_use_behavior="stop_on_first_tool",
+        )
+        model.set_next_output(
+            [get_function_tool_call("approval_tool", "{}", call_id="call_approval")]
+        )
+        return model, agent
+
+    _, streamed_agent = _build()
+    streamed_first = Runner.run_streamed(streamed_agent, input="hello")
+    await consume_stream(streamed_first)
+    assert len(streamed_first.interruptions) == 1
+    streamed = await resume_streamed_after_first_approval(streamed_agent, streamed_first)
+
+    assert streamed.final_output == "approved-result"
+    assert len(streamed.tool_input_guardrail_results) == 1
+    assert streamed.tool_input_guardrail_results[0].output.output_info == "input-checked"
+    assert len(streamed.tool_output_guardrail_results) == 1
+    assert streamed.tool_output_guardrail_results[0].output.output_info == "output-checked"
+
+    _, non_streamed_agent = _build()
+    non_streamed_first = await Runner.run(non_streamed_agent, "hello")
+    assert len(non_streamed_first.interruptions) == 1
+    non_streamed_state = non_streamed_first.to_state()
+    non_streamed_state.approve(non_streamed_first.interruptions[0])
+    non_streamed = await Runner.run(non_streamed_agent, non_streamed_state)
+
+    assert len(streamed.tool_input_guardrail_results) == len(
+        non_streamed.tool_input_guardrail_results
+    )
+    assert len(streamed.tool_output_guardrail_results) == len(
+        non_streamed.tool_output_guardrail_results
+    )
+
+
+@pytest.mark.asyncio
+async def test_streamed_resume_handoff_turn_reports_tool_guardrail_results():
+    """A resumed streamed turn that hands off keeps the guardrail results it produced."""
+
+    def _build() -> tuple[FakeModel, Agent[Any]]:
+        @tool_input_guardrail
+        def record_input(_data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+            return ToolGuardrailFunctionOutput.allow(output_info="input-checked")
+
+        @tool_output_guardrail
+        def record_output(_data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+            return ToolGuardrailFunctionOutput.allow(output_info="output-checked")
+
+        @function_tool(
+            name_override="approval_tool",
+            needs_approval=True,
+            tool_input_guardrails=[record_input],
+            tool_output_guardrails=[record_output],
+        )
+        def approval_tool() -> str:
+            return "approved-result"
+
+        model = FakeModel()
+        target = Agent(name="target", model=model)
+        agent = Agent(
+            name="TestAgent",
+            model=model,
+            tools=[approval_tool],
+            handoffs=[target],
+        )
+        model.add_multiple_turn_outputs(
+            [
+                [
+                    get_function_tool_call("approval_tool", "{}", call_id="call_approval"),
+                    get_handoff_tool_call(target),
+                ],
+                [get_text_message("done")],
+            ]
+        )
+        return model, agent
+
+    _, streamed_agent = _build()
+    streamed_first = Runner.run_streamed(streamed_agent, input="hello")
+    await consume_stream(streamed_first)
+    assert len(streamed_first.interruptions) == 1
+    streamed = await resume_streamed_after_first_approval(streamed_agent, streamed_first)
+
+    assert streamed.final_output == "done"
+    assert len(streamed.tool_input_guardrail_results) == 1
+    assert len(streamed.tool_output_guardrail_results) == 1
+
+    _, non_streamed_agent = _build()
+    non_streamed_first = await Runner.run(non_streamed_agent, "hello")
+    non_streamed_state = non_streamed_first.to_state()
+    non_streamed_state.approve(non_streamed_first.interruptions[0])
+    non_streamed = await Runner.run(non_streamed_agent, non_streamed_state)
+
+    assert len(streamed.tool_input_guardrail_results) == len(
+        non_streamed.tool_input_guardrail_results
+    )
+    assert len(streamed.tool_output_guardrail_results) == len(
+        non_streamed.tool_output_guardrail_results
+    )


### PR DESCRIPTION
### Summary

`RunResultStreaming.tool_input_guardrail_results` and `RunResultStreaming.tool_output_guardrail_results` were always empty. Streamed runs execute tool guardrails and build them into each `SingleStepResult`, but the streaming loop never carried them onto the run result, so anything that relies on these fields sees nothing in `Runner.run_streamed()` while `Runner.run()` reports them correctly.

**Affected component:** `src/agents/run_internal/run_loop.py` (`start_streaming`), streaming runner lifecycle.

**Minimal reproduction** (no API key, no live request — uses `tests/fake_model.py`):

```python
@tool_input_guardrail
def record_input(_data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
    return ToolGuardrailFunctionOutput.allow(output_info="input-checked")

@function_tool(name_override="guarded_tool", tool_input_guardrails=[record_input])
def guarded_tool() -> str:
    return "tool-result"

# model yields: [function_call guarded_tool] then [text "done"]
non_streamed = await Runner.run(agent, "hello")
streamed = Runner.run_streamed(agent, "hello")
async for _ in streamed.stream_events():
    pass

len(non_streamed.tool_input_guardrail_results)  # 1
len(streamed.tool_input_guardrail_results)      # 0  <-- bug
```

**Current behavior:** the guardrail runs (its rejection message reaches the model, and `new_items` shows the rejected/allowed tool output), but `streamed.tool_input_guardrail_results` and `streamed.tool_output_guardrail_results` stay `[]`. `RunResultStreaming.to_state()` therefore also persists empty `_tool_input_guardrail_results` / `_tool_output_guardrail_results`.

**Corrected behavior:** streamed runs report the same tool guardrail results as the equivalent non-streamed run.

**Root cause:** the non-streaming loop in `run.py` extends its run-wide accumulators from every turn (`tool_input_guardrail_results.extend(turn_result.tool_input_guardrail_results)`), and `RunResultStreaming` is constructed with these lists seeded only from a resumed `RunState`. `start_streaming` never extended them from `turn_result`, so for a fresh streamed run they stayed at their initial `[]` for the whole run. This is the streaming-side counterpart of the plumbing #3237 fixed inside `SingleStepResult`; the values arrive correctly at the streaming loop and are then dropped.

**Implementation:** `start_streaming` now extends both lists from each completed `turn_result`, via a small `_accumulate_tool_guardrail_results` helper called from the two places a `turn_result` is produced:

1. The regular turn loop, immediately next to the existing `streamed_result.raw_responses` accumulation and before the `next_step` branching — the same position and ordering the non-streaming loop uses, so interruption, handoff, run-again, and final-output turns are covered by one site.
2. The resume branch, which finalizes on its own when a resumed turn is terminal (for example an approved tool under `tool_use_behavior="stop_on_first_tool"`, or a resumed turn that hands off) and so never reaches site 1. This site skips `NextStepRunAgain`, matching the non-streaming resume path, so a pre-approval guardrail that re-runs for the same tool call is not counted twice.

Rebinding (rather than `list.extend`) matches how `input_guardrail_results` / `output_guardrail_results` are updated elsewhere in this module and avoids mutating a caller-visible list in place.

**Why this is minimal:** ~25 added lines, no behavior change outside the streaming loop. No public API, exception type, hook contract, event ordering, usage accounting, or session behavior changes; nothing is added to the non-streaming path.

Parity was verified directly for all five resumed outcomes — terminal final output, run-again, handoff, a second interruption, and pre-approval run-again — and streamed now matches non-streamed exactly in each.

### Test plan

Eight tests added to `tests/test_agent_runner_streamed.py`, all using `FakeModel` — no API key, no network, no sleeps.

Seven fail on `upstream/main` (`a134f3a`) and pass with the fix:

- `test_streamed_run_reports_tool_guardrail_results` — the demonstrated failure; input and output guardrail results are reported.
- `test_streamed_tool_guardrail_results_match_non_streamed` — two guarded tool calls across two turns; streamed counts equal non-streamed counts (no drops, no duplicates).
- `test_streamed_tool_guardrail_results_survive_handoff` — guarded tool call and a handoff in the same response, covering the `execute_handoffs` path from #3237 in streaming mode.
- `test_streamed_interruption_reports_tool_guardrail_results` — a turn that ends in an approval interruption still reports the guardrails that ran for the tool executed alongside it.
- `test_streamed_tool_guardrail_results_persist_into_run_state` — the results survive `RunResultStreaming.to_state()`.
- `test_streamed_resume_terminal_turn_reports_tool_guardrail_results` — resume under `tool_use_behavior="stop_on_first_tool"`, where the approved tool produces the final output inside the resumed turn and the run finalizes from the resume branch.
- `test_streamed_resume_handoff_turn_reports_tool_guardrail_results` — resume where the approved turn also hands off.

One test passes both before and after; it is a parity guard, not a regression test:

- `test_streamed_resume_tool_guardrail_results_match_non_streamed` — pins streamed and non-streamed *resumed* turns to the same value, so this change provably does not alter resumed-turn accounting. It asserts equality rather than a specific count deliberately (see non-goals).

Commands run from the repository root at commit `b00e159`, all passing:

```
bash .agents/skills/code-change-verification/scripts/run.sh   # all commands passed
uv run ruff format --check                                    # 844 files already formatted
uv run ruff check                                             # All checks passed!
make typecheck                                                # mypy: no issues in 835 source files; pyright: 0 errors
uv run pytest -n auto --dist loadfile -m "not serial" -q      # 6023 passed, 3 skipped
uv run pytest -m serial -q                                    # 45 passed, 4 skipped
git diff --check                                              # clean
```

Red/green evidence: with `src/agents/run_internal/run_loop.py` reverted to `upstream/main` and the tests kept, `uv run pytest tests/test_agent_runner_streamed.py -k "tool_guardrail or interruption_reports"` reports `7 failed, 1 passed`; with the fix applied it reports `8 passed`. The focused selection was also run five times consecutively and under `-W error::RuntimeWarning` with identical results (no pending-task or unclosed-resource warnings).

Environment: macOS 15.7.3 (arm64), Python 3.12.13 via `uv`, base commit `a134f3a29869f3aa0e10e37447897046d18c2d23`.

**Not run:** `make coverage`, `make build-docs`, and the `integration-tests-*` targets. Coverage and docs are unaffected (no docs or public-surface change), and the integration profiles require credentials and live services.

**Non-goals / limitations**

- `NextStepRunAgain` accounting on resume is deliberately preserved, not changed. The non-streaming loop skips accumulation for a resumed turn that loops back to the model, which is what keeps `test_pre_approval_tool_input_guardrails_rerun_after_resume` at one result rather than re-counting the same tool call. This PR matches that rule rather than relitigating it, and `test_streamed_resume_tool_guardrail_results_match_non_streamed` pins the two modes together so the decision stays in one place.
- Partial results are still not reported when a tool guardrail returns `raise_exception`. This is pre-existing and symmetric: `RunErrorDetails` has no `tool_input_guardrail_results` / `tool_output_guardrail_results` fields, so the non-streaming path does not surface them on a tripwire either, and the triggering result is already reachable through the raised `ToolInputGuardrailTripwireTriggered` / `ToolOutputGuardrailTripwireTriggered`. Surfacing the turn's partial results would mean either threading a mutable sink from `start_streaming` through `run_single_turn_streamed` → `get_single_step_result_from_response` → `execute_tools_and_side_effects` → `execute_tool_runs` → `execute_function_tool_calls`, or adding public fields to `RunErrorDetails`. Both are cross-module changes with their own design decision, and doing it for streaming alone would create exactly the asymmetry this PR removes. Happy to do it as a follow-up if maintainers want that reporting.
- No change to guardrail execution, ordering, or `reject_content` / `raise_exception` behavior — only to reporting.

### Issue number

None. `AGENTS.md` asks for an issue number "if applicable" and does not require filing one before a small fix, so no speculative issue was created.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR — not applicable, this was not authored with Codex.
