### PR TITLE
fix: resolve agent tool name collisions consistently

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -115,6 +115,7 @@ from .run import (
     ToolErrorFormatter,
     ToolErrorFormatterArgs,
     ToolExecutionConfig,
+    ToolNameCollisionPolicy,
     ToolNotFoundBehavior,
 )
 from .run_context import AgentHookContext, RunContextWrapper, TContext
@@ -476,6 +477,7 @@ __all__ = [
     "RunResultStreaming",
     "ResponsesWebSocketSession",
     "RunConfig",
+    "ToolNameCollisionPolicy",
     "ReasoningItemIdPolicy",
     "ToolExecutionConfig",
     "ToolErrorFormatter",

--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -5,7 +5,9 @@ from typing import Any, Literal, cast
 
 from typing_extensions import Required, TypedDict
 
+from . import _debug
 from .exceptions import UserError
+from .logger import logger
 
 BareFunctionToolLookupKey = tuple[Literal["bare"], str]
 NamespacedFunctionToolLookupKey = tuple[Literal["namespaced"], str, str]
@@ -317,6 +319,130 @@ def validate_function_tool_namespace_shape(
         "Responses tool-search reserves the synthetic namespace "
         f"`{reserved_key}` for deferred top-level function tools. "
         "Rename the namespace or tool name to avoid ambiguous dispatch."
+    )
+
+
+def _format_tool_name_collision_message(
+    lookup_key: BareFunctionToolLookupKey,
+    entries: Sequence[tuple[str, int, Any]],
+) -> str:
+    """Build a detailed diagnostic for errors or unredacted warnings."""
+    derived_owners: dict[str, str] = {}
+    for entry_type, _, entry in entries:
+        identity_attribute = (
+            "_agent_tool_default_identity" if entry_type == "tool" else "_default_tool_identity"
+        )
+        default_identity = getattr(entry, identity_attribute, None)
+        if not (
+            isinstance(default_identity, tuple)
+            and len(default_identity) == 2
+            and all(isinstance(value, str) for value in default_identity)
+        ):
+            continue
+        agent_name, derived_tool_name = default_identity
+        current_tool_name = (
+            get_function_tool_public_name(entry)
+            if entry_type == "tool"
+            else getattr(entry, "tool_name", None)
+        )
+        if current_tool_name == derived_tool_name:
+            override_parameter = "tool_name" if entry_type == "tool" else "tool_name_override"
+            derived_owners.setdefault(agent_name, override_parameter)
+
+    if len(entries) == 2 and len(derived_owners) == 2:
+        (
+            (prior_agent_name, prior_override_parameter),
+            (agent_name, override_parameter),
+        ) = list(derived_owners.items())[:2]
+        if override_parameter == prior_override_parameter == "tool_name":
+            configuration_type = "agent tool"
+            name_label = "tool name"
+            override_instruction = "`tool_name=`"
+        elif override_parameter == prior_override_parameter == "tool_name_override":
+            configuration_type = "handoff"
+            name_label = "handoff tool name"
+            override_instruction = "`tool_name_override=`"
+        else:
+            configuration_type = "agent routing"
+            name_label = "tool name"
+            override_instruction = "`tool_name=` or `tool_name_override=`"
+        return (
+            f"Ambiguous {configuration_type} configuration: agents "
+            f"{prior_agent_name!r} and {agent_name!r} both derive the {name_label} "
+            f"`{lookup_key[1]}`. Pass an explicit {override_instruction} to one of them."
+        )
+
+    entry_types = {entry_type for entry_type, _, _ in entries}
+    if entry_types == {"tool"}:
+        return (
+            "Ambiguous function tool configuration: the tool name "
+            f"`{lookup_key[1]}` is used by multiple tools. Assign a unique routed name "
+            "to every colliding function tool with `name_override=`, `tool_name=`, or "
+            "a namespace."
+        )
+    if entry_types == {"handoff"}:
+        return (
+            "Ambiguous handoff configuration: the handoff tool name "
+            f"`{lookup_key[1]}` is used by multiple handoffs. Pass a unique "
+            "`tool_name_override=` to each handoff."
+        )
+    return (
+        "Ambiguous tool routing configuration: the tool name "
+        f"`{lookup_key[1]}` is used by both a function tool and a handoff. "
+        "Assign a unique routed name to every colliding function tool and handoff "
+        "with `name_override=`, `tool_name=`, `tool_name_override=`, or a namespace."
+    )
+
+
+def resolve_tool_name_collisions(
+    tools: Sequence[Any],
+    handoffs: Sequence[Any] = (),
+    *,
+    collision_policy: Literal["warn", "error"],
+) -> tuple[list[Any], list[Any]]:
+    """Resolve bare function-tool and handoff name collisions before model exposure."""
+    validate_function_tool_lookup_configuration(tools)
+
+    owners: dict[BareFunctionToolLookupKey, list[tuple[str, int, Any]]] = {}
+    for index, tool in enumerate(tools):
+        lookup_key = get_function_tool_lookup_key_for_tool(tool)
+        if lookup_key is not None and lookup_key[0] == "bare":
+            owners.setdefault(lookup_key, []).append(("tool", index, tool))
+
+    for index, handoff in enumerate(handoffs):
+        tool_name = getattr(handoff, "tool_name", None)
+        if isinstance(tool_name, str) and tool_name:
+            owners.setdefault(("bare", tool_name), []).append(("handoff", index, handoff))
+
+    retained_tool_indices = set(range(len(tools)))
+    retained_handoff_indices = set(range(len(handoffs)))
+    for lookup_key, entries in owners.items():
+        if len(entries) < 2:
+            continue
+
+        if collision_policy == "error":
+            raise UserError(_format_tool_name_collision_message(lookup_key, entries))
+        if _debug.DONT_LOG_TOOL_DATA:
+            logger.warning(
+                "Tool name collision detected. Assign unique routed tool names or enable tool "
+                "data logging for details."
+            )
+        else:
+            logger.warning("%s", _format_tool_name_collision_message(lookup_key, entries))
+
+        handoff_entries = [entry for entry in entries if entry[0] == "handoff"]
+        winner = handoff_entries[-1] if handoff_entries else entries[-1]
+        for entry_type, index, _ in entries:
+            if (entry_type, index) == (winner[0], winner[1]):
+                continue
+            if entry_type == "tool":
+                retained_tool_indices.discard(index)
+            else:
+                retained_handoff_indices.discard(index)
+
+    return (
+        [tool for index, tool in enumerate(tools) if index in retained_tool_indices],
+        [handoff for index, handoff in enumerate(handoffs) if index in retained_handoff_indices],
     )
 
 

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -985,6 +985,8 @@ class Agent(AgentBase, Generic[TContext]):
             ),
         )
         run_agent_tool._is_agent_tool = True
+        if not tool_name:
+            run_agent_tool._agent_tool_default_identity = (self.name, tool_name_resolved)
         run_agent_tool._agent_instance = self
 
         return run_agent_tool

--- a/src/agents/handoffs/__init__.py
+++ b/src/agents/handoffs/__init__.py
@@ -169,6 +169,9 @@ class Handoff(Generic[TContext, TAgent]):
     )
     """Weak reference to the target agent when constructed via `handoff()`."""
 
+    _default_tool_identity: tuple[str, str] | None = field(default=None, kw_only=True, repr=False)
+    """The target agent name and derived tool name when the default was used."""
+
     def get_transfer_message(self, agent: AgentBase[Any]) -> str:
         return json.dumps({"assistant": agent.name})
 
@@ -336,6 +339,7 @@ def handoff(
         nest_handoff_history=nest_handoff_history,
         agent_name=agent.name,
         is_enabled=_is_enabled if callable(is_enabled) else is_enabled,
+        _default_tool_identity=(agent.name, tool_name) if not tool_name_override else None,
     )
     handoff_obj._agent_ref = weakref.ref(agent)
     return handoff_obj

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 from typing_extensions import Unpack
 
 from . import _debug
-from ._tool_identity import get_tool_trace_name_for_tool
 from .agent import Agent
 from .agent_tool_state import set_agent_tool_state_scope
 from .exceptions import (
@@ -42,6 +41,7 @@ from .run_config import (
     ToolErrorFormatter,
     ToolErrorFormatterArgs,
     ToolExecutionConfig,
+    ToolNameCollisionPolicy as ToolNameCollisionPolicy,
     ToolNotFoundBehavior,
     _coerce_run_config,
 )
@@ -87,7 +87,6 @@ from .run_internal.run_grouping import resolve_run_grouping_id
 from .run_internal.run_loop import (
     cleanup_models_after_run,
     get_all_tools,
-    get_handoffs,
     get_output_schema,
     initialize_computer_tools,
     resolve_interrupted_turn,
@@ -143,6 +142,7 @@ __all__ = [
     "ModelInputData",
     "CallModelData",
     "CallModelInputFilter",
+    "ToolNameCollisionPolicy",
     "ReasoningItemIdPolicy",
     "ToolExecutionConfig",
     "ToolErrorFormatter",
@@ -1081,10 +1081,6 @@ class AgentRunner:
                     )
 
                     if current_span is None:
-                        handoff_names = [
-                            h.agent_name
-                            for h in await get_handoffs(execution_agent, context_wrapper)
-                        ]
                         if output_schema := get_output_schema(execution_agent):
                             output_type_name = output_schema.name()
                         else:
@@ -1092,15 +1088,11 @@ class AgentRunner:
 
                         current_span = agent_span(
                             name=current_agent.name,
-                            handoffs=handoff_names,
+                            handoffs=[],
+                            tools=[],
                             output_type=output_type_name,
                         )
                         current_span.start(mark_as_current=True)
-                        current_span.span_data.tools = [
-                            tool_name
-                            for tool in all_tools
-                            if (tool_name := get_tool_trace_name_for_tool(tool)) is not None
-                        ]
 
                     current_turn += 1
                     if max_turns is not None and current_turn > max_turns:
@@ -1268,6 +1260,7 @@ class AgentRunner:
                                     reasoning_item_id_policy=resolved_reasoning_item_id_policy,
                                     prompt_cache_key_resolver=prompt_cache_key_resolver,
                                     error_handlers=error_handlers,
+                                    agent_span=current_span,
                                 )
                             )
 
@@ -1338,6 +1331,7 @@ class AgentRunner:
                                 reasoning_item_id_policy=resolved_reasoning_item_id_policy,
                                 prompt_cache_key_resolver=prompt_cache_key_resolver,
                                 error_handlers=error_handlers,
+                                agent_span=current_span,
                             )
                     finally:
                         if current_turn_span:

--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -74,6 +74,7 @@ class CallModelData(Generic[TContext]):
 CallModelInputFilter = Callable[[CallModelData[Any]], MaybeAwaitable[ModelInputData]]
 ReasoningItemIdPolicy = Literal["preserve", "omit"]
 ToolNotFoundBehavior = Literal["raise_error", "return_error_to_model"]
+ToolNameCollisionPolicy = Literal["warn", "error"]
 
 
 @dataclass
@@ -429,6 +430,15 @@ class RunConfig:
       the run continue.
     """
 
+    tool_name_collision_policy: ToolNameCollisionPolicy = "warn"
+    """Controls collisions between function tool and handoff names.
+
+    - ``"warn"`` logs an actionable warning and exposes only the current dispatch winner.
+    - ``"error"`` raises ``UserError`` before the model is called.
+
+    Existing strict validation for namespaced and deferred-loading tools is unchanged.
+    """
+
     if TYPE_CHECKING:
 
         def __init__(
@@ -456,9 +466,12 @@ class RunConfig:
             sandbox: SandboxRunConfig | dict[str, Any] | None = None,
             tool_execution: ToolExecutionConfig | dict[str, Any] | None = None,
             tool_not_found_behavior: ToolNotFoundBehavior = "raise_error",
+            tool_name_collision_policy: ToolNameCollisionPolicy = "warn",
         ) -> None: ...
 
     def __post_init__(self) -> None:
+        if self.tool_name_collision_policy not in ("warn", "error"):
+            raise ValueError("tool_name_collision_policy must be either 'warn' or 'error'")
         if self.model_settings is not None:
             self.model_settings = _coerce_model_settings(
                 self.model_settings,
@@ -526,6 +539,7 @@ def _coerce_run_config(value: RunConfig | dict[str, Any]) -> RunConfig:
 
 __all__ = [
     "DEFAULT_MAX_TURNS",
+    "ToolNameCollisionPolicy",
     "CallModelData",
     "CallModelInputFilter",
     "ModelInputData",

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -28,6 +28,7 @@ from .._tool_identity import (
     build_function_tool_lookup_map,
     get_function_tool_lookup_key_for_call,
     get_tool_trace_name_for_tool,
+    resolve_tool_name_collisions,
 )
 from ..agent import Agent
 from ..agent_output import AgentOutputSchemaBase
@@ -990,9 +991,6 @@ async def start_streaming(
             )
 
             if current_span is None:
-                handoff_names = [
-                    h.agent_name for h in await get_handoffs(execution_agent, context_wrapper)
-                ]
                 if output_schema := get_output_schema(execution_agent):
                     output_type_name = output_schema.name()
                 else:
@@ -1000,16 +998,11 @@ async def start_streaming(
 
                 current_span = agent_span(
                     name=current_agent.name,
-                    handoffs=handoff_names,
+                    handoffs=[],
+                    tools=[],
                     output_type=output_type_name,
                 )
                 current_span.start(mark_as_current=True)
-                tool_names = [
-                    tool_name
-                    for tool in all_tools
-                    if (tool_name := get_tool_trace_name_for_tool(tool)) is not None
-                ]
-                current_span.span_data.tools = tool_names
 
             current_turn += 1
             streamed_result.current_turn = current_turn
@@ -1176,6 +1169,7 @@ async def start_streaming(
                         reasoning_item_id_policy=resolved_reasoning_item_id_policy,
                         prompt_cache_key_resolver=prompt_cache_key_resolver,
                         error_handlers=error_handlers,
+                        agent_span=current_span,
                     )
                 finally:
                     if current_turn_span:
@@ -1422,6 +1416,7 @@ async def run_single_turn_streamed(
     reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
     prompt_cache_key_resolver: PromptCacheKeyResolver | None = None,
     error_handlers: RunErrorHandlers[TContext] | None = None,
+    agent_span: Span[AgentSpanData] | None = None,
 ) -> SingleStepResult:
     """Run a single streamed turn and emit events as results arrive."""
     public_agent = bindings.public_agent
@@ -1447,21 +1442,6 @@ async def run_single_turn_streamed(
     emitted_tool_call_ids: set[str] = set()
     emitted_reasoning_item_ids: set[str] = set()
     emitted_tool_search_fingerprints: set[str] = set()
-    # Precompute the lookup map used for streaming descriptions. Function tools use the same
-    # collision-free lookup keys as runtime dispatch, including deferred top-level aliases.
-    tool_map: dict[NamedToolLookupKey, Any] = cast(
-        dict[NamedToolLookupKey, Any],
-        build_function_tool_lookup_map(
-            [tool for tool in all_tools if isinstance(tool, FunctionTool)]
-        ),
-    )
-    for tool in all_tools:
-        tool_name = getattr(tool, "name", None)
-        if not isinstance(tool_name, str) or not tool_name:
-            continue
-        if isinstance(tool, FunctionTool):
-            continue
-        tool_map[tool_name] = tool
 
     def _tool_search_fingerprint(raw_item: Any) -> str:
         if isinstance(raw_item, Mapping):
@@ -1508,6 +1488,34 @@ async def run_single_turn_streamed(
     )
 
     handoffs = await get_handoffs(execution_agent, context_wrapper)
+    all_tools, handoffs = resolve_tool_name_collisions(
+        all_tools,
+        handoffs,
+        collision_policy=run_config.tool_name_collision_policy,
+    )
+    if agent_span is not None:
+        agent_span.span_data.handoffs = [handoff.agent_name for handoff in handoffs]
+        agent_span.span_data.tools = [
+            tool_name
+            for tool in all_tools
+            if (tool_name := get_tool_trace_name_for_tool(tool)) is not None
+        ]
+
+    # Precompute the lookup map used for streaming descriptions. Function tools use the same
+    # collision-free lookup keys as runtime dispatch, including deferred top-level aliases.
+    tool_map: dict[NamedToolLookupKey, Any] = cast(
+        dict[NamedToolLookupKey, Any],
+        build_function_tool_lookup_map(
+            [tool for tool in all_tools if isinstance(tool, FunctionTool)]
+        ),
+    )
+    for tool in all_tools:
+        tool_name = getattr(tool, "name", None)
+        if not isinstance(tool_name, str) or not tool_name:
+            continue
+        if isinstance(tool, FunctionTool):
+            continue
+        tool_map[tool_name] = tool
     model = get_model(execution_agent, run_config)
     tool_use_tracker.record_model(model)
     model_settings = get_model_settings(execution_agent, run_config)
@@ -1886,6 +1894,7 @@ async def run_single_turn(
     reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
     prompt_cache_key_resolver: PromptCacheKeyResolver | None = None,
     error_handlers: RunErrorHandlers[TContext] | None = None,
+    agent_span: Span[AgentSpanData] | None = None,
 ) -> SingleStepResult:
     """Run a single non-streaming turn of the agent loop."""
     public_agent = bindings.public_agent
@@ -1917,8 +1926,21 @@ async def run_single_turn(
         execution_agent.get_prompt(context_wrapper),
     )
 
-    output_schema = get_output_schema(execution_agent)
     handoffs = await get_handoffs(execution_agent, context_wrapper)
+    all_tools, handoffs = resolve_tool_name_collisions(
+        all_tools,
+        handoffs,
+        collision_policy=run_config.tool_name_collision_policy,
+    )
+    if agent_span is not None:
+        agent_span.span_data.handoffs = [handoff.agent_name for handoff in handoffs]
+        agent_span.span_data.tools = [
+            tool_name
+            for tool in all_tools
+            if (tool_name := get_tool_trace_name_for_tool(tool)) is not None
+        ]
+
+    output_schema = get_output_schema(execution_agent)
     if server_conversation_tracker is not None:
         input = server_conversation_tracker.prepare_input(original_input, generated_items)
     else:

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -546,6 +546,11 @@ class FunctionTool:
     _is_agent_tool: bool = field(default=False, kw_only=True, repr=False)
     """Internal flag indicating if this tool is an agent-as-tool."""
 
+    _agent_tool_default_identity: tuple[str, str] | None = field(
+        default=None, kw_only=True, repr=False
+    )
+    """The source agent name and derived tool name when the default was used."""
+
     _is_codex_tool: bool = field(default=False, kw_only=True, repr=False)
     """Internal flag indicating if this tool is a Codex tool wrapper."""
 

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -34,8 +34,10 @@ from agents import (
     ToolCallOutputItem,
     TResponseInputItem,
     Usage,
+    UserError,
     tool_namespace,
 )
+from agents._tool_identity import resolve_tool_name_collisions
 from agents.agent_tool_input import StructuredToolInputBuilderOptions
 from agents.agent_tool_state import (
     get_agent_tool_state_scope,
@@ -54,6 +56,165 @@ from tests.utils.hitl import make_function_tool_call
 
 class BoolCtx(BaseModel):
     enable_tools: bool
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_rejects_colliding_derived_names():
+    refund = Agent(name="Refund")
+    normalized_refund = Agent(name="refund")
+    orchestrator = Agent(
+        name="orchestrator",
+        tools=[
+            refund.as_tool(tool_name=None, tool_description="First refund agent"),
+            normalized_refund.as_tool(tool_name=None, tool_description="Second refund agent"),
+        ],
+    )
+
+    tools = await orchestrator.get_all_tools(RunContextWrapper(None))
+    with pytest.raises(UserError) as exc_info:
+        resolve_tool_name_collisions(tools, collision_policy="error")
+
+    assert str(exc_info.value) == (
+        "Ambiguous agent tool configuration: agents 'Refund' and 'refund' both derive the tool "
+        "name `refund`. Pass an explicit `tool_name=` to one of them."
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_derived_name_collision_allows_explicit_override():
+    refund = Agent(name="Refund")
+    normalized_refund = Agent(name="refund")
+    orchestrator = Agent(
+        name="orchestrator",
+        tools=[
+            refund.as_tool(tool_name=None, tool_description="First refund agent"),
+            normalized_refund.as_tool(
+                tool_name="normalized_refund",
+                tool_description="Second refund agent",
+            ),
+        ],
+    )
+
+    tools = await orchestrator.get_all_tools(RunContextWrapper(None))
+
+    assert [tool.name for tool in tools] == ["refund", "normalized_refund"]
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_rejects_distinct_agents_with_the_same_name():
+    orchestrator = Agent(
+        name="orchestrator",
+        tools=[
+            Agent(name="Refund").as_tool(
+                tool_name=None,
+                tool_description="First refund agent",
+            ),
+            Agent(name="Refund").as_tool(
+                tool_name=None,
+                tool_description="Second refund agent",
+            ),
+        ],
+    )
+
+    tools = await orchestrator.get_all_tools(RunContextWrapper(None))
+    with pytest.raises(UserError, match="the tool name `refund` is used by multiple tools"):
+        resolve_tool_name_collisions(tools, collision_policy="error")
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_warns_and_keeps_last_distinct_agent_with_the_same_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    first_tool = Agent(name="Refund").as_tool(
+        tool_name=None,
+        tool_description="First refund agent",
+    )
+    second_tool = Agent(name="Refund").as_tool(
+        tool_name=None,
+        tool_description="Second refund agent",
+    )
+    orchestrator = Agent(name="orchestrator", tools=[first_tool, second_tool])
+    tools = await orchestrator.get_all_tools(RunContextWrapper(None))
+
+    with caplog.at_level("WARNING", logger="openai.agents"):
+        resolved_tools, _ = resolve_tool_name_collisions(tools, collision_policy="warn")
+
+    assert resolved_tools == [second_tool]
+    assert caplog.messages == [
+        "Ambiguous function tool configuration: the tool name `refund` is used by multiple "
+        "tools. Assign a unique routed name to every colliding function tool with "
+        "`name_override=`, `tool_name=`, or a namespace."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_ignores_disabled_derived_name_collision():
+    refund = Agent(name="Refund")
+    normalized_refund = Agent(name="refund")
+    orchestrator = Agent(
+        name="orchestrator",
+        tools=[
+            refund.as_tool(tool_name=None, tool_description="First refund agent"),
+            normalized_refund.as_tool(
+                tool_name=None,
+                tool_description="Second refund agent",
+                is_enabled=False,
+            ),
+        ],
+    )
+
+    tools = await orchestrator.get_all_tools(RunContextWrapper(None))
+
+    assert [tool.name for tool in tools] == ["refund"]
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_default_identity_tracks_the_current_tool_name():
+    refund = Agent(name="Refund")
+    derived_tool = refund.as_tool(tool_name=None, tool_description="Refund agent")
+    copied_tool = dataclasses.replace(derived_tool)
+    renamed_tool = dataclasses.replace(derived_tool, name="renamed_refund")
+    normalized_refund = Agent(name="refund")
+    colliding_tool = normalized_refund.as_tool(
+        tool_name=None,
+        tool_description="Normalized refund agent",
+    )
+
+    copied_orchestrator = Agent(name="copied", tools=[copied_tool, colliding_tool])
+    copied_tools = await copied_orchestrator.get_all_tools(RunContextWrapper(None))
+    with pytest.raises(UserError, match="Ambiguous agent tool configuration"):
+        resolve_tool_name_collisions(copied_tools, collision_policy="error")
+
+    renamed_orchestrator = Agent(name="renamed", tools=[renamed_tool, colliding_tool])
+    tools = await renamed_orchestrator.get_all_tools(RunContextWrapper(None))
+    resolve_tool_name_collisions(tools, collision_policy="error")
+    assert [tool.name for tool in tools] == ["renamed_refund", "refund"]
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_derived_names_are_disambiguated_by_namespace():
+    refund = Agent(name="Refund").as_tool(tool_name=None, tool_description="Sales refunds")
+    normalized_refund = Agent(name="refund").as_tool(
+        tool_name=None,
+        tool_description="Support refunds",
+    )
+    sales_refund = tool_namespace(name="sales", description="Sales", tools=[refund])[0]
+    support_refund = tool_namespace(
+        name="support",
+        description="Support",
+        tools=[normalized_refund],
+    )[0]
+    orchestrator = Agent(name="orchestrator", tools=[sales_refund, support_refund])
+
+    tools = await orchestrator.get_all_tools(RunContextWrapper(None))
+
+    assert all(isinstance(tool, FunctionTool) for tool in tools)
+    assert [cast(FunctionTool, tool).qualified_name for tool in tools] == [
+        "sales.refund",
+        "support.refund",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import tempfile
 import warnings
 from collections.abc import Callable
@@ -39,6 +40,7 @@ from agents import (
     ToolExecutionConfig,
     ToolGuardrailFunctionOutput,
     ToolInputGuardrailData,
+    ToolNameCollisionPolicy,
     ToolTimeoutError,
     UserError,
     handoff,
@@ -46,6 +48,7 @@ from agents import (
     tool_input_guardrail,
     tool_namespace,
 )
+from agents._tool_identity import resolve_tool_name_collisions
 from agents.agent import ToolsToFinalOutputResult
 from agents.computer import Computer
 from agents.items import (
@@ -166,6 +169,360 @@ async def _run_agent_with_optional_streaming(
             pass
         return result
     return await Runner.run(agent, input=input, **kwargs)
+
+
+@pytest.mark.parametrize("surface", ["agent_tool", "handoff", "mixed"])
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("collision_policy", ["warn", "error"])
+@pytest.mark.asyncio
+async def test_run_reports_derived_agent_name_collisions_before_model_call(
+    surface: str,
+    streamed: bool,
+    collision_policy: ToolNameCollisionPolicy,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    model = FakeModel(initial_output=[get_text_message("done")])
+    billing = Agent(name="Billing Agent")
+    normalized_billing = Agent(name="billing agent")
+    if surface == "agent_tool":
+        agent = Agent(
+            name="triage",
+            model=model,
+            tools=[
+                billing.as_tool(tool_name=None, tool_description="First billing agent"),
+                normalized_billing.as_tool(
+                    tool_name=None,
+                    tool_description="Second billing agent",
+                ),
+            ],
+        )
+    elif surface == "handoff":
+        agent = Agent(
+            name="triage",
+            model=model,
+            handoffs=[billing, normalized_billing],
+        )
+    else:
+        agent = Agent(
+            name="triage",
+            model=model,
+            tools=[
+                Agent(name="transfer to Billing Agent").as_tool(
+                    tool_name=None,
+                    tool_description="Billing tool",
+                )
+            ],
+            handoffs=[billing],
+        )
+
+    run_config = RunConfig(tool_name_collision_policy=collision_policy)
+    if collision_policy == "error":
+        with pytest.raises(
+            UserError,
+            match="Ambiguous (agent tool|handoff|agent routing) configuration",
+        ):
+            await _run_agent_with_optional_streaming(
+                agent,
+                input="Route this request",
+                streamed=streamed,
+                run_config=run_config,
+            )
+
+        assert model.first_turn_args is None
+        assert not model.last_turn_args
+    else:
+        with caplog.at_level("WARNING", logger="openai.agents"):
+            await _run_agent_with_optional_streaming(
+                agent,
+                input="Route this request",
+                streamed=streamed,
+                run_config=run_config,
+            )
+
+        assert model.first_turn_args is not None
+        collision_messages = [
+            message for message in caplog.messages if message.startswith("Ambiguous ")
+        ]
+        assert len(collision_messages) == 1
+        assert "Pass an explicit" in collision_messages[0]
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_run_warns_and_keeps_last_duplicate_function_tool(
+    streamed: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    calls: list[str] = []
+
+    @function_tool(name_override="lookup")
+    def first_lookup() -> str:
+        calls.append("first")
+        return "first"
+
+    @function_tool(name_override="lookup")
+    def second_lookup() -> str:
+        calls.append("second")
+        return "second"
+
+    model = FakeModel(initial_output=[get_function_tool_call("lookup", "{}")])
+    model.set_next_output([get_text_message("done")])
+    agent = Agent(name="agent", model=model, tools=[first_lookup, second_lookup])
+
+    with caplog.at_level("WARNING", logger="openai.agents"):
+        await _run_agent_with_optional_streaming(
+            agent,
+            input="Look this up",
+            streamed=streamed,
+        )
+
+    assert calls == ["second"]
+    assert model.first_turn_args is not None
+    assert model.first_turn_args["tools"] == [second_lookup]
+    collision_messages = [
+        message for message in caplog.messages if message.startswith("Ambiguous ")
+    ]
+    assert len(collision_messages) == 2
+    assert all(
+        message
+        == (
+            "Ambiguous function tool configuration: the tool name `lookup` is used by multiple "
+            "tools. Assign a unique routed name to every colliding function tool with "
+            "`name_override=`, `tool_name=`, or a namespace."
+        )
+        for message in collision_messages
+    )
+
+
+def test_collision_warning_redacts_tool_data(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    secret_tool_name = "tenant_secret_tool_token"
+
+    @function_tool(name_override=secret_tool_name)
+    def first_tool() -> str:
+        return "first"
+
+    @function_tool(name_override=secret_tool_name)
+    def second_tool() -> str:
+        return "second"
+
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", True)
+    with caplog.at_level("WARNING", logger="openai.agents"):
+        resolved_tools, resolved_handoffs = resolve_tool_name_collisions(
+            [first_tool, second_tool],
+            collision_policy="warn",
+        )
+
+    assert resolved_tools == [second_tool]
+    assert resolved_handoffs == []
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.msg == (
+        "Tool name collision detected. Assign unique routed tool names or enable tool data "
+        "logging for details."
+    )
+    assert record.args == ()
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert all(
+        secret_tool_name not in value
+        for value in record.__dict__.values()
+        if isinstance(value, str)
+    )
+    assert secret_tool_name not in logging.Formatter().format(record)
+
+
+def test_collision_warning_preserves_tool_diagnostics_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tool_name = "diagnostic_tool_name"
+
+    @function_tool(name_override=tool_name)
+    def first_tool() -> str:
+        return "first"
+
+    @function_tool(name_override=tool_name)
+    def second_tool() -> str:
+        return "second"
+
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    with caplog.at_level("WARNING", logger="openai.agents"):
+        resolve_tool_name_collisions(
+            [first_tool, second_tool],
+            collision_policy="warn",
+        )
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.msg == "%s"
+    assert isinstance(record.args, tuple)
+    assert len(record.args) == 1
+    assert isinstance(record.args[0], str)
+    assert tool_name in record.args[0]
+    assert tool_name in logging.Formatter().format(record)
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_run_rejects_duplicate_function_tools_in_error_mode(streamed: bool) -> None:
+    @function_tool(name_override="lookup")
+    def first_lookup() -> str:
+        return "first"
+
+    @function_tool(name_override="lookup")
+    def second_lookup() -> str:
+        return "second"
+
+    model = FakeModel(initial_output=[get_text_message("done")])
+    agent = Agent(name="agent", model=model, tools=[first_lookup, second_lookup])
+
+    with pytest.raises(
+        UserError,
+        match="the tool name `lookup` is used by multiple tools",
+    ):
+        await _run_agent_with_optional_streaming(
+            agent,
+            input="Look this up",
+            streamed=streamed,
+            run_config=RunConfig(tool_name_collision_policy="error"),
+        )
+
+    assert model.first_turn_args is None
+
+
+@pytest.mark.asyncio
+async def test_run_warns_once_for_repeated_source_agent_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    model = FakeModel(initial_output=[get_text_message("done")])
+    agent = Agent(
+        name="orchestrator",
+        model=model,
+        tools=[
+            Agent(name="Refund").as_tool(tool_name=None, tool_description="First refund agent"),
+            Agent(name="refund").as_tool(tool_name=None, tool_description="Second refund agent"),
+            Agent(name="refund").as_tool(tool_name=None, tool_description="Third refund agent"),
+        ],
+    )
+
+    with caplog.at_level("WARNING", logger="openai.agents"):
+        await Runner.run(agent, "Route this request")
+
+    collision_messages = [
+        message for message in caplog.messages if message.startswith("Ambiguous ")
+    ]
+    assert collision_messages == [
+        "Ambiguous function tool configuration: the tool name `refund` is used by multiple "
+        "tools. Assign a unique routed name to every colliding function tool with "
+        "`name_override=`, `tool_name=`, or a namespace."
+    ]
+    assert model.first_turn_args is not None
+    assert model.first_turn_args["tools"] == [agent.tools[-1]]
+
+
+def test_multiway_mixed_collision_reports_every_owner_must_be_unique(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    @function_tool(name_override="route")
+    def first_route() -> str:
+        return "first"
+
+    @function_tool(name_override="route")
+    def second_route() -> str:
+        return "second"
+
+    route_handoff = handoff(Agent(name="Billing"), tool_name_override="route")
+
+    with caplog.at_level("WARNING", logger="openai.agents"):
+        resolved_tools, resolved_handoffs = resolve_tool_name_collisions(
+            [first_route, second_route],
+            [route_handoff],
+            collision_policy="warn",
+        )
+
+    assert resolved_tools == []
+    assert resolved_handoffs == [route_handoff]
+    assert caplog.messages == [
+        "Ambiguous tool routing configuration: the tool name `route` is used by both a function "
+        "tool and a handoff. Assign a unique routed name to every colliding function tool and "
+        "handoff with `name_override=`, `tool_name=`, `tool_name_override=`, or a namespace."
+    ]
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_handoff_enablement_uses_initialized_turn_context(streamed: bool) -> None:
+    model = FakeModel()
+    target = Agent(name="target", model=model)
+    model.add_multiple_turn_outputs(
+        [
+            [get_handoff_tool_call(target)],
+            [get_text_message("done")],
+        ]
+    )
+    observed_context: list[tuple[list[TResponseInputItem], dict[str, bool]]] = []
+
+    class InitializeContextHooks(RunHooks[dict[str, bool]]):
+        async def on_agent_start(self, context, agent) -> None:
+            if agent.name == "source":
+                context.context["hook_initialized"] = True
+
+    def dynamic_prompt(data):
+        data.context.context["prompt_initialized"] = True
+        return {"id": "prompt-id"}
+
+    def handoff_is_enabled(context: RunContextWrapper[dict[str, bool]], agent: Agent[Any]) -> bool:
+        observed_context.append((list(context.turn_input), dict(context.context)))
+        return (
+            agent.name == "source"
+            and context.turn_input == [{"content": "current turn", "role": "user"}]
+            and context.context.get("hook_initialized") is True
+            and context.context.get("prompt_initialized") is True
+        )
+
+    source = Agent(
+        name="source",
+        model=model,
+        prompt=dynamic_prompt,
+        handoffs=[handoff(target, is_enabled=handoff_is_enabled)],
+    )
+    hooks = InitializeContextHooks()
+
+    if streamed:
+        result = Runner.run_streamed(
+            source,
+            "current turn",
+            context={},
+            hooks=hooks,
+        )
+        async for _ in result.stream_events():
+            pass
+    else:
+        await Runner.run(
+            source,
+            "current turn",
+            context={},
+            hooks=hooks,
+        )
+
+    assert observed_context == [
+        (
+            [{"content": "current turn", "role": "user"}],
+            {"hook_initialized": True, "prompt_initialized": True},
+        )
+    ]
 
 
 def test_set_default_agent_runner_roundtrip():

--- a/tests/test_agent_tracing.py
+++ b/tests/test_agent_tracing.py
@@ -70,6 +70,66 @@ async def test_single_run_is_single_trace():
     )
 
 
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("surface", ["function_tool", "handoff", "mixed"])
+@pytest.mark.asyncio
+async def test_agent_span_uses_resolved_tool_name_collision_view(
+    surface: str,
+    streamed: bool,
+) -> None:
+    model = FakeModel(initial_output=[get_text_message("done")])
+    expected_tools: list[str]
+    expected_handoffs: list[str]
+
+    if surface == "function_tool":
+
+        @function_tool(name_override="lookup")
+        def first_lookup() -> str:
+            return "first"
+
+        @function_tool(name_override="lookup")
+        def second_lookup() -> str:
+            return "second"
+
+        agent = Agent(name="test_agent", model=model, tools=[first_lookup, second_lookup])
+        expected_tools = ["lookup"]
+        expected_handoffs = []
+    elif surface == "handoff":
+        agent = Agent(
+            name="test_agent",
+            model=model,
+            handoffs=[Agent(name="Billing Agent"), Agent(name="billing agent")],
+        )
+        expected_tools = []
+        expected_handoffs = ["billing agent"]
+    else:
+        agent = Agent(
+            name="test_agent",
+            model=model,
+            tools=[
+                Agent(name="transfer to Billing Agent").as_tool(
+                    tool_name=None,
+                    tool_description="Billing tool",
+                )
+            ],
+            handoffs=[Agent(name="Billing Agent")],
+        )
+        expected_tools = []
+        expected_handoffs = ["Billing Agent"]
+
+    if streamed:
+        result = Runner.run_streamed(agent, input="test")
+        async for _ in result.stream_events():
+            pass
+    else:
+        await Runner.run(agent, input="test")
+
+    agent_spans = [span for span in fetch_ordered_spans() if span.span_data.type == "agent"]
+    assert len(agent_spans) == 1
+    assert agent_spans[0].span_data.tools == expected_tools
+    assert agent_spans[0].span_data.handoffs == expected_handoffs
+
+
 @pytest.mark.asyncio
 async def test_task_and_turn_spans_export_aggregate_usage():
     @function_tool

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import inspect
 import json
 import logging
@@ -8,6 +9,7 @@ import pytest
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from pydantic import BaseModel
 
+import agents._debug as _debug
 from agents import (
     Agent,
     Handoff,
@@ -18,6 +20,7 @@ from agents import (
     UserError,
     handoff,
 )
+from agents._tool_identity import resolve_tool_name_collisions
 from agents.run_internal.run_loop import get_handoffs
 
 
@@ -81,6 +84,123 @@ async def test_multiple_handoffs_setup():
 
     assert handoff_objects[0].agent_name == agent_1.name
     assert handoff_objects[1].agent_name == agent_2.name
+
+
+@pytest.mark.asyncio
+async def test_handoffs_reject_colliding_derived_names():
+    billing = Agent(name="Billing Agent")
+    normalized_billing = Agent(name="billing agent")
+    triage = Agent(name="triage", handoffs=[billing, normalized_billing])
+
+    handoffs = await get_handoffs(triage, RunContextWrapper(None))
+    with pytest.raises(UserError) as exc_info:
+        resolve_tool_name_collisions((), handoffs, collision_policy="error")
+
+    assert str(exc_info.value) == (
+        "Ambiguous handoff configuration: agents 'Billing Agent' and 'billing agent' both derive "
+        "the handoff tool name `transfer_to_billing_agent`. Pass an explicit "
+        "`tool_name_override=` to one of them."
+    )
+
+
+@pytest.mark.asyncio
+async def test_handoff_derived_name_collision_allows_explicit_override():
+    billing = Agent(name="Billing Agent")
+    normalized_billing = Agent(name="billing agent")
+    triage = Agent(
+        name="triage",
+        handoffs=[
+            billing,
+            handoff(normalized_billing, tool_name_override="transfer_to_normalized_billing"),
+        ],
+    )
+
+    handoffs = await get_handoffs(triage, RunContextWrapper(None))
+
+    assert [item.tool_name for item in handoffs] == [
+        "transfer_to_billing_agent",
+        "transfer_to_normalized_billing",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handoff_rejects_distinct_agents_with_the_same_name():
+    triage = Agent(
+        name="triage",
+        handoffs=[Agent(name="Billing"), Agent(name="Billing")],
+    )
+
+    handoffs = await get_handoffs(triage, RunContextWrapper(None))
+    with pytest.raises(
+        UserError,
+        match="handoff tool name `transfer_to_billing` is used by multiple handoffs",
+    ):
+        resolve_tool_name_collisions((), handoffs, collision_policy="error")
+
+
+@pytest.mark.asyncio
+async def test_handoff_warns_and_keeps_last_distinct_agent_with_the_same_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    triage = Agent(
+        name="triage",
+        handoffs=[Agent(name="Billing"), Agent(name="Billing")],
+    )
+    handoffs = await get_handoffs(triage, RunContextWrapper(None))
+
+    with caplog.at_level("WARNING", logger="openai.agents"):
+        _, resolved_handoffs = resolve_tool_name_collisions(
+            (),
+            handoffs,
+            collision_policy="warn",
+        )
+
+    assert resolved_handoffs == [handoffs[1]]
+    assert any(
+        "handoff tool name `transfer_to_billing` is used by multiple handoffs" in message
+        for message in caplog.messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_handoffs_ignore_disabled_derived_name_collision():
+    billing = Agent(name="Billing Agent")
+    normalized_billing = Agent(name="billing agent")
+    triage = Agent(
+        name="triage",
+        handoffs=[billing, handoff(normalized_billing, is_enabled=False)],
+    )
+
+    handoffs = await get_handoffs(triage, RunContextWrapper(None))
+
+    assert [item.agent_name for item in handoffs] == ["Billing Agent"]
+
+
+@pytest.mark.asyncio
+async def test_handoff_default_identity_tracks_the_current_tool_name():
+    billing = Agent(name="Billing Agent")
+    derived_handoff = handoff(billing)
+    copied_handoff = dataclasses.replace(derived_handoff)
+    renamed_handoff = dataclasses.replace(
+        derived_handoff,
+        tool_name="transfer_to_primary_billing",
+    )
+    normalized_billing = Agent(name="billing agent")
+
+    copied_triage = Agent(name="copied", handoffs=[copied_handoff, normalized_billing])
+    copied_handoffs = await get_handoffs(copied_triage, RunContextWrapper(None))
+    with pytest.raises(UserError, match="Ambiguous handoff configuration"):
+        resolve_tool_name_collisions((), copied_handoffs, collision_policy="error")
+
+    renamed_triage = Agent(name="renamed", handoffs=[renamed_handoff, normalized_billing])
+    handoffs = await get_handoffs(renamed_triage, RunContextWrapper(None))
+    resolve_tool_name_collisions((), handoffs, collision_policy="error")
+    assert [item.tool_name for item in handoffs] == [
+        "transfer_to_primary_billing",
+        "transfer_to_billing_agent",
+    ]
 
 
 def test_default_handoff_tool_name_allows_whitespace_without_warning(

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 from agents import (
@@ -8,10 +10,12 @@ from agents import (
     Runner,
     SessionSettings,
     ToolExecutionConfig,
+    ToolNameCollisionPolicy,
     ToolNotFoundBehavior,
 )
 from agents.model_settings import ModelSettings
 from agents.models.interface import Model, ModelProvider
+from agents.run import __all__ as run_exports
 from agents.run_config import SandboxConcurrencyLimits, SandboxRunConfig
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.snapshot import NoopSnapshotSpec
@@ -322,3 +326,43 @@ def test_tool_not_found_behavior_is_public_from_agents_package() -> None:
     config = RunConfig(tool_not_found_behavior=behavior)
 
     assert config.tool_not_found_behavior == "return_error_to_model"
+
+
+def test_tool_name_collision_policy_defaults_to_warn() -> None:
+    config = RunConfig()
+
+    assert config.tool_name_collision_policy == "warn"
+
+
+def test_tool_name_collision_policy_is_public_from_agents_package() -> None:
+    policy: ToolNameCollisionPolicy = "error"
+    config = RunConfig(tool_name_collision_policy=policy)
+
+    assert config.tool_name_collision_policy == "error"
+    assert "ToolNameCollisionPolicy" in run_exports
+
+
+def test_tool_name_collision_policy_rejects_invalid_value() -> None:
+    with pytest.raises(
+        ValueError,
+        match="tool_name_collision_policy must be either 'warn' or 'error'",
+    ):
+        RunConfig(tool_name_collision_policy=cast(Any, "erorr"))
+
+
+@pytest.mark.asyncio
+async def test_runner_dictionary_rejects_invalid_tool_name_collision_policy() -> None:
+    model = FakeModel(initial_output=[get_text_message("done")])
+    agent = Agent(name="test", model=model)
+
+    with pytest.raises(
+        ValueError,
+        match="tool_name_collision_policy must be either 'warn' or 'error'",
+    ):
+        await Runner.run(
+            agent,
+            "hello",
+            run_config={"tool_name_collision_policy": cast(Any, "erorr")},
+        )
+
+    assert model.first_turn_args is None

--- a/tests/test_source_compat_constructors.py
+++ b/tests/test_source_compat_constructors.py
@@ -169,6 +169,44 @@ def test_run_config_tool_not_found_behavior_append_preserves_tool_execution_posi
     assert config.tool_not_found_behavior == "return_error_to_model"
 
 
+def test_run_config_tool_name_collision_policy_append_preserves_prior_positions() -> None:
+    session_settings = SessionSettings(limit=123)
+    tool_execution = ToolExecutionConfig(max_function_tool_concurrency=2)
+    config = RunConfig(
+        None,
+        MultiProvider(),
+        None,
+        None,
+        False,
+        None,
+        None,
+        None,
+        False,
+        None,
+        True,
+        "Agent workflow",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        session_settings,
+        "omit",
+        None,
+        tool_execution,
+        "return_error_to_model",
+        "error",
+    )
+
+    assert config.session_settings == session_settings
+    assert config.reasoning_item_id_policy == "omit"
+    assert config.sandbox is None
+    assert config.tool_execution is tool_execution
+    assert config.tool_not_found_behavior == "return_error_to_model"
+    assert config.tool_name_collision_policy == "error"
+
+
 def test_tool_execution_config_pre_approval_append_preserves_max_concurrency() -> None:
     config = ToolExecutionConfig(2, True)
 

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -249,7 +249,7 @@ async def test_multiple_handoff_doesnt_error():
                         "type": "agent",
                         "data": {
                             "name": "test",
-                            "handoffs": ["test", "test"],
+                            "handoffs": ["test"],
                             "tools": ["some_function"],
                             "output_type": "str",
                         },

--- a/tests/test_tracing_errors_streamed.py
+++ b/tests/test_tracing_errors_streamed.py
@@ -314,7 +314,7 @@ async def test_multiple_handoff_doesnt_error():
                         "type": "agent",
                         "data": {
                             "name": "test",
-                            "handoffs": ["test", "test"],
+                            "handoffs": ["test"],
                             "tools": ["some_function"],
                             "output_type": "str",
                         },


### PR DESCRIPTION
This pull request fixes ambiguous tool names derived from agents used through `Agent.as_tool()` or handoffs.

It adds `tool_name_collision_policy` with a backward-compatible `"warn"` default and an opt-in `"error"` mode. Warning mode exposes only the existing dispatch winner to the model, while error mode raises `UserError` before the model is called.

Handoff enablement is evaluated after the current turn input, agent start hooks, and dynamic prompt have been initialized. The resulting tool and handoff lists are resolved once and shared across agent span metadata, model exposure, retries, and dispatch.

Collision warnings also respect `OPENAI_AGENTS_DONT_LOG_TOOL_DATA`. Redacted mode emits a fixed generic warning without attaching tool or agent names, while diagnostic mode retains actionable collision details.

The same policy covers duplicate ordinary function tool names, partially addressing #4116 without changing the default to an unconditional error.

This pull request resolves #4118. Related to #4116.

 Docs will be updated separately.