### PR TITLE
fix(models): pair Anthropic thinking signatures with their own block

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -149,7 +149,12 @@ class Converter:
 
             # Store thinking blocks for Anthropic compatibility
             if hasattr(message, "thinking_blocks") and message.thinking_blocks:
-                # Store thinking text in content and signature in encrypted_content
+                # Store thinking text in content and signature in encrypted_content.
+                # The two lists are replayed positionally, so a signature is recorded for
+                # every content entry -- an empty string when the block has none. Appending
+                # only the signatures that exist would shift each later signature onto the
+                # preceding thinking block, and Anthropic verifies a signature against the
+                # thinking text it was issued for.
                 reasoning_item.content = []
                 signatures: list[str] = []
                 for block in message.thinking_blocks:
@@ -159,12 +164,11 @@ class Converter:
                             reasoning_item.content.append(
                                 Content(text=thinking_text, type="reasoning_text")
                             )
-                        # Store the signature if present
-                        if signature := block.get("signature"):
-                            signatures.append(signature)
+                            # Store the signature if present, keeping the slot either way.
+                            signatures.append(block.get("signature") or "")
 
-                # Store the signatures in encrypted_content with newline delimiter
-                if signatures:
+                # Store the signatures in encrypted_content with newline delimiter.
+                if any(signatures):
                     reasoning_item.encrypted_content = "\n".join(signatures)
 
             items.append(reasoning_item)
@@ -820,8 +824,12 @@ class Converter:
                 ):
                     signatures = encrypted_content.split("\n") if encrypted_content else []
 
-                    # Reconstruct thinking blocks from content and signature
+                    # Reconstruct thinking blocks from content and signature. Signatures are
+                    # matched to reasoning text by position, so a missing trailing entry or an
+                    # empty placeholder leaves that block unsigned instead of consuming the
+                    # signature that belongs to a later block.
                     reconstructed_thinking_blocks = []
+                    reasoning_text_index = 0
                     for content_item in content_items:
                         if (
                             isinstance(content_item, dict)
@@ -831,9 +839,15 @@ class Converter:
                                 "type": "thinking",
                                 "thinking": content_item.get("text", ""),
                             }
+                            signature = (
+                                signatures[reasoning_text_index]
+                                if reasoning_text_index < len(signatures)
+                                else ""
+                            )
+                            reasoning_text_index += 1
                             # Add signatures if available
-                            if signatures:
-                                thinking_block["signature"] = signatures.pop(0)
+                            if signature:
+                                thinking_block["signature"] = signature
                             reconstructed_thinking_blocks.append(thinking_block)
 
                     # Store thinking blocks as pending for the next assistant message

--- a/tests/models/test_anthropic_thinking_blocks.py
+++ b/tests/models/test_anthropic_thinking_blocks.py
@@ -464,3 +464,172 @@ def test_thinking_blocks_do_not_leak_across_an_intervening_user_turn():
     assistant_messages = [msg for msg in messages if msg.get("role") == "assistant"]
     assert len(assistant_messages) == 1
     assert assistant_messages[0].get("content") == "an answer"
