### PR TITLE
fix(sandbox): harden default snapshot path resolution

### DIFF
--- a/src/agents/sandbox/snapshot_defaults.py
+++ b/src/agents/sandbox/snapshot_defaults.py
@@ -4,7 +4,7 @@ import os
 import sys
 import time
 from collections.abc import Mapping
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from .snapshot import LocalSnapshotSpec
 
@@ -30,7 +30,7 @@ def default_local_snapshot_base_dir(
     os_name: str | None = None,
 ) -> Path:
     resolved_home = home or Path.home()
-    resolved_env = env or os.environ
+    resolved_env = os.environ if env is None else env
     resolved_platform = platform or sys.platform
     resolved_os_name = os_name or os.name
 
@@ -45,7 +45,11 @@ def default_local_snapshot_base_dir(
         base = env_base if env_base is not None else resolved_home / "AppData" / "Local"
     else:
         xdg_state_home = resolved_env.get("XDG_STATE_HOME")
-        base = Path(xdg_state_home) if xdg_state_home else resolved_home / ".local" / "state"
+        base = (
+            Path(xdg_state_home)
+            if xdg_state_home and PurePosixPath(xdg_state_home).is_absolute()
+            else resolved_home / ".local" / "state"
+        )
 
     return base / _DEFAULT_LOCAL_SNAPSHOT_SUBDIR
 

--- a/tests/sandbox/test_snapshot_defaults.py
+++ b/tests/sandbox/test_snapshot_defaults.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
+
 from agents.sandbox.snapshot import LocalSnapshotSpec
 from agents.sandbox.snapshot_defaults import (
     _DEFAULT_LOCAL_SNAPSHOT_TTL_SECONDS,
@@ -13,15 +15,47 @@ from agents.sandbox.snapshot_defaults import (
 
 
 def test_default_local_snapshot_base_dir_uses_xdg_state_home(tmp_path: Path) -> None:
-    state_home = tmp_path / "state"
+    state_home = "/state"
     result = default_local_snapshot_base_dir(
         home=tmp_path / "home",
-        env={"XDG_STATE_HOME": str(state_home)},
+        env={"XDG_STATE_HOME": state_home},
         platform="linux",
         os_name="posix",
     )
 
-    assert result == state_home / "openai-agents-python" / "sandbox" / "snapshots"
+    assert result == Path(state_home) / "openai-agents-python" / "sandbox" / "snapshots"
+
+
+def test_default_local_snapshot_base_dir_honors_explicit_empty_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("XDG_STATE_HOME", "/ambient/state")
+
+    result = default_local_snapshot_base_dir(
+        home=home,
+        env={},
+        platform="linux",
+        os_name="posix",
+    )
+
+    assert result == home / ".local" / "state" / "openai-agents-python" / "sandbox" / "snapshots"
+
+
+def test_default_local_snapshot_base_dir_ignores_relative_xdg_state_home(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+
+    result = default_local_snapshot_base_dir(
+        home=home,
+        env={"XDG_STATE_HOME": "relative-state"},
+        platform="linux",
+        os_name="posix",
+    )
+
+    assert result == home / ".local" / "state" / "openai-agents-python" / "sandbox" / "snapshots"
 
 
 def test_default_local_snapshot_base_dir_uses_macos_application_support(tmp_path: Path) -> None:
@@ -124,8 +158,8 @@ def test_cleanup_stale_default_local_snapshots_removes_only_old_tar_files(tmp_pa
 def test_resolve_default_local_snapshot_spec_keeps_existing_stale_files(
     tmp_path: Path,
 ) -> None:
-    state_home = tmp_path / "state"
-    managed_dir = state_home / "openai-agents-python" / "sandbox" / "snapshots"
+    home = tmp_path / "home"
+    managed_dir = home / ".local" / "state" / "openai-agents-python" / "sandbox" / "snapshots"
     managed_dir.mkdir(parents=True)
     stale = managed_dir / "stale.tar"
     stale.write_bytes(b"stale")
@@ -134,8 +168,8 @@ def test_resolve_default_local_snapshot_spec_keeps_existing_stale_files(
     os.utime(stale, (stale_mtime, stale_mtime))
 
     spec = resolve_default_local_snapshot_spec(
-        home=tmp_path / "home",
-        env={"XDG_STATE_HOME": str(state_home)},
+        home=home,
+        env={},
         platform="linux",
         os_name="posix",
         now=now,


### PR DESCRIPTION
This pull request fixes two default local snapshot path-resolution bugs reported in #4059.

An explicitly empty `env` mapping is now honored instead of falling back to the ambient process environment. On POSIX platforms, relative `XDG_STATE_HOME` values are ignored in favor of the standard home-directory fallback, while absolute POSIX paths remain supported consistently across test hosts.

The released cleanup helper, TTL behavior, `resolve_default_local_snapshot_spec(now=...)` signature, and non-destructive snapshot resolution behavior remain unchanged. Default resolution does not automatically delete archives that may still back paused or serialized resume state.

This pull request resolves #4059.
