### PR TITLE
fix: reconcile resumed tool name collisions

### DIFF
--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -206,6 +206,34 @@ def _remove_tool_call_namespace(tool_call: Any) -> Any:
     return tool_call
 
 
+def restore_tool_call_routing_identity(
+    tool_call: Any,
+    lookup_key: FunctionToolLookupKey | None,
+) -> Any:
+    """Fill an absent call namespace from a persisted lookup key."""
+    if lookup_key is None or get_tool_call_name(tool_call) != lookup_key[-1]:
+        return tool_call
+    if get_tool_call_namespace(tool_call) is not None or lookup_key[0] == "bare":
+        return tool_call
+
+    namespace = lookup_key[1]
+    if isinstance(tool_call, dict):
+        restored = dict(tool_call)
+        restored["namespace"] = namespace
+        return restored
+
+    model_dump = getattr(tool_call, "model_dump", None)
+    if callable(model_dump):
+        payload = model_dump(exclude_unset=True)
+        if isinstance(payload, dict):
+            payload["namespace"] = namespace
+            try:
+                return type(tool_call)(**payload)
+            except Exception:
+                return payload
+    return tool_call
+
+
 def has_function_tool_shape(tool: Any) -> bool:
     """Return True when the object looks like a FunctionTool instance."""
     return callable(getattr(tool, "on_invoke_tool", None)) and isinstance(

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import dataclasses
 import inspect
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, cast
 
@@ -91,6 +93,11 @@ ToolsToFinalOutputFunction: TypeAlias = Callable[
 """A function that takes a run context and a list of tool results, and returns a
 `ToolsToFinalOutputResult`.
 """
+
+
+_mcp_handoff_snapshot: contextvars.ContextVar[
+    tuple[object, tuple[Handoff[Any, Any], ...]] | None
+] = contextvars.ContextVar("mcp_handoff_snapshot", default=None)
 
 
 def _validate_codex_tool_name_collisions(tools: list[Tool]) -> None:
@@ -205,6 +212,11 @@ class AgentBase(Generic[TContext]):
     ) -> set[str]:
         reserved_tool_names = {tool.name for tool in self.tools if isinstance(tool, FunctionTool)}
 
+        snapshot = _mcp_handoff_snapshot.get()
+        if snapshot is not None and snapshot[0] is self:
+            reserved_tool_names.update(handoff.tool_name for handoff in snapshot[1])
+            return reserved_tool_names
+
         async def _check_handoff_enabled(handoff_obj: Handoff[Any, Any]) -> bool:
             attr = handoff_obj.is_enabled
             if isinstance(attr, bool):
@@ -221,6 +233,18 @@ class AgentBase(Generic[TContext]):
             elif isinstance(handoff_item, AgentBase):
                 reserved_tool_names.add(Handoff.default_tool_name(handoff_item))
         return reserved_tool_names
+
+    @contextmanager
+    def _use_mcp_handoff_snapshot(
+        self,
+        enabled_handoffs: Sequence[Handoff[Any, Any]],
+    ) -> Iterator[None]:
+        """Keep MCP reserved-name generation on one enabled-handoff snapshot."""
+        token = _mcp_handoff_snapshot.set((self, tuple(enabled_handoffs)))
+        try:
+            yield
+        finally:
+            _mcp_handoff_snapshot.reset(token)
 
     async def get_mcp_tools(self, run_context: RunContextWrapper[TContext]) -> list[Tool]:
         """Fetches the available tools from the MCP servers."""

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable, Container, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import replace
 from typing import Any, Literal, cast
 
 from openai.types.responses import (
@@ -32,20 +34,26 @@ from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 from .. import _debug
 from .._mcp_tool_metadata import collect_mcp_list_tools_metadata
 from .._tool_identity import (
+    FunctionToolLookupKey,
     build_function_tool_lookup_map,
     get_function_tool_lookup_key,
     get_function_tool_lookup_key_for_call,
     get_function_tool_lookup_key_for_tool,
-    get_function_tool_qualified_name,
     get_tool_call_namespace,
     get_tool_call_qualified_name,
     get_tool_call_trace_name,
-    normalize_tool_call_for_function_tool,
+    resolve_tool_name_collisions,
+    restore_tool_call_routing_identity,
     should_allow_bare_name_approval_alias,
 )
 from ..agent import Agent, ToolsToFinalOutputResult
 from ..agent_output import AgentOutputSchemaBase
-from ..agent_tool_state import get_agent_tool_state_scope, peek_agent_tool_run_result
+from ..agent_tool_state import (
+    drop_agent_tool_run_result,
+    get_agent_tool_state_scope,
+    peek_agent_tool_run_result,
+    record_agent_tool_run_result,
+)
 from ..exceptions import ModelBehaviorError, ModelRefusalError, UserError
 from ..handoffs import Handoff, HandoffInputData, HandoffInputFilter, nest_handoff_history
 from ..handoffs.history import (
@@ -150,7 +158,6 @@ from .tool_execution import (
     parse_apply_patch_function_args,
     process_hosted_mcp_approvals,
     resolve_approval_rejection_message,
-    resolve_enabled_function_tools,
     should_keep_hosted_mcp_item,
 )
 from .tool_planning import (
@@ -166,6 +173,7 @@ from .tool_planning import (
     _make_unique_item_appender,
     _select_function_tool_runs_for_resume,
 )
+from .turn_preparation import get_handoffs, get_output_schema
 
 _DEFAULT_NEST_HANDOFF_HISTORY = nest_handoff_history
 
@@ -1057,7 +1065,10 @@ async def resolve_interrupted_turn(
                 call_id=call_id,
                 tool_namespace=tool_namespace,
                 tool_lookup_key=get_function_tool_lookup_key_for_tool(function_tool),
-                existing_pending=approval_items_by_call_id.get(call_id),
+                existing_pending=(
+                    function_approval_items_by_call_id.get(call_id)
+                    or approval_items_by_call_id.get(call_id)
+                ),
             )
         rejected_function_outputs.append(
             function_rejection_item(
@@ -1102,6 +1113,7 @@ async def resolve_interrupted_turn(
     rerun_function_call_ids: set[str] = set()
     pending_interruptions: list[ToolApprovalItem] = []
     pending_interruption_keys: set[str] = set()
+    stable_function_approval_sources: dict[int, ToolApprovalItem] = {}
 
     output_index = _build_tool_output_index(original_pre_step_items)
 
@@ -1280,6 +1292,19 @@ async def resolve_interrupted_turn(
     def _add_pending_interruption(item: ToolApprovalItem | None) -> None:
         if item is None:
             return
+        source_item = stable_function_approval_sources.get(id(item))
+        if source_item is not None:
+            source_item.agent = item.agent
+            source_item.raw_item = cast(
+                ResponseFunctionToolCall,
+                item.raw_item,
+            ).model_copy(deep=True)
+            source_item.tool_name = item.tool_name
+            source_item.tool_namespace = item.tool_namespace
+            source_item.tool_origin = item.tool_origin
+            source_item.tool_lookup_key = item.tool_lookup_key
+            source_item._allow_bare_name_alias = item._allow_bare_name_alias
+            item = source_item
         call_id = extract_tool_call_id(item.raw_item)
         key = call_id or f"raw:{id(item.raw_item)}"
         if key in pending_interruption_keys:
@@ -1311,155 +1336,551 @@ async def resolve_interrupted_turn(
             return True
         return allow_legacy_name_agent_match and approval_agent.name == public_agent.name
 
-    available_function_tools = await resolve_enabled_function_tools(
-        execution_agent,
-        context_wrapper,
-    )
-    approval_rebuild_function_tools = available_function_tools
-    if pending_approval_items and execution_agent.mcp_servers:
-        approval_rebuild_function_tools = [
-            tool
-            for tool in await execution_agent.get_all_tools(context_wrapper)
-            if isinstance(tool, FunctionTool)
+    def _approval_persisted_lookup_key(
+        approval: ToolApprovalItem,
+    ) -> FunctionToolLookupKey | None:
+        persisted_key = approval.tool_lookup_key
+        if persisted_key is not None:
+            return persisted_key
+        if not approval.tool_name:
+            return None
+        return get_function_tool_lookup_key(
+            approval.tool_name,
+            approval.tool_namespace,
+        )
+
+    queued_call_id_counts: dict[str, int] = {}
+    queued_call_items = [
+        *(run.tool_call for run in processed_response.functions),
+        *(run.tool_call for run in processed_response.handoffs),
+        *(run.tool_call for run in processed_response.computer_actions),
+        *(run.tool_call for run in processed_response.custom_tool_calls),
+        *(run.tool_call for run in processed_response.local_shell_calls),
+        *(run.tool_call for run in processed_response.shell_calls),
+        *(run.tool_call for run in processed_response.apply_patch_calls),
+        *(run.request_item for run in processed_response.mcp_approval_requests),
+        *(run.tool_call for run in processed_response.function_tools_not_found),
+    ]
+    for queued_call_item in queued_call_items:
+        queued_call_id = extract_tool_call_id(queued_call_item)
+        if queued_call_id is not None:
+            queued_call_id_counts[queued_call_id] = queued_call_id_counts.get(queued_call_id, 0) + 1
+    duplicate_queued_call_ids = {
+        call_id for call_id, count in queued_call_id_counts.items() if count > 1
+    }
+    non_function_owned_call_ids = {
+        call_id
+        for call_item in [
+            *(run.tool_call for run in processed_response.computer_actions),
+            *(run.tool_call for run in processed_response.custom_tool_calls),
+            *(run.tool_call for run in processed_response.local_shell_calls),
+            *(run.tool_call for run in processed_response.shell_calls),
+            *(run.tool_call for run in processed_response.apply_patch_calls),
+            *(run.request_item for run in processed_response.mcp_approval_requests),
         ]
-    program_call_ids, completed_program_call_ids = _collect_program_parent_state(
-        [*original_pre_step_items, *new_response.output],
-        server_manages_conversation=server_manages_conversation,
-    )
-    programmatic_tool_present = any(
-        isinstance(tool, ProgrammaticToolCallingTool) for tool in execution_agent.tools
-    )
+        if (call_id := extract_tool_call_id(call_item)) is not None
+    }
 
-    async def _rebuild_function_runs_from_approvals() -> list[ToolRunFunction]:
-        if not pending_approval_items:
-            return []
-        tool_map = build_function_tool_lookup_map(approval_rebuild_function_tools)
-        existing_pending_call_ids: set[str] = set()
-        for existing_pending in pending_interruptions:
-            if isinstance(existing_pending, ToolApprovalItem):
-                existing_call_id = extract_tool_call_id(existing_pending.raw_item)
-                if existing_call_id:
-                    existing_pending_call_ids.add(existing_call_id)
-        rebuilt_runs: list[ToolRunFunction] = []
+    stable_function_call_sources: dict[int, ResponseFunctionToolCall] = {}
 
-        def _add_unmatched_pending(approval: ToolApprovalItem) -> None:
-            call_id = extract_tool_call_id(approval.raw_item)
-            if not call_id:
-                _add_pending_interruption(approval)
-                return
-            tool_name = approval.tool_name or ""
-            approval_status = context_wrapper.get_approval_status(
-                tool_name,
-                call_id,
-                tool_namespace=approval.tool_namespace,
-                existing_pending=approval,
+    def _snapshot_function_run(run: ToolRunFunction) -> ToolRunFunction:
+        if run.tool_call.call_id in duplicate_queued_call_ids:
+            return run
+        stable_call = run.tool_call.model_copy(deep=True)
+        stable_function_call_sources[id(stable_call)] = run.tool_call
+        nested_result = peek_agent_tool_run_result(
+            run.tool_call,
+            scope_id=tool_state_scope_id,
+        )
+        if nested_result is not None:
+            record_agent_tool_run_result(
+                stable_call,
+                nested_result,
+                scope_id=tool_state_scope_id,
             )
-            if approval_status is None:
-                _add_pending_interruption(approval)
+        return ToolRunFunction(
+            tool_call=stable_call,
+            function_tool=run.function_tool,
+        )
 
-        for approval in pending_approval_items:
-            if not isinstance(approval, ToolApprovalItem):
-                continue
-            if not _approval_matches_agent(approval):
-                _add_unmatched_pending(approval)
-                continue
-            raw = approval.raw_item
-            raw_type = get_mapping_or_attr(raw, "type")
-            if raw_type != "function_call":
-                _add_unmatched_pending(approval)
-                continue
-            name = get_mapping_or_attr(raw, "name")
-            namespace = get_tool_call_namespace(raw)
-            if namespace is None and isinstance(approval.tool_namespace, str):
-                namespace = approval.tool_namespace
-            approval_key = getattr(approval, "tool_lookup_key", None)
-            if approval_key is None:
-                approval_key = get_function_tool_lookup_key(name, namespace)
-            resolved_tool = tool_map.get(approval_key) if approval_key is not None else None
-            if not (isinstance(name, str) and resolved_tool is not None):
-                _add_unmatched_pending(approval)
-                continue
+    stable_function_runs = [_snapshot_function_run(run) for run in processed_response.functions]
+    stable_handoff_runs = [
+        run
+        if run.tool_call.call_id in duplicate_queued_call_ids
+        else ToolRunHandoff(
+            handoff=run.handoff,
+            tool_call=run.tool_call.model_copy(deep=True),
+        )
+        for run in processed_response.handoffs
+    ]
+    response_function_calls = [
+        output.model_copy(deep=True)
+        for output in new_response.output
+        if isinstance(output, ResponseFunctionToolCall)
+    ]
+    authoritative_response_function_calls = [
+        call for call in response_function_calls if call.call_id not in non_function_owned_call_ids
+    ]
+    response_call_positions: dict[str, int] = {}
+    for index, output in enumerate(new_response.output):
+        output_call_id = extract_tool_call_id(output)
+        if output_call_id is not None:
+            response_call_positions.setdefault(output_call_id, index)
 
-            rebuilt_call_id: str | None
-            arguments: str | None
-            tool_call: ResponseFunctionToolCall
-            if isinstance(raw, ResponseFunctionToolCall):
-                rebuilt_call_id = raw.call_id
-                arguments = raw.arguments
-                tool_call = raw
-            else:
-                rebuilt_call_id = extract_tool_call_id(raw)
-                arguments = get_mapping_or_attr(raw, "arguments") or "{}"
-                status = get_mapping_or_attr(raw, "status")
-                if not (isinstance(rebuilt_call_id, str) and isinstance(arguments, str)):
-                    _add_unmatched_pending(approval)
-                    continue
-                valid_status: Literal["in_progress", "completed", "incomplete"] | None = None
-                if isinstance(status, str) and status in (
-                    "in_progress",
-                    "completed",
-                    "incomplete",
-                ):
-                    valid_status = status  # type: ignore[assignment]
-                tool_call_payload: dict[str, Any] = {
-                    "type": "function_call",
-                    "name": name,
-                    "call_id": rebuilt_call_id,
-                    "arguments": arguments,
-                    "status": valid_status,
-                }
-                if namespace is not None:
-                    tool_call_payload["namespace"] = namespace
-                caller = get_mapping_or_attr(raw, "caller")
-                if caller is not None:
-                    tool_call_payload["caller"] = caller
-                tool_call = ResponseFunctionToolCall(**tool_call_payload)
-            tool_call = cast(
+    queued_function_call_ids_by_lookup_key: dict[FunctionToolLookupKey, set[str]] = {}
+    queued_function_lookup_keys_by_call_id: dict[str, set[FunctionToolLookupKey]] = {}
+    canonical_queued_function_calls: dict[str, ResponseFunctionToolCall] = {}
+    authoritative_function_calls = [
+        *(run.tool_call for run in stable_function_runs),
+        *authoritative_response_function_calls,
+    ]
+    for function_call in authoritative_function_calls:
+        lookup_key = get_function_tool_lookup_key_for_call(function_call)
+        if lookup_key is None:
+            continue
+        queued_function_call_ids_by_lookup_key.setdefault(lookup_key, set()).add(
+            function_call.call_id
+        )
+        queued_function_lookup_keys_by_call_id.setdefault(
+            function_call.call_id,
+            set(),
+        ).add(lookup_key)
+    for function_run in stable_function_runs:
+        if function_run.tool_call.call_id not in duplicate_queued_call_ids:
+            canonical_queued_function_calls[function_run.tool_call.call_id] = function_run.tool_call
+    for response_call in authoritative_response_function_calls:
+        if response_call.call_id not in duplicate_queued_call_ids:
+            canonical_queued_function_calls.setdefault(response_call.call_id, response_call)
+    queued_function_call_ids = {
+        call_id
+        for call_ids in queued_function_call_ids_by_lookup_key.values()
+        for call_id in call_ids
+    }
+
+    def _is_function_approval(approval: ToolApprovalItem) -> bool:
+        call_id = extract_tool_call_id(approval.raw_item)
+        if call_id in non_function_owned_call_ids and call_id not in queued_function_call_ids:
+            return False
+        if get_mapping_or_attr(approval.raw_item, "type") == "function_call":
+            return True
+        return approval.tool_lookup_key is not None or call_id in queued_function_call_ids
+
+    function_approval_items = [
+        approval
+        for approval in pending_approval_items
+        if _approval_matches_agent(approval) and _is_function_approval(approval)
+    ]
+
+    def _validate_approval_identity(approval: ToolApprovalItem) -> None:
+        persisted_key = _approval_persisted_lookup_key(approval)
+        raw_name = get_mapping_or_attr(approval.raw_item, "name")
+        if persisted_key is None or not isinstance(raw_name, str) or not raw_name:
+            return
+        raw_namespace = get_tool_call_namespace(approval.raw_item)
+        raw_key = get_function_tool_lookup_key(raw_name, raw_namespace)
+        if persisted_key[-1] == raw_name and (raw_namespace is None or persisted_key == raw_key):
+            return
+        raw_identity = get_tool_call_qualified_name(approval.raw_item) or raw_name
+        raise ModelBehaviorError(
+            f"Persisted tool identity {persisted_key!r} does not match raw tool call "
+            f"{raw_identity}. Restore a consistent RunState before resuming."
+        )
+
+    def _coerce_approval_call(
+        approval: ToolApprovalItem,
+    ) -> ResponseFunctionToolCall | None:
+        raw = approval.raw_item
+        if get_mapping_or_attr(raw, "type") != "function_call":
+            return None
+        name = get_mapping_or_attr(raw, "name")
+        call_id = get_mapping_or_attr(raw, "call_id")
+        arguments = get_mapping_or_attr(raw, "arguments")
+        if not (
+            isinstance(name, str)
+            and isinstance(call_id, str)
+            and call_id
+            and isinstance(arguments, str)
+        ):
+            return None
+        payload: dict[str, Any] = {
+            "type": "function_call",
+            "name": name,
+            "call_id": call_id,
+            "arguments": arguments,
+        }
+        status = get_mapping_or_attr(raw, "status")
+        if status in ("in_progress", "completed", "incomplete"):
+            payload["status"] = status
+        namespace = get_tool_call_namespace(raw)
+        if namespace is not None:
+            payload["namespace"] = namespace
+        caller = get_mapping_or_attr(raw, "caller")
+        if caller is not None:
+            payload["caller"] = deepcopy(caller)
+        item_id = get_mapping_or_attr(raw, "id")
+        if isinstance(item_id, str):
+            payload["id"] = item_id
+        call = ResponseFunctionToolCall(**payload)
+
+        persisted_key = _approval_persisted_lookup_key(approval)
+        if get_tool_call_namespace(call) is None and persisted_key is not None:
+            call = cast(
                 ResponseFunctionToolCall,
-                normalize_tool_call_for_function_tool(tool_call, resolved_tool),
+                restore_tool_call_routing_identity(call, persisted_key),
             )
-            ensure_programmatic_tool_call_parent(
-                tool_call=tool_call,
-                programmatic_tool_present=programmatic_tool_present,
-                program_call_ids=program_call_ids,
-                completed_program_call_ids=completed_program_call_ids,
-                agent_name=public_agent.name,
-            )
-            ensure_tool_caller_allowed(
-                tool_call=tool_call,
-                allowed_callers=resolved_tool.allowed_callers,
-                tool_name=get_function_tool_qualified_name(resolved_tool) or resolved_tool.name,
-                agent_name=public_agent.name,
-            )
+        return call
 
-            if not (isinstance(rebuilt_call_id, str) and isinstance(arguments, str)):
-                _add_unmatched_pending(approval)
-                continue
+    validated_function_approval_items: dict[ToolApprovalItem, ToolApprovalItem] = {}
+    malformed_function_approvals: list[ToolApprovalItem] = []
+    for approval in function_approval_items:
+        _validate_approval_identity(approval)
+        approval_call = _coerce_approval_call(approval)
+        if approval_call is None:
+            malformed_function_approvals.append(approval)
+            continue
+        persisted_key = _approval_persisted_lookup_key(approval)
+        queued_lookup_keys = queued_function_lookup_keys_by_call_id.get(
+            approval_call.call_id,
+            set(),
+        )
+        if queued_lookup_keys and (
+            persisted_key is None or persisted_key not in queued_lookup_keys
+        ):
+            malformed_function_approvals.append(approval)
+            continue
+        queued_call_ids = (
+            queued_function_call_ids_by_lookup_key.get(persisted_key, set())
+            if persisted_key is not None
+            else set()
+        )
+        if queued_call_ids and approval_call.call_id not in queued_call_ids:
+            malformed_function_approvals.append(approval)
+            continue
+        stable_approval = ToolApprovalItem(
+            agent=public_agent,
+            raw_item=approval_call,
+            tool_name=approval.tool_name,
+            tool_namespace=approval.tool_namespace,
+            tool_origin=approval.tool_origin,
+            tool_lookup_key=approval.tool_lookup_key,
+            _allow_bare_name_alias=approval._allow_bare_name_alias,
+        )
+        validated_function_approval_items[approval] = stable_approval
+        stable_function_approval_sources[id(stable_approval)] = approval
 
-            approval_status = context_wrapper.get_approval_status(
-                name,
-                rebuilt_call_id,
-                tool_namespace=namespace,
-                existing_pending=approval,
+    if malformed_function_approvals:
+        processed_response.interruptions = list(pending_approval_items)
+        return SingleStepResult(
+            original_input=original_input,
+            model_response=new_response,
+            pre_step_items=original_pre_step_items,
+            new_step_items=[],
+            next_step=NextStepInterruption(interruptions=list(pending_approval_items)),
+            tool_input_guardrail_results=[],
+            tool_output_guardrail_results=[],
+            processed_response=processed_response,
+        )
+
+    function_approval_items = list(validated_function_approval_items.values())
+    function_approval_items_by_call_id = {
+        cast(ResponseFunctionToolCall, approval.raw_item).call_id: approval
+        for approval in function_approval_items
+    }
+
+    classifier_context_items = [
+        deepcopy(output)
+        for output in new_response.output
+        if get_mapping_or_attr(output, "type") in ("program", "program_output")
+    ]
+    classifier_existing_items = cast(
+        Sequence[RunItem],
+        [deepcopy(getattr(item, "raw_item", item)) for item in original_pre_step_items],
+    )
+    classifier_server_managed_input_items = (
+        deepcopy(ItemHelpers.input_to_new_input_list(original_input))
+        if server_manages_conversation
+        else None
+    )
+
+    available_handoffs = await get_handoffs(execution_agent, context_wrapper)
+    with execution_agent._use_mcp_handoff_snapshot(available_handoffs):
+        current_tool_inventory = await execution_agent.get_all_tools(context_wrapper)
+    resolved_tools, resolved_handoffs = resolve_tool_name_collisions(
+        current_tool_inventory,
+        available_handoffs,
+        collision_policy=run_config.tool_name_collision_policy,
+    )
+    resolved_function_tools = [tool for tool in resolved_tools if isinstance(tool, FunctionTool)]
+    local_function_tool_ids = {
+        id(tool) for tool in execution_agent.tools if isinstance(tool, FunctionTool)
+    }
+    available_function_tools = [
+        tool for tool in resolved_function_tools if id(tool) in local_function_tool_ids
+    ]
+
+    stale_functions = {
+        run.tool_call.call_id: run
+        for run in stable_function_runs
+        if run.tool_call.call_id not in duplicate_queued_call_ids
+    }
+    executed_handoff_call_ids = {
+        executed_handoff_call_id
+        for item in original_pre_step_items
+        if isinstance(item, HandoffOutputItem)
+        and (executed_handoff_call_id := extract_tool_call_id(item.raw_item)) is not None
+    }
+
+    calls_to_reconcile: list[ResponseFunctionToolCall] = []
+    reconciled_call_ids: set[str] = set()
+
+    def _append_reconciliation_call(call: ResponseFunctionToolCall) -> None:
+        call_id = call.call_id
+        if (
+            call_id in duplicate_queued_call_ids
+            or call_id in reconciled_call_ids
+            or call_id in executed_handoff_call_ids
+        ):
+            return
+        stale_run = stale_functions.get(call_id)
+        nested_result = (
+            peek_agent_tool_run_result(stale_run.tool_call, scope_id=tool_state_scope_id)
+            if stale_run is not None
+            else None
+        )
+        if _has_output_item(call_id, "function_call_output") and not (
+            nested_result and getattr(nested_result, "interruptions", None)
+        ):
+            return
+        approval = function_approval_items_by_call_id.get(call_id)
+        queued_call = canonical_queued_function_calls.get(call_id)
+        if queued_call is not None:
+            call = queued_call.model_copy(deep=True)
+        elif approval is not None:
+            call = cast(ResponseFunctionToolCall, approval.raw_item)
+        reconciled_call_ids.add(call_id)
+        calls_to_reconcile.append(call)
+
+    for output in authoritative_response_function_calls:
+        _append_reconciliation_call(output)
+    for function_run in stable_function_runs:
+        _append_reconciliation_call(function_run.tool_call)
+    for handoff_run in stable_handoff_runs:
+        _append_reconciliation_call(handoff_run.tool_call)
+    for approval_item in function_approval_items:
+        _append_reconciliation_call(cast(ResponseFunctionToolCall, approval_item.raw_item))
+
+    classifier_tools: list[Tool] = [*resolved_function_tools]
+    classifier_tools.extend(
+        tool for tool in resolved_tools if isinstance(tool, ProgrammaticToolCallingTool)
+    )
+    classifier_response = ModelResponse(
+        output=cast(Any, [*classifier_context_items, *calls_to_reconcile]),
+        usage=new_response.usage,
+        response_id=new_response.response_id,
+        request_id=new_response.request_id,
+    )
+    classified = process_model_response(
+        agent=public_agent,
+        all_tools=classifier_tools,
+        response=classifier_response,
+        output_schema=get_output_schema(execution_agent),
+        handoffs=cast(list[Handoff], resolved_handoffs),
+        existing_items=classifier_existing_items,
+        run_config=replace(run_config, tool_not_found_behavior="return_error_to_model"),
+        server_manages_conversation=server_manages_conversation,
+        server_managed_input_items=classifier_server_managed_input_items,
+        allow_apply_patch_function_fallback=False,
+    )
+    current_functions = {run.tool_call.call_id: run for run in classified.functions}
+    current_handoffs = {run.tool_call.call_id: run for run in classified.handoffs}
+    current_missing = {run.tool_call.call_id: run for run in classified.function_tools_not_found}
+    pending_nested_transfers: list[tuple[ResponseFunctionToolCall, Any]] = []
+    pending_nested_drops: list[ResponseFunctionToolCall] = []
+
+    def _cached_nested_result(run: ToolRunFunction) -> Any | None:
+        return peek_agent_tool_run_result(run.tool_call, scope_id=tool_state_scope_id)
+
+    def _drop_stable_nested_result(call: ResponseFunctionToolCall) -> None:
+        drop_agent_tool_run_result(call, scope_id=tool_state_scope_id)
+        source_call = stable_function_call_sources.get(id(call))
+        if source_call is not None:
+            drop_agent_tool_run_result(source_call, scope_id=tool_state_scope_id)
+
+    def _pending_nested_result(run: ToolRunFunction) -> Any | None:
+        result = _cached_nested_result(run)
+        return result if result and getattr(result, "interruptions", None) else None
+
+    def _reject_nested_replacement(run: ToolRunFunction) -> None:
+        if _pending_nested_result(run) is None:
+            pending_nested_drops.append(run.tool_call)
+            return
+        qualified_name = get_tool_call_qualified_name(run.tool_call) or run.tool_call.name
+        # TODO: Persist Agent.as_tool() owner identity so replacement before RunState
+        # restoration can be detected and safely migrated.
+        raise ModelBehaviorError(
+            f"Cannot reconcile queued tool {qualified_name} with a new tool or handoff while "
+            "its Agent.as_tool() run is interrupted. Restore the original tool configuration "
+            "or start a new run."
+        )
+
+    def _rebind_function_run(
+        stale_run: ToolRunFunction | None,
+        current_run: ToolRunFunction,
+    ) -> ToolRunFunction:
+        if stale_run is None:
+            return current_run
+        cached_result = _cached_nested_result(stale_run)
+        pending_result = _pending_nested_result(stale_run)
+        if stale_run.function_tool is not current_run.function_tool:
+            stale_owner = getattr(stale_run.function_tool, "_agent_instance", None)
+            current_owner = getattr(current_run.function_tool, "_agent_instance", None)
+            if pending_result is not None and (
+                stale_owner is None or stale_owner is not current_owner
+            ):
+                _reject_nested_replacement(stale_run)
+            if cached_result is not None and pending_result is None:
+                pending_nested_drops.append(stale_run.tool_call)
+        if pending_result is not None and current_run.tool_call is not stale_run.tool_call:
+            pending_nested_transfers.append((current_run.tool_call, pending_result))
+            pending_nested_drops.append(stale_run.tool_call)
+        return current_run
+
+    reconciled_functions: list[ToolRunFunction] = [
+        run for run in stable_function_runs if run.tool_call.call_id not in reconciled_call_ids
+    ]
+    reconciled_handoffs: list[ToolRunHandoff] = [
+        run for run in stable_handoff_runs if run.tool_call.call_id not in reconciled_call_ids
+    ]
+    missing_function_tools: list[ToolRunFunctionNotFound] = []
+    missing_state_calls: list[ResponseFunctionToolCall] = []
+    missing_function_call_ids: set[str] = set()
+
+    for call in calls_to_reconcile:
+        call_id = call.call_id
+        approval_record = function_approval_items_by_call_id.get(call_id)
+        approval_status = (
+            context_wrapper.get_approval_status(
+                approval_record.tool_name or call.name,
+                call_id,
+                tool_namespace=approval_record.tool_namespace,
+                existing_pending=approval_record,
             )
-            if approval_status is False:
-                await _record_function_rejection(
-                    rebuilt_call_id,
-                    tool_call,
-                    resolved_tool,
+            if approval_record is not None
+            else True
+        )
+        stale_function = stale_functions.get(call_id)
+        current_function = current_functions.get(call_id)
+        if current_function is not None:
+            reconciled_functions.append(_rebind_function_run(stale_function, current_function))
+            continue
+
+        current_handoff = current_handoffs.get(call_id)
+        if current_handoff is not None and approval_status is True:
+            if stale_function is not None:
+                _reject_nested_replacement(stale_function)
+            reconciled_handoffs.append(current_handoff)
+            continue
+
+        missing = current_missing.get(call_id)
+        if missing is not None and approval_status is True:
+            if run_config.tool_not_found_behavior != "return_error_to_model":
+                qualified_name = (
+                    get_tool_call_qualified_name(missing.tool_call) or missing.tool_name
                 )
-                continue
-            if approval_status is None:
-                if rebuilt_call_id not in existing_pending_call_ids:
-                    _add_pending_interruption(approval)
-                    existing_pending_call_ids.add(rebuilt_call_id)
-                continue
-            rebuilt_runs.append(ToolRunFunction(function_tool=resolved_tool, tool_call=tool_call))
-        return rebuilt_runs
+                raise ModelBehaviorError(
+                    f"Tool {qualified_name} not found in agent {public_agent.name}"
+                )
+            cached_result = (
+                _cached_nested_result(stale_function)
+                if stale_function is not None
+                else peek_agent_tool_run_result(
+                    missing.tool_call,
+                    scope_id=tool_state_scope_id,
+                )
+            )
+            if cached_result is not None:
+                state_call = missing.tool_call
+                if stale_function is not None:
+                    reconciled_functions.append(stale_function)
+                    state_call = stale_function.tool_call
+                missing_state_calls.append(state_call)
+            missing_function_call_ids.add(call_id)
+            missing_function_tools.append(missing)
+            continue
 
+        if stale_function is not None:
+            reconciled_functions.append(stale_function)
+        elif approval_record is not None:
+            if approval_status is None:
+                _add_pending_interruption(approval_record)
+            elif approval_status is False:
+                rejection_call = cast(
+                    ResponseFunctionToolCall,
+                    approval_record.raw_item,
+                )
+                rejection_message = await resolve_approval_rejection_message(
+                    context_wrapper=context_wrapper,
+                    run_config=run_config,
+                    tool_type="function",
+                    tool_name=get_tool_call_trace_name(rejection_call) or rejection_call.name,
+                    call_id=call_id,
+                    tool_namespace=get_tool_call_namespace(rejection_call),
+                    tool_lookup_key=approval_record.tool_lookup_key,
+                    existing_pending=approval_record,
+                )
+                rejected_function_outputs.append(
+                    function_rejection_item(
+                        public_agent,
+                        rejection_call,
+                        rejection_message=rejection_message,
+                        output_json_schema=None,
+                        scope_id=tool_state_scope_id,
+                        tool_origin=approval_record.tool_origin,
+                    )
+                )
+                rejected_function_call_ids.add(call_id)
+
+    for original_approval in pending_approval_items:
+        approval_snapshot = validated_function_approval_items.get(original_approval)
+        if approval_snapshot is None:
+            approval = original_approval
+            approval_call_id = extract_tool_call_id(approval.raw_item)
+            if (
+                approval_call_id is None
+                or context_wrapper.get_approval_status(
+                    approval.tool_name or "",
+                    approval_call_id,
+                    tool_namespace=approval.tool_namespace,
+                    existing_pending=approval,
+                )
+                is None
+            ):
+                _add_pending_interruption(approval)
+            continue
+        approval_call_id = cast(
+            ResponseFunctionToolCall,
+            approval_snapshot.raw_item,
+        ).call_id
+        if (
+            approval_call_id not in reconciled_call_ids
+            and context_wrapper.get_approval_status(
+                approval_snapshot.tool_name or "",
+                approval_call_id,
+                tool_namespace=approval_snapshot.tool_namespace,
+                existing_pending=approval_snapshot,
+            )
+            is None
+        ):
+            _add_pending_interruption(approval_snapshot)
+
+    selectable_function_runs = [
+        run
+        for run in reconciled_functions
+        if run.tool_call.call_id not in missing_function_call_ids
+    ]
     function_tool_runs = await _select_function_tool_runs_for_resume(
-        processed_response.functions,
-        approval_items_by_call_id=approval_items_by_call_id,
+        selectable_function_runs,
+        approval_items_by_call_id=function_approval_items_by_call_id,
         context_wrapper=context_wrapper,
         needs_approval_checker=_function_requires_approval,
         output_exists_checker=_function_output_exists,
@@ -1478,21 +1899,6 @@ async def resolve_interrupted_turn(
             ),
         ),
     )
-
-    rebuilt_function_tool_runs = await _rebuild_function_runs_from_approvals()
-    if rebuilt_function_tool_runs:
-        existing_call_ids: set[str] = set()
-        for run in function_tool_runs:
-            call_id = extract_tool_call_id(run.tool_call)
-            if call_id:
-                existing_call_ids.add(call_id)
-        for run in rebuilt_function_tool_runs:
-            call_id = extract_tool_call_id(run.tool_call)
-            if call_id and call_id in existing_call_ids:
-                continue
-            function_tool_runs.append(run)
-            if call_id:
-                existing_call_ids.add(call_id)
 
     pending_computer_actions: list[ToolRunComputerAction] = []
     for action in processed_response.computer_actions:
@@ -1554,6 +1960,29 @@ async def resolve_interrupted_turn(
         apply_patch_calls=approved_apply_patch_calls,
     )
 
+    missing_output_items = await _build_tool_not_found_output_items(
+        agent=public_agent,
+        calls=missing_function_tools,
+        context_wrapper=context_wrapper,
+        run_config=run_config,
+    )
+
+    for current_call, nested_result in pending_nested_transfers:
+        record_agent_tool_run_result(
+            current_call,
+            nested_result,
+            scope_id=tool_state_scope_id,
+        )
+    processed_response.functions = reconciled_functions
+    processed_response.handoffs = reconciled_handoffs
+    processed_response.function_tools_not_found = missing_function_tools
+    dropped_nested_call_ids: set[int] = set()
+    for stale_call in pending_nested_drops:
+        if id(stale_call) in dropped_nested_call_ids:
+            continue
+        dropped_nested_call_ids.add(id(stale_call))
+        _drop_stable_nested_result(stale_call)
+
     (
         function_results,
         tool_input_guardrail_results,
@@ -1581,8 +2010,35 @@ async def resolve_interrupted_turn(
 
     new_items, append_if_new = _make_unique_item_appender(original_pre_step_items)
 
-    for item in _build_tool_result_items(
+    function_result_items = _build_tool_result_items(
         function_results=function_results,
+        computer_results=[],
+        custom_tool_results=[],
+        shell_results=[],
+        apply_patch_results=[],
+        local_shell_results=[],
+    )
+    call_positions = dict(response_call_positions)
+    next_call_position = len(new_response.output)
+    for call in calls_to_reconcile:
+        if call.call_id not in call_positions:
+            call_positions[call.call_id] = next_call_position
+            next_call_position += 1
+    function_outcomes = [
+        *function_result_items,
+        *missing_output_items,
+        *rejected_function_outputs,
+    ]
+    function_outcomes.sort(
+        key=lambda item: call_positions.get(
+            extract_tool_call_id(getattr(item, "raw_item", None)) or "",
+            len(call_positions),
+        )
+    )
+    for item in function_outcomes:
+        append_if_new(item)
+    for item in _build_tool_result_items(
+        function_results=[],
         computer_results=computer_results,
         custom_tool_results=custom_tool_results,
         shell_results=shell_results,
@@ -1590,8 +2046,6 @@ async def resolve_interrupted_turn(
         local_shell_results=[],
     ):
         append_if_new(item)
-    for rejection_item in rejected_function_outputs:
-        append_if_new(rejection_item)
     for pending_item in pending_interruptions:
         if pending_item:
             append_if_new(pending_item)
@@ -1604,19 +2058,32 @@ async def resolve_interrupted_turn(
     for approved_response in plan.approved_mcp_responses:
         append_if_new(approved_response)
 
+    def _commit_missing_state(result: SingleStepResult) -> SingleStepResult:
+        if missing_function_call_ids:
+            processed_response.functions = [
+                run
+                for run in processed_response.functions
+                if run.tool_call.call_id not in missing_function_call_ids
+            ]
+        for call in missing_state_calls:
+            _drop_stable_nested_result(call)
+        return result
+
     processed_response.interruptions = pending_interruptions
     if pending_interruptions:
-        return SingleStepResult(
-            original_input=original_input,
-            model_response=new_response,
-            pre_step_items=original_pre_step_items,
-            new_step_items=new_items,
-            next_step=NextStepInterruption(
-                interruptions=[item for item in pending_interruptions if item]
-            ),
-            tool_input_guardrail_results=tool_input_guardrail_results,
-            tool_output_guardrail_results=tool_output_guardrail_results,
-            processed_response=processed_response,
+        return _commit_missing_state(
+            SingleStepResult(
+                original_input=original_input,
+                model_response=new_response,
+                pre_step_items=original_pre_step_items,
+                new_step_items=new_items,
+                next_step=NextStepInterruption(
+                    interruptions=[item for item in pending_interruptions if item]
+                ),
+                tool_input_guardrail_results=tool_input_guardrail_results,
+                tool_output_guardrail_results=tool_output_guardrail_results,
+                processed_response=processed_response,
+            )
         )
 
     await _append_mcp_callback_results(
@@ -1672,13 +2139,6 @@ async def resolve_interrupted_turn(
             )
         ]
 
-    executed_handoff_call_ids: set[str] = set()
-    for item in original_pre_step_items:
-        if isinstance(item, HandoffOutputItem):
-            handoff_call_id = extract_tool_call_id(item.raw_item)
-            if handoff_call_id:
-                executed_handoff_call_ids.add(handoff_call_id)
-
     pending_handoffs = [
         handoff
         for handoff in processed_response.handoffs
@@ -1687,20 +2147,22 @@ async def resolve_interrupted_turn(
     ]
 
     if pending_handoffs:
-        return await execute_handoffs_call(
-            public_agent=public_agent,
-            original_input=original_input,
-            pre_step_items=pre_step_items,
-            new_step_items=new_items,
-            new_response=new_response,
-            run_handoffs=pending_handoffs,
-            hooks=hooks,
-            context_wrapper=context_wrapper,
-            run_config=run_config,
-            server_manages_conversation=server_manages_conversation,
-            nest_handoff_history_fn=nest_handoff_history_fn,
-            tool_input_guardrail_results=tool_input_guardrail_results,
-            tool_output_guardrail_results=tool_output_guardrail_results,
+        return _commit_missing_state(
+            await execute_handoffs_call(
+                public_agent=public_agent,
+                original_input=original_input,
+                pre_step_items=pre_step_items,
+                new_step_items=new_items,
+                new_response=new_response,
+                run_handoffs=pending_handoffs,
+                hooks=hooks,
+                context_wrapper=context_wrapper,
+                run_config=run_config,
+                server_manages_conversation=server_manages_conversation,
+                nest_handoff_history_fn=nest_handoff_history_fn,
+                tool_input_guardrail_results=tool_input_guardrail_results,
+                tool_output_guardrail_results=tool_output_guardrail_results,
+            )
         )
 
     tool_final_output = await _maybe_finalize_from_tool_results(
@@ -1716,16 +2178,18 @@ async def resolve_interrupted_turn(
         tool_output_guardrail_results=tool_output_guardrail_results,
     )
     if tool_final_output is not None:
-        return tool_final_output
+        return _commit_missing_state(tool_final_output)
 
-    return SingleStepResult(
-        original_input=original_input,
-        model_response=new_response,
-        pre_step_items=pre_step_items,
-        new_step_items=new_items,
-        next_step=NextStepRunAgain(),
-        tool_input_guardrail_results=tool_input_guardrail_results,
-        tool_output_guardrail_results=tool_output_guardrail_results,
+    return _commit_missing_state(
+        SingleStepResult(
+            original_input=original_input,
+            model_response=new_response,
+            pre_step_items=pre_step_items,
+            new_step_items=new_items,
+            next_step=NextStepRunAgain(),
+            tool_input_guardrail_results=tool_input_guardrail_results,
+            tool_output_guardrail_results=tool_output_guardrail_results,
+        )
     )
 
 
@@ -1740,6 +2204,7 @@ def process_model_response(
     run_config: RunConfig | None = None,
     server_manages_conversation: bool = False,
     server_managed_input_items: Sequence[Any] | None = None,
+    allow_apply_patch_function_fallback: bool = True,
 ) -> ProcessedResponse:
     items: list[RunItem] = []
 
@@ -2307,6 +2772,7 @@ def process_model_response(
                 raise ModelBehaviorError(f"Tool {output.name} not found in agent {agent.name}")
         elif (
             isinstance(output, ResponseFunctionToolCall)
+            and allow_apply_patch_function_fallback
             and is_apply_patch_name(output.name, apply_patch_tool)
             and get_function_tool_lookup_key_for_call(output) not in function_map
         ):

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -1382,6 +1382,7 @@ async def resolve_interrupted_turn(
     }
 
     stable_function_call_sources: dict[int, ResponseFunctionToolCall] = {}
+    stable_function_nested_results: dict[int, Any] = {}
 
     def _snapshot_function_run(run: ToolRunFunction) -> ToolRunFunction:
         if run.tool_call.call_id in duplicate_queued_call_ids:
@@ -1393,11 +1394,7 @@ async def resolve_interrupted_turn(
             scope_id=tool_state_scope_id,
         )
         if nested_result is not None:
-            record_agent_tool_run_result(
-                stable_call,
-                nested_result,
-                scope_id=tool_state_scope_id,
-            )
+            stable_function_nested_results[id(stable_call)] = nested_result
         return ToolRunFunction(
             tool_call=stable_call,
             function_tool=run.function_tool,
@@ -1698,9 +1695,13 @@ async def resolve_interrupted_turn(
     pending_nested_drops: list[ResponseFunctionToolCall] = []
 
     def _cached_nested_result(run: ToolRunFunction) -> Any | None:
+        stable_result = stable_function_nested_results.get(id(run.tool_call))
+        if stable_result is not None:
+            return stable_result
         return peek_agent_tool_run_result(run.tool_call, scope_id=tool_state_scope_id)
 
     def _drop_stable_nested_result(call: ResponseFunctionToolCall) -> None:
+        stable_function_nested_results.pop(id(call), None)
         drop_agent_tool_run_result(call, scope_id=tool_state_scope_id)
         source_call = stable_function_call_sources.get(id(call))
         if source_call is not None:

--- a/tests/test_tool_name_collision_policy.py
+++ b/tests/test_tool_name_collision_policy.py
@@ -1,0 +1,1420 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+from openai.types.responses import ResponseFunctionToolCall
+from openai.types.responses.response_function_tool_call import CallerProgram
+from openai.types.responses.response_output_item import Program
+
+from agents import (
+    Agent,
+    ApplyPatchTool,
+    ModelBehaviorError,
+    ProgrammaticToolCallingTool,
+    RunConfig,
+    RunContextWrapper,
+    Runner,
+    RunState,
+    ShellTool,
+    UserError,
+    handoff,
+    tool_namespace,
+)
+from agents.items import ToolCallOutputItem
+from agents.tool import Tool, function_tool
+
+from .fake_model import FakeModel
+from .mcp.helpers import FakeMCPServer
+from .test_responses import get_function_tool_call, get_handoff_tool_call, get_text_message
+
+
+def _record(calls: list[str], value: str, result: str | None = None) -> str:
+    calls.append(value)
+    return value if result is None else result
+
+
+@pytest.mark.asyncio
+async def test_resume_warn_mode_rebinds_queued_mcp_call_to_local_winner() -> None:
+    calls: list[str] = []
+    server = FakeMCPServer(require_approval="always")
+    server.add_tool("lookup", {"type": "object", "properties": {}})
+
+    def local_lookup() -> str:
+        calls.append("local")
+        return "local"
+
+    local_tool = function_tool(local_lookup, name_override="lookup")
+    model = FakeModel(initial_output=[get_function_tool_call("lookup", "{}")])
+    agent = Agent(name="agent", model=model, mcp_servers=[server])
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = await RunState.from_json(agent, initial_result.to_state().to_json())
+    interruption = state.get_interruptions()[0]
+    state.approve(interruption)
+    agent.tools = [local_tool]
+    model.set_next_output([get_text_message("done")])
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "done"
+    assert calls == ["local"]
+    assert server.tool_calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_error_mode_rejects_current_collision_before_side_effects() -> None:
+    calls: list[str] = []
+    queued_tool = function_tool(
+        lambda: _record(calls, "queued"),
+        name_override="lookup",
+        needs_approval=True,
+    )
+    colliding_tool = function_tool(
+        lambda: _record(calls, "colliding"),
+        name_override="lookup",
+    )
+    model = FakeModel(
+        initial_output=[get_function_tool_call("lookup", "{}", call_id="lookup_call")]
+    )
+    agent = Agent(name="agent", model=model, tools=[queued_tool])
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = initial_result.to_state()
+    state.approve(state.get_interruptions()[0])
+    agent.tools = [queued_tool, colliding_tool]
+
+    with pytest.raises(UserError, match="Ambiguous function tool configuration"):
+        await Runner.run(
+            agent,
+            state,
+            run_config=RunConfig(tool_name_collision_policy="error"),
+        )
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("deserialize", [False, True])
+@pytest.mark.asyncio
+async def test_resume_reclassifies_function_call_to_current_handoff(
+    deserialize: bool,
+) -> None:
+    calls: list[str] = []
+    filter_calls: list[str] = []
+
+    class FalsyFilter:
+        def __bool__(self) -> bool:
+            return False
+
+        def __call__(self, data: Any) -> Any:
+            filter_calls.append("filter")
+            return data
+
+    def route_function() -> str:
+        calls.append("function")
+        return "function"
+
+    route_tool = function_tool(
+        route_function,
+        name_override="route",
+        needs_approval=True,
+    )
+    target = Agent(
+        name="target",
+        model=FakeModel(initial_output=[get_text_message("target done")]),
+    )
+    route_handoff = handoff(
+        target,
+        tool_name_override="route",
+        on_handoff=lambda _: calls.append("handoff"),
+        input_filter=FalsyFilter(),
+    )
+    model = FakeModel(initial_output=[get_function_tool_call("route", "{}", call_id="route_call")])
+    agent = Agent(name="agent", model=model, tools=[route_tool])
+
+    initial_result = await Runner.run(agent, "Route this request")
+    state_json = initial_result.to_state().to_json()
+    agent.tools = []
+    agent.handoffs = [route_handoff]
+    state = (
+        await RunState.from_json(agent, state_json) if deserialize else initial_result.to_state()
+    )
+    state._model_responses[-1] = replace(state._model_responses[-1], output=[])
+    state.approve(state.get_interruptions()[0])
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "target done"
+    assert calls == ["handoff"]
+    assert filter_calls == ["filter"]
+
+
+@pytest.mark.asyncio
+async def test_resume_reclassifies_queued_handoff_to_current_function() -> None:
+    calls: list[str] = []
+
+    def approved_function() -> str:
+        calls.append("approved")
+        return "approved"
+
+    def route_function() -> str:
+        calls.append("route")
+        return "route"
+
+    approval_tool = function_tool(
+        approved_function,
+        name_override="approval_tool",
+        needs_approval=True,
+    )
+    route_tool = function_tool(route_function, name_override="route")
+    target = Agent(name="target")
+    route_handoff = handoff(target, tool_name_override="route")
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("approval_tool", "{}", call_id="approval_call"),
+            get_handoff_tool_call(target, override_name="route", args="{}"),
+        ]
+    )
+    model.set_next_output([get_text_message("done")])
+    agent = Agent(
+        name="agent",
+        model=model,
+        tools=[approval_tool],
+        handoffs=[route_handoff],
+    )
+
+    initial_result = await Runner.run(agent, "Route this request")
+    state = initial_result.to_state()
+    state.approve(state.get_interruptions()[0])
+    agent.tools = [approval_tool, route_tool]
+    agent.handoffs = []
+    state._model_responses[-1] = replace(state._model_responses[-1], output=[])
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "done"
+    assert calls == ["approved", "route"]
+
+
+@pytest.mark.asyncio
+async def test_resume_rebinds_queued_handoff_to_current_warn_winner() -> None:
+    calls: list[str] = []
+
+    approval_tool = function_tool(
+        lambda: _record(calls, "approved"),
+        name_override="approval_tool",
+        needs_approval=True,
+    )
+    first_target = Agent(
+        name="first",
+        model=FakeModel(initial_output=[get_text_message("first done")]),
+    )
+    second_target = Agent(
+        name="second",
+        model=FakeModel(initial_output=[get_text_message("second done")]),
+    )
+    first_handoff = handoff(
+        first_target,
+        tool_name_override="route",
+        on_handoff=lambda _: calls.append("first"),
+    )
+    second_handoff = handoff(
+        second_target,
+        tool_name_override="route",
+        on_handoff=lambda _: calls.append("second"),
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("approval_tool", "{}", call_id="approval_call"),
+            get_handoff_tool_call(second_target, override_name="route", args="{}"),
+        ]
+    )
+    agent = Agent(
+        name="agent",
+        model=model,
+        tools=[approval_tool],
+        handoffs=[first_handoff, second_handoff],
+    )
+
+    initial_result = await Runner.run(agent, "Route this request")
+    state = initial_result.to_state()
+    state.approve(state.get_interruptions()[0])
+    agent.handoffs = [second_handoff, first_handoff]
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "first done"
+    assert calls == ["approved", "first"]
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_missing_queued_handoff_before_side_effects() -> None:
+    calls: list[str] = []
+    approval_tool = function_tool(
+        lambda: _record(calls, "approved"),
+        name_override="approval_tool",
+        needs_approval=True,
+    )
+    target = Agent(name="target")
+    route_handoff = handoff(
+        target,
+        tool_name_override="route",
+        on_handoff=lambda _: calls.append("handoff"),
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("approval_tool", "{}", call_id="approval_call"),
+            get_handoff_tool_call(target, override_name="route", args="{}"),
+        ]
+    )
+    agent = Agent(
+        name="agent",
+        model=model,
+        tools=[approval_tool],
+        handoffs=[route_handoff],
+    )
+
+    initial_result = await Runner.run(agent, "Route this request")
+    state = initial_result.to_state()
+    state.approve(state.get_interruptions()[0])
+    agent.handoffs = []
+
+    with pytest.raises(ModelBehaviorError, match="Tool route not found in agent agent"):
+        await Runner.run(agent, state)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_interrupted_agent_tool_preserves_nested_state_for_retry() -> None:
+    calls: list[str] = []
+    before_tool = function_tool(
+        lambda: _record(calls, "before"),
+        name_override="before_pause",
+    )
+    sensitive_tool = function_tool(
+        lambda: _record(calls, "sensitive"),
+        name_override="sensitive",
+        needs_approval=True,
+    )
+    inner_model = FakeModel(
+        initial_output=[
+            get_function_tool_call("before_pause", "{}", call_id="before_call"),
+            get_function_tool_call("sensitive", "{}", call_id="sensitive_call"),
+        ]
+    )
+    inner_model.set_next_output([get_text_message("inner done")])
+    inner_agent = Agent(
+        name="inner",
+        model=inner_model,
+        tools=[before_tool, sensitive_tool],
+    )
+    nested_tool = inner_agent.as_tool(
+        tool_name="lookup",
+        tool_description="Look up a value with the inner agent.",
+    )
+    outer_model = FakeModel(
+        initial_output=[
+            get_function_tool_call(
+                "lookup",
+                '{"input":"hi"}',
+                call_id="outer_call",
+            )
+        ]
+    )
+    outer_model.set_next_output([get_text_message("outer done")])
+    outer_agent = Agent(name="outer", model=outer_model, tools=[nested_tool])
+
+    initial_result = await Runner.run(outer_agent, "Look this up")
+    state = await RunState.from_json(outer_agent, initial_result.to_state().to_json())
+    state.approve(state.get_interruptions()[0])
+    assert calls == ["before"]
+
+    outer_agent.tools = []
+    with pytest.raises(ModelBehaviorError, match="Tool lookup not found in agent outer"):
+        await Runner.run(outer_agent, state)
+
+    outer_agent.tools = [nested_tool]
+    resumed_result = await Runner.run(outer_agent, state)
+
+    assert resumed_result.final_output == "outer done"
+    assert calls == ["before", "sensitive"]
+
+
+@pytest.mark.asyncio
+async def test_missing_formatter_cancellation_keeps_nested_state_serializable() -> None:
+    calls: list[str] = []
+    formatter_started = asyncio.Event()
+    keep_formatter_waiting = asyncio.Event()
+    before_tool = function_tool(
+        lambda: _record(calls, "serial_before"),
+        name_override="serial_before_pause",
+    )
+    sensitive_tool = function_tool(
+        lambda: _record(calls, "serial_sensitive"),
+        name_override="serial_sensitive",
+        needs_approval=True,
+    )
+    inner_model = FakeModel(
+        initial_output=[
+            get_function_tool_call(
+                "serial_before_pause",
+                "{}",
+                call_id="serial_before_call",
+            ),
+            get_function_tool_call(
+                "serial_sensitive",
+                "{}",
+                call_id="serial_sensitive_call",
+            ),
+        ]
+    )
+    inner_model.set_next_output([get_text_message("inner done")])
+    inner_agent = Agent(
+        name="inner",
+        model=inner_model,
+        tools=[before_tool, sensitive_tool],
+    )
+    nested_tool = inner_agent.as_tool(
+        tool_name="serial_lookup",
+        tool_description="Look up a value with the inner agent.",
+    )
+    outer_model = FakeModel(
+        initial_output=[
+            get_function_tool_call(
+                "serial_lookup",
+                '{"input":"hi"}',
+                call_id="serial_outer_call",
+            )
+        ]
+    )
+    outer_model.set_next_output([get_text_message("outer done")])
+    outer_agent = Agent(name="outer", model=outer_model, tools=[nested_tool])
+
+    initial_result = await Runner.run(outer_agent, "Look this up")
+    state = await RunState.from_json(outer_agent, initial_result.to_state().to_json())
+    state.approve(state.get_interruptions()[0])
+    assert calls == ["serial_before"]
+    outer_agent.tools = []
+
+    async def blocking_formatter(_args: Any) -> str:
+        formatter_started.set()
+        await keep_formatter_waiting.wait()
+        return "missing"
+
+    resume_task = asyncio.create_task(
+        Runner.run(
+            outer_agent,
+            state,
+            run_config=RunConfig(
+                tool_not_found_behavior="return_error_to_model",
+                tool_error_formatter=blocking_formatter,
+            ),
+        )
+    )
+    await formatter_started.wait()
+    resume_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await resume_task
+
+    outer_agent.tools = [nested_tool]
+    restored_state = await RunState.from_json(outer_agent, state.to_json())
+    resumed_result = await Runner.run(outer_agent, restored_state)
+
+    assert resumed_result.final_output == "outer done"
+    assert calls == ["serial_before", "serial_sensitive"]
+
+
+@pytest.mark.asyncio
+async def test_replacing_interrupted_agent_tool_fails_before_side_effects() -> None:
+    calls: list[str] = []
+    sensitive_tool = function_tool(
+        lambda: "sensitive",
+        name_override="sensitive",
+        needs_approval=True,
+    )
+    inner_agent = Agent(
+        name="inner",
+        model=FakeModel(initial_output=[get_function_tool_call("sensitive", "{}")]),
+        tools=[sensitive_tool],
+    )
+    nested_tool = inner_agent.as_tool(
+        tool_name="lookup",
+        tool_description="Look up a value with the inner agent.",
+    )
+    outer_agent = Agent(
+        name="outer",
+        model=FakeModel(initial_output=[get_function_tool_call("lookup", '{"input":"hi"}')]),
+        tools=[nested_tool],
+    )
+
+    initial_result = await Runner.run(outer_agent, "Look this up")
+    state = await RunState.from_json(outer_agent, initial_result.to_state().to_json())
+    state.approve(state.get_interruptions()[0])
+    outer_agent.tools = [
+        function_tool(
+            lambda input: _record(calls, input, "local"),
+            name_override="lookup",
+        )
+    ]
+
+    with pytest.raises(
+        ModelBehaviorError,
+        match="Cannot reconcile queued tool lookup with a new tool",
+    ):
+        await Runner.run(outer_agent, state)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_model_order_for_function_outcomes() -> None:
+    calls: list[str] = []
+    missing_tool = function_tool(
+        lambda: _record(calls, "missing"),
+        name_override="missing_lookup",
+        needs_approval=True,
+    )
+    rejected_tool = function_tool(
+        lambda: _record(calls, "rejected"),
+        name_override="rejected_lookup",
+        needs_approval=True,
+    )
+    available_tool = function_tool(
+        lambda: _record(calls, "available"),
+        name_override="available_lookup",
+        needs_approval=True,
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("missing_lookup", "{}", call_id="missing_call"),
+            get_function_tool_call("rejected_lookup", "{}", call_id="rejected_call"),
+            get_function_tool_call("available_lookup", "{}", call_id="available_call"),
+        ]
+    )
+    agent = Agent(
+        name="agent",
+        model=model,
+        tools=[missing_tool, rejected_tool, available_tool],
+    )
+
+    initial_result = await Runner.run(agent, "Look these up")
+    state = await RunState.from_json(agent, initial_result.to_state().to_json())
+    for interruption in state.get_interruptions():
+        if interruption.tool_name == "rejected_lookup":
+            state.reject(interruption)
+        else:
+            state.approve(interruption)
+    agent.tools = [rejected_tool, available_tool]
+    model.set_next_output([get_text_message("done")])
+
+    resumed_result = await Runner.run(
+        agent,
+        state,
+        run_config=RunConfig(tool_not_found_behavior="return_error_to_model"),
+    )
+
+    assert resumed_result.final_output == "done"
+    assert calls == ["available"]
+    output_ids = [
+        cast(dict[str, Any], item.raw_item)["call_id"]
+        for item in resumed_result.new_items
+        if isinstance(item, ToolCallOutputItem)
+        and isinstance(item.raw_item, dict)
+        and item.raw_item.get("type") == "function_call_output"
+    ]
+    assert output_ids == ["missing_call", "rejected_call", "available_call"]
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_duplicate_agent_tool_calls() -> None:
+    inner_calls: list[str] = []
+
+    @function_tool(needs_approval=True)
+    async def inner_hitl_tool() -> str:
+        inner_calls.append("inner")
+        return "ok"
+
+    inner_model = FakeModel()
+    inner_model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call(inner_hitl_tool.name, "{}", call_id="inner-1")],
+            [get_function_tool_call(inner_hitl_tool.name, "{}", call_id="inner-2")],
+            [get_text_message("inner done")],
+            [get_text_message("inner done")],
+        ]
+    )
+    inner_agent = Agent(name="inner", model=inner_model, tools=[inner_hitl_tool])
+    agent_tool = inner_agent.as_tool(
+        tool_name="inner_agent_tool",
+        tool_description="Run the inner agent.",
+        needs_approval=False,
+    )
+    outer_model = FakeModel(
+        initial_output=[
+            get_function_tool_call(
+                agent_tool.name,
+                '{"input":"a"}',
+                call_id="outer-dup",
+            ),
+            get_function_tool_call(
+                agent_tool.name,
+                '{"input":"b"}',
+                call_id="outer-dup",
+            ),
+        ]
+    )
+    outer_agent = Agent(name="outer", model=outer_model, tools=[agent_tool])
+    initial_result = await Runner.run(outer_agent, "start")
+    state = initial_result.to_state()
+    for interruption in state.get_interruptions():
+        state.approve(interruption)
+    outer_model.set_next_output([get_text_message("done")])
+
+    resumed_result = await Runner.run(outer_agent, state)
+
+    assert resumed_result.final_output == "done"
+    assert inner_calls == ["inner", "inner"]
+    outer_outputs = [
+        item
+        for item in resumed_result.new_items
+        if isinstance(item, ToolCallOutputItem)
+        and isinstance(item.raw_item, dict)
+        and item.raw_item.get("type") == "function_call_output"
+        and item.raw_item.get("call_id") == "outer-dup"
+    ]
+    assert len(outer_outputs) == 2
+
+
+@pytest.mark.parametrize("override_all_tools", [False, True])
+@pytest.mark.asyncio
+async def test_resume_reuses_handoff_snapshot_for_delegating_overrides(
+    override_all_tools: bool,
+) -> None:
+    resume_phase = False
+    resume_enablement_checks: list[bool] = []
+    calls: list[str] = []
+    server = FakeMCPServer()
+    server.add_tool("search", {"type": "object", "properties": {}})
+
+    def handoff_enabled(
+        _context: RunContextWrapper[None],
+        _agent: Agent[None],
+    ) -> bool:
+        if not resume_phase:
+            return True
+        enabled = not resume_enablement_checks
+        resume_enablement_checks.append(enabled)
+        return enabled
+
+    approval_tool = function_tool(
+        lambda: _record(calls, "approved"),
+        name_override="approval_tool",
+        needs_approval=True,
+    )
+    target = Agent(
+        name="target",
+        model=FakeModel(initial_output=[get_text_message("done")]),
+    )
+    route_handoff = handoff(
+        target,
+        tool_name_override="route",
+        on_handoff=lambda _: calls.append("handoff"),
+        is_enabled=handoff_enabled,
+    )
+
+    class DelegatingMCPAgent(Agent[None]):
+        async def get_mcp_tools(
+            self,
+            run_context: RunContextWrapper[None],
+        ) -> list[Tool]:
+            return await super().get_mcp_tools(run_context)
+
+    class DelegatingAllToolsAgent(Agent[None]):
+        async def get_all_tools(
+            self,
+            run_context: RunContextWrapper[None],
+        ) -> list[Tool]:
+            return await super().get_all_tools(run_context)
+
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("approval_tool", "{}", call_id="approval_call"),
+            get_handoff_tool_call(target, override_name="route", args="{}"),
+        ]
+    )
+    agent_class = DelegatingAllToolsAgent if override_all_tools else DelegatingMCPAgent
+    agent = agent_class(
+        name="agent",
+        model=model,
+        tools=[approval_tool],
+        handoffs=[route_handoff],
+        mcp_servers=[server],
+        mcp_config={"include_server_in_tool_names": True},
+    )
+
+    initial_result = await Runner.run(agent, "Route this request")
+    state = initial_result.to_state()
+    state.approve(state.get_interruptions()[0])
+    resume_phase = True
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "done"
+    assert resume_enablement_checks == [True]
+    assert calls == ["approved", "handoff"]
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_conflicting_persisted_identity_before_sibling_effects() -> None:
+    calls: list[str] = []
+    conflicting_tool = function_tool(
+        lambda: _record(calls, "conflicting"),
+        name_override="lookup",
+        needs_approval=True,
+    )
+    sibling_tool = function_tool(
+        lambda: _record(calls, "sibling"),
+        name_override="sibling",
+        needs_approval=True,
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("lookup", "{}", call_id="conflicting_call"),
+            get_function_tool_call("sibling", "{}", call_id="sibling_call"),
+        ]
+    )
+    agent = Agent(name="agent", model=model, tools=[conflicting_tool, sibling_tool])
+
+    initial_result = await Runner.run(agent, "Look these up")
+    state = initial_result.to_state()
+    interruptions = state.get_interruptions()
+    for interruption in interruptions:
+        state.approve(interruption)
+    conflicting = next(item for item in interruptions if item.call_id == "conflicting_call")
+    conflicting.raw_item = {
+        "type": "function_call",
+        "name": "lookup",
+        "namespace": "current",
+        "call_id": "conflicting_call",
+    }
+    conflicting.tool_lookup_key = ("namespaced", "legacy", "lookup")
+
+    with pytest.raises(ModelBehaviorError, match="Persisted tool identity"):
+        await Runner.run(agent, state)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_legacy_approval_name_change_before_side_effects() -> None:
+    calls: list[str] = []
+    old_tool = function_tool(
+        lambda: _record(calls, "old"),
+        name_override="old_lookup",
+        needs_approval=True,
+    )
+    new_tool = function_tool(
+        lambda: _record(calls, "new"),
+        name_override="new_lookup",
+    )
+    model = FakeModel(
+        initial_output=[get_function_tool_call("old_lookup", "{}", call_id="lookup_call")]
+    )
+    agent = Agent(name="agent", model=model, tools=[old_tool])
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = initial_result.to_state()
+    interruption = state.get_interruptions()[0]
+    state.approve(interruption)
+    interruption.tool_lookup_key = None
+    interruption.raw_item = {
+        "type": "function_call",
+        "name": "new_lookup",
+        "arguments": "{}",
+        "call_id": "lookup_call",
+    }
+    agent.tools = [new_tool]
+
+    with pytest.raises(ModelBehaviorError, match="Persisted tool identity"):
+        await Runner.run(agent, state)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("namespace", [None, "tools"])
+@pytest.mark.parametrize("return_error_to_model", [False, True])
+@pytest.mark.asyncio
+async def test_resume_treats_apply_patch_prefixed_queued_function_as_function(
+    namespace: str | None,
+    return_error_to_model: bool,
+) -> None:
+    calls: list[str] = []
+    base_tool = function_tool(
+        lambda: _record(calls, "function"),
+        name_override="apply_patch_lookup",
+        needs_approval=True,
+    )
+    tools: list[Tool] = []
+    if namespace is not None:
+        tools.extend(tool_namespace(name=namespace, description="Lookup tools", tools=[base_tool]))
+    else:
+        tools.append(base_tool)
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call(
+                "apply_patch_lookup",
+                "{}",
+                call_id="lookup_call",
+                namespace=namespace,
+            )
+        ]
+    )
+    model.set_next_output([get_text_message("done")])
+    agent = Agent(name="agent", model=model, tools=tools)
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = initial_result.to_state()
+    state.approve(state.get_interruptions()[0])
+    agent.tools = []
+    run_config = RunConfig(
+        tool_not_found_behavior=(
+            "return_error_to_model" if return_error_to_model else "raise_error"
+        )
+    )
+
+    if return_error_to_model:
+        resumed_result = await Runner.run(agent, state, run_config=run_config)
+        assert resumed_result.final_output == "done"
+    else:
+        with pytest.raises(
+            ModelBehaviorError,
+            match=r"Tool .*apply_patch_lookup not found in agent agent",
+        ):
+            await Runner.run(agent, state, run_config=run_config)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "malformed_raw_item",
+    [
+        {
+            "type": "function_call",
+            "name": "lookup",
+            "call_id": "lookup_call",
+        },
+        {
+            "type": "function_call",
+            "name": "lookup",
+            "arguments": "{}",
+            "id": "lookup_call",
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_approved_malformed_approval_only_stays_pending_without_side_effects(
+    malformed_raw_item: dict[str, Any],
+) -> None:
+    calls: list[str] = []
+    tool = function_tool(
+        lambda: _record(calls, "lookup"),
+        name_override="lookup",
+        needs_approval=True,
+    )
+    model = FakeModel(
+        initial_output=[get_function_tool_call("lookup", "{}", call_id="lookup_call")]
+    )
+    agent = Agent(name="agent", model=model, tools=[tool])
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = initial_result.to_state()
+    interruption = state.get_interruptions()[0]
+    state.approve(interruption)
+    assert state._last_processed_response is not None
+    state._last_processed_response.functions = []
+    state._model_responses[-1] = replace(state._model_responses[-1], output=[])
+    interruption.raw_item = malformed_raw_item
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert len(resumed_result.interruptions) == 1
+    assert resumed_result.interruptions[0].call_id == "lookup_call"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_snapshots_function_approval_before_tool_inventory_await() -> None:
+    calls: list[str] = []
+    approval_holder: dict[str, Any] = {}
+
+    lookup_tool = function_tool(
+        lambda: _record(calls, "lookup"),
+        name_override="lookup",
+        needs_approval=True,
+    )
+    other_tool = function_tool(
+        lambda: _record(calls, "other"),
+        name_override="other",
+    )
+
+    class MutatingAgent(Agent[None]):
+        async def get_all_tools(
+            self,
+            run_context: RunContextWrapper[None],
+        ) -> list[Tool]:
+            approval = approval_holder.get("approval")
+            if approval is not None:
+                approval.tool_name = "other"
+                approval.tool_namespace = None
+                approval.tool_origin = "local"
+                approval.tool_lookup_key = ("bare", "other")
+                approval._allow_bare_name_alias = True
+                approval.raw_item.name = "other"
+            return await super().get_all_tools(run_context)
+
+    model = FakeModel(
+        initial_output=[get_function_tool_call("lookup", "{}", call_id="lookup_call")]
+    )
+    model.set_next_output([get_text_message("done")])
+    agent = MutatingAgent(name="agent", model=model, tools=[lookup_tool, other_tool])
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = initial_result.to_state()
+    approval = state.get_interruptions()[0]
+    state.approve(approval)
+    approval_holder["approval"] = approval
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "done"
+    assert calls == ["lookup"]
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_queued_arguments_instead_of_mutated_approval_arguments() -> None:
+    calls: list[int] = []
+
+    def lookup(amount: int) -> str:
+        calls.append(amount)
+        return str(amount)
+
+    lookup_tool = function_tool(
+        lookup,
+        name_override="lookup",
+        needs_approval=True,
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call(
+                "lookup",
+                '{"amount":10}',
+                call_id="lookup_call",
+            )
+        ]
+    )
+    model.set_next_output([get_text_message("done")])
+    agent = Agent(name="agent", model=model, tools=[lookup_tool])
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = await RunState.from_json(agent, initial_result.to_state().to_json())
+    approval = state.get_interruptions()[0]
+    state.approve(approval)
+    cast(Any, approval.raw_item).arguments = '{"amount":999}'
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "done"
+    assert calls == [10]
+
+
+@pytest.mark.asyncio
+async def test_resume_deep_copies_approval_only_program_caller_before_inventory_await() -> None:
+    calls: list[str] = []
+    approval_holder: dict[str, Any] = {}
+    program = Program(
+        id="program_item",
+        call_id="program_call",
+        code="lookup()",
+        fingerprint="fingerprint",
+        type="program",
+    )
+    function_call = cast(
+        ResponseFunctionToolCall,
+        get_function_tool_call("lookup", "{}", call_id="lookup_call"),
+    )
+    function_call.caller = CallerProgram(type="program", caller_id="program_call")
+
+    lookup_tool = function_tool(
+        lambda: _record(calls, "lookup"),
+        name_override="lookup",
+        needs_approval=True,
+        allowed_callers=["programmatic"],
+    )
+
+    class MutatingCallerAgent(Agent[None]):
+        async def get_all_tools(
+            self,
+            run_context: RunContextWrapper[None],
+        ) -> list[Tool]:
+            approval = approval_holder.get("approval")
+            if approval is not None:
+                cast(Any, approval.raw_item).caller.caller_id = "mutated_program"
+            return await super().get_all_tools(run_context)
+
+    model = FakeModel(initial_output=[program, function_call])
+    model.set_next_output([get_text_message("done")])
+    agent = MutatingCallerAgent(
+        name="agent",
+        model=model,
+        tools=[ProgrammaticToolCallingTool(), lookup_tool],
+    )
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = initial_result.to_state()
+    approval = state.get_interruptions()[0]
+    state.approve(approval)
+    assert state._last_processed_response is not None
+    state._last_processed_response.functions = []
+    state._model_responses[-1] = replace(
+        state._model_responses[-1],
+        output=[program],
+    )
+    approval_holder["approval"] = approval
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "done"
+    assert calls == ["lookup"]
+
+
+@pytest.mark.asyncio
+async def test_resume_snapshots_program_parent_context_before_inventory_await() -> None:
+    calls: list[str] = []
+    mutate_parent = False
+    program = Program(
+        id="program_item",
+        call_id="legit_program",
+        code="lookup()",
+        fingerprint="fingerprint",
+        type="program",
+    )
+    function_call = cast(
+        ResponseFunctionToolCall,
+        get_function_tool_call("lookup", "{}", call_id="lookup_call"),
+    )
+    function_call.caller = CallerProgram(type="program", caller_id="legit_program")
+    lookup_tool = function_tool(
+        lambda: _record(calls, "lookup"),
+        name_override="lookup",
+        needs_approval=True,
+        allowed_callers=["programmatic"],
+    )
+
+    class MutatingParentAgent(Agent[None]):
+        async def get_all_tools(
+            self,
+            run_context: RunContextWrapper[None],
+        ) -> list[Tool]:
+            if mutate_parent:
+                program.call_id = "forged_program"
+            return await super().get_all_tools(run_context)
+
+    model = FakeModel(initial_output=[program, function_call])
+    agent = MutatingParentAgent(
+        name="agent",
+        model=model,
+        tools=[ProgrammaticToolCallingTool(), lookup_tool],
+    )
+
+    initial_result = await Runner.run(agent, "Look this up")
+    state = initial_result.to_state()
+    approval = state.get_interruptions()[0]
+    state.approve(approval)
+    cast(Any, approval.raw_item).caller.caller_id = "forged_program"
+    assert state._last_processed_response is not None
+    state._last_processed_response.functions = []
+    state._model_responses[-1] = replace(
+        state._model_responses[-1],
+        output=[program],
+    )
+    mutate_parent = True
+
+    with pytest.raises(ModelBehaviorError, match="does not match a parent program item"):
+        await Runner.run(agent, state)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_response_backed_approval_lookup_mismatch_before_effects() -> None:
+    calls: list[str] = []
+    lookup_tool = function_tool(
+        lambda: _record(calls, "lookup"),
+        name_override="lookup",
+        needs_approval=True,
+    )
+    sibling_tool = function_tool(
+        lambda: _record(calls, "sibling"),
+        name_override="sibling",
+        needs_approval=True,
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("lookup", "{}", call_id="lookup_call"),
+            get_function_tool_call("sibling", "{}", call_id="sibling_call"),
+        ]
+    )
+    agent = Agent(name="agent", model=model, tools=[lookup_tool, sibling_tool])
+
+    initial_result = await Runner.run(agent, "Look these up")
+    state = await RunState.from_json(agent, initial_result.to_state().to_json())
+    interruptions = state.get_interruptions()
+    for interruption in interruptions:
+        state.approve(interruption)
+    assert state._last_processed_response is not None
+    state._last_processed_response.functions = [
+        run
+        for run in state._last_processed_response.functions
+        if run.tool_call.call_id != "lookup_call"
+    ]
+    lookup_approval = next(item for item in interruptions if item.call_id == "lookup_call")
+    cast(Any, lookup_approval.raw_item).name = "other"
+    lookup_approval.tool_name = "other"
+    lookup_approval.tool_lookup_key = ("bare", "other")
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert len(resumed_result.interruptions) == 2
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_function_shaped_apply_patch_owner() -> None:
+    operations: list[Any] = []
+
+    class Editor:
+        def create_file(self, operation: Any) -> dict[str, str]:
+            operations.append(operation)
+            return {"output": "created", "status": "completed"}
+
+        def update_file(self, operation: Any) -> dict[str, str]:
+            operations.append(operation)
+            return {"output": "updated", "status": "completed"}
+
+        def delete_file(self, operation: Any) -> dict[str, str]:
+            operations.append(operation)
+            return {"output": "deleted", "status": "completed"}
+
+    patch_tool = ApplyPatchTool(editor=cast(Any, Editor()), needs_approval=True)
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call(
+                "apply_patch",
+                '{"type":"update_file","path":"test.md","diff":"-a\\n+b\\n"}',
+                call_id="patch_call",
+            )
+        ]
+    )
+    model.set_next_output([get_text_message("done")])
+    agent = Agent(name="agent", model=model, tools=[patch_tool])
+
+    initial_result = await Runner.run(agent, "Update the file")
+    state = initial_result.to_state()
+    state.approve(state.get_interruptions()[0])
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert resumed_result.final_output == "done"
+    assert len(operations) == 1
+
+
+@pytest.mark.asyncio
+async def test_nested_rebind_is_not_committed_before_later_strict_missing_error() -> None:
+    calls: list[str] = []
+    before_tool = function_tool(
+        lambda: _record(calls, "before"),
+        name_override="before",
+    )
+    sensitive_tool = function_tool(
+        lambda: _record(calls, "sensitive"),
+        name_override="sensitive",
+        needs_approval=True,
+    )
+    inner_model = FakeModel(
+        initial_output=[
+            get_function_tool_call("before", "{}", call_id="before_call"),
+            get_function_tool_call("sensitive", "{}", call_id="sensitive_call"),
+        ]
+    )
+    inner_model.set_next_output([get_text_message("inner done")])
+    inner_agent = Agent(
+        name="inner",
+        model=inner_model,
+        tools=[before_tool, sensitive_tool],
+    )
+    nested_tool = inner_agent.as_tool(
+        tool_name="nested",
+        tool_description="Run the inner agent.",
+    )
+    missing_tool = function_tool(
+        lambda: _record(calls, "missing"),
+        name_override="missing",
+        needs_approval=True,
+    )
+    outer_model = FakeModel(
+        initial_output=[
+            get_function_tool_call("nested", '{"input":"go"}', call_id="nested_call"),
+            get_function_tool_call("missing", "{}", call_id="missing_call"),
+        ]
+    )
+    outer_model.set_next_output([get_text_message("outer done")])
+    outer_agent = Agent(
+        name="outer",
+        model=outer_model,
+        tools=[nested_tool, missing_tool],
+    )
+
+    initial_result = await Runner.run(outer_agent, "Start")
+    assert calls == ["before"]
+    state = initial_result.to_state()
+    for interruption in state.get_interruptions():
+        state.approve(interruption)
+    outer_agent.tools = [nested_tool]
+
+    with pytest.raises(ModelBehaviorError, match="Tool missing not found"):
+        await Runner.run(outer_agent, state)
+
+    outer_agent.tools = [nested_tool, missing_tool]
+    restored_state = await RunState.from_json(outer_agent, state.to_json())
+    resumed_result = await Runner.run(outer_agent, restored_state)
+
+    assert resumed_result.final_output == "outer done"
+    assert calls[0] == "before"
+    assert sorted(calls[1:]) == ["missing", "sensitive"]
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_cross_kind_duplicate_call_id_baseline() -> None:
+    calls: list[str] = []
+    missing_tool = function_tool(
+        lambda: _record(calls, "missing"),
+        name_override="missing",
+        needs_approval=True,
+    )
+    original_tool = function_tool(
+        lambda: _record(calls, "original"),
+        name_override="lookup",
+        needs_approval=True,
+    )
+    replacement_tool = function_tool(
+        lambda: _record(calls, "replacement"),
+        name_override="lookup",
+    )
+    shell_tool = ShellTool(
+        executor=lambda _request: _record(calls, "shell"),
+    )
+    shell_call = cast(
+        Any,
+        {
+            "type": "shell_call",
+            "id": "shell_item",
+            "call_id": "shared_call",
+            "status": "completed",
+            "action": {
+                "type": "exec",
+                "commands": ["echo test"],
+                "timeout_ms": 1000,
+            },
+        },
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("missing", "{}", call_id="missing_call"),
+            get_function_tool_call("lookup", "{}", call_id="shared_call"),
+            shell_call,
+        ]
+    )
+    model.set_next_output([get_text_message("done")])
+    agent = Agent(
+        name="agent",
+        model=model,
+        tools=[missing_tool, original_tool, shell_tool],
+    )
+
+    initial_result = await Runner.run(agent, "Look this up")
+    assert calls == ["shell"]
+    state = initial_result.to_state()
+    for interruption in state.get_interruptions():
+        state.approve(interruption)
+    agent.tools = [replacement_tool, shell_tool]
+
+    resumed_result = await Runner.run(
+        agent,
+        state,
+        run_config=RunConfig(tool_not_found_behavior="return_error_to_model"),
+    )
+
+    assert resumed_result.final_output == "done"
+    assert calls == ["shell", "original"]
+    output_ids = [
+        cast(dict[str, Any], item.raw_item)["call_id"]
+        for item in resumed_result.new_items
+        if isinstance(item, ToolCallOutputItem)
+        and isinstance(item.raw_item, dict)
+        and item.raw_item.get("type") == "function_call_output"
+    ]
+    assert output_ids == ["missing_call", "shared_call"]
+
+
+@pytest.mark.parametrize(
+    "malformed_raw_item",
+    [
+        {"name": "lookup"},
+        {
+            "type": "function_call",
+            "name": "lookup",
+            "arguments": "{}",
+            "call_id": "changed_call",
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_approved_malformed_queued_approval_stays_pending_without_side_effects(
+    malformed_raw_item: dict[str, Any],
+) -> None:
+    calls: list[str] = []
+    lookup_tool = function_tool(
+        lambda: _record(calls, "lookup"),
+        name_override="lookup",
+        needs_approval=True,
+    )
+    sibling_tool = function_tool(
+        lambda: _record(calls, "sibling"),
+        name_override="sibling",
+        needs_approval=True,
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("lookup", "{}", call_id="lookup_call"),
+            get_function_tool_call("sibling", "{}", call_id="sibling_call"),
+        ]
+    )
+    agent = Agent(name="agent", model=model, tools=[lookup_tool, sibling_tool])
+
+    initial_result = await Runner.run(agent, "Look these up")
+    state = initial_result.to_state()
+    interruptions = state.get_interruptions()
+    for interruption in interruptions:
+        state.approve(interruption)
+    lookup_approval = next(item for item in interruptions if item.call_id == "lookup_call")
+    lookup_approval.raw_item = malformed_raw_item
+
+    resumed_result = await Runner.run(agent, state)
+
+    assert lookup_approval in resumed_result.interruptions
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_cross_kind_approval_identity_before_sibling_effects() -> None:
+    calls: list[str] = []
+    lookup_tool = function_tool(
+        lambda: _record(calls, "lookup"),
+        name_override="lookup",
+        needs_approval=True,
+    )
+    sibling_tool = function_tool(
+        lambda: _record(calls, "sibling"),
+        name_override="sibling",
+        needs_approval=True,
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("lookup", "{}", call_id="lookup_call"),
+            get_function_tool_call("sibling", "{}", call_id="sibling_call"),
+        ]
+    )
+    agent = Agent(name="agent", model=model, tools=[lookup_tool, sibling_tool])
+
+    initial_result = await Runner.run(agent, "Look these up")
+    state = initial_result.to_state()
+    interruptions = state.get_interruptions()
+    for interruption in interruptions:
+        state.approve(interruption)
+    lookup_approval = next(item for item in interruptions if item.call_id == "lookup_call")
+    lookup_approval.raw_item = {
+        "type": "custom_tool_call",
+        "name": "evil",
+        "call_id": "lookup_call",
+        "input": "{}",
+    }
+
+    with pytest.raises(ModelBehaviorError, match="Persisted tool identity"):
+        await Runner.run(agent, state)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_formatter_cancellation_precedes_sibling_side_effects() -> None:
+    calls: list[str] = []
+    formatter_started = asyncio.Event()
+    keep_formatter_waiting = asyncio.Event()
+    missing_tool = function_tool(
+        lambda: _record(calls, "missing"),
+        name_override="missing",
+        needs_approval=True,
+    )
+    available_tool = function_tool(
+        lambda: _record(calls, "available"),
+        name_override="available",
+        needs_approval=True,
+    )
+    model = FakeModel(
+        initial_output=[
+            get_function_tool_call("missing", "{}", call_id="missing_call"),
+            get_function_tool_call("available", "{}", call_id="available_call"),
+        ]
+    )
+    model.set_next_output([get_text_message("done")])
+    agent = Agent(name="agent", model=model, tools=[missing_tool, available_tool])
+
+    initial_result = await Runner.run(agent, "Look these up")
+    state = initial_result.to_state()
+    for interruption in state.get_interruptions():
+        state.approve(interruption)
+    agent.tools = [available_tool]
+
+    async def blocking_formatter(_args: Any) -> str:
+        formatter_started.set()
+        await keep_formatter_waiting.wait()
+        return "missing"
+
+    resume_task = asyncio.create_task(
+        Runner.run(
+            agent,
+            state,
+            run_config=RunConfig(
+                tool_not_found_behavior="return_error_to_model",
+                tool_error_formatter=blocking_formatter,
+            ),
+        )
+    )
+    await formatter_started.wait()
+    resume_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await resume_task
+
+    assert calls == []
+
+    resumed_result = await Runner.run(
+        agent,
+        state,
+        run_config=RunConfig(tool_not_found_behavior="return_error_to_model"),
+    )
+
+    assert resumed_result.final_output == "done"
+    assert calls == ["available"]

--- a/tests/test_tool_name_collision_policy.py
+++ b/tests/test_tool_name_collision_policy.py
@@ -333,7 +333,10 @@ async def test_missing_interrupted_agent_tool_preserves_nested_state_for_retry()
     assert calls == ["before"]
 
     outer_agent.tools = []
-    with pytest.raises(ModelBehaviorError, match="Tool lookup not found in agent outer"):
+    with pytest.raises(
+        ModelBehaviorError,
+        match="Tool lookup not found in agent outer",
+    ) as strict_error:
         await Runner.run(outer_agent, state)
 
     outer_agent.tools = [nested_tool]
@@ -341,6 +344,7 @@ async def test_missing_interrupted_agent_tool_preserves_nested_state_for_retry()
 
     assert resumed_result.final_output == "outer done"
     assert calls == ["before", "sensitive"]
+    assert strict_error.value is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes stale tool and handoff routing when a run resumes after a human-in-the-loop approval.

Before this change, queued function-tool and handoff runs retained the tool objects selected before the pause. If the enabled tools, handoffs, or their ordering changed while the run was interrupted, resuming could execute a stale or disabled tool even when `RunConfig.tool_name_collision_policy` selected a different current winner.

The resume path now rebuilds the current tool inventory using a consistent enabled-handoff snapshot, applies the canonical collision resolver, and reconciles queued calls with the resulting winners before allowing side effects. Under the default `warn` policy, queued calls are rebound to the current winning function tool or handoff. Under the `error` policy, current collisions fail before tool execution or handoff transfer.

The implementation also:

- reconciles function-to-function, function-to-handoff, handoff-to-function, and handoff-to-handoff winner changes;
- respects `tool_not_found_behavior` when a queued tool is no longer available;
- preserves model call order when combining executed, rejected, and missing-tool results;
- validates persisted approval identity before dynamic tool inventory callbacks run;
- snapshots approval and invocation metadata so mutable callbacks cannot change routing or authorization decisions during resume;
- preserves interrupted `Agent.as_tool()` state when a strict missing-tool error or formatter cancellation aborts a resume;
- transfers nested run state only after reconciliation succeeds, preventing failed or ambiguous replacements from corrupting retryable state;
- propagates the same handoff snapshot through custom `get_mcp_tools()` and `get_all_tools()` overrides that delegate to the base implementation.

This does not add a new public API or change the serialized `RunState` schema. It uses the existing `tool_name_collision_policy` configuration.

Queued calls with duplicate call IDs intentionally retain the existing ordered owner-binding behavior because they cannot be reconciled unambiguously. Applications that need tool replacement across an interruption should use unique provider call IDs. Replacing an interrupted `Agent.as_tool()` with a different owner before deserializing the state also remains unsupported because the current persisted state does not contain a durable owner identity.

Documentation is intentionally excluded from this pull request and will be handled separately.

This pull request resolves #4116.