### PR TITLE
fix(models): let an in-flight provider stream close finish after cancellation

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -418,7 +418,7 @@ class LitellmModel(Model):
             finally:
                 if not close_stream_in_background:
                     try:
-                        await self._maybe_aclose(stream)
+                        await self._close_stream_allowing_background_completion(stream)
                     except Exception as exc:
                         if yielded_terminal_event:
                             log_model_action_debug(
@@ -870,11 +870,31 @@ class LitellmModel(Model):
                 await result
 
     def _schedule_async_iterator_close(self, iterator: Any) -> None:
-        task = asyncio.create_task(self._maybe_aclose(iterator))
-        task.add_done_callback(self._consume_background_cleanup_task_result)
+        self._detach_stream_close(asyncio.ensure_future(self._maybe_aclose(iterator)))
+
+    async def _close_stream_allowing_background_completion(self, iterator: Any) -> None:
+        """Close the provider stream, letting an in-flight close finish in the background.
+
+        Cancellation can arrive while `aclose()` is already awaiting the provider. Shielding the
+        close and detaching that exact task keeps it running instead of abandoning it half-done,
+        and avoids starting a second close: re-closing a provider stream is not guaranteed to be
+        safe or idempotent.
+        """
+        close_task = asyncio.ensure_future(self._maybe_aclose(iterator))
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            self._detach_stream_close(close_task)
+            raise
+
+    def _detach_stream_close(self, close_task: asyncio.Future[None]) -> None:
+        if close_task.done():
+            self._consume_background_cleanup_task_result(close_task)
+            return
+        close_task.add_done_callback(self._consume_background_cleanup_task_result)
 
     @staticmethod
-    def _consume_background_cleanup_task_result(task: asyncio.Task[Any]) -> None:
+    def _consume_background_cleanup_task_result(task: asyncio.Future[Any]) -> None:
         try:
             task.result()
         except asyncio.CancelledError:

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -139,11 +139,33 @@ class OpenAIChatCompletionsModel(Model):
                 await close_result
 
     def _schedule_async_iterator_close(self, iterator: Any) -> None:
-        task = asyncio.create_task(self._maybe_aclose_async_iterator(iterator))
-        task.add_done_callback(self._consume_background_cleanup_task_result)
+        self._detach_stream_close(
+            asyncio.ensure_future(self._maybe_aclose_async_iterator(iterator))
+        )
+
+    async def _close_stream_allowing_background_completion(self, iterator: Any) -> None:
+        """Close the provider stream, letting an in-flight close finish in the background.
+
+        Cancellation can arrive while `aclose()` is already awaiting the provider. Shielding the
+        close and detaching that exact task keeps it running instead of abandoning it half-done,
+        and avoids starting a second close: re-closing a provider stream is not guaranteed to be
+        safe or idempotent.
+        """
+        close_task = asyncio.ensure_future(self._maybe_aclose_async_iterator(iterator))
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            self._detach_stream_close(close_task)
+            raise
+
+    def _detach_stream_close(self, close_task: asyncio.Future[None]) -> None:
+        if close_task.done():
+            self._consume_background_cleanup_task_result(close_task)
+            return
+        close_task.add_done_callback(self._consume_background_cleanup_task_result)
 
     @staticmethod
-    def _consume_background_cleanup_task_result(task: asyncio.Task[Any]) -> None:
+    def _consume_background_cleanup_task_result(task: asyncio.Future[Any]) -> None:
         try:
             task.result()
         except asyncio.CancelledError:
@@ -386,7 +408,7 @@ class OpenAIChatCompletionsModel(Model):
             finally:
                 if not close_stream_in_background:
                     try:
-                        await self._maybe_aclose_async_iterator(stream)
+                        await self._close_stream_allowing_background_completion(stream)
                     except Exception as exc:
                         if yielded_terminal_event:
                             log_model_action_debug(

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -444,11 +444,33 @@ class OpenAIResponsesModel(Model):
                 await close_result
 
     def _schedule_async_iterator_close(self, iterator: Any) -> None:
-        task = asyncio.create_task(self._maybe_aclose_async_iterator(iterator))
-        task.add_done_callback(self._consume_background_cleanup_task_result)
+        self._detach_stream_close(
+            asyncio.ensure_future(self._maybe_aclose_async_iterator(iterator))
+        )
+
+    async def _close_stream_allowing_background_completion(self, iterator: Any) -> None:
+        """Close the provider stream, letting an in-flight close finish in the background.
+
+        Cancellation can arrive while `aclose()` is already awaiting the provider. Shielding the
+        close and detaching that exact task keeps it running instead of abandoning it half-done,
+        and avoids starting a second close: re-closing a provider stream is not guaranteed to be
+        safe or idempotent.
+        """
+        close_task = asyncio.ensure_future(self._maybe_aclose_async_iterator(iterator))
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            self._detach_stream_close(close_task)
+            raise
+
+    def _detach_stream_close(self, close_task: asyncio.Future[None]) -> None:
+        if close_task.done():
+            self._consume_background_cleanup_task_result(close_task)
+            return
+        close_task.add_done_callback(self._consume_background_cleanup_task_result)
 
     @staticmethod
-    def _consume_background_cleanup_task_result(task: asyncio.Task[Any]) -> None:
+    def _consume_background_cleanup_task_result(task: asyncio.Future[Any]) -> None:
         try:
             task.result()
         except asyncio.CancelledError:
@@ -601,7 +623,7 @@ class OpenAIResponsesModel(Model):
                 finally:
                     if not close_stream_in_background:
                         try:
-                            await self._maybe_aclose_async_iterator(stream)
+                            await self._close_stream_allowing_background_completion(stream)
                         except Exception as exc:
                             if yielded_terminal_event:
                                 log_model_action_debug(

--- a/tests/models/test_litellm_chatcompletions_stream.py
+++ b/tests/models/test_litellm_chatcompletions_stream.py
@@ -764,6 +764,31 @@ class _SlowCloseChatStream(_ClosableChatStream):
         self.aclose_completed += 1
 
 
+class _CloseSignalingChatStream(_ClosableChatStream):
+    """Exhausts normally, then signals from `aclose` and blocks until released.
+
+    Unlike `_SlowCloseChatStream` this does not block in `__anext__`, so the consumer reaches
+    the cleanup `finally` on its own and a test can cancel while that close is in flight.
+    """
+
+    def __init__(
+        self,
+        chunks: list[ChatCompletionChunk],
+        close_started: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        super().__init__(chunks)
+        self._close_started = close_started
+        self._release = release
+        self.aclose_completed = 0
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+        self._close_started.set()
+        await self._release.wait()
+        self.aclose_completed += 1
+
+
 class _FailingCloseChatStream(_ClosableChatStream):
     """Raises from `aclose` after recording the cleanup attempt."""
 
@@ -958,6 +983,53 @@ async def test_stream_response_does_not_block_cancellation_on_slow_close(monkeyp
             if provider_stream.aclose_completed == 1:
                 break
             await asyncio.sleep(0.01)
+        assert provider_stream.aclose_completed == 1
+    finally:
+        release.set()
+        task.cancel()
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_lets_in_flight_close_finish_after_cancellation(
+    monkeypatch,
+) -> None:
+    """Cancelling during the cleanup `aclose` continues that close instead of abandoning it."""
+    close_started = asyncio.Event()
+    release = asyncio.Event()
+    provider_stream = _CloseSignalingChatStream([_text_chunk("He")], close_started, release)
+    _patch_fetch_response(monkeypatch, provider_stream)
+    model = LitellmProvider().get_model("gpt-4")
+
+    stream_agen = cast(Any, _stream_response(model))
+
+    async def consume() -> None:
+        async for _event in stream_agen:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        # The stream exhausts on its own, so the consumer reaches the cleanup `finally`
+        # and suspends inside the provider close.
+        await asyncio.wait_for(close_started.wait(), timeout=5)
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 0
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+
+        # The cancelled consumer must not have started a second close.
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 0
+
+        release.set()
+        for _ in range(200):
+            if provider_stream.aclose_completed == 1:
+                break
+            await asyncio.sleep(0.01)
+
+        assert provider_stream.aclose_calls == 1
         assert provider_stream.aclose_completed == 1
     finally:
         release.set()

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections.abc import AsyncIterator
 from typing import Any, cast
@@ -351,6 +352,104 @@ async def test_stream_response_close_closes_provider_stream_with_async_close(
     await stream_agen.aclose()
 
     assert provider_stream.close_calls == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_lets_in_flight_close_finish_after_cancellation(
+    monkeypatch,
+) -> None:
+    """Cancelling during the cleanup `aclose` continues that close instead of abandoning it."""
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="Hi"))],
+    )
+
+    class CloseSignalingChatStream:
+        """Exhausts normally, then signals from `aclose` and blocks until released."""
+
+        def __init__(self, close_started: asyncio.Event, release: asyncio.Event) -> None:
+            self._yielded = False
+            self._close_started = close_started
+            self._release = release
+            self.aclose_calls = 0
+            self.aclose_completed = 0
+
+        def __aiter__(self) -> "CloseSignalingChatStream":
+            return self
+
+        async def __anext__(self) -> ChatCompletionChunk:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return chunk
+
+        async def aclose(self) -> None:
+            self.aclose_calls += 1
+            self._close_started.set()
+            await self._release.wait()
+            self.aclose_completed += 1
+
+    close_started = asyncio.Event()
+    release = asyncio.Event()
+    provider_stream = CloseSignalingChatStream(close_started, release)
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return _empty_response(), provider_stream
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    stream_agen = cast(
+        Any,
+        model.stream_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        ),
+    )
+
+    async def consume() -> None:
+        async for _event in stream_agen:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        # The stream exhausts on its own, so the consumer reaches the cleanup `finally`
+        # and suspends inside the provider close.
+        await asyncio.wait_for(close_started.wait(), timeout=5)
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 0
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+
+        # The cancelled consumer must not have started a second close.
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 0
+
+        release.set()
+        for _ in range(200):
+            if provider_stream.aclose_completed == 1:
+                break
+            await asyncio.sleep(0.01)
+
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 1
+    finally:
+        release.set()
+        task.cancel()
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4185,3 +4185,97 @@ def test_websocket_pre_event_disconnect_retry_respects_websocket_retry_disable()
 
     with websocket_pre_event_retries_disabled(True):
         assert _should_retry_pre_event_websocket_disconnect() is False
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_lets_in_flight_close_finish_after_cancellation() -> None:
+    """Cancelling during the cleanup `aclose` continues that close instead of abandoning it."""
+
+    class CloseSignalingStream:
+        """Exhausts normally, then signals from `aclose` and blocks until released."""
+
+        def __init__(self, close_started: asyncio.Event, release: asyncio.Event) -> None:
+            self._yielded = False
+            self._close_started = close_started
+            self._release = release
+            self.aclose_calls = 0
+            self.aclose_completed = 0
+
+        def __aiter__(self) -> CloseSignalingStream:
+            return self
+
+        async def __anext__(self):
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return ResponseCompletedEvent(
+                type="response.completed",
+                response=get_response_obj([]),
+                sequence_number=0,
+            )
+
+        async def aclose(self) -> None:
+            self.aclose_calls += 1
+            self._close_started.set()
+            await self._release.wait()
+            self.aclose_completed += 1
+
+    close_started = asyncio.Event()
+    release = asyncio.Event()
+    provider_stream = CloseSignalingStream(close_started, release)
+
+    class DummyResponses:
+        async def create(self, **kwargs):
+            return provider_stream
+
+    class DummyResponsesClient:
+        def __init__(self):
+            self.responses = DummyResponses()
+
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=DummyResponsesClient())  # type: ignore[arg-type]
+
+    stream_agen = cast(
+        Any,
+        model.stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+        ),
+    )
+
+    async def consume() -> None:
+        async for _event in stream_agen:
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        # The stream exhausts on its own, so the consumer reaches the cleanup `finally`
+        # and suspends inside the provider close.
+        await asyncio.wait_for(close_started.wait(), timeout=5)
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 0
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+
+        # The cancelled consumer must not have started a second close.
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 0
+
+        release.set()
+        for _ in range(200):
+            if provider_stream.aclose_completed == 1:
+                break
+            await asyncio.sleep(0.01)
+
+        assert provider_stream.aclose_calls == 1
+        assert provider_stream.aclose_completed == 1
+    finally:
+        release.set()
+        task.cancel()


