### PR TITLE
fix(run): preserve tool call and output order when deduplicating inputs

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -35,6 +35,10 @@ _TOOL_CALL_TO_OUTPUT_TYPE: dict[str, str] = {
     "local_shell_call": "local_shell_call_output",
     "tool_search_call": "tool_search_output",
 }
+# These items must retain their original position relative to required follower items.
+_DEDUPE_EARLIEST_ANCHOR_ITEM_TYPES = frozenset(
+    {*_TOOL_CALL_TO_OUTPUT_TYPE, "mcp_approval_request", "reasoning"}
+)
 _PROGRAM_OWNED_HOSTED_ITEM_TYPES = frozenset(
     {
         "hosted_tool_call",
@@ -730,9 +734,9 @@ def deduplicate_input_items_preferring_latest(
 ) -> list[TResponseInputItem]:
     """Deduplicate by stable identifiers while keeping the latest value.
 
-    Tool calls stay at their earliest position so they cannot move behind matching outputs.
-    Other identified items stay at their latest position so replacing a stale value does not
-    move the replacement earlier in the conversation.
+    Causal precursor items stay at their earliest position so they cannot move behind required
+    followers. Other identified items stay at their latest position so replacing a stale value
+    does not move the replacement earlier in the conversation.
     """
     latest_by_key: dict[str, TResponseInputItem] = {}
     anchor_index_by_key: dict[str, int] = {}
@@ -744,7 +748,10 @@ def deduplicate_input_items_preferring_latest(
         latest_by_key[dedupe_key] = item
         payload = _coerce_to_dict(item)
         item_type = payload.get("type") if payload is not None else None
-        if dedupe_key not in anchor_index_by_key or item_type not in _TOOL_CALL_TO_OUTPUT_TYPE:
+        if (
+            dedupe_key not in anchor_index_by_key
+            or item_type not in _DEDUPE_EARLIEST_ANCHOR_ITEM_TYPES
+        ):
             anchor_index_by_key[dedupe_key] = index
 
     deduplicated: list[TResponseInputItem] = []

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -728,25 +728,32 @@ def deduplicate_input_items(items: Sequence[TResponseInputItem]) -> list[TRespon
 def deduplicate_input_items_preferring_latest(
     items: Sequence[TResponseInputItem],
 ) -> list[TResponseInputItem]:
-    """Deduplicate by stable identifiers, keeping the latest value at the earliest position.
+    """Deduplicate by stable identifiers while keeping the latest value.
 
-    Duplicates collapse onto the first occurrence of their dedupe key so the caller's item
-    order is preserved, while the last occurrence supplies the value. Relocating an item to
-    the position of its final duplicate would move a `function_call` behind its
-    `function_call_output`, which the Responses API rejects.
+    Tool calls stay at their earliest position so they cannot move behind matching outputs.
+    Other identified items stay at their latest position so replacing a stale value does not
+    move the replacement earlier in the conversation.
     """
     latest_by_key: dict[str, TResponseInputItem] = {}
-    for item in items:
+    anchor_index_by_key: dict[str, int] = {}
+    for index, item in enumerate(items):
         dedupe_key = _dedupe_key(item)
-        if dedupe_key is not None:
-            latest_by_key[dedupe_key] = item
+        if dedupe_key is None:
+            continue
 
-    # deduplicate_input_items keeps the first item per dedupe key, which is what preserves the
-    # caller's order; swapping in the latest value per surviving key is all this adds.
+        latest_by_key[dedupe_key] = item
+        payload = _coerce_to_dict(item)
+        item_type = payload.get("type") if payload is not None else None
+        if dedupe_key not in anchor_index_by_key or item_type not in _TOOL_CALL_TO_OUTPUT_TYPE:
+            anchor_index_by_key[dedupe_key] = index
+
     deduplicated: list[TResponseInputItem] = []
-    for item in deduplicate_input_items(items):
+    for index, item in enumerate(items):
         dedupe_key = _dedupe_key(item)
-        deduplicated.append(item if dedupe_key is None else latest_by_key[dedupe_key])
+        if dedupe_key is None:
+            deduplicated.append(item)
+        elif anchor_index_by_key[dedupe_key] == index:
+            deduplicated.append(latest_by_key[dedupe_key])
     return deduplicated
 
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -3169,6 +3169,41 @@ async def test_save_result_to_session_keeps_tool_call_before_its_output():
 
 
 @pytest.mark.asyncio
+async def test_save_result_to_session_keeps_latest_output_after_its_call():
+    session = SimpleListSession()
+    old_output = cast(
+        TResponseInputItem,
+        {"type": "function_call_output", "call_id": "call_ordered", "output": "old"},
+    )
+    call_item = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call",
+            "call_id": "call_ordered",
+            "name": "tool_ordered",
+            "arguments": "{}",
+        },
+    )
+    new_output = _DummyRunItem(
+        {"type": "function_call_output", "call_id": "call_ordered", "output": "new"}
+    )
+
+    await save_result_to_session(
+        session,
+        [old_output, call_item],
+        [cast(RunItem, new_output)],
+        None,
+    )
+
+    saved_items = [cast(dict[str, Any], item) for item in session.saved_items]
+    assert [item.get("type") for item in saved_items] == [
+        "function_call",
+        "function_call_output",
+    ]
+    assert saved_items[1]["output"] == "new"
+
+
+@pytest.mark.asyncio
 async def test_rewind_handles_id_stripped_sessions() -> None:
     session = IdStrippingSession()
     item = cast(TResponseInputItem, {"id": "message-1", "type": "message", "content": "hello"})

--- a/tests/test_call_model_input_filter.py
+++ b/tests/test_call_model_input_filter.py
@@ -232,6 +232,28 @@ def _duplicate_tool_call_input() -> list[TResponseInputItem]:
     ]
 
 
+def _duplicate_tool_output_input() -> list[TResponseInputItem]:
+    return [
+        cast(
+            TResponseInputItem,
+            {"type": "function_call_output", "call_id": "ordered-output", "output": "old"},
+        ),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "function_call",
+                "call_id": "ordered-output",
+                "name": "tool_ordered",
+                "arguments": "{}",
+            },
+        ),
+        cast(
+            TResponseInputItem,
+            {"type": "function_call_output", "call_id": "ordered-output", "output": "new"},
+        ),
+    ]
+
+
 def _sent_item_types(sent_input: Any) -> list[str | None]:
     return [
         cast(dict[str, Any], item).get("type")
@@ -290,3 +312,55 @@ async def test_call_model_input_filter_keeps_duplicate_item_order_streamed() -> 
         "function_call",
         "function_call_output",
     ]
+
+
+@pytest.mark.asyncio
+async def test_call_model_input_filter_keeps_duplicate_output_order_non_streamed() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model)
+    model.set_next_output([get_text_message("ok")])
+
+    def filter_fn(data: CallModelData[Any]) -> ModelInputData:
+        return ModelInputData(
+            input=list(data.model_data.input) + _duplicate_tool_output_input(),
+            instructions=data.model_data.instructions,
+        )
+
+    await Runner.run(
+        agent,
+        input="start",
+        run_config=RunConfig(call_model_input_filter=filter_fn),
+    )
+
+    assert _sent_item_types(model.last_turn_args["input"]) == [
+        "function_call",
+        "function_call_output",
+    ]
+    assert model.last_turn_args["input"][-1]["output"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_call_model_input_filter_keeps_duplicate_output_order_streamed() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model)
+    model.set_next_output([get_text_message("ok")])
+
+    async def filter_fn(data: CallModelData[Any]) -> ModelInputData:
+        return ModelInputData(
+            input=list(data.model_data.input) + _duplicate_tool_output_input(),
+            instructions=data.model_data.instructions,
+        )
+
+    result = Runner.run_streamed(
+        agent,
+        input="start",
+        run_config=RunConfig(call_model_input_filter=filter_fn),
+    )
+    async for _ in result.stream_events():
+        pass
+
+    assert _sent_item_types(model.last_turn_args["input"]) == [
+        "function_call",
+        "function_call_output",
+    ]
+    assert model.last_turn_args["input"][-1]["output"] == "new"

--- a/tests/test_call_model_input_filter.py
+++ b/tests/test_call_model_input_filter.py
@@ -254,6 +254,36 @@ def _duplicate_tool_output_input() -> list[TResponseInputItem]:
     ]
 
 
+def _duplicate_reasoning_input() -> list[TResponseInputItem]:
+    return [
+        cast(
+            TResponseInputItem,
+            {
+                "type": "reasoning",
+                "id": "ordered-reasoning",
+                "summary": [{"type": "summary_text", "text": "old"}],
+            },
+        ),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "function_call",
+                "call_id": "reasoning-call",
+                "name": "tool_ordered",
+                "arguments": "{}",
+            },
+        ),
+        cast(
+            TResponseInputItem,
+            {
+                "type": "reasoning",
+                "id": "ordered-reasoning",
+                "summary": [{"type": "summary_text", "text": "new"}],
+            },
+        ),
+    ]
+
+
 def _sent_item_types(sent_input: Any) -> list[str | None]:
     return [
         cast(dict[str, Any], item).get("type")
@@ -364,3 +394,32 @@ async def test_call_model_input_filter_keeps_duplicate_output_order_streamed() -
         "function_call_output",
     ]
     assert model.last_turn_args["input"][-1]["output"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_call_model_input_filter_keeps_reasoning_before_required_follower() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model)
+    model.set_next_output([get_text_message("ok")])
+
+    def filter_fn(data: CallModelData[Any]) -> ModelInputData:
+        return ModelInputData(
+            input=list(data.model_data.input) + _duplicate_reasoning_input(),
+            instructions=data.model_data.instructions,
+        )
+
+    await Runner.run(
+        agent,
+        input="start",
+        run_config=RunConfig(call_model_input_filter=filter_fn),
+    )
+
+    assert _sent_item_types(model.last_turn_args["input"]) == [
+        "reasoning",
+        "function_call",
+    ]
+    reasoning_items = [
+        item for item in model.last_turn_args["input"] if item.get("type") == "reasoning"
+    ]
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0]["summary"] == [{"type": "summary_text", "text": "new"}]

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -1032,7 +1032,7 @@ def test_deduplicate_input_items_preferring_latest_keeps_original_order() -> Non
     assert cast(dict[str, Any], deduplicated[2])["role"] == "assistant"
 
 
-def test_deduplicate_input_items_preferring_latest_uses_latest_value_at_first_position() -> None:
+def test_deduplicate_input_items_preferring_latest_keeps_latest_output_position() -> None:
     old_output = cast(
         TResponseInputItem,
         {"type": "function_call_output", "call_id": "call-1", "output": "old"},
@@ -1048,8 +1048,33 @@ def test_deduplicate_input_items_preferring_latest_uses_latest_value_at_first_po
     )
 
     assert len(deduplicated) == 2
-    assert cast(dict[str, Any], deduplicated[0])["output"] == "new"
-    assert cast(dict[str, Any], deduplicated[1])["content"] == "next"
+    assert cast(dict[str, Any], deduplicated[0])["content"] == "next"
+    assert cast(dict[str, Any], deduplicated[1])["output"] == "new"
+
+
+def test_deduplicate_input_items_preferring_latest_keeps_output_after_matching_call() -> None:
+    old_output = cast(
+        TResponseInputItem,
+        {"type": "function_call_output", "call_id": "call-1", "output": "old"},
+    )
+    call = cast(
+        TResponseInputItem,
+        {"type": "function_call", "call_id": "call-1", "name": "tool", "arguments": "{}"},
+    )
+    new_output = cast(
+        TResponseInputItem,
+        {"type": "function_call_output", "call_id": "call-1", "output": "new"},
+    )
+
+    deduplicated = run_items.deduplicate_input_items_preferring_latest(
+        [old_output, call, new_output]
+    )
+
+    assert [cast(dict[str, Any], item).get("type") for item in deduplicated] == [
+        "function_call",
+        "function_call_output",
+    ]
+    assert cast(dict[str, Any], deduplicated[1])["output"] == "new"
 
 
 def test_deduplicate_input_items_preferring_latest_leaves_unique_items_untouched() -> None:

--- a/tests/test_run_internal_items.py
+++ b/tests/test_run_internal_items.py
@@ -1077,6 +1077,82 @@ def test_deduplicate_input_items_preferring_latest_keeps_output_after_matching_c
     assert cast(dict[str, Any], deduplicated[1])["output"] == "new"
 
 
+def test_deduplicate_input_items_preferring_latest_keeps_reasoning_before_follower() -> None:
+    old_reasoning = cast(
+        TResponseInputItem,
+        {
+            "type": "reasoning",
+            "id": "rs-1",
+            "summary": [{"type": "summary_text", "text": "old"}],
+        },
+    )
+    call = cast(
+        TResponseInputItem,
+        {"type": "function_call", "call_id": "call-1", "name": "tool", "arguments": "{}"},
+    )
+    new_reasoning = cast(
+        TResponseInputItem,
+        {
+            "type": "reasoning",
+            "id": "rs-1",
+            "summary": [{"type": "summary_text", "text": "new"}],
+        },
+    )
+
+    deduplicated = run_items.deduplicate_input_items_preferring_latest(
+        [old_reasoning, call, new_reasoning]
+    )
+
+    assert [cast(dict[str, Any], item).get("type") for item in deduplicated] == [
+        "reasoning",
+        "function_call",
+    ]
+    assert cast(dict[str, Any], deduplicated[0])["summary"] == [
+        {"type": "summary_text", "text": "new"}
+    ]
+
+
+def test_deduplicate_input_items_preferring_latest_keeps_approval_request_before_response() -> None:
+    old_request = cast(
+        TResponseInputItem,
+        {
+            "type": "mcp_approval_request",
+            "id": "approval-1",
+            "arguments": "old",
+            "name": "lookup",
+            "server_label": "server",
+        },
+    )
+    response = cast(
+        TResponseInputItem,
+        {
+            "type": "mcp_approval_response",
+            "approval_request_id": "approval-1",
+            "approve": True,
+        },
+    )
+    new_request = cast(
+        TResponseInputItem,
+        {
+            "type": "mcp_approval_request",
+            "id": "approval-1",
+            "arguments": "new",
+            "name": "lookup",
+            "server_label": "server",
+        },
+    )
+
+    deduplicated = run_items.deduplicate_input_items_preferring_latest(
+        [old_request, response, new_request]
+    )
+
+    assert [cast(dict[str, Any], item).get("type") for item in deduplicated] == [
+        "mcp_approval_request",
+        "mcp_approval_response",
+    ]
+    assert cast(dict[str, Any], deduplicated[0])["arguments"] == "new"
+
+
 def test_deduplicate_input_items_preferring_latest_leaves_unique_items_untouched() -> None:
     items = [
         cast(TResponseInputItem, {"role": "user", "content": "hi"}),


### PR DESCRIPTION
### Background

`deduplicate_input_items_preferring_latest` was originally introduced to collapse items with the same stable identifier while retaining the latest value. Its original reverse-based implementation also retained the latest occurrence as the surviving position.

#4140 addressed a failure in that behavior: when a duplicated tool call appeared after its output, retaining the latest occurrence moved the call behind the output and produced an invalid Responses API sequence. It changed every duplicate to retain its earliest position while still using the latest value.

That rule was too broad and mirrored the failure for duplicated outputs:

```text
[stale output, call, fresh output]
-> [fresh output, call]
```

It also changed ordinary conversation chronology. For example, `[old output, message, new output]` became `[new output, message]`, presenting the replacement as if it had occurred before the intervening message.

The underlying issue is that tool calls and other items need different positioning rules. Tool calls must not move behind their matching outputs, while outputs and other identified items should retain their latest position.

### Change

This updates deduplication to separate value selection from position selection:

- The latest value always wins.
- Tool-call types defined by the existing `_TOOL_CALL_TO_OUTPUT_TYPE` mapping retain their earliest position.
- Outputs and other identified items retain their latest position.

This preserves the call-before-output invariant fixed by #4140 while restoring the latest-occurrence chronology used before that change. It does not attempt to repair arbitrary malformed input or reorder unique items.