### PR TITLE
fix(mcp): don't serve a non-object tool schema as strict

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -535,7 +535,18 @@ class MCPUtil:
         schema, is_strict = copy.deepcopy(tool.inputSchema), False
 
         # MCP spec doesn't require the inputSchema to have `properties`, but OpenAI spec does.
-        if "properties" not in schema:
+        # Only inject it on schemas that are actually objects. `properties` is meaningless on a
+        # scalar or array schema, and injecting it there makes the schema incoherent: strict
+        # conversion treats any node carrying `properties` as an object and rewrites `required`,
+        # while `additionalProperties: false` is still skipped because the declared type is not
+        # `object`. That is exactly the mismatch #4114 described, and the tool would then be
+        # served with `strict: true` and rejected by the provider - without the non-strict
+        # fallback below firing, because nothing raised.
+        declared_type = schema.get("type")
+        is_object_schema = declared_type == "object" or (
+            isinstance(declared_type, list) and "object" in declared_type
+        )
+        if "properties" not in schema and (declared_type is None or is_object_schema):
             schema["properties"] = {}
 
         if convert_schemas_to_strict:
@@ -545,13 +556,34 @@ class MCPUtil:
             # non-strict. Convert a separate copy so the non-strict fallback keeps
             # the original schema intact.
             try:
-                schema = ensure_strict_json_schema(copy.deepcopy(schema))
-                is_strict = True
+                converted = ensure_strict_json_schema(copy.deepcopy(schema))
             except Exception as e:
                 if _debug.DONT_LOG_TOOL_DATA:
                     logger.info("Error converting MCP schema to strict mode")
                 else:
                     logger.info("Error converting MCP schema to strict mode: %s", e)
+            else:
+                # Conversion can succeed without producing a schema the provider will accept as
+                # strict: `ensure_strict_json_schema` closes object nodes, but a root that is not
+                # an object (a scalar or array `inputSchema`) is returned unchanged and has no
+                # `additionalProperties: false` to offer. Serving that with `strict: true` earns
+                # an opaque provider 400, so treat "converted but not a closed object root" the
+                # same as a conversion failure and use the documented non-strict fallback.
+                if converted.get("type") == "object" and (
+                    converted.get("additionalProperties") is False
+                ):
+                    schema = converted
+                    is_strict = True
+                elif _debug.DONT_LOG_TOOL_DATA:
+                    logger.info(
+                        "MCP tool schema is not a strict-capable object; serving it as non-strict"
+                    )
+                else:
+                    logger.info(
+                        "MCP tool %s has a non-object schema root (%r); serving it as non-strict",
+                        tool.name,
+                        converted.get("type"),
+                    )
 
         needs_approval: (
             bool | Callable[[RunContextWrapper[Any], dict[str, Any], str], Awaitable[bool]]

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1883,6 +1883,62 @@ def test_to_function_tool_nullable_root_falls_back_to_non_strict():
     assert function_tool.params_json_schema == {**schema, "properties": {}}
 
 
+@pytest.mark.parametrize(
+    ("shape", "schema"),
+    [
+        ("scalar", {"type": "string"}),
+        ("array", {"type": "array", "items": {"type": "string"}}),
+        ("integer", {"type": "integer"}),
+    ],
+)
+def test_to_function_tool_non_object_root_falls_back_to_non_strict(
+    shape: str, schema: dict[str, Any]
+):
+    """A non-object ``inputSchema`` root cannot be strict, so it must use the fallback.
+
+    Sibling of ``test_to_function_tool_nullable_root_falls_back_to_non_strict``. Strict mode
+    requires ``additionalProperties: false`` on the root, and only object nodes get it, so a
+    scalar or array root has nothing to offer. Two things previously went wrong here and
+    neither raised, so the documented non-strict fallback never fired:
+
+    * ``properties: {}`` was injected unconditionally, and strict conversion treats any node
+      carrying ``properties`` as an object -- so a *string* schema got the strict ``required``
+      rewrite while ``additionalProperties`` was still skipped. That is the exact mismatch
+      #4114 described, re-created by this function's own pre-processing.
+    * The tool was then served with ``strict: true``, which the provider rejects with an
+      opaque 400.
+    """
+    tool = MCPTool(name="test_tool", inputSchema=dict(schema))
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False, shape
+    # The original schema is served unchanged: no injected `properties`, and in particular no
+    # `required` rewrite applied to a non-object schema.
+    assert function_tool.params_json_schema == schema, shape
+    assert "required" not in function_tool.params_json_schema, shape
+
+
+def test_to_function_tool_object_root_without_properties_stays_strict():
+    """The injection must still happen for object roots, which is what it exists for.
+
+    Guards the narrowing above: MCP allows an object ``inputSchema`` with no ``properties``,
+    and the OpenAI schema requires the key, so that case must keep being filled in and must
+    still convert to a closed strict object.
+    """
+    tool = MCPTool(name="test_tool", inputSchema={"type": "object"})
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+        "required": [],
+    }
+
+
 class StructuredContentTestServer(FakeMCPServer):
     """Test server that allows setting both content and structured content for testing."""
 


