### PR TITLE
fix(trimmer): keep definition names and instance data in trimmed schemas

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -40,6 +40,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Prose keywords worth dropping from a replayed schema: they cost tokens but the model can
+# still call the tool without them.
+_PROSE_SCHEMA_KEYWORDS = frozenset({"description", "title", "$comment", "examples"})
+
+# Keywords whose value is a map keyed by *user-chosen names* — parameter names, definition
+# names, regexes — rather than by schema keywords. Their keys must survive even when they
+# spell one of the prose keywords above, so they are recursed into by value only.
+_NAME_KEYED_SCHEMA_MAPS = frozenset(
+    {
+        "properties",
+        "patternProperties",
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+        "dependentRequired",
+    }
+)
+
+# Keywords whose value is instance *data* rather than a subschema. Nothing inside them is a
+# schema keyword, so they are copied through untouched.
+_DATA_SCHEMA_KEYWORDS = frozenset({"default", "const", "enum"})
+
 
 @dataclass
 class ToolOutputTrimmer:
@@ -289,15 +311,21 @@ class ToolOutputTrimmer:
         """Remove verbose prose from a JSON schema while preserving its structure."""
         trimmed_schema: dict[str, Any] = {}
         for key, value in schema.items():
-            # Keys of a "properties" mapping are parameter names, not schema keywords, so
-            # they must survive even when they collide with the prose keywords below.
-            if key == "properties" and isinstance(value, dict):
+            # A name-keyed map is keyed by parameter/definition names, not by schema
+            # keywords, so recurse into its values while keeping its keys verbatim.
+            # Dropping a key here would delete a declared parameter or dangle a $ref.
+            if key in _NAME_KEYED_SCHEMA_MAPS and isinstance(value, dict):
                 trimmed_schema[key] = {
                     name: self._trim_json_schema(sub) if isinstance(sub, dict) else sub
                     for name, sub in value.items()
                 }
                 continue
-            if key in {"description", "title", "$comment", "examples"}:
+            # These hold instance data. A "title" key inside a default value is part of the
+            # value, so trimming it would silently change the tool's contract.
+            if key in _DATA_SCHEMA_KEYWORDS:
+                trimmed_schema[key] = value
+                continue
+            if key in _PROSE_SCHEMA_KEYWORDS:
                 continue
             if isinstance(value, dict):
                 trimmed_schema[key] = self._trim_json_schema(value)

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -423,6 +423,138 @@ class TestTrimming:
         # Schema-level prose is still trimmed.
         assert "description" not in trimmed_parameters
 
+    def test_keeps_definition_names_and_instance_data_in_schema(self) -> None:
+        """Name-keyed schema maps keep their keys; data-valued keywords stay verbatim.
+
+        ``properties`` is not the only map keyed by user-chosen names, and ``default`` /
+        ``const`` / ``enum`` hold instance data rather than subschemas. Trimming a prose
+        keyword out of either dangles a ``$ref`` or rewrites the tool's contract.
+        """
+        parameters = {
+            "type": "object",
+            "description": "schema prose " * 200,
+            "$defs": {
+                "description": {"type": "object", "properties": {"text": {"type": "string"}}},
+                "Priority": {"enum": ["low", "high"]},
+            },
+            "definitions": {"title": {"type": "string"}},
+            "patternProperties": {"title": {"type": "string"}},
+            "dependentSchemas": {"title": {"required": ["note"]}},
+            "dependentRequired": {"title": ["note"]},
+            "properties": {
+                "note": {"$ref": "#/$defs/description"},
+                "prio": {"$ref": "#/$defs/Priority"},
+                "opts": {
+                    "type": "object",
+                    "description": "options " * 200,
+                    "default": {"title": "Untitled", "description": "auto", "retries": 3},
+                },
+                "mode": {"const": {"title": "A", "kind": "fast"}},
+                "choice": {"enum": [{"title": "A", "id": 1}, {"title": "B", "id": 2}]},
+            },
+            "required": ["note"],
+        }
+        items = [
+            _user("q1"),
+            {"type": "tool_search_call", "call_id": "ts1", "arguments": {"query": "reports"}},
+            {
+                "type": "tool_search_output",
+                "call_id": "ts1",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "make_report",
+                        "description": "tool description " * 200,
+                        "parameters": parameters,
+                    }
+                ],
+            },
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+
+        trimmer = ToolOutputTrimmer(max_output_chars=400, preview_chars=60)
+        result = trimmer(_make_data(items))
+        trimmed_item_dict = cast(dict[str, Any], result.input[2])
+        trimmed = trimmed_item_dict["tools"][0]["parameters"]
+
+        # Every $ref still resolves — deleting a definition would silently break the schema.
+        assert sorted(trimmed["$defs"]) == ["Priority", "description"]
+        for name in ("note", "prio"):
+            target = trimmed["properties"][name]["$ref"].removeprefix("#/$defs/")
+            assert target in trimmed["$defs"]
+
+        # The other name-keyed maps keep their keys too.
+        assert sorted(trimmed["definitions"]) == ["title"]
+        assert sorted(trimmed["patternProperties"]) == ["title"]
+        assert sorted(trimmed["dependentSchemas"]) == ["title"]
+        assert trimmed["dependentRequired"] == {"title": ["note"]}
+
+        # Instance data is preserved byte for byte.
+        assert trimmed["properties"]["opts"]["default"] == {
+            "title": "Untitled",
+            "description": "auto",
+            "retries": 3,
+        }
+        assert trimmed["properties"]["mode"]["const"] == {"title": "A", "kind": "fast"}
+        assert trimmed["properties"]["choice"]["enum"] == [
+            {"title": "A", "id": 1},
+            {"title": "B", "id": 2},
+        ]
+
+        # Prose is still trimmed, at the schema level and inside a nested subschema.
+        assert "description" not in trimmed
+        assert "description" not in trimmed["properties"]["opts"]
+
+    def test_trims_prose_inside_genuine_subschema_keywords(self) -> None:
+        """Keywords whose value really is a subschema must keep getting trimmed."""
+        parameters = {
+            "type": "object",
+            "description": "schema prose " * 200,
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string", "description": "a tag " * 200},
+                },
+                "bag": {
+                    "type": "object",
+                    "propertyNames": {"pattern": "^x", "description": "a key " * 200},
+                },
+            },
+        }
+        items = [
+            _user("q1"),
+            {"type": "tool_search_call", "call_id": "ts1", "arguments": {"query": "tags"}},
+            {
+                "type": "tool_search_output",
+                "call_id": "ts1",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "tag_it",
+                        "description": "tool description " * 200,
+                        "parameters": parameters,
+                    }
+                ],
+            },
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+
+        trimmer = ToolOutputTrimmer(max_output_chars=400, preview_chars=60)
+        result = trimmer(_make_data(items))
+        trimmed_item_dict = cast(dict[str, Any], result.input[2])
+        trimmed = trimmed_item_dict["tools"][0]["parameters"]
+
+        assert trimmed["properties"]["tags"]["items"] == {"type": "string"}
+        assert trimmed["properties"]["bag"]["propertyNames"] == {"pattern": "^x"}
+
     def test_trims_legacy_tool_search_output_results(self) -> None:
         """Legacy tool_search_output snapshots with free-text results should still trim."""
         large = "x" * 2000


### PR DESCRIPTION
### Summary

Follow-up to #4036, which fixed `ToolOutputTrimmer` deleting tool parameters whose names collide with JSON Schema prose keywords and explicitly left the `$defs` case out of scope. This covers that case and one more of the same kind.

`_trim_json_schema` drops `description`, `title`, `$comment` and `examples` at every recursion depth. #4036 recognised that `properties` is keyed by user-chosen **parameter names**, not schema keywords, and special-cased it. Two groups are still walked as if they were subschemas:

**1. Other name-keyed maps** — `$defs`, `definitions`, `patternProperties`, `dependentSchemas`, `dependentRequired`. A definition named `description` is deleted while the `$ref` pointing at it survives, so the schema stops resolving. This is the case #4036 flagged as out of scope, and it is reachable through the SDK's own `function_schema` path, not just hand-written schemas — Pydantic keys `$defs` by class name, and a nested model class named `description` or `examples` produces exactly this:

```
$defs keys emitted by function_schema: ['description', 'examples']
after trim:                            []
dangling refs: [('note', '#/$defs/description'), ('samples', '#/$defs/examples')]
```

Through the public filter API (`CallModelData`, no network or API key), the trimmed schema is not merely lossy — it fails validation outright:

```
$defs in : ['Priority', 'description']
$defs out: ['Priority']
  #/$defs/description -> resolvable: False
jsonschema.Draft202012Validator(params).validate(...)
  -> PointerToNowhere: '/$defs/description' does not exist
```

`patternProperties` is affected whenever the pattern is an unanchored bare word (`{"title": …}` → `{}`); an anchored `^title$` happens to survive, which is why this is easy to miss.

**2. Keywords holding instance data rather than subschemas** — `default`, `const`, `enum`. Nothing inside these is a schema keyword, so a `title` key in a default value is part of the value:

```
default in : {'title': 'Untitled', 'description': 'auto', 'retries': 3}
default out: {'retries': 3}
```

The model is then shown a different default than the tool actually has. `enum` items and `const` objects lose the same keys.

The three categories are lifted into named module-level frozensets (`_PROSE_SCHEMA_KEYWORDS`, `_NAME_KEYED_SCHEMA_MAPS`, `_DATA_SCHEMA_KEYWORDS`) so the distinction is stated rather than implied by control flow, and adding a keyword later is a one-line change in one place. This only ever narrows what gets deleted — genuine subschema keywords such as `items` and `propertyNames` are still trimmed exactly as before, and no public API, signature or field order changes.

### Test plan

Two cases added to `tests/extensions/test_tool_output_trimmer.py`, both driven through the public trimmer call rather than the private method:

- `test_keeps_definition_names_and_instance_data_in_schema` — every `$ref` still resolves, all five name-keyed maps keep their keys, `default`/`const`/`enum` are preserved byte for byte, and schema-level *and* nested prose is still stripped (so the trimming feature stays exercised).
- `test_trims_prose_inside_genuine_subschema_keywords` — a guard in the opposite direction: `items` and `propertyNames` must keep losing their prose, so the fix can't silently grow into a no-op.

Verified:

- `tests/extensions/test_tool_output_trimmer.py`: **41 passed** with the fix; **1 failed, 40 passed** with the `src` change reverted and the tests kept (fails on the `$defs` assertion, `['Priority'] != ['Priority', 'description']`).
- `tests/extensions/` (whole directory): **1105 passed, 40 skipped, 11 failed**. I diffed the failing-test names against clean `main` (`fc084ae2`) — the two sets are **identical**, so there is no regression. They are pre-existing sandbox/session failures (`test_bootstrap_persistent_resources_*`, `test_query_run_loop_*`, `test_get_items_*`, `test_runner_with_session_settings_override`, `test_run_loop_extension_reexports_cloud_bucket_strategy`).
- `ruff check`: all checks passed. `ruff format --check`: 2 files already formatted.
- `mypy` on the two changed files: the only 2 errors are in `sandbox/util/tar_utils.py:161` and `extensions/sandbox/modal/sandbox.py:126`; I confirmed both reproduce with my changes stashed, so they are pre-existing and untouched by this PR.

Verification-script note: `.agents/skills/code-change-verification/scripts/run.sh` could not run here — `make` is unavailable on this machine — so I ran the underlying targets directly.

### Issue number

None — self-reported. This is the follow-up #4036 described as *"a one-line follow-up ... if you'd rather have it covered here"*; the `default`/`const`/`enum` half was not part of that description.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` — could not: `make` unavailable locally (see Test plan); ran the equivalent targets directly instead
- [x] I've confirmed all verification steps pass (format, lint, typecheck and the affected tests; remaining failures verified pre-existing on `main` by diffing failure sets)
- [ ] If using Codex, I've run `/review` before submitting this PR — n/a

*AI assistance was used to draft this change; it was reviewed, reproduced and verified by me.*
