### PR TITLE
fix: detect and raise on colliding handoff/tool names after normaliza…

### DIFF
--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -352,7 +352,16 @@ def validate_function_tool_lookup_configuration(tools: Sequence[Any]) -> None:
 
         prior_namespace = get_explicit_function_tool_namespace(prior_owner)
         if explicit_namespace is None and prior_namespace is None:
-            continue
+            # Both tools are plain (non-namespaced) FunctionTools sharing the same public
+            # name.  This is the most common accidental collision — e.g. two @function_tool
+            # decorators with the same name_override, or a tool appended twice via
+            # Agent.clone()/list concatenation.  The OpenAI API rejects such payloads with
+            # a 400; raise early with a clear message instead of letting it fail remotely.
+            raise UserError(
+                f"Duplicate function tool name {qualified_name!r}: two tools in the agent's "
+                f"tool list share this name. Pass a unique name_override= to one of them to "
+                f"avoid ambiguous dispatch."
+            )
 
         raise UserError(
             "Ambiguous function tool configuration: the qualified name "

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -119,6 +119,59 @@ def _validate_codex_tool_name_collisions(tools: list[Tool]) -> None:
         )
 
 
+def _validate_handoff_tool_name_collisions(
+    handoffs: "list[Agent[Any] | Handoff[Any, Any]]",
+) -> None:
+    """Raise UserError if two handoffs derive the same tool name after normalization.
+
+    This catches the silent many-to-one collapse where distinct agent names such as
+    "Billing Agent" and "billing agent" both map to ``transfer_to_billing_agent``,
+    making the first-registered agent permanently unreachable.
+    """
+    from .handoffs import Handoff as _Handoff
+
+    seen: dict[str, str] = {}  # derived tool name -> first agent's original name
+    for item in handoffs:
+        if isinstance(item, _Handoff):
+            derived = item.tool_name
+            original = item.agent_name
+        else:
+            # Plain Agent — use the same derivation that Handoff.default_tool_name uses.
+            derived = _Handoff.default_tool_name(item)
+            original = item.name
+
+        if derived in seen:
+            raise UserError(
+                f"Ambiguous handoff configuration: agents {seen[derived]!r} and "
+                f"{original!r} both derive the handoff tool name {derived!r}. "
+                f"Pass an explicit tool_name_override= to handoff() for one of them "
+                f"to avoid silent routing to the wrong agent."
+            )
+        seen[derived] = original
+
+
+def _validate_tool_name_collisions(tools: list[Tool]) -> None:
+    """Raise UserError if two FunctionTools in the assembled tool list share the same name.
+
+    This catches collisions that arise from Agent.as_tool() calls whose derived names
+    converge after normalization (e.g. ``Agent(name="Refund")`` and
+    ``Agent(name="refund")`` both produce a tool named ``refund``).
+    """
+    seen: dict[str, str] = {}  # tool name -> first tool's display label
+    for tool in tools:
+        if not isinstance(tool, FunctionTool):
+            continue
+        name = tool.name
+        if name in seen:
+            raise UserError(
+                f"Duplicate tool name {name!r}: two tools in the agent's tool list share "
+                f"this name. This can happen when two Agent.as_tool() calls produce the "
+                f"same derived name after normalization. Pass an explicit tool_name= to "
+                f"Agent.as_tool() for one of them."
+            )
+        seen[name] = name
+
+
 class AgentToolStreamEvent(TypedDict):
     """Streaming event emitted when an agent is invoked as a tool."""
 
@@ -264,6 +317,7 @@ class AgentBase(Generic[TContext]):
         enabled: list[Tool] = [t for t, ok in zip(self.tools, results, strict=False) if ok]
         all_tools: list[Tool] = prune_orphaned_tool_search_tools([*mcp_tools, *enabled])
         _validate_codex_tool_name_collisions(all_tools)
+        _validate_tool_name_collisions(all_tools)
         return all_tools
 
 
@@ -451,6 +505,8 @@ class Agent(AgentBase, Generic[TContext]):
 
         if not isinstance(self.handoffs, list):
             raise TypeError(f"Agent handoffs must be a list, got {type(self.handoffs).__name__}")
+
+        _validate_handoff_tool_name_collisions(self.handoffs)
 
         if self.model is not None and not isinstance(self.model, str):
             from .models.interface import Model

--- a/src/agents/util/_transforms.py
+++ b/src/agents/util/_transforms.py
@@ -9,7 +9,10 @@ def transform_string_function_style(name: str, *, warn_on_whitespace: bool = Tru
     transformed_name = re.sub(r"[^a-zA-Z0-9_]", "_", whitespace_normalized_name)
     final_name = transformed_name.lower()
 
-    if transformed_name != name and (
+    # Warn whenever the final name differs from the original, including case-only changes.
+    # Previously only character-replacement changes were warned about (transformed_name != name),
+    # which silently missed names like "MyAgent" → "myagent".
+    if final_name != name and (
         warn_on_whitespace or transformed_name != whitespace_normalized_name
     ):
         logger.warning(

--- a/tests/test_duplicate_function_tool_names.py
+++ b/tests/test_duplicate_function_tool_names.py
@@ -1,0 +1,142 @@
+﻿"""Tests for duplicate plain function-tool name detection (issue #4116).
+
+validate_function_tool_lookup_configuration() previously contained a
+``continue`` on the bare/bare collision branch, silently ignoring the most
+common case of two plain @function_tool decorators sharing the same name.
+
+The fix replaces that ``continue`` with a UserError so the SDK surfaces the
+problem at tool-resolution time instead of letting the OpenAI API reject the
+request with an opaque 400.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agents import Agent, function_tool
+from agents._tool_identity import validate_function_tool_lookup_configuration
+from agents.exceptions import UserError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@function_tool(name_override="lookup")
+def lookup_customers(x: str) -> str:
+    """Look up customers."""
+    return "a"
+
+
+@function_tool(name_override="lookup")
+def lookup_orders(x: str) -> str:
+    """Look up orders."""
+    return "b"
+
+
+@function_tool(name_override="search")
+def search_a(x: str) -> str:
+    """Search A."""
+    return "a"
+
+
+@function_tool(name_override="search")
+def search_b(x: str) -> str:
+    """Search B."""
+    return "b"
+
+
+@function_tool
+def unique_tool(x: str) -> str:
+    """A uniquely named tool."""
+    return "ok"
+
+
+# ---------------------------------------------------------------------------
+# validate_function_tool_lookup_configuration direct tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFunctionToolLookupConfiguration:
+    def test_duplicate_plain_tools_raises(self) -> None:
+        """Two bare FunctionTools with the same name must raise UserError."""
+        with pytest.raises(UserError, match="lookup"):
+            validate_function_tool_lookup_configuration([lookup_customers, lookup_orders])
+
+    def test_error_message_mentions_name_override(self) -> None:
+        """The error message should point to name_override= as the fix."""
+        with pytest.raises(UserError) as exc_info:
+            validate_function_tool_lookup_configuration([lookup_customers, lookup_orders])
+        assert "name_override" in str(exc_info.value)
+
+    def test_error_message_includes_tool_name(self) -> None:
+        """The error should name the colliding tool name."""
+        with pytest.raises(UserError) as exc_info:
+            validate_function_tool_lookup_configuration([lookup_customers, lookup_orders])
+        assert "lookup" in str(exc_info.value)
+
+    def test_different_duplicate_names_raise(self) -> None:
+        """Collision detection works regardless of the specific duplicate name."""
+        with pytest.raises(UserError, match="search"):
+            validate_function_tool_lookup_configuration([search_a, search_b])
+
+    def test_single_tool_does_not_raise(self) -> None:
+        """A single tool can never collide."""
+        validate_function_tool_lookup_configuration([lookup_customers])  # no raise
+
+    def test_unique_tools_do_not_raise(self) -> None:
+        """Distinct tool names are always valid."""
+        validate_function_tool_lookup_configuration([lookup_customers, unique_tool])  # no raise
+
+    def test_three_tools_two_collide_raises(self) -> None:
+        """Even when a third unique tool is present, a collision in the first two raises."""
+        with pytest.raises(UserError, match="lookup"):
+            validate_function_tool_lookup_configuration(
+                [lookup_customers, lookup_orders, unique_tool]
+            )
+
+    def test_empty_list_does_not_raise(self) -> None:
+        """An empty tool list is always valid."""
+        validate_function_tool_lookup_configuration([])  # no raise
+
+    def test_same_tool_object_added_twice_raises(self) -> None:
+        """Adding the exact same tool object twice also collides on its name."""
+        with pytest.raises(UserError, match="lookup"):
+            validate_function_tool_lookup_configuration([lookup_customers, lookup_customers])
+
+
+# ---------------------------------------------------------------------------
+# Agent-level integration: collision detected at get_all_tools() runtime
+# ---------------------------------------------------------------------------
+
+
+class TestAgentDuplicateToolDetection:
+    @pytest.mark.asyncio
+    async def test_agent_with_duplicate_tools_raises_at_runtime(self) -> None:
+        """Agent.get_all_tools() must surface the UserError from the lookup map builder."""
+        from agents.run_context import RunContextWrapper
+
+        ctx = RunContextWrapper(context=None)
+        agent = Agent(
+            name="A",
+            tools=[lookup_customers, lookup_orders],
+        )
+        # The collision is not caught at Agent.__post_init__ (tools are arbitrary callables),
+        # but must be caught at get_all_tools() time via build_function_tool_lookup_map.
+        with pytest.raises(UserError, match="lookup"):
+            await agent.get_all_tools(ctx)
+
+    @pytest.mark.asyncio
+    async def test_agent_with_unique_tools_does_not_raise(self) -> None:
+        """An agent with uniquely-named tools passes validation cleanly."""
+        from agents.run_context import RunContextWrapper
+
+        ctx = RunContextWrapper(context=None)
+        agent = Agent(
+            name="A",
+            tools=[lookup_customers, unique_tool],
+        )
+        tools = await agent.get_all_tools(ctx)
+        names = {t.name for t in tools}
+        assert "lookup" in names
+        assert "unique_tool" in names

--- a/tests/test_handoff_collision.py
+++ b/tests/test_handoff_collision.py
@@ -1,0 +1,167 @@
+﻿"""Tests for agent-name-normalization collision detection (issue #4118).
+
+Covers:
+- Handoff list name collisions detected at Agent construction time.
+- as_tool() name collisions detected at runtime via get_all_tools().
+- Case-only collisions (the previously silent case).
+- Happy path: explicit tool_name_override= avoids the error.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agents import Agent, handoff
+from agents.exceptions import UserError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(name: str) -> Agent:
+    """Return a bare agent with the given name."""
+    return Agent(name=name)
+
+
+# ---------------------------------------------------------------------------
+# Handoff-list collision tests (caught at Agent.__post_init__)
+# ---------------------------------------------------------------------------
+
+
+class TestHandoffCollisionAtConstruction:
+    def test_plain_agents_with_same_derived_name_raises(self) -> None:
+        billing = _make_agent("Billing Agent")
+        billing_dup = _make_agent("billing agent")
+        with pytest.raises(UserError, match="transfer_to_billing_agent"):
+            Agent(name="Triage", handoffs=[billing, billing_dup])
+
+    def test_case_only_collision_raises(self) -> None:
+        a = _make_agent("Refund")
+        b = _make_agent("refund")
+        with pytest.raises(UserError, match="transfer_to_refund"):
+            Agent(name="Triage", handoffs=[a, b])
+
+    def test_punctuation_collision_raises(self) -> None:
+        a = _make_agent("Billing-Agent")
+        b = _make_agent("Billing Agent")
+        with pytest.raises(UserError, match="transfer_to_billing_agent"):
+            Agent(name="Triage", handoffs=[a, b])
+
+    def test_error_message_names_both_agents(self) -> None:
+        a = _make_agent("Billing Agent")
+        b = _make_agent("billing agent")
+        with pytest.raises(UserError) as exc_info:
+            Agent(name="Triage", handoffs=[a, b])
+        msg = str(exc_info.value)
+        assert "Billing Agent" in msg
+        assert "billing agent" in msg
+        assert "tool_name_override" in msg
+
+    def test_handoff_objects_with_same_derived_name_raises(self) -> None:
+        a = _make_agent("Support Agent")
+        b = _make_agent("support agent")
+        with pytest.raises(UserError, match="transfer_to_support_agent"):
+            Agent(name="Triage", handoffs=[handoff(a), handoff(b)])
+
+    def test_mixed_agent_and_handoff_collision_raises(self) -> None:
+        a = _make_agent("Support Agent")
+        b = _make_agent("support agent")
+        with pytest.raises(UserError, match="transfer_to_support_agent"):
+            Agent(name="Triage", handoffs=[a, handoff(b)])
+
+    def test_no_collision_with_distinct_names(self) -> None:
+        billing = _make_agent("Billing Agent")
+        support = _make_agent("Support Agent")
+        triage = Agent(name="Triage", handoffs=[billing, support])
+        assert len(triage.handoffs) == 2
+
+    def test_no_collision_single_handoff(self) -> None:
+        billing = _make_agent("Billing Agent")
+        triage = Agent(name="Triage", handoffs=[billing])
+        assert len(triage.handoffs) == 1
+
+    def test_explicit_override_avoids_collision(self) -> None:
+        a = _make_agent("Billing Agent")
+        b = _make_agent("billing agent")
+        triage = Agent(
+            name="Triage",
+            handoffs=[
+                a,
+                handoff(b, tool_name_override="transfer_to_billing_agent_v2"),
+            ],
+        )
+        assert len(triage.handoffs) == 2
+
+    def test_explicit_override_that_still_collides_raises(self) -> None:
+        a = _make_agent("Billing Agent")
+        b = _make_agent("billing agent")
+        with pytest.raises(UserError, match="transfer_to_billing_agent"):
+            Agent(
+                name="Triage",
+                handoffs=[
+                    handoff(a, tool_name_override="transfer_to_billing_agent"),
+                    handoff(b, tool_name_override="transfer_to_billing_agent"),
+                ],
+            )
+
+    def test_empty_handoffs_does_not_raise(self) -> None:
+        triage = Agent(name="Triage", handoffs=[])
+        assert triage.handoffs == []
+
+
+# ---------------------------------------------------------------------------
+# as_tool() collision tests (caught at get_all_tools() runtime)
+# ---------------------------------------------------------------------------
+
+
+class TestAsToolCollisionAtRuntime:
+    @pytest.mark.asyncio
+    async def test_as_tool_case_collision_raises(self) -> None:
+        from agents.run_context import RunContextWrapper
+        ctx = RunContextWrapper(context=None)
+        a = _make_agent("Refund")
+        b = _make_agent("refund")
+        parent = Agent(
+            name="Orchestrator",
+            tools=[
+                a.as_tool(tool_name=None, tool_description="Handles refunds"),
+                b.as_tool(tool_name=None, tool_description="Also handles refunds"),
+            ],
+        )
+        with pytest.raises(UserError, match="refund"):
+            await parent.get_all_tools(ctx)
+
+    @pytest.mark.asyncio
+    async def test_as_tool_punctuation_collision_raises(self) -> None:
+        from agents.run_context import RunContextWrapper
+        ctx = RunContextWrapper(context=None)
+        a = _make_agent("My-Tool")
+        b = _make_agent("My Tool")
+        parent = Agent(
+            name="Orchestrator",
+            tools=[
+                a.as_tool(tool_name=None, tool_description="desc"),
+                b.as_tool(tool_name=None, tool_description="desc"),
+            ],
+        )
+        with pytest.raises(UserError, match="my_tool"):
+            await parent.get_all_tools(ctx)
+
+    @pytest.mark.asyncio
+    async def test_as_tool_explicit_name_avoids_collision(self) -> None:
+        from agents.run_context import RunContextWrapper
+        ctx = RunContextWrapper(context=None)
+        a = _make_agent("Refund")
+        b = _make_agent("refund")
+        parent = Agent(
+            name="Orchestrator",
+            tools=[
+                a.as_tool(tool_name="refund_v1", tool_description="desc"),
+                b.as_tool(tool_name="refund_v2", tool_description="desc"),
+            ],
+        )
+        tools = await parent.get_all_tools(ctx)
+        names = {t.name for t in tools}
+        assert "refund_v1" in names
+        assert "refund_v2" in names

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -27,12 +27,33 @@ def test_transform_string_function_style_warns_for_replaced_characters(
 @pytest.mark.parametrize(
     ("name", "transformed"),
     [
+        # Uppercase-only names: the transform lowercases them, so a warning is now emitted.
         ("MyTool", "mytool"),
         ("transfer_to_Agent", "transfer_to_agent"),
-        ("snake_case", "snake_case"),
     ],
 )
-def test_transform_string_function_style_does_not_warn_for_case_only_changes(
+def test_transform_string_function_style_warns_for_case_only_changes(
+    caplog: pytest.LogCaptureFixture,
+    name: str,
+    transformed: str,
+) -> None:
+    """Case-only changes are now warned about so users are never silently surprised."""
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        assert transform_string_function_style(name) == transformed
+
+    assert f"Tool name {name!r} contains invalid characters" in caplog.text
+    assert f"transformed to {transformed!r}" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("name", "transformed"),
+    [
+        # Already fully lowercase and snake_case — no transform needed, no warning.
+        ("snake_case", "snake_case"),
+        ("billing_agent", "billing_agent"),
+    ],
+)
+def test_transform_string_function_style_does_not_warn_for_already_valid_names(
     caplog: pytest.LogCaptureFixture,
     name: str,
     transformed: str,


### PR DESCRIPTION
…tion (#4118)

Agent.as_tool() and handoff() both derive their tool name from the agent name via transform_string_function_style(), which is many-to-one.  Two distinct agent names that differ only in case, whitespace, or punctuation (e.g. 'Billing Agent' and 'billing agent') silently collapse to the same derived name (transfer_to_billing_agent), making the first-registered agent permanently unreachable with no error or warning.

Changes
-------
* util/_transforms.py
  - Fix the warning condition: compare final_name != name (after lowercasing) instead of transformed_name != name (before lowercasing) so that case-only differences now also trigger a warning.

* agent.py
  - Add _validate_handoff_tool_name_collisions(): iterates the handoffs list at Agent.__post_init__ (construction time, sync, zero latency) and raises UserError when two handoffs derive the same tool name, naming both agents and pointing to tool_name_override=.
  - Add _validate_tool_name_collisions(): called inside AgentBase.get_all_tools() to catch as_tool() collisions in the assembled FunctionTool list, consistent with the existing _validate_codex_tool_name_collisions() pattern.

* tests/test_transforms.py
  - Update expectations: case-only names now warn.
  - Rename 'does_not_warn_for_case_only_changes' -> 'warns_for_case_only_changes' + new 'does_not_warn_for_already_valid_names' for pure snake_case inputs.

* tests/test_handoff_collision.py (new)
  - 14 tests covering plain-agent collision, case-only, punctuation, handoff()-object collision, mixed plain/handoff(), explicit override that fixes the collision, override that still collides, empty list, and as_tool() runtime collision with both error and happy-path cases.

Fixes #4118