### PR DESCRIPTION
### Summary

An MCP tool whose `inputSchema` root is not an object (a scalar or an array) is served to the provider with `strict: true`, which the provider rejects with an opaque 400. `to_function_tool` has a documented non-strict fallback for exactly this situation, but it is an `except` clause, so it only fires when something *raises* — and nothing here does.

Two things go wrong, and they compound:

1. **`properties: {}` is injected unconditionally.** Strict conversion treats any node carrying `properties` as an object and rewrites `required`, while `additionalProperties: false` is still skipped because the declared type is not `object`. So an `inputSchema` of `{"type": "string"}` becomes:

   ```json
   {"type": "string", "properties": {}, "required": []}
   ```

   That is precisely the `type`/`additionalProperties` incoherence #4114 described — re-created here by this function's own pre-processing, on a schema the server never wrote that way.

2. **`is_strict = True` is set on the sole basis that conversion did not raise.** Converting successfully is not the same as being valid for strict mode. #4139 made `ensure_strict_json_schema` reject `anyOf` roots and nullable object roots with a clear local `UserError`, but a plain non-object root is still returned unchanged — and it has no `additionalProperties: false` to offer, because only object nodes get one.

The fix keeps the injection where it is meaningful (object and typeless roots, which is what it exists for) and gates `is_strict` on the converted schema actually being a closed object root, using the existing non-strict fallback otherwise.

**Not a regression from #4139.** I A/B'd against a worktree at `7de6ccf0^` (immediately pre-#4139): all five of these root shapes passed straight through at that commit, so #4139 closed two of five and this is a sibling it left open, not something it broke.

**Scope question for maintainers.** This PR deliberately fixes only the MCP layer. Three root shapes still pass through the shared `ensure_strict_json_schema` helper and reach the provider with `strict: true` when they come from a hand-built `FunctionTool`:

| root | current behaviour |
|---|---|
| `{"anyOf": [...]}` | `UserError` (#4139) |
| `{"type": ["object", "null"]}` | `UserError` (#4139) |
| `{"type": "string"}` | passes through unchanged |
| `{"type": "array", "items": {...}}` | passes through unchanged |
| `{"description": "a tool"}` (typeless, no `properties`) | passes through unchanged |

I first tried rejecting non-object roots in `_ensure_strict_root` itself and backed it out: it breaks five tests, one of which — `test_explicit_non_object_with_properties_is_not_closed` — was added by #4139 in the same commit, so a `type: string` root round-tripping unchanged looks like a deliberate decision, and four others use `ensure_strict_json_schema` as a general-purpose *node* processor rather than a root validator. Tightening the shared helper is therefore your call, not something I wanted to do unilaterally. Happy to follow up with that change if you'd like it.

### Test plan

Two tests in `tests/mcp/test_mcp_util.py`, modelled on the existing sibling `test_to_function_tool_nullable_root_falls_back_to_non_strict`:

* `test_to_function_tool_non_object_root_falls_back_to_non_strict` — parametrized over scalar / array / integer roots; asserts `strict_json_schema is False`, that the schema is served unchanged, and specifically that no `required` rewrite was applied to a non-object schema.
* `test_to_function_tool_object_root_without_properties_stays_strict` — guards the narrowing: an object root with no `properties` must still get one injected and must still convert to a closed strict object.

A/B of the new tests: **3 failed / 2 passed** on `main` → **5 passed** with the fix.

Full verification (`make format` / `lint` / `typecheck` / `tests`), each result compared against `main`:

* `ruff format --check`: 847 files already formatted. `ruff check`: all checks passed.
* `mypy . --exclude site`: 13 errors in 10 files — **identical count on `main`**, none in the files this PR touches (verified by stashing). They are Windows-local (`signal.SIGQUIT`, `asyncio.eager_task_factory`) plus a `_TemporaryFileWrapper` issue in `sandbox/`.
* `pyright`: 1 error, in `src/agents/sandbox/util/tar_utils.py`, untouched here.
* `pytest -n auto --dist loadfile -m "not serial"`: 55 failed / 5532 passed. I diffed the failure list against `main` on the affected subtrees: **nothing this PR breaks**, and one test (`test_normal_interrupt_targets_response_and_interrupts_audio`) differs only by xdist sharding — it fails deterministically in isolation on `main` as well. The remainder are tracing-processor `KeyError`s and symlink-dependent `sandbox`/`tar_utils` tests that need Windows symlink privileges.
* `pytest -m serial`: 38 passed / 5 skipped.

Scoped `tests/mcp` + `tests/test_function_schema.py` + `tests/test_strict_schema.py`: 473 passed / 4 failed, byte-identical to `main` (the 4 are the `test_mcp_tracing.py` processor `KeyError`s).

I could not run `.agents/skills/code-change-verification/scripts/run.sh` directly — it needs `setsid` and a FIFO for parallel process-group management, which this Windows/Git Bash environment does not provide — so I ran the four `make` targets it invokes individually, as above.

### Issue number

Related to #4114 and #4139.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (ran the four `make` targets it wraps individually; see test plan)
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
