### PR TITLE
fix(memory): avoid creating remote conversation on uninitialized clear_session

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -129,8 +129,13 @@ class OpenAIConversationsSession(SessionABC):
         return items[0]
 
     async def clear_session(self) -> None:
-        session_id = await self._get_session_id()
+        async with self._session_id_lock:
+            session_id = self._session_id
+            self._session_id = None
+
+        if session_id is None:
+            return
+
         await self._openai_client.conversations.delete(
             conversation_id=session_id,
         )
-        await self._clear_session_id()

--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -71,11 +71,10 @@ class OpenAIConversationsSession(SessionABC):
         self._session_id = value
 
     async def _get_session_id(self) -> str:
-        if self._session_id is None:
-            async with self._session_id_lock:
-                if self._session_id is None:
-                    self._session_id = await start_openai_conversations_session(self._openai_client)
-        return self._session_id
+        async with self._session_id_lock:
+            if self._session_id is None:
+                self._session_id = await start_openai_conversations_session(self._openai_client)
+            return self._session_id
 
     async def _clear_session_id(self) -> None:
         self._session_id = None
@@ -130,12 +129,10 @@ class OpenAIConversationsSession(SessionABC):
 
     async def clear_session(self) -> None:
         async with self._session_id_lock:
-            session_id = self._session_id
+            if self._session_id is None:
+                return
+
+            await self._openai_client.conversations.delete(
+                conversation_id=self._session_id,
+            )
             self._session_id = None
-
-        if session_id is None:
-            return
-
-        await self._openai_client.conversations.delete(
-            conversation_id=session_id,
-        )

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -275,17 +275,28 @@ class TestOpenAIConversationsSessionBasicOperations:
         assert session._session_id is None
 
     @pytest.mark.asyncio
-    async def test_clear_session_creates_session_id_first(self, mock_openai_client):
-        """Test that clear_session creates session_id if it doesn't exist."""
+    async def test_clear_session_uninitialized_does_not_create_session(self, mock_openai_client):
+        """Test that clear_session on an uninitialized session does not call create or delete."""
         session = OpenAIConversationsSession(openai_client=mock_openai_client)
 
         await session.clear_session()
 
-        # Should create conversation first, then delete it
-        mock_openai_client.conversations.create.assert_called_once_with(items=[])
-        mock_openai_client.conversations.delete.assert_called_once_with(
-            conversation_id="test_conversation_id"
-        )
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.delete.assert_not_called()
+        assert session._session_id is None
+
+    @pytest.mark.asyncio
+    async def test_clear_session_uninitialized_no_api_calls_on_create_failure(
+        self, mock_openai_client
+    ):
+        """Test that clear_session on an uninitialized session succeeds even if create raises."""
+        mock_openai_client.conversations.create.side_effect = RuntimeError("API connection error")
+        session = OpenAIConversationsSession(openai_client=mock_openai_client)
+
+        await session.clear_session()
+
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.delete.assert_not_called()
         assert session._session_id is None
 
 

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -298,6 +299,83 @@ class TestOpenAIConversationsSessionBasicOperations:
         mock_openai_client.conversations.create.assert_not_called()
         mock_openai_client.conversations.delete.assert_not_called()
         assert session._session_id is None
+
+    @pytest.mark.asyncio
+    async def test_clear_session_failed_delete_retains_session_id(self, mock_openai_client):
+        """Test that a failed delete retains the session ID for potential retries."""
+        mock_openai_client.conversations.delete.side_effect = RuntimeError("Delete failed")
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        with pytest.raises(RuntimeError, match="Delete failed"):
+            await session.clear_session()
+
+        assert session._session_id == "test_id"
+
+    @pytest.mark.asyncio
+    async def test_clear_session_retry_after_failed_delete(self, mock_openai_client):
+        """Test that retrying clear_session after a failed delete targets the same ID
+        without calling create.
+        """
+        mock_openai_client.conversations.delete.side_effect = [
+            RuntimeError("Transient delete error"),
+            None,
+        ]
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        with pytest.raises(RuntimeError, match="Transient delete error"):
+            await session.clear_session()
+
+        assert session._session_id == "test_id"
+
+        # Retry clear_session
+        await session.clear_session()
+
+        mock_openai_client.conversations.create.assert_not_called()
+        assert mock_openai_client.conversations.delete.call_count == 2
+        mock_openai_client.conversations.delete.assert_called_with(conversation_id="test_id")
+        assert session._session_id is None
+
+    @pytest.mark.asyncio
+    async def test_clear_session_concurrent_get_does_not_clobber_new_session_id(
+        self, mock_openai_client
+    ):
+        """Test that a concurrent _get_session_id during clear_session waits for lock
+        and preserves new ID.
+        """
+
+        session = OpenAIConversationsSession(
+            conversation_id="old_id", openai_client=mock_openai_client
+        )
+        mock_openai_client.conversations.create.return_value = MagicMock(id="new_id")
+
+        delete_started = asyncio.Event()
+        allow_delete_finish = asyncio.Event()
+
+        async def slow_delete(*args: Any, **kwargs: Any) -> Any:
+            delete_started.set()
+            await allow_delete_finish.wait()
+            return None
+
+        mock_openai_client.conversations.delete.side_effect = slow_delete
+
+        clear_task = asyncio.create_task(session.clear_session())
+        await delete_started.wait()
+
+        # Concurrently attempt _get_session_id() while clear_session is deleting
+        get_task = asyncio.create_task(session._get_session_id())
+
+        # Allow delete to complete
+        allow_delete_finish.set()
+        await clear_task
+        new_id = await get_task
+
+        assert new_id == "new_id"
+        assert session._session_id == "new_id"
+        mock_openai_client.conversations.create.assert_called_once_with(items=[])
 
 
 class TestOpenAIConversationsSessionRunnerIntegration:


