### PR TITLE
fix(streaming): synchronize after-turn cancellation with event consumption

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -579,6 +579,10 @@ class RunResultStreaming(RunResultBase):
     interruptions: list[ToolApprovalItem] = field(default_factory=list)
     """Pending tool approval requests (interruptions) for this run."""
     _waiting_on_event_queue: bool = field(default=False, repr=False)
+    _active_stream_consumers: int = field(default=0, init=False, repr=False)
+    _stream_consumers_stopped: asyncio.Event = field(
+        default_factory=asyncio.Event, init=False, repr=False
+    )
 
     _current_turn_persisted_item_count: int = 0
     """Number of items from new_items already persisted to session for the
@@ -775,6 +779,22 @@ class RunResultStreaming(RunResultBase):
             # Don't call _cleanup_tasks() or clear queues yet
             pass
 
+    async def _wait_for_turn_event_consumption(self) -> None:
+        """Wait for active consumers to finish processing the current turn's events."""
+        if self._active_stream_consumers == 0:
+            return
+
+        queue_drained = asyncio.create_task(self._event_queue.join())
+        consumers_stopped = asyncio.create_task(self._stream_consumers_stopped.wait())
+        tasks = {queue_drained, consumers_stopped}
+        try:
+            await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
     async def stream_events(self) -> AsyncIterator[StreamEvent]:
         """Stream deltas for new items as they are generated. We're using the types from the
         OpenAI Responses API, so these are semantic events: each event has a `type` field that
@@ -784,9 +804,53 @@ class RunResultStreaming(RunResultBase):
         - A MaxTurnsExceeded exception if the agent exceeds the max_turns limit.
         - A GuardrailTripwireTriggered exception if a guardrail is tripped.
         """
+        consumer_registered = False
+        registered_consumer_task: asyncio.Task[Any] | None = None
+        item_acknowledgement_pending = False
+
+        def acknowledge_item() -> None:
+            nonlocal item_acknowledgement_pending
+            if not item_acknowledgement_pending:
+                return
+            item_acknowledgement_pending = False
+            self._event_queue.task_done()
+
+        def unregister_consumer() -> None:
+            nonlocal consumer_registered, registered_consumer_task
+            if not consumer_registered:
+                return
+            acknowledge_item()
+            consumer_registered = False
+            registered_consumer_task = None
+            self._active_stream_consumers -= 1
+            if self._active_stream_consumers == 0:
+                self._stream_consumers_stopped.set()
+
+        def consumer_task_done(task: asyncio.Task[Any]) -> None:
+            if registered_consumer_task is not task:
+                return
+            if task.cancelled() or task.exception() is not None:
+                unregister_consumer()
+
+        def register_current_consumer() -> None:
+            nonlocal consumer_registered, registered_consumer_task
+            current_task = asyncio.current_task()
+            if current_task is None or registered_consumer_task is current_task:
+                return
+            if registered_consumer_task is not None:
+                registered_consumer_task.remove_done_callback(consumer_task_done)
+            registered_consumer_task = current_task
+            if not consumer_registered:
+                consumer_registered = True
+                self._active_stream_consumers += 1
+                self._stream_consumers_stopped.clear()
+            current_task.add_done_callback(consumer_task_done)
+
+        register_current_consumer()
         cancelled = False
         try:
             while True:
+                register_current_consumer()
                 self._check_errors()
                 should_drain_queued_events = isinstance(
                     self._stored_exception, MaxTurnsExceeded
@@ -826,9 +890,15 @@ class RunResultStreaming(RunResultBase):
                     self._check_errors()
                     break
 
-                yield item
-                self._event_queue.task_done()
+                item_acknowledgement_pending = True
+                try:
+                    yield item
+                finally:
+                    acknowledge_item()
         finally:
+            if registered_consumer_task is not None:
+                registered_consumer_task.remove_done_callback(consumer_task_done)
+            unregister_consumer()
             try:
                 if cancelled:
                     # Cancellation should return promptly, so avoid waiting on long-running tasks.

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -325,6 +325,28 @@ def _complete_stream_interruption(
     streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
 
 
+async def _wait_for_streamed_turn_events_and_stop_if_cancelled(
+    streamed_result: RunResultStreaming,
+) -> bool:
+    """Let consumers process the completed turn before starting another one."""
+    await streamed_result._wait_for_turn_event_consumption()
+    if streamed_result._cancel_mode != "after_turn":
+        return False
+
+    streamed_result.is_complete = True
+    streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+    return True
+
+
+def _publish_streamed_result_agent(
+    streamed_result: RunResultStreaming,
+    agent: Agent[Any],
+) -> None:
+    """Publish an agent transition before cancellation can complete the streamed run."""
+    streamed_result.current_agent = agent
+    streamed_result._current_agent_output_schema = get_output_schema(agent)
+
+
 async def _save_resumed_stream_items(
     *,
     session: Session | None,
@@ -909,6 +931,7 @@ async def start_streaming(
                         current_agent = turn_result.next_step.new_agent
                         if run_state is not None:
                             run_state._current_agent = current_agent
+                        _publish_streamed_result_agent(streamed_result, current_agent)
                         if current_span:
                             current_span.finish(reset_current=True)
                         current_span = None
@@ -917,6 +940,10 @@ async def start_streaming(
                             AgentUpdatedStreamEvent(new_agent=current_agent)
                         )
                         run_state._current_step = NextStepRunAgain()  # type: ignore[assignment]
+                        if await _wait_for_streamed_turn_events_and_stop_if_cancelled(
+                            streamed_result
+                        ):
+                            break
                         continue
 
                     if isinstance(turn_result.next_step, NextStepFinalOutput):
@@ -941,6 +968,10 @@ async def start_streaming(
                             store_setting,
                         )
                         run_state._current_step = NextStepRunAgain()  # type: ignore[assignment]
+                        if await _wait_for_streamed_turn_events_and_stop_if_cancelled(
+                            streamed_result
+                        ):
+                            break
                         continue
 
                     run_state._current_step = None
@@ -1220,6 +1251,7 @@ async def start_streaming(
                     current_agent = turn_result.next_step.new_agent
                     if run_state is not None:
                         run_state._current_agent = current_agent
+                    _publish_streamed_result_agent(streamed_result, current_agent)
                     current_span.finish(reset_current=True)
                     current_span = None
                     should_run_agent_start_hooks = True
@@ -1229,9 +1261,7 @@ async def start_streaming(
                     if streamed_result._state is not None:
                         streamed_result._state._current_step = NextStepRunAgain()
 
-                    if streamed_result._cancel_mode == "after_turn":  # type: ignore[comparison-overlap]
-                        streamed_result.is_complete = True
-                        streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+                    if await _wait_for_streamed_turn_events_and_stop_if_cancelled(streamed_result):
                         break
                 elif isinstance(turn_result.next_step, NextStepFinalOutput):
                     await _finalize_streamed_final_output(
@@ -1282,9 +1312,7 @@ async def start_streaming(
                         store_setting,
                     )
 
-                    if streamed_result._cancel_mode == "after_turn":  # type: ignore[comparison-overlap]
-                        streamed_result.is_complete = True
-                        streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+                    if await _wait_for_streamed_turn_events_and_stop_if_cancelled(streamed_result):
                         break
             except Exception as e:
                 if current_span and _should_attach_generic_agent_error(e):

--- a/tests/test_run_impl_resume_paths.py
+++ b/tests/test_run_impl_resume_paths.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, cast
 
@@ -7,6 +8,7 @@ from openai.types.responses import ResponseFunctionToolCall, ResponseOutputMessa
 import agents.run as run_module
 from agents import Agent, Runner, function_tool
 from agents.agent import ToolsToFinalOutputResult
+from agents.agent_output import AgentOutputSchema
 from agents.items import (
     MessageOutputItem,
     ModelResponse,
@@ -21,6 +23,7 @@ from agents.run_internal import run_loop, turn_resolution
 from agents.run_internal.agent_bindings import bind_public_agent
 from agents.run_internal.run_loop import (
     NextStepFinalOutput,
+    NextStepHandoff,
     NextStepInterruption,
     NextStepRunAgain,
     ProcessedResponse,
@@ -230,6 +233,122 @@ async def test_resumed_run_again_resets_persisted_count(monkeypatch) -> None:
         for item in session.saved_items
     ]
     assert "function_call" in saved_types
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("continuation", ["run_again", "handoff"])
+async def test_resumed_stream_waits_for_event_consumption_before_continuing(
+    monkeypatch: pytest.MonkeyPatch,
+    continuation: str,
+) -> None:
+    agent = Agent(name="resume-agent")
+    delegate = Agent(name="delegate", output_type=int)
+    state: RunState[dict[str, str]] = RunState(
+        context=RunContextWrapper(context={}),
+        original_input="input",
+        starting_agent=agent,
+        max_turns=2,
+    )
+    state._current_step = NextStepInterruption(interruptions=[])
+    state._model_responses = [
+        ModelResponse(output=[], usage=Usage(), response_id="resp_1"),
+    ]
+    state._last_processed_response = ProcessedResponse(
+        new_items=[],
+        handoffs=[],
+        functions=[],
+        computer_actions=[],
+        local_shell_calls=[],
+        shell_calls=[],
+        apply_patch_calls=[],
+        tools_used=[],
+        mcp_approval_requests=[],
+        interruptions=[],
+    )
+
+    tool_output_item = ToolCallOutputItem(
+        agent=agent,
+        raw_item={
+            "type": "function_call_output",
+            "call_id": "call-resume",
+            "output": "ok",
+        },
+        output="ok",
+    )
+    next_step = NextStepHandoff(delegate) if continuation == "handoff" else NextStepRunAgain()
+    allow_resume_resolution = asyncio.Event()
+
+    async def fake_resolve_interrupted_turn(**_kwargs: object) -> SingleStepResult:
+        await allow_resume_resolution.wait()
+        return SingleStepResult(
+            original_input="input",
+            model_response=ModelResponse(output=[], usage=Usage(), response_id="resp_resume"),
+            pre_step_items=[],
+            new_step_items=[tool_output_item],
+            next_step=next_step,
+            tool_input_guardrail_results=[],
+            tool_output_guardrail_results=[],
+        )
+
+    next_model_turn_started = asyncio.Event()
+    allow_model_turn_to_finish = asyncio.Event()
+
+    async def fake_run_single_turn_streamed(*_args: object, **_kwargs: object) -> SingleStepResult:
+        next_model_turn_started.set()
+        await allow_model_turn_to_finish.wait()
+        return SingleStepResult(
+            original_input="input",
+            model_response=ModelResponse(output=[], usage=Usage(), response_id="unexpected"),
+            pre_step_items=[],
+            new_step_items=[],
+            next_step=NextStepFinalOutput("unexpected"),
+            tool_input_guardrail_results=[],
+            tool_output_guardrail_results=[],
+        )
+
+    monkeypatch.setattr(run_loop, "resolve_interrupted_turn", fake_resolve_interrupted_turn)
+    monkeypatch.setattr(run_loop, "run_single_turn_streamed", fake_run_single_turn_streamed)
+
+    result = Runner.run_streamed(agent, state)
+    consumer_active = asyncio.Event()
+    consumer_suspended = asyncio.Event()
+    release_consumer = asyncio.Event()
+    cancel_called = asyncio.Event()
+
+    async def consume_events() -> None:
+        async for event in result.stream_events():
+            if event.type == "agent_updated_stream_event":
+                consumer_active.set()
+            if event.type == "run_item_stream_event" and event.name == "tool_output":
+                consumer_suspended.set()
+                await release_consumer.wait()
+                result.cancel(mode="after_turn")
+                cancel_called.set()
+
+    consumer_task = asyncio.create_task(consume_events())
+    await asyncio.wait_for(consumer_active.wait(), timeout=1)
+    allow_resume_resolution.set()
+    await asyncio.wait_for(consumer_suspended.wait(), timeout=1)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert not next_model_turn_started.is_set()
+
+    release_consumer.set()
+    await asyncio.wait_for(cancel_called.wait(), timeout=1)
+    allow_model_turn_to_finish.set()
+    await asyncio.wait_for(consumer_task, timeout=1)
+
+    assert not next_model_turn_started.is_set()
+    assert result.final_output is None
+    expected_agent = delegate if continuation == "handoff" else agent
+    assert result.current_agent is expected_agent
+    assert result.last_agent is expected_agent
+    assert result.to_state()._current_agent is expected_agent
+    if continuation == "handoff":
+        assert result._current_agent_output_schema is not None
+        assert isinstance(result._current_agent_output_schema, AgentOutputSchema)
+        assert result._current_agent_output_schema.output_type is int
 
 
 @pytest.mark.parametrize(

--- a/tests/test_soft_cancel.py
+++ b/tests/test_soft_cancel.py
@@ -1,13 +1,23 @@
 """Tests for soft cancel (after_turn mode) functionality."""
 
+import asyncio
 import json
+from collections.abc import AsyncGenerator
+from typing import cast
 
 import pytest
 
 from agents import Agent, Runner, SQLiteSession
+from agents.agent_output import AgentOutputSchema
+from agents.stream_events import StreamEvent
 
 from .fake_model import FakeModel
-from .test_responses import get_function_tool, get_function_tool_call, get_text_message
+from .test_responses import (
+    get_function_tool,
+    get_function_tool_call,
+    get_handoff_tool_call,
+    get_text_message,
+)
 
 
 @pytest.mark.asyncio
@@ -140,7 +150,8 @@ async def test_soft_cancel_tracks_usage():
 
 
 @pytest.mark.asyncio
-async def test_soft_cancel_stops_next_turn():
+@pytest.mark.parametrize("consumer_suspensions", [0, 1, 3])
+async def test_soft_cancel_stops_next_turn(consumer_suspensions: int):
     """Verify soft cancel prevents next turn from starting."""
     model = FakeModel()
     agent = Agent(
@@ -165,9 +176,167 @@ async def test_soft_cancel_stops_next_turn():
         if event.type == "run_item_stream_event" and event.name == "tool_output":
             turns_completed += 1
             if turns_completed == 1:
+                for _ in range(consumer_suspensions):
+                    await asyncio.sleep(0)
                 result.cancel(mode="after_turn")
 
     assert turns_completed == 1, "Should complete exactly 1 turn"
+    assert result.final_output is None
+    assert result.context_wrapper.usage.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_soft_cancel_stops_next_turn_with_short_lived_anext_tasks():
+    """Per-event tasks must not acknowledge a turn before the caller handles its event."""
+    model = FakeModel()
+    agent = Agent(
+        name="Assistant",
+        model=model,
+        tools=[get_function_tool("tool1", "result1")],
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("tool1", "{}")],
+            [get_text_message("Turn 2")],
+        ]
+    )
+
+    result = Runner.run_streamed(agent, input="Hello")
+    events = cast(AsyncGenerator[StreamEvent, None], result.stream_events())
+    try:
+        while True:
+            event = await asyncio.create_task(anext(events))
+            if event.type == "run_item_stream_event" and event.name == "tool_output":
+                result.cancel(mode="after_turn")
+    except StopAsyncIteration:
+        pass
+
+    assert result.final_output is None
+    assert result.context_wrapper.usage.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_completes_without_an_event_consumer():
+    """Turn acknowledgement must not block a run whose events are not consumed."""
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("tool1", "{}")],
+            [get_text_message("Turn 2")],
+        ]
+    )
+    agent = Agent(
+        name="Assistant",
+        model=model,
+        tools=[get_function_tool("tool1", "result1")],
+    )
+
+    result = Runner.run_streamed(agent, input="Hello")
+    assert result.run_loop_task is not None
+    await asyncio.wait_for(result.run_loop_task, timeout=1)
+
+    assert result.final_output == "Turn 2"
+    assert result.context_wrapper.usage.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_closing_stream_consumer_releases_turn_acknowledgement():
+    """Closing an iterator must not deadlock while a turn awaits its consumer."""
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("tool1", "{}")],
+            [get_text_message("Turn 2")],
+        ]
+    )
+    agent = Agent(
+        name="Assistant",
+        model=model,
+        tools=[get_function_tool("tool1", "result1")],
+    )
+
+    result = Runner.run_streamed(agent, input="Hello")
+    events = cast(AsyncGenerator[StreamEvent, None], result.stream_events())
+    while True:
+        event = await anext(events)
+        if event.type == "run_item_stream_event" and event.name == "tool_output":
+            break
+
+    await asyncio.wait_for(events.aclose(), timeout=1)
+
+    assert result.final_output == "Turn 2"
+    assert result.context_wrapper.usage.requests == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stream_consumer_releases_turn_acknowledgement():
+    """Cancelling a consumer suspended after yield must release the completed turn."""
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("tool1", "{}")],
+            [get_text_message("Turn 2")],
+        ]
+    )
+    agent = Agent(
+        name="Assistant",
+        model=model,
+        tools=[get_function_tool("tool1", "result1")],
+    )
+
+    result = Runner.run_streamed(agent, input="Hello")
+    events = cast(AsyncGenerator[StreamEvent, None], result.stream_events())
+    consumer_suspended = asyncio.Event()
+    keep_consumer_suspended = asyncio.Event()
+
+    async def consume_events() -> None:
+        async for event in events:
+            if event.type == "run_item_stream_event" and event.name == "tool_output":
+                consumer_suspended.set()
+                await keep_consumer_suspended.wait()
+
+    consumer_task = asyncio.create_task(consume_events())
+    await asyncio.wait_for(consumer_suspended.wait(), timeout=1)
+
+    consumer_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consumer_task
+
+    assert result.run_loop_task is not None
+    await asyncio.wait_for(result.run_loop_task, timeout=1)
+
+    assert result.final_output == "Turn 2"
+    assert result.context_wrapper.usage.requests == 2
+    assert result._active_stream_consumers == 0
+
+    await asyncio.wait_for(events.aclose(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_immediate_cancel_releases_turn_acknowledgement():
+    """Immediate cancellation must cancel a run waiting for streamed event acknowledgement."""
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("tool1", "{}")],
+            [get_text_message("Turn 2")],
+        ]
+    )
+    agent = Agent(
+        name="Assistant",
+        model=model,
+        tools=[get_function_tool("tool1", "result1")],
+    )
+
+    result = Runner.run_streamed(agent, input="Hello")
+    async for event in result.stream_events():
+        if event.type == "run_item_stream_event" and event.name == "tool_output":
+            await asyncio.sleep(0)
+            result.cancel(mode="immediate")
+
+    assert result.is_complete
+    assert result.final_output is None
+    assert result.context_wrapper.usage.requests == 1
 
 
 @pytest.mark.asyncio
