### PR TITLE
fix(voice): finish trailing STT transcription span on session end

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -123,9 +123,6 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
         self._tracing_span.start()
 
     def _end_turn(self, _transcript: str) -> None:
-        if len(_transcript) < 1:
-            return
-
         if self._tracing_span:
             # Only encode audio if tracing is enabled AND buffer is not empty
             if self._trace_include_sensitive_audio_data and self._turn_audio_buffer:

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -319,7 +319,6 @@ async def test_transcription_event_puts_output_in_queue(created, updated, comple
         )
         turns = session.transcribe_turns()
 
-        # We'll collect transcribed turns in a list
         collected_turns = []
         async for turn in turns:
             collected_turns.append(turn)
@@ -328,6 +327,43 @@ async def test_transcription_event_puts_output_in_queue(created, updated, comple
         # Check we got "Hello world!"
         assert "Hello world!" in collected_turns
         # Cleanup
+
+
+@pytest.mark.asyncio
+async def test_transcribe_turns_finishes_trailing_trace_span() -> None:
+    """
+    A streamed session starts a transcription span for the next (never-completing)
+    turn after the final transcript. That trailing span must be finished when the
+    session ends instead of being left dangling in the trace processor.
+    """
+    mock_ws = create_mock_websocket(
+        [
+            json.dumps({"type": "transcription_session.created"}),
+            json.dumps({"type": "transcription_session.updated"}),
+            json.dumps(
+                {"type": "input_audio_transcription_completed", "transcript": "Hello world!"}
+            ),
+        ]
+    )
+
+    with patch("websockets.connect", return_value=mock_ws):
+        audio_input = await FakeStreamedAudioInput.get(count=2)
+        session = OpenAISTTTranscriptionSession(
+            input=audio_input,
+            client=AsyncMock(api_key="FAKE_KEY"),
+            model="whisper-1",
+            settings=STTModelSettings(),
+            trace_include_sensitive_data=False,
+            trace_include_sensitive_audio_data=False,
+        )
+
+        collected_turns: list[str] = []
+        async for turn in session.transcribe_turns():
+            collected_turns.append(turn)
+        await session.close()
+
+        assert collected_turns == ["Hello world!"]
+        assert session._tracing_span is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes a trace-span leak in the streamed STT transcription session.

### Bug

An `OpenAISTTTranscriptionSession` keeps a listening `transcription` span for the "current" turn. `_stream_audio` starts a span, and each completed transcript ends the previous turn and starts a new span. That leaves one trailing open span for the never-completing next turn. At session end (and on consumer cancellation), `transcribe_turns` tries to close it via `_end_turn("")`, but `_end_turn` early-returned whenever the transcript was empty, so the trailing span was never finished — leaving a dangling `transcription` span in the trace processor (plus an uncleared turn audio buffer) for every streamed session.

### Fix

`_end_turn` no longer bails on an empty transcript; it finishes the open span when one exists. The transcript-driven call site already guards on `len(transcript) > 0`, so the only affected paths are the normal session end and the cancellation path — exactly the two places that should close the trailing span.

### Details

- `OpenAISTTTranscriptionSession._end_turn` closes the active span even for an empty transcript.
- Added `tests/voice/test_openai_stt.py::test_transcribe_turns_finishes_trailing_trace_span`, which reproduces the leak (the trailing `_tracing_span` is still set after the session ends) and passes after the fix.

This affects only the internal tracing lifecycle of the streamed transcription path; the public transcript contract is unchanged.