### PR TITLE
fix(schema): normalize typeless strict object schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -20,6 +20,13 @@ _EMPTY_SCHEMA = {
 # example, tool schemas advertised by a third-party MCP server).
 _MAX_SCHEMA_NODES = 100_000
 
+_ADDITIONAL_PROPERTIES_ERROR = (
+    "additionalProperties should not be set for object types. This could be because "
+    "you're using an older version of Pydantic, or because you configured additional "
+    "properties to be allowed. If you really need this, update the function or output tool "
+    "to not use a strict schema."
+)
+
 
 class _NodeBudget:
     """Tracks the remaining schema-node expansion budget across the recursion."""
@@ -45,9 +52,27 @@ def ensure_strict_json_schema(
     """
     if schema == {}:
         return copy.deepcopy(_EMPTY_SCHEMA)
-    return _ensure_strict_json_schema(
+    converted = _ensure_strict_json_schema(
         schema, path=(), root=schema, budget=_NodeBudget(_MAX_SCHEMA_NODES)
     )
+    return _ensure_strict_root(converted)
+
+
+def _ensure_strict_root(schema: dict[str, Any]) -> dict[str, Any]:
+    if is_list(schema.get("anyOf")):
+        raise UserError("The root of a strict JSON schema must not use `anyOf`.")
+
+    typ = schema.get("type")
+    if is_list(typ) and "object" in typ:
+        if typ == ["object"]:
+            schema["type"] = "object"
+        else:
+            raise UserError(
+                "The root of a strict JSON schema must be a non-nullable object, but its type is "
+                f"{typ}. Make the root a plain object, or update the function or output tool to "
+                "not use a strict schema."
+            )
+    return schema
 
 
 # Adapted from https://github.com/openai/openai-python/blob/main/src/openai/lib/_pydantic.py
@@ -85,26 +110,26 @@ def _ensure_strict_json_schema(
             )
 
     typ = json_schema.get("type")
-    if typ == "object" and "additionalProperties" not in json_schema:
+    properties = json_schema.get("properties")
+    if typ is None and is_dict(properties):
+        typ = json_schema["type"] = "object"
+    elif typ is None and json_schema.get("additionalProperties", False) is not False:
+        raise UserError(_ADDITIONAL_PROPERTIES_ERROR)
+    is_object = typ == "object" or (is_list(typ) and "object" in typ)
+    if is_object and "additionalProperties" not in json_schema:
         json_schema["additionalProperties"] = False
     elif (
-        typ == "object"
+        is_object
         and "additionalProperties" in json_schema
         # Compare with ``is not False`` rather than truthiness: OpenAPI/MCP schemas often use
         # ``additionalProperties: {}`` (an empty schema meaning "allow anything"). That value is
         # falsy in Python, so a truthiness check would silently leave a non-strict schema in place.
         and json_schema["additionalProperties"] is not False
     ):
-        raise UserError(
-            "additionalProperties should not be set for object types. This could be because "
-            "you're using an older version of Pydantic, or because you configured additional "
-            "properties to be allowed. If you really need this, update the function or output tool "
-            "to not use a strict schema."
-        )
+        raise UserError(_ADDITIONAL_PROPERTIES_ERROR)
 
     # object types
     # { 'type': 'object', 'properties': { 'a':  {...} } }
-    properties = json_schema.get("properties")
     if is_dict(properties):
         json_schema["required"] = list(properties.keys())
         json_schema["properties"] = {
@@ -158,6 +183,7 @@ def _ensure_strict_json_schema(
                 )
             )
             json_schema.pop("allOf")
+            return _ensure_strict_json_schema(json_schema, path=path, root=root, budget=budget)
         else:
             json_schema["allOf"] = [
                 _ensure_strict_json_schema(

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1852,7 +1852,7 @@ def test_to_function_tool_failed_strict_conversion_keeps_original_schema():
     schema = {
         "type": "object",
         "properties": {
-            "x": {"type": "object", "additionalProperties": True},
+            "x": {"additionalProperties": True},
         },
     }
     tool = MCPTool(name="test_tool", inputSchema=schema)
@@ -1863,9 +1863,24 @@ def test_to_function_tool_failed_strict_conversion_keeps_original_schema():
     assert function_tool.params_json_schema == {
         "type": "object",
         "properties": {
-            "x": {"type": "object", "additionalProperties": True},
+            "x": {"additionalProperties": True},
         },
     }
+
+
+def test_to_function_tool_nullable_root_falls_back_to_non_strict():
+    schema = {
+        "anyOf": [
+            {"type": "object", "properties": {"value": {"type": "string"}}},
+            {"type": "null"},
+        ]
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == {**schema, "properties": {}}
 
 
 class StructuredContentTestServer(FakeMCPServer):

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -332,6 +332,83 @@ def test_func_schema_is_strict():
     )
 
 
+def test_manual_function_tool_normalizes_typeless_object_schemas():
+    async def run_function(ctx: ToolContext[Any], args: str) -> str:
+        return args
+
+    tool = FunctionTool(
+        name="test",
+        description="Processes nested data",
+        params_json_schema={
+            "properties": {
+                "config": {"properties": {"key": {"type": "string"}}},
+                "optional": {
+                    "type": ["object", "null"],
+                    "properties": {"value": {"type": "integer"}},
+                },
+            }
+        },
+        on_invoke_tool=run_function,
+    )
+
+    assert tool.strict_json_schema is True
+    assert tool.params_json_schema == {
+        "type": "object",
+        "properties": {
+            "config": {
+                "type": "object",
+                "properties": {"key": {"type": "string"}},
+                "additionalProperties": False,
+                "required": ["key"],
+            },
+            "optional": {
+                "type": ["object", "null"],
+                "properties": {"value": {"type": "integer"}},
+                "additionalProperties": False,
+                "required": ["value"],
+            },
+        },
+        "additionalProperties": False,
+        "required": ["config", "optional"],
+    }
+
+
+def test_manual_function_tool_rejects_root_union():
+    async def run_function(ctx: ToolContext[Any], args: str) -> str:
+        return args
+
+    with pytest.raises(UserError, match="root of a strict JSON schema"):
+        FunctionTool(
+            name="test",
+            description="Processes nullable data",
+            params_json_schema={
+                "anyOf": [
+                    {"properties": {"value": {"type": "string"}}},
+                    {"type": "null"},
+                ]
+            },
+            on_invoke_tool=run_function,
+        )
+
+
+def test_manual_function_tool_rejects_nested_typeless_open_map():
+    async def run_function(ctx: ToolContext[Any], args: str) -> str:
+        return args
+
+    with pytest.raises(UserError, match="additionalProperties"):
+        FunctionTool(
+            name="test",
+            description="Processes metadata",
+            params_json_schema={
+                "type": "object",
+                "properties": {
+                    "metadata": {"additionalProperties": {"type": "string"}},
+                },
+            },
+            on_invoke_tool=run_function,
+        )
+
+
 @pytest.mark.asyncio
 async def test_manual_function_tool_creation_works():
     def do_some_work(data: str) -> str:

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
@@ -375,6 +375,17 @@ def test_handoff_input_schema_is_strict():
         "additionalProperties" in obj.input_json_schema
         and not obj.input_json_schema["additionalProperties"]
     ), "Input schema should be strict and have additionalProperties=False"
+
+
+def test_handoff_rejects_nullable_input_root():
+    agent = Agent(name="test")
+
+    with pytest.raises(UserError, match="root of a strict JSON schema"):
+        handoff(
+            agent,
+            input_type=cast(type[Any], Foo | None),
+            on_handoff=lambda ctx, input: None,
+        )
 
 
 def test_get_transfer_message_is_valid_json() -> None:

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -45,6 +45,105 @@ def test_object_without_additional_properties():
     assert result["properties"]["a"] == {"type": "string"}
 
 
+def test_typeless_root_is_normalized_to_object():
+    result = ensure_strict_json_schema({"properties": {"a": {"type": "string"}}})
+
+    assert result == {
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "additionalProperties": False,
+        "required": ["a"],
+    }
+
+
+def test_nullable_object_root_errors():
+    with pytest.raises(UserError, match="root of a strict JSON schema"):
+        ensure_strict_json_schema(
+            {"type": ["object", "null"], "properties": {"a": {"type": "string"}}}
+        )
+
+
+def test_open_map_root_errors():
+    with pytest.raises(UserError):
+        ensure_strict_json_schema({"additionalProperties": {"type": "string"}})
+
+
+def test_nested_typeless_open_map_errors():
+    with pytest.raises(UserError):
+        ensure_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "metadata": {"additionalProperties": {"type": "string"}},
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize("union_keyword", ["anyOf", "oneOf"])
+def test_union_root_errors(union_keyword):
+    with pytest.raises(UserError, match="root of a strict JSON schema"):
+        ensure_strict_json_schema(
+            {
+                union_keyword: [
+                    {"properties": {"a": {"type": "string"}}},
+                    {"type": "null"},
+                ]
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("schema", "path"),
+    [
+        (
+            {"type": "object", "properties": {"config": {"properties": {}}}},
+            ("properties", "config"),
+        ),
+        (
+            {"type": "array", "items": {"properties": {}}},
+            ("items",),
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"value": {"anyOf": [{"properties": {}}, {"type": "null"}]}},
+            },
+            ("properties", "value", "anyOf", 0),
+        ),
+    ],
+    ids=["property", "array-item", "any-of"],
+)
+def test_nested_typeless_objects_get_additional_properties(schema, path):
+    node = ensure_strict_json_schema(schema)
+    for key in path:
+        node = node[key]
+
+    assert node["type"] == "object"
+    assert node["additionalProperties"] is False
+
+
+def test_nested_nullable_object_preserves_type_union():
+    result = ensure_strict_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": ["object", "null"],
+                    "properties": {"key": {"type": "string"}},
+                }
+            },
+        }
+    )
+
+    assert result["properties"]["config"] == {
+        "type": ["object", "null"],
+        "properties": {"key": {"type": "string"}},
+        "additionalProperties": False,
+        "required": ["key"],
+    }
+
+
 def test_object_with_true_additional_properties():
     # If additionalProperties is explicitly set to True for an object, a UserError should be raised.
     schema = {
@@ -54,6 +153,31 @@ def test_object_with_true_additional_properties():
     }
     with pytest.raises(UserError):
         ensure_strict_json_schema(schema)
+
+
+def test_typeless_object_with_additional_properties_errors():
+    schema = {
+        "properties": {"a": {"type": "number"}},
+        "additionalProperties": True,
+    }
+    with pytest.raises(UserError):
+        ensure_strict_json_schema(schema)
+
+
+def test_explicit_non_object_with_properties_is_not_closed():
+    schema = {
+        "type": "string",
+        "properties": {},
+        "required": [],
+        "additionalProperties": True,
+    }
+
+    assert ensure_strict_json_schema(schema) == {
+        "type": "string",
+        "properties": {},
+        "required": [],
+        "additionalProperties": True,
+    }
 
 
 def test_object_with_empty_dict_additional_properties():
@@ -106,20 +230,26 @@ def test_array_items_processing_and_default_removal():
 def test_anyOf_processing():
     # Test that anyOf schemas are processed.
     schema = {
-        "anyOf": [
-            {"type": "object", "properties": {"a": {"type": "string"}}},
-            {"type": "number", "default": None},
-        ]
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}},
+                    {"type": "number", "default": None},
+                ]
+            }
+        },
     }
     result = ensure_strict_json_schema(schema)
+    variants = result["properties"]["value"]["anyOf"]
     # For the first variant: object type should get additionalProperties and required keys set.
-    variant0 = result["anyOf"][0]
+    variant0 = variants[0]
     assert variant0["type"] == "object"
     assert variant0["additionalProperties"] is False
     assert variant0["required"] == ["a"]
 
     # For the second variant: the "default": None should be removed.
-    variant1 = result["anyOf"][1]
+    variant1 = variants[1]
     assert variant1["type"] == "number"
     assert "default" not in variant1
 
@@ -138,6 +268,17 @@ def test_allOf_single_entry_merging():
     assert result["required"] == ["a"]
     assert "a" in result["properties"]
     assert result["properties"]["a"]["type"] == "boolean"
+
+
+@pytest.mark.parametrize("additional_properties", [True, {}], ids=["true", "schema"])
+def test_allOf_single_entry_cannot_overwrite_strict_object(additional_properties):
+    schema = {
+        "properties": {"a": {"type": "string"}},
+        "allOf": [{"additionalProperties": additional_properties}],
+    }
+
+    with pytest.raises(UserError):
+        ensure_strict_json_schema(schema)
 
 
 def test_default_removal_on_non_object():

--- a/tests/test_strict_schema_oneof.py
+++ b/tests/test_strict_schema_oneof.py
@@ -135,26 +135,44 @@ def test_discriminated_union_with_pydantic():
 def test_oneof_merged_with_existing_anyof():
     schema = {
         "type": "object",
-        "anyOf": [{"type": "string"}],
-        "oneOf": [{"type": "integer"}, {"type": "boolean"}],
+        "properties": {
+            "value": {
+                "anyOf": [{"type": "string"}],
+                "oneOf": [{"type": "integer"}, {"type": "boolean"}],
+            }
+        },
     }
 
     result = ensure_strict_json_schema(schema)
 
     expected = {
         "type": "object",
-        "anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "boolean"}],
+        "properties": {
+            "value": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "integer"},
+                    {"type": "boolean"},
+                ]
+            }
+        },
         "additionalProperties": False,
+        "required": ["value"],
     }
     assert result == expected
 
 
 def test_discriminator_preserved():
     schema = {
-        "oneOf": [{"$ref": "#/$defs/TypeA"}, {"$ref": "#/$defs/TypeB"}],
-        "discriminator": {
-            "propertyName": "type",
-            "mapping": {"a": "#/$defs/TypeA", "b": "#/$defs/TypeB"},
+        "type": "object",
+        "properties": {
+            "value": {
+                "oneOf": [{"$ref": "#/$defs/TypeA"}, {"$ref": "#/$defs/TypeB"}],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {"a": "#/$defs/TypeA", "b": "#/$defs/TypeB"},
+                },
+            }
         },
         "$defs": {
             "TypeA": {
@@ -171,10 +189,15 @@ def test_discriminator_preserved():
     result = ensure_strict_json_schema(schema)
 
     expected = {
-        "anyOf": [{"$ref": "#/$defs/TypeA"}, {"$ref": "#/$defs/TypeB"}],
-        "discriminator": {
-            "propertyName": "type",
-            "mapping": {"a": "#/$defs/TypeA", "b": "#/$defs/TypeB"},
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [{"$ref": "#/$defs/TypeA"}, {"$ref": "#/$defs/TypeB"}],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {"a": "#/$defs/TypeA", "b": "#/$defs/TypeB"},
+                },
+            }
         },
         "$defs": {
             "TypeA": {
@@ -190,6 +213,8 @@ def test_discriminator_preserved():
                 "required": ["type", "value_b"],
             },
         },
+        "additionalProperties": False,
+        "required": ["value"],
     }
     assert result == expected
 


### PR DESCRIPTION
This pull request fixes strict JSON schema normalization for typeless object schemas reported in #4114. It recursively infers object types for properties-bearing nodes, enforces strict object constraints, rejects unsupported strict roots and open maps before provider calls, and preserves MCP's non-strict fallback without mutating the original schema.

This pull request resolves #4114.