### PR TITLE
fix(memory): enforce closed state in MongoDBSession

### DIFF
--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -448,7 +448,7 @@ await session.close()
 
 Notes:
 
--   `from_uri(...)` creates and owns the `AsyncMongoClient` and closes it on `session.close()`. If your application already manages a client, construct `MongoDBSession(...)` directly with `client=...`; in that case `session.close()` is a no-op and lifecycle stays with the caller.
+-   `from_uri(...)` creates and owns the `AsyncMongoClient` and closes it on `session.close()`. An owned-client session is terminal after `close()`: subsequent session operations raise `RuntimeError`, while repeated or concurrent `close()` calls are safe and release the client exactly once. If your application already manages a client, construct `MongoDBSession(...)` directly with `client=...`; in that case `session.close()` is a no-op, and lifecycle plus session usability stay with the caller.
 -   Connect to [MongoDB Atlas](https://www.mongodb.com/products/platform) by passing an `mongodb+srv://user:password@cluster.example.mongodb.net` URI to `from_uri(...)` with no other changes.
 -   Two collections are used and both names are configurable via `sessions_collection=` (default `agent_sessions`) and `messages_collection=` (default `agent_messages`). Indexes are created automatically on first use. Each message document carries a monotonically increasing `seq` counter that preserves ordering across concurrent writers and processes.
 -   Use `await session.ping()` to verify connectivity before your first run.

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -31,11 +31,9 @@ Usage::
 
 from __future__ import annotations
 
-import asyncio
 import json
 import threading
 import weakref
-from contextlib import AbstractAsyncContextManager
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 
@@ -143,12 +141,10 @@ class MongoDBSession(SessionABC):
         self._owns_client = False
         self._closed = False
         self._client_released = False
-        # Serializes close() so concurrent callers cannot both release the client.
-        # Created lazily rather than here: an asyncio.Lock binds to the loop that
-        # first acquires it, and this session is usable from more than one loop
-        # (see the _init_state notes above).
-        self._close_lock: asyncio.Lock | None = None
-        self._close_lock_loop: asyncio.AbstractEventLoop | None = None
+        # True while one caller is inside client.close(), so concurrent callers
+        # cannot start a second release. Guarded by _init_guard (a threading.Lock)
+        # rather than an asyncio.Lock, which would only serialize a single loop.
+        self._releasing_client = False
 
         client.append_metadata(_DRIVER_INFO)
 
@@ -399,21 +395,26 @@ class MongoDBSession(SessionABC):
     # Lifecycle helpers
     # ------------------------------------------------------------------
 
-    def _close_guard(self) -> AbstractAsyncContextManager[Any]:
-        """Return the lock serializing ``close()`` on the current event loop.
+    def _claim_client_release(self) -> bool:
+        """Return True if this caller is the one that should release the client.
 
-        The lock is created on first use and rebound if the session is closed
-        from a different loop than the one that created it — an ``asyncio.Lock``
-        is bound to a single loop, so a session shared across loops cannot hold
-        one for its whole lifetime.  Rebinding is safe because a differing loop
-        means no concurrent close is in flight on the previous one.
+        Only a ``threading.Lock`` is used, never an ``asyncio.Lock``: a lock bound
+        to one event loop cannot serialize callers on another, and this session may
+        be closed from a different loop or thread than the one that created it (the
+        same constraint documented for ``_init_state``).  The claim only guards two
+        flag flips, so no async coordination is required.
         """
         with self._init_guard:
-            loop = asyncio.get_running_loop()
-            if self._close_lock is None or self._close_lock_loop is not loop:
-                self._close_lock = asyncio.Lock()
-                self._close_lock_loop = loop
-            return self._close_lock
+            if self._client_released or self._releasing_client:
+                return False
+            self._releasing_client = True
+            return True
+
+    def _finish_client_release(self, released: bool) -> None:
+        """Record the outcome of a release attempt, freeing the claim either way."""
+        with self._init_guard:
+            self._client_released = released
+            self._releasing_client = False
 
     async def close(self) -> None:
         """Close the underlying MongoDB connection.
@@ -427,18 +428,24 @@ class MongoDBSession(SessionABC):
         The session is terminal from the first close attempt.  If releasing the
         client fails or is cancelled, operations still raise and a later
         ``close()`` retries the unfinished cleanup.  Once the client is released,
-        repeated calls are safe no-ops, and concurrent calls release the client
-        exactly once.
+        repeated calls are safe no-ops, and concurrent calls — including from
+        different event loops or threads — release the client exactly once.
         """
         if not self._owns_client:
             return
-        # Mark terminal before awaiting the lock so a caller blocked behind a
-        # slow release still cannot issue commands in the meantime.
+        # Mark terminal before releasing, so a concurrent caller that returns
+        # early below still cannot issue commands against a closing client.
         self._closed = True
-        async with self._close_guard():
-            if not self._client_released:
-                await self._client.close()
-                self._client_released = True
+        if not self._claim_client_release():
+            return
+        released = False
+        try:
+            await self._client.close()
+            released = True
+        finally:
+            # On failure or cancellation the claim is freed without marking the
+            # client released, so a later close() retries the cleanup.
+            self._finish_client_release(released)
 
     async def ping(self) -> bool:
         """Test MongoDB connectivity.

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -501,6 +501,14 @@ class MongoDBSession(SessionABC):
         """Publish the outcome of a release attempt and free the claim.
 
         On failure the client is left unreleased, so a later ``close()`` retries.
+
+        A cancellation is translated rather than forwarded.  Publishing it verbatim would
+        reach the waiters in :meth:`_await_client_release` as an ``asyncio.CancelledError``
+        (``asyncio`` maps a ``concurrent.futures.CancelledError`` back to its own on the way
+        out of ``wrap_future``), marking tasks nobody cancelled as *cancelled* rather than
+        *failed*: the real cause becomes invisible to the caller and whatever the teardown
+        path sequenced after the await is silently skipped.  Only the caller that was
+        actually cancelled sees ``CancelledError``, which ``close()`` re-raises itself.
         """
         with self._init_guard:
             attempt = self._release_attempt
@@ -510,6 +518,10 @@ class MongoDBSession(SessionABC):
             return
         if error is None:
             attempt.set_result(None)
+        elif isinstance(error, asyncio.CancelledError):
+            attempt.set_exception(
+                RuntimeError("MongoDB client release was cancelled; call close() again to retry")
+            )
         else:
             attempt.set_exception(error)
 

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -31,9 +31,11 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 import weakref
+from concurrent.futures import Future
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 
@@ -141,10 +143,11 @@ class MongoDBSession(SessionABC):
         self._owns_client = False
         self._closed = False
         self._client_released = False
-        # True while one caller is inside client.close(), so concurrent callers
-        # cannot start a second release. Guarded by _init_guard (a threading.Lock)
-        # rather than an asyncio.Lock, which would only serialize a single loop.
-        self._releasing_client = False
+        # Set while one caller is inside client.close(); other callers await it
+        # instead of starting a second release. A concurrent.futures.Future and
+        # the _init_guard threading.Lock are used rather than asyncio primitives,
+        # which would only serialize callers on a single event loop.
+        self._release_attempt: Future[None] | None = None
 
         client.append_metadata(_DRIVER_INFO)
 
@@ -395,26 +398,44 @@ class MongoDBSession(SessionABC):
     # Lifecycle helpers
     # ------------------------------------------------------------------
 
-    def _claim_client_release(self) -> bool:
-        """Return True if this caller is the one that should release the client.
+    def _claim_client_release(self) -> tuple[bool, Future[None] | None]:
+        """Claim the right to release the client, or report what to wait for.
+
+        Returns ``(True, None)`` for the caller that should perform the release,
+        and ``(False, pending)`` otherwise, where ``pending`` is the in-flight
+        attempt to wait on or ``None`` if the client is already released.
 
         Only a ``threading.Lock`` is used, never an ``asyncio.Lock``: a lock bound
         to one event loop cannot serialize callers on another, and this session may
         be closed from a different loop or thread than the one that created it (the
-        same constraint documented for ``_init_state``).  The claim only guards two
-        flag flips, so no async coordination is required.
+        same constraint documented for ``_init_state``).  A
+        ``concurrent.futures.Future`` is used for the same reason — unlike an
+        asyncio future it can be awaited from any loop via
+        :func:`asyncio.wrap_future`.
         """
         with self._init_guard:
-            if self._client_released or self._releasing_client:
-                return False
-            self._releasing_client = True
-            return True
+            if self._client_released:
+                return False, None
+            if self._release_attempt is not None:
+                return False, self._release_attempt
+            self._release_attempt = Future()
+            return True, None
 
-    def _finish_client_release(self, released: bool) -> None:
-        """Record the outcome of a release attempt, freeing the claim either way."""
+    def _finish_client_release(self, error: BaseException | None) -> None:
+        """Publish the outcome of a release attempt and free the claim.
+
+        On failure the client is left unreleased, so a later ``close()`` retries.
+        """
         with self._init_guard:
-            self._client_released = released
-            self._releasing_client = False
+            attempt = self._release_attempt
+            self._release_attempt = None
+            self._client_released = error is None
+        if attempt is None:  # pragma: no cover - defensive
+            return
+        if error is None:
+            attempt.set_result(None)
+        else:
+            attempt.set_exception(error)
 
     async def close(self) -> None:
         """Close the underlying MongoDB connection.
@@ -426,26 +447,33 @@ class MongoDBSession(SessionABC):
         caller is responsible for managing its lifecycle and this is a no-op.
 
         The session is terminal from the first close attempt.  If releasing the
-        client fails or is cancelled, operations still raise and a later
-        ``close()`` retries the unfinished cleanup.  Once the client is released,
-        repeated calls are safe no-ops, and concurrent calls — including from
-        different event loops or threads — release the client exactly once.
+        client fails or is cancelled, operations still raise, every concurrent
+        caller sees the failure, and a later ``close()`` retries the unfinished
+        cleanup.  Once the client is released, repeated calls are safe no-ops, and
+        concurrent calls — including from different event loops or threads —
+        release the client exactly once.
         """
         if not self._owns_client:
             return
-        # Mark terminal before releasing, so a concurrent caller that returns
-        # early below still cannot issue commands against a closing client.
+        # Mark terminal before releasing, so a caller waiting on another's
+        # release cannot issue commands against a closing client.
         self._closed = True
-        if not self._claim_client_release():
+        claimed, pending = self._claim_client_release()
+        if not claimed:
+            if pending is not None:
+                # Await the in-flight release rather than returning early, so a
+                # failed cleanup surfaces here too instead of looking successful.
+                await asyncio.wrap_future(pending)
             return
-        released = False
+
+        error: BaseException | None = None
         try:
             await self._client.close()
-            released = True
+        except BaseException as exc:
+            error = exc
+            raise
         finally:
-            # On failure or cancellation the claim is freed without marking the
-            # client released, so a later close() retries the cleanup.
-            self._finish_client_release(released)
+            self._finish_client_release(error)
 
     async def ping(self) -> bool:
         """Test MongoDB connectivity.

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -140,6 +140,7 @@ class MongoDBSession(SessionABC):
         self._client = client
         self._owns_client = False
         self._closed = False
+        self._client_released = False
 
         client.append_metadata(_DRIVER_INFO)
 
@@ -394,18 +395,22 @@ class MongoDBSession(SessionABC):
         """Close the underlying MongoDB connection.
 
         Only closes the client if this session owns it (i.e. it was created
-        via :meth:`from_uri`).  If the client was injected externally the
-        caller is responsible for managing its lifecycle.
+        via :meth:`from_uri`).  In that case the session becomes terminal and
+        subsequent operations raise ``RuntimeError`` rather than issuing commands
+        against a closed client.  If the client was injected externally the
+        caller is responsible for managing its lifecycle and this is a no-op.
 
-        The session becomes terminal from the first close attempt: subsequent
-        operations raise ``RuntimeError`` rather than issuing commands against a
-        closed client.  Repeated calls are safe no-ops, and an injected client is
-        still left untouched.
+        The session is terminal from the first close attempt.  If releasing the
+        client fails or is cancelled, operations still raise and a later
+        ``close()`` retries the unfinished cleanup.  Once the client is released,
+        repeated calls are safe no-ops.
         """
-        already_closed = self._closed
+        if not self._owns_client:
+            return
         self._closed = True
-        if self._owns_client and not already_closed:
+        if not self._client_released:
             await self._client.close()
+            self._client_released = True
 
     async def ping(self) -> bool:
         """Test MongoDB connectivity.

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -32,9 +32,11 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import threading
 import weakref
+from collections.abc import Iterator
 from concurrent.futures import Future
 from datetime import datetime, timezone
 from typing import Any, ClassVar
@@ -148,6 +150,11 @@ class MongoDBSession(SessionABC):
         # the _init_guard threading.Lock are used rather than asyncio primitives,
         # which would only serialize callers on a single event loop.
         self._release_attempt: Future[None] | None = None
+        # Number of session operations that have passed the closed check and may
+        # still issue commands. close() drains these before releasing the client
+        # so an in-flight operation never runs against a closed one.
+        self._active_operations = 0
+        self._idle: Future[None] | None = None
 
         client.append_metadata(_DRIVER_INFO)
 
@@ -270,6 +277,34 @@ class MongoDBSession(SessionABC):
         if self._closed:
             raise RuntimeError("MongoDBSession is closed")
 
+    @contextlib.contextmanager
+    def _operation(self) -> Iterator[None]:
+        """Reject operations on a closed session and keep ``close()`` from racing them.
+
+        Entering registers the operation so a concurrent ``close()`` waits for it to
+        finish before releasing the client; otherwise an operation that already passed
+        the closed check could issue its command against a closed client.  The counter
+        is guarded by the same ``threading.Lock`` as the rest of this class's state, so
+        it works across event loops and threads where an ``asyncio.Lock`` would not.
+
+        Unlike the lock the other backends hold for their whole operation, this only
+        bounds ``close()`` -- concurrent reads and writes still overlap, which is the
+        behaviour MongoDB users get today.
+        """
+        with self._init_guard:
+            self._check_not_closed()
+            self._active_operations += 1
+        try:
+            yield
+        finally:
+            with self._init_guard:
+                self._active_operations -= 1
+                idle = self._idle if self._active_operations == 0 else None
+                if idle is not None:
+                    self._idle = None
+            if idle is not None and not idle.done():
+                idle.set_result(None)
+
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
@@ -283,44 +318,44 @@ class MongoDBSession(SessionABC):
         Returns:
             List of input items representing the conversation history.
         """
-        self._check_not_closed()
-        await self._ensure_indexes()
+        with self._operation():
+            await self._ensure_indexes()
 
-        session_limit = resolve_session_limit(limit, self.session_settings)
+            session_limit = resolve_session_limit(limit, self.session_settings)
 
-        if session_limit is not None and session_limit <= 0:
-            return []
+            if session_limit is not None and session_limit <= 0:
+                return []
 
-        query = {"session_id": self.session_id}
+            query = {"session_id": self.session_id}
 
-        async def _decode_docs(docs: list[Any]) -> list[TResponseInputItem]:
-            items: list[TResponseInputItem] = []
-            for doc in docs:
-                try:
-                    items.append(await self._deserialize_item(doc["message_data"]))
-                except (json.JSONDecodeError, KeyError, TypeError):
-                    # Skip corrupted or malformed documents (including non-string BSON values).
-                    continue
-            return items
-
-        if session_limit is None:
-            cursor = self._messages.find(query).sort("seq", 1)
-            return await _decode_docs(await cursor.to_list())
-
-        # Fetch the latest N documents in reverse order, then reverse the
-        # list to restore chronological order. Expand the fetch window when corrupt
-        # documents sit among the newest entries so limit counts valid conversation
-        # items, matching pop_item and the SQLite backends.
-        window = session_limit
-        while True:
-            cursor = self._messages.find(query).sort("seq", -1).limit(window)
-            docs = await cursor.to_list()
-            items = await _decode_docs(docs[::-1])
-            if len(items) >= session_limit:
-                return items[-session_limit:]
-            if len(docs) < window:
+            async def _decode_docs(docs: list[Any]) -> list[TResponseInputItem]:
+                items: list[TResponseInputItem] = []
+                for doc in docs:
+                    try:
+                        items.append(await self._deserialize_item(doc["message_data"]))
+                    except (json.JSONDecodeError, KeyError, TypeError):
+                        # Skip corrupted or malformed documents (including non-string BSON values).
+                        continue
                 return items
-            window *= 2
+
+            if session_limit is None:
+                cursor = self._messages.find(query).sort("seq", 1)
+                return await _decode_docs(await cursor.to_list())
+
+            # Fetch the latest N documents in reverse order, then reverse the
+            # list to restore chronological order. Expand the fetch window when corrupt
+            # documents sit among the newest entries so limit counts valid conversation
+            # items, matching pop_item and the SQLite backends.
+            window = session_limit
+            while True:
+                cursor = self._messages.find(query).sort("seq", -1).limit(window)
+                docs = await cursor.to_list()
+                items = await _decode_docs(docs[::-1])
+                if len(items) >= session_limit:
+                    return items[-session_limit:]
+                if len(docs) < window:
+                    return items
+                window *= 2
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
         """Add new items to the conversation history.
@@ -328,39 +363,40 @@ class MongoDBSession(SessionABC):
         Args:
             items: List of input items to append to the session.
         """
-        self._check_not_closed()
         if not items:
+            self._check_not_closed()
             return
 
-        await self._ensure_indexes()
+        with self._operation():
+            await self._ensure_indexes()
 
-        now = datetime.now(timezone.utc)
+            now = datetime.now(timezone.utc)
 
-        # Atomically reserve a block of sequence numbers for this batch.
-        # $inc returns the new value, so subtract len(items) to get the first
-        # number in the block.
-        result = await self._sessions.find_one_and_update(
-            {"session_id": self.session_id},
-            {
-                "$setOnInsert": {"session_id": self.session_id, "created_at": now},
-                "$set": {"updated_at": now},
-                "$inc": {"_seq": len(items)},
-            },
-            upsert=True,
-            return_document=True,
-        )
-        next_seq: int = (result["_seq"] if result else len(items)) - len(items)
+            # Atomically reserve a block of sequence numbers for this batch.
+            # $inc returns the new value, so subtract len(items) to get the first
+            # number in the block.
+            result = await self._sessions.find_one_and_update(
+                {"session_id": self.session_id},
+                {
+                    "$setOnInsert": {"session_id": self.session_id, "created_at": now},
+                    "$set": {"updated_at": now},
+                    "$inc": {"_seq": len(items)},
+                },
+                upsert=True,
+                return_document=True,
+            )
+            next_seq: int = (result["_seq"] if result else len(items)) - len(items)
 
-        payload = [
-            {
-                "session_id": self.session_id,
-                "seq": next_seq + i,
-                "message_data": await self._serialize_item(item),
-            }
-            for i, item in enumerate(items)
-        ]
+            payload = [
+                {
+                    "session_id": self.session_id,
+                    "seq": next_seq + i,
+                    "message_data": await self._serialize_item(item),
+                }
+                for i, item in enumerate(items)
+            ]
 
-        await self._messages.insert_many(payload, ordered=True)
+            await self._messages.insert_many(payload, ordered=True)
 
     async def pop_item(self) -> TResponseInputItem | None:
         """Remove and return the most recent item from the session.
@@ -373,30 +409,48 @@ class MongoDBSession(SessionABC):
         matches :meth:`get_items`, which also skips corrupt documents, so a
         single bad row cannot make a non-empty session look empty to callers.
         """
-        await self._ensure_indexes()
+        with self._operation():
+            await self._ensure_indexes()
 
-        while True:
-            doc = await self._messages.find_one_and_delete(
-                {"session_id": self.session_id},
-                sort=[("seq", -1)],
-            )
-            if doc is None:
-                return None
-            try:
-                return await self._deserialize_item(doc["message_data"])
-            except (json.JSONDecodeError, KeyError, TypeError):
-                # Corrupt — drop it and try the next-most-recent document.
-                continue
+            while True:
+                doc = await self._messages.find_one_and_delete(
+                    {"session_id": self.session_id},
+                    sort=[("seq", -1)],
+                )
+                if doc is None:
+                    return None
+                try:
+                    return await self._deserialize_item(doc["message_data"])
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    # Corrupt — drop it and try the next-most-recent document.
+                    continue
 
     async def clear_session(self) -> None:
         """Clear all items for this session."""
-        await self._ensure_indexes()
-        await self._messages.delete_many({"session_id": self.session_id})
-        await self._sessions.delete_one({"session_id": self.session_id})
+        with self._operation():
+            await self._ensure_indexes()
+            await self._messages.delete_many({"session_id": self.session_id})
+            await self._sessions.delete_one({"session_id": self.session_id})
 
     # ------------------------------------------------------------------
     # Lifecycle helpers
     # ------------------------------------------------------------------
+
+    async def _drain_active_operations(self) -> None:
+        """Wait for operations that already passed the closed check to finish.
+
+        ``_closed`` is set before this runs, so no new operation can start; this only
+        waits out the ones already in flight.  A ``concurrent.futures.Future`` is used
+        so the wait works from any event loop, and it is shielded because a cancelled
+        ``close()`` must not abort a drain other callers are also waiting on.
+        """
+        with self._init_guard:
+            if self._active_operations == 0:
+                return
+            if self._idle is None:
+                self._idle = Future()
+            idle = self._idle
+        await self._await_client_release(idle)
 
     def _claim_client_release(self) -> tuple[bool, Future[None] | None]:
         """Claim the right to release the client, or report what to wait for.
@@ -428,16 +482,19 @@ class MongoDBSession(SessionABC):
         The attempt is shared, so cancelling this coroutine must not cancel it:
         :func:`asyncio.wrap_future` forwards cancellation to the wrapped
         ``concurrent.futures.Future``, which would leave the releasing caller unable
-        to publish its outcome.  :func:`asyncio.shield` keeps the wrapper alive, and
-        the done callback discards the eventual outcome so an abandoned wrapper
-        holding an exception does not log "exception was never retrieved".
+        to publish its outcome.  :func:`asyncio.shield` keeps the wrapper alive.
+
+        On cancellation the wrapper is abandoned, so its outcome is consumed via a
+        done callback -- otherwise a release that goes on to fail would surface as
+        "Future exception was never retrieved".  The callback is added
+        unconditionally: asyncio invokes it immediately for an already-completed
+        wrapper, and re-reading a retrieved outcome is harmless.
         """
         wrapper = asyncio.wrap_future(pending)
         try:
             await asyncio.shield(wrapper)
         except asyncio.CancelledError:
-            if not wrapper.done():
-                wrapper.add_done_callback(lambda f: f.cancelled() or f.exception())
+            wrapper.add_done_callback(lambda f: f.cancelled() or f.exception())
             raise
 
     def _finish_client_release(self, error: BaseException | None) -> None:
@@ -477,6 +534,7 @@ class MongoDBSession(SessionABC):
         # Mark terminal before releasing, so a caller waiting on another's
         # release cannot issue commands against a closing client.
         self._closed = True
+        await self._drain_active_operations()
         claimed, pending = self._claim_client_release()
         if not claimed:
             if pending is not None:
@@ -503,9 +561,9 @@ class MongoDBSession(SessionABC):
         Raises:
             RuntimeError: If the session has been closed.
         """
-        self._check_not_closed()
-        try:
-            await self._client.admin.command("ping")
-            return True
-        except Exception:
-            return False
+        with self._operation():
+            try:
+                await self._client.admin.command("ping")
+                return True
+            except Exception:
+                return False

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -421,6 +421,25 @@ class MongoDBSession(SessionABC):
             self._release_attempt = Future()
             return True, None
 
+    @staticmethod
+    async def _await_client_release(pending: Future[None]) -> None:
+        """Await another caller's in-flight release without being able to abort it.
+
+        The attempt is shared, so cancelling this coroutine must not cancel it:
+        :func:`asyncio.wrap_future` forwards cancellation to the wrapped
+        ``concurrent.futures.Future``, which would leave the releasing caller unable
+        to publish its outcome.  :func:`asyncio.shield` keeps the wrapper alive, and
+        the done callback discards the eventual outcome so an abandoned wrapper
+        holding an exception does not log "exception was never retrieved".
+        """
+        wrapper = asyncio.wrap_future(pending)
+        try:
+            await asyncio.shield(wrapper)
+        except asyncio.CancelledError:
+            if not wrapper.done():
+                wrapper.add_done_callback(lambda f: f.cancelled() or f.exception())
+            raise
+
     def _finish_client_release(self, error: BaseException | None) -> None:
         """Publish the outcome of a release attempt and free the claim.
 
@@ -463,7 +482,7 @@ class MongoDBSession(SessionABC):
             if pending is not None:
                 # Await the in-flight release rather than returning early, so a
                 # failed cleanup surfaces here too instead of looking successful.
-                await asyncio.wrap_future(pending)
+                await self._await_client_release(pending)
             return
 
         error: BaseException | None = None

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -31,9 +31,11 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 import weakref
+from contextlib import AbstractAsyncContextManager
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 
@@ -141,6 +143,12 @@ class MongoDBSession(SessionABC):
         self._owns_client = False
         self._closed = False
         self._client_released = False
+        # Serializes close() so concurrent callers cannot both release the client.
+        # Created lazily rather than here: an asyncio.Lock binds to the loop that
+        # first acquires it, and this session is usable from more than one loop
+        # (see the _init_state notes above).
+        self._close_lock: asyncio.Lock | None = None
+        self._close_lock_loop: asyncio.AbstractEventLoop | None = None
 
         client.append_metadata(_DRIVER_INFO)
 
@@ -391,6 +399,22 @@ class MongoDBSession(SessionABC):
     # Lifecycle helpers
     # ------------------------------------------------------------------
 
+    def _close_guard(self) -> AbstractAsyncContextManager[Any]:
+        """Return the lock serializing ``close()`` on the current event loop.
+
+        The lock is created on first use and rebound if the session is closed
+        from a different loop than the one that created it — an ``asyncio.Lock``
+        is bound to a single loop, so a session shared across loops cannot hold
+        one for its whole lifetime.  Rebinding is safe because a differing loop
+        means no concurrent close is in flight on the previous one.
+        """
+        with self._init_guard:
+            loop = asyncio.get_running_loop()
+            if self._close_lock is None or self._close_lock_loop is not loop:
+                self._close_lock = asyncio.Lock()
+                self._close_lock_loop = loop
+            return self._close_lock
+
     async def close(self) -> None:
         """Close the underlying MongoDB connection.
 
@@ -403,14 +427,18 @@ class MongoDBSession(SessionABC):
         The session is terminal from the first close attempt.  If releasing the
         client fails or is cancelled, operations still raise and a later
         ``close()`` retries the unfinished cleanup.  Once the client is released,
-        repeated calls are safe no-ops.
+        repeated calls are safe no-ops, and concurrent calls release the client
+        exactly once.
         """
         if not self._owns_client:
             return
