### PR TITLE
fix(models): release AnyLLM provider streams and preserve completed runs

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -309,6 +309,10 @@ class AnyLLMModel(Model):
     ) -> AsyncIterator[TResponseStreamEvent]:
         # `aclosing` forwards an early `aclose()` on this generator to the delegate, so the
         # delegate's cleanup runs deterministically instead of waiting for garbage collection.
+        # The guarantee stops at the iterator any-llm returns: as of any-llm 1.11.0 its
+        # exception and provider wrappers delegate with bare `async for ... yield`, so they do
+        # not forward `aclose()` to the underlying transport. Closing that transport is an
+        # upstream any-llm concern, not something to reach into from here.
         if self._selected_api() == "responses":
             async with contextlib.aclosing(
                 self._stream_response_via_responses(
@@ -463,6 +467,11 @@ class AnyLLMModel(Model):
                         "response.error",
                     }:
                         yielded_terminal_event = True
+                        # Populate the span before yielding the terminal event so a consumer
+                        # that stops there still leaves a fully recorded span.
+                        if tracing.include_data() and final_response:
+                            span_response.span_data.response = final_response
+                            span_response.span_data.input = input
                     yield chunk
             except asyncio.CancelledError:
                 close_stream_in_background = True
@@ -471,7 +480,7 @@ class AnyLLMModel(Model):
             finally:
                 if not close_stream_in_background:
                     try:
-                        await self._maybe_aclose(stream)
+                        await self._close_stream_allowing_background_completion(stream)
                     except Exception as exc:
                         if yielded_terminal_event:
                             log_model_action_debug(
@@ -484,10 +493,6 @@ class AnyLLMModel(Model):
 
             if terminal_failure_error is not None:
                 raise terminal_failure_error
-
-            if tracing.include_data() and final_response:
-                span_response.span_data.response = final_response
-                span_response.span_data.input = input
 
     async def _get_response_via_chat(
         self,
@@ -634,11 +639,14 @@ class AnyLLMModel(Model):
                     cast(Any, self._normalize_chat_stream(stream)),
                     model=self.model,
                 ):
-                    # Record terminal state before yielding so a consumer that stops at the
-                    # completed event still leaves the tracing data and cleanup policy correct.
+                    # Record terminal state and populate the span before yielding so a consumer
+                    # that stops at the completed event still leaves a fully recorded span.
                     if chunk.type == "response.completed":
                         final_response = chunk.response
                         yielded_terminal_event = True
+                        self._populate_chat_generation_span(
+                            span_generation, final_response, tracing
+                        )
 
                     yield chunk
             except asyncio.CancelledError:
@@ -648,7 +656,7 @@ class AnyLLMModel(Model):
             finally:
                 if not close_stream_in_background:
                     try:
-                        await self._maybe_aclose(stream)
+                        await self._close_stream_allowing_background_completion(stream)
                     except Exception as exc:
                         if yielded_terminal_event:
                             log_model_action_debug(
@@ -659,26 +667,32 @@ class AnyLLMModel(Model):
                         else:
                             raise
 
-            if tracing.include_data() and final_response:
-                span_generation.span_data.output = [final_response.model_dump()]
+    @staticmethod
+    def _populate_chat_generation_span(
+        span_generation: Span[GenerationSpanData],
+        final_response: Response,
+        tracing: ModelTracing,
+    ) -> None:
+        if tracing.include_data():
+            span_generation.span_data.output = [final_response.model_dump()]
 
-            if final_response and final_response.usage:
-                span_generation.span_data.usage = {
-                    "requests": 1,
-                    "input_tokens": final_response.usage.input_tokens,
-                    "output_tokens": final_response.usage.output_tokens,
-                    "total_tokens": final_response.usage.total_tokens,
-                    "input_tokens_details": (
-                        final_response.usage.input_tokens_details.model_dump()
-                        if final_response.usage.input_tokens_details
-                        else {"cached_tokens": 0, "cache_write_tokens": 0}
-                    ),
-                    "output_tokens_details": (
-                        final_response.usage.output_tokens_details.model_dump()
-                        if final_response.usage.output_tokens_details
-                        else {"reasoning_tokens": 0}
-                    ),
-                }
+        if final_response.usage:
+            span_generation.span_data.usage = {
+                "requests": 1,
+                "input_tokens": final_response.usage.input_tokens,
+                "output_tokens": final_response.usage.output_tokens,
+                "total_tokens": final_response.usage.total_tokens,
+                "input_tokens_details": (
+                    final_response.usage.input_tokens_details.model_dump()
+                    if final_response.usage.input_tokens_details
+                    else {"cached_tokens": 0, "cache_write_tokens": 0}
+                ),
+                "output_tokens_details": (
+                    final_response.usage.output_tokens_details.model_dump()
+                    if final_response.usage.output_tokens_details
+                    else {"reasoning_tokens": 0}
+                ),
+            }
 
     @overload
     async def _fetch_chat_response(
@@ -1157,11 +1171,31 @@ class AnyLLMModel(Model):
                 await result
 
     def _schedule_async_iterator_close(self, iterator: Any) -> None:
-        task = asyncio.create_task(self._maybe_aclose(iterator))
-        task.add_done_callback(self._consume_background_cleanup_task_result)
+        self._detach_stream_close(asyncio.ensure_future(self._maybe_aclose(iterator)))
+
+    async def _close_stream_allowing_background_completion(self, iterator: Any) -> None:
+        """Close the provider iterator, letting an in-flight close finish in the background.
+
+        Cancellation can arrive while `aclose()` is already awaiting the provider. Shielding the
+        close and detaching that exact task keeps it running instead of abandoning it half-done,
+        and avoids starting a second close: re-closing a provider iterator is not guaranteed to
+        be safe or idempotent.
+        """
+        close_task = asyncio.ensure_future(self._maybe_aclose(iterator))
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            self._detach_stream_close(close_task)
+            raise
+
+    def _detach_stream_close(self, close_task: asyncio.Future[None]) -> None:
+        if close_task.done():
+            self._consume_background_cleanup_task_result(close_task)
+            return
+        close_task.add_done_callback(self._consume_background_cleanup_task_result)
 
     @staticmethod
-    def _consume_background_cleanup_task_result(task: asyncio.Task[Any]) -> None:
+    def _consume_background_cleanup_task_result(task: asyncio.Future[Any]) -> None:
         try:
             task.result()
         except asyncio.CancelledError:

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import importlib
 import inspect
 import json
 import time
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncGenerator, AsyncIterator, Iterable
 from copy import copy
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
@@ -26,7 +28,7 @@ from ...agent_output import AgentOutputSchemaBase
 from ...exceptions import ModelBehaviorError, UserError
 from ...handoffs import Handoff
 from ...items import ItemHelpers, ModelResponse, TResponseInputItem, TResponseStreamEvent
-from ...logger import logger
+from ...logger import log_model_action_debug, logger
 from ...model_settings import ModelSettings
 from ...models._openai_retry import get_openai_retry_advice
 from ...models._response_terminal import (
@@ -305,8 +307,29 @@ class AnyLLMModel(Model):
         conversation_id: str | None = None,
         prompt: ResponsePromptParam | None = None,
     ) -> AsyncIterator[TResponseStreamEvent]:
+        # `aclosing` forwards an early `aclose()` on this generator to the delegate, so the
+        # delegate's cleanup runs deterministically instead of waiting for garbage collection.
         if self._selected_api() == "responses":
-            async for chunk in self._stream_response_via_responses(
+            async with contextlib.aclosing(
+                self._stream_response_via_responses(
+                    system_instructions=system_instructions,
+                    input=input,
+                    model_settings=model_settings,
+                    tools=tools,
+                    output_schema=output_schema,
+                    handoffs=handoffs,
+                    tracing=tracing,
+                    previous_response_id=previous_response_id,
+                    conversation_id=conversation_id,
+                    prompt=prompt,
+                )
+            ) as responses_stream:
+                async for chunk in responses_stream:
+                    yield chunk
+            return
+
+        async with contextlib.aclosing(
+            self._stream_response_via_chat(
                 system_instructions=system_instructions,
                 input=input,
                 model_settings=model_settings,
@@ -314,24 +337,11 @@ class AnyLLMModel(Model):
                 output_schema=output_schema,
                 handoffs=handoffs,
                 tracing=tracing,
-                previous_response_id=previous_response_id,
-                conversation_id=conversation_id,
                 prompt=prompt,
-            ):
+            )
+        ) as chat_stream:
+            async for chunk in chat_stream:
                 yield chunk
-            return
-
-        async for chunk in self._stream_response_via_chat(
-            system_instructions=system_instructions,
-            input=input,
-            model_settings=model_settings,
-            tools=tools,
-            output_schema=output_schema,
-            handoffs=handoffs,
-            tracing=tracing,
-            prompt=prompt,
-        ):
-            yield chunk
 
     async def _get_response_via_responses(
         self,
@@ -410,7 +420,7 @@ class AnyLLMModel(Model):
         previous_response_id: str | None,
         conversation_id: str | None,
         prompt: ResponsePromptParam | None,
-    ) -> AsyncIterator[ResponseStreamEvent]:
+    ) -> AsyncGenerator[ResponseStreamEvent, None]:
         with response_span(disabled=tracing.is_disabled()) as span_response:
             stream = await self._fetch_responses_response(
                 system_instructions=system_instructions,
@@ -427,6 +437,8 @@ class AnyLLMModel(Model):
 
             final_response: Response | None = None
             terminal_failure_error: ModelBehaviorError | None = None
+            yielded_terminal_event = False
+            close_stream_in_background = False
             try:
                 async for chunk in stream:
                     chunk_type = getattr(chunk, "type", None)
@@ -443,9 +455,32 @@ class AnyLLMModel(Model):
                             cast(str, chunk_type),
                             chunk,
                         )
+                    if chunk_type in {
+                        "response.completed",
+                        "response.failed",
+                        "response.incomplete",
+                        "error",
+                        "response.error",
+                    }:
+                        yielded_terminal_event = True
                     yield chunk
+            except asyncio.CancelledError:
+                close_stream_in_background = True
+                self._schedule_async_iterator_close(stream)
+                raise
             finally:
-                await self._maybe_aclose(stream)
+                if not close_stream_in_background:
+                    try:
+                        await self._maybe_aclose(stream)
+                    except Exception as exc:
+                        if yielded_terminal_event:
+                            log_model_action_debug(
+                                logger,
+                                "Ignoring stream cleanup error after terminal event",
+                                exc,
+                            )
+                        else:
+                            raise
 
             if terminal_failure_error is not None:
                 raise terminal_failure_error
@@ -567,7 +602,7 @@ class AnyLLMModel(Model):
         handoffs: list[Handoff],
         tracing: ModelTracing,
         prompt: ResponsePromptParam | None,
-    ) -> AsyncIterator[TResponseStreamEvent]:
+    ) -> AsyncGenerator[TResponseStreamEvent, None]:
         with generation_span(
             model=str(self.model),
             model_config=model_config_for_trace(
@@ -591,17 +626,38 @@ class AnyLLMModel(Model):
             )
 
             final_response: Response | None = None
+            yielded_terminal_event = False
+            close_stream_in_background = False
             try:
                 async for chunk in ChatCmplStreamHandler.handle_stream(
                     response,
                     cast(Any, self._normalize_chat_stream(stream)),
                     model=self.model,
                 ):
-                    yield chunk
+                    # Record terminal state before yielding so a consumer that stops at the
+                    # completed event still leaves the tracing data and cleanup policy correct.
                     if chunk.type == "response.completed":
                         final_response = chunk.response
+                        yielded_terminal_event = True
+
+                    yield chunk
+            except asyncio.CancelledError:
+                close_stream_in_background = True
+                self._schedule_async_iterator_close(stream)
+                raise
             finally:
-                await self._maybe_aclose(stream)
+                if not close_stream_in_background:
+                    try:
+                        await self._maybe_aclose(stream)
+                    except Exception as exc:
+                        if yielded_terminal_event:
+                            log_model_action_debug(
+                                logger,
+                                "Ignoring stream cleanup error after terminal event",
+                                exc,
+                            )
+                        else:
+                            raise
 
             if tracing.include_data() and final_response:
                 span_generation.span_data.output = [final_response.model_dump()]
@@ -1099,6 +1155,21 @@ class AnyLLMModel(Model):
             result = close()
             if inspect.isawaitable(result):
                 await result
+
+    def _schedule_async_iterator_close(self, iterator: Any) -> None:
+        task = asyncio.create_task(self._maybe_aclose(iterator))
+        task.add_done_callback(self._consume_background_cleanup_task_result)
+
+    @staticmethod
+    def _consume_background_cleanup_task_result(task: asyncio.Task[Any]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            log_model_action_debug(
+                logger, "Background stream cleanup failed after cancellation", exc
+            )
 
     def _build_chat_extra_kwargs(self, model_settings: ModelSettings) -> dict[str, Any]:
         extra_kwargs: dict[str, Any] = {}

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -39,6 +39,7 @@ from agents import (
     Tool,
     TResponseInputItem,
     __version__,
+    trace,
 )
 from agents.exceptions import UserError
 from agents.models.chatcmpl_helpers import HEADERS_OVERRIDE
@@ -1132,7 +1133,14 @@ async def test_any_llm_chat_omits_logprobs_when_top_logprobs_unset(monkeypatch) 
 
 
 class _ClosableStream:
-    """Minimal async iterator that records how often the provider stream was closed."""
+    """Stands in for the iterator any-llm returns, recording how often it was closed.
+
+    These fakes deliberately cover only the SDK's own boundary. any-llm's exception and
+    provider wrappers (`utils/exception_handler.py::_wrap_async_iterator`, the per-provider
+    `chunk_iterator` / `_stream_completion_async` generators) delegate with bare
+    `async for ... yield` as of 1.11.0 and do not forward `aclose()` to the underlying
+    transport, so no assertion here should be read as proving the transport was closed.
+    """
 
     def __init__(self, chunks: list[Any]) -> None:
         self._chunks = list(chunks)
@@ -1205,7 +1213,7 @@ def _completed_event() -> ResponseCompletedEvent:
     )
 
 
-def _stream_events(model: Any) -> Any:
+def _stream_events(model: Any, tracing: ModelTracing = ModelTracing.DISABLED) -> Any:
     return model.stream_response(
         system_instructions=None,
         input="hi",
@@ -1213,14 +1221,14 @@ def _stream_events(model: Any) -> Any:
         tools=[],
         output_schema=None,
         handoffs=[],
-        tracing=ModelTracing.DISABLED,
+        tracing=tracing,
         previous_response_id=None,
         conversation_id=None,
         prompt=None,
     )
 
 
-def _chat_model_with_stream(monkeypatch, stream: _ClosableStream) -> Any:
+def _chat_module_and_model_with_stream(monkeypatch, stream: _ClosableStream) -> tuple[Any, Any]:
     """Build an AnyLLMModel whose Chat Completions path yields one completed event."""
     provider = FakeAnyLLMProvider(supports_responses=False, chat_response=stream)
     module, _create_calls = _import_any_llm_module(monkeypatch, provider)
@@ -1231,13 +1239,39 @@ def _chat_model_with_stream(monkeypatch, stream: _ClosableStream) -> Any:
         yield _completed_event()
 
     monkeypatch.setattr(module.ChatCmplStreamHandler, "handle_stream", fake_handle_stream)
-    return module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    return module, module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+
+
+def _chat_model_with_stream(monkeypatch, stream: _ClosableStream) -> Any:
+    _module, model = _chat_module_and_model_with_stream(monkeypatch, stream)
+    return model
+
+
+def _responses_module_and_model_with_stream(
+    monkeypatch, stream: _ClosableStream
+) -> tuple[Any, Any]:
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=stream)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    return module, module.AnyLLMModel(model="openai/gpt-5.4-mini")
 
 
 def _responses_model_with_stream(monkeypatch, stream: _ClosableStream) -> Any:
-    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=stream)
-    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
-    return module.AnyLLMModel(model="openai/gpt-5.4-mini")
+    _module, model = _responses_module_and_model_with_stream(monkeypatch, stream)
+    return model
+
+
+def _capture_spans(monkeypatch, module: Any, factory_name: str) -> list[Any]:
+    """Record the live span objects the module creates so tests can read them mid-stream."""
+    original = getattr(module, factory_name)
+    captured: list[Any] = []
+
+    def recording_factory(*args: Any, **kwargs: Any) -> Any:
+        span = original(*args, **kwargs)
+        captured.append(span)
+        return span
+
+    monkeypatch.setattr(module, factory_name, recording_factory)
+    return captured
 
 
 @pytest.mark.allow_call_model_methods
@@ -1469,3 +1503,160 @@ async def test_any_llm_responses_stream_closes_provider_stream_after_cancellatio
     await stream_agen.aclose()
 
     assert stream.aclose_calls == 1
+
+
+class _CloseSignalingStream(_ClosableStream):
+    """Signals when `aclose` starts and blocks until released, so a test can cancel mid-close."""
+
+    def __init__(
+        self,
+        chunks: list[Any],
+        close_started: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        super().__init__(chunks)
+        self._close_started = close_started
+        self._release = release
+        self.aclose_completed = 0
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+        self._close_started.set()
+        await self._release.wait()
+        self.aclose_completed += 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_stream_populates_span_before_yielding_completed(monkeypatch) -> None:
+    """The generation span must carry output and usage when the completed event is delivered."""
+    stream = _ClosableStream([_chat_chunk("Hello")])
+    module, model = _chat_module_and_model_with_stream(monkeypatch, stream)
+    spans = _capture_spans(monkeypatch, module, "generation_span")
+
+    with trace(workflow_name="any-llm-chat-span"):
+        stream_agen = cast(Any, _stream_events(model, ModelTracing.ENABLED))
+        async for event in stream_agen:
+            if event.type == "response.completed":
+                # Assert while the generator is suspended at the terminal yield.
+                [span] = spans
+                assert span.span_data.output == [_response("Hello").model_dump()]
+                assert span.span_data.usage == {
+                    "requests": 1,
+                    "input_tokens": 11,
+                    "output_tokens": 13,
+                    "total_tokens": 24,
+                    "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                }
+                break
+        await stream_agen.aclose()
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_populates_span_before_yielding_completed(
+    monkeypatch,
+) -> None:
+    """The response span must carry the response and input when the completed event arrives."""
+    stream = _ClosableStream([_completed_event()])
+    module, model = _responses_module_and_model_with_stream(monkeypatch, stream)
+    spans = _capture_spans(monkeypatch, module, "response_span")
+
+    with trace(workflow_name="any-llm-responses-span"):
+        stream_agen = cast(Any, _stream_events(model, ModelTracing.ENABLED))
+        async for event in stream_agen:
+            if event.type == "response.completed":
+                [span] = spans
+                assert span.span_data.response is not None
+                assert span.span_data.response.id == "resp_123"
+                assert span.span_data.input == "hi"
+                break
+        await stream_agen.aclose()
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_stream_lets_in_flight_close_finish_after_cancellation(
+    monkeypatch,
+) -> None:
+    """Cancelling during `aclose` continues that close instead of starting a second one."""
+    close_started = asyncio.Event()
+    release = asyncio.Event()
+    stream = _CloseSignalingStream([_chat_chunk("Hello")], close_started, release)
+    model = _chat_model_with_stream(monkeypatch, stream)
+
+    async def consume() -> None:
+        async for _event in _stream_events(model):
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(close_started.wait(), timeout=5)
+        assert stream.aclose_calls == 1
+        assert stream.aclose_completed == 0
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+
+        # The cancelled consumer must not have started a second close.
+        assert stream.aclose_calls == 1
+        assert stream.aclose_completed == 0
+
+        release.set()
+        for _ in range(200):
+            if stream.aclose_completed == 1:
+                break
+            await asyncio.sleep(0.01)
+
+        assert stream.aclose_calls == 1
+        assert stream.aclose_completed == 1
+    finally:
+        release.set()
+        task.cancel()
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_lets_in_flight_close_finish_after_cancellation(
+    monkeypatch,
+) -> None:
+    """Cancelling during `aclose` continues that close instead of starting a second one."""
+    close_started = asyncio.Event()
+    release = asyncio.Event()
+    stream = _CloseSignalingStream([_completed_event()], close_started, release)
+    model = _responses_model_with_stream(monkeypatch, stream)
+
+    async def consume() -> None:
+        async for _event in _stream_events(model):
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(close_started.wait(), timeout=5)
+        assert stream.aclose_calls == 1
+        assert stream.aclose_completed == 0
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+
+        assert stream.aclose_calls == 1
+        assert stream.aclose_completed == 0
+
+        release.set()
+        for _ in range(200):
+            if stream.aclose_completed == 1:
+                break
+            await asyncio.sleep(0.01)
+
+        assert stream.aclose_calls == 1
+        assert stream.aclose_completed == 1
+    finally:
+        release.set()
+        task.cancel()

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
 import types as pytypes
@@ -14,9 +15,10 @@ from openai.types.chat import (
     ChatCompletionMessageFunctionToolCall,
 )
 from openai.types.chat.chat_completion import Choice
-from openai.types.chat.chat_completion_chunk import ChoiceDelta
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, ChoiceDelta
 from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
 from openai.types.responses import Response, ResponseCompletedEvent, ResponseOutputMessage
+from openai.types.responses.response_created_event import ResponseCreatedEvent
 from openai.types.responses.response_error_event import ResponseErrorEvent
 from openai.types.responses.response_failed_event import ResponseFailedEvent
 from openai.types.responses.response_incomplete_event import ResponseIncompleteEvent
@@ -1127,3 +1129,343 @@ async def test_any_llm_chat_omits_logprobs_when_top_logprobs_unset(monkeypatch) 
     )
 
     assert "logprobs" not in provider.chat_calls[0]
+
+
+class _ClosableStream:
+    """Minimal async iterator that records how often the provider stream was closed."""
+
+    def __init__(self, chunks: list[Any]) -> None:
+        self._chunks = list(chunks)
+        self.aclose_calls = 0
+
+    def __aiter__(self) -> _ClosableStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+class _FailingCloseStream(_ClosableStream):
+    """Raises from `aclose` after recording the cleanup attempt."""
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+        raise RuntimeError("close-failure")
+
+
+class _BlockingStream(_ClosableStream):
+    """Blocks forever after its chunks are exhausted so the consumer can be cancelled."""
+
+    def __init__(self, chunks: list[Any], blocked: asyncio.Event) -> None:
+        super().__init__(chunks)
+        self._blocked = blocked
+
+    async def __anext__(self) -> Any:
+        if self._chunks:
+            return self._chunks.pop(0)
+        self._blocked.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+
+class _SlowCloseStream(_BlockingStream):
+    """Blocks in `aclose` until released, mirroring a close that waits on transport I/O."""
+
+    def __init__(self, chunks: list[Any], blocked: asyncio.Event, release: asyncio.Event) -> None:
+        super().__init__(chunks, blocked)
+        self._release = release
+        self.aclose_completed = 0
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+        await self._release.wait()
+        self.aclose_completed += 1
+
+
+def _chat_chunk(text: str) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="chunk_123",
+        created=0,
+        model="fake-model",
+        object="chat.completion.chunk",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(content=text))],
+    )
+
+
+def _completed_event() -> ResponseCompletedEvent:
+    return ResponseCompletedEvent(
+        type="response.completed",
+        response=_response("Hello"),
+        sequence_number=1,
+    )
+
+
+def _stream_events(model: Any) -> Any:
+    return model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+
+def _chat_model_with_stream(monkeypatch, stream: _ClosableStream) -> Any:
+    """Build an AnyLLMModel whose Chat Completions path yields one completed event."""
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=stream)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    async def fake_handle_stream(response, chunk_stream, model=None):
+        async for _chunk in chunk_stream:
+            pass
+        yield _completed_event()
+
+    monkeypatch.setattr(module.ChatCmplStreamHandler, "handle_stream", fake_handle_stream)
+    return module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+
+
+def _responses_model_with_stream(monkeypatch, stream: _ClosableStream) -> Any:
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=stream)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    return module.AnyLLMModel(model="openai/gpt-5.4-mini")
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_stream_ignores_close_failure_after_terminal_event(monkeypatch) -> None:
+    """A completed Chat Completions response stays successful when provider cleanup fails."""
+    stream = _FailingCloseStream([_chat_chunk("Hello")])
+    model = _chat_model_with_stream(monkeypatch, stream)
+
+    events = [event async for event in _stream_events(model)]
+
+    assert [event.type for event in events] == ["response.completed"]
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_stream_ignores_close_failure_when_closed_at_terminal_event(
+    monkeypatch,
+) -> None:
+    """Terminal state must be recorded before the completed event is yielded."""
+    stream = _FailingCloseStream([_chat_chunk("Hello")])
+    model = _chat_model_with_stream(monkeypatch, stream)
+    stream_agen = cast(Any, _stream_events(model))
+
+    async for event in stream_agen:
+        if event.type == "response.completed":
+            break
+    await stream_agen.aclose()
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_stream_closes_provider_stream_after_cancellation(monkeypatch) -> None:
+    """Cancelling the consumer must still release the provider stream."""
+    blocked = asyncio.Event()
+    stream = _BlockingStream([_chat_chunk("He")], blocked)
+    model = _chat_model_with_stream(monkeypatch, stream)
+    stream_agen = cast(Any, _stream_events(model))
+
+    async def consume() -> None:
+        async for _event in stream_agen:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(blocked.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        task.cancel()
+
+    await stream_agen.aclose()
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_stream_does_not_block_cancellation_on_slow_close(monkeypatch) -> None:
+    """A provider close that waits on transport I/O must not delay cancellation."""
+    blocked = asyncio.Event()
+    release = asyncio.Event()
+    stream = _SlowCloseStream([_chat_chunk("He")], blocked, release)
+    model = _chat_model_with_stream(monkeypatch, stream)
+    stream_agen = cast(Any, _stream_events(model))
+
+    async def consume() -> None:
+        async for _event in stream_agen:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(blocked.wait(), timeout=5)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+        assert stream.aclose_calls == 1
+        assert stream.aclose_completed == 0
+
+        release.set()
+        for _ in range(200):
+            if stream.aclose_completed == 1:
+                break
+            await asyncio.sleep(0.01)
+        assert stream.aclose_completed == 1
+    finally:
+        release.set()
+        task.cancel()
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_stream_propagates_close_failure_before_terminal_event(
+    monkeypatch,
+) -> None:
+    """Cleanup failures before completion stay observable by the caller."""
+    stream = _FailingCloseStream([_chat_chunk("Hello")])
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=stream)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    async def fake_handle_stream(response, chunk_stream, model=None):
+        yield ResponseCreatedEvent(
+            type="response.created",
+            response=_response("partial"),
+            sequence_number=0,
+        )
+        async for _chunk in chunk_stream:
+            pass
+        yield _completed_event()
+
+    monkeypatch.setattr(module.ChatCmplStreamHandler, "handle_stream", fake_handle_stream)
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    stream_agen = cast(Any, _stream_events(model))
+
+    first_event = await anext(stream_agen)
+    assert first_event.type == "response.created"
+
+    with pytest.raises(RuntimeError, match="close-failure"):
+        await stream_agen.aclose()
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_ignores_close_failure_after_terminal_event(
+    monkeypatch,
+) -> None:
+    """A completed Responses stream stays successful when provider cleanup fails."""
+    stream = _FailingCloseStream([_completed_event()])
+    model = _responses_model_with_stream(monkeypatch, stream)
+
+    events = [event async for event in _stream_events(model)]
+
+    assert [event.type for event in events] == ["response.completed"]
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_ignores_close_failure_after_terminal_failure(
+    monkeypatch,
+) -> None:
+    """A cleanup failure must not replace the terminal failure the caller should see."""
+    stream = _FailingCloseStream(
+        [
+            ResponseFailedEvent(
+                type="response.failed",
+                response=_response("partial", response_id="resp-terminal"),
+                sequence_number=1,
+            )
+        ]
+    )
+    model = _responses_model_with_stream(monkeypatch, stream)
+
+    with pytest.raises(ModelBehaviorError, match="response.failed"):
+        async for _event in _stream_events(model):
+            pass
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_propagates_close_failure_before_terminal_event(
+    monkeypatch,
+) -> None:
+    """Cleanup failures before completion stay observable by the caller."""
+    stream = _FailingCloseStream(
+        [
+            ResponseCreatedEvent(
+                type="response.created",
+                response=_response("partial"),
+                sequence_number=0,
+            ),
+            _completed_event(),
+        ]
+    )
+    model = _responses_model_with_stream(monkeypatch, stream)
+    stream_agen = cast(Any, _stream_events(model))
+
+    first_event = await anext(stream_agen)
+    assert first_event.type == "response.created"
+
+    with pytest.raises(RuntimeError, match="close-failure"):
+        await stream_agen.aclose()
+
+    assert stream.aclose_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_closes_provider_stream_after_cancellation(
+    monkeypatch,
+) -> None:
+    """Cancelling the consumer must still release the provider Responses stream."""
+    blocked = asyncio.Event()
+    stream = _BlockingStream(
+        [
+            ResponseCreatedEvent(
+                type="response.created",
+                response=_response("partial"),
+                sequence_number=0,
+            )
+        ],
+        blocked,
+    )
+    model = _responses_model_with_stream(monkeypatch, stream)
+    stream_agen = cast(Any, _stream_events(model))
+
+    async def consume() -> None:
+        async for _event in stream_agen:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(blocked.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        task.cancel()
+
+    await stream_agen.aclose()
+
+    assert stream.aclose_calls == 1


### PR DESCRIPTION
### Summary

`AnyLLMModel`'s streamed model calls never adopted the provider-stream lifecycle that the other adapters use, so a streamed run could leak the iterator any-llm returns, lose its span data, and let a cleanup error turn a completed run into a failure.

**Affected component:** `src/agents/extensions/models/any_llm_model.py` (`AnyLLMModel.stream_response`, `_stream_response_via_chat`, `_stream_response_via_responses`).

**Problem**

1. `stream_response` delegates to `_stream_response_via_chat` / `_stream_response_via_responses` with a bare `async for ... yield`. Closing the returned generator early (`aclose()`, `break` followed by `aclose()`, a consumer that stops at `response.completed`) never propagates to the delegate, so the delegate's `finally` — the only place the provider iterator is closed — does not run until the delegate is garbage collected.
2. Both delegates close the iterator in a plain `finally: await self._maybe_aclose(stream)`. If that close raises after the run already yielded its terminal event, the cleanup error replaces a successful result and surfaces to the caller.
3. Cancellation arriving *while* that `aclose()` is already awaiting the provider abandons the close half-done.
4. Span data (`output`/`usage` for Chat, `response`/`input` for Responses) was populated only after the iteration loop finished, so a consumer that stops at the terminal event left an empty span. The Chat path also assigned `final_response` after `yield`, so it was never set in that case.

`OpenAIChatCompletionsModel`, `OpenAIResponsesModel` and `LitellmModel` all already implement the close-on-cancel and terminal-event cleanup parts of this contract (#3689, #4066, #4077). `AnyLLMModel` is the only streaming adapter that does not.

**Corrected behavior**

- An early `aclose()` deterministically closes the iterator any-llm returned.
- A completed run stays successful when cleanup fails; the error is logged at debug level. Cleanup errors *before* a terminal event still propagate.
- Cancellation during an in-flight `aclose()` detaches that exact close to the background so it finishes, and never starts a second close — re-closing a provider iterator is not guaranteed to be safe or idempotent.
- Span data is populated before the terminal event is yielded, so a consumer that stops there still leaves a fully recorded span.

**Scope of the early-close guarantee**

This change guarantees the SDK closes **the iterator any-llm hands back**. It deliberately stops there. As of any-llm 1.11.0, `utils/exception_handler.py::_wrap_async_iterator` and the per-provider `chunk_iterator` / `_stream_completion_async` / `_stream` generators all delegate with bare `async for ... yield` and no `try/finally`, so they do not forward `aclose()` down to the underlying HTTP transport. Propagating a close through those layers is an upstream any-llm concern and should be tracked there; working around it would mean reaching into any-llm internals from the SDK, which this PR does not do. The tests use fake provider iterators and therefore assert only the SDK-side boundary — a docstring on the fake makes that explicit so no assertion reads as proof that the transport was closed.

**Implementation**

- Wrap both delegations in `contextlib.aclosing(...)` so an early `aclose()` reaches the delegate.
- Add `_close_stream_allowing_background_completion`, which runs `_maybe_aclose` as a shielded task and, on cancellation, detaches that same task instead of starting another close.
- In both delegates: `except asyncio.CancelledError` → close in the background and re-raise; `finally` → close and, when a terminal event was already yielded, log the failure instead of raising.
- Populate the span inside the terminal-event branch, before `yield`. The Chat path's span population moved into `_populate_chat_generation_span` so the ordering is explicit rather than implied by position.
- Narrow the two private delegate return annotations from `AsyncIterator[...]` to `AsyncGenerator[..., None]` so `aclosing` type-checks. No public signature changes.

**Why this is minimal:** it reuses the pattern already reviewed and merged for the other three streaming adapters rather than introducing a shared abstraction, and touches one source file. Note that the in-flight-close handling is slightly *stronger* than what the sibling adapters do today (they `await` the close directly); applying it to them is deliberately left out of this PR.

### Test plan

13 regression tests in `tests/models/test_any_llm_model.py`, covering both AnyLLM streaming paths with local fake provider iterators — no API key, no network, and no sleeps for synchronization (`asyncio.Event` gates every cancellation and in-flight-close test):

- cleanup failure after a terminal event keeps the run successful (both paths)
- cleanup failure after a terminal *failure* event still surfaces the terminal failure, not the cleanup error (Responses path)
- cleanup failure before a terminal event still propagates (both paths)
- terminal state is recorded before the completed event is yielded (Chat path)
- span data is populated before `response.completed` is delivered, asserted while the generator is suspended at the terminal yield — `output` + `usage` for Chat, `response` + `input` for Responses (both paths)
- cancellation while `aclose()` is in flight: exactly one close is started, it is still incomplete at cancellation, and it completes in the background once released (both paths)
- cancellation still releases the provider iterator (both paths)
- a slow provider close does not delay cancellation and completes in the background (Chat path)

7 tests fail on `upstream/main` at d6f82c00; the 4 span/in-flight-close tests fail on the first commit of this PR and pass on the second. The 2 plain cancellation tests pass throughout and guard behavior this change preserves.

Commands run from the repository root:

```
uv run pytest tests/models/test_any_llm_model.py -q
```
→ `49 passed`

```
env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh
```
→ `make format` (no changes), `make lint` passed, `make typecheck` passed (mypy + pyright, `0 errors`), `make tests` passed — `all commands passed`.

Oldest supported interpreter, per `AGENTS.md`:

```
UV_PROJECT_ENVIRONMENT=.venv_310 uv sync --python 3.10 --all-extras --all-packages --group dev
UV_PROJECT_ENVIRONMENT=.venv_310 uv run --python 3.10 -m pytest tests/models/test_any_llm_model.py -q
```
→ `45 passed, 4 skipped` (the 4 skips are the pre-existing `any-llm-sdk` optional-dependency skips). `contextlib.aclosing` is available on 3.10+.

The focused module was also run 5 times consecutively and under `-W error::RuntimeWarning` with no flakiness, pending-task warnings, or unclosed-resource warnings.

**Compatibility:** no public API, constructor, field-order, dependency, or lockfile changes. Only the two private `_stream_response_via_*` return annotations were narrowed. Event ordering, terminal-failure exceptions, usage accounting and span contents are unchanged on the success path — only *when* the span is populated changed.

**Non-goals / not changed:** no shared cleanup helper extracted across the four adapters; no back-porting of the in-flight-close handling to the OpenAI/LiteLLM adapters; no workaround for any-llm's own missing `aclose()` propagation; no changes to the non-streaming AnyLLM paths.

### Issue number

None — found by comparing `AnyLLMModel` against the sibling adapters after #4066/#4077. Searched open and closed issues and PRs for `any_llm`, `AnyLLMModel`, `any-llm stream`, and `stream cleanup`; no existing report or PR covers the AnyLLM adapter.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
