### PR TITLE
fix(run): honor falsey handoff input filters

### DIFF
--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -562,8 +562,10 @@ async def execute_handoffs(
             ),
         )
 
-        input_filter = handoff.input_filter or (
-            run_config.handoff_input_filter if run_config else None
+        input_filter = (
+            handoff.input_filter
+            if handoff.input_filter is not None
+            else run_config.handoff_input_filter
         )
         handoff_nest_setting = handoff.nest_handoff_history
         should_nest_history = (
@@ -583,7 +585,7 @@ async def execute_handoffs(
         handoff_input_data: HandoffInputData | None = None
         session_step_items: list[RunItem] | None = None
         nested_history_owned_items: list[NestedHistoryOwnedItem] | None = None
-        if input_filter or should_nest_history:
+        if input_filter is not None or should_nest_history:
             handoff_input_data = HandoffInputData(
                 input_history=tuple(original_input)
                 if isinstance(original_input, list)
@@ -593,7 +595,7 @@ async def execute_handoffs(
                 run_context=context_wrapper,
             )
 
-        if input_filter and handoff_input_data is not None:
+        if input_filter is not None and handoff_input_data is not None:
             filter_name = getattr(input_filter, "__qualname__", repr(input_filter))
             from_agent = getattr(public_agent, "name", public_agent.__class__.__name__)
             to_agent = getattr(new_agent, "name", new_agent.__class__.__name__)

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1833,6 +1833,52 @@ async def test_opt_in_handoff_history_nested_and_filters_respected():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True], ids=["non_streamed", "streamed"])
+async def test_falsey_per_handoff_input_filter_takes_precedence(streamed: bool) -> None:
+    triage_model = FakeModel()
+    delegate_model = FakeModel()
+    delegate = Agent(name="delegate", model=delegate_model)
+
+    class FalseyInputFilter:
+        def __init__(self) -> None:
+            self.call_count = 0
+
+        def __bool__(self) -> bool:
+            return False
+
+        def __call__(self, data: HandoffInputData) -> HandoffInputData:
+            self.call_count += 1
+            return data
+
+    per_handoff_filter = FalseyInputFilter()
+
+    def global_filter(_data: HandoffInputData) -> HandoffInputData:
+        raise AssertionError("The run-level filter must not replace the per-handoff filter")
+
+    triage = Agent(
+        name="triage",
+        model=triage_model,
+        handoffs=[handoff(delegate, input_filter=per_handoff_filter)],
+    )
+    triage_model.add_multiple_turn_outputs([[get_handoff_tool_call(delegate)]])
+    delegate_model.add_multiple_turn_outputs([[get_text_message("done")]])
+
+    result = await _run_agent_with_optional_streaming(
+        triage,
+        input="user_message",
+        streamed=streamed,
+        run_config=RunConfig(
+            handoff_input_filter=global_filter,
+            nest_handoff_history=True,
+        ),
+    )
+
+    assert result.final_output == "done"
+    assert result.input == "user_message"
+    assert per_handoff_filter.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_opt_in_handoff_history_accumulates_across_multiple_handoffs():
     triage_model = FakeModel()
     delegate_model = FakeModel()


### PR DESCRIPTION
### Summary

This pull request fixes handoff input-filter selection for callable objects that evaluate to false. An explicit `Handoff.input_filter` now remains selected by presence, takes precedence over `RunConfig.handoff_input_filter`, and continues to suppress nested-history mapping in both streamed and non-streamed runs.

The change uses `None` as the existing omission sentinel throughout the handoff-resolution path. Ordinary functions, async filters, public signatures, and invalid-filter error behavior are unchanged.

### Test plan

- Public Runner reproduction: `v0.19.2` and unmodified `main` selected the run-level filter instead of the explicit falsey per-handoff filter; this branch invokes the per-handoff filter once and completes successfully.
- `pytest -q tests/test_agent_runner.py` — 184 passed.
- `.agents/skills/code-change-verification/scripts/run.sh` — format, lint, typecheck, and full tests passed.
- Mypy — no issues in 835 source files; Pyright — 0 errors, 0 warnings, 0 informations.
- Full tests — 6,241 parallel tests passed with 4 skipped; 38 serial tests passed with 5 skipped.

### Issue number

N/A — searches across open and closed issues and pull requests found no duplicate, and the repository does not require an issue for a focused fix.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