### PR DESCRIPTION
### Summary

#4133 gave `AnyLLMModel` a shielded cleanup close (`_close_stream_allowing_background_completion`) so that cancellation arriving *while* the provider close is in flight doesn't abandon it half-done. The three sibling adapters were left on the older bare `await`, so they still have the bug that helper exists to fix.

**Affected components:**
- `src/agents/models/openai_chatcompletions.py` (`OpenAIChatCompletionsModel.stream_response`)
- `src/agents/models/openai_responses.py` (`OpenAIResponsesModel.stream_response`)
- `src/agents/extensions/models/litellm_model.py` (`LitellmModel.stream_response`)

### Problem

All four adapters share the same cleanup shape introduced by #4004 and #4077:

```python
except asyncio.CancelledError:
    close_stream_in_background = True
    self._schedule_async_iterator_close(stream)   # detached -- fine
    raise
finally:
    if not close_stream_in_background:
        try:
            await self._maybe_aclose(stream)      # <-- not shielded in the three siblings
        except Exception as exc:
            ...
```

The `except asyncio.CancelledError` branch is correct: it detaches the close so it survives. The gap is the `finally`. When the consumer is cancelled *after* the stream has already been exhausted or broken out of — so it is suspended inside the `finally`'s own `await`, waiting on the provider's `aclose()` — the `CancelledError` is delivered *into that await*. The close is cancelled mid-way and the transport is never released.

`AnyLLMModel` is immune because #4133 shields it. The other three are not.

### Repro

A provider stream that exhausts normally and then blocks inside `aclose()` (a transport waiting on the socket), with the consumer cancelled while that close is suspended:

```
=== cancellation arriving while the finally's aclose() is in flight ===
openai_chatcompletions     calls=1 completed_after_cancel=0 completed_after_release=0  >>> ABANDONED
openai_responses           calls=1 completed_after_cancel=0 completed_after_release=0  >>> ABANDONED
litellm_model              calls=1 completed_after_cancel=0 completed_after_release=0  >>> ABANDONED
```

`calls=1` shows the close started; `completed_after_release=0` shows it never finished even once the transport was released. After the change all three report `completed_after_release=1`.

This is reachable from ordinary shutdown paths — a tripped guardrail, an `asyncio.timeout` around a run, or `Runner.run_streamed` being cancelled — any of which cancel the consuming task at an arbitrary moment, including during cleanup.

### Fix

Port #4133's helper verbatim to the three adapters, and route each `finally` through it. Also switch `_schedule_async_iterator_close` and `_consume_background_cleanup_task_result` to the `ensure_future` / `asyncio.Future` forms #4133 uses, so the detach path is shared by both call sites rather than duplicated.

I kept the docstring #4133 wrote, because its second sentence is the part that's easy to lose in a later refactor: re-closing a provider iterator is not guaranteed to be safe or idempotent, which is why the shielded task is *detached* rather than a second close being started.

