### PR TITLE
fix(agent): reject distinct agents whose names collapse to one derived tool name

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -119,6 +119,48 @@ def _validate_codex_tool_name_collisions(tools: list[Tool]) -> None:
         )
 
 
+def validate_derived_agent_name_collisions(
+    entries: list[tuple[str, str]],
+    *,
+    config_label: str,
+    name_label: str,
+    override_hint: str,
+) -> None:
+    """Reject distinct agents whose names normalize to the same derived tool name.
+
+    `transform_string_function_style()` is many-to-one -- case, whitespace, and punctuation all
+    collapse into the same output -- so two agents a user considers distinct can land on one
+    derived name. Dispatch then resolves last-wins and the earlier agent is advertised to the
+    model but can never be selected.
+
+    Entries are `(derived name, source agent name)`. Agents sharing both are the same target,
+    so only differing agent names collide.
+    """
+    owners: dict[str, str] = {}
+    for derived_name, agent_name in entries:
+        prior_agent_name = owners.setdefault(derived_name, agent_name)
+        if prior_agent_name != agent_name:
+            raise UserError(
+                f"Ambiguous {config_label} configuration: agents {prior_agent_name!r} and "
+                f"{agent_name!r} both derive the {name_label} `{derived_name}`. "
+                f"Pass an explicit `{override_hint}` to one of them."
+            )
+
+
+def _agent_tool_name_entries(tools: list[Tool]) -> list[tuple[str, str]]:
+    """Return `(tool name, source agent name)` for every `Agent.as_tool()` entry."""
+    entries: list[tuple[str, str]] = []
+    for tool in tools:
+        if not isinstance(tool, FunctionTool):
+            continue
+        origin = getattr(tool, "_tool_origin", None)
+        if origin is None or origin.type is not ToolOriginType.AGENT_AS_TOOL:
+            continue
+        if origin.agent_name:
+            entries.append((tool.name, origin.agent_name))
+    return entries
+
+
 class AgentToolStreamEvent(TypedDict):
     """Streaming event emitted when an agent is invoked as a tool."""
 
@@ -264,6 +306,12 @@ class AgentBase(Generic[TContext]):
         enabled: list[Tool] = [t for t, ok in zip(self.tools, results, strict=False) if ok]
         all_tools: list[Tool] = prune_orphaned_tool_search_tools([*mcp_tools, *enabled])
         _validate_codex_tool_name_collisions(all_tools)
+        validate_derived_agent_name_collisions(
+            _agent_tool_name_entries(all_tools),
+            config_label="agent tool",
+            name_label="agent tool name",
+            override_hint="tool_name=",
+        )
         return all_tools
 
 

--- a/src/agents/run_internal/turn_preparation.py
+++ b/src/agents/run_internal/turn_preparation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from typing import Any
 
-from ..agent import Agent
+from ..agent import Agent, validate_derived_agent_name_collisions
 from ..agent_output import AgentOutputSchema, AgentOutputSchemaBase
 from ..exceptions import UserError
 from ..handoffs import Handoff, handoff
@@ -113,6 +113,14 @@ async def get_handoffs(agent: Agent[Any], context_wrapper: RunContextWrapper[Any
 
     results = await gather_with_cancel(*(check_handoff_enabled(h) for h in handoffs))
     enabled: list[Handoff] = [h for h, ok in zip(handoffs, results, strict=False) if ok]
+    # Validate after `is_enabled` filtering, so agents whose derived names collide stay usable
+    # as long as only one of them is enabled per turn.
+    validate_derived_agent_name_collisions(
+        [(h.tool_name, h.agent_name) for h in enabled],
+        config_label="handoff",
+        name_label="handoff tool name",
+        override_hint="tool_name_override=",
+    )
     return enabled
 
 

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -4,7 +4,7 @@ import pytest
 from openai.types.shared import Reasoning
 from pydantic import BaseModel
 
-from agents import Agent, AgentOutputSchema, Handoff, RunContextWrapper, handoff
+from agents import Agent, AgentOutputSchema, Handoff, RunContextWrapper, UserError, handoff
 from agents.lifecycle import AgentHooksBase
 from agents.model_settings import ModelSettings
 from agents.retry import ModelRetryBackoffSettings
@@ -290,3 +290,108 @@ def test_agent_does_not_promote_model_settings_to_constructor(setting_name: str)
     arguments: dict[str, Any] = {setting_name: None}
     with pytest.raises(TypeError, match=f"unexpected keyword argument '{setting_name}'"):
         Agent(name="test", **arguments)
+
+
+@pytest.mark.asyncio
+async def test_handoffs_with_colliding_derived_names_raise():
+    # `transform_string_function_style` is many-to-one: case, whitespace, and punctuation all
+    # normalize away, so these three distinct agents land on one handoff tool name.
+    billing = Agent(name="Billing Agent")
+    billing_lower = Agent(name="billing agent")
+    billing_dotted = Agent(name="billing.agent")
+
+    assert (
+        handoff(billing).tool_name
+        == handoff(billing_lower).tool_name
+        == handoff(billing_dotted).tool_name
+    )
+
+    for other in (billing_lower, billing_dotted):
+        triage = Agent(name="Triage", handoffs=[billing, other])
+        with pytest.raises(UserError, match="transfer_to_billing_agent"):
+            await get_handoffs(triage, RunContextWrapper(None))
+
+
+@pytest.mark.asyncio
+async def test_handoff_collision_is_resolved_by_an_explicit_override():
+    billing = Agent(name="Billing Agent")
+    billing_lower = Agent(name="billing agent")
+
+    triage = Agent(
+        name="Triage",
+        handoffs=[billing, handoff(billing_lower, tool_name_override="transfer_to_billing_b2b")],
+    )
+    handoffs = await get_handoffs(triage, RunContextWrapper(None))
+
+    assert [h.tool_name for h in handoffs] == [
+        "transfer_to_billing_agent",
+        "transfer_to_billing_b2b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handoff_collision_ignores_the_same_agent_listed_twice():
+    # Same target either way, so last-wins is harmless and must not raise.
+    billing = Agent(name="Billing Agent")
+
+    triage = Agent(name="Triage", handoffs=[billing, billing])
+    handoffs = await get_handoffs(triage, RunContextWrapper(None))
+
+    assert [h.tool_name for h in handoffs] == [
+        "transfer_to_billing_agent",
+        "transfer_to_billing_agent",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handoff_collision_allows_one_enabled_agent_per_turn():
+    billing = Agent(name="Billing Agent")
+    billing_lower = Agent(name="billing agent")
+
+    triage = Agent(
+        name="Triage",
+        handoffs=[handoff(billing, is_enabled=False), billing_lower],
+    )
+    handoffs = await get_handoffs(triage, RunContextWrapper(None))
+
+    assert [h.agent_name for h in handoffs] == ["billing agent"]
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_with_colliding_derived_names_raises():
+    # Case-only differences normalize silently -- `transform_string_function_style` does not even
+    # warn for them -- so this collision was previously invisible.
+    refund = Agent(name="Refund")
+    refund_lower = Agent(name="refund")
+
+    assert (
+        refund.as_tool(tool_name=None, tool_description="d").name
+        == refund_lower.as_tool(tool_name=None, tool_description="d").name
+    )
+
+    router = Agent(
+        name="Router",
+        tools=[
+            refund.as_tool(tool_name=None, tool_description="d"),
+            refund_lower.as_tool(tool_name=None, tool_description="d"),
+        ],
+    )
+    with pytest.raises(UserError, match="`refund`"):
+        await router.get_all_tools(RunContextWrapper(None))
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_collision_is_resolved_by_an_explicit_tool_name():
+    refund = Agent(name="Refund")
+    refund_lower = Agent(name="refund")
+
+    router = Agent(
+        name="Router",
+        tools=[
+            refund.as_tool(tool_name=None, tool_description="d"),
+            refund_lower.as_tool(tool_name="refund_legacy", tool_description="d"),
+        ],
+    )
+    tools = await router.get_all_tools(RunContextWrapper(None))
+
+    assert [t.name for t in tools] == ["refund", "refund_legacy"]


### PR DESCRIPTION
## Description

Closes #4118

`transform_string_function_style()` is many-to-one — whitespace, punctuation, and case
all normalize away — and nothing checked whether two agents in the same handoff list or
tool list landed on the same derived name:

| Agent name | Derived handoff tool |
|---|---|
| `Billing Agent` | `transfer_to_billing_agent` |
| `billing agent` | `transfer_to_billing_agent` |
| `Billing-Agent` | `transfer_to_billing_agent` |
| `billing.agent` | `transfer_to_billing_agent` |

Dispatch then resolved last-wins. The earlier agent was registered, advertised to the
model, and permanently unreachable. In a routing setup the symptom is just "the router
keeps picking the wrong specialist", which is very hard to trace back to name
normalization — and the case-only variant produced no warning at all, since
`transformed_name != name` is false before lowercasing.

## Changes

**`src/agents/agent.py`** — `validate_derived_agent_name_collisions()` takes
`(derived name, source agent name)` pairs and raises when one derived name is claimed by
two different agent names:

Ambiguous handoff configuration: agents 'Billing Agent' and 'billing agent' both derive the
handoff tool name transfer_to_billing_agent. Pass an explicit tool_name_override= to one of them.

Ambiguous agent tool configuration: agents 'Refund' and 'refund' both derive the agent tool
name refund. Pass an explicit tool_name= to one of them.

Matching agent names on both sides mean the same target, so listing one agent twice
stays harmless — only a genuine collapse raises.

It is wired into the two surfaces the issue names:

- **`get_handoffs()`** (`run_internal/turn_preparation.py`) — where `agent.handoffs`
  resolves `Agent` → `Handoff` and `is_enabled` is applied. Validating after the filter
  means two agents whose names collide stay usable as long as only one is enabled per
  turn.
- **`Agent.get_all_tools()`** — `_agent_tool_name_entries()` picks out `as_tool()`
  entries through their existing `_tool_origin` metadata, which already carries
  `agent_name` (`ToolOriginType.AGENT_AS_TOOL`), so the agents can be named in the error
  with no new bookkeeping. Scoped to agent tools; plain duplicate `@function_tool` names
  are out of scope here.

This mirrors how the SDK already handles derived-name collisions elsewhere —
`MCPUtil._build_prefixed_tool_name_overrides` disambiguates with a hash suffix, and
`_validate_codex_tool_name_collisions` raises.

## Tests

`tests/test_agent_config.py`, which already exercises `get_handoffs`:

- collisions raise for whitespace-, case-, and punctuation-only differences
- an explicit `tool_name_override=` / `tool_name=` resolves the collision
- the same agent listed twice does not raise
- `is_enabled=False` on one side keeps a colliding pair valid
- the `as_tool()` case-only collision — previously silent, with no warning — now raises

## Not included

The issue's "at minimum" fallback: making `transform_string_function_style` warn on
case-only normalization. I read that as the alternative to raising rather than an
addition, and it would require reversing
`tests/test_transforms.py::test_transform_string_function_style_does_not_warn_for_case_only_changes`,
which pins that exemption deliberately. Happy to add it if you'd prefer both.

Full suite shows no new failures against the `main` baseline.