### PR DESCRIPTION
### Summary

Fix `OpenAIConversationsSession.clear_session()` attempting to create a remote conversation on the server when called on an uninitialized session (`_session_id is None`), while protecting the session ID under `_session_id_lock` until remote deletion succeeds.

#### Affected Component
`agents.memory.openai_conversations_session.OpenAIConversationsSession`

#### Problem & Root Cause
When `OpenAIConversationsSession` is instantiated without an existing conversation ID, `self._session_id` is initialized to `None`.
1. **Uninitialized `clear_session`**: If `clear_session()` was invoked before any items had been added or retrieved, `clear_session()` called `await self._get_session_id()`. Because `_session_id` was `None`, `_get_session_id()` invoked `start_openai_conversations_session()`, sending an HTTP API request (`conversations.create(items=[])`) to create a brand new conversation resource on OpenAI's servers, which `clear_session()` immediately deleted.
2. **Transient Deletion Error & Lock Safety**: If `self._session_id` was cleared before remote deletion completed, a transient delete error would orphan the remote session ID and lose the retry handle. Furthermore, if `_get_session_id()` checked `self._session_id` outside `_session_id_lock`, concurrent callers could read a stale ID or race with deletion.

#### Implementation & Corrected Behavior
In `OpenAIConversationsSession`:
- In `clear_session()`: Hold `self._session_id_lock` across the `conversations.delete()` call. If `self._session_id` is `None`, return early (no-op). Only set `self._session_id = None` after `conversations.delete()` succeeds. If deletion fails, `self._session_id` is preserved so a retry targets the same remote ID without calling `conversations.create()`.
- In `_get_session_id()`: Synchronize `_get_session_id()` under `self._session_id_lock` so concurrent read/initialization callers wait until active deletion finishes, preventing stale ID reads or overwriting newly published session IDs.

### Test plan

Added unit tests in `tests/memory/test_openai_conversations_session.py`:
- `test_clear_session_uninitialized_does_not_create_session`: Verifies that calling `clear_session()` on an uninitialized session does not invoke `conversations.create` or `conversations.delete`.
- `test_clear_session_uninitialized_no_api_calls_on_create_failure`: Verifies that calling `clear_session()` on an uninitialized session succeeds without making API calls even if `conversations.create` would raise an error.
- `test_clear_session_failed_delete_retains_session_id`: Verifies that if `conversations.delete()` fails, `self._session_id` retains its value for retries.
- `test_clear_session_retry_after_failed_delete`: Verifies that retrying `clear_session()` after a transient deletion failure deletes the retained session ID without calling `conversations.create()`.
- `test_clear_session_concurrent_get_does_not_clobber_new_session_id`: Verifies that concurrent `_get_session_id()` during `clear_session()` waits for the lock and preserves the newly created session ID.

#### Execution modes & lifecycle verified
- Uninitialized session `clear_session()`
- Initialized session `clear_session()`
- Transient deletion failure & retry handling
- Concurrent `_get_session_id()` / `clear_session()` lock synchronization

#### Exact Validation Commands & Results
- `uv run pytest tests/memory/test_openai_conversations_session.py`: 33 passed in 0.09s
- `uv run pytest tests/memory/`: 155 passed in 0.57s
- `make format`: `uv run ruff format` and `uv run ruff check --fix` passed cleanly
- `make lint`: `uv run ruff check` passed cleanly
- `uv run pyright src/agents/memory/openai_conversations_session.py tests/memory/test_openai_conversations_session.py`: 0 errors, 0 warnings
- `git diff --check`: 0 errors

### Issue number

N/A (unreported correctness issue discovered and fixed directly)

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
