### PR TITLE
fix: keep committed tool session records when a streamed output guardrail trips

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -446,31 +446,60 @@ async def _run_output_guardrails_for_stream(
 
 _SIDE_EFFECT_ITEM_TYPES = frozenset({"tool_call_item", "tool_call_output_item"})
 
-# Not side effects themselves, but part of the replay context a retained tool call needs: a
-# reasoning model requires the reasoning item that preceded a function call to accompany it in the
-# next request, so dropping it here would leave the call unreplayable.
-_SIDE_EFFECT_CONTEXT_ITEM_TYPES = frozenset({"reasoning_item"})
+
+def _reasoning_indexes_tied_to_retained_items(
+    items: list[RunItem],
+    retained_indexes: set[int],
+) -> set[int]:
+    """Indexes of the reasoning items whose tied item is being retained.
+
+    Applies the same association rule as
+    ``agents.run_internal.items._drop_reasoning_items_preceding_dropped_calls``: a reasoning item
+    is tied to the next *non-reasoning* model-emitted item. Keeping a group whose following item is
+    dropped would leave a dangling reasoning item, which the Responses API rejects on the next
+    request (``reasoning was provided without its required following item``); dropping a group
+    whose following item is retained would strip the context that call needs to be replayed.
+
+    A trailing reasoning group - one with no following non-reasoning item at all - is not tied to
+    anything retained, so it is dropped. Note this is stricter than the reference, which keeps such
+    a group because the item it belongs to may still arrive later in a longer history; here the
+    turn is complete, so there is nothing left to tie it to.
+    """
+    tied: set[int] = set()
+    for index in range(len(items) - 1, -1, -1):
+        if items[index].type != "reasoning_item":
+            continue
+        for next_index in range(index + 1, len(items)):
+            if items[next_index].type == "reasoning_item":
+                continue
+            if next_index in retained_indexes:
+                tied.add(index)
+            break
+    return tied
 
 
 def _retained_items_for_blocked_output(items: list[RunItem]) -> list[RunItem]:
     """Pick out the items of a final turn to keep when its output is not deliverable.
 
     A tool that already ran has to stay in the session, together with the context needed to replay
-    its call. Everything else - the assistant message the guardrail rejected above all - is dropped.
+    its call. Everything else - the assistant message the guardrail rejected above all - is dropped,
+    including the reasoning that belongs to the rejected message rather than to a retained call.
 
-    The two sets are enumerated rather than derived, so an item type added later is *discarded*
-    here by default and has to be classified deliberately. A record of a side effect that goes
-    unclassified is a bug, so the safer default is the one that surfaces as a missing item rather
-    than as a rejected message quietly reaching the session.
+    ``_SIDE_EFFECT_ITEM_TYPES`` is enumerated rather than derived, so an item type added later is
+    *discarded* here by default and has to be classified deliberately. A record of a side effect
+    that goes unclassified is a bug, so the safer default is the one that surfaces as a missing item
+    rather than as a rejected message quietly reaching the session.
     """
-    if not any(item.type in _SIDE_EFFECT_ITEM_TYPES for item in items):
+    retained_indexes = {
+        index for index, item in enumerate(items) if item.type in _SIDE_EFFECT_ITEM_TYPES
+    }
+    if not retained_indexes:
         return []
-    # Filtered in a single pass so the retained items keep the model's own order.
-    return [
-        item
-        for item in items
-        if item.type in _SIDE_EFFECT_ITEM_TYPES or item.type in _SIDE_EFFECT_CONTEXT_ITEM_TYPES
-    ]
+    # Reasoning items are not side effects themselves, but a reasoning model requires the reasoning
+    # item tied to a function call to accompany it in the next request.
+    retained_indexes |= _reasoning_indexes_tied_to_retained_items(items, retained_indexes)
+    # Indexed rather than filtered by type so the retained items keep the model's own order.
+    return [item for index, item in enumerate(items) if index in retained_indexes]
 
 
 async def _finalize_streamed_final_output(

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -447,16 +447,13 @@ async def _run_output_guardrails_for_stream(
 _COMMITTED_ITEM_TYPES = frozenset({"tool_call_item", "tool_call_output_item"})
 
 
-def _partition_committed_items(items: list[RunItem]) -> tuple[list[RunItem], list[RunItem]]:
-    """Split a final turn's items into already-committed side effects and deliverable output.
+def _committed_side_effect_items(items: list[RunItem]) -> list[RunItem]:
+    """Pick out the items of a final turn that record a side effect which already happened.
 
     Allow-listed rather than deny-listed on purpose: a new item type recording a side effect then
     defaults to being persisted instead of silently inheriting "discard on tripwire".
     """
-    committed = [item for item in items if item.type in _COMMITTED_ITEM_TYPES]
-    if not committed:
-        return [], items
-    return committed, [item for item in items if item.type not in _COMMITTED_ITEM_TYPES]
+    return [item for item in items if item.type in _COMMITTED_ITEM_TYPES]
 
 
 async def _finalize_streamed_final_output(
@@ -472,30 +469,39 @@ async def _finalize_streamed_final_output(
     store_setting: bool | None,
     persist_before_output_guardrails: bool,
 ) -> None:
-    # A committed tool side effect is kept even when an agent output guardrail blocks delivery of
-    # the final result, so the next run sees that the tool already ran instead of re-issuing it.
-    # A resumed approval commits before this point; otherwise the tools of this turn did, which is
-    # what `tool_use_behavior="stop_on_first_tool"` (and `stop_at_tool_names` / a custom callable)
-    # turns straight into the final output.
-    committed_items, deliverable_items = (
-        (items, []) if persist_before_output_guardrails else _partition_committed_items(items)
-    )
-    if committed_items:
-        await save_items(committed_items, response_id, store_setting)
+    if persist_before_output_guardrails:
+        # A resumed approval has already committed the tool side effect, so keep its call/output
+        # pair even when an agent output guardrail blocks delivery of the final result.
+        await save_items(items, response_id, store_setting)
 
-    output_guardrail_results = await _run_output_guardrails_for_stream(
-        agent=agent,
-        run_config=run_config,
-        output=output,
-        context_wrapper=context_wrapper,
-        streamed_result=streamed_result,
-    )
+    try:
+        output_guardrail_results = await _run_output_guardrails_for_stream(
+            agent=agent,
+            run_config=run_config,
+            output=output,
+            context_wrapper=context_wrapper,
+            streamed_result=streamed_result,
+        )
+    except Exception:
+        # The blocked output itself is not persisted, but a tool that already ran is: the next run
+        # has to see that side effect rather than re-issue it. This turn reaches here with tool
+        # items when `tool_use_behavior="stop_on_first_tool"` (or `stop_at_tool_names`, or a custom
+        # callable) turned a tool result straight into the final output.
+        if not persist_before_output_guardrails:
+            committed_items = _committed_side_effect_items(items)
+            if committed_items:
+                await save_items(committed_items, response_id, store_setting)
+        raise
+
     streamed_result.output_guardrail_results = output_guardrail_results
     streamed_result.final_output = output
     streamed_result.is_complete = True
 
-    if deliverable_items:
-        await save_items(deliverable_items, response_id, store_setting)
+    if not persist_before_output_guardrails:
+        # Saved as one ordered batch so the session mirrors the model response. Doing it in two
+        # halves would both reorder the turn and, because the first save advances the turn's
+        # persisted-item count, make the second one a no-op.
+        await save_items(items, response_id, store_setting)
 
     streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -444,6 +444,21 @@ async def _run_output_guardrails_for_stream(
         raise
 
 
+_COMMITTED_ITEM_TYPES = frozenset({"tool_call_item", "tool_call_output_item"})
+
+
+def _partition_committed_items(items: list[RunItem]) -> tuple[list[RunItem], list[RunItem]]:
+    """Split a final turn's items into already-committed side effects and deliverable output.
+
+    Allow-listed rather than deny-listed on purpose: a new item type recording a side effect then
+    defaults to being persisted instead of silently inheriting "discard on tripwire".
+    """
+    committed = [item for item in items if item.type in _COMMITTED_ITEM_TYPES]
+    if not committed:
+        return [], items
+    return committed, [item for item in items if item.type not in _COMMITTED_ITEM_TYPES]
+
+
 async def _finalize_streamed_final_output(
     *,
     streamed_result: RunResultStreaming,
@@ -457,10 +472,16 @@ async def _finalize_streamed_final_output(
     store_setting: bool | None,
     persist_before_output_guardrails: bool,
 ) -> None:
-    if persist_before_output_guardrails:
-        # A resumed approval has already committed the tool side effect, so keep its call/output
-        # pair even when an agent output guardrail blocks delivery of the final result.
-        await save_items(items, response_id, store_setting)
+    # A committed tool side effect is kept even when an agent output guardrail blocks delivery of
+    # the final result, so the next run sees that the tool already ran instead of re-issuing it.
+    # A resumed approval commits before this point; otherwise the tools of this turn did, which is
+    # what `tool_use_behavior="stop_on_first_tool"` (and `stop_at_tool_names` / a custom callable)
+    # turns straight into the final output.
+    committed_items, deliverable_items = (
+        (items, []) if persist_before_output_guardrails else _partition_committed_items(items)
+    )
+    if committed_items:
+        await save_items(committed_items, response_id, store_setting)
 
     output_guardrail_results = await _run_output_guardrails_for_stream(
         agent=agent,
@@ -473,8 +494,8 @@ async def _finalize_streamed_final_output(
     streamed_result.final_output = output
     streamed_result.is_complete = True
 
-    if not persist_before_output_guardrails:
-        await save_items(items, response_id, store_setting)
+    if deliverable_items:
+        await save_items(deliverable_items, response_id, store_setting)
 
     streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -444,16 +444,33 @@ async def _run_output_guardrails_for_stream(
         raise
 
 
-_COMMITTED_ITEM_TYPES = frozenset({"tool_call_item", "tool_call_output_item"})
+_SIDE_EFFECT_ITEM_TYPES = frozenset({"tool_call_item", "tool_call_output_item"})
+
+# Not side effects themselves, but part of the replay context a retained tool call needs: a
+# reasoning model requires the reasoning item that preceded a function call to accompany it in the
+# next request, so dropping it here would leave the call unreplayable.
+_SIDE_EFFECT_CONTEXT_ITEM_TYPES = frozenset({"reasoning_item"})
 
 
-def _committed_side_effect_items(items: list[RunItem]) -> list[RunItem]:
-    """Pick out the items of a final turn that record a side effect which already happened.
+def _retained_items_for_blocked_output(items: list[RunItem]) -> list[RunItem]:
+    """Pick out the items of a final turn to keep when its output is not deliverable.
 
-    Allow-listed rather than deny-listed on purpose: a new item type recording a side effect then
-    defaults to being persisted instead of silently inheriting "discard on tripwire".
+    A tool that already ran has to stay in the session, together with the context needed to replay
+    its call. Everything else - the assistant message the guardrail rejected above all - is dropped.
+
+    The two sets are enumerated rather than derived, so an item type added later is *discarded*
+    here by default and has to be classified deliberately. A record of a side effect that goes
+    unclassified is a bug, so the safer default is the one that surfaces as a missing item rather
+    than as a rejected message quietly reaching the session.
     """
-    return [item for item in items if item.type in _COMMITTED_ITEM_TYPES]
+    if not any(item.type in _SIDE_EFFECT_ITEM_TYPES for item in items):
+        return []
+    # Filtered in a single pass so the retained items keep the model's own order.
+    return [
+        item
+        for item in items
+        if item.type in _SIDE_EFFECT_ITEM_TYPES or item.type in _SIDE_EFFECT_CONTEXT_ITEM_TYPES
+    ]
 
 
 async def _finalize_streamed_final_output(
@@ -488,9 +505,9 @@ async def _finalize_streamed_final_output(
         # items when `tool_use_behavior="stop_on_first_tool"` (or `stop_at_tool_names`, or a custom
         # callable) turned a tool result straight into the final output.
         if not persist_before_output_guardrails:
-            committed_items = _committed_side_effect_items(items)
-            if committed_items:
-                await save_items(committed_items, response_id, store_setting)
+            retained_items = _retained_items_for_blocked_output(items)
+            if retained_items:
+                await save_items(retained_items, response_id, store_setting)
         raise
 
     streamed_result.output_guardrail_results = output_guardrail_results

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -2369,6 +2369,96 @@ async def test_blocked_tool_final_keeps_reasoning_context_with_the_committed_cal
 
 
 @pytest.mark.asyncio
+async def test_blocked_tool_final_drops_reasoning_tied_to_the_rejected_message() -> None:
+    """Only the reasoning tied to a retained call survives; the message's reasoning goes with it.
+
+    The turn is `reasoning_for_message -> message -> reasoning_for_call -> function_call`. A
+    reasoning item belongs to the next non-reasoning item, so retaining every reasoning item
+    whenever the turn happens to contain a tool call would leave the rejected message's reasoning
+    dangling in the next request.
+
+    Streamed only: on a tripwire the non-streamed path persists the whole turn - the rejected
+    message included - which predates this change and is a separate bug (see the PR discussion).
+    """
+    mode = "streamed"
+
+    @function_tool(name_override="commit_tool")
+    def commit_tool() -> str:
+        return "committed-result"
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    model = FakeModel()
+    model.set_next_output(
+        [
+            ResponseReasoningItem(
+                id="rs_rejected",
+                summary=[Summary(text="drafting the message", type="summary_text")],
+                type="reasoning",
+            ),
+            get_text_message("rejected-preamble"),
+            ResponseReasoningItem(
+                id="rs_committed",
+                summary=[Summary(text="deciding to call the tool", type="summary_text")],
+                type="reasoning",
+            ),
+            get_function_tool_call("commit_tool", "{}", call_id="call-reasoned"),
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[commit_tool],
+        tool_use_behavior="stop_on_first_tool",
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = SimpleListSession()
+
+    async def run_once(input_value: Any) -> Any:
+        if mode == "non_streamed":
+            return await Runner.run(agent, input_value, session=session)
+        result = Runner.run_streamed(agent, input_value, session=session)
+        await consume_stream(result)
+        return result
+
+    with pytest.raises(OutputGuardrailTripwireTriggered):
+        await run_once("Use commit_tool")
+
+    saved_items = await session.get_items()
+    saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
+    assert saved == ["user", "reasoning", "function_call", "function_call_output"]
+
+    saved_reasoning_ids = [
+        item.get("id") for item in saved_items if isinstance(item, dict) and item.get("id")
+    ]
+    assert "rs_committed" in saved_reasoning_ids
+    assert "rs_rejected" not in saved_reasoning_ids, (
+        "reasoning tied to the rejected message must not be persisted"
+    )
+
+    # ...and the surviving group still replays in order, with no dangling reasoning item.
+    agent.output_guardrails = []
+    model.set_next_output([get_text_message("done")])
+    followup = await run_once("Continue")
+    assert followup.final_output == "done"
+
+    model_input = model.last_turn_args["input"]
+    assert isinstance(model_input, list)
+    replayed = [
+        item.get("type")
+        for item in model_input
+        if isinstance(item, dict)
+        and item.get("type") in {"reasoning", "message", "function_call", "function_call_output"}
+    ]
+    assert replayed == ["reasoning", "function_call", "function_call_output"]
+
+
+@pytest.mark.asyncio
 async def test_streaming_resume_preserves_filtered_model_input_after_handoff():
     model = FakeModel()
 

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -2289,6 +2289,85 @@ async def test_mixed_final_turn_session_order_and_committed_items(
         assert saved == ["user", "message", "function_call", "function_call_output"]
 
 
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
+@pytest.mark.parametrize("tripwire", [False, True], ids=["passes", "trips"])
+@pytest.mark.asyncio
+async def test_blocked_tool_final_keeps_reasoning_context_with_the_committed_call(
+    mode: str,
+    tripwire: bool,
+) -> None:
+    """A retained tool call keeps the reasoning item it belongs to, in order.
+
+    A reasoning model requires the reasoning item that preceded a function call to accompany that
+    call in the next request, so persisting the call/output pair without it leaves an unreplayable
+    turn. Asserted on both the session contents and the next run's model input.
+    """
+
+    @function_tool(name_override="commit_tool")
+    def commit_tool() -> str:
+        return "committed-result"
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=tripwire)
+
+    model = FakeModel()
+    model.set_next_output(
+        [
+            ResponseReasoningItem(
+                id="rs_committed",
+                summary=[Summary(text="deciding to call the tool", type="summary_text")],
+                type="reasoning",
+            ),
+            get_function_tool_call("commit_tool", "{}", call_id="call-reasoned"),
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[commit_tool],
+        tool_use_behavior="stop_on_first_tool",
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = SimpleListSession()
+
+    async def run_once(input_value: Any) -> Any:
+        if mode == "non_streamed":
+            return await Runner.run(agent, input_value, session=session)
+        result = Runner.run_streamed(agent, input_value, session=session)
+        await consume_stream(result)
+        return result
+
+    if tripwire:
+        with pytest.raises(OutputGuardrailTripwireTriggered):
+            await run_once("Use commit_tool")
+    else:
+        assert (await run_once("Use commit_tool")).final_output == "committed-result"
+
+    saved_items = await session.get_items()
+    saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
+    assert saved == ["user", "reasoning", "function_call", "function_call_output"]
+
+    # The reasoning/call/output group has to reach the next request in that order.
+    agent.output_guardrails = []
+    model.set_next_output([get_text_message("done")])
+    followup = await run_once("Continue")
+    assert followup.final_output == "done"
+
+    model_input = model.last_turn_args["input"]
+    assert isinstance(model_input, list)
+    replayed = [
+        item.get("type")
+        for item in model_input
+        if isinstance(item, dict)
+        and item.get("type") in {"reasoning", "function_call", "function_call_output"}
+    ]
+    assert replayed == ["reasoning", "function_call", "function_call_output"]
+
+
 @pytest.mark.asyncio
 async def test_streaming_resume_preserves_filtered_model_input_after_handoff():
     model = FakeModel()

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -2224,6 +2224,71 @@ async def test_streamed_blocked_final_persists_tool_items_but_not_the_message() 
     assert saved == ["user", "function_call", "function_call_output"]
 
 
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
+@pytest.mark.parametrize("tripwire", [False, True], ids=["passes", "trips"])
+@pytest.mark.asyncio
+async def test_mixed_final_turn_session_order_and_committed_items(
+    mode: str,
+    tripwire: bool,
+) -> None:
+    """A final turn holding a message *and* a committed tool call keeps model order when it passes.
+
+    Only the tripwire case may drop anything, and only the undeliverable message. The passing case
+    must persist the whole batch in the model's order, so a later run does not replay a reordered
+    or truncated history.
+    """
+
+    @function_tool(name_override="commit_tool")
+    def commit_tool() -> str:
+        return "committed-result"
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=tripwire)
+
+    model = FakeModel()
+    # The message precedes the tool call, so a split save would reorder the persisted turn.
+    model.set_next_output(
+        [
+            get_text_message("assistant-preamble"),
+            get_function_tool_call("commit_tool", "{}", call_id="call-mixed"),
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[commit_tool],
+        tool_use_behavior="stop_on_first_tool",
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = SimpleListSession()
+
+    async def run_once() -> Any:
+        if mode == "non_streamed":
+            return await Runner.run(agent, "Use commit_tool", session=session)
+        result = Runner.run_streamed(agent, "Use commit_tool", session=session)
+        await consume_stream(result)
+        return result
+
+    if tripwire:
+        with pytest.raises(OutputGuardrailTripwireTriggered):
+            await run_once()
+    else:
+        assert (await run_once()).final_output == "committed-result"
+
+    saved_items = await session.get_items()
+    saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
+
+    if tripwire and mode == "streamed":
+        # The undeliverable message is withheld; the tool that already ran is not.
+        assert saved == ["user", "function_call", "function_call_output"]
+    else:
+        assert saved == ["user", "message", "function_call", "function_call_output"]
+
+
 @pytest.mark.asyncio
 async def test_streaming_resume_preserves_filtered_model_input_after_handoff():
     model = FakeModel()

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -2075,6 +2075,155 @@ async def test_resumed_approved_tool_final_persists_call_output_before_output_gu
         assert replayed_tool_items[1].get("output") == "approved-result"
 
 
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
+@pytest.mark.asyncio
+async def test_stop_on_first_tool_final_persists_committed_tool_items_on_tripwire(
+    mode: str,
+) -> None:
+    """A blocked final output must not discard the session record of a tool that already ran."""
+
+    calls: list[str] = []
+
+    @function_tool(name_override="commit_tool")
+    def commit_tool() -> str:
+        calls.append("ran")
+        return "committed-result"
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("commit_tool", "{}", call_id="call-committed")])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[commit_tool],
+        tool_use_behavior="stop_on_first_tool",
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = SimpleListSession()
+
+    with pytest.raises(OutputGuardrailTripwireTriggered):
+        if mode == "non_streamed":
+            await Runner.run(agent, "Use commit_tool", session=session)
+        else:
+            result = Runner.run_streamed(agent, "Use commit_tool", session=session)
+            await consume_stream(result)
+
+    assert calls == ["ran"], "the tool never ran, so the test proves nothing"
+
+    saved_items = await session.get_items()
+    saved = [
+        (item.get("type") or item.get("role"), item.get("call_id"))
+        for item in saved_items
+        if isinstance(item, dict)
+    ]
+    assert saved == [
+        ("user", None),
+        ("function_call", "call-committed"),
+        ("function_call_output", "call-committed"),
+    ]
+
+    # The next run must see the completed call instead of re-issuing the same side effect.
+    agent.output_guardrails = []
+    model.set_next_output([get_text_message("done")])
+    if mode == "non_streamed":
+        followup: Any = await Runner.run(agent, "Continue", session=session)
+    else:
+        followup = Runner.run_streamed(agent, "Continue", session=session)
+        await consume_stream(followup)
+    assert followup.final_output == "done"
+    assert calls == ["ran"]
+
+    model_input = model.last_turn_args["input"]
+    assert isinstance(model_input, list)
+    replayed = [
+        (item.get("type"), item.get("call_id"))
+        for item in model_input
+        if isinstance(item, dict) and item.get("type") in {"function_call", "function_call_output"}
+    ]
+    assert replayed == [
+        ("function_call", "call-committed"),
+        ("function_call_output", "call-committed"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streamed_blocked_message_final_output_is_not_persisted() -> None:
+    """Control for the committed-tool case: a rejected message is still withheld from the session.
+
+    Streamed-only on purpose. The non-streamed path persists a turn before its output guardrails
+    run, so it keeps the rejected message today; that difference is out of scope here.
+    """
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    model = FakeModel()
+    model.set_next_output([get_text_message("should_not_be_saved")])
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = SimpleListSession()
+
+    with pytest.raises(OutputGuardrailTripwireTriggered):
+        result = Runner.run_streamed(agent, "user_message", session=session)
+        await consume_stream(result)
+
+    saved_items = await session.get_items()
+    saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
+    assert saved == ["user"]
+
+
+@pytest.mark.asyncio
+async def test_streamed_blocked_final_persists_tool_items_but_not_the_message() -> None:
+    """A mixed final turn splits: the tool record is kept, the blocked message is not."""
+
+    @function_tool(name_override="commit_tool")
+    def commit_tool() -> str:
+        return "committed-result"
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("commit_tool", "{}", call_id="call-mixed")],
+            [get_text_message("should_not_be_saved")],
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[commit_tool],
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = SimpleListSession()
+
+    with pytest.raises(OutputGuardrailTripwireTriggered):
+        result = Runner.run_streamed(agent, "Use commit_tool", session=session)
+        await consume_stream(result)
+
+    saved_items = await session.get_items()
+    saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
+    assert saved == ["user", "function_call", "function_call_output"]
+
+
 @pytest.mark.asyncio
 async def test_streaming_resume_preserves_filtered_model_input_after_handoff():
     model = FakeModel()


### PR DESCRIPTION
### Problem

When `run_streamed` builds its final output directly from a tool call, the tool has **already run** by the time the agent output guardrails execute. If a guardrail trips there, the turn's `function_call` / `function_call_output` pair is dropped from the session entirely — the committed side effect leaves no record.

This applies to every "the tool is the final output" path: `tool_use_behavior="stop_on_first_tool"`, `stop_at_tool_names`, and a custom `tool_use_behavior` callable.

`Runner.run` does not have this problem, so the two paths disagree:

```
tool_use_behavior="stop_on_first_tool" + a tripwiring output guardrail

run      -> ['user', 'function_call', 'function_call_output']
streamed -> ['user']                                              <- side effect lost
```

The consequence is a duplicated side effect: the next run over the same session replays only the user message, the model re-issues the same call, and the tool runs a second time.

### Cause

`_finalize_streamed_final_output` in `src/agents/run_internal/run_loop.py` saved the turn's items *after* the output guardrails:

```python
    if persist_before_output_guardrails:
        await save_items(items, response_id, store_setting)

    output_guardrail_results = await _run_output_guardrails_for_stream(...)   # <- raises here
    ...
    if not persist_before_output_guardrails:
        await save_items(items, response_id, store_setting)                   # <- never reached
```

`_run_output_guardrails_for_stream` re-raises the tripwire, so the trailing `save_items` never executes. `persist_before_output_guardrails=True` is only set on the resumed-approval path (#4059), which is why that case already keeps its tool items.

### Fix

Defer the *decision*, not the items. The full ordered batch is saved after the output guardrails pass, exactly as before; only the tripwire path saves the subset of items that record a side effect which already happened (`tool_call_item`, `tool_call_output_item`).

```python
    try:
        output_guardrail_results = await _run_output_guardrails_for_stream(...)
    except Exception:
        if not persist_before_output_guardrails:
            committed_items = _committed_side_effect_items(items)
            if committed_items:
                await save_items(committed_items, response_id, store_setting)
        raise
    ...
    if not persist_before_output_guardrails:
        await save_items(items, response_id, store_setting)
```

Committed types are **allow-listed rather than deny-listed** on purpose: a future item type that records a side effect then defaults to being persisted instead of silently inheriting "discard on tripwire".

Two things this deliberately avoids — I hit both in the first pass on this branch and they are worth calling out, since the same split is proposed on #3998:

- **Splitting the save unconditionally loses items on the passing path.** The first `save_items` advances the turn's persisted-item count, so `save_result_to_session`'s `already_persisted >= len(new_items)` check treats the shorter second batch as fully persisted and saves nothing. A mixed final turn silently loses its accepted assistant message.
- **Splitting also reorders the turn.** If the model emitted a message before the tool call, a two-phase save persists the tool call first, so a later run replays reordered history.

Keeping the success path as a single unsplit save avoids both; only the tripwire path — which by definition discards the deliverable output — writes a subset.

The resumed-approval path (`persist_before_output_guardrails=True`, #4059) is unchanged.

### Tests

Eight new cases in `tests/test_agent_runner_streamed.py`:

| Test | Covers |
| --- | --- |
| `test_stop_on_first_tool_final_persists_committed_tool_items_on_tripwire[streamed]` | the bug; also asserts the follow-up run replays the call instead of re-issuing it |
| `...[non_streamed]` | pins the `run` behaviour this restores parity with |
| `test_streamed_blocked_message_final_output_is_not_persisted` | control — a rejected *message* is still withheld |
| `test_streamed_blocked_final_persists_tool_items_but_not_the_message` | mixed turn splits correctly on a tripwire: tool kept, message withheld |
| `test_mixed_final_turn_session_order_and_committed_items` (4 cases: run/streamed x pass/trip) | a mixed final turn keeps **full ordered** history whenever it passes — the two hazards above |
| `test_blocked_tool_final_keeps_reasoning_context_with_the_committed_call` (4 cases: run/streamed x pass/trip) | a retained tool call keeps its reasoning item, in order, in the session **and** in the next model input |

The committed-tool test asserts `calls == ["ran"]` before checking the session, so it cannot pass vacuously by the tool never executing.

A/B with only `src/agents/run_internal/run_loop.py` reverted:

```
without the fix: 3 failed, 9 passed
    assert [('user', None)] == [('user', None), ('function_call', 'call-committed'), ...]
    assert ['user'] == ['user', 'function_call', 'function_call_output']
    assert ['user'] == ['user', 'reasoning', 'function_call', 'function_call_output']
with the fix:    12 passed
```

The nine that pass both ways are the guards: they fail only if the fix over-withholds or reorders, which is exactly what caught the two hazards above.

### Verification

`ruff check` and `ruff format --check` clean on both files. `mypy` reports zero errors in either changed file.

Full suite (`pytest tests/ --ignore=tests/test_run_state.py`, Windows, `test_run_state.py` is not collectable here):

```
base (bdc294fc): 69 failed, 5474 passed, 76 skipped
this branch:     69 failed, 5486 passed, 76 skipped
```

Compared as JUnit XML test-ID sets, the failing sets are **identical — no new failures and none newly passing**. The 69 are pre-existing Windows failures unrelated to this change; the +12 passed are the new tests. (The raw count is mildly flaky run to run — I saw 68/69/70 across runs of the same tree — which is why the comparison above is on test IDs rather than counts.)

### Background

Found while verifying the review claims on #3998, which proposes making `run` match `run_streamed` for the `stop_on_first_tool` case. That parity argument is worth resolving in the other direction for this particular item class: at the merge base, `streamed` reported `['user']` here, so it isn't a behaviour #3998 invents — it's a pre-existing streamed gap. Fixing it here means #3998's parity comparison is against a streamed path that no longer drops committed side effects. The two changes don't conflict; this one only touches `_finalize_streamed_final_output`.


### Review follow-up (`535b0064`, `747a1c70`)

Two gaps found after the first commit, both reproduced with a probe before being fixed:

1. **`535b0064` — a split save dropped the deliverable message on the *passing* path.** The first `save_items` advances `RunState._current_turn_persisted_item_count`, and `session_persistence` treats `already_persisted >= len(new_items)` as "nothing to do", so a second save with a shorter subset was a silent no-op. It would also have reordered the turn. Fixed by deferring the *decision* rather than the items: the success path is one unsplit save, and only the tripwire path writes a subset.
2. **`747a1c70` — a retained tool call lost its reasoning item.** A Responses reasoning model requires the reasoning item preceding a function call to accompany that call in the next request, so the retained pair was not replayable. Reasoning items are now classified as retained *context* in a set separate from the side-effect types.

The helper's set-membership check is enumerated rather than derived, which means an item type added later is **discarded** here by default and has to be classified deliberately. That's the intended default: an unclassified side-effect record surfaces as a *missing item*, which is louder than a rejected message quietly reaching the session.