### PR TITLE
fix(extensions): preserve thinking blocks for replay

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Mapping
+from copy import deepcopy
 from typing import Any, Literal, cast
 
 from openai import Omit, omit
@@ -131,39 +132,52 @@ class Converter:
         """
         items: list[TResponseOutputItem] = []
 
-        # Check if message is agents.extensions.models.litellm_model.InternalChatCompletionMessage
-        # We can't actually import it here because litellm is an optional dependency
-        # So we use hasattr to check for reasoning_content and thinking_blocks
-        if hasattr(message, "reasoning_content") and message.reasoning_content:
+        # Check if message is agents.extensions.models.litellm_model.InternalChatCompletionMessage.
+        # We can't actually import it here because litellm is an optional dependency.
+        # So we use hasattr to check for reasoning_content and thinking_blocks.
+        reasoning_content = getattr(message, "reasoning_content", "")
+        raw_thinking_blocks = getattr(message, "thinking_blocks", None)
+        thinking_blocks = (
+            [deepcopy(block) for block in raw_thinking_blocks if isinstance(block, dict)]
+            if isinstance(raw_thinking_blocks, list)
+            else []
+        )
+
+        if reasoning_content or thinking_blocks:
             reasoning_kwargs: dict[str, Any] = {
                 "id": FAKE_RESPONSES_ID,
-                "summary": [Summary(text=message.reasoning_content, type="summary_text")],
+                "summary": (
+                    [Summary(text=reasoning_content, type="summary_text")]
+                    if reasoning_content
+                    else []
+                ),
                 "type": "reasoning",
             }
 
-            # Add provider_data if available
-            if provider_data:
-                reasoning_kwargs["provider_data"] = provider_data
+            reasoning_provider_data = dict(provider_data or {})
+            if thinking_blocks:
+                # The normalized reasoning fields below cannot represent empty thinking text or
+                # redacted_thinking blocks. Keep the complete provider sequence as the replay
+                # source of truth while retaining those released fields as derived data.
+                reasoning_provider_data["thinking_blocks"] = thinking_blocks
+            if reasoning_provider_data:
+                reasoning_kwargs["provider_data"] = reasoning_provider_data
 
             reasoning_item = ResponseReasoningItem(**reasoning_kwargs)
 
-            # Store thinking blocks for Anthropic compatibility
-            if hasattr(message, "thinking_blocks") and message.thinking_blocks:
-                # Store thinking text in content and signature in encrypted_content
+            # Retain the released normalized representation for callers and legacy histories.
+            if thinking_blocks:
                 reasoning_item.content = []
                 signatures: list[str] = []
-                for block in message.thinking_blocks:
-                    if isinstance(block, dict):
-                        thinking_text = block.get("thinking", "")
-                        if thinking_text:
-                            reasoning_item.content.append(
-                                Content(text=thinking_text, type="reasoning_text")
-                            )
-                        # Store the signature if present
-                        if signature := block.get("signature"):
-                            signatures.append(signature)
+                for block in thinking_blocks:
+                    thinking_text = block.get("thinking", "")
+                    if thinking_text:
+                        reasoning_item.content.append(
+                            Content(text=thinking_text, type="reasoning_text")
+                        )
+                    if signature := block.get("signature"):
+                        signatures.append(signature)
 
-                # Store the signatures in encrypted_content with newline delimiter
                 if signatures:
                     reasoning_item.encrypted_content = "\n".join(signatures)
 
@@ -534,12 +548,14 @@ class Converter:
 
         result: list[ChatCompletionMessageParam] = []
         current_assistant_msg: ChatCompletionAssistantMessageParam | None = None
-        pending_thinking_blocks: list[dict[str, str]] | None = None
+        pending_thinking_blocks: list[dict[str, Any]] | None = None
+        pending_thinking_blocks_are_native = False
         pending_reasoning_content: str | None = None  # For DeepSeek reasoning_content
         normalized_base_url = base_url.rstrip("/") if base_url is not None else None
 
         def flush_assistant_message(*, clear_pending_reasoning: bool = True) -> None:
-            nonlocal current_assistant_msg, pending_reasoning_content, pending_thinking_blocks
+            nonlocal current_assistant_msg, pending_reasoning_content
+            nonlocal pending_thinking_blocks, pending_thinking_blocks_are_native
             if current_assistant_msg is not None:
                 # The API doesn't support empty arrays for tool_calls
                 if not current_assistant_msg.get("tool_calls"):
@@ -555,6 +571,37 @@ class Converter:
                 # reasoning item that is not directly followed by that turn's assistant
                 # message must not leak its signed blocks into a later one.
                 pending_thinking_blocks = None
+                pending_thinking_blocks_are_native = False
+
+        def apply_pending_thinking_blocks(
+            assistant_msg: ChatCompletionAssistantMessageParam,
+        ) -> None:
+            nonlocal pending_thinking_blocks, pending_thinking_blocks_are_native
+            if not pending_thinking_blocks:
+                return
+
+            if pending_thinking_blocks_are_native:
+                # LiteLLM's native field preserves the complete Anthropic block sequence,
+                # including empty thinking and redacted_thinking blocks.
+                assistant_msg["thinking_blocks"] = pending_thinking_blocks  # type: ignore[typeddict-unknown-key]
+            else:
+                # Legacy stored reasoning items only contain normalized text and signatures.
+                # Preserve their released inline-content reconstruction behavior.
+                current_content = assistant_msg.get("content")
+                if isinstance(current_content, str):
+                    text_content = ChatCompletionContentPartTextParam(
+                        text=current_content, type="text"
+                    )
+                    content_parts: list[Any] = [text_content]
+                elif current_content is None:
+                    content_parts = []
+                else:
+                    content_parts = list(current_content)
+
+                assistant_msg["content"] = pending_thinking_blocks + content_parts
+
+            pending_thinking_blocks = None
+            pending_thinking_blocks_are_native = False
 
         def apply_pending_reasoning_content(
             assistant_msg: ChatCompletionAssistantMessageParam,
@@ -571,6 +618,7 @@ class Converter:
                 current_assistant_msg["content"] = None
                 current_assistant_msg["tool_calls"] = []
 
+            apply_pending_thinking_blocks(current_assistant_msg)
             apply_pending_reasoning_content(current_assistant_msg)
 
             return current_assistant_msg
@@ -665,24 +713,7 @@ class Converter:
                     combined = "\n".join(text_segments)
                     new_asst["content"] = combined
 
-                # If we have pending thinking blocks, prepend them to the content
-                # This is required for Anthropic API with interleaved thinking
-                if pending_thinking_blocks:
-                    # If there is a text content, convert it to a list to prepend thinking blocks
-                    if "content" in new_asst and isinstance(new_asst["content"], str):
-                        text_content = ChatCompletionContentPartTextParam(
-                            text=new_asst["content"], type="text"
-                        )
-                        new_asst["content"] = [text_content]
-
-                    if "content" not in new_asst or new_asst["content"] is None:
-                        new_asst["content"] = []
-
-                    # Thinking blocks MUST come before any other content
-                    # We ignore type errors because pending_thinking_blocks is not openai standard
-                    new_asst["content"] = pending_thinking_blocks + new_asst["content"]  # type: ignore
-                    pending_thinking_blocks = None  # Clear after using
-
+                apply_pending_thinking_blocks(new_asst)
                 new_asst["tool_calls"] = []
                 apply_pending_reasoning_content(new_asst)
                 current_assistant_msg = new_asst
@@ -709,25 +740,6 @@ class Converter:
 
             elif func_call := cls.maybe_function_tool_call(item):
                 asst = ensure_assistant_message()
-
-                # If we have pending thinking blocks, use them as the content
-                # This is required for Anthropic API tool calls with interleaved thinking
-                if pending_thinking_blocks:
-                    # If there is a text content, save it to append after thinking blocks
-                    # content type is Union[str, Iterable[ContentArrayOfContentPart], None]
-                    if "content" in asst and isinstance(asst["content"], str):
-                        text_content = ChatCompletionContentPartTextParam(
-                            text=asst["content"], type="text"
-                        )
-                        asst["content"] = [text_content]
-
-                    if "content" not in asst or asst["content"] is None:
-                        asst["content"] = []
-
-                    # Thinking blocks MUST come before any other content
-                    # We ignore type errors because pending_thinking_blocks is not openai standard
-                    asst["content"] = pending_thinking_blocks + asst["content"]  # type: ignore
-                    pending_thinking_blocks = None  # Clear after using
 
                 tool_calls = list(asst.get("tool_calls", []))
                 arguments = func_call["arguments"] if func_call["arguments"] else "{}"
@@ -807,38 +819,49 @@ class Converter:
 
                 item_provider_data: dict[str, Any] = reasoning_item.get("provider_data", {})  # type: ignore[assignment]
                 item_model = item_provider_data.get("model", "")
+                origin_provider_data = {
+                    key: value
+                    for key, value in item_provider_data.items()
+                    if key != "thinking_blocks"
+                }
                 should_replay = False
 
                 if (
                     model
                     and ("claude" in model.lower() or "anthropic" in model.lower())
-                    and content_items
                     and preserve_thinking_blocks
                     # Items may not all originate from Claude, so we need to check for model match.
-                    # For backward compatibility, if provider_data is missing, we ignore the check.
-                    and (model == item_model or item_provider_data == {})
+                    # New thinking-block metadata alone does not establish a conflicting origin,
+                    # but other provider metadata without a model must remain origin-unknown.
+                    and (model == item_model or not origin_provider_data)
                 ):
-                    signatures = encrypted_content.split("\n") if encrypted_content else []
+                    complete_thinking_blocks = item_provider_data.get("thinking_blocks")
+                    if (
+                        isinstance(complete_thinking_blocks, list)
+                        and complete_thinking_blocks
+                        and all(isinstance(block, dict) for block in complete_thinking_blocks)
+                    ):
+                        pending_thinking_blocks = deepcopy(complete_thinking_blocks)
+                        pending_thinking_blocks_are_native = True
+                    elif content_items:
+                        signatures = encrypted_content.split("\n") if encrypted_content else []
 
-                    # Reconstruct thinking blocks from content and signature
-                    reconstructed_thinking_blocks = []
-                    for content_item in content_items:
-                        if (
-                            isinstance(content_item, dict)
-                            and content_item.get("type") == "reasoning_text"
-                        ):
-                            thinking_block = {
-                                "type": "thinking",
-                                "thinking": content_item.get("text", ""),
-                            }
-                            # Add signatures if available
-                            if signatures:
-                                thinking_block["signature"] = signatures.pop(0)
-                            reconstructed_thinking_blocks.append(thinking_block)
+                        reconstructed_thinking_blocks: list[dict[str, Any]] = []
+                        for content_item in content_items:
+                            if (
+                                isinstance(content_item, dict)
+                                and content_item.get("type") == "reasoning_text"
+                            ):
+                                thinking_block = {
+                                    "type": "thinking",
+                                    "thinking": content_item.get("text", ""),
+                                }
+                                if signatures:
+                                    thinking_block["signature"] = signatures.pop(0)
+                                reconstructed_thinking_blocks.append(thinking_block)
 
-                    # Store thinking blocks as pending for the next assistant message
-                    # This preserves the original behavior
-                    pending_thinking_blocks = reconstructed_thinking_blocks
+                        pending_thinking_blocks = reconstructed_thinking_blocks
+                        pending_thinking_blocks_are_native = False
 
                 if model is not None:
                     replay_context = ReasoningContentReplayContext(

--- a/src/agents/models/reasoning_content_replay.py
+++ b/src/agents/models/reasoning_content_replay.py
@@ -46,9 +46,14 @@ def default_should_replay_reasoning_content(context: ReasoningContentReplayConte
     # Replay only when the current request targets DeepSeek and the reasoning item either
     # came from a DeepSeek model or predates provider tracking. This avoids mixing reasoning
     # content from a different model family into the DeepSeek assistant message.
+    provider_data_without_thinking_blocks = {
+        key: value
+        for key, value in context.reasoning.provider_data.items()
+        if key != "thinking_blocks"
+    }
     return (
         origin_model is not None and "deepseek" in origin_model.lower()
-    ) or context.reasoning.provider_data == {}
+    ) or not provider_data_without_thinking_blocks
 
 
 __all__ = [

--- a/tests/models/test_anthropic_thinking_blocks.py
+++ b/tests/models/test_anthropic_thinking_blocks.py
@@ -12,10 +12,16 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import httpx
+from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+from litellm.types.utils import ModelResponse as LiteLLMModelResponse
 from openai.types.chat import ChatCompletionMessageToolCall
 from openai.types.chat.chat_completion_message_tool_call import Function
 
-from agents.extensions.models.litellm_model import InternalChatCompletionMessage
+from agents.extensions.models.litellm_model import (
+    InternalChatCompletionMessage,
+    LitellmConverter,
+)
 from agents.models.chatcmpl_converter import Converter
 
 
@@ -34,6 +40,99 @@ def create_mock_anthropic_response_with_thinking() -> InternalChatCompletionMess
         ],
     )
     return message
+
+
+def _assistant_thinking_blocks(message: Any) -> list[dict[str, Any]]:
+    thinking_blocks = message.get("thinking_blocks")
+    assert isinstance(thinking_blocks, list)
+    assert all(isinstance(block, dict) for block in thinking_blocks)
+    return cast(list[dict[str, Any]], thinking_blocks)
+
+
+def _litellm_anthropic_message(
+    thinking_blocks: list[dict[str, Any]],
+    *,
+    tool_call: bool = False,
+) -> Any:
+    response_tail = (
+        {
+            "type": "tool_use",
+            "id": "toolu-weather",
+            "name": "get_weather",
+            "input": {"city": "Tokyo"},
+        }
+        if tool_call
+        else {"type": "text", "text": "answer"}
+    )
+    completion_response = {
+        "id": "msg-thinking",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [*thinking_blocks, response_tail],
+        "stop_reason": "tool_use" if tool_call else "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+    raw_response = httpx.Response(
+        200,
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+    )
+    response = AnthropicConfig().transform_parsed_response(
+        completion_response=completion_response,
+        raw_response=raw_response,
+        model_response=LiteLLMModelResponse(model="claude-sonnet-4-5"),
+    )
+    return response.choices[0].message
+
+
+def _round_trip_litellm_anthropic_blocks(
+    thinking_blocks: list[dict[str, Any]],
+    *,
+    tool_call: bool = False,
+) -> tuple[Any, list[dict[str, Any]]]:
+    litellm_message = _litellm_anthropic_message(thinking_blocks, tool_call=tool_call)
+    internal_message = LitellmConverter.convert_message_to_openai(
+        litellm_message,
+        model="anthropic/claude-sonnet-4-5",
+    )
+    output_items = Converter.message_to_output_items(
+        internal_message,
+        provider_data={"model": "anthropic/claude-sonnet-4-5"},
+    )
+    serialized_items: list[Any] = [item.model_dump() for item in output_items]
+    messages = Converter.items_to_messages(
+        serialized_items,
+        model="anthropic/claude-sonnet-4-5",
+        preserve_thinking_blocks=True,
+    )
+    outbound_request = AnthropicConfig().transform_request(
+        model="claude-sonnet-4-5",
+        messages=cast(Any, [*messages, {"role": "user", "content": "continue"}]),
+        optional_params={
+            "max_tokens": 1024,
+            **(
+                {
+                    "tools": [
+                        {
+                            "name": "get_weather",
+                            "description": "Get the weather.",
+                            "input_schema": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        }
+                    ]
+                }
+                if tool_call
+                else {}
+            ),
+        },
+        litellm_params={},
+        headers={},
+    )
+    return output_items, cast(list[dict[str, Any]], outbound_request["messages"])
 
 
 def test_converter_skips_reasoning_items():
@@ -92,6 +191,9 @@ def test_reasoning_items_preserved_in_message_conversion():
 
     reasoning_item = reasoning_items[0]
     assert reasoning_item.summary[0].text == "I need to call the weather function for Paris"
+    assert reasoning_item.model_dump()["provider_data"]["thinking_blocks"] == (
+        mock_message.thinking_blocks
+    )
 
     # Verify thinking blocks are stored if we preserve them
     if (
@@ -197,15 +299,11 @@ def test_anthropic_thinking_blocks_with_tool_calls():
 
     assistant_msg = assistant_messages[0]
 
-    # Content must start with thinking blocks, not text
-    content = assistant_msg.get("content")
-    assert content is not None, "Assistant message should have content"
+    # Thinking blocks must remain ahead of text in Anthropic's native block sequence.
+    thinking_blocks = _assistant_thinking_blocks(assistant_msg)
+    assert thinking_blocks, "Assistant message should have thinking blocks"
 
-    assert isinstance(content, list) and len(content) > 0, (
-        "Assistant message content should be a non-empty list"
-    )
-
-    first_content = content[0]
+    first_content = thinking_blocks[0]
     assert first_content.get("type") == "thinking", (
         f"First content must be 'thinking' type for Anthropic compatibility, "
         f"but got '{first_content.get('type')}'"
@@ -216,12 +314,11 @@ def test_anthropic_thinking_blocks_with_tool_calls():
     assert first_content.get("thinking") == expected_thinking, (
         "Thinking content should be preserved"
     )
-    # Signature should also be preserved
     assert first_content.get("signature") == "TestSignature123", (
         "Signature should be preserved in thinking block"
     )
 
-    second_content = content[1]
+    second_content = thinking_blocks[1]
     assert second_content.get("type") == "thinking", (
         f"Second content must be 'thinking' type for Anthropic compatibility, "
         f"but got '{second_content.get('type')}'"
@@ -230,17 +327,12 @@ def test_anthropic_thinking_blocks_with_tool_calls():
     assert second_content.get("thinking") == expected_thinking, (
         "Thinking content should be preserved"
     )
-    # Signature should also be preserved
     assert second_content.get("signature") == "TestSignature456", (
         "Signature should be preserved in thinking block"
     )
 
-    last_content = content[2]
-    assert last_content.get("type") == "text", (
-        f"First content must be 'text' type but got '{last_content.get('type')}'"
-    )
     expected_text = "I'll check the weather for you."
-    assert last_content.get("text") == expected_text, "Content text should be preserved"
+    assert assistant_msg.get("content") == expected_text, "Content text should be preserved"
 
     # Verify tool calls are preserved
     tool_calls = assistant_msg.get("tool_calls", [])
@@ -296,11 +388,8 @@ def test_items_to_messages_preserves_positional_bool_arguments():
     assert len(assistant_messages) == 1, "Should have exactly one assistant message with tool calls"
 
     assistant_msg = assistant_messages[0]
-    content = assistant_msg.get("content")
-    assert isinstance(content, list) and len(content) > 0, (
-        "Positional bool arguments should still preserve thinking blocks"
-    )
-    assert content[0].get("type") == "thinking", (
+    thinking_blocks = _assistant_thinking_blocks(assistant_msg)
+    assert thinking_blocks[0].get("type") == "thinking", (
         "The third positional argument must continue to map to preserve_thinking_blocks"
     )
 
@@ -383,20 +472,13 @@ def test_anthropic_thinking_blocks_without_tool_calls():
 
     assistant_msg = assistant_messages[0]
 
-    # Content must start with thinking blocks even WITHOUT tool calls
-    content = assistant_msg.get("content")
-    assert content is not None, "Assistant message should have content"
-    assert isinstance(content, list), (
-        f"Assistant message content should be a list when thinking blocks are present, "
-        f"but got {type(content)}"
-    )
-    assert len(content) >= 2, (
-        f"Assistant message should have at least 2 content items "
-        f"(thinking + text), got {len(content)}"
+    # Thinking blocks stay in LiteLLM's native field even without tool calls.
+    thinking_blocks = _assistant_thinking_blocks(assistant_msg)
+    assert len(thinking_blocks) == 1, (
+        f"Assistant message should have exactly one thinking block, got {len(thinking_blocks)}"
     )
 
-    # First content should be thinking block
-    first_content = content[0]
+    first_content = thinking_blocks[0]
     assert first_content.get("type") == "thinking", (
         f"First content must be 'thinking' type for Anthropic compatibility, "
         f"but got '{first_content.get('type')}'"
@@ -408,14 +490,146 @@ def test_anthropic_thinking_blocks_without_tool_calls():
         "Signature should be preserved in thinking block"
     )
 
-    # Second content should be text
-    second_content = content[1]
-    assert second_content.get("type") == "text", (
-        f"Second content must be 'text' type, but got '{second_content.get('type')}'"
-    )
-    assert (
-        second_content.get("text") == "The weather in Paris is sunny with a temperature of 22°C."
+    assert assistant_msg.get("content") == (
+        "The weather in Paris is sunny with a temperature of 22°C."
     ), "Text content should be preserved"
+
+
+def test_litellm_round_trip_preserves_omitted_thinking_block() -> None:
+    thinking_blocks = [{"type": "thinking", "thinking": "", "signature": "OmittedSignature"}]
+
+    output_items, outbound_messages = _round_trip_litellm_anthropic_blocks(thinking_blocks)
+
+    reasoning_items = [item for item in output_items if item.type == "reasoning"]
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0].summary == []
+    assert reasoning_items[0].model_dump()["provider_data"]["thinking_blocks"] == thinking_blocks
+    assert outbound_messages[0]["content"][:1] == thinking_blocks
+
+
+def test_litellm_round_trip_preserves_complete_thinking_block_sequence() -> None:
+    thinking_blocks = [
+        {"type": "thinking", "thinking": "", "signature": "OmittedSignature"},
+        {"type": "redacted_thinking", "data": "EncryptedRedactedThinking"},
+        {"type": "thinking", "thinking": "visible", "signature": "VisibleSignature"},
+    ]
+
+    _, outbound_messages = _round_trip_litellm_anthropic_blocks(
+        thinking_blocks,
+        tool_call=True,
+    )
+
+    assert outbound_messages[0]["content"][:3] == thinking_blocks
+    assert outbound_messages[0]["content"][3] == {
+        "type": "tool_use",
+        "id": "toolu-weather",
+        "name": "get_weather",
+        "input": {"city": "Tokyo"},
+    }
+
+
+def test_complete_thinking_blocks_respect_replay_guards() -> None:
+    message = InternalChatCompletionMessage(
+        role="assistant",
+        content="answer",
+        reasoning_content="visible",
+        thinking_blocks=[{"type": "thinking", "thinking": "visible", "signature": "Signature"}],
+    )
+    items: list[Any] = [
+        item.model_dump()
+        for item in Converter.message_to_output_items(
+            message,
+            provider_data={"model": "anthropic/claude-sonnet-4-5"},
+        )
+    ]
+
+    disabled_messages = Converter.items_to_messages(
+        items,
+        model="anthropic/claude-sonnet-4-5",
+        preserve_thinking_blocks=False,
+    )
+    mismatched_messages = Converter.items_to_messages(
+        items,
+        model="anthropic/claude-opus-4-5",
+        preserve_thinking_blocks=True,
+    )
+    unknown_origin_items: list[Any] = [
+        item.model_dump()
+        for item in Converter.message_to_output_items(
+            message,
+            provider_data={"response_id": "response-from-unknown-provider"},
+        )
+    ]
+    unknown_origin_messages = Converter.items_to_messages(
+        unknown_origin_items,
+        model="anthropic/claude-sonnet-4-5",
+        preserve_thinking_blocks=True,
+    )
+
+    assert all("thinking_blocks" not in message for message in disabled_messages)
+    assert all("thinking_blocks" not in message for message in mismatched_messages)
+    assert all("thinking_blocks" not in message for message in unknown_origin_messages)
+
+
+def test_originless_thinking_blocks_preserve_legacy_deepseek_reasoning_replay() -> None:
+    message = InternalChatCompletionMessage(
+        role="assistant",
+        content="answer",
+        reasoning_content="legacy reasoning",
+        thinking_blocks=[{"type": "thinking", "thinking": "visible", "signature": "Signature"}],
+    )
+    items: list[Any] = [item.model_dump() for item in Converter.message_to_output_items(message)]
+
+    reasoning_item = next(item for item in items if item["type"] == "reasoning")
+    assert reasoning_item["provider_data"] == {
+        "thinking_blocks": [{"type": "thinking", "thinking": "visible", "signature": "Signature"}]
+    }
+
+    messages = Converter.items_to_messages(items, model="deepseek/deepseek-reasoner")
+
+    assistant_message = next(message for message in messages if message["role"] == "assistant")
+    assert assistant_message["reasoning_content"] == "legacy reasoning"  # type: ignore[typeddict-item]
+    assert "thinking_blocks" not in assistant_message
+
+
+def test_legacy_reasoning_item_reconstructs_inline_thinking_blocks() -> None:
+    for provider_data in (None, {"thinking_blocks": ["invalid-block"]}):
+        reasoning_item: dict[str, Any] = {
+            "id": "reasoning_legacy",
+            "type": "reasoning",
+            "summary": [],
+            "content": [{"type": "reasoning_text", "text": "legacy thinking"}],
+            "encrypted_content": "LegacySignature",
+        }
+        if provider_data is not None:
+            reasoning_item["provider_data"] = provider_data
+
+        history: list[dict[str, Any]] = [
+            reasoning_item,
+            {
+                "id": "message_legacy",
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "answer", "annotations": []}],
+            },
+        ]
+
+        messages = Converter.items_to_messages(
+            history,  # type: ignore[arg-type]
+            model="anthropic/claude-sonnet-4-5",
+            preserve_thinking_blocks=True,
+        )
+
+        assert messages[0]["content"] == [
+            {
+                "type": "thinking",
+                "thinking": "legacy thinking",
+                "signature": "LegacySignature",
+            },
+            {"type": "text", "text": "answer"},
+        ]
+        assert "thinking_blocks" not in messages[0]
 
 
 def test_thinking_blocks_do_not_leak_across_an_intervening_user_turn():


### PR DESCRIPTION
This pull request fixes the loss of extended-thinking blocks when LiteLLM responses are serialized as SDK output items and replayed from client-managed history.

The converter now preserves the complete ordered block sequence, including empty signed and redacted thinking blocks, and replays it through LiteLLM's native `thinking_blocks` field. It retains normalized reasoning fields, legacy `content` and `encrypted_content` reconstruction, replay guards, and same-model origin checks.

Runtime verification exercised LiteLLM 1.83.0's actual inbound and outbound transformations. A signed thinking block from the first response survived SDK item JSON serialization, was replayed exactly through the native `thinking_blocks` field, and was accepted by Anthropic in the follow-up request.

Exact streaming block segmentation and `OpenAIConversationsSession` provider-data stripping remain unchanged.