### Tests

One regression test per adapter, mirroring `test_any_llm_chat_stream_lets_in_flight_close_finish_after_cancellation`:

- `tests/models/test_openai_chatcompletions_stream.py::test_stream_response_lets_in_flight_close_finish_after_cancellation`
- `tests/models/test_openai_responses.py::test_stream_response_lets_in_flight_close_finish_after_cancellation`
- `tests/models/test_litellm_chatcompletions_stream.py::test_stream_response_lets_in_flight_close_finish_after_cancellation`

Each asserts the close is entered exactly once, that cancelling does not start a second close, and that the original close completes once released.

**A/B against the merge base** — with the source change stashed and only the tests applied:

```
base c546ca12:  3 failed   (all three: assert 0 == 1 on aclose_completed)
head:           3 passed
```

The existing `_SlowCloseChatStream` tests block in `__anext__`, so they exercise the `except CancelledError` branch, which was already correct. The new fixtures exhaust normally so the consumer reaches the `finally` on its own — that's what makes them non-vacuous here.

I also checked the obvious objection to `asyncio.shield`, that it might stall shutdown behind a hung close. It doesn't: with an `aclose()` that never returns, cancellation of the consumer completes in **0.0 ms**, with `aclose_calls == 1`. `shield` propagates the cancellation to the awaiting coroutine immediately and leaves the inner task running.

### Verification

- `ruff format --check` and `ruff check`: clean (593 files).
- `mypy src`: 7 errors, all in `src/agents/sandbox/`, **identical at the merge base**.
- Targeted suites: `tests/models/`, `tests/test_cancel_streaming.py`, `tests/test_agent_runner_streamed.py`, `tests/test_extra_headers.py`, `tests/test_logprobs.py`, `tests/test_config.py` → **741 passed, 7 skipped**.
- `make tests-serial` equivalent (`pytest -m serial`): **38 passed, 5 skipped**.
- `make tests-parallel` equivalent (`pytest -n auto --dist loadfile -m "not serial"`): 53 failed / 5532 passed here vs **56 failed / 5526 passed at the merge base**. I did not treat that delta as a win — diffing the failure *lists* gives 5 tests failing only at base and 2 failing only at head, and re-running all 6 of those files together in a single process with `-p no:randomly` gives an **identical 35 failures at both heads**. It's xdist sharding, not my change. (`test_interrupt_force_cancel_overrides_auto_cancellation` even fails at base in isolation and passes at head — same cause, opposite direction.)

Two environment notes so nobody chases them as regressions:

1. **`tests/voice/test_openai_stt.py::test_session_error_event` hangs indefinitely on my machine at both heads** (Windows 11, Python 3.10). It's what produced the `[gw18] node down: Not properly terminated` worker crash that prevented the parallel run from ever printing a summary. I deselected just that one test to get a full run; everything else in `tests/voice/` passes (42 in `test_pipeline.py`, etc.). Flagging it in case it's also flaky in CI rather than platform-specific.
2. The remaining pre-existing failures are the usual local tracing/sandbox cluster, unchanged at both heads.

### Scope question

`OpenAIResponsesModel` also has a websocket transport path with its own cleanup, and `voice/models/openai_stt.py` does its own task draining after #4131. I deliberately did **not** touch either — this PR is strictly the port of one merged helper to the three adapters that share the exact `finally` shape it was written for. Happy to extend if you'd like the same audit applied to those.
