### PR TITLE
fix(memory): skip conversation creation on empty add_items

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -107,10 +107,10 @@ class OpenAIConversationsSession(SessionABC):
         return all_items  # type: ignore
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
-        session_id = await self._get_session_id()
         if not items:
             return
 
+        session_id = await self._get_session_id()
         await self._openai_client.conversations.items.create(
             conversation_id=session_id,
             items=items,

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -231,6 +231,30 @@ class TestOpenAIConversationsSessionBasicOperations:
         )
 
     @pytest.mark.asyncio
+    async def test_add_items_empty_does_not_create_session(self, mock_openai_client):
+        """Test that add_items with no items does not create a remote conversation."""
+        session = OpenAIConversationsSession(openai_client=mock_openai_client)
+
+        await session.add_items([])
+
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.items.create.assert_not_called()
+        assert session._session_id is None
+
+    @pytest.mark.asyncio
+    async def test_add_items_empty_keeps_existing_session_id(self, mock_openai_client):
+        """Test that add_items with no items leaves an initialized session untouched."""
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        await session.add_items([])
+
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.items.create.assert_not_called()
+        assert session._session_id == "test_id"
+
+    @pytest.mark.asyncio
     async def test_pop_item_with_items(self, mock_openai_client):
         """Test popping item when items exist using method patching."""
         session = OpenAIConversationsSession(


### PR DESCRIPTION
### Summary

`OpenAIConversationsSession.add_items` called `_get_session_id()` before its `if not items: return` guard. On an uninitialized session that made a no-op write provision a real remote conversation through `conversations.create`, leaving a stray conversation on the OpenAI platform and a session object that now reports as initialized — all as a side effect of writing nothing.

This is the same ordering bug #4111 fixed for `clear_session`. Moving the empty-list guard ahead of session-ID resolution means nothing touches the network when there is nothing to write.

### Test plan

Added `test_add_items_empty_does_not_create_session` and `test_add_items_empty_keeps_existing_session_id` to `tests/memory/test_openai_conversations_session.py`. The first fails on `main` with `Expected 'create' to not have been called. Called 1 times.` and passes with the change. Full file: 35 passed. `.agents/skills/code-change-verification/scripts/run.sh` passed.

### Issue number

N/A — found while auditing session backends for network side effects on no-op writes.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR