### PR TITLE
fix(run): keep input item order when collapsing duplicates

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -728,10 +728,26 @@ def deduplicate_input_items(items: Sequence[TResponseInputItem]) -> list[TRespon
 def deduplicate_input_items_preferring_latest(
     items: Sequence[TResponseInputItem],
 ) -> list[TResponseInputItem]:
-    """Deduplicate by stable identifiers while keeping the latest occurrence."""
-    # deduplicate_input_items keeps the first item per dedupe key. Reverse twice so that
-    # the latest item in the original order wins for duplicate IDs/call_ids.
-    return list(reversed(deduplicate_input_items(list(reversed(items)))))
+    """Deduplicate by stable identifiers, keeping the latest value at the earliest position.
+
+    Duplicates collapse onto the first occurrence of their dedupe key so the caller's item
+    order is preserved, while the last occurrence supplies the value. Relocating an item to
+    the position of its final duplicate would move a `function_call` behind its
+    `function_call_output`, which the Responses API rejects.
+    """
+    latest_by_key: dict[str, TResponseInputItem] = {}
+    for item in items:
+        dedupe_key = _dedupe_key(item)
+        if dedupe_key is not None:
+            latest_by_key[dedupe_key] = item
+
+    # deduplicate_input_items keeps the first item per dedupe key, which is what preserves the
+    # caller's order; swapping in the latest value per surviving key is all this adds.
+    deduplicated: list[TResponseInputItem] = []
+    for item in deduplicate_input_items(items):
+        dedupe_key = _dedupe_key(item)
+        deduplicated.append(item if dedupe_key is None else latest_by_key[dedupe_key])
+    return deduplicated
 
 
 def function_tool_error_output(

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -3126,6 +3126,49 @@ async def test_save_result_to_session_prefers_latest_duplicate_function_outputs(
 
 
 @pytest.mark.asyncio
+async def test_save_result_to_session_keeps_tool_call_before_its_output():
+    session = SimpleListSession()
+    call_item = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call",
+            "call_id": "call_ordered",
+            "name": "tool_ordered",
+            "arguments": "{}",
+        },
+    )
+    output_item = cast(
+        TResponseInputItem,
+        {"type": "function_call_output", "call_id": "call_ordered", "output": "result"},
+    )
+    # A resumed turn can replay a tool call the input list already carries. Collapsing the
+    # duplicate must not move the call behind its output in the persisted history.
+    repeated_call = _DummyRunItem(
+        {
+            "type": "function_call",
+            "call_id": "call_ordered",
+            "name": "tool_ordered",
+            "arguments": "{}",
+        },
+        item_type="tool_call_item",
+    )
+
+    await save_result_to_session(
+        session,
+        [call_item, output_item],
+        [cast(RunItem, repeated_call)],
+        None,
+    )
+
+    saved_types = [
+        cast(dict[str, Any], item).get("type")
+        for item in session.saved_items
+        if isinstance(item, dict)
+    ]
+    assert saved_types == ["function_call", "function_call_output"]
+
+
+@pytest.mark.asyncio
 async def test_rewind_handles_id_stripped_sessions() -> None:
     session = IdStrippingSession()
     item = cast(TResponseInputItem, {"id": "message-1", "type": "message", "content": "hello"})

--- a/tests/test_call_model_input_filter.py
+++ b/tests/test_call_model_input_filter.py
@@ -203,3 +203,90 @@ async def test_call_model_input_filter_prefers_latest_duplicate_outputs_streamed
     ]
     assert len(outputs) == 1
     assert outputs[0]["output"] == "new-value"
+
+
+def _duplicate_tool_call_input() -> list[TResponseInputItem]:
+    return [
+        cast(
+            TResponseInputItem,
+            {
+                "type": "function_call",
+                "call_id": "ordered-call",
+                "name": "tool_ordered",
+                "arguments": "{}",
+            },
+        ),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call_output", "call_id": "ordered-call", "output": "result"},
+        ),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "function_call",
+                "call_id": "ordered-call",
+                "name": "tool_ordered",
+                "arguments": "{}",
+            },
+        ),
+    ]
+
+
+def _sent_item_types(sent_input: Any) -> list[str | None]:
+    return [
+        cast(dict[str, Any], item).get("type")
+        for item in sent_input
+        if isinstance(item, dict) and item.get("type") is not None
+    ]
+
+
+@pytest.mark.asyncio
+async def test_call_model_input_filter_keeps_duplicate_item_order_non_streamed() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model)
+    model.set_next_output([get_text_message("ok")])
+
+    def filter_fn(data: CallModelData[Any]) -> ModelInputData:
+        return ModelInputData(
+            input=list(data.model_data.input) + _duplicate_tool_call_input(),
+            instructions=data.model_data.instructions,
+        )
+
+    await Runner.run(
+        agent,
+        input="start",
+        run_config=RunConfig(call_model_input_filter=filter_fn),
+    )
+
+    # Collapsing the repeated call must not move it behind its output; the Responses API
+    # rejects a function_call_output whose function_call has not been sent yet.
+    assert _sent_item_types(model.last_turn_args["input"]) == [
+        "function_call",
+        "function_call_output",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_call_model_input_filter_keeps_duplicate_item_order_streamed() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model)
+    model.set_next_output([get_text_message("ok")])
+
+    async def filter_fn(data: CallModelData[Any]) -> ModelInputData:
+        return ModelInputData(
+            input=list(data.model_data.input) + _duplicate_tool_call_input(),
+            instructions=data.model_data.instructions,
+        )
+
+    result = Runner.run_streamed(
+        agent,
+        input="start",
+        run_config=RunConfig(call_model_input_filter=filter_fn),
+    )
+    async for _ in result.stream_events():
+        pass
+
+    assert _sent_item_types(model.last_turn_args["input"]) == [
+        "function_call",
+        "function_call_output",
+    ]

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -1001,3 +1001,69 @@ def test_run_result_to_input_list_preserves_tool_search_items() -> None:
 def test_coerce_tool_search_output_raw_item_rejects_legacy_type() -> None:
     with pytest.raises(AgentsException, match="Unexpected tool search output item type"):
         coerce_tool_search_output_raw_item({"type": "tool_search_result", "results": []})
+
+
+def test_deduplicate_input_items_preferring_latest_keeps_original_order() -> None:
+    call = cast(
+        TResponseInputItem,
+        {"type": "function_call", "call_id": "call-1", "name": "tool", "arguments": "{}"},
+    )
+    output = cast(
+        TResponseInputItem,
+        {"type": "function_call_output", "call_id": "call-1", "output": "result"},
+    )
+    message = cast(TResponseInputItem, {"role": "assistant", "content": "ack"})
+    repeated_call = cast(
+        TResponseInputItem,
+        {"type": "function_call", "call_id": "call-1", "name": "tool", "arguments": "{}"},
+    )
+
+    deduplicated = run_items.deduplicate_input_items_preferring_latest(
+        [call, output, message, repeated_call]
+    )
+
+    # The repeated call collapses onto the first occurrence, so the call still precedes its
+    # output. Relocating it to the end would produce an item order the Responses API rejects.
+    assert [cast(dict[str, Any], item).get("type") for item in deduplicated] == [
+        "function_call",
+        "function_call_output",
+        None,
+    ]
+    assert cast(dict[str, Any], deduplicated[2])["role"] == "assistant"
+
+
+def test_deduplicate_input_items_preferring_latest_uses_latest_value_at_first_position() -> None:
+    old_output = cast(
+        TResponseInputItem,
+        {"type": "function_call_output", "call_id": "call-1", "output": "old"},
+    )
+    message = cast(TResponseInputItem, {"role": "user", "content": "next"})
+    new_output = cast(
+        TResponseInputItem,
+        {"type": "function_call_output", "call_id": "call-1", "output": "new"},
+    )
+
+    deduplicated = run_items.deduplicate_input_items_preferring_latest(
+        [old_output, message, new_output]
+    )
+
+    assert len(deduplicated) == 2
+    assert cast(dict[str, Any], deduplicated[0])["output"] == "new"
+    assert cast(dict[str, Any], deduplicated[1])["content"] == "next"
+
+
+def test_deduplicate_input_items_preferring_latest_leaves_unique_items_untouched() -> None:
+    items = [
+        cast(TResponseInputItem, {"role": "user", "content": "hi"}),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call", "call_id": "call-1", "name": "tool", "arguments": "{}"},
+        ),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call_output", "call_id": "call-1", "output": "result"},
+        ),
+        cast(TResponseInputItem, {"role": "user", "content": "hi"}),
+    ]
+
+    assert run_items.deduplicate_input_items_preferring_latest(items) == items


### PR DESCRIPTION
### Summary

`deduplicate_input_items_preferring_latest` collapses items that share a stable identifier (`id`, `call_id`, `approval_request_id`) and keeps the latest value. It is implemented by reversing the list, running the first-wins `deduplicate_input_items`, and reversing back:

```python
return list(reversed(deduplicate_input_items(list(reversed(items)))))
```

That keeps the latest *value*, but it also relocates the surviving item to the position of its **last** duplicate rather than its first. Deduplication therefore reorders the conversation.

The concrete failure: when a `function_call` is repeated after its `function_call_output`, the call is moved behind the output. The Responses API rejects that ordering, and the same helper also decides the order items are written to a session, so an invalid ordering can be persisted and replayed on every later turn.

Affected component: `src/agents/run_internal/items.py`. The helper feeds three call sites:

- `run_internal/run_loop.py` — the final model input for streamed and non-streamed turns (applied to whatever `RunConfig.call_model_input_filter` returned).
- `run_internal/session_persistence.py:287` — `prepare_input_with_session`.
- `run_internal/session_persistence.py:423` — `save_result_to_session`, i.e. the persisted session history.

#### Minimal reproduction

Helper level:

```python
from agents.run_internal.items import deduplicate_input_items_preferring_latest

call = {"type": "function_call", "call_id": "c1", "name": "t", "arguments": "{}"}
output = {"type": "function_call_output", "call_id": "c1", "output": "result"}

deduplicate_input_items_preferring_latest([call, output, dict(call)])
# [{'type': 'function_call_output', ...}, {'type': 'function_call', ...}]
```

Session level — `save_result_to_session` with an input list carrying a tool call plus its output, and a run item that replays the same call, persists `["function_call_output", "function_call"]`.

Run level — a `call_model_input_filter` whose returned list repeats an earlier `function_call` sends the output before the call to the model, in both `Runner.run` and `Runner.run_streamed`.

No API key, network access, or paid model call is involved; the repro uses `FakeModel` and the existing in-repo session test doubles.

### Current behavior

The surviving item is emitted at the index of its final duplicate, so the item list is reordered and a `function_call` can end up after its `function_call_output`.

### Corrected behavior

Duplicates collapse onto the **first** occurrence of their dedupe key, so caller order is preserved, while the **last** occurrence still supplies the value. Latest-value preference is unchanged.

### Root cause

Reverse → first-wins dedupe → reverse is only equivalent to "prefer the latest value" when position does not matter. It conflates *which value survives* with *where it survives*.

### Implementation

`deduplicate_input_items_preferring_latest` now records the latest item per dedupe key, delegates ordering to the existing `deduplicate_input_items` (first-wins, order-preserving), and substitutes the recorded latest value for each surviving key.

#### Why this is minimal

- One function body; no signature, no public API, and no call-site change.
- `deduplicate_input_items` stays the single source of truth for dedupe keys and ordering; no parallel dedupe path is introduced.
- Items without a dedupe key (messages, plain values) are still passed through untouched, so lists with no duplicates are returned unchanged.

### Regression tests

`tests/test_run_internal_items.py`

- `test_deduplicate_input_items_preferring_latest_keeps_original_order` — a repeated `function_call` stays ahead of its output.
- `test_deduplicate_input_items_preferring_latest_uses_latest_value_at_first_position` — latest value, earliest position.
- `test_deduplicate_input_items_preferring_latest_leaves_unique_items_untouched` — no-duplicate lists are returned identically.

`tests/test_call_model_input_filter.py`

- `test_call_model_input_filter_keeps_duplicate_item_order_non_streamed`
- `test_call_model_input_filter_keeps_duplicate_item_order_streamed`

`tests/test_agent_runner.py`

- `test_save_result_to_session_keeps_tool_call_before_its_output` — persisted session order.

All five order assertions fail on `main` at `9f4292e5` and pass with this change. The existing latest-value tests added in #2411 (`test_call_model_input_filter_prefers_latest_duplicate_outputs_non_streamed` / `_streamed`, `test_save_result_to_session_prefers_latest_duplicate_function_outputs`, `test_prepare_input_with_session_prefers_latest_function_call_output`) still pass unchanged.

### Execution modes covered

`Runner.run` and `Runner.run_streamed` for the model-input path, plus a direct `save_result_to_session` test for the persistence path. `Runner.run_sync` shares the `Runner.run` code path and needs no separate case.

### Cleanup and lifecycle considerations

Pure function change: no tasks, streams, sessions, traces, or transports are created or closed, no global or per-run state is introduced, and caller-owned lists are not mutated (a new list is returned, as before).

### Validation

Run from the repository root on macOS (Darwin 24.6.0), Python 3.12.13, `uv` 0.11.24, branch based on `upstream/main` at `9f4292e5`:

| Command | Result |
| --- | --- |
| `make format` | `847 files left unchanged`, `All checks passed!` |
| `make lint` | `All checks passed!` |
| `make typecheck` | mypy: `Success: no issues found in 835 source files`; pyright: `0 errors, 0 warnings, 0 informations` |
| `make tests` | parallel: `6227 passed, 3 skipped`; serial: `45 passed, 4 skipped` |
| `bash .agents/skills/code-change-verification/scripts/run.sh` | `code-change-verification: all commands passed.` |
| `git diff --check` | clean |
| `uv run pytest tests/test_run_internal_items.py tests/test_call_model_input_filter.py tests/test_agent_runner.py -q` | `240 passed` (repeated 3x, stable) |

Pre-fix confirmation: reverting only `src/agents/run_internal/items.py` and rerunning that focused command gives `5 failed, 235 passed`, failing exactly on the five new order assertions.

Not run: the Python 3.10 matrix (`UV_PROJECT_ENVIRONMENT=.venv_310`), `make coverage`, `make build-docs`, and the integration-test profiles. The change adds no new syntax or dependency and touches no docs, examples, or generated files.

### Compatibility considerations

No public API, signature, field order, import path, or `__all__` change. The latest-value contract from #2411 is preserved; only the position of a collapsed duplicate changes, and only when the input actually contains duplicates. Lists without duplicate identifiers are returned exactly as before.

### Non-goals

- No change to `deduplicate_input_items` (first-wins) or to the dedupe-key rules in `_dedupe_key`.
- No change to `drop_orphan_function_calls`, `normalize_input_items_for_api`, or any session backend.
- No broader reordering or validation of model input beyond restoring the caller's order.

### Test plan

See **Validation** above. `make format`, `make lint`, `make typecheck`, and `make tests` all pass; the five new tests are demonstrated red on `main` and green with the fix.

### Issue number

N/A — filed directly as a small fix, consistent with recent maintenance PRs in this repository.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