+        # Mark terminal before awaiting the lock so a caller blocked behind a
+        # slow release still cannot issue commands in the meantime.
         self._closed = True
-        if not self._client_released:
-            await self._client.close()
-            self._client_released = True
+        async with self._close_guard():
+            if not self._client_released:
+                await self._client.close()
+                self._client_released = True
 
     async def ping(self) -> bool:
         """Test MongoDB connectivity.

--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -139,6 +139,7 @@ class MongoDBSession(SessionABC):
         )
         self._client = client
         self._owns_client = False
+        self._closed = False
 
         client.append_metadata(_DRIVER_INFO)
 
@@ -227,6 +228,7 @@ class MongoDBSession(SessionABC):
         round-trip is issued.  The threading-lock-guarded boolean prevents that
         extra round-trip after the first call completes.
         """
+        self._check_not_closed()
         if self._is_init_done():
             return
 
@@ -255,6 +257,11 @@ class MongoDBSession(SessionABC):
     # Session protocol implementation
     # ------------------------------------------------------------------
 
+    def _check_not_closed(self) -> None:
+        """Raise if the session has already been closed."""
+        if self._closed:
+            raise RuntimeError("MongoDBSession is closed")
+
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
         """Retrieve the conversation history for this session.
 
@@ -268,6 +275,7 @@ class MongoDBSession(SessionABC):
         Returns:
             List of input items representing the conversation history.
         """
+        self._check_not_closed()
         await self._ensure_indexes()
 
         session_limit = resolve_session_limit(limit, self.session_settings)
@@ -312,6 +320,7 @@ class MongoDBSession(SessionABC):
         Args:
             items: List of input items to append to the session.
         """
+        self._check_not_closed()
         if not items:
             return
 
@@ -387,8 +396,15 @@ class MongoDBSession(SessionABC):
         Only closes the client if this session owns it (i.e. it was created
         via :meth:`from_uri`).  If the client was injected externally the
         caller is responsible for managing its lifecycle.
+
+        The session becomes terminal from the first close attempt: subsequent
+        operations raise ``RuntimeError`` rather than issuing commands against a
+        closed client.  Repeated calls are safe no-ops, and an injected client is
+        still left untouched.
         """
-        if self._owns_client:
+        already_closed = self._closed
+        self._closed = True
+        if self._owns_client and not already_closed:
             await self._client.close()
 
     async def ping(self) -> bool:
@@ -396,7 +412,11 @@ class MongoDBSession(SessionABC):
 
         Returns:
             ``True`` if the server is reachable, ``False`` otherwise.
+
+        Raises:
+            RuntimeError: If the session has been closed.
         """
+        self._check_not_closed()
         try:
             await self._client.admin.command("ping")
             return True

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -730,15 +730,21 @@ async def test_close_owned_client_is_closed() -> None:
         assert fake_client._closed
 
 
-async def test_closed_operations_raise_runtime_error() -> None:
-    """Operations on a closed session must fail instead of using a closed client."""
+def _make_owned_session(session_id: str = "owned") -> tuple[MongoDBSession, FakeAsyncMongoClient]:
+    """Create a from_uri session (which owns its client) backed by a fake client."""
     MongoDBSession._init_state.clear()
     fake_client = FakeAsyncMongoClient()
     with patch(
         "agents.extensions.memory.mongodb_session.AsyncMongoClient",
         return_value=fake_client,
     ):
-        s = MongoDBSession.from_uri("closed-state", uri="mongodb://localhost:27017", database="t")
+        s = MongoDBSession.from_uri(session_id, uri="mongodb://localhost:27017", database="t")
+    return s, fake_client
+
+
+async def test_closed_operations_raise_runtime_error() -> None:
+    """Operations on a closed session must fail instead of using a closed client."""
+    s, _ = _make_owned_session("closed-state")
 
     await s.add_items([{"role": "user", "content": "before close"}])
     await s.close()
@@ -761,7 +767,7 @@ async def test_closed_operations_raise_runtime_error() -> None:
 
 async def test_closed_rejects_empty_add_items() -> None:
     """add_items([]) must not bypass the closed check through the empty-list fast path."""
-    s = _make_session("closed-empty-add")
+    s, _ = _make_owned_session("closed-empty-add")
     await s.close()
 
     with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
@@ -770,7 +776,7 @@ async def test_closed_rejects_empty_add_items() -> None:
 
 async def test_closed_rejects_non_positive_limit_get_items() -> None:
     """get_items(limit=0) must not bypass the closed check through the early return."""
-    s = _make_session("closed-zero-limit")
+    s, _ = _make_owned_session("closed-zero-limit")
     await s.close()
 
     with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
@@ -779,17 +785,49 @@ async def test_closed_rejects_non_positive_limit_get_items() -> None:
 
 async def test_close_before_use_is_terminal() -> None:
     """close() before any command is issued must still make the session terminal."""
-    s = _make_session("close-before-use")
+    s, _ = _make_owned_session("close-before-use")
     await s.close()
 
     with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
         await s.get_items()
 
 
+async def test_failed_owned_client_close_can_be_retried() -> None:
+    """A failed client release must not be suppressed by the idempotence fast path."""
+    s, fake_client = _make_owned_session("close-retry")
+    attempts = 0
+    original_close = fake_client.close
+
+    async def _flaky_close() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ConnectionError("release failed")
+        await original_close()
+
+    fake_client.close = _flaky_close  # type: ignore[method-assign]
+
+    with pytest.raises(ConnectionError):
+        await s.close()
+
+    # The session is terminal even though cleanup did not finish...
+    assert not fake_client._closed
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.get_items()
+
+    # ...and a later close() retries the unfinished release.
+    await s.close()
+    assert fake_client._closed
+    assert attempts == 2
+
+    # Now that the client is released, further calls are no-ops.
+    await s.close()
+    assert attempts == 2
+
+
 async def test_close_is_idempotent_and_closes_owned_client_once() -> None:
     """Repeated and concurrent close() calls must remain safe no-ops."""
-    MongoDBSession._init_state.clear()
-    fake_client = FakeAsyncMongoClient()
+    s, fake_client = _make_owned_session("close-twice")
     close_calls = 0
     original_close = fake_client.close
 
@@ -800,12 +838,6 @@ async def test_close_is_idempotent_and_closes_owned_client_once() -> None:
 
     fake_client.close = _counting_close  # type: ignore[method-assign]
 
-    with patch(
-        "agents.extensions.memory.mongodb_session.AsyncMongoClient",
-        return_value=fake_client,
-    ):
-        s = MongoDBSession.from_uri("close-twice", uri="mongodb://localhost:27017", database="t")
-
     await s.add_items([{"role": "user", "content": "before close"}])
 
     await asyncio.gather(s.close(), s.close())
@@ -815,8 +847,8 @@ async def test_close_is_idempotent_and_closes_owned_client_once() -> None:
     assert close_calls == 1
 
 
-async def test_close_injected_client_still_makes_session_terminal() -> None:
-    """An injected client is left open, but the session itself must still be terminal."""
+async def test_close_injected_client_is_a_noop() -> None:
+    """With an injected client, close() must stay a no-op: the session is not terminal."""
     MongoDBSession._init_state.clear()
     client = FakeAsyncMongoClient()
     s = MongoDBSession("injected", client=client, database="agents_test")  # type: ignore[arg-type]
@@ -824,13 +856,12 @@ async def test_close_injected_client_still_makes_session_terminal() -> None:
 
     await s.close()
 
+    # Lifecycle stays with the caller, so the session keeps working.
     assert not client._closed
-    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
-        await s.get_items()
-
-    # The caller still owns the client and can keep using it through a new session.
-    other = MongoDBSession("injected", client=client, database="agents_test")  # type: ignore[arg-type]
-    assert len(await other.get_items()) == 1
+    assert len(await s.get_items()) == 1
+    await s.add_items([{"role": "user", "content": "after close"}])
+    assert len(await s.get_items()) == 2
+    assert await s.ping() is True
 
 
 async def test_operations_unaffected_before_close(session: MongoDBSession) -> None:

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -879,6 +879,35 @@ async def test_concurrent_close_observes_a_failed_release() -> None:
     assert attempts == 2
 
 
+async def test_cancelled_waiter_does_not_break_the_in_flight_release() -> None:
+    """Cancelling a waiting close() must not abort the release it is waiting on."""
+    s, fake_client = _make_owned_session("close-cancelled-waiter")
+    original_close = fake_client.close
+
+    async def _slow_close() -> None:
+        await asyncio.sleep(0.2)
+        await original_close()
+
+    fake_client.close = _slow_close  # type: ignore[method-assign]
+
+    releaser = asyncio.create_task(s.close())
+    await asyncio.sleep(0.02)  # let the releaser claim the release
+    waiter = asyncio.create_task(s.close())
+    await asyncio.sleep(0.02)  # let the waiter block on the shared attempt
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    # The release owner must still finish and publish its outcome.
+    await releaser
+    assert fake_client._closed
+
+    # And the session is still consistent afterwards.
+    await s.close()
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.get_items()
+
+
 async def test_concurrent_close_across_event_loops_releases_client_once() -> None:
     """Two loops closing the same session must not both release the owned client."""
     s, fake_client = _make_owned_session("close-two-loops")

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -910,6 +910,49 @@ async def test_cancelled_waiter_does_not_break_the_in_flight_release() -> None:
         await s.get_items()
 
 
+async def test_cancelling_the_release_owner_fails_waiters_without_cancelling_them() -> None:
+    """A cancelled release must reach waiters as a failure, not as a cancellation.
+
+    ``asyncio`` maps a ``concurrent.futures.CancelledError`` back to its own on the way out of
+    ``wrap_future``, so forwarding the owner's cancellation verbatim would mark a waiting task
+    as *cancelled* rather than *failed* -- hiding the cause and skipping whatever the caller
+    sequenced after the await.
+    """
+    s, fake_client = _make_owned_session("close-owner-cancelled")
+
+    started = asyncio.Event()
+    unblock = asyncio.Event()
+    original_close = fake_client.close
+
+    async def _blocking_close() -> None:
+        started.set()
+        await unblock.wait()
+        await original_close()
+
+    fake_client.close = _blocking_close  # type: ignore[method-assign]
+
+    releaser = asyncio.create_task(s.close())
+    await started.wait()  # the releaser owns the attempt and is inside client.close()
+    waiter = asyncio.create_task(s.close())
+    await asyncio.sleep(0.02)  # let the waiter block on the shared attempt
+
+    releaser.cancel()
+    unblock.set()
+
+    # Only the caller that was actually cancelled sees CancelledError.
+    with pytest.raises(asyncio.CancelledError):
+        await releaser
+    with pytest.raises(RuntimeError, match="release was cancelled"):
+        await waiter
+    assert not waiter.cancelled()
+
+    # The client was never released, so a later close() retries the unfinished cleanup.
+    assert not fake_client._closed
+    fake_client.close = original_close  # type: ignore[method-assign]
+    await s.close()
+    assert fake_client._closed
+
+
 async def test_close_waits_for_an_in_flight_operation() -> None:
     """close() must not release the client under an operation that already started."""
     s, fake_client = _make_owned_session("close-drains")

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
 import types
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -834,6 +835,9 @@ async def test_close_is_idempotent_and_closes_owned_client_once() -> None:
     async def _counting_close() -> None:
         nonlocal close_calls
         close_calls += 1
+        # Suspend mid-release, as a real client awaiting network I/O would. Without
+        # this a concurrent second close() can never observe the in-flight one.
+        await asyncio.sleep(0)
         await original_close()
 
     fake_client.close = _counting_close  # type: ignore[method-assign]
@@ -845,6 +849,32 @@ async def test_close_is_idempotent_and_closes_owned_client_once() -> None:
 
     assert fake_client._closed
     assert close_calls == 1
+
+
+async def test_close_from_a_second_event_loop_does_not_error() -> None:
+    """The lazily-created close lock must not bind the session to one event loop."""
+    s, fake_client = _make_owned_session("close-other-loop")
+    await s.add_items([{"role": "user", "content": "before close"}])
+
+    # Close from a different loop, in its own thread. A lock bound to this test's
+    # loop would raise "is bound to a different event loop" instead.
+    error: list[BaseException] = []
+
+    def _close_in_new_loop() -> None:
+        try:
+            asyncio.run(s.close())
+        except BaseException as exc:  # pragma: no cover - only on regression
+            error.append(exc)
+
+    thread = threading.Thread(target=_close_in_new_loop)
+    thread.start()
+    thread.join()
+
+    assert not error, f"close() failed on a second loop: {error}"
+    assert fake_client._closed
+
+    # Closing again, back on the original loop, stays a no-op.
+    await s.close()
 
 
 async def test_close_injected_client_is_a_noop() -> None:

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -851,6 +851,36 @@ async def test_close_is_idempotent_and_closes_owned_client_once() -> None:
     assert close_calls == 1
 
 
+async def test_concurrent_close_across_event_loops_releases_client_once() -> None:
+    """Two loops closing the same session must not both release the owned client."""
+    s, fake_client = _make_owned_session("close-two-loops")
+    close_calls = 0
+    original_close = fake_client.close
+    gate = threading.Barrier(2)
+
+    async def _counting_close() -> None:
+        nonlocal close_calls
+        close_calls += 1
+        # Stay in-flight long enough for the other loop to reach the guard.
+        await asyncio.sleep(0.05)
+        await original_close()
+
+    fake_client.close = _counting_close  # type: ignore[method-assign]
+
+    def _close_in_new_loop() -> None:
+        gate.wait()
+        asyncio.run(s.close())
+
+    threads = [threading.Thread(target=_close_in_new_loop) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert fake_client._closed
+    assert close_calls == 1
+
+
 async def test_close_from_a_second_event_loop_does_not_error() -> None:
     """The lazily-created close lock must not bind the session to one event loop."""
     s, fake_client = _make_owned_session("close-other-loop")

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -9,10 +9,12 @@ dependency-free while exercising the full session logic.
 from __future__ import annotations
 
 import asyncio
+import gc
 import sys
 import threading
 import types
 from collections import defaultdict
+from concurrent.futures import Future
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
@@ -906,6 +908,67 @@ async def test_cancelled_waiter_does_not_break_the_in_flight_release() -> None:
     await s.close()
     with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
         await s.get_items()
+
+
+async def test_close_waits_for_an_in_flight_operation() -> None:
+    """close() must not release the client under an operation that already started."""
+    s, fake_client = _make_owned_session("close-drains")
+    await s.add_items([{"role": "user", "content": "first"}])
+
+    saw_closed_client: list[bool] = []
+    original_insert = s._messages.insert_many
+
+    async def _slow_insert(documents: list[Any], ordered: bool = True) -> None:
+        # Suspend after the closed check has already passed, like a real round-trip.
+        await asyncio.sleep(0.1)
+        saw_closed_client.append(fake_client._closed)
+        await original_insert(documents, ordered=ordered)
+
+    s._messages.insert_many = _slow_insert  # type: ignore[assignment,method-assign]
+
+    op = asyncio.create_task(s.add_items([{"role": "user", "content": "in flight"}]))
+    await asyncio.sleep(0.02)  # op is past the guard and suspended mid-command
+    await s.close()
+
+    await op
+    assert saw_closed_client == [False], "command ran against a closed client"
+    assert fake_client._closed
+
+    # The session is still terminal once the drain completes.
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.get_items()
+
+
+@pytest.mark.parametrize("cancel_first", [True, False])
+async def test_cancelled_waiter_consumes_a_failed_release(cancel_first: bool) -> None:
+    """An abandoned waiter must not leave a failed release's exception unretrieved."""
+    logged: list[str] = []
+    asyncio.get_running_loop().set_exception_handler(
+        lambda loop, context: logged.append(context.get("message", ""))
+    )
+
+    pending: Future[None] = Future()
+    task = asyncio.create_task(MongoDBSession._await_client_release(pending))
+    await asyncio.sleep(0.01)  # let the waiter block on the shared attempt
+
+    # Both interleavings matter: asyncio.shield only marks the wrapped outcome
+    # retrieved when the failure lands before the cancellation is delivered.
+    if cancel_first:
+        task.cancel()
+        pending.set_exception(ConnectionError("release failed"))
+    else:
+        pending.set_exception(ConnectionError("release failed"))
+        task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    del task, pending
+    for _ in range(3):
+        gc.collect()
+        await asyncio.sleep(0.01)
+
+    assert logged == [], logged
 
 
 async def test_concurrent_close_across_event_loops_releases_client_once() -> None:

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -8,6 +8,7 @@ dependency-free while exercising the full session logic.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 from collections import defaultdict
@@ -727,6 +728,119 @@ async def test_close_owned_client_is_closed() -> None:
 
         await s.close()
         assert fake_client._closed
+
+
+async def test_closed_operations_raise_runtime_error() -> None:
+    """Operations on a closed session must fail instead of using a closed client."""
+    MongoDBSession._init_state.clear()
+    fake_client = FakeAsyncMongoClient()
+    with patch(
+        "agents.extensions.memory.mongodb_session.AsyncMongoClient",
+        return_value=fake_client,
+    ):
+        s = MongoDBSession.from_uri("closed-state", uri="mongodb://localhost:27017", database="t")
+
+    await s.add_items([{"role": "user", "content": "before close"}])
+    await s.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.get_items()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.add_items([{"role": "user", "content": "after close"}])
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.pop_item()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.clear_session()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.ping()
+
+
+async def test_closed_rejects_empty_add_items() -> None:
+    """add_items([]) must not bypass the closed check through the empty-list fast path."""
+    s = _make_session("closed-empty-add")
+    await s.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.add_items([])
+
+
+async def test_closed_rejects_non_positive_limit_get_items() -> None:
+    """get_items(limit=0) must not bypass the closed check through the early return."""
+    s = _make_session("closed-zero-limit")
+    await s.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.get_items(limit=0)
+
+
+async def test_close_before_use_is_terminal() -> None:
+    """close() before any command is issued must still make the session terminal."""
+    s = _make_session("close-before-use")
+    await s.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.get_items()
+
+
+async def test_close_is_idempotent_and_closes_owned_client_once() -> None:
+    """Repeated and concurrent close() calls must remain safe no-ops."""
+    MongoDBSession._init_state.clear()
+    fake_client = FakeAsyncMongoClient()
+    close_calls = 0
+    original_close = fake_client.close
+
+    async def _counting_close() -> None:
+        nonlocal close_calls
+        close_calls += 1
+        await original_close()
+
+    fake_client.close = _counting_close  # type: ignore[method-assign]
+
+    with patch(
+        "agents.extensions.memory.mongodb_session.AsyncMongoClient",
+        return_value=fake_client,
+    ):
+        s = MongoDBSession.from_uri("close-twice", uri="mongodb://localhost:27017", database="t")
+
+    await s.add_items([{"role": "user", "content": "before close"}])
+
+    await asyncio.gather(s.close(), s.close())
+    await s.close()
+
+    assert fake_client._closed
+    assert close_calls == 1
+
+
+async def test_close_injected_client_still_makes_session_terminal() -> None:
+    """An injected client is left open, but the session itself must still be terminal."""
+    MongoDBSession._init_state.clear()
+    client = FakeAsyncMongoClient()
+    s = MongoDBSession("injected", client=client, database="agents_test")  # type: ignore[arg-type]
+    await s.add_items([{"role": "user", "content": "before close"}])
+
+    await s.close()
+
+    assert not client._closed
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await s.get_items()
+
+    # The caller still owns the client and can keep using it through a new session.
+    other = MongoDBSession("injected", client=client, database="agents_test")  # type: ignore[arg-type]
+    assert len(await other.get_items()) == 1
+
+
+async def test_operations_unaffected_before_close(session: MongoDBSession) -> None:
+    """Negative control: the closed check must not disturb normal operation."""
+    await session.add_items([{"role": "user", "content": "hello"}])
+    assert len(await session.get_items()) == 1
+    assert await session.ping() is True
+    assert await session.pop_item() is not None
+    await session.clear_session()
+    assert await session.get_items() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -851,6 +851,34 @@ async def test_close_is_idempotent_and_closes_owned_client_once() -> None:
     assert close_calls == 1
 
 
+async def test_concurrent_close_observes_a_failed_release() -> None:
+    """A caller waiting on someone else's release must see that release fail."""
+    s, fake_client = _make_owned_session("close-shared-failure")
+    attempts = 0
+    original_close = fake_client.close
+
+    async def _failing_then_ok_close() -> None:
+        nonlocal attempts
+        attempts += 1
+        await asyncio.sleep(0.05)
+        if attempts == 1:
+            raise ConnectionError("release failed")
+        await original_close()
+
+    fake_client.close = _failing_then_ok_close  # type: ignore[method-assign]
+
+    # Both callers must see the failure, not just the one that ran the release.
+    results = await asyncio.gather(s.close(), s.close(), return_exceptions=True)
+    assert attempts == 1
+    assert all(isinstance(r, ConnectionError) for r in results), results
+    assert not fake_client._closed
+
+    # Cleanup is still retryable afterwards.
+    await s.close()
+    assert fake_client._closed
+    assert attempts == 2
+
+
 async def test_concurrent_close_across_event_loops_releases_client_once() -> None:
     """Two loops closing the same session must not both release the owned client."""
     s, fake_client = _make_owned_session("close-two-loops")


### PR DESCRIPTION
### Summary

`MongoDBSession.close()` closes the underlying client when the session owns it (created via `from_uri`), but it never records that the session is closed. Every session method then keeps issuing commands against a closed client instead of failing fast.

This is the same gap that was closed for the other backends:

- #4035 — `RedisSession` / `DaprSession`
- #4109 — `AsyncSQLiteSession`

`MongoDBSession` was the remaining backend with an unguarded `close()`.

### Repro

Against `main`, with an owned client (`from_uri`) after `await session.close()`:

```
=== MongoDBSession, OWNED client (from_uri), after close() ===
   client._closed = True
   add_items      -> RETURNED None
   get_items      -> RETURNED '2 items'
   pop_item       -> RETURNED {'role': 'user', 'content': 'after'}
   clear_session  -> RETURNED None
```

The same script against the already-fixed backend:

```
=== AsyncSQLiteSession (fixed by #4109), after close() ===
   add_items / get_items / pop_item / clear_session -> RuntimeError: AsyncSQLiteSession is closed
```

`get_items` returning items and `add_items` returning `None` after the client is closed is the worst shape of this: the caller has no signal that the write went nowhere.

### Fix

Mirrors the merged pattern exactly:

- `self._closed = False` in `__init__`, set to `True` in `close()`.
- A `_check_not_closed()` helper raising `RuntimeError("MongoDBSession is closed")`.
- The check runs when each session-protocol method enters the `_operation()` context manager, so all four methods and `ping()` are covered at a single point. `add_items` checks the flag directly on its empty-list fast path, which returns before doing any work.
- `ping()` is guarded too, matching how #4035 guarded Redis's `ping`.
- Operations register on an `_active_operations` counter guarded by that same `threading.Lock`, and `close()` drains it after marking the session closed and before releasing the client, so an operation that already passed the guard cannot issue its command against a closed client. The other backends get this by holding an `asyncio.Lock` across both the operation and `close()`, which is not available here; the counter also keeps concurrent reads and writes overlapping as they do today, with only `close()` waiting.
- `close()` follows the Redis/Dapr shape: it returns early for an injected client (a no-op, per the documented contract that lifecycle stays with the caller), and for an owned client the session is terminal from the first attempt while `_client_released` tracks whether the release actually completed, so a failed or cancelled `client.close()` is retried by a later `close()`. The release is claimed under the `threading.Lock` this class already uses for `_init_state`, not an `asyncio.Lock`, so concurrent closes are serialized even across event loops and threads — this session is documented as usable from more than one loop, and an `asyncio.Lock` binds to whichever loop first acquires it.

After the fix:

```
=== MongoDBSession, OWNED client (from_uri), after close() ===
   client._closed = True
   add_items      -> RuntimeError: MongoDBSession is closed
   get_items      -> RuntimeError: MongoDBSession is closed
   pop_item       -> RuntimeError: MongoDBSession is closed
   clear_session  -> RuntimeError: MongoDBSession is closed
   close (again)  -> RETURNED None
```

The MongoDB bullet in `docs/sessions/index.md` is also updated: it documented only client ownership, while the Redis and Dapr bullets already state the terminal-after-close behaviour. Translations are generated, so they are left to `make translate_docs`.

### Tests

Fifteen tests added to `tests/extensions/memory/test_mongodb_session.py`, following the convention from #4109:

- all four protocol methods plus `ping` raise after `close()`
- `add_items([])` does not slip past the guard via the empty-list fast path
- `get_items(limit=0)` does not slip past it via the non-positive-limit fast path
- `close()` before any command still makes the session terminal
- concurrent + repeated `close()` are no-ops and the owned client is closed exactly once (the fake client suspends mid-release, without which a same-loop race is unobservable)
- two threads with their own event loops closing at once still release the client exactly once
- a caller waiting on someone else's release observes that release failing, rather than returning success
- cancelling a waiting `close()` does not abort the release it was waiting on (the shared attempt is shielded, so the releasing caller can still publish its outcome)
- an abandoned waiter consumes a failed release's exception, in both cancel/fail interleavings
- `close()` drains an operation that already passed the guard instead of releasing the client underneath it
- `close()` from a second event loop does not raise
- a failed client release is retried by a later `close()` rather than being suppressed
- with an injected client, `close()` stays a no-op and the session keeps working
- a negative control asserting normal operation is unchanged

All six guard tests fail on `main` (`DID NOT RAISE <class 'RuntimeError'>`) and pass with the fix; the negative control passes on both.

`pytest tests/extensions/memory/test_mongodb_session.py` → 52 passed (290 across `tests/extensions/memory`). `ruff check`, `ruff format`, `mypy` and `pyright` are clean on both changed files, and the full suite shows no change against the merge base.
