### PR TITLE
fix(run): persist the max-turns handler output to the session

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1174,12 +1174,18 @@ class AgentRunner:
                                 if session_input_items_for_persistence is not None
                                 else []
                             )
+                            # The synthesized item is a fresh one-item list, not the
+                            # cumulative turn item list, so the run state's per-turn
+                            # persisted count must not be applied as a slice offset here.
+                            # Pass the reasoning item id policy explicitly instead, the same
+                            # way `save_resumed_turn_items` does.
                             await save_result_to_session(
                                 session,
                                 handler_input_items_for_save,
                                 [synthesized_item],
-                                run_state,
+                                None,
                                 response_id=None,
+                                reasoning_item_id_policy=resolved_reasoning_item_id_policy,
                                 store=store_setting,
                             )
                         result._original_input = copy_input_items(original_input)

--- a/tests/test_max_turns.py
+++ b/tests/test_max_turns.py
@@ -14,6 +14,7 @@ from agents import (
     ModelRefusalError,
     RunErrorHandlerResult,
     Runner,
+    SQLiteSession,
     UserError,
 )
 from agents.stream_events import RunItemStreamEvent
@@ -487,3 +488,62 @@ async def test_streamed_max_turns_handler_list_output():
     assert run_item_events[0].name == "message_output_created"
     assert isinstance(run_item_events[0].item, MessageOutputItem)
     assert ItemHelpers.text_message_output(run_item_events[0].item) == '{"response":["a","b"]}'
+
+
+async def _run_max_turns_handler_with_session(streamed: bool) -> list[str]:
+    """Run one tool turn, trip max turns, and return the session's persisted item types."""
+    model = FakeModel()
+    agent = Agent(
+        name="test_1",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+    )
+    model.add_multiple_turn_outputs(
+        [[get_function_tool_call("some_function", json.dumps({"a": "b"}))]]
+    )
+    session = SQLiteSession("max-turns-handler", ":memory:")
+    try:
+        if streamed:
+            streamed_result = Runner.run_streamed(
+                agent,
+                input="user_message",
+                max_turns=1,
+                session=session,
+                error_handlers={"max_turns": lambda data: "fallback answer"},
+            )
+            async for _ in streamed_result.stream_events():
+                pass
+            assert streamed_result.final_output == "fallback answer"
+        else:
+            run_result = await Runner.run(
+                agent,
+                input="user_message",
+                max_turns=1,
+                session=session,
+                error_handlers={"max_turns": lambda data: "fallback answer"},
+            )
+            assert run_result.final_output == "fallback answer"
+
+        return [str(item.get("type", item.get("role"))) for item in await session.get_items()]
+    finally:
+        session.close()
+
+
+@pytest.mark.asyncio
+async def test_non_streamed_max_turns_handler_persists_output_to_session():
+    """The synthesized max-turns final output must reach the session.
+
+    It is a brand new item, so the per-turn persisted-item count left over from the previous
+    turn must not be applied as an offset into the one-item list handed to the session save.
+    """
+    item_types = await _run_max_turns_handler_with_session(streamed=False)
+
+    assert item_types == ["user", "function_call", "function_call_output", "message"]
+
+
+@pytest.mark.asyncio
+async def test_streamed_max_turns_handler_persists_output_to_session():
+    """The streamed path already persists the synthesized output; keep both paths aligned."""
+    item_types = await _run_max_turns_handler_with_session(streamed=True)
+
+    assert item_types == ["user", "function_call", "function_call_output", "message"]


### PR DESCRIPTION
### Summary

When a `max_turns` run error handler returns a final output with `include_in_history=True`, the non-streamed runner never wrote the synthesized assistant message to the session.

`save_result_to_session` uses `run_state._current_turn_persisted_item_count` as a slice offset into the `new_items` list it is given. That is only valid when the caller passes the cumulative turn item list. The max-turns block passes a fresh one-item list `[synthesized_item]`, and it runs before the per-turn counter reset, so any previous turn that persisted at least one item makes `already_persisted >= len(new_items)` and nothing is saved at all. The next run on that session has no record of the assistant's answer.

The streamed path resets the counter before the max-turns check and persists the item correctly, so the two paths silently disagreed on what ends up in history.

Fix: pass `run_state=None` with an explicit `reasoning_item_id_policy` at that call site, matching what `save_resumed_turn_items` already does for the same "this is not a cumulative turn list" situation. Per-turn counter semantics are untouched everywhere else.

### Test plan

Added a shared helper in `tests/test_max_turns.py` that runs one tool turn, trips `max_turns=1` with a handler returning `include_in_history=True`, and asserts the resulting `SQLiteSession` contents.

- non-streamed: fails on `main` (session is missing the final `message`), passes with the fix
- streamed twin: passes both before and after, locking in the alignment between the two paths

`tests/test_max_turns.py` → 22 passed. `tests/test_agent_runner.py tests/test_run_state.py tests/memory tests/test_hitl_session_scenario.py` → 579 passed. `.agents/skills/code-change-verification/scripts/run.sh` passed.

### Issue number

N/A — found while auditing session persistence parity between the streamed and non-streamed runners.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR