### PR TITLE
fix(run): cancel sibling work when a concurrent run-path task fails

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -97,6 +97,7 @@ from ..tracing.model_tracing import get_model_tracing_impl
 from ..tracing.span_data import AgentSpanData, TaskSpanData
 from ..usage import Usage, _response_usage_to_usage
 from ..util import _coro, _error_tracing
+from ..util._asyncio_tasks import gather_with_cancel
 from .agent_bindings import AgentBindings, bind_public_agent
 from .agent_runner_helpers import (
     apply_resumed_conversation_settings,
@@ -1468,7 +1469,7 @@ async def run_single_turn_streamed(
             _approvals=context_wrapper._approvals,
             turn_input=turn_input,
         )
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_agent_start(agent_hook_context, public_agent),
             (
                 public_agent.hooks.on_start(agent_hook_context, public_agent)
@@ -1482,7 +1483,7 @@ async def run_single_turn_streamed(
     streamed_result.current_agent = public_agent
     streamed_result._current_agent_output_schema = get_output_schema(public_agent)
 
-    system_prompt, prompt_config = await asyncio.gather(
+    system_prompt, prompt_config = await gather_with_cancel(
         execution_agent.get_system_prompt(context_wrapper),
         execution_agent.get_prompt(context_wrapper),
     )
@@ -1565,7 +1566,7 @@ async def run_single_turn_streamed(
         # explicitly rewind this state before replaying a failed request.
         server_conversation_tracker.mark_input_as_sent(filtered.input)
 
-    await asyncio.gather(
+    await gather_with_cancel(
         hooks.on_llm_start(context_wrapper, public_agent, filtered.instructions, filtered.input),
         (
             public_agent.hooks.on_llm_start(
@@ -1798,7 +1799,7 @@ async def run_single_turn_streamed(
 
     if final_response is not None:
         context_wrapper.usage.add(final_response.usage)
-        await asyncio.gather(
+        await gather_with_cancel(
             (
                 public_agent.hooks.on_llm_end(context_wrapper, public_agent, final_response)
                 if public_agent.hooks
@@ -1912,7 +1913,7 @@ async def run_single_turn(
             _approvals=context_wrapper._approvals,
             turn_input=turn_input,
         )
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_agent_start(agent_hook_context, public_agent),
             (
                 public_agent.hooks.on_start(agent_hook_context, public_agent)
@@ -1921,7 +1922,7 @@ async def run_single_turn(
             ),
         )
 
-    system_prompt, prompt_config = await asyncio.gather(
+    system_prompt, prompt_config = await gather_with_cancel(
         execution_agent.get_system_prompt(context_wrapper),
         execution_agent.get_prompt(context_wrapper),
     )
@@ -2019,7 +2020,7 @@ async def get_new_response(
     if server_conversation_tracker is not None:
         server_conversation_tracker.mark_input_as_sent(filtered.input)
 
-    await asyncio.gather(
+    await gather_with_cancel(
         hooks.on_llm_start(context_wrapper, public_agent, filtered.instructions, filtered.input),
         (
             public_agent.hooks.on_llm_start(
@@ -2099,7 +2100,7 @@ async def get_new_response(
 
     context_wrapper.usage.add(new_response.usage)
 
-    await asyncio.gather(
+    await gather_with_cancel(
         (
             public_agent.hooks.on_llm_end(context_wrapper, public_agent, new_response)
             if public_agent.hooks

--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -5,7 +5,6 @@ functions and approval plumbing live in tool_execution.py.
 
 from __future__ import annotations
 
-import asyncio
 import copy
 import dataclasses
 import inspect
@@ -40,6 +39,7 @@ from ..tool_context import ToolContext
 from ..tracing import SpanError
 from ..util import _coro
 from ..util._approvals import evaluate_needs_approval_setting
+from ..util._asyncio_tasks import gather_with_cancel
 from ..util._custom_data import maybe_extract_custom_data
 from .items import apply_patch_rejection_item, shell_rejection_item
 from .tool_execution import (
@@ -126,7 +126,7 @@ class ComputerAction:
                 tool=action.computer_tool, run_context=context_wrapper
             )
             agent_hooks = agent.hooks
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_start(context_wrapper, agent, action.computer_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, action.computer_tool)
@@ -177,7 +177,7 @@ class ComputerAction:
                 ),
             )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output)
@@ -393,7 +393,7 @@ class LocalShellAction:
     ) -> RunItem:
         """Run a local shell tool call and wrap the result as a ToolCallOutputItem."""
         agent_hooks = agent.hooks
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool),
             (
                 agent_hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool)
@@ -409,7 +409,7 @@ class LocalShellAction:
         output = call.local_shell_tool.executor(request)
         result = await output if inspect.isawaitable(output) else output
 
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result),
             (
                 agent_hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result)
@@ -486,7 +486,7 @@ class ShellAction:
                 if approval_status is not True:
                     return approval_item
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_start(context_wrapper, agent, shell_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, shell_tool)
@@ -560,7 +560,7 @@ class ShellAction:
                     output_text = output_text[:max_output_length]
                 log_tool_action_error("Shell executor failed", exc)
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text)
@@ -685,7 +685,7 @@ class CustomToolAction:
                 if approval_status is not True:
                     return approval_item
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_start(tool_context, agent, custom_tool),
                 (
                     agent_hooks.on_tool_start(tool_context, agent, custom_tool)
@@ -732,7 +732,7 @@ class CustomToolAction:
                 ),
             )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_end(tool_context, agent, custom_tool, output_text),
                 (
                     agent_hooks.on_tool_end(tool_context, agent, custom_tool, output_text)
@@ -867,7 +867,7 @@ class ApplyPatchAction:
                 if approval_status is not True:
                     return approval_item
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_start(context_wrapper, agent, apply_patch_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, apply_patch_tool)
@@ -944,7 +944,7 @@ class ApplyPatchAction:
                 ),
             )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text)

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -93,7 +93,7 @@ from ..tool_guardrails import (
 from ..tracing import Span, SpanError, function_span, get_current_trace
 from ..util import _coro, _error_tracing
 from ..util._approvals import evaluate_needs_approval_setting, parse_function_tool_arguments
-from ..util._asyncio_tasks import gather_with_cancel
+from ..util._asyncio_tasks import cancelled_by_failing_sibling, gather_with_cancel
 from ..util._custom_data import maybe_extract_custom_data, merge_custom_data
 from ..util._tool_errors import get_trace_tool_error
 from ..util._types import MaybeAwaitable
@@ -166,6 +166,7 @@ TToolSpanResult = TypeVar("TToolSpanResult")
 _FUNCTION_TOOL_CANCELLED_DRAIN_SECONDS = 0.25
 _FUNCTION_TOOL_CANCELLED_IMMEDIATE_STEP_LIMIT = 64
 _FUNCTION_TOOL_POST_INVOKE_WAIT_SECONDS = 0.1
+_FUNCTION_TOOL_TEARDOWN_DRAIN_SECONDS = 0.25
 
 
 _FunctionToolFailureSource = Literal["direct", "cancelled_teardown", "post_invoke"]
@@ -1516,7 +1517,7 @@ class _FunctionToolBatchExecutor:
         except asyncio.CancelledError as exc:
             if self.propagating_failure is exc:
                 raise
-            self._cancel_pending_tasks_for_parent_cancellation()
+            await self._cancel_pending_tasks_for_parent_cancellation()
             raise
 
         return (
@@ -1635,13 +1636,36 @@ class _FunctionToolBatchExecutor:
             timeout_seconds=_FUNCTION_TOOL_POST_INVOKE_WAIT_SECONDS,
         )
 
-    def _cancel_pending_tasks_for_parent_cancellation(self) -> None:
-        self.teardown_cancelled_tasks.update(self.pending_tasks)
-        _cancel_function_tool_tasks(self.pending_tasks)
+    async def _cancel_pending_tasks_for_parent_cancellation(self) -> None:
+        cancelled_tasks = set(self.pending_tasks)
+        self.teardown_cancelled_tasks.update(cancelled_tasks)
+        _cancel_function_tool_tasks(cancelled_tasks)
+        # The callbacks are attached before the wait below so a task that finishes
+        # while we wait still has its result consumed, and so a task that outlives
+        # the window is still reported at the loop level.
         _attach_function_tool_task_result_callbacks(
-            self.pending_tasks,
+            cancelled_tasks,
             message_for_exception=_parent_cancelled_task_exception_message,
         )
+        if not cancelled_tasks or not cancelled_by_failing_sibling():
+            # A genuine parent cancellation must not be held up by tool cleanup, so
+            # the loop-level callbacks above are the whole story there.
+            return
+        # A failing sibling category in the `_execute_tool_plan` fan-out is different:
+        # the fan-out treats our return as "this category is drained", so returning
+        # while handlers are mid-unwind would let their side effects land after the
+        # run has already raised. Give them a bounded window to finish. Bounded
+        # because a handler that swallows cancellation must not stall the run.
+        try:
+            await asyncio.wait(
+                cancelled_tasks,
+                timeout=_FUNCTION_TOOL_TEARDOWN_DRAIN_SECONDS,
+            )
+        except asyncio.CancelledError:
+            # A second cancellation (the parent run itself going away) takes
+            # priority over draining. The callbacks above still report whatever
+            # is left, so nothing is silently dropped.
+            pass
 
     async def _run_single_tool(
         self,

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -1637,17 +1637,37 @@ class _FunctionToolBatchExecutor:
         )
 
     async def _cancel_pending_tasks_for_parent_cancellation(self) -> None:
-        cancelled_tasks = set(self.pending_tasks)
-        self.teardown_cancelled_tasks.update(cancelled_tasks)
-        _cancel_function_tool_tasks(cancelled_tasks)
-        # The callbacks are attached before the wait below so a task that finishes
-        # while we wait still has its result consumed, and so a task that outlives
-        # the window is still reported at the loop level.
+        if not self.pending_tasks:
+            return
+
+        drain_for_failing_sibling = cancelled_by_failing_sibling()
+        if drain_for_failing_sibling:
+            # Same split the in-batch sibling-failure path uses: a handler that has
+            # already returned is running its post-invoke lifecycle (output
+            # guardrails, custom output extraction, on_tool_end), and cancelling
+            # that would land the tool's side effect while skipping the work the
+            # tool contract requires after it. Only genuinely in-flight handlers
+            # are cancellable.
+            cancellable_tasks, post_invoke_tasks = self._partition_pending_tasks()
+        else:
+            # A parent cancellation is tearing the whole run down, so there is no
+            # lifecycle left to protect and nothing waits on the outcome.
+            cancellable_tasks, post_invoke_tasks = set(self.pending_tasks), set()
+
+        self.teardown_cancelled_tasks.update(cancellable_tasks)
+        _cancel_function_tool_tasks(cancellable_tasks)
+        # Attached before any wait below so a task finishing inside the window still
+        # has its result consumed, and one outliving it is still reported.
         _attach_function_tool_task_result_callbacks(
-            cancelled_tasks,
+            cancellable_tasks,
             message_for_exception=_parent_cancelled_task_exception_message,
         )
-        if not cancelled_tasks or not cancelled_by_failing_sibling():
+        if post_invoke_tasks:
+            _attach_function_tool_task_result_callbacks(
+                post_invoke_tasks,
+                message_for_exception=_background_post_invoke_task_exception_message,
+            )
+        if not drain_for_failing_sibling:
             # A genuine parent cancellation must not be held up by tool cleanup, so
             # the loop-level callbacks above are the whole story there.
             return
@@ -1658,7 +1678,7 @@ class _FunctionToolBatchExecutor:
         # because a handler that swallows cancellation must not stall the run.
         try:
             await asyncio.wait(
-                cancelled_tasks,
+                cancellable_tasks | post_invoke_tasks,
                 timeout=_FUNCTION_TOOL_TEARDOWN_DRAIN_SECONDS,
             )
         except asyncio.CancelledError:

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -602,7 +602,7 @@ async def initialize_computer_tools(
         tool for tool in computer_tools if _computer_tool_uses_run_scoped_initializer(tool)
     }
 
-    resolved_computers = await asyncio.gather(
+    resolved_computers = await gather_with_cancel(
         *(resolve_computer(tool=tool, run_context=context_wrapper) for tool in computer_tools)
     )
     resolved_by_tool = dict(zip(computer_tools, resolved_computers, strict=True))
@@ -1847,7 +1847,7 @@ class _FunctionToolBatchExecutor:
             self.schema_bypassed_tool_runs.add(id(task_state.tool_run))
             return rejected_message
 
-        await asyncio.gather(
+        await gather_with_cancel(
             self.hooks.on_tool_start(tool_context, self.public_agent, func_tool),
             (
                 agent_hooks.on_tool_start(tool_context, self.public_agent, func_tool)
@@ -1963,7 +1963,7 @@ class _FunctionToolBatchExecutor:
         if custom_data:
             self.custom_data_by_tool_run[id(task_state.tool_run)] = custom_data
 
-        await asyncio.gather(
+        await gather_with_cancel(
             self.hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result),
             (
                 agent_hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result)

--- a/src/agents/run_internal/tool_planning.py
+++ b/src/agents/run_internal/tool_planning.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import dataclasses as _dc
 import inspect
 import json
@@ -25,6 +24,7 @@ from ..items import (
 from ..run_context import RunContextWrapper
 from ..tool import FunctionTool, MCPToolApprovalRequest, get_function_tool_origin
 from ..tool_guardrails import ToolInputGuardrailResult, ToolOutputGuardrailResult
+from ..util._asyncio_tasks import gather_with_cancel
 from .agent_bindings import AgentBindings
 from .run_steps import (
     ToolRunApplyPatchCall,
@@ -136,7 +136,7 @@ async def execute_mcp_approval_requests(
         )
 
     tasks = [run_single_approval(approval_request) for approval_request in approval_requests]
-    return await asyncio.gather(*tasks)
+    return list(await gather_with_cancel(*tasks))
 
 
 def _build_tool_output_index(items: Sequence[RunItem]) -> set[tuple[str, str]]:
@@ -580,7 +580,7 @@ async def _execute_tool_plan(
             shell_results,
             apply_patch_results,
             local_shell_results,
-        ) = await asyncio.gather(
+        ) = await gather_with_cancel(
             execute_function_tool_calls(
                 bindings=bindings,
                 tool_runs=plan.function_runs,

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -99,6 +99,7 @@ from ..tool_guardrails import ToolInputGuardrailResult, ToolOutputGuardrailResul
 from ..tracing import SpanError, handoff_span
 from ..util import _coro, _error_tracing
 from ..util._approvals import evaluate_needs_approval_setting
+from ..util._asyncio_tasks import gather_with_cancel
 from .agent_bindings import AgentBindings
 from .error_handlers import (
     build_run_error_data,
@@ -311,7 +312,7 @@ async def run_final_output_hooks(
         turn_input=context_wrapper.turn_input,
     )
 
-    await asyncio.gather(
+    await gather_with_cancel(
         hooks.on_agent_end(agent_hook_context, agent, final_output),
         agent.hooks.on_end(agent_hook_context, agent, final_output)
         if agent.hooks
@@ -534,7 +535,7 @@ async def execute_handoffs(
             )
         )
 
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_handoff(
                 context=context_wrapper,
                 from_agent=public_agent,

--- a/src/agents/util/_asyncio_tasks.py
+++ b/src/agents/util/_asyncio_tasks.py
@@ -8,6 +8,9 @@ T = TypeVar("T")
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+T6 = TypeVar("T6")
 
 
 @overload
@@ -25,6 +28,39 @@ async def gather_with_cancel(
     awaitable_3: Awaitable[T3],
     /,
 ) -> tuple[T1, T2, T3]: ...
+
+
+@overload
+async def gather_with_cancel(
+    awaitable_1: Awaitable[T1],
+    awaitable_2: Awaitable[T2],
+    awaitable_3: Awaitable[T3],
+    awaitable_4: Awaitable[T4],
+    /,
+) -> tuple[T1, T2, T3, T4]: ...
+
+
+@overload
+async def gather_with_cancel(
+    awaitable_1: Awaitable[T1],
+    awaitable_2: Awaitable[T2],
+    awaitable_3: Awaitable[T3],
+    awaitable_4: Awaitable[T4],
+    awaitable_5: Awaitable[T5],
+    /,
+) -> tuple[T1, T2, T3, T4, T5]: ...
+
+
+@overload
+async def gather_with_cancel(
+    awaitable_1: Awaitable[T1],
+    awaitable_2: Awaitable[T2],
+    awaitable_3: Awaitable[T3],
+    awaitable_4: Awaitable[T4],
+    awaitable_5: Awaitable[T5],
+    awaitable_6: Awaitable[T6],
+    /,
+) -> tuple[T1, T2, T3, T4, T5, T6]: ...
 
 
 @overload

--- a/src/agents/util/_asyncio_tasks.py
+++ b/src/agents/util/_asyncio_tasks.py
@@ -2,7 +2,36 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable
+from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Any, TypeVar, overload
+
+
+@dataclass
+class _SiblingCancellationScope:
+    """Records whether `gather_with_cancel` is the one doing the cancelling."""
+
+    cancelling: bool = False
+
+
+# Holds a mutable scope rather than a bool so the flag stays observable from the
+# child tasks: each task copies the context at creation time, and the copy keeps a
+# reference to this same object.
+_sibling_cancellation_scope: ContextVar[_SiblingCancellationScope | None] = ContextVar(
+    "agents_sibling_cancellation_scope", default=None
+)
+
+
+def cancelled_by_failing_sibling() -> bool:
+    """True when the current task is being cancelled because a sibling arm raised.
+
+    Concurrent arms use this to tell "a peer failed, so finish unwinding and let the
+    caller observe a drained arm" apart from "an ancestor is being torn down, so get
+    out of the way immediately".
+    """
+    scope = _sibling_cancellation_scope.get()
+    return scope is not None and scope.cancelling
+
 
 T = TypeVar("T")
 T1 = TypeVar("T1")
@@ -69,12 +98,21 @@ async def gather_with_cancel(*awaitables: Awaitable[T]) -> tuple[T, ...]: ...
 
 async def gather_with_cancel(*awaitables: Awaitable[Any]) -> tuple[Any, ...]:
     """Gather awaitables, cancelling and draining siblings when one raises."""
-    tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
+    scope = _SiblingCancellationScope()
+    token = _sibling_cancellation_scope.set(scope)
     try:
-        return tuple(await asyncio.gather(*tasks))
-    except BaseException:
-        for task in tasks:
-            if not task.done():
-                task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        raise
+        tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
+        try:
+            return tuple(await asyncio.gather(*tasks))
+        except BaseException as error:
+            # Only a genuine sibling failure flips the flag. If the gather itself was
+            # cancelled, an ancestor is going away and arms should unwind promptly
+            # rather than drain.
+            scope.cancelling = not isinstance(error, asyncio.CancelledError)
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+    finally:
+        _sibling_cancellation_scope.reset(token)

--- a/src/agents/util/_asyncio_tasks.py
+++ b/src/agents/util/_asyncio_tasks.py
@@ -6,6 +6,8 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
+from ..logger import logger
+
 
 @dataclass
 class _SiblingCancellationScope:
@@ -33,11 +35,36 @@ def cancelled_by_failing_sibling() -> bool:
     return scope is not None and scope.cancelling
 
 
+# Long enough for an arm to run its own bounded teardown (function tools drain for
+# _FUNCTION_TOOL_TEARDOWN_DRAIN_SECONDS), short enough that one executor which
+# resists cancellation cannot hold the run open.
+_ARM_DRAIN_SECONDS = 1.0
+
+
+def _report_unfinished_arm(task: asyncio.Task[Any]) -> None:
+    """Report an arm that outlived the drain window, at the loop level."""
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is not None:
+        logger.warning("Cancelled concurrent task failed after teardown: %s", error)
+
+
 async def _cancel_and_drain(tasks: list[asyncio.Task[Any]]) -> None:
     for task in tasks:
         if not task.done():
             task.cancel()
-    await asyncio.gather(*tasks, return_exceptions=True)
+    # Bounded: an executor that catches CancelledError and keeps cleaning up must
+    # not stop the original failure from propagating. Anything still running is
+    # reported through a done callback instead of being waited on.
+    done, pending = await asyncio.wait(tasks, timeout=_ARM_DRAIN_SECONDS)
+    for task in done:
+        if not task.cancelled():
+            # Retrieved so a failure during teardown is not reported as an
+            # exception that was never retrieved.
+            task.exception()
+    for task in pending:
+        task.add_done_callback(_report_unfinished_arm)
 
 
 T = TypeVar("T")

--- a/src/agents/util/_asyncio_tasks.py
+++ b/src/agents/util/_asyncio_tasks.py
@@ -33,6 +33,13 @@ def cancelled_by_failing_sibling() -> bool:
     return scope is not None and scope.cancelling
 
 
+async def _cancel_and_drain(tasks: list[asyncio.Task[Any]]) -> None:
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
 T = TypeVar("T")
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
@@ -98,21 +105,35 @@ async def gather_with_cancel(*awaitables: Awaitable[T]) -> tuple[T, ...]: ...
 
 async def gather_with_cancel(*awaitables: Awaitable[Any]) -> tuple[Any, ...]:
     """Gather awaitables, cancelling and draining siblings when one raises."""
+    if not awaitables:
+        return ()
+
     scope = _SiblingCancellationScope()
     token = _sibling_cancellation_scope.set(scope)
     try:
         tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
         try:
-            return tuple(await asyncio.gather(*tasks))
-        except BaseException as error:
-            # Only a genuine sibling failure flips the flag. If the gather itself was
-            # cancelled, an ancestor is going away and arms should unwind promptly
-            # rather than drain.
-            scope.cancelling = not isinstance(error, asyncio.CancelledError)
-            for task in tasks:
-                if not task.done():
-                    task.cancel()
-            await asyncio.gather(*tasks, return_exceptions=True)
+            # Waiting on completion rather than `asyncio.gather` is what makes the
+            # two cancellation causes distinguishable. An arm that ends badly comes
+            # back as a finished task here, so this frame is demonstrably still
+            # alive and the cancellation that follows originates with us. An
+            # ancestor cancelling us instead raises out of the wait itself, leaving
+            # `scope.cancelling` false so arms unwind promptly. Note that the arm may
+            # end badly by *being cancelled* rather than raising, which is why this
+            # cannot use FIRST_EXCEPTION: cancellation does not satisfy it.
+            pending = set(tasks)
+            while pending:
+                done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+                # Ordered by original position so which failure wins is deterministic
+                # when several arms finish in the same pass.
+                for task in sorted(done, key=tasks.index):
+                    if task.cancelled() or task.exception() is not None:
+                        scope.cancelling = True
+                        await _cancel_and_drain(tasks)
+                        task.result()  # re-raises the arm's exception
+        except BaseException:
+            await _cancel_and_drain(tasks)
             raise
+        return tuple(task.result() for task in tasks)
     finally:
         _sibling_cancellation_scope.reset(token)

--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+from typing import Any
+
 import pytest
 from openai import omit
 
 from agents import Agent, Prompt, RunConfig, RunContextWrapper, Runner
 from agents.models.interface import Model, ModelProvider
 from agents.models.openai_responses import OpenAIResponsesModel
+from agents.prompts import GenerateDynamicPromptData
 
 from .fake_model import FakeModel, get_response_obj
 from .test_responses import get_text_message
@@ -142,3 +146,84 @@ async def test_agent_prompt_with_default_model_omits_model_and_tools_parameters(
     assert called_kwargs["prompt"] == expected_prompt
     assert called_kwargs["model"] is omit
     assert called_kwargs["tools"] is omit
+
+
+@pytest.mark.asyncio
+async def test_run_cancels_sibling_instructions_when_prompt_resolution_fails() -> None:
+    """A failing prompt callable must not leave the instructions callable running.
+
+    `get_system_prompt` and `get_prompt` are both user-supplied callables gathered
+    concurrently. The realtime path already gathers `get_system_prompt` with
+    `gather_with_cancel` (see `openai_realtime.py`), so a failure there cancels its
+    siblings; the run path gathered the same call with a bare `asyncio.gather`, which
+    propagates the first exception while the sibling keeps running detached.
+    """
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_instructions(_ctx: RunContextWrapper[Any], _agent: Agent[Any]) -> str:
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return "unreachable"
+
+    async def failing_prompt(_data: GenerateDynamicPromptData) -> Prompt:
+        await slow_started.wait()
+        raise RuntimeError("prompt resolution failed")
+
+    agent = Agent(
+        name="prompt-agent",
+        model=FakeModel(),
+        instructions=slow_instructions,
+        prompt=failing_prompt,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt resolution failed"):
+        await Runner.run(agent, input="hi")
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_streamed_cancels_sibling_instructions_when_prompt_resolution_fails() -> None:
+    """Same invariant on the streamed loop, which resolves the pair separately."""
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_instructions(_ctx: RunContextWrapper[Any], _agent: Agent[Any]) -> str:
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return "unreachable"
+
+    async def failing_prompt(_data: GenerateDynamicPromptData) -> Prompt:
+        await slow_started.wait()
+        raise RuntimeError("prompt resolution failed")
+
+    agent = Agent(
+        name="prompt-agent",
+        model=FakeModel(),
+        instructions=slow_instructions,
+        prompt=failing_prompt,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt resolution failed"):
+        result = Runner.run_streamed(agent, input="hi")
+        async for _event in result.stream_events():
+            pass
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -11,7 +11,11 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 import pytest
-from openai.types.responses import ResponseFunctionToolCall
+from openai.types.responses import ResponseComputerToolCall, ResponseFunctionToolCall
+from openai.types.responses.response_computer_tool_call import (
+    ActionScreenshot,
+    PendingSafetyCheck,
+)
 from openai.types.responses.response_output_item import McpApprovalRequest
 from openai.types.responses.response_output_message import ResponseOutputMessage
 from openai.types.responses.response_output_refusal import ResponseOutputRefusal
@@ -21,6 +25,7 @@ from agents import (
     Agent,
     AgentBase,
     ApplyPatchTool,
+    ComputerTool,
     FunctionTool,
     HostedMCPTool,
     MCPApprovalRequestItem,
@@ -3618,3 +3623,98 @@ async def test_execute_tools_emits_hosted_mcp_rejection_reason_from_explicit_mes
     assert responses[0].raw_item["approve"] is False
     assert responses[0].raw_item["approval_request_id"] == "mcp-approval-reject-reason"
     assert responses[0].raw_item["reason"] == "Denied by policy"
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_plan_cancels_sibling_category_on_failure() -> None:
+    """A failing tool category must not leave a sibling category running.
+
+    `_execute_tool_plan` fans the six tool categories out concurrently. Only
+    function tools go through `_FunctionToolBatchExecutor`, and its cancel-and-drain
+    never sees a failure raised by a sibling arm of that fan-out, so a rejected
+    computer safety check used to leave an in-flight shell command executing after
+    the run had already raised.
+    """
+    from agents.run_internal.agent_bindings import bind_public_agent
+    from agents.run_internal.tool_planning import ToolExecutionPlan, _execute_tool_plan
+
+    from .test_computer_tool_lifecycle import FakeComputer
+
+    shell_started = asyncio.Event()
+    shell_cancelled = asyncio.Event()
+    shell_finished = asyncio.Event()
+
+    async def blocking_executor(_request: Any) -> str:
+        shell_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            shell_cancelled.set()
+            raise
+        finally:
+            shell_finished.set()
+        return "unreachable"
+
+    async def reject_once_shell_is_running(_data: Any) -> bool:
+        # Fail only after the sibling is genuinely in flight, so the test pins the
+        # interleaving rather than a race between the two categories starting.
+        await shell_started.wait()
+        return False
+
+    shell_tool = ShellTool(executor=blocking_executor)
+    computer_tool = ComputerTool(
+        computer=FakeComputer(), on_safety_check=reject_once_shell_is_running
+    )
+    agent: Agent[Any] = Agent(name="test", tools=[shell_tool, computer_tool])
+
+    plan = ToolExecutionPlan(
+        shell_calls=[
+            ToolRunShellCall(
+                tool_call=cast(
+                    Any,
+                    {
+                        "type": "shell_call",
+                        "id": "shell-1",
+                        "call_id": "shell-1",
+                        "status": "in_progress",
+                        "action": {
+                            "type": "exec",
+                            "commands": ["sleep 1000"],
+                            "timeout_ms": None,
+                            "working_directory": None,
+                            "env": {},
+                            "user": None,
+                        },
+                    },
+                ),
+                shell_tool=shell_tool,
+            )
+        ],
+        computer_actions=[
+            ToolRunComputerAction(
+                tool_call=ResponseComputerToolCall(
+                    id="computer-1",
+                    type="computer_call",
+                    call_id="computer-1",
+                    action=ActionScreenshot(type="screenshot"),
+                    pending_safety_checks=[
+                        PendingSafetyCheck(id="sc-1", code="malicious", message="nope")
+                    ],
+                    status="completed",
+                ),
+                computer_tool=computer_tool,
+            )
+        ],
+    )
+
+    with pytest.raises(UserError, match="safety check was not acknowledged"):
+        await _execute_tool_plan(
+            plan=plan,
+            bindings=bind_public_agent(agent),
+            hooks=RunHooks[Any](),
+            context_wrapper=RunContextWrapper(context=None),
+            run_config=RunConfig(),
+        )
+
+    assert shell_cancelled.is_set(), "sibling shell command was not cancelled"
+    assert shell_finished.is_set(), "sibling shell command did not finish unwinding"

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -3840,3 +3840,163 @@ async def test_sibling_failure_drain_does_not_apply_to_parent_cancellation() -> 
     # Outside any gather_with_cancel the flag stays False, which is what keeps the
     # parent-cancellation path prompt.
     assert cancelled_by_failing_sibling() is False
+
+
+@pytest.mark.asyncio
+async def test_arm_raising_cancellederror_counts_as_a_sibling_failure() -> None:
+    """An arm that reports its own cancellation is still a sibling failure.
+
+    A tool executor can raise `CancelledError` to report tool-local cancellation.
+    The caller is not going away in that case, so the other arms still owe the
+    fan-out a drained result and must not take the prompt teardown path.
+    """
+    from agents.util._asyncio_tasks import cancelled_by_failing_sibling, gather_with_cancel
+
+    observed: list[bool] = []
+
+    async def blocker() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            observed.append(cancelled_by_failing_sibling())
+            raise
+
+    async def tool_local_cancel() -> None:
+        await asyncio.sleep(0)
+        raise asyncio.CancelledError("executor reported its own cancellation")
+
+    with pytest.raises(asyncio.CancelledError):
+        await gather_with_cancel(blocker(), tool_local_cancel())
+
+    assert observed == [True]
+
+
+@pytest.mark.asyncio
+async def test_ancestor_cancellation_is_not_read_as_a_sibling_failure() -> None:
+    """Cancelling the gather from outside must leave the flag False."""
+    from agents.util._asyncio_tasks import cancelled_by_failing_sibling, gather_with_cancel
+
+    observed: list[bool] = []
+    started = asyncio.Event()
+
+    async def blocker() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            observed.append(cancelled_by_failing_sibling())
+            raise
+
+    async def other() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(gather_with_cancel(blocker(), other()))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert observed == [False]
+
+
+@pytest.mark.asyncio
+async def test_gather_with_cancel_preserves_argument_order() -> None:
+    """Results stay positional even though completion order differs."""
+    from agents.util._asyncio_tasks import gather_with_cancel
+
+    async def slow() -> str:
+        await asyncio.sleep(0.02)
+        return "first"
+
+    async def fast() -> str:
+        return "second"
+
+    assert await gather_with_cancel(slow(), fast()) == ("first", "second")
+    assert await gather_with_cancel() == ()
+
+
+class _SlowToolEndHooks(RunHooks[Any]):
+    """Hooks whose `on_tool_end` is still running when a sibling category fails."""
+
+    def __init__(self, started: asyncio.Event, finished: asyncio.Event) -> None:
+        self.started = started
+        self.finished = finished
+
+    async def on_tool_end(self, context: Any, agent: Any, tool: Any, result: Any) -> None:
+        self.started.set()
+        await asyncio.sleep(0.05)
+        self.finished.set()
+
+
+@pytest.mark.asyncio
+async def test_sibling_failure_does_not_cancel_post_invoke_work() -> None:
+    """A handler that already returned keeps its post-invoke lifecycle.
+
+    Once the handler itself is done the task is running output guardrails, custom
+    output extraction and `on_tool_end`. Cancelling that would land the tool's
+    side effect while skipping the work the tool contract requires after it, so
+    the cross-category drain partitions exactly the way the in-batch
+    sibling-failure path does.
+    """
+    from agents.run_internal.agent_bindings import bind_public_agent
+    from agents.run_internal.tool_planning import ToolExecutionPlan, _execute_tool_plan
+
+    from .test_computer_tool_lifecycle import FakeComputer
+
+    post_invoke_started = asyncio.Event()
+    post_invoke_finished = asyncio.Event()
+
+    @function_tool
+    async def quick_tool() -> str:
+        return "ok"
+
+    async def reject_once_post_invoke_is_running(_data: Any) -> bool:
+        await post_invoke_started.wait()
+        return False
+
+    computer_tool = ComputerTool(
+        computer=FakeComputer(), on_safety_check=reject_once_post_invoke_is_running
+    )
+    agent: Agent[Any] = Agent(name="test", tools=[quick_tool, computer_tool])
+
+    plan = ToolExecutionPlan(
+        function_runs=[
+            ToolRunFunction(
+                tool_call=ResponseFunctionToolCall(
+                    id="fn-1",
+                    call_id="fn-1",
+                    name="quick_tool",
+                    arguments="{}",
+                    type="function_call",
+                ),
+                function_tool=cast(Any, quick_tool),
+            )
+        ],
+        computer_actions=[
+            ToolRunComputerAction(
+                tool_call=ResponseComputerToolCall(
+                    id="computer-1",
+                    type="computer_call",
+                    call_id="computer-1",
+                    action=ActionScreenshot(type="screenshot"),
+                    pending_safety_checks=[
+                        PendingSafetyCheck(id="sc-1", code="malicious", message="nope")
+                    ],
+                    status="completed",
+                ),
+                computer_tool=computer_tool,
+            )
+        ],
+    )
+
+    with pytest.raises(UserError, match="safety check was not acknowledged"):
+        await _execute_tool_plan(
+            plan=plan,
+            bindings=bind_public_agent(agent),
+            hooks=_SlowToolEndHooks(post_invoke_started, post_invoke_finished),
+            context_wrapper=RunContextWrapper(context=None),
+            run_config=RunConfig(),
+        )
+
+    assert post_invoke_started.is_set()
+    assert post_invoke_finished.is_set(), "post-invoke lifecycle work was cancelled"

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -4000,3 +4000,39 @@ async def test_sibling_failure_does_not_cancel_post_invoke_work() -> None:
 
     assert post_invoke_started.is_set()
     assert post_invoke_finished.is_set(), "post-invoke lifecycle work was cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_resistant_arm_cannot_block_the_failure() -> None:
+    """One executor that ignores cancellation must not hold the run open.
+
+    Function tools already bound their own teardown. The fan-out drain has to be
+    bounded for the same reason: a shell or custom executor that catches
+    `CancelledError` and keeps cleaning up would otherwise stop the failure that
+    triggered the cancellation from ever reaching the caller. The real drain
+    window is used rather than a patched one so this fails by timing out on an
+    unbounded drain, which is the behavior being pinned.
+    """
+    from agents.util._asyncio_tasks import _ARM_DRAIN_SECONDS, gather_with_cancel
+
+    cleanup_running = asyncio.Event()
+
+    async def resists_cancellation() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_running.set()
+            while True:
+                await asyncio.sleep(0.01)
+
+    async def fails() -> None:
+        await asyncio.sleep(0)
+        raise UserError("sibling failed")
+
+    with pytest.raises(UserError, match="sibling failed"):
+        await asyncio.wait_for(
+            gather_with_cancel(resists_cancellation(), fails()),
+            timeout=_ARM_DRAIN_SECONDS + 2,
+        )
+
+    assert cleanup_running.is_set(), "the resistant arm never reached its cleanup"

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -3718,3 +3718,125 @@ async def test_execute_tool_plan_cancels_sibling_category_on_failure() -> None:
 
     assert shell_cancelled.is_set(), "sibling shell command was not cancelled"
     assert shell_finished.is_set(), "sibling shell command did not finish unwinding"
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_plan_drains_function_tools_on_sibling_failure() -> None:
+    """A cancelled function tool must finish unwinding before the run raises.
+
+    Function tools are the one category that runs through
+    `_FunctionToolBatchExecutor`, which spawns its own task per tool call. When a
+    sibling category fails, `gather_with_cancel` cancels the executor coroutine and
+    treats its return as "this category is drained" -- but the executor used to
+    cancel its internal tasks and return immediately, so handlers were still
+    mid-unwind (and still landing side effects) after the run had raised.
+    """
+    from agents.run_internal.agent_bindings import bind_public_agent
+    from agents.run_internal.tool_planning import ToolExecutionPlan, _execute_tool_plan
+
+    from .test_computer_tool_lifecycle import FakeComputer
+
+    tool_started = asyncio.Event()
+    tool_cancelled = asyncio.Event()
+    tool_unwound = asyncio.Event()
+
+    @function_tool
+    async def slow_tool() -> str:
+        tool_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            tool_cancelled.set()
+            # Real handlers await during unwind (closing a client, releasing a
+            # lock). Shielded so the sleep itself is not cancelled again, which
+            # is what makes the missing drain observable.
+            await asyncio.shield(asyncio.sleep(0.05))
+            tool_unwound.set()
+            raise
+        return "unreachable"
+
+    async def reject_once_tool_is_running(_data: Any) -> bool:
+        await tool_started.wait()
+        return False
+
+    computer_tool = ComputerTool(
+        computer=FakeComputer(), on_safety_check=reject_once_tool_is_running
+    )
+    agent: Agent[Any] = Agent(name="test", tools=[slow_tool, computer_tool])
+
+    plan = ToolExecutionPlan(
+        function_runs=[
+            ToolRunFunction(
+                tool_call=ResponseFunctionToolCall(
+                    id="fn-1",
+                    call_id="fn-1",
+                    name="slow_tool",
+                    arguments="{}",
+                    type="function_call",
+                ),
+                function_tool=cast(Any, slow_tool),
+            )
+        ],
+        computer_actions=[
+            ToolRunComputerAction(
+                tool_call=ResponseComputerToolCall(
+                    id="computer-1",
+                    type="computer_call",
+                    call_id="computer-1",
+                    action=ActionScreenshot(type="screenshot"),
+                    pending_safety_checks=[
+                        PendingSafetyCheck(id="sc-1", code="malicious", message="nope")
+                    ],
+                    status="completed",
+                ),
+                computer_tool=computer_tool,
+            )
+        ],
+    )
+
+    with pytest.raises(UserError, match="safety check was not acknowledged"):
+        await _execute_tool_plan(
+            plan=plan,
+            bindings=bind_public_agent(agent),
+            hooks=RunHooks[Any](),
+            context_wrapper=RunContextWrapper(context=None),
+            run_config=RunConfig(),
+        )
+
+    assert tool_cancelled.is_set(), "function tool was not cancelled"
+    assert tool_unwound.is_set(), "function tool did not finish unwinding before the run raised"
+
+
+@pytest.mark.asyncio
+async def test_sibling_failure_drain_does_not_apply_to_parent_cancellation() -> None:
+    """The drain must not turn parent cancellation into a wait on tool cleanup.
+
+    `cancelled_by_failing_sibling()` is what separates the two, so this pins the
+    negative case directly: outside a failing-sibling gather, a cancelled batch
+    returns without waiting even though cleanup is still blocked.
+    """
+    from agents.util._asyncio_tasks import cancelled_by_failing_sibling, gather_with_cancel
+
+    observed: list[bool] = []
+
+    async def record_then_block() -> None:
+        observed.append(cancelled_by_failing_sibling())
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            observed.append(cancelled_by_failing_sibling())
+            raise
+
+    async def fail_fast() -> None:
+        await asyncio.sleep(0)
+        raise UserError("sibling failed")
+
+    with pytest.raises(UserError, match="sibling failed"):
+        await gather_with_cancel(record_then_block(), fail_fast())
+
+    # False while running, True once a failing sibling is the reason for cancellation.
+    assert observed == [False, True]
+
+    # Outside any gather_with_cancel the flag stays False, which is what keeps the
+    # parent-cancellation path prompt.
+    assert cancelled_by_failing_sibling() is False


### PR DESCRIPTION
### Summary

[#4005](https://github.com/openai/openai-agents-python/pull/4005) established that a failing branch of a concurrent fan-out must not leave its siblings running, and shipped `gather_with_cancel` (`util/_asyncio_tasks.py`) for it. That fix was applied to enablement checks. The run path still used bare `asyncio.gather`, which propagates the first exception while the siblings keep executing, detached, after the run has already unwound.

The sharpest instance is `_execute_tool_plan` (`run_internal/tool_planning.py`), which gathers six tool-execution categories with no surrounding `try`:

```python
) = await asyncio.gather(
    execute_function_tool_calls(...),
    execute_computer_actions(...),
    execute_custom_tool_calls(...),
    execute_shell_calls(...),
    execute_apply_patch_calls(...),
    execute_local_shell_calls(...),
)
```

If `execute_computer_actions` raises — e.g. `UserError("Computer tool safety check was not acknowledged")` — the shell and apply-patch arms are not cancelled, so commands run and patches are written to disk after the run has failed. It also bypasses `_FunctionToolBatchExecutor._raise_failure_after_draining_siblings`, which exists to prevent exactly this one level down, because the failure originates in a sibling gather arm rather than inside the batch.

The inconsistency is concrete for one specific pair of user-supplied callables: `realtime/openai_realtime.py` gathers `agent.get_system_prompt(...)` with `gather_with_cancel`, while both run-path turn functions (`run_single_turn` and `run_single_turn_streamed`) gathered the same call with a bare `asyncio.gather`. Separately, `run.py` hand-rolls cancel-and-drain inline for the guardrail/model race, with a comment describing the invariant. So the rule is applied in three places in the codebase and is absent from `run_internal/`.

This switches the 25 `run_internal/` gathers that lack `return_exceptions=True` to the existing helper — the tool-execution fan-out, the two prompt-resolution pairs, and the lifecycle-hook pairs. Mechanical call-site change, no new abstraction, no behavior change on the success path. `execute_mcp_approval_requests` wraps the result in `list()` because `gather_with_cancel` returns a tuple and the function declares `-> list[RunItem]`.

**Deliberately unchanged:** `run.py`'s guardrail/model race (already cancels and drains, and its tripwire branch cancels conditionally — a mechanical swap would change semantics); the 7 `voice/` and `sandbox/` gathers (separate subsystems); and every `gather(..., return_exceptions=True)` call, which already drains rather than orphaning.

### Test plan

Two regression tests in `tests/test_agent_prompt.py`, one per loop, following the pattern #4005 established in `tests/test_handoff_tool.py` (three `asyncio.Event`s: `slow_started` / `slow_cancelled` / `slow_finished`).

An agent is given an async `instructions` callable that blocks forever and records whether it was cancelled, plus an async `prompt` callable that waits for the first to start and then raises. Since `get_system_prompt` and `get_prompt` are gathered concurrently, the failing prompt must cancel the in-flight instructions callable:

- `test_run_cancels_sibling_instructions_when_prompt_resolution_fails` — non-streamed loop
- `test_run_streamed_cancels_sibling_instructions_when_prompt_resolution_fails` — streamed loop

Both assert `slow_cancelled.is_set()` and `slow_finished.is_set()`. On `main` both fail with `assert False` on `slow_cancelled` — the callable is still running when the run raises. With this change both pass.

Verification (mandatory local run order from `AGENTS.md`):

```
make format     # 847 files left unchanged
make lint       # All checks passed!
make typecheck  # mypy + pyright, exit 0
make tests      # 6223 passed, 4 skipped  /  38 passed, 5 skipped (serial)
```

### Issue number

N/A — searched open and closed issues and PRs for `gather_with_cancel`, `asyncio.gather`, `noop_coroutine`, `sibling`, and `on_tool_start`; the only related hits are #4005 (merged, established the helper) and #3406 (adds an `on_tool_progress` hook, which introduces another instance of the pattern rather than changing it). No duplicate found.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

Developed with Claude Code; reviewed and tested by Pranav before marking ready for review.
