### PR TITLE
fix(extensions): serialize structured tool outputs as JSON when trimming

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -223,7 +223,10 @@ class ToolOutputTrimmer:
     ) -> tuple[dict[str, Any] | None, int]:
         """Trim a function_call_output item when its serialized output is too large."""
         output = item.get("output", "")
-        output_str = output if isinstance(output, str) else str(output)
+        # A function_call_output may carry a list of content parts instead of a string.
+        # Serialize those as JSON so the preview stays readable to the model and the size
+        # check measures the payload rather than its Python repr.
+        output_str = output if isinstance(output, str) else self._serialize_json_like(output)
         output_len = len(output_str)
         if output_len <= self.max_output_chars:
             return None, 0

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -203,6 +203,51 @@ class TestTrimming:
         assert "1000 chars" in trimmed
         assert len(trimmed) < len(large)
 
+    def test_trims_structured_output_as_json(self) -> None:
+        """List-shaped tool outputs should preview as JSON, not as a Python repr."""
+        structured = [{"type": "input_text", "text": "x" * 400}]
+        items = [
+            _user("q1"),
+            _func_call("c1", "search"),
+            {"type": "function_call_output", "call_id": "c1", "output": structured},
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+        trimmer = ToolOutputTrimmer(max_output_chars=100, preview_chars=60)
+        result = trimmer(_make_data(items))
+
+        serialized = json.dumps(structured, ensure_ascii=False, sort_keys=True, default=str)
+        assert _output(result, 2) == (
+            f"[Trimmed: search output — {len(serialized)} chars → 60 char preview]\n"
+            f"{serialized[:60]}..."
+        )
+
+    def test_structured_output_threshold_uses_serialized_size(self) -> None:
+        """The trim threshold should measure the JSON payload, not its Python repr."""
+        # repr leaves the embedded double quotes unescaped, so it under-reports the size
+        # of what actually reaches the model by one character per quote.
+        structured = [{"type": "input_text", "text": 'a"b' * 40}]
+        serialized = json.dumps(structured, ensure_ascii=False, sort_keys=True, default=str)
+        assert len(str(structured)) < 170 < len(serialized)
+
+        items = [
+            _user("q1"),
+            _func_call("c1", "search"),
+            {"type": "function_call_output", "call_id": "c1", "output": structured},
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+        trimmer = ToolOutputTrimmer(max_output_chars=170, preview_chars=40)
+        result = trimmer(_make_data(items))
+
+        assert _output(result, 2).startswith(f"[Trimmed: search output — {len(serialized)} chars")
+
     def test_preserves_small_old_output(self) -> None:
         """Small outputs should never be trimmed."""
         small = "x" * 100


### PR DESCRIPTION
### Summary

A `function_call_output` may carry a list of content parts rather than a string — the SDK produces that shape itself whenever a tool returns `ToolOutputText`, `ToolOutputImage`, or `ToolOutputFileContent` (`ResponseFunctionCallOutputItemListParam`, via `_convert_tool_output_as_structured` in `items.py`). Those items land in session history and flow straight into the trimmer.

`ToolOutputTrimmer._trim_function_call_output` stringified them with `str()`, which caused two problems:

1. The preview handed back to the model was a Python repr (`[{'type': 'input_text', ...}]`) — single-quoted and not valid JSON.
2. The `max_output_chars` check measured the repr instead of the payload. Because repr leaves embedded double quotes unescaped, an output that exceeds the threshold on the wire can measure under it and escape trimming entirely — in the added test, 196 JSON chars measured as 156 against a 170 limit.

Reuse `_serialize_json_like()`, which the sibling `tool_search_output` path already uses and which falls back to `str()` for values JSON cannot encode, so behavior is preserved exactly for non-serializable values. The `isinstance(output, str)` branch is untouched, so all existing string outputs behave identically.

### Test plan

Added `test_trims_structured_output_as_json` (exact-match assertion on the JSON preview) and `test_structured_output_threshold_uses_serialized_size` (the mis-sizing case). Both fail on `main` — the first on a repr-vs-JSON diff, the second with `AttributeError: 'list' object has no attribute 'startswith'` because the item was never trimmed — and pass with the change. Existing string-output tests are unchanged.

Full file: 43 passed. `.agents/skills/code-change-verification/scripts/run.sh` passed.

### Issue number

N/A — found while auditing serialization consistency within `ToolOutputTrimmer`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR