### PR TITLE
fix(run): withhold guardrail-blocked output from the session

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -200,6 +200,39 @@ def _sandbox_memory_input(
     return copy_input_items(original_input)
 
 
+async def _save_turn_items(
+    *,
+    session: Session | None,
+    run_state: RunState[Any] | None,
+    items: list[RunItem],
+    resumed: bool,
+    response_id: str | None,
+    store: bool | None,
+) -> None:
+    """Persist a turn's items, tracking the persisted count while a turn is being resumed."""
+    logger.debug("Persisting turn items (types=%s)", [item.type for item in items])
+    if resumed and run_state is not None:
+        saved_count = await save_result_to_session(
+            session,
+            [],
+            items,
+            None,
+            response_id=response_id,
+            reasoning_item_id_policy=run_state._reasoning_item_id_policy,
+            store=store,
+        )
+        run_state._current_turn_persisted_item_count += saved_count
+    else:
+        await save_result_to_session(
+            session,
+            [],
+            items,
+            run_state,
+            response_id=response_id,
+            store=store,
+        )
+
+
 class Runner:
     @classmethod
     async def run(
@@ -1377,6 +1410,11 @@ class AgentRunner:
                     tool_output_guardrail_results.extend(turn_result.tool_output_guardrail_results)
 
                     items_to_save_turn = list(turn_session_items)
+                    # A final-output turn defers its save until the output guardrails have
+                    # passed, so a tripwire does not leave the blocked message in the session
+                    # store. The streaming loop already works this way.
+                    deferred_turn_items: list[RunItem] | None = None
+                    deferred_turn_resumed = False
                     if not isinstance(turn_result.next_step, NextStepInterruption):
                         # When resuming a turn we have already persisted the tool_call items;
                         if (
@@ -1419,29 +1457,15 @@ class AgentRunner:
                                 ):
                                     items_to_save_turn.append(item)
                             if items_to_save_turn:
-                                logger.debug(
-                                    "Persisting turn items (types=%s)",
-                                    [item.type for item in items_to_save_turn],
-                                )
-                                if is_resumed_state and run_state is not None:
-                                    saved_count = await save_result_to_session(
-                                        session,
-                                        [],
-                                        items_to_save_turn,
-                                        None,
-                                        response_id=turn_result.model_response.response_id,
-                                        reasoning_item_id_policy=(
-                                            run_state._reasoning_item_id_policy
-                                        ),
-                                        store=store_setting,
-                                    )
-                                    run_state._current_turn_persisted_item_count += saved_count
+                                if isinstance(turn_result.next_step, NextStepFinalOutput):
+                                    deferred_turn_items = items_to_save_turn
+                                    deferred_turn_resumed = is_resumed_state
                                 else:
-                                    await save_result_to_session(
-                                        session,
-                                        [],
-                                        items_to_save_turn,
-                                        run_state,
+                                    await _save_turn_items(
+                                        session=session,
+                                        run_state=run_state,
+                                        items=items_to_save_turn,
+                                        resumed=is_resumed_state,
                                         response_id=turn_result.model_response.response_id,
                                         store=store_setting,
                                     )
@@ -1460,6 +1484,18 @@ class AgentRunner:
                                 context_wrapper,
                                 output_guardrail_results,
                             )
+
+                            # The guardrails passed, so the turn's items can now be persisted.
+                            if deferred_turn_items is not None:
+                                await _save_turn_items(
+                                    session=session,
+                                    run_state=run_state,
+                                    items=deferred_turn_items,
+                                    resumed=deferred_turn_resumed,
+                                    response_id=turn_result.model_response.response_id,
+                                    store=store_setting,
+                                )
+                                deferred_turn_items = None
 
                             # Ensure starting_input is not None and not RunState
                             final_output_result_input: str | list[TResponseInputItem] = (

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1921,6 +1921,100 @@ async def test_input_guardrail_tripwire_does_not_save_assistant_message_to_sessi
 
 
 @pytest.mark.asyncio
+async def test_output_guardrail_tripwire_does_not_save_assistant_message_to_session():
+    # The blocked message must not stay in the session store, or the next turn replays the
+    # very output the guardrail rejected. `Runner.run_streamed` already behaves this way.
+    async def guardrail_function(
+        context: RunContextWrapper[Any], agent: Agent[Any], output: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    session = SimpleListSession()
+
+    model = FakeModel()
+    model.set_next_output([get_text_message("should_not_be_saved")])
+
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+    )
+
+    with pytest.raises(OutputGuardrailTripwireTriggered):
+        await Runner.run(agent, input="user_message", session=session)
+
+    items = await session.get_items()
+
+    assert len(items) == 1
+    first_item = cast(dict[str, Any], items[0])
+    assert first_item.get("role") == "user"
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_tripwire_keeps_tool_items_in_session():
+    # Only the rejected assistant message is withheld. Tool calls and their outputs really
+    # happened, so dropping them would leave the model unable to see completed side effects.
+    async def guardrail_function(
+        context: RunContextWrapper[Any], agent: Agent[Any], output: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    session = SimpleListSession()
+
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("foo", "{}")],
+            [get_text_message("should_not_be_saved")],
+        ]
+    )
+
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("foo", "tool_result")],
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+    )
+
+    with pytest.raises(OutputGuardrailTripwireTriggered):
+        await Runner.run(agent, input="user_message", session=session)
+
+    items = await session.get_items()
+
+    types = [cast(dict[str, Any], item).get("type") for item in items]
+    assert types == [None, "function_call", "function_call_output"]
+    assert cast(dict[str, Any], items[0]).get("role") == "user"
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_pass_still_saves_assistant_message_to_session():
+    # Control for the two tests above: without a tripwire the message is persisted as before.
+    async def guardrail_function(
+        context: RunContextWrapper[Any], agent: Agent[Any], output: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    session = SimpleListSession()
+
+    model = FakeModel()
+    model.set_next_output([get_text_message("saved")])
+
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+    )
+
+    await Runner.run(agent, input="user_message", session=session)
+
+    items = await session.get_items()
+
+    assert len(items) == 2
+    assert cast(dict[str, Any], items[0]).get("role") == "user"
+    assert cast(dict[str, Any], items[1]).get("role") == "assistant"
+
+
+@pytest.mark.asyncio
 async def test_prepare_input_with_session_keeps_function_call_outputs():
     history_item = cast(
         TResponseInputItem,


### PR DESCRIPTION
### Summary

`Runner.run` persists a final-output turn's items **before** running the output guardrails, so a tripwire leaves the rejected assistant message in the session store. The next turn then replays the very output the guardrail blocked.

`Runner.run_streamed` already runs its output guardrails before saving (`_finalize_streamed_final_output` in `run_internal/run_loop.py`), so the two entry points disagree on durable state. This makes the non-streamed path match.

### Reproduction

Turn 1: the model emits `SECRET-LEAK` and an output guardrail blocks it. Turn 2: the guardrail is satisfied — what does the model see?

```
run       turn1=blocked
   turn2 model input = ['user:turn one', 'assistant:SECRET-LEAK', 'user:turn two']   <-- replayed
streamed  turn1=blocked
   turn2 model input = ['user:turn one', 'user:turn two']
```

Both paths agree after the fix (second line for both).

### Scope

- Only the rejected **assistant message** is withheld. Tool calls and their outputs are still persisted — they really executed, so dropping them would hide completed side effects from the model.
- Non-final-output turns (handoff, run-again, interruption) save exactly as before.
- Mirrors the existing `test_input_guardrail_tripwire_does_not_save_assistant_message_to_session` contract for the output side.

The save/count logic moved into a module-level `_save_turn_items` helper rather than being duplicated at the second call site; behaviour including the resumed-turn `_current_turn_persisted_item_count` bookkeeping is unchanged.

### Tests

Three added in `tests/test_agent_runner.py`:

- `test_output_guardrail_tripwire_does_not_save_assistant_message_to_session`
- `test_output_guardrail_tripwire_keeps_tool_items_in_session`
- `test_output_guardrail_pass_still_saves_assistant_message_to_session` (control)

Verified the first two fail on `main` and pass with the fix; the control passes both ways. Full suite diffed with and without the change: **no new failures** (`ruff check`, `ruff format --check`, `mypy` clean). The remaining local failures are pre-existing on `main` at `6e2095d` — tracing-processor `KeyError`s and two guardrail-cancellation timing tests — and are identical with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