+
+
+def _replayed_thinking_blocks(
+    thinking_blocks: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Round-trip thinking blocks through the converter and return what Claude would receive."""
+    message = InternalChatCompletionMessage(
+        role="assistant",
+        content="visible answer",
+        reasoning_content="reasoning",
+        thinking_blocks=thinking_blocks,
+    )
+    output_items = Converter.message_to_output_items(message)
+    items_as_dicts: list[dict[str, Any]] = [item.model_dump() for item in output_items]
+    messages = Converter.items_to_messages(
+        items_as_dicts,  # type: ignore[arg-type]
+        model="anthropic/claude-4-opus",
+        preserve_thinking_blocks=True,
+    )
+
+    assistant_messages = [msg for msg in messages if msg.get("role") == "assistant"]
+    assert len(assistant_messages) == 1
+    content = assistant_messages[0].get("content")
+    assert isinstance(content, list)
+    blocks = cast(list[dict[str, Any]], content)
+    return [block for block in blocks if block.get("type") == "thinking"]
+
+
+def test_unsigned_thinking_block_does_not_steal_a_later_signature():
+    """An unsigned block must not consume the next block's signature.
+
+    LiteLLM types the Anthropic thinking signature as optional, so a block can carry
+    thinking text without one. Thinking text and signatures are replayed as two parallel
+    lists, so recording only the signatures that exist shifts every later signature onto
+    the preceding block. Anthropic verifies a signature against the thinking text it was
+    issued for, so a shifted signature is rejected.
+    """
+    replayed = _replayed_thinking_blocks(
+        [
+            {"type": "thinking", "thinking": "unsigned step"},
+            {"type": "thinking", "thinking": "signed step", "signature": "SecondSignature"},
+        ]
+    )
+
+    assert [block.get("thinking") for block in replayed] == ["unsigned step", "signed step"]
+    assert "signature" not in replayed[0], (
+        "An unsigned thinking block must stay unsigned rather than take the next block's signature"
+    )
+    assert replayed[1].get("signature") == "SecondSignature", (
+        "A signature must be replayed on the thinking block it was issued for"
+    )
+
+
+def test_trailing_unsigned_thinking_block_keeps_earlier_signature_in_place():
+    """A trailing unsigned block must not disturb the signature that precedes it."""
+    replayed = _replayed_thinking_blocks(
+        [
+            {"type": "thinking", "thinking": "signed step", "signature": "FirstSignature"},
+            {"type": "thinking", "thinking": "unsigned step"},
+        ]
+    )
+
+    assert [block.get("thinking") for block in replayed] == ["signed step", "unsigned step"]
+    assert replayed[0].get("signature") == "FirstSignature"
+    assert "signature" not in replayed[1]
+
+
+def test_signature_without_thinking_text_does_not_shift_later_signatures():
+    """A block with a signature but no text contributes no content, so it takes no slot.
+
+    Its signature cannot be replayed -- Anthropic verifies a signature against the
+    thinking text it was issued for, and there is no text here -- so it must be dropped
+    rather than attached to the next block.
+    """
+    replayed = _replayed_thinking_blocks(
+        [
+            {"type": "thinking", "thinking": "", "signature": "OrphanSignature"},
+            {"type": "thinking", "thinking": "real step", "signature": "RealSignature"},
+        ]
+    )
+
+    assert [block.get("thinking") for block in replayed] == ["real step"]
+    assert replayed[0].get("signature") == "RealSignature"
+
+
+def test_redacted_thinking_block_does_not_shift_signatures():
+    """LiteLLM puts redacted_thinking blocks in the same list; they carry neither field."""
+    replayed = _replayed_thinking_blocks(
+        [
+            {"type": "redacted_thinking", "data": "encrypted-blob"},
+            {"type": "thinking", "thinking": "real step", "signature": "RealSignature"},
+        ]
+    )
+
+    assert [block.get("thinking") for block in replayed] == ["real step"]
+    assert replayed[0].get("signature") == "RealSignature"
+
+
+def test_fully_unsigned_thinking_blocks_leave_encrypted_content_unset():
+    """Placeholder slots must not fabricate an encrypted_content value."""
+    message = InternalChatCompletionMessage(
+        role="assistant",
+        content="visible answer",
+        reasoning_content="reasoning",
+        thinking_blocks=[
+            {"type": "thinking", "thinking": "first step"},
+            {"type": "thinking", "thinking": "second step"},
+        ],
+    )
+
+    reasoning_items = [
+        item for item in Converter.message_to_output_items(message) if item.type == "reasoning"
+    ]
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0].encrypted_content is None
+
+    replayed = _replayed_thinking_blocks(
+        [
+            {"type": "thinking", "thinking": "first step"},
+            {"type": "thinking", "thinking": "second step"},
+        ]
+    )
+    assert [block.get("thinking") for block in replayed] == ["first step", "second step"]
+    assert all("signature" not in block for block in replayed)
+
+
+def test_legacy_encrypted_content_still_pairs_signatures_by_position():
+    """History written before placeholder slots existed must keep replaying correctly.
+
+    A stored item whose signature count matches its reasoning_text count is the shape the
+    previous implementation always wrote for fully signed responses, so it must pair the
+    same way after the change.
+    """
+    stored_history: list[dict[str, Any]] = [
+        {
+            "id": "reasoning_legacy",
+            "type": "reasoning",
+            "summary": [],
+            "content": [
+                {"type": "reasoning_text", "text": "first step"},
+                {"type": "reasoning_text", "text": "second step"},
+            ],
+            "encrypted_content": "LegacySignature1\nLegacySignature2",
+        },
+        {
+            "id": "msg_legacy",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "an answer", "annotations": []}],
+        },
+    ]
+
+    messages = Converter.items_to_messages(
+        stored_history,  # type: ignore[arg-type]
+        model="anthropic/claude-4-opus",
+        preserve_thinking_blocks=True,
+    )
+
+    assistant_messages = [msg for msg in messages if msg.get("role") == "assistant"]
+    assert len(assistant_messages) == 1
+    content = assistant_messages[0].get("content")
+    assert isinstance(content, list)
+    thinking = [block for block in content if block.get("type") == "thinking"]
+
+    assert thinking == [
+        {"type": "thinking", "thinking": "first step", "signature": "LegacySignature1"},
+        {"type": "thinking", "thinking": "second step", "signature": "LegacySignature2"},
+    ]


### PR DESCRIPTION
### Summary

Anthropic thinking blocks are stored on the reasoning item as two parallel lists — the thinking text in `content`, the signatures newline-joined in `encrypted_content` — and `items_to_messages()` zips them back together by position when replaying the conversation to Claude.

`message_to_output_items()` built those lists with two independent filters: `content` was appended only for blocks with thinking text, and `signatures` only for blocks that had a signature. The positional correspondence therefore held only when *every* block had both. A block with text but no signature (LiteLLM types it as `Optional[str]`), or a signature but no text, desynced the lists — `signatures.pop(0)` then reattached every later signature to the preceding thinking block and left the last one unsigned.

Anthropic verifies a signature against the exact thinking text it was issued for, so the next request carries a block signed for different text.

```
before:  'step one' -> signature='SIG-2'      # SIG-2 was issued for 'step two'
         'step two' -> signature=None

after:   'step one' -> signature=None
         'step two' -> signature='SIG-2'
```

The fix records a signature slot for every content entry, using an empty string when the block has none, and pairs by index instead of `pop(0)` when reconstructing. A block with a signature but no thinking text now takes no slot, since there is no text to replay it against.

Scope notes:

- **No public API or schema change.** Fully signed responses — the common case, and what every existing test covers — serialize byte-identically to today.
- **Backward compatible.** History written by earlier versions, where the signature count already matches the `reasoning_text` count, pairs exactly as before; a regression test pins this.
- The streaming path in `chatcmpl_stream_handler.py` needed no change: it accumulates one concatenated thinking string and one signature, so its pairing was already aligned. This change makes the non-streaming path agree with it.

### Test plan

Six regression tests added to `tests/models/test_anthropic_thinking_blocks.py`, covering unsigned-then-signed, signed-then-unsigned, signature-without-text, a `redacted_thinking` block interleaved with a signed one, a fully unsigned response, and legacy `encrypted_content` pairing.

Two of them fail on `main` and pass with the fix; the other four are guards that hold both before and after:

```
FAILED tests/models/test_anthropic_thinking_blocks.py::test_unsigned_thinking_block_does_not_steal_a_later_signature
FAILED tests/models/test_anthropic_thinking_blocks.py::test_signature_without_thinking_text_does_not_shift_later_signatures
2 failed, 10 passed
```

Verification run from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean, 847 files unchanged |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/models/` | 632 passed |
| `uv run pytest tests/models/test_anthropic_thinking_blocks.py` | 12 passed |
| `make tests` | 5543 passed |

The full-suite run was done on Windows, where a set of sandbox symlink tests and the `TestSendEventAndConfig` realtime class fail and flake independently of this change. I diffed the failing set against a clean `main` checkout in the same environment: for the affected test families the two sets are identical, and the only whole-suite difference is one realtime interrupt test that alternates between 3, 1 and 3 failures across identical consecutive runs on `main` alone. Nothing in the diff touches realtime, tracing, or sandbox code.

### Issue number

Closes #4154

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`; I ran the underlying `make format`, `make lint`, `make mypy`, `make pyright` and `make tests` steps individually instead, with the results above.

---

@seratch one design question if you have a moment. I kept the empty-string placeholder so `encrypted_content` stays a plain newline-joined string and old history keeps parsing, which means a partially signed response now serializes as e.g. `"\nSIG-2"`. The alternative is to keep the signature list dense and store the pairing explicitly (an index map, or a JSON payload) with a version marker. That is cleaner to read but changes the stored shape, so I went with the narrower option. Happy to switch if you would rather fix the format properly while this path is still Chat Completions-only.