@@ -434,6 +603,64 @@ async def test_soft_cancel_with_handoff():
 
     # Cleanup
     await session.clear_session()
+
+
+@pytest.mark.asyncio
+async def test_soft_cancel_waits_for_handoff_event_consumption_before_next_turn():
+    """A suspended handoff consumer can stop the run before the delegate model starts."""
+    second_request_started = asyncio.Event()
+
+    class HandoffModel(FakeModel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.request_count = 0
+
+        async def stream_response(self, *args, **kwargs):
+            self.request_count += 1
+            if self.request_count == 2:
+                second_request_started.set()
+            async for event in super().stream_response(*args, **kwargs):
+                yield event
+
+    model = HandoffModel()
+    delegate = Agent(name="Delegate", model=model, output_type=int)
+    triage = Agent(name="Triage", model=model, handoffs=[delegate])
+    model.add_multiple_turn_outputs(
+        [
+            [get_handoff_tool_call(delegate)],
+            [get_text_message("Delegate response")],
+        ]
+    )
+
+    result = Runner.run_streamed(triage, input="Route this request")
+    consumer_suspended = asyncio.Event()
+    release_consumer = asyncio.Event()
+
+    async def consume_events() -> None:
+        async for event in result.stream_events():
+            if event.type == "run_item_stream_event" and event.name == "handoff_requested":
+                consumer_suspended.set()
+                await release_consumer.wait()
+                result.cancel(mode="after_turn")
+
+    consumer_task = asyncio.create_task(consume_events())
+    await asyncio.wait_for(consumer_suspended.wait(), timeout=1)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert not second_request_started.is_set()
+
+    release_consumer.set()
+    await asyncio.wait_for(consumer_task, timeout=1)
+
+    assert result.final_output is None
+    assert result.context_wrapper.usage.requests == 1
+    assert result.current_agent is delegate
+    assert result.last_agent is delegate
+    assert result.to_state()._current_agent is delegate
+    assert result._current_agent_output_schema is not None
+    assert isinstance(result._current_agent_output_schema, AgentOutputSchema)
+    assert result._current_agent_output_schema.output_type is int
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes a race between streamed event consumption and `cancel(mode="after_turn")`.

This work was originally included in #3933, which combined three separate Realtime and streaming lifecycle changes. We are replacing that PR with three focused pull requests:

1. Text-only Realtime output guardrails, completed in #4124.
2. Streamed `after_turn` cancellation synchronization, implemented by this pull request.
3. The remaining Realtime guardrail recovery and late-audio lifecycle hardening, which will be handled separately.

#3933 can therefore be closed in favor of these smaller changes.

Previously, the run loop could begin the next model turn before a `stream_events()` consumer finished processing the completed turn's events. If the consumer called `cancel(mode="after_turn")` after suspending during event handling, the cancellation could arrive after the next model request had already started.

This pull request:

- acknowledges streamed events only after caller-side processing returns;
- waits for active consumers before ordinary and resumed run-again or handoff continuations;
- publishes the handed-off agent and output schema before honoring cancellation;
- releases the wait when a consumer closes or is cancelled;
- preserves non-blocking behavior when no event consumer is active;
- preserves the existing immediate cancellation behavior and public API.