### PR TITLE
fix(realtime): release the websocket when the initial session config fails

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -588,7 +588,14 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
             transport_config=self._transport_config,
         )
         self._websocket_task = asyncio.create_task(self._listen_for_messages())
-        await self._update_session_config(model_settings)
+        try:
+            await self._update_session_config(model_settings)
+        except BaseException:
+            # The websocket and its listener task are owned by this method, so release them
+            # when the initial session config fails. Otherwise the connection stays open and
+            # the model can never be reconnected because of the asserts above.
+            await self.close()
+            raise
 
     async def _create_websocket_connection(
         self,

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -10,7 +10,7 @@ import pytest
 import websockets
 from pydantic import TypeAdapter
 
-from agents import Agent, function_tool
+from agents import Agent, WebSearchTool, function_tool
 from agents.exceptions import UserError
 from agents.handoffs import handoff
 from agents.realtime.model import RealtimeModelConfig
@@ -337,6 +337,30 @@ class TestConnectionLifecycle(TestOpenAIRealtimeWebSocketModel):
         # Verify internal state remains clean after failure
         assert model._websocket is None
         assert model._websocket_task is None
+
+    @pytest.mark.asyncio
+    async def test_connect_session_config_failure_releases_websocket(self, model, mock_websocket):
+        """A failure while sending the initial session config must not leak the connection."""
+        config: RealtimeModelConfig = {
+            "api_key": "test-key",
+            # A hosted tool is rejected by `_tools_to_session_tools`, which runs only after the
+            # websocket is open and the listener task has started.
+            "initial_model_settings": {"tools": [WebSearchTool()]},
+        }
+
+        async def async_websocket(*args, **kwargs):
+            return mock_websocket
+
+        with patch("websockets.connect", side_effect=async_websocket):
+            with pytest.raises(UserError, match="Must be a function tool"):
+                await model.connect(config)
+
+        # The websocket and its listener task are owned by connect(), so a failure after they
+        # were acquired must release them. Otherwise the socket stays open and the model is
+        # permanently unusable because connect() asserts `_websocket is None`.
+        assert model._websocket is None
+        assert model._websocket_task is None
+        mock_websocket.close.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_connect_with_empty_transport_config(self, mock_websocket):


### PR DESCRIPTION
### Summary

`OpenAIRealtimeWebSocketModel.connect()` opens the websocket and starts the listener task, then sends the initial session config. If that send fails, neither the socket nor the task is released.

This is reachable from ordinary agent configuration, not just transport errors: `_tools_to_session_tools` raises `UserError("Tool ... is unsupported. Must be a function tool.")` for any non-`FunctionTool`, and `RealtimeSession._get_updated_model_settings_from_agent` does not reject hosted tools beforehand. So a realtime agent configured with, say, a `WebSearchTool` leaks a live connection. `ensure_tool_choice_supports_backend` and a `ConnectionClosed` on send reach the same point.

The caller cannot clean up after it either. `RealtimeSession.__aenter__` only calls `remove_listener`, and Python does not invoke `__aexit__` when `__aenter__` raises, so the usual `async with await runner.run() as session:` form gives no cleanup hook. On top of the leaked socket and background task, `connect()` opens with `assert self._websocket is None`, so the model instance can never be reconnected.

Fix: wrap the initial `_update_session_config` call and `await self.close()` before re-raising, restoring the same clean state that `test_connect_websocket_failure_propagates` already asserts for a failure one step earlier. `.agents/references/realtime-session-lifecycle.md` states this ownership rule; this is the untested half of it.

### Test plan

Added `test_connect_session_config_failure_releases_websocket`: connects with a `WebSearchTool` in `initial_model_settings`, asserts the `UserError` propagates, and asserts `_websocket is None`, `_websocket_task is None`, and that `close()` was awaited on the socket.

Fails on `main` (`assert <AsyncMock> is None`), passes with the fix. Full `tests/realtime/` suite: 378 passed. `.agents/skills/code-change-verification/scripts/run.sh` passed.

### Issue number

N/A — found while auditing connection ownership on realtime failure paths.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR