### PR TITLE
fix(function_schema): raise UserError for parameters with leading underscores

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -381,6 +381,20 @@ def function_schema(
     fields: dict[str, Any] = {}
 
     for name, param in filtered_params:
+        # Pydantic reserves leading-underscore attribute names for private attributes and refuses
+        # them as field names, so `create_model` below would fail with a NameError raised deep in
+        # pydantic internals. Detect it here so the error names the tool and the parameter. Only
+        # model-visible params are checked: a leading-underscore context param (e.g. `_ctx`) was
+        # already filtered out above and never becomes a field.
+        if name.startswith("_"):
+            suggestion = name.lstrip("_")
+            rename = f"Rename it to {suggestion!r}" if suggestion else "Rename it"
+            raise UserError(
+                f"Function tool {func_name!r} has a parameter named {name!r}. Tool parameter "
+                "names cannot start with an underscore, because they are exposed to the model as "
+                f"JSON schema properties. {rename}, or exclude it from the tool signature."
+            )
+
         ann = type_hints.get(name, param.annotation)
         default = param.default
 

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -399,6 +399,59 @@ def test_run_context_in_non_first_position_raises_value_error():
         function_schema(func, use_docstring_info=False)
 
 
+def test_leading_underscore_param_raises_user_error():
+    # Pydantic cannot use a leading-underscore name as a field, so function_schema() should
+    # raise a UserError naming the tool and the parameter instead of letting a NameError
+    # escape from pydantic internals.
+    def read_config(_path: str, verbose: bool = False) -> str:
+        return _path
+
+    with pytest.raises(UserError) as exc_info:
+        function_schema(read_config, use_docstring_info=False)
+
+    message = str(exc_info.value)
+    assert "read_config" in message
+    assert "_path" in message
+    assert "'path'" in message
+
+
+def test_bare_underscore_param_raises_user_error():
+    # A bare `_` has no sensible rename target, so the message omits the suggestion but must
+    # still be a UserError rather than a pydantic NameError.
+    def ping(_: str) -> str:
+        return "pong"
+
+    with pytest.raises(UserError) as exc_info:
+        function_schema(ping, use_docstring_info=False)
+
+    assert "ping" in str(exc_info.value)
+
+
+def test_leading_underscore_var_args_raise_user_error():
+    # Variadic params become fields too, so `*_args` / `**_kwargs` hit the same pydantic limit.
+    def var_positional(*_args: int) -> int:
+        return 0
+
+    def var_keyword(**_kwargs: int) -> int:
+        return 0
+
+    for func in (var_positional, var_keyword):
+        with pytest.raises(UserError):
+            function_schema(func, use_docstring_info=False)
+
+
+def test_leading_underscore_context_param_is_allowed():
+    # `_ctx` is a common convention for an unused context param. It is filtered out before the
+    # pydantic model is built, so it must keep working.
+    def func(_ctx: RunContextWrapper, city: str) -> str:
+        return city
+
+    schema = function_schema(func, use_docstring_info=False)
+
+    assert schema.takes_context is True
+    assert set(schema.params_json_schema.get("properties", {}).keys()) == {"city"}
+
+
 def test_var_positional_tuple_annotation():
     # When a function has a var-positional parameter annotated with a tuple type,
     # function_schema() should convert it into a field with type List[<tuple-element>].


### PR DESCRIPTION
### Summary

`@function_tool` currently crashes with an unhandled `NameError` raised from pydantic internals whenever a decorated function has a parameter whose name starts with `_`:

```
NameError: Fields must not use names with leading underscores; e.g., use 'path' instead of '_path'.
```

`function_schema()` builds a dynamic pydantic model from the signature via `create_model(...)`. Pydantic reserves leading-underscore names for private attributes and refuses them as field names, so the call fails before the SDK can produce a domain-level error. The resulting traceback is six frames deep in `pydantic._internal._model_construction` and never mentions `@function_tool`, the offending function, or that a *tool parameter* is at fault — users reasonably read `NameError` as "an undefined name in my module".

This is not about supporting such names: pydantic's restriction is real. It's that a detectable, user-facing configuration error escapes as an internal `NameError` instead of the `UserError` the SDK already raises for every comparable case (misplaced `RunContextWrapper`/`ToolContext`, mapping types in strict mode, duplicate MCP tool names).

This PR adds the check to the `filtered_params` loop in `function_schema()`, before `create_model()` is reached:

```
UserError: Function tool 'read_config' has a parameter named '_path'. Tool parameter names
cannot start with an underscore, because they are exposed to the model as JSON schema
properties. Rename it to 'path', or exclude it from the tool signature.
```

Two details worth calling out for review:

- **The check iterates `filtered_params`, not `params`.** A leading-underscore *context* parameter (`def tool(_ctx: RunContextWrapper, city: str)`) is stripped out earlier and never becomes a pydantic field, so it must keep working. `_ctx` is a widespread convention — the repo's own human-in-the-loop docs use `async def needs_oakland_approval(_ctx, params, _call_id)`. Validating raw `params` would have broken it. There is a regression test for this.
- **A bare `_` degrades gracefully.** `name.lstrip("_")` is empty there, so the message drops the rename suggestion (`"Rename it, or exclude it..."`) rather than emitting `Rename it to ''`.

The message uses the resolved tool name, so `@function_tool(name_override="lookup")` on `def whatever(_q: str)` reports `Function tool 'lookup'`.

I considered wrapping `create_model()` in `except NameError` instead — a smaller diff, but it would swallow unrelated `NameError`s and could only recover the parameter name by parsing pydantic's prose. The explicit pre-check is also where the issue suggested it belongs.

### Test plan

Four tests added to `tests/test_function_schema.py`:

- `test_leading_underscore_param_raises_user_error` — the issue's primary repro (`_path`); asserts the message names the tool, the parameter, and the suggested rename.
- `test_bare_underscore_param_raises_user_error` — bare `_`, the most common form; asserts `UserError` with no bogus suggestion.
- `test_leading_underscore_var_args_raise_user_error` — `*_args` and `**_kwargs` also become fields and hit the same pydantic limit.
- `test_leading_underscore_context_param_is_allowed` — regression guard: `_ctx: RunContextWrapper` still resolves, `takes_context is True`, and the schema exposes only `city`.

All 41 tests in `tests/test_function_schema.py` pass. Full suite: **4633 passed**. I diffed the failing-test list against a stashed clean tree and it is **identical (34 for 34)** — those are pre-existing failures in this local environment (Windows symlink permissions in the sandbox tests, plus missing `mcp`/voice extras causing collection errors), unrelated to this change.

`ruff format --check` and `ruff check` pass on both changed files. The new code introduces no mypy errors; the one `Unused "type: ignore"` reported on `function_schema.py:12` (the `griffe` import) is pre-existing and reproduces on a clean tree.

### Issue number

Fixes #4107

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass

Two notes on the checks I left honest rather than ticking blindly: no docs change, since this converts an internal crash into a clear error without altering supported behaviour. And I ran ruff/pytest directly rather than through make, because the local uv (0.9.21) can't parse this repo's uv.lock (exclude-newer-package is a newer schema) — worth flagging if CI surfaces anything the local run couldn't.