### PR TITLE
fix(tool): reject duplicate function tool names instead of silently shadowing

### DIFF
--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -352,7 +352,21 @@ def validate_function_tool_lookup_configuration(tools: Sequence[Any]) -> None:
 
         prior_namespace = get_explicit_function_tool_namespace(prior_owner)
         if explicit_namespace is None and prior_namespace is None:
-            continue
+            # A deferred top-level tool dispatches through its own synthetic lookup key and is
+            # not advertised next to visible tools, so sharing a bare name with one is not
+            # ambiguous. Duplicates among deferred tools are caught by the check above.
+            if is_deferred_top_level_function_tool(tool) or is_deferred_top_level_function_tool(
+                prior_owner
+            ):
+                continue
+            # Two visible tools sharing a name. Dispatch would resolve last-wins and the earlier
+            # tool would be permanently unreachable, so reject it the way duplicate MCP and
+            # Codex tool names already are.
+            raise UserError(
+                "Ambiguous function tool configuration: the tool name "
+                f"`{qualified_name}` is used by multiple tools. "
+                "Pass a unique `name_override=` to one of them to avoid ambiguous dispatch."
+            )
 
         raise UserError(
             "Ambiguous function tool configuration: the qualified name "

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -11,7 +11,10 @@ from openai.types.responses.response_prompt_param import ResponsePromptParam
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from typing_extensions import NotRequired, TypedDict
 
-from ._tool_identity import get_function_tool_approval_keys
+from ._tool_identity import (
+    get_function_tool_approval_keys,
+    validate_function_tool_lookup_configuration,
+)
 from .agent_output import AgentOutputSchemaBase
 from .agent_tool_input import (
     AgentAsToolInput,
@@ -264,6 +267,10 @@ class AgentBase(Generic[TContext]):
         enabled: list[Tool] = [t for t, ok in zip(self.tools, results, strict=False) if ok]
         all_tools: list[Tool] = prune_orphaned_tool_search_tools([*mcp_tools, *enabled])
         _validate_codex_tool_name_collisions(all_tools)
+        # Validate here, after `is_enabled` filtering, so the error surfaces before the model
+        # call for every provider. Dispatch-time callers of `build_function_tool_lookup_map`
+        # only reach this check after the request has already been sent.
+        validate_function_tool_lookup_configuration(all_tools)
         return all_tools
 
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -5266,7 +5266,7 @@ async def test_deferred_collision_rejection_prefers_explicit_message() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_approved_tools_uses_last_duplicate_top_level_function():
+async def test_execute_approved_tools_rejects_duplicate_top_level_function():
     first_calls: list[str] = []
     second_calls: list[str] = []
 
@@ -5286,17 +5286,16 @@ async def test_execute_approved_tools_uses_last_duplicate_top_level_function():
     assert isinstance(tool_call, ResponseFunctionToolCall)
     approval_item = ToolApprovalItem(agent=agent, raw_item=tool_call)
 
-    generated_items = await run_execute_approved_tools(
-        agent=agent,
-        approval_item=approval_item,
-        approve=True,
-    )
+    # The duplicate used to resolve last-wins, permanently shadowing `first_tool`.
+    with pytest.raises(UserError, match="`lookup_account` is used by multiple tools"):
+        await run_execute_approved_tools(
+            agent=agent,
+            approval_item=approval_item,
+            approve=True,
+        )
 
-    assert len(generated_items) == 1
-    assert isinstance(generated_items[0], ToolCallOutputItem)
-    assert generated_items[0].output == "second"
     assert first_calls == []
-    assert second_calls == ["second"]
+    assert second_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_identity.py
+++ b/tests/test_tool_identity.py
@@ -8,9 +8,13 @@ and tool-output trimmer code paths.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+from agents import function_tool
 from agents._tool_identity import (
+    build_function_tool_lookup_map,
     deserialize_function_tool_lookup_key,
     get_function_tool_lookup_key,
     get_tool_call_name,
@@ -21,6 +25,7 @@ from agents._tool_identity import (
     serialize_function_tool_lookup_key,
     tool_qualified_name,
     tool_trace_name,
+    validate_function_tool_lookup_configuration,
 )
 from agents.exceptions import UserError
 
@@ -165,3 +170,80 @@ def test_validate_function_tool_namespace_shape_rejects_synthetic() -> None:
     # The reserved synthetic shape (name == namespace) is rejected.
     with pytest.raises(UserError, match="reserves the synthetic namespace"):
         validate_function_tool_namespace_shape("search", "search")
+
+
+class TestDuplicateFunctionToolNames:
+    """Two visible tools resolving to the same public name are ambiguous on the wire."""
+
+    @staticmethod
+    def _tool(name: str, *, defer_loading: bool = False) -> Any:
+        @function_tool(name_override=name, defer_loading=defer_loading)
+        def f(x: str) -> str:
+            """F."""
+            return name
+
+        return f
+
+    def test_duplicate_bare_names_raise(self) -> None:
+        tools = [self._tool("lookup"), self._tool("lookup")]
+        with pytest.raises(UserError, match="`lookup` is used by multiple tools"):
+            validate_function_tool_lookup_configuration(tools)
+
+    def test_duplicate_bare_names_raise_when_building_lookup_map(self) -> None:
+        tools = [self._tool("lookup"), self._tool("lookup")]
+        with pytest.raises(UserError, match="`lookup` is used by multiple tools"):
+            build_function_tool_lookup_map(tools)
+
+    def test_distinct_names_are_accepted(self) -> None:
+        validate_function_tool_lookup_configuration([self._tool("a"), self._tool("b")])
+
+    def test_deferred_tool_may_share_a_name_with_a_visible_tool(self) -> None:
+        # These occupy different lookup keys and the deferred one is not advertised alongside
+        # the visible one, so this stays a supported configuration.
+        validate_function_tool_lookup_configuration(
+            [self._tool("lookup"), self._tool("lookup", defer_loading=True)]
+        )
+        validate_function_tool_lookup_configuration(
+            [self._tool("lookup", defer_loading=True), self._tool("lookup")]
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_get_all_tools_rejects_duplicate_names_before_the_model_call() -> None:
+    from agents import Agent
+    from agents.run_context import RunContextWrapper
+
+    @function_tool(name_override="lookup")
+    def a(x: str) -> str:
+        """A."""
+        return "a"
+
+    @function_tool(name_override="lookup")
+    def b(x: str) -> str:
+        """B."""
+        return "b"
+
+    agent = Agent(name="TestAgent", tools=[a, b])
+    with pytest.raises(UserError, match="`lookup` is used by multiple tools"):
+        await agent.get_all_tools(RunContextWrapper(None))
+
+
+@pytest.mark.asyncio
+async def test_agent_get_all_tools_allows_duplicates_when_only_one_is_enabled() -> None:
+    # `is_enabled` filtering runs first, so toggling between same-named tools stays valid.
+    from agents import Agent
+    from agents.run_context import RunContextWrapper
+
+    @function_tool(name_override="lookup", is_enabled=False)
+    def a(x: str) -> str:
+        """A."""
+        return "a"
+
+    @function_tool(name_override="lookup")
+    def b(x: str) -> str:
+        """B."""
+        return "b"
+
+    agent = Agent(name="TestAgent", tools=[a, b])
+    tools = await agent.get_all_tools(RunContextWrapper(None))
+    assert [t.name for t in tools] == ["lookup"]


### PR DESCRIPTION
## Description

Closes #4116

`validate_function_tool_lookup_configuration()` exists to "reject function-tool
combinations that are ambiguous on the Responses wire". It detected two bare tools
sharing a name and then `continue`d past the collision, so the common case — two plain
`@function_tool`s — went unvalidated. Both tools were advertised to the model, and
dispatch resolved last-wins, leaving the first tool permanently unreachable.

Against OpenAI that surfaces as a duplicate-function-name 400. On providers that
tolerate duplicates it is worse: the run succeeds while executing the wrong tool.

Plain function tools were the only category with no such check — duplicate MCP tool
names and duplicate Codex tool names already raise `UserError`.

## Changes

**`src/agents/_tool_identity.py`** — the `continue` now raises, with the message the
issue proposes:

Ambiguous function tool configuration: the tool name lookup is used by multiple tools.
Pass a unique name_override= to one of them to avoid ambiguous dispatch.

**`src/agents/agent.py`** — `get_all_tools()` calls the validator next to the existing
`_validate_codex_tool_name_collisions()`.

Fixing the `continue` alone was not enough to meet the issue's "at tool-resolution
time" bar. The dispatch-time callers of `build_function_tool_lookup_map()` only run
after the request has gone out — `run_loop.py:1417` is in the streaming path, past the
model output — and `validate_responses_tool_search_configuration()` is Responses-only.
`get_all_tools()` is the single funnel every provider passes through before the model
call, and it runs after `is_enabled` filtering, so toggling between same-named tools
stays valid. In the issue's repro the error is now raised with `first_turn_args` still
unset: no request is ever sent.

## Deferred top-level tools are exempt

A visible tool and a `defer_loading=True` tool may share a name. They occupy different
lookup keys (`("bare", n)` vs `("deferred_top_level", n)`), the deferred one is not
advertised alongside the visible one, and duplicates *among* deferred tools are already
caught by the check immediately above. The new raise is skipped when either side is a
deferred top-level tool, preserving
`test_execute_approved_tools_prefers_visible_top_level_function_over_deferred_same_name_tool`.

## Behavior change worth flagging

`test_execute_approved_tools_uses_last_duplicate_top_level_function` asserted the exact
shadowing this issue reports as the bug — that the second tool runs and the first never
does. It is renamed to `..._rejects_duplicate_top_level_function` and now asserts the
`UserError`, with neither implementation invoked. Anyone relying on last-wins
registration will need a unique `name_override=`.

## Tests

`tests/test_tool_identity.py`:

- duplicate bare names raise, via both the validator and `build_function_tool_lookup_map()`
- distinct names still pass
- deferred/visible same-name pairs still pass, in both registration orders
- `Agent.get_all_tools()` raises before the model call
- `is_enabled=False` on one duplicate keeps the agent valid

Full suite shows no new failures against the `main` baseline.