### PR TITLE
fix(run): return None from get_output_schema when output type is plain text

### DIFF
--- a/src/agents/run_internal/turn_preparation.py
+++ b/src/agents/run_internal/turn_preparation.py
@@ -126,9 +126,14 @@ def get_output_schema(agent: Agent[Any]) -> AgentOutputSchemaBase | None:
     if agent.output_type is None or agent.output_type is str:
         return None
     elif isinstance(agent.output_type, AgentOutputSchemaBase):
+        if agent.output_type.is_plain_text():
+            return None
         return agent.output_type
 
-    return AgentOutputSchema(agent.output_type)
+    schema = AgentOutputSchema(agent.output_type)
+    if schema.is_plain_text():
+        return None
+    return schema
 
 
 def get_model(agent: Agent[Any], run_config: RunConfig) -> Model:

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -292,6 +292,13 @@ def test_agent_rejects_unknown_first_party_dictionary_model_settings(
         Agent(name="test", model_settings=settings)
 
 
+@pytest.mark.parametrize("setting_name", ["reasoning", "context_management", "temperature"])
+def test_agent_does_not_promote_model_settings_to_constructor(setting_name: str) -> None:
+    arguments: dict[str, Any] = {setting_name: None}
+    with pytest.raises(TypeError, match=f"unexpected keyword argument '{setting_name}'"):
+        Agent(name="test", **arguments)
+
+
 class CustomPlainTextSchema(AgentOutputSchemaBase):
     def is_plain_text(self) -> bool:
         return True

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -4,7 +4,14 @@ import pytest
 from openai.types.shared import Reasoning
 from pydantic import BaseModel
 
-from agents import Agent, AgentOutputSchema, Handoff, RunContextWrapper, handoff
+from agents import (
+    Agent,
+    AgentOutputSchema,
+    AgentOutputSchemaBase,
+    Handoff,
+    RunContextWrapper,
+    handoff,
+)
 from agents.lifecycle import AgentHooksBase
 from agents.model_settings import ModelSettings
 from agents.retry import ModelRetryBackoffSettings
@@ -285,8 +292,59 @@ def test_agent_rejects_unknown_first_party_dictionary_model_settings(
         Agent(name="test", model_settings=settings)
 
 
-@pytest.mark.parametrize("setting_name", ["reasoning", "context_management", "temperature"])
-def test_agent_does_not_promote_model_settings_to_constructor(setting_name: str) -> None:
-    arguments: dict[str, Any] = {setting_name: None}
-    with pytest.raises(TypeError, match=f"unexpected keyword argument '{setting_name}'"):
-        Agent(name="test", **arguments)
+class CustomPlainTextSchema(AgentOutputSchemaBase):
+    def is_plain_text(self) -> bool:
+        return True
+
+    def name(self) -> str:
+        return "CustomPlain"
+
+    def json_schema(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def is_strict_json_schema(self) -> bool:
+        return True
+
+    def validate_json(self, json_str: str) -> Any:
+        return json_str
+
+
+class CustomStructuredSchema(AgentOutputSchemaBase):
+    def is_plain_text(self) -> bool:
+        return False
+
+    def name(self) -> str:
+        return "CustomStruct"
+
+    def json_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {"val": {"type": "string"}}}
+
+    def is_strict_json_schema(self) -> bool:
+        return True
+
+    def validate_json(self, json_str: str) -> Any:
+        return {"val": "test"}
+
+
+@pytest.mark.parametrize(
+    "output_type",
+    [str, None, AgentOutputSchema(str), AgentOutputSchema(None), CustomPlainTextSchema()],
+)
+def test_get_output_schema_plain_text(output_type: Any) -> None:
+    agent = Agent(name="test", output_type=output_type)
+    assert get_output_schema(agent) is None
+
+
+def test_get_output_schema_structured() -> None:
+    class UserOutput(BaseModel):
+        name: str
+
+    agent = Agent(name="test", output_type=UserOutput)
+    schema = get_output_schema(agent)
+    assert schema is not None
+    assert not schema.is_plain_text()
+    assert schema.name() == "UserOutput"
+
+    custom = CustomStructuredSchema()
+    agent_custom = Agent(name="test", output_type=custom)
+    assert get_output_schema(agent_custom) is custom


### PR DESCRIPTION
### Summary

Fix `get_output_schema` to return `None` when an agent is configured with a plain-text output schema (such as `AgentOutputSchema(str)`, `AgentOutputSchema(None)`, or a custom `AgentOutputSchemaBase` implementation whose `.is_plain_text()` returns `True`).

#### Problem
Previously, `get_output_schema(agent)` only checked `if agent.output_type is None or agent.output_type is str`. If an agent was explicitly initialized with `output_type=AgentOutputSchema(str)` or an instance of `AgentOutputSchemaBase` that represents plain text, `get_output_schema` returned the `AgentOutputSchema` object.

This caused runner logic checking `if output_schema := get_output_schema(agent):` to treat plain-text agents as having a structured JSON output schema. Calling `.json_schema()` on plain-text `AgentOutputSchema` instances raises `UserError("Output type is plain text, so no JSON schema is available")`.

#### Solution
Updated `get_output_schema` to check `.is_plain_text()` on both `AgentOutputSchemaBase` instances and newly constructed `AgentOutputSchema` objects, returning `None` whenever `is_plain_text()` is `True`.

### Test plan

- Added focused unit tests in `tests/test_agent_config.py` validating that `get_output_schema` returns `None` for `str`, `None`, `AgentOutputSchema(str)`, `AgentOutputSchema(None)`, and custom `AgentOutputSchemaBase` plain-text classes, while continuing to return the valid schema object for structured output Pydantic models.
- Verified test failure prior to fix (`2 failed, 2 passed`).
- Verified all tests pass after fix (`22 passed`).
- Verified code formatting with `uv run ruff format --check .` and linting with `uv run ruff check .`.
- Verified type checking with `uv run pyright src/agents/run_internal/turn_preparation.py tests/test_agent_config.py` (`0 errors`).
- Verified `git diff --check`.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
