### PR TITLE
fix(memory): reject reused branch IDs when creating a branch

### DIFF
--- a/docs/sessions/advanced_sqlite_session.md
+++ b/docs/sessions/advanced_sqlite_session.md
@@ -161,6 +161,8 @@ branch_id = await session.create_branch_from_content(
 )
 ```
 
+Branch IDs must be unique. Passing a `branch_name` that an existing branch already uses raises `ValueError`; use [`switch_to_branch()`][agents.extensions.memory.advanced_sqlite_session.AdvancedSQLiteSession.switch_to_branch] to continue an existing branch instead. Omitting `branch_name` always produces an unused ID.
+
 ### Branch management
 
 ```python

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import sqlite3
+import time
 from contextlib import closing
 from pathlib import Path
 from typing import Any, cast
@@ -812,16 +813,16 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         Args:
             turn_number: The branch turn number of the user message to branch from
-            branch_name: Optional name for the branch (auto-generated if None)
+            branch_name: Optional name for the branch. Must not name an existing branch.
+                Auto-generated as a unique id if None.
 
         Returns:
             The branch_id of the newly created branch
 
         Raises:
-            ValueError: If turn doesn't exist or doesn't contain a user message
+            ValueError: If turn doesn't exist, doesn't contain a user message, or
+                `branch_name` names a branch that already exists
         """
-        import time
-
         # Capture the generation before any DB work so a clear that commits
         # while this branch is being created cannot be overwritten by the
         # pointer update below.
@@ -859,13 +860,11 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         turn_content = await asyncio.to_thread(_validate_turn)
 
-        # Generate branch name if not provided
-        if branch_name is None:
-            timestamp = int(time.time())
-            branch_name = f"branch_from_turn_{turn_number}_{timestamp}"
-
-        # Copy messages before the branch point to the new branch
-        await self._copy_messages_to_new_branch(branch_name, turn_number)
+        # Copy messages before the branch point to the new branch. The target branch id is
+        # resolved inside that call, under the same connection lock that performs the copy,
+        # so a generated id cannot collide with an existing branch and an explicit id cannot
+        # silently append the copied history to one.
+        branch_name = await self._copy_messages_to_new_branch(branch_name, turn_number)
 
         # Switch to new branch under the lock; skipped if a clear_session has
         # committed since `generation` was captured (its reset to 'main' wins),
@@ -1087,18 +1086,65 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         return await asyncio.to_thread(_list_branches_sync)
 
-    async def _copy_messages_to_new_branch(self, new_branch_id: str, from_turn_number: int) -> None:
+    def _branch_id_exists(self, cursor: sqlite3.Cursor, branch_id: str) -> bool:
+        """Report whether any message is already recorded under this branch id."""
+        cursor.execute(
+            """
+            SELECT 1 FROM message_structure
+            WHERE session_id = ? AND branch_id = ?
+            LIMIT 1
+            """,
+            (self.session_id, branch_id),
+        )
+        return cursor.fetchone() is not None
+
+    def _generate_branch_id(self, cursor: sqlite3.Cursor, from_turn_number: int) -> str:
+        """Build a branch id that no existing branch is using.
+
+        The base name only has one-second resolution, so branching twice from the same turn
+        within the same second would otherwise reuse an id.
+        """
+        base_branch_id = f"branch_from_turn_{from_turn_number}_{int(time.time())}"
+        branch_id = base_branch_id
+        suffix = 1
+        while self._branch_id_exists(cursor, branch_id):
+            suffix += 1
+            branch_id = f"{base_branch_id}_{suffix}"
+        return branch_id
+
+    async def _copy_messages_to_new_branch(
+        self, new_branch_id: str | None, from_turn_number: int
+    ) -> str:
         """Copy messages before the branch point to the new branch.
 
         Args:
-            new_branch_id: The ID of the new branch to copy messages to.
+            new_branch_id: The ID of the new branch to copy messages to, or None to
+                generate an unused one.
             from_turn_number: The turn number to copy messages up to (exclusive).
+
+        Returns:
+            The branch ID the messages were copied to.
+
+        Raises:
+            ValueError: If `new_branch_id` is already in use by another branch.
         """
 
-        def _copy_sync():
+        def _copy_sync() -> str:
             """Synchronous helper to copy messages to new branch."""
             with self._locked_connection() as conn:
                 with closing(conn.cursor()) as cursor:
+                    # Resolve the target branch id before any write so the existence check and
+                    # the inserts below cannot be separated by a concurrent branch creation.
+                    if new_branch_id is None:
+                        branch_id = self._generate_branch_id(cursor, from_turn_number)
+                    else:
+                        branch_id = new_branch_id
+                        if self._branch_id_exists(cursor, branch_id):
+                            raise ValueError(
+                                f"Branch '{branch_id}' already exists. Branch IDs must be "
+                                "unique; use switch_to_branch() to continue an existing branch."
+                            )
+
                     # Get all messages before the branch point
                     cursor.execute(
                         """
@@ -1146,7 +1192,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                                 (
                                     self.session_id,
                                     msg_id,  # Same message_id (sharing the actual message data)
-                                    new_branch_id,
+                                    branch_id,
                                     msg_type,
                                     seq_start + i + 1,  # New sequence number
                                     user_turn,  # Keep same global turn number
@@ -1166,8 +1212,9 @@ class AdvancedSQLiteSession(SQLiteSession):
                         )
 
                     conn.commit()
+                    return branch_id
 
