### PR TITLE
fix(run): replace closed default loop in run_sync

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1699,6 +1699,10 @@ class AgentRunner:
                 default_loop = policy.new_event_loop()
                 policy.set_event_loop(default_loop)
 
+        if default_loop.is_closed():
+            default_loop = policy.new_event_loop()
+            policy.set_event_loop(default_loop)
+
         # We intentionally leave the default loop open even if we had to create one above. Session
         # instances and other helpers stash loop-bound primitives between calls and expect to find
         # the same default loop every time run_sync is invoked on this thread.

--- a/tests/test_agent_runner_sync.py
+++ b/tests/test_agent_runner_sync.py
@@ -66,6 +66,33 @@ def test_run_sync_creates_default_loop_when_missing(monkeypatch, fresh_event_loo
     created_loop.close()
 
 
+def test_run_sync_replaces_closed_default_loop(monkeypatch, fresh_event_loop_policy):
+    runner = AgentRunner()
+    observed_loops: list[asyncio.AbstractEventLoop] = []
+
+    async def fake_run(self, *_args, **_kwargs):
+        observed_loops.append(asyncio.get_running_loop())
+        return object()
+
+    monkeypatch.setattr(AgentRunner, "run", fake_run, raising=False)
+
+    closed_loop = asyncio.new_event_loop()
+    fresh_event_loop_policy.set_event_loop(closed_loop)
+    closed_loop.close()
+
+    try:
+        runner.run_sync(Agent(name="test-agent"), "input")
+        replacement_loop = observed_loops[0]
+        assert replacement_loop is fresh_event_loop_policy.get_event_loop()
+        assert replacement_loop is not closed_loop
+        assert not replacement_loop.is_closed()
+    finally:
+        current_loop = fresh_event_loop_policy.get_event_loop()
+        fresh_event_loop_policy.set_event_loop(None)
+        if not current_loop.is_closed():
+            current_loop.close()
+
+
 def test_run_sync_errors_when_loop_already_running(monkeypatch, fresh_event_loop_policy):
     runner = AgentRunner()
 


### PR DESCRIPTION
### Summary

`AgentRunner.run_sync()` reuses the thread's default event loop so loop-bound session primitives remain compatible across synchronous calls. If application code closes that default loop and then calls `run_sync()`, the SDK currently schedules onto the closed loop and raises `RuntimeError: Event loop is closed` before the run begins.

This change detects that state, creates a replacement loop through the active event-loop policy, and registers it as the new thread default before scheduling the run. Open default loops are still reused, calls from an already-running loop are still rejected, and the synchronous runner's cancellation and async-generator cleanup paths are unchanged.

A regression test installs a closed default loop and verifies that `run_sync()` completes on a distinct, open replacement that is retained as the policy's default loop.

### Test plan

- RED before the production change, repeated three times: `env UV_PYTHON=3.12 uv run pytest tests/test_agent_runner_sync.py::test_run_sync_replaces_closed_default_loop -q` failed consistently at `default_loop.create_task(...)` with `RuntimeError: Event loop is closed`.
- GREEN after the production change: `env UV_PYTHON=3.12 uv run pytest tests/test_agent_runner_sync.py::test_run_sync_replaces_closed_default_loop -q` — `1 passed`.
- Sync-runner regression module: `env UV_PYTHON=3.12 uv run pytest tests/test_agent_runner_sync.py -q` — `6 passed`.
- Neighboring run smoke tests: `env UV_PYTHON=3.12 uv run pytest tests/test_run.py -q` — `2 passed`.
- Repository verifier: `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` — format, lint, full tests, and type checking all passed.
- `git diff --check` passed.

No live API or model calls were used.

### Issue number

N/A — no issue was required for this small correctness fix, and exhaustive open/closed issue and pull-request searches found no existing report or competing fix.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
