### PR TITLE
test: make parallel input guardrail overlap deterministic

### DIFF
--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1245,15 +1245,17 @@ async def test_blocking_guardrail_passes_agent_continues_streaming():
 
 @pytest.mark.asyncio
 async def test_mixed_blocking_and_parallel_guardrails():
-    timestamps = {}
+    blocking_finished = asyncio.Event()
+    model_called = asyncio.Event()
+    parallel_finished = asyncio.Event()
+    observed: dict[str, bool] = {}
 
     @input_guardrail(run_in_parallel=False)
     async def blocking_check(
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
-        timestamps["blocking_start"] = time.time()
         await asyncio.sleep(MEDIUM_DELAY)
-        timestamps["blocking_end"] = time.time()
+        blocking_finished.set()
         return GuardrailFunctionOutput(
             output_info="blocking_passed",
             tripwire_triggered=False,
@@ -1263,9 +1265,12 @@ async def test_mixed_blocking_and_parallel_guardrails():
     async def parallel_check(
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
-        timestamps["parallel_start"] = time.time()
-        await asyncio.sleep(MEDIUM_DELAY)
-        timestamps["parallel_end"] = time.time()
+        observed["blocking_finished_at_parallel_start"] = blocking_finished.is_set()
+        # Stay in flight until the model is invoked. If the runner ever waited for this
+        # guardrail before calling the model, the wait would time out instead of relying
+        # on wall-clock margins to detect the missing overlap.
+        await asyncio.wait_for(model_called.wait(), timeout=1)
+        parallel_finished.set()
         return GuardrailFunctionOutput(
             output_info="parallel_passed",
             tripwire_triggered=False,
@@ -1276,7 +1281,9 @@ async def test_mixed_blocking_and_parallel_guardrails():
     original_get_response = model.get_response
 
     async def tracked_get_response(*args, **kwargs):
-        timestamps["model_called"] = time.time()
+        observed["blocking_finished_at_model_call"] = blocking_finished.is_set()
+        observed["parallel_finished_at_model_call"] = parallel_finished.is_set()
+        model_called.set()
         return await original_get_response(*args, **kwargs)
 
     agent = Agent(
@@ -1293,21 +1300,16 @@ async def test_mixed_blocking_and_parallel_guardrails():
     assert result.final_output is not None
     assert len(result.input_guardrail_results) == 2
 
-    assert "blocking_start" in timestamps
-    assert "blocking_end" in timestamps
-    assert "parallel_start" in timestamps
-    assert "parallel_end" in timestamps
-    assert "model_called" in timestamps
-
-    assert timestamps["blocking_end"] <= timestamps["parallel_start"], (
+    assert observed["blocking_finished_at_parallel_start"] is True, (
         "Blocking must complete before parallel starts"
     )
-    assert timestamps["blocking_end"] <= timestamps["model_called"], (
+    assert observed["blocking_finished_at_model_call"] is True, (
         "Blocking must complete before model is called"
     )
-    assert timestamps["model_called"] <= timestamps["parallel_end"], (
+    assert observed["parallel_finished_at_model_call"] is False, (
         "Model called while parallel guardrail still running"
     )
+    assert parallel_finished.is_set() is True, "Parallel guardrail should have completed"
     assert model.first_turn_args is not None, (
         "Model should have been called after blocking guardrails passed"
     )
@@ -1315,15 +1317,17 @@ async def test_mixed_blocking_and_parallel_guardrails():
 
 @pytest.mark.asyncio
 async def test_mixed_blocking_and_parallel_guardrails_streaming():
-    timestamps = {}
+    blocking_finished = asyncio.Event()
+    model_called = asyncio.Event()
+    parallel_finished = asyncio.Event()
+    observed: dict[str, bool] = {}
 
     @input_guardrail(run_in_parallel=False)
     async def blocking_check(
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
-        timestamps["blocking_start"] = time.time()
         await asyncio.sleep(MEDIUM_DELAY)
-        timestamps["blocking_end"] = time.time()
+        blocking_finished.set()
         return GuardrailFunctionOutput(
             output_info="blocking_passed",
             tripwire_triggered=False,
@@ -1333,9 +1337,12 @@ async def test_mixed_blocking_and_parallel_guardrails_streaming():
     async def parallel_check(
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
-        timestamps["parallel_start"] = time.time()
-        await asyncio.sleep(MEDIUM_DELAY)
-        timestamps["parallel_end"] = time.time()
+        observed["blocking_finished_at_parallel_start"] = blocking_finished.is_set()
+        # Stay in flight until the model is invoked. If the runner ever waited for this
+        # guardrail before calling the model, the wait would time out instead of relying
+        # on wall-clock margins to detect the missing overlap.
+        await asyncio.wait_for(model_called.wait(), timeout=1)
+        parallel_finished.set()
         return GuardrailFunctionOutput(
             output_info="parallel_passed",
             tripwire_triggered=False,
@@ -1346,7 +1353,9 @@ async def test_mixed_blocking_and_parallel_guardrails_streaming():
     original_stream_response = model.stream_response
 
     async def tracked_stream_response(*args, **kwargs):
-        timestamps["model_called"] = time.time()
+        observed["blocking_finished_at_model_call"] = blocking_finished.is_set()
+        observed["parallel_finished_at_model_call"] = parallel_finished.is_set()
+        model_called.set()
         async for event in original_stream_response(*args, **kwargs):
             yield event
 
@@ -1366,21 +1375,17 @@ async def test_mixed_blocking_and_parallel_guardrails_streaming():
             received_events = True
 
     assert received_events is True
-    assert "blocking_start" in timestamps
-    assert "blocking_end" in timestamps
-    assert "parallel_start" in timestamps
-    assert "parallel_end" in timestamps
-    assert "model_called" in timestamps
 
-    assert timestamps["blocking_end"] <= timestamps["parallel_start"], (
+    assert observed["blocking_finished_at_parallel_start"] is True, (
         "Blocking must complete before parallel starts"
     )
-    assert timestamps["blocking_end"] <= timestamps["model_called"], (
+    assert observed["blocking_finished_at_model_call"] is True, (
         "Blocking must complete before model is called"
     )
-    assert timestamps["model_called"] <= timestamps["parallel_end"], (
+    assert observed["parallel_finished_at_model_call"] is False, (
         "Model called while parallel guardrail still running"
     )
+    assert parallel_finished.is_set() is True, "Parallel guardrail should have completed"
     assert model.first_turn_args is not None, (
         "Model should have been called after blocking guardrails passed"
     )


### PR DESCRIPTION
### Summary

`tests/test_guardrails.py::test_mixed_blocking_and_parallel_guardrails` and its streaming twin fail intermittently under `make tests-parallel`, while passing reliably in isolation.

Both tests proved that a `run_in_parallel=True` input guardrail overlaps the model call by sampling `time.time()` around a fixed `asyncio.sleep(MEDIUM_DELAY)` in each guardrail, then asserting `timestamps["model_called"] <= timestamps["parallel_end"]`.

That assertion has a zero-width margin: it only holds while the runner reaches the model within the ~30ms the parallel guardrail spends sleeping. Under pytest-xdist the workers saturate the CPU, the process gets descheduled, the guardrail's timer expires first, and the guardrail resumes before the model call is issued — so the test fails even though the runner behaved correctly and did schedule the model concurrently with the guardrail:

    assert timestamps["model_called"] <= timestamps["parallel_end"]
    AssertionError: Model called while parallel guardrail still running
    assert 1785804845.201256 <= 1785804845.149035

This is test timing-sensitivity, not a runtime bug. `run.py` creates the model task and the parallel guardrail task before gathering both, and `run_internal/run_loop.py` starts the parallel guardrail task before awaiting `run_single_turn_streamed`; the overlap itself is correct.

This PR drives the overlap with explicit `asyncio.Event` synchronization instead. The parallel guardrail stays in flight until the model call sets `model_called`, and the model call records whether the blocking guardrail had already finished and whether the parallel guardrail was still running. Ordering is now enforced by happens-before edges rather than wall-clock margins, so scheduling latency cannot flip the result. This matches the `asyncio.Event` rendezvous idiom already used elsewhere in this file, for example `test_parallel_guardrail_trip_before_tool_execution_stops_streaming_turn`.

The tests keep their teeth. Forcing `run_in_parallel=True` guardrails to run blocking (patching `run.py` and `run_internal/run_loop.py` so every input guardrail lands in `sequential_guardrails`) makes both tests fail, because the guardrail's wait for the model call is never satisfied and `wait_for` raises. The blocking-before-parallel and blocking-before-model checks are unchanged in intent and still fail if a blocking guardrail stops completing first.

### Test plan

- Reproduced the original flake with `uv run pytest tests/test_guardrails.py -q -n 8 -k mixed_blocking` while saturating the machine with 24 CPU-bound processes: **2 failures across 21 iterations** on `main`, hitting both the streaming and non-streaming variant.
- Same load, same command, with this change: **0 failures across 15 iterations**.
- Regression check: temporarily forced parallel input guardrails to run blocking; both tests fail with `TimeoutError` from the guardrail rendezvous. Reverted afterwards.
- No runtime cost on the passing path: with deterministic ordering (`-p no:randomly`) the streaming test takes 0.11s before and after, so the 1s timeout is never approached.
- `bash .agents/skills/code-change-verification/scripts/run.sh` — all commands passed (`make format`, `make lint`, `make typecheck`, `make tests`).

Only `tests/test_guardrails.py` is touched; no runtime code changes.

### Issue number

N/A — flake found while running the suite; no existing issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR