### PR TITLE
fix(memory): prevent writes to cleared conversations

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -129,8 +129,15 @@ class OpenAIConversationsSession(SessionABC):
         return items[0]
 
     async def clear_session(self) -> None:
-        session_id = await self._get_session_id()
-        await self._openai_client.conversations.delete(
-            conversation_id=session_id,
-        )
-        await self._clear_session_id()
+        async with self._session_id_lock:
+            if self._session_id is None:
+                self._session_id = await start_openai_conversations_session(self._openai_client)
+            session_id = self._session_id
+            self._session_id = None
+            try:
+                await self._openai_client.conversations.delete(
+                    conversation_id=session_id,
+                )
+            except BaseException:
+                self._session_id = session_id
+                raise

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -389,6 +389,32 @@ class TestOpenAIConversationsSessionErrorHandling:
         with pytest.raises(Exception, match="Clear session failed"):
             await session.clear_session()
 
+        assert session.session_id == "test_id"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_clear_session_restores_session_id(self, mock_openai_client):
+        """Test that cancelling a clear keeps the prior conversation available."""
+        delete_started = asyncio.Event()
+        hold_delete = asyncio.Event()
+
+        async def delete_conversation(*, conversation_id):
+            delete_started.set()
+            await hold_delete.wait()
+
+        mock_openai_client.conversations.delete.side_effect = delete_conversation
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        clear_task = asyncio.create_task(session.clear_session())
+        await delete_started.wait()
+        clear_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await clear_task
+
+        assert session.session_id == "test_id"
+
     @pytest.mark.asyncio
     async def test_invalid_item_id_in_pop_item(self, mock_openai_client):
         """Test handling of invalid item ID during pop_item."""
@@ -523,6 +549,64 @@ class TestOpenAIConversationsSessionConcurrentAccess:
             conversation_id="surviving_conversation", items=surviving_items
         )
         assert session.session_id == "surviving_conversation"
+
+    @pytest.mark.asyncio
+    async def test_write_during_clear_waits_for_new_conversation(
+        self, mock_openai_client, monkeypatch
+    ):
+        """Test that a write cannot target the conversation being cleared."""
+        delete_started = asyncio.Event()
+        release_delete = asyncio.Event()
+        write_lookup_started = asyncio.Event()
+        item_write_started = asyncio.Event()
+
+        async def delete_conversation(*, conversation_id):
+            assert conversation_id == "conversation_to_clear"
+            delete_started.set()
+            await release_delete.wait()
+
+        async def create_items(*, conversation_id, items):
+            item_write_started.set()
+
+        mock_openai_client.conversations.delete.side_effect = delete_conversation
+        mock_openai_client.conversations.create.return_value = MagicMock(
+            id="replacement_conversation"
+        )
+        mock_openai_client.conversations.items.create.side_effect = create_items
+        session = OpenAIConversationsSession(
+            conversation_id="conversation_to_clear",
+            openai_client=mock_openai_client,
+        )
+
+        clear_task = asyncio.create_task(session.clear_session())
+        await delete_started.wait()
+
+        original_get_session_id = session._get_session_id
+
+        async def tracked_get_session_id():
+            write_lookup_started.set()
+            return await original_get_session_id()
+
+        monkeypatch.setattr(session, "_get_session_id", tracked_get_session_id)
+        new_items: list[TResponseInputItem] = [{"role": "user", "content": "New message"}]
+        write_task = asyncio.create_task(session.add_items(new_items))
+        await write_lookup_started.wait()
+
+        try:
+            assert not item_write_started.is_set()
+        finally:
+            release_delete.set()
+            await asyncio.gather(clear_task, write_task)
+
+        mock_openai_client.conversations.delete.assert_awaited_once_with(
+            conversation_id="conversation_to_clear"
+        )
+        mock_openai_client.conversations.create.assert_awaited_once_with(items=[])
+        mock_openai_client.conversations.items.create.assert_awaited_once_with(
+            conversation_id="replacement_conversation",
+            items=new_items,
+        )
+        assert session.session_id == "replacement_conversation"
 
 
 # ============================================================================


### PR DESCRIPTION
### Summary

`OpenAIConversationsSession.clear_session()` kept its current conversation ID visible while awaiting `conversations.delete`. A concurrent `add_items()` could therefore write to that same conversation during deletion, return successfully, and have its item disappear with the deleted conversation.

Clear now detaches the old ID while holding the existing session-ID lock. Operations that start during deletion wait for the clear to finish and lazily create a replacement conversation. If deletion fails or is cancelled, the prior ID is restored so the existing failure behavior remains usable.

The regression uses events and mocked Conversations methods: deletion is paused, a write starts, and the test proves no item request is issued until deletion is released; the write then targets the replacement conversation. It fails on unmodified `main` because the item request starts immediately against the old conversation.

### Test plan

- Focused regression before the production change: failed at `assert not item_write_started.is_set()`.
- `pytest -q tests/memory/test_openai_conversations_session.py` (`30 passed` before the cancellation boundary test was added; the final full suite includes both tests).
- `pytest -q tests/memory/test_session_limit.py tests/memory/test_session.py` (`52 passed`).
- Repeated the clear/write and cancellation regressions five times (`2 passed` on each run).
- Ran `.agents/skills/code-change-verification/scripts/run.sh`; format, lint, typecheck, and the complete test suite passed.

### Issue number

N/A — found through code-path review; no open or closed issue, pull request, or upstream branch covers concurrent writes during `OpenAIConversationsSession.clear_session()`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

`/review` was not invoked because this task prohibited additional live model calls; the final two-file diff was manually reviewed after all verification gates passed.

### Scope and risk

- No public API, session method signature, or dependency changes.
- Lazy initialization and clear-on-uninitialized behavior are preserved.
- Delete exceptions and cancellation restore the original conversation ID.
