### PR TITLE
fix(tools): reject duplicate bare function tool names

### DIFF
--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -401,7 +401,7 @@ def resolve_tool_name_collisions(
     collision_policy: Literal["warn", "error"],
 ) -> tuple[list[Any], list[Any]]:
     """Resolve bare function-tool and handoff name collisions before model exposure."""
-    validate_function_tool_lookup_configuration(tools)
+    validate_function_tool_lookup_configuration(tools, allow_bare_name_collisions=True)
 
     owners: dict[BareFunctionToolLookupKey, list[tuple[str, int, Any]]] = {}
     for index, tool in enumerate(tools):
@@ -446,7 +446,9 @@ def resolve_tool_name_collisions(
     )
 
 
-def validate_function_tool_lookup_configuration(tools: Sequence[Any]) -> None:
+def validate_function_tool_lookup_configuration(
+    tools: Sequence[Any], *, allow_bare_name_collisions: bool = False
+) -> None:
     """Reject function-tool combinations that are ambiguous on the Responses wire."""
     qualified_name_owners: dict[str, Any] = {}
     deferred_top_level_name_owners: dict[str, Any] = {}
@@ -478,7 +480,13 @@ def validate_function_tool_lookup_configuration(tools: Sequence[Any]) -> None:
 
         prior_namespace = get_explicit_function_tool_namespace(prior_owner)
         if explicit_namespace is None and prior_namespace is None:
-            continue
+            if allow_bare_name_collisions:
+                continue
+            raise UserError(
+                "Ambiguous function tool configuration: the tool name "
+                f"`{qualified_name}` is used by multiple tools. Pass a unique "
+                "`name_override=` to one of them to avoid ambiguous dispatch."
+            )
 
         raise UserError(
             "Ambiguous function tool configuration: the qualified name "
@@ -488,9 +496,14 @@ def validate_function_tool_lookup_configuration(tools: Sequence[Any]) -> None:
         )
 
 
-def build_function_tool_lookup_map(tools: Sequence[Any]) -> dict[FunctionToolLookupKey, Any]:
-    """Build a function-tool lookup map using last-wins precedence."""
-    validate_function_tool_lookup_configuration(tools)
+def build_function_tool_lookup_map(
+    tools: Sequence[Any], *, allow_bare_name_collisions: bool = False
+) -> dict[FunctionToolLookupKey, Any]:
+    """Build a function-tool lookup map after validating its dispatch keys."""
+    validate_function_tool_lookup_configuration(
+        tools,
+        allow_bare_name_collisions=allow_bare_name_collisions,
+    )
     tool_map: dict[FunctionToolLookupKey, Any] = {}
     for tool in tools:
         for lookup_key in get_function_tool_lookup_keys(tool):

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -2298,7 +2298,8 @@ async def execute_approved_tools(
     tool_map: dict[NamedToolLookupKey, Tool] = cast(
         dict[NamedToolLookupKey, Tool],
         build_function_tool_lookup_map(
-            [tool for tool in all_tools or [] if isinstance(tool, FunctionTool)]
+            [tool for tool in all_tools or [] if isinstance(tool, FunctionTool)],
+            allow_bare_name_collisions=True,
         ),
     )
     for tool in all_tools or []:

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -1331,7 +1331,10 @@ async def resolve_interrupted_turn(
     async def _rebuild_function_runs_from_approvals() -> list[ToolRunFunction]:
         if not pending_approval_items:
             return []
-        tool_map = build_function_tool_lookup_map(approval_rebuild_function_tools)
+        tool_map = build_function_tool_lookup_map(
+            approval_rebuild_function_tools,
+            allow_bare_name_collisions=True,
+        )
         existing_pending_call_ids: set[str] = set()
         for existing_pending in pending_interruptions:
             if isinstance(existing_pending, ToolApprovalItem):
@@ -1753,7 +1756,8 @@ def process_model_response(
     tools_used: list[str] = []
     handoff_map = {handoff.tool_name: handoff for handoff in handoffs}
     function_map = build_function_tool_lookup_map(
-        [tool for tool in all_tools if isinstance(tool, FunctionTool)]
+        [tool for tool in all_tools if isinstance(tool, FunctionTool)],
+        allow_bare_name_collisions=True,
     )
     custom_tool_map = {tool.name: tool for tool in all_tools if isinstance(tool, CustomTool)}
     computer_tool = next((tool for tool in all_tools if isinstance(tool, ComputerTool)), None)

--- a/tests/test_tool_identity.py
+++ b/tests/test_tool_identity.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import pytest
 
+from agents import function_tool
 from agents._tool_identity import (
+    build_function_tool_lookup_map,
     deserialize_function_tool_lookup_key,
     get_function_tool_lookup_key,
     get_tool_call_name,
@@ -21,6 +23,7 @@ from agents._tool_identity import (
     serialize_function_tool_lookup_key,
     tool_qualified_name,
     tool_trace_name,
+    validate_function_tool_lookup_configuration,
 )
 from agents.exceptions import UserError
 
@@ -165,3 +168,22 @@ def test_validate_function_tool_namespace_shape_rejects_synthetic() -> None:
     # The reserved synthetic shape (name == namespace) is rejected.
     with pytest.raises(UserError, match="reserves the synthetic namespace"):
         validate_function_tool_namespace_shape("search", "search")
+
+
+def test_validate_function_tool_lookup_configuration_rejects_duplicate_bare_names() -> None:
+    @function_tool(name_override="lookup")
+    def first_lookup() -> str:
+        return "first"
+
+    @function_tool(name_override="lookup")
+    def second_lookup() -> str:
+        return "second"
+
+    with pytest.raises(
+        UserError,
+        match=r"the tool name `lookup` is used by multiple tools.*name_override=",
+    ):
+        validate_function_tool_lookup_configuration([first_lookup, second_lookup])
+
+    with pytest.raises(UserError, match="the tool name `lookup` is used by multiple tools"):
+        build_function_tool_lookup_map([first_lookup, second_lookup])


### PR DESCRIPTION
This pull request fixes silent last-wins behavior for duplicate bare function tool names during strict lookup validation.

## Problem

When two `FunctionTool` instances expose the same public name without an explicit namespace, the validator detects the collision but currently continues without raising an error. This can allow ambiguous dispatch and make one tool silently shadow another.

## Approach

- Make strict function-tool lookup validation raise `UserError` for duplicate bare names.
- Include the conflicting tool name and recommend using `name_override=` to resolve it.
- Keep the existing warning-and-deduplication behavior for `tool_name_collision_policy="warn"`.
- Preserve last-wins behavior only in approval and historical-response recovery paths where it is required for compatibility.
- Add regression coverage for direct validation and lookup-map construction.

## Compatibility

This change does not alter MCP or Codex tool naming, permissions, persistence, or wire schemas. It only makes ambiguous strict lookup configurations fail earlier and more clearly.

## Validation

- Focused boundary tests: 293 passed.
- Changed-file mypy: passed.
- Changed-file pyright: passed.
- Full repository validation remains blocked by unrelated optional dependencies and Windows-specific sandbox/MCP failures.

This pull request resolves #4116.
