### PR TITLE
fix(memory): roll back a failed SQLiteSession insert

### DIFF
--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -288,8 +288,17 @@ class SQLiteSession(SessionABC):
 
         def _add_items_sync():
             with self._locked_connection() as conn:
-                self._insert_items(conn, items)
-                conn.commit()
+                try:
+                    self._insert_items(conn, items)
+                    conn.commit()
+                except Exception:
+                    # _locked_connection() does not manage transactions; roll back
+                    # explicitly so a failure partway through the insert never leaves a
+                    # partial mutation or an open transaction on this cached connection.
+                    # An open write transaction would hold the SQLite write lock for the
+                    # lifetime of the connection and block every later writer.
+                    conn.rollback()
+                    raise
 
         await asyncio.to_thread(_add_items_sync)
 

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -4,6 +4,7 @@ import asyncio
 import sqlite3
 import tempfile
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -691,6 +692,40 @@ async def test_sqlite_session_file_lock_is_shared_across_instances():
         session_2.close()
         assert lock_path not in SQLiteSession._file_lock_counts
         assert lock_path not in SQLiteSession._file_locks
+
+
+@pytest.mark.asyncio
+async def test_sqlite_session_failed_add_items_releases_write_lock():
+    """A failed add_items must not leave an open write transaction on the cached connection."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test_rollback.db"
+        session = SQLiteSession("rollback_test", db_path)
+
+        # json.dumps() fails only after _insert_items() has already opened a write
+        # transaction with the sessions-table upsert.
+        unserializable = cast(TResponseInputItem, {"role": "user", "content": object()})
+        with pytest.raises(TypeError):
+            await session.add_items([unserializable])
+
+        # timeout=0 disables the busy handler, so this raises immediately if the failed
+        # write is still holding the SQLite write lock.
+        probe = sqlite3.connect(str(db_path), timeout=0)
+        try:
+            probe.execute("INSERT INTO agent_sessions (session_id) VALUES ('probe')")
+            probe.commit()
+            rolled_back = probe.execute(
+                "SELECT COUNT(*) FROM agent_sessions WHERE session_id = 'rollback_test'"
+            ).fetchone()[0]
+        finally:
+            probe.close()
+
+        assert rolled_back == 0
+
+        # The session must remain usable after the failure.
+        await session.add_items([{"role": "user", "content": "after failure"}])
+        assert [item.get("content") for item in await session.get_items()] == ["after failure"]
+
+        session.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`_locked_connection()` does not manage transactions, and `SQLiteSession.add_items` had no rollback. When `_insert_items` raised partway — for example `json.dumps()` failing on a non-serializable item, which happens *after* the sessions-table upsert has already opened a write transaction — that transaction was left open on a cached connection (shared for `:memory:`, thread-local for file DBs).

SQLite then held the write lock for the lifetime of that connection, so every later writer against the same file failed with `database is locked`, including the same session called from another thread. The wedge outlives the failed call:

    control (successful add_items): probe write OK
    add_items raised: TypeError Object of type object is not JSON serializable
    after failed add_items: probe write FAILED -> database is locked
    later add_items FAILED -> OperationalError: database is locked

Roll back explicitly on failure, matching what the `AdvancedSQLiteSession` subclass already does for its own multi-statement writes.

### Test plan

Added `test_sqlite_session_failed_add_items_releases_write_lock`, which triggers a mid-insert failure and then writes from an independent `sqlite3` connection opened with `timeout=0` — the busy handler is disabled so a retained lock fails immediately rather than after a 5s wait, keeping the test fast and non-flaky. It fails on `main` with `sqlite3.OperationalError: database is locked` and passes with the change. It also asserts the partial sessions-table row was rolled back and that the session remains usable afterwards.

Full file: 41 passed. `.agents/skills/code-change-verification/scripts/run.sh` passed.

### Issue number

N/A — found while auditing session backends for transaction handling on failure paths.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR