### PR TITLE
fix(voice): clean up tasks when streams close early

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -123,9 +123,6 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
         self._tracing_span.start()
 
     def _end_turn(self, _transcript: str) -> None:
-        if len(_transcript) < 1:
-            return
-
         if self._tracing_span:
             # Only encode audio if tracing is enabled AND buffer is not empty
             if self._trace_include_sensitive_audio_data and self._turn_audio_buffer:
@@ -306,77 +303,113 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             raise
 
     def _check_errors(self) -> None:
-        if self._connection_task and self._connection_task.done():
+        if (
+            self._connection_task
+            and self._connection_task.done()
+            and not self._connection_task.cancelled()
+        ):
             exc = self._connection_task.exception()
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-        if self._process_events_task and self._process_events_task.done():
+        if (
+            self._process_events_task
+            and self._process_events_task.done()
+            and not self._process_events_task.cancelled()
+        ):
             exc = self._process_events_task.exception()
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-        if self._stream_audio_task and self._stream_audio_task.done():
+        if (
+            self._stream_audio_task
+            and self._stream_audio_task.done()
+            and not self._stream_audio_task.cancelled()
+        ):
             exc = self._stream_audio_task.exception()
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-        if self._listener_task and self._listener_task.done():
+        if (
+            self._listener_task
+            and self._listener_task.done()
+            and not self._listener_task.cancelled()
+        ):
             exc = self._listener_task.exception()
             if exc and isinstance(exc, Exception):
                 self._stored_exception = exc
 
-    def _cleanup_tasks(self) -> None:
-        if self._listener_task and not self._listener_task.done():
-            self._listener_task.cancel()
+    async def _cleanup_tasks(self) -> None:
+        owned_tasks = [
+            task
+            for task in (
+                self._listener_task,
+                self._process_events_task,
+                self._stream_audio_task,
+                self._connection_task,
+            )
+            if task is not None and task is not asyncio.current_task()
+        ]
+        for task in owned_tasks:
+            if not task.done():
+                task.cancel()
 
-        if self._process_events_task and not self._process_events_task.done():
-            self._process_events_task.cancel()
-
-        if self._stream_audio_task and not self._stream_audio_task.done():
-            self._stream_audio_task.cancel()
-
-        if self._connection_task and not self._connection_task.done():
-            self._connection_task.cancel()
+        if owned_tasks:
+            await asyncio.gather(*owned_tasks, return_exceptions=True)
 
     async def transcribe_turns(self) -> AsyncIterator[str]:
         self._connection_task = asyncio.create_task(self._process_websocket_connection())
 
-        while True:
-            try:
+        primary_exception_active = False
+        try:
+            while True:
                 turn = await self._output_queue.get()
-            except asyncio.CancelledError:
-                if self._tracing_span:
-                    self._end_turn("")
-                if self._websocket:
-                    await self._websocket.close()
-                raise
-
-            if (
-                turn is None
-                or isinstance(turn, ErrorSentinel)
-                or isinstance(turn, SessionCompleteSentinel)
-            ):
-                self._output_queue.task_done()
-                break
-            yield turn
-            self._output_queue.task_done()
-
-        if self._tracing_span:
-            self._end_turn("")
-
-        if self._websocket:
-            await self._websocket.close()
+                if (
+                    turn is None
+                    or isinstance(turn, ErrorSentinel)
+                    or isinstance(turn, SessionCompleteSentinel)
+                ):
+                    self._output_queue.task_done()
+                    break
+                try:
+                    yield turn
+                finally:
+                    self._output_queue.task_done()
+        except BaseException:
+            primary_exception_active = True
+            raise
+        finally:
+            try:
+                await self.close()
+            except BaseException as cleanup_exception:
+                # Cancellation must always propagate, even while preserving a primary consumer
+                # exception, so callers that cancel or time out STT cleanup observe the
+                # cancellation instead of a successful close.
+                if isinstance(cleanup_exception, asyncio.CancelledError) or (
+                    not primary_exception_active
+                ):
+                    raise
+                try:
+                    logger.warning(
+                        "STT session cleanup failed while preserving the consumer exception"
+                    )
+                except Exception:
+                    # Logging must not replace the original consumer exception.
+                    pass
 
         self._check_errors()
         if self._stored_exception:
             raise self._stored_exception
 
     async def close(self) -> None:
-        if self._websocket:
-            await self._websocket.close()
-
-        self._cleanup_tasks()
+        try:
+            if self._websocket:
+                await self._websocket.close()
+        finally:
+            try:
+                await self._cleanup_tasks()
+            finally:
+                self._end_turn("")
 
 
 class OpenAISTTModel(STTModel):

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -7,7 +7,11 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from ..exceptions import UserError
-from ..logger import log_model_action_error, log_model_and_tool_action_error, logger
+from ..logger import (
+    log_model_action_error,
+    log_model_and_tool_action_error,
+    logger,
+)
 from ..tracing import Span, SpeechGroupSpanData, speech_group_span, speech_span
 from ..tracing.util import time_iso
 from ..util._error_tracing import get_trace_error
@@ -289,7 +293,7 @@ class StreamedAudioResult:
             tasks.append(self._dispatcher_task)
         await asyncio.gather(*tasks)
 
-    async def _cleanup_tasks(self):
+    async def _cleanup_tasks(self) -> None:
         current_task = asyncio.current_task()
         tasks: list[asyncio.Task[Any]] = []
         seen: set[asyncio.Task[Any]] = set()
@@ -311,7 +315,7 @@ class StreamedAudioResult:
 
     def _check_errors(self):
         for task in self._tasks:
-            if task.done():
+            if task.done() and not task.cancelled():
                 if task.exception():
                     self._stored_exception = task.exception()
                     break
@@ -319,38 +323,67 @@ class StreamedAudioResult:
     async def stream(self) -> AsyncIterator[VoiceStreamEvent]:
         """Stream the events and audio data as they're generated."""
         saw_session_end = False
-        while True:
-            try:
-                event = await self._queue.get()
-            except asyncio.CancelledError:
-                await self._cleanup_tasks()
-                raise
-            if isinstance(event, VoiceStreamEventError):
-                self._stored_exception = event.error
-                log_model_and_tool_action_error(
-                    logger, "Error processing voice output", event.error
-                )
-                break
-            if event is None:
-                break
-            yield event
-            if event.type == "voice_stream_event_lifecycle" and event.event == "session_ended":
-                saw_session_end = True
-                break
-
-        # On the normal completion path, let the producer task finish gracefully so any active
-        # trace context can emit `trace_end` before we run cleanup.
+        primary_exception: BaseException | None = None
         try:
-            if (
-                saw_session_end
-                and self.text_generation_task is not None
-                and not self.text_generation_task.done()
-            ):
-                await asyncio.shield(self.text_generation_task)
+            while True:
+                event = await self._queue.get()
+                if isinstance(event, VoiceStreamEventError):
+                    self._stored_exception = event.error
+                    log_model_and_tool_action_error(
+                        logger, "Error processing voice output", event.error
+                    )
+                    break
+                if event is None:
+                    break
+                is_session_end = (
+                    event.type == "voice_stream_event_lifecycle" and event.event == "session_ended"
+                )
+                if is_session_end:
+                    saw_session_end = True
+                yield event
+                if is_session_end:
+                    break
 
             self._check_errors()
+            if self._stored_exception:
+                raise self._stored_exception
+        except BaseException as exc:
+            primary_exception = exc
+            raise
         finally:
-            await self._cleanup_tasks()
+            try:
+                try:
+                    # Let the producer finish gracefully after terminal event delivery so any
+                    # active trace context can emit `trace_end` before cleanup.
+                    if (
+                        saw_session_end
+                        and self.text_generation_task is not None
+                        and not self.text_generation_task.done()
+                    ):
+                        await asyncio.shield(self.text_generation_task)
+                finally:
+                    await self._cleanup_tasks()
+            except BaseException as cleanup_exception:
+                # Cancellation must always propagate, even while preserving a primary consumer
+                # exception, so callers that cancel or time out stream cleanup observe the
+                # cancellation instead of a successful close.
+                if isinstance(cleanup_exception, asyncio.CancelledError) or (
+                    primary_exception is None
+                ):
+                    raise
+                # When the consumer closes right after a delivered terminal event, the
+                # injected GeneratorExit must not hide a producer/task error that surfaces
+                # during finalization; the caller observes `stream()`'s real outcome.
+                if isinstance(primary_exception, GeneratorExit) and saw_session_end:
+                    raise
+                try:
+                    logger.warning(
+                        "Voice stream cleanup failed while preserving the consumer exception"
+                    )
+                except Exception:
+                    # Logging must not replace the original consumer exception.
+                    pass
 
+        self._check_errors()
         if self._stored_exception:
             raise self._stored_exception

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -354,12 +354,10 @@ class StreamedAudioResult:
             try:
                 try:
                     # Let the producer finish gracefully after terminal event delivery so any
-                    # active trace context can emit `trace_end` before cleanup.
-                    if (
-                        saw_session_end
-                        and self.text_generation_task is not None
-                        and not self.text_generation_task.done()
-                    ):
+                    # active trace context can emit `trace_end` before cleanup. Await it even
+                    # when it already finished so an already-raised producer/TTS failure is
+                    # surfaced here instead of being swallowed by cleanup's return_exceptions.
+                    if saw_session_end and self.text_generation_task is not None:
                         await asyncio.shield(self.text_generation_task)
                 finally:
                     await self._cleanup_tasks()

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -3,13 +3,17 @@
 import asyncio
 import base64
 import json
+import logging
 import time
-from unittest.mock import AsyncMock, patch
+from collections.abc import AsyncGenerator
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import numpy.typing as npt
 import pytest
 
+import agents._debug as _debug
 from agents import trace
 from agents.exceptions import UserError
 from tests.testing_processor import fetch_span_errors
@@ -92,6 +96,206 @@ async def test_transcribe_turns_propagates_consumer_cancellation(monkeypatch) ->
     finally:
         await session.close()
         if session._connection_task is not None:
+            await asyncio.gather(session._connection_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_transcribe_turns_closes_owned_tasks_after_yield(monkeypatch) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    session._websocket = AsyncMock()
+    tracing_span = MagicMock()
+    session._tracing_span = tracing_span
+    never_finishes = asyncio.Event()
+    started = [asyncio.Event() for _ in range(4)]
+    stopped = [asyncio.Event() for _ in range(4)]
+
+    async def hold_open(index: int) -> None:
+        started[index].set()
+        try:
+            await never_finishes.wait()
+        finally:
+            stopped[index].set()
+
+    async def hold_connection_open() -> None:
+        await hold_open(0)
+
+    monkeypatch.setattr(session, "_process_websocket_connection", hold_connection_open)
+    session._listener_task = asyncio.create_task(hold_open(1))
+    session._process_events_task = asyncio.create_task(hold_open(2))
+    session._stream_audio_task = asyncio.create_task(hold_open(3))
+    await session._output_queue.put("hello")
+
+    turns = cast(AsyncGenerator[str, None], session.transcribe_turns())
+    assert await anext(turns) == "hello"
+    await asyncio.gather(*(event.wait() for event in started))
+
+    owned_tasks = (
+        session._connection_task,
+        session._listener_task,
+        session._process_events_task,
+        session._stream_audio_task,
+    )
+    try:
+        await turns.aclose()
+        await asyncio.wait_for(
+            asyncio.gather(*(event.wait() for event in stopped)),
+            timeout=1,
+        )
+        assert all(task is not None and task.cancelled() for task in owned_tasks)
+        session._websocket.close.assert_awaited_once()
+        tracing_span.finish.assert_called_once_with()
+        assert session._tracing_span is None
+    finally:
+        tasks = [task for task in owned_tasks if task is not None]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_close_finishes_span_started_while_websocket_close_is_pending() -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    old_span = MagicMock()
+    replacement_span = MagicMock()
+    session._tracing_span = old_span
+    websocket_close_started = asyncio.Event()
+    allow_websocket_close = asyncio.Event()
+
+    async def close_websocket() -> None:
+        websocket_close_started.set()
+        await allow_websocket_close.wait()
+
+    session._websocket = AsyncMock()
+    session._websocket.close.side_effect = close_websocket
+    session._process_events_task = asyncio.create_task(session._handle_events())
+
+    with patch(
+        "agents.voice.models.openai_stt.transcription_span",
+        return_value=replacement_span,
+    ):
+        close_task = asyncio.create_task(session.close())
+        try:
+            await websocket_close_started.wait()
+            await session._event_queue.put(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "transcript": "late transcript",
+                }
+            )
+            assert await session._output_queue.get() == "late transcript"
+            session._output_queue.task_done()
+
+            allow_websocket_close.set()
+            await close_task
+        finally:
+            allow_websocket_close.set()
+            if not close_task.done():
+                close_task.cancel()
+            await asyncio.gather(close_task, return_exceptions=True)
+
+    old_span.finish.assert_called_once_with()
+    replacement_span.start.assert_called_once_with()
+    replacement_span.finish.assert_called_once_with()
+    assert session._tracing_span is None
+    assert session._process_events_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_transcribe_turns_preserves_consumer_exception_when_cleanup_fails(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    never_finishes = asyncio.Event()
+
+    async def hold_connection_open() -> None:
+        await never_finishes.wait()
+
+    async def fail_cleanup() -> None:
+        raise RuntimeError("sensitive cleanup detail")
+
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
+    monkeypatch.setattr(session, "_process_websocket_connection", hold_connection_open)
+    monkeypatch.setattr(session, "_cleanup_tasks", fail_cleanup)
+    await session._output_queue.put("hello")
+    turns = cast(AsyncGenerator[str, None], session.transcribe_turns())
+    assert await anext(turns) == "hello"
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="openai.agents"):
+            with pytest.raises(ValueError, match="sensitive consumer detail"):
+                await turns.athrow(ValueError("sensitive consumer detail"))
+    finally:
+        if session._connection_task is not None:
+            session._connection_task.cancel()
+            await asyncio.gather(session._connection_task, return_exceptions=True)
+
+    message = "STT session cleanup failed while preserving the consumer exception"
+    record = caplog.records[-1]
+    assert record.msg == message
+    assert record.args == ()
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert record.getMessage() == message
+    assert logging.Formatter().format(record) == message
+    assert all(
+        not isinstance(value, RuntimeError | ValueError) for value in record.__dict__.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_transcribe_turns_propagates_cancellation_during_cleanup(monkeypatch) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=False,
+    )
+    never_finishes = asyncio.Event()
+
+    async def hold_connection_open() -> None:
+        await never_finishes.wait()
+
+    async def cancelled_cleanup() -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(session, "_process_websocket_connection", hold_connection_open)
+    monkeypatch.setattr(session, "_cleanup_tasks", cancelled_cleanup)
+    await session._output_queue.put("hello")
+    turns = cast(AsyncGenerator[str, None], session.transcribe_turns())
+    assert await anext(turns) == "hello"
+
+    try:
+        # A primary consumer exception is active, but a cancellation raised while the STT
+        # session is closing must still propagate rather than be swallowed as secondary.
+        with pytest.raises(asyncio.CancelledError):
+            await turns.athrow(ValueError("consumer detail"))
+    finally:
+        if session._connection_task is not None:
+            session._connection_task.cancel()
             await asyncio.gather(session._connection_task, return_exceptions=True)
 
 

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -334,6 +334,40 @@ async def test_streamed_audio_result_surfaces_producer_error_on_close_after_sess
         await asyncio.gather(close_task, producer_task, return_exceptions=True)
 
 
+@pytest.mark.asyncio
+async def test_streamed_audio_result_surfaces_failed_producer_already_done_on_close() -> None:
+    """Closing the consumer right after `session_ended` must surface a producer error that
+    already raised before close, not report a clean close."""
+
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    producer_error = RuntimeError("producer-failed-before-terminal-close")
+
+    async def produce_session() -> None:
+        raise producer_error
+
+    producer_task = asyncio.create_task(produce_session())
+    result._set_task(producer_task)
+    await asyncio.sleep(0)
+    assert producer_task.done()
+    await result._queue.put(VoiceStreamEventLifecycle(event="session_ended"))
+
+    stream = cast(AsyncGenerator[VoiceStreamEvent, None], result.stream())
+    event = await anext(stream)
+    assert isinstance(event, VoiceStreamEventLifecycle)
+    assert event.event == "session_ended"
+
+    # The producer already finished with an error, so the shield await must re-raise it out of
+    # aclose() instead of the GeneratorExit reporting a clean close.
+    with pytest.raises(RuntimeError, match="producer-failed-before-terminal-close"):
+        await stream.aclose()
+
+    await asyncio.gather(producer_task, return_exceptions=True)
+
+
 def test_voice_pipeline_config_normalizes_dictionary_settings() -> None:
     config = VoicePipelineConfig(
         stt_settings={"language": "ja", "temperature": 0.0},

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -96,6 +97,241 @@ async def test_streamed_audio_result_propagates_consumer_cancellation(monkeypatc
         await consumer
     await producer_stopped.wait()
     assert producer.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_preserves_cancellation_when_cleanup_fails(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    get_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+
+    async def wait_for_event() -> VoiceStreamEvent:
+        get_started.set()
+        await never_finishes.wait()
+        raise AssertionError("Unreachable")
+
+    async def fail_cleanup() -> None:
+        raise RuntimeError("sensitive cleanup detail")
+
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
+    monkeypatch.setattr(result._queue, "get", wait_for_event)
+    monkeypatch.setattr(result, "_cleanup_tasks", fail_cleanup)
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        consumer = asyncio.ensure_future(anext(result.stream()))
+        await get_started.wait()
+        consumer.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+
+    message = "Voice stream cleanup failed while preserving the consumer exception"
+    record = caplog.records[-1]
+    assert record.msg == message
+    assert record.args == ()
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert record.getMessage() == message
+    assert logging.Formatter().format(record) == message
+    assert all(
+        not isinstance(value, RuntimeError | asyncio.CancelledError)
+        for value in record.__dict__.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_closes_owned_tasks_after_yield() -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    never_finishes = asyncio.Event()
+    started = [asyncio.Event() for _ in range(3)]
+    stopped = [asyncio.Event() for _ in range(3)]
+
+    async def hold_open(index: int) -> None:
+        started[index].set()
+        try:
+            await never_finishes.wait()
+        finally:
+            stopped[index].set()
+
+    synthesis_task = asyncio.create_task(hold_open(0))
+    dispatcher_task = asyncio.create_task(hold_open(1))
+    producer_task = asyncio.create_task(hold_open(2))
+    result._tasks.append(synthesis_task)
+    result._dispatcher_task = dispatcher_task
+    result._set_task(producer_task)
+    await asyncio.gather(*(event.wait() for event in started))
+    await result._queue.put(VoiceStreamEventLifecycle(event="turn_started"))
+
+    stream = cast(AsyncGenerator[VoiceStreamEvent, None], result.stream())
+    event = await anext(stream)
+    assert isinstance(event, VoiceStreamEventLifecycle)
+    assert event.event == "turn_started"
+
+    owned_tasks = (synthesis_task, dispatcher_task, producer_task)
+    try:
+        await stream.aclose()
+        await asyncio.wait_for(
+            asyncio.gather(*(event.wait() for event in stopped)),
+            timeout=1,
+        )
+        assert all(task.cancelled() for task in owned_tasks)
+    finally:
+        for task in owned_tasks:
+            task.cancel()
+        await asyncio.gather(*owned_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_closes_gracefully_after_session_end_yield() -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    producer_started = asyncio.Event()
+    allow_producer_finish = asyncio.Event()
+    producer_completed = asyncio.Event()
+    producer_cancelled = asyncio.Event()
+
+    async def produce_session() -> None:
+        producer_started.set()
+        try:
+            await allow_producer_finish.wait()
+        except asyncio.CancelledError:
+            producer_cancelled.set()
+            raise
+        else:
+            producer_completed.set()
+
+    producer_task = asyncio.create_task(produce_session())
+    result._set_task(producer_task)
+    await producer_started.wait()
+    await result._queue.put(VoiceStreamEventLifecycle(event="session_ended"))
+
+    stream = cast(AsyncGenerator[VoiceStreamEvent, None], result.stream())
+    event = await anext(stream)
+    assert isinstance(event, VoiceStreamEventLifecycle)
+    assert event.event == "session_ended"
+
+    close_task = asyncio.create_task(stream.aclose())
+    try:
+        await asyncio.sleep(0)
+        assert not close_task.done()
+        assert not producer_cancelled.is_set()
+        allow_producer_finish.set()
+        await asyncio.wait_for(close_task, timeout=1)
+        assert producer_completed.is_set()
+        assert not producer_cancelled.is_set()
+        assert not producer_task.cancelled()
+    finally:
+        allow_producer_finish.set()
+        if not close_task.done():
+            close_task.cancel()
+        if not producer_task.done():
+            producer_task.cancel()
+        await asyncio.gather(close_task, producer_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_propagates_cancellation_during_session_end_cleanup() -> None:
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    producer_started = asyncio.Event()
+    producer_release = asyncio.Event()
+
+    async def produce_session() -> None:
+        producer_started.set()
+        await producer_release.wait()
+
+    producer_task = asyncio.create_task(produce_session())
+    result._set_task(producer_task)
+    await producer_started.wait()
+    await result._queue.put(VoiceStreamEventLifecycle(event="session_ended"))
+
+    stream = cast(AsyncGenerator[VoiceStreamEvent, None], result.stream())
+    event = await anext(stream)
+    assert isinstance(event, VoiceStreamEventLifecycle)
+    assert event.event == "session_ended"
+
+    # aclose() blocks in the finally awaiting asyncio.shield(text_generation_task). Cancelling
+    # that cleanup (as asyncio.wait_for would on timeout) must surface the cancellation instead
+    # of reporting a successful close.
+    close_task = asyncio.create_task(stream.aclose())
+    try:
+        await asyncio.sleep(0)
+        assert not close_task.done()
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+    finally:
+        producer_release.set()
+        if not producer_task.done():
+            producer_task.cancel()
+        await asyncio.gather(producer_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_streamed_audio_result_surfaces_producer_error_on_close_after_session_end() -> None:
+    """Closing the consumer right after `session_ended` must surface a producer error that
+    surfaces during finalization, not report a clean close."""
+
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    producer_started = asyncio.Event()
+    producer_release = asyncio.Event()
+    producer_error = RuntimeError("producer-failed-after-terminal")
+
+    async def produce_session() -> None:
+        producer_started.set()
+        try:
+            await producer_release.wait()
+        except asyncio.CancelledError:
+            raise
+        raise producer_error
+
+    producer_task = asyncio.create_task(produce_session())
+    result._set_task(producer_task)
+    await producer_started.wait()
+    await result._queue.put(VoiceStreamEventLifecycle(event="session_ended"))
+
+    stream = cast(AsyncGenerator[VoiceStreamEvent, None], result.stream())
+    event = await anext(stream)
+    assert isinstance(event, VoiceStreamEventLifecycle)
+    assert event.event == "session_ended"
+
+    # aclose() blocks in the finally awaiting asyncio.shield(text_generation_task). When the
+    # producer then fails, `stream()` is the terminal error boundary, so the failure must
+    # propagate out of aclose() instead of being swallowed as a cleanup failure.
+    close_task = asyncio.create_task(stream.aclose())
+    try:
+        await asyncio.sleep(0)
+        assert not close_task.done()
+        producer_release.set()
+        with pytest.raises(RuntimeError, match="producer-failed-after-terminal"):
+            await asyncio.wait_for(close_task, timeout=1)
+    finally:
+        producer_release.set()
+        if not close_task.done():
+            close_task.cancel()
+        if not producer_task.done():
+            producer_task.cancel()
+        await asyncio.gather(close_task, producer_task, return_exceptions=True)
 
 
 def test_voice_pipeline_config_normalizes_dictionary_settings() -> None:


### PR DESCRIPTION
## Summary

Fixes voice stream/task lifecycle cleanup when streams close early. When a consumer closes a `StreamedAudioResult` (or an STT transcription session) right after receiving a terminal event, finalization must not hide the real producer outcome.

Key changes in `src/agents/voice/result.py` and `src/agents/voice/models/openai_stt.py`:

1. **Surface terminal producer errors on close.** `stream()` now tracks the primary exception object and re-raises the cleanup exception when the primary exception is `GeneratorExit` after a delivered `session_ended`. Previously the injected `GeneratorExit` swallowed a producer/TTS error that surfaced during finalization (via the `asyncio.shield` re-raise), so `aclose()` reported a clean close instead of the real failure.

2. **Graceful producer completion on early close.** After a terminal event is recorded (before the yield), finalization shields the producer task so the session-close and `trace_end` path completes before cleanup, instead of cancelling the producer mid-flight.

3. **Cancellation always propagates.** Cleanup failure handling always re-raises `CancelledError` and preserves the primary consumer exception; non-cancellation cleanup errors only emit a fixed `logger.warning(...)` with no attached consumer context.

4. **Single finalization path.** Both iterators drain owned tasks and finish the tracing span after tasks settle (cancel + drain, then span finish in a `finally`).

The branch is based on current `upstream/main` with no conflicts.

## Test Plan

- `uv run pytest tests/voice/test_pipeline.py tests/voice/test_openai_stt.py -q` — 57 passed.
- New regressions: producer finishes (not cancelled) when consumer closes after `session_ended`; cancellation during session-end cleanup propagates; terminal producer error after `session_ended` surfaces from `aclose()` (fails before the fix).
- `uv run ruff check` and `uv run ruff format --check` clean; `uv run mypy` on voice sources/tests clean.
- Full-suite collection errors (`tee not found` in `tests/mcp/helpers.py`, sandbox symlink/tracing failures) are pre-existing on Windows `upstream/main` and reproduce identically without this branch.