-        await asyncio.to_thread(_copy_sync)
+        return await asyncio.to_thread(_copy_sync)
 
     async def get_conversation_turns(self, branch_id: str | None = None) -> list[dict[str, Any]]:
         """Get user turns with content for easy browsing and branching decisions.

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -6,6 +6,7 @@ import json
 import logging
 import tempfile
 import threading
+import time
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import Mock, patch
@@ -2587,5 +2588,161 @@ async def test_clear_session_rolls_back_on_failure_after_earlier_delete(usage_da
         assert _count_rows(session, "message_structure") == 0
         assert _count_rows(session, "turn_usage") == 0
         assert await session.get_items() == []
+    finally:
+        session.close()
+
+
+def _branch_test_items() -> list[TResponseInputItem]:
+    """Three user turns, each with an assistant reply, for branch-creation tests."""
+    return [
+        {"role": "user", "content": "Turn one question"},
+        {"role": "assistant", "content": "Turn one answer"},
+        {"role": "user", "content": "Turn two question"},
+        {"role": "assistant", "content": "Turn two answer"},
+        {"role": "user", "content": "Turn three question"},
+        {"role": "assistant", "content": "Turn three answer"},
+    ]
+
+
+async def test_create_branch_rejects_an_existing_branch_id():
+    """An explicit branch id that is already in use must not be written into."""
+    session = AdvancedSQLiteSession(
+        session_id="branch_existing_id",
+        create_tables=True,
+    )
+    items = _branch_test_items()
+
+    try:
+        await session.add_items(items)
+        await session.create_branch_from_turn(3, "existing_branch")
+        branch_items_before = await session.get_items()
+        await session.switch_to_branch("main")
+
+        with pytest.raises(ValueError, match="already exists"):
+            await session.create_branch_from_turn(2, "existing_branch")
+
+        # The rejected call must leave both branches and the current pointer untouched.
+        assert session._current_branch_id == "main"
+        assert await session.get_items(branch_id="main") == items
+        assert await session.get_items(branch_id="existing_branch") == branch_items_before
+    finally:
+        session.close()
+
+
+async def test_create_branch_rejects_the_main_branch_id():
+    """Branching into 'main' must not duplicate the base conversation into itself."""
+    session = AdvancedSQLiteSession(
+        session_id="branch_into_main",
+        create_tables=True,
+    )
+    items = _branch_test_items()
+
+    try:
+        await session.add_items(items)
+
+        with pytest.raises(ValueError, match="already exists"):
+            await session.create_branch_from_turn(2, "main")
+
+        assert await session.get_items(branch_id="main") == items
+        assert [branch["branch_id"] for branch in await session.list_branches()] == ["main"]
+    finally:
+        session.close()
+
+
+async def test_generated_branch_ids_stay_unique_within_the_same_second(monkeypatch):
+    """The generated default name must not collide when the clock has not ticked."""
+    monkeypatch.setattr(time, "time", lambda: 1_700_000_000.0)
+    session = AdvancedSQLiteSession(
+        session_id="branch_generated_collision",
+        create_tables=True,
+    )
+    items = _branch_test_items()
+
+    try:
+        await session.add_items(items)
+
+        first_branch = await session.create_branch_from_turn(3)
+        first_items = await session.get_items()
+        assert first_items == items[:4]
+
+        await session.switch_to_branch("main")
+        second_branch = await session.create_branch_from_turn(3)
+
+        assert second_branch != first_branch
+        assert session._current_branch_id == second_branch
+        # Each branch holds one copy of the pre-branch history, not a merged pair.
+        assert await session.get_items() == items[:4]
+        assert await session.get_items(branch_id=first_branch) == first_items
+        assert await session.get_items(branch_id="main") == items
+        assert sorted(branch["branch_id"] for branch in await session.list_branches()) == sorted(
+            ["main", first_branch, second_branch]
+        )
+    finally:
+        session.close()
+
+
+async def test_generated_branch_ids_stay_unique_across_many_calls(monkeypatch):
+    """Repeated same-second branching keeps generating fresh ids."""
+    monkeypatch.setattr(time, "time", lambda: 1_700_000_000.0)
+    session = AdvancedSQLiteSession(
+        session_id="branch_generated_repeated",
+        create_tables=True,
+    )
+    items = _branch_test_items()
+
+    try:
+        await session.add_items(items)
+
+        branch_ids: list[str] = []
+        for _ in range(3):
+            await session.switch_to_branch("main")
+            branch_ids.append(await session.create_branch_from_turn(3))
+
+        assert len(set(branch_ids)) == 3
+        for branch_id in branch_ids:
+            assert await session.get_items(branch_id=branch_id) == items[:4]
+        assert await session.get_items(branch_id="main") == items
+    finally:
+        session.close()
+
+
+async def test_create_branch_from_content_rejects_an_existing_branch_id():
+    """create_branch_from_content inherits the branch-id uniqueness contract."""
+    session = AdvancedSQLiteSession(
+        session_id="branch_from_content_existing",
+        create_tables=True,
+    )
+    items = _branch_test_items()
+
+    try:
+        await session.add_items(items)
+        await session.create_branch_from_turn(3, "content_branch")
+        await session.switch_to_branch("main")
+
+        with pytest.raises(ValueError, match="already exists"):
+            await session.create_branch_from_content("Turn two", "content_branch")
+
+        assert await session.get_items(branch_id="main") == items
+    finally:
+        session.close()
+
+
+async def test_create_branch_from_the_first_turn_still_succeeds():
+    """Branching from turn 1 copies nothing and must remain allowed."""
+    session = AdvancedSQLiteSession(
+        session_id="branch_first_turn",
+        create_tables=True,
+    )
+    items = _branch_test_items()
+
+    try:
+        await session.add_items(items)
+
+        branch_id = await session.create_branch_from_turn(1, "empty_branch")
+
+        assert branch_id == "empty_branch"
+        assert session._current_branch_id == "empty_branch"
+        assert await session.get_items() == []
+        assert await session.get_items(branch_id="main") == items
     finally:
         session.close()


### PR DESCRIPTION
### Summary

`AdvancedSQLiteSession.create_branch_from_turn()` never checked whether the target branch ID was already in use. `_copy_messages_to_new_branch()` inserted `message_structure` rows tagged with that ID unconditionally, so creating a branch whose ID already existed appended the copied history to that branch instead of creating a new one. The call still returned the ID and switched to it, so the caller got no signal.

Two ways to hit it:

1. **The generated default ID can collide.** With `branch_name` omitted the ID is `f"branch_from_turn_{turn_number}_{int(time.time())}"`. That is one-second resolution, so branching twice from the same turn within the same second — the documented `await session.create_branch_from_turn(2)` form — reuses the ID and silently duplicates the copied history. No user error is involved.
2. **An explicit existing name was accepted**, including `"main"`, which duplicated the base branch's own history into itself.

This resolves the target branch ID inside the locked connection that performs the copy: an explicit ID that is already in use raises `ValueError`, and a generated ID is disambiguated with a numeric suffix.

**Affected component:** `src/agents/extensions/memory/advanced_sqlite_session.py` (`AdvancedSQLiteSession` conversation branching). `create_branch_from_content()` inherits the fix since it delegates.

**Minimal reproduction (no API key, no model call, no network):**

```python
import asyncio
import time
from unittest.mock import patch

from agents.extensions.memory import AdvancedSQLiteSession

ITEMS = [
    {"role": "user", "content": "turn one"},
    {"role": "assistant", "content": "reply one"},
    {"role": "user", "content": "turn two"},
    {"role": "assistant", "content": "reply two"},
    {"role": "user", "content": "turn three"},
    {"role": "assistant", "content": "reply three"},
]


async def main() -> None:
    session = AdvancedSQLiteSession(session_id="collide", create_tables=True)
    await session.add_items(ITEMS)
    with patch.object(time, "time", lambda: 1_700_000_000.0):
        first = await session.create_branch_from_turn(3)
        await session.switch_to_branch("main")
        second = await session.create_branch_from_turn(3)
    print(first == second, len(await session.get_items()))
    session.close()


asyncio.run(main())
```

**Current behavior:** prints `True 8`. Both calls return `branch_from_turn_3_1700000000`, the branch holds the first two turns twice, and `list_branches()` reports one branch where the caller created two. Separately, `create_branch_from_turn(2, "main")` grows `main` from 6 items to 8.

**Corrected behavior:** prints `False 4`. The two calls produce distinct IDs and each branch holds exactly one copy of the pre-branch history. `create_branch_from_turn(2, "main")` now raises `ValueError` and leaves `main` untouched.

### Root cause

`_copy_messages_to_new_branch()` selected the rows to copy and inserted them under `new_branch_id` with no existence check on that ID, and `create_branch_from_turn()` derived its default ID from a one-second timestamp without consulting existing branches.

### Implementation

- `_branch_id_exists()` — a small helper that asks whether any `message_structure` row already uses a branch ID, matching how `switch_to_branch()`, `delete_branch()`, and `list_branches()` already define branch existence.
- `_generate_branch_id()` — appends a numeric suffix to the timestamp-based base name until it is unused.
- `_copy_messages_to_new_branch()` now takes `str | None` and returns the resolved branch ID. Both the existence check and the ID generation run against the cursor that performs the inserts, inside the same `_locked_connection()`, so the check cannot be separated from the write by a concurrent branch creation. Doing this in a separate `asyncio.to_thread()` step would release the lock in between.
- `create_branch_from_turn()` drops its local ID generation and uses the returned ID for the branch pointer, the debug log, and its return value.

**Why this is minimal:** no public API signature changes, no schema change, and the copy semantics (which rows are copied, sequence numbering, shared message rows) are untouched. The rejection uses `ValueError`, which the method already documented for invalid branch requests and which `delete_branch()` and `switch_to_branch()` already raise for branch-state errors. The `ValueError` is raised before any DML, so a rejected call performs no write and leaves the current-branch pointer alone.

### Test plan

Six regression tests in `tests/extensions/memory/test_advanced_sqlite_session.py`. All five that assert the corrected behavior fail on `upstream/main` at c546ca1 and pass with the fix; the sixth is a boundary guard that passes both before and after.

| Test | Covers |
| --- | --- |
| `test_create_branch_rejects_an_existing_branch_id` | Explicit reused ID raises, both branches and the current pointer are unchanged |
| `test_create_branch_rejects_the_main_branch_id` | Branching into `main` raises instead of duplicating it into itself |
| `test_generated_branch_ids_stay_unique_within_the_same_second` | Frozen clock, two branches from the same turn get distinct IDs and one copy of history each |
| `test_generated_branch_ids_stay_unique_across_many_calls` | Frozen clock, three consecutive generated IDs stay distinct and correct |
| `test_create_branch_from_content_rejects_an_existing_branch_id` | `create_branch_from_content()` inherits the contract |
| `test_create_branch_from_the_first_turn_still_succeeds` | Branching from turn 1 copies nothing and remains allowed (passes before and after) |

The clock is frozen with `monkeypatch.setattr(time, "time", ...)`, so the collision is deterministic rather than timing-dependent. No API key, model call, network access, or sleep is involved; the sessions are in-memory SQLite.

Before the fix:

```
$ uv run pytest tests/extensions/memory/test_advanced_sqlite_session.py -q -k "branch_rejects or generated_branch or from_content_rejects or first_turn_still"
5 failed, 1 passed, 67 deselected in 0.41s
```

After the fix:

```
$ uv run pytest tests/extensions/memory/test_advanced_sqlite_session.py -q
73 passed in 0.32s

$ uv run pytest tests/extensions/memory/ -q
288 passed, 4 skipped in 8.59s
```

The focused module was run 5x with `-p no:randomly` and the memory suite 3x under the default random ordering; results were identical each time.

Full verification stack via `.agents/skills/code-change-verification/scripts/run.sh` — all commands passed:

```
make format     -> 847 files left unchanged; ruff check --fix: All checks passed!
make lint       -> passed in 0s
make tests      -> passed in 87s
make typecheck  -> passed in 1557s
code-change-verification: all commands passed.
```

The docs line was added after that run, so `uv run ruff format --check .` (847 files already formatted), `uv run ruff check .` (All checks passed), `uv run pytest tests/test_doc_parsing.py tests/extensions/memory/test_advanced_sqlite_session.py -q` (77 passed), and `make build-docs` (built successfully, no new warnings) were re-run afterwards. `git diff --check` is clean.

### Compatibility

Callers that previously reused a branch ID now get a `ValueError` instead of a silently corrupted branch. That path never produced a usable new branch, so no working behavior is lost. Generated IDs keep their existing `branch_from_turn_{turn}_{timestamp}` shape and only gain a `_2`, `_3`, ... suffix when that exact ID is already taken. The stored schema, the copy semantics, and every public signature are unchanged.

### Non-goals

- No change to which rows are copied or to the exclusive-turn semantics of `from_turn_number`.
- No validation of empty or whitespace branch names — unrelated to the demonstrated defect.
- No change to `switch_to_branch()`, `delete_branch()`, or `clear_session()`.

### Limitations

- The `ValueError` covers a branch that already holds messages. Branching from turn 1 copies no rows, so such a branch leaves no `message_structure` row and is not "existing" by the definition the rest of the class already uses; that behavior is unchanged and is covered by `test_create_branch_from_the_first_turn_still_succeeds`.
- The check is atomic per connection lock, which is the same scope every other write in this class relies on. Cross-process access to the same SQLite file is outside that scope, as it already was.
- Only `docs/sessions/advanced_sqlite_session.md` was updated; the generated `docs/ja`, `docs/ko`, and `docs/zh` pages were intentionally left alone.

### Issue number

Closes #4150

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
