### PR TITLE
test: make timing-sensitive tool and guardrail tests deterministic

### DIFF
--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -493,8 +493,12 @@ async def test_parallel_guardrail_may_not_prevent_tool_execution():
     guardrail_executed = False
     tool_executed = asyncio.Event()
 
+    # Async so the tool body runs on the event-loop thread. A sync tool is dispatched
+    # through asyncio.to_thread, and asyncio.Event is not thread-safe, so setting it
+    # from the worker thread would be the new race. This test covers guardrail/tool
+    # ordering, not sync-tool offloading.
     @function_tool
-    def fast_tool() -> str:
+    async def fast_tool() -> str:
         nonlocal tool_was_executed
         tool_was_executed = True
         tool_executed.set()
@@ -850,8 +854,12 @@ async def test_parallel_guardrail_may_not_prevent_tool_execution_streaming():
     guardrail_executed = False
     tool_executed = asyncio.Event()
 
+    # Async so the tool body runs on the event-loop thread. A sync tool is dispatched
+    # through asyncio.to_thread, and asyncio.Event is not thread-safe, so setting it
+    # from the worker thread would be the new race. This test covers guardrail/tool
+    # ordering, not sync-tool offloading.
     @function_tool
-    def fast_tool() -> str:
+    async def fast_tool() -> str:
         nonlocal tool_was_executed
         tool_was_executed = True
         tool_executed.set()

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -491,11 +491,13 @@ async def test_blocking_guardrail_prevents_agent_execution_streaming():
 async def test_parallel_guardrail_may_not_prevent_tool_execution():
     tool_was_executed = False
     guardrail_executed = False
+    tool_executed = asyncio.Event()
 
     @function_tool
     def fast_tool() -> str:
         nonlocal tool_was_executed
         tool_was_executed = True
+        tool_executed.set()
         return "tool_executed"
 
     @input_guardrail(run_in_parallel=True)
@@ -503,7 +505,9 @@ async def test_parallel_guardrail_may_not_prevent_tool_execution():
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal guardrail_executed
-        await asyncio.sleep(LONG_DELAY)
+        # Trip only after the tool ran. If parallel guardrails gated the turn, this
+        # would deadlock instead of silently losing a wall-clock race.
+        await asyncio.wait_for(tool_executed.wait(), timeout=5)
         guardrail_executed = True
         return GuardrailFunctionOutput(
             output_info="slow_parallel_triggered",
@@ -646,7 +650,8 @@ async def test_model_error_cancels_parallel_input_guardrail_task():
     ) -> GuardrailFunctionOutput:
         guardrail_started.set()
         try:
-            await asyncio.sleep(LONG_DELAY)
+            # Never finishes on its own, so only cancellation can end this guardrail.
+            await asyncio.Event().wait()
             guardrail_finished.set()
             return GuardrailFunctionOutput(
                 output_info="parallel_ok",
@@ -671,7 +676,7 @@ async def test_model_error_cancels_parallel_input_guardrail_task():
 
     with patch.object(model, "get_response", side_effect=boom_get_response):
         with pytest.raises(RuntimeError, match="model boom"):
-            await Runner.run(agent, "trigger guardrail")
+            await asyncio.wait_for(Runner.run(agent, "trigger guardrail"), timeout=5)
 
     # By the time Runner.run returns, the guardrail task must already be
     # cancelled rather than left running to completion in the background.
@@ -703,7 +708,8 @@ async def test_parallel_guardrail_non_tripwire_error_not_swallowed():
     async def slow_get_response(*args, **kwargs):
         model_started.set()
         try:
-            await asyncio.sleep(LONG_DELAY)
+            # Never finishes on its own, so only cancellation can end the model call.
+            await asyncio.Event().wait()
             return await original_get_response(*args, **kwargs)
         except asyncio.CancelledError:
             model_cancelled.set()
@@ -720,7 +726,7 @@ async def test_parallel_guardrail_non_tripwire_error_not_swallowed():
 
     with patch.object(model, "get_response", side_effect=slow_get_response):
         with pytest.raises(ValueError, match="guardrail boom"):
-            await Runner.run(agent, "trigger guardrail")
+            await asyncio.wait_for(Runner.run(agent, "trigger guardrail"), timeout=5)
 
     await asyncio.wait_for(model_finished.wait(), timeout=1)
     assert model_started.is_set() is True
@@ -842,11 +848,13 @@ async def test_model_error_before_guardrail_error_preserves_stream_finalization(
 async def test_parallel_guardrail_may_not_prevent_tool_execution_streaming():
     tool_was_executed = False
     guardrail_executed = False
+    tool_executed = asyncio.Event()
 
     @function_tool
     def fast_tool() -> str:
         nonlocal tool_was_executed
         tool_was_executed = True
+        tool_executed.set()
         return "tool_executed"
 
     @input_guardrail(run_in_parallel=True)
@@ -854,7 +862,9 @@ async def test_parallel_guardrail_may_not_prevent_tool_execution_streaming():
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal guardrail_executed
-        await asyncio.sleep(LONG_DELAY)
+        # Trip only after the tool ran. If parallel guardrails gated the turn, this
+        # would deadlock instead of silently losing a wall-clock race.
+        await asyncio.wait_for(tool_executed.wait(), timeout=5)
         guardrail_executed = True
         return GuardrailFunctionOutput(
             output_info="slow_parallel_triggered_streaming",
@@ -1709,17 +1719,16 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger():
     fast_guardrail_executed = False
     slow_guardrail_executed = False
     slow_guardrail_cancelled = False
-    timestamps = {}
+    slow_guardrail_started = asyncio.Event()
 
     @input_guardrail(run_in_parallel=False)
     async def fast_guardrail_that_triggers(
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal fast_guardrail_executed
-        timestamps["fast_start"] = time.time()
-        await asyncio.sleep(SHORT_DELAY)
+        # Trip only once the sibling is provably in flight and therefore cancellable.
+        await asyncio.wait_for(slow_guardrail_started.wait(), timeout=5)
         fast_guardrail_executed = True
-        timestamps["fast_end"] = time.time()
         return GuardrailFunctionOutput(
             output_info="fast_triggered",
             tripwire_triggered=True,
@@ -1730,18 +1739,17 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger():
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal slow_guardrail_executed, slow_guardrail_cancelled
-        timestamps["slow_start"] = time.time()
+        slow_guardrail_started.set()
         try:
-            await asyncio.sleep(MEDIUM_DELAY)
+            # Never finishes on its own, so only cancellation can end this guardrail.
+            await asyncio.Event().wait()
             slow_guardrail_executed = True
-            timestamps["slow_end"] = time.time()
             return GuardrailFunctionOutput(
                 output_info="slow_completed",
                 tripwire_triggered=False,
             )
         except asyncio.CancelledError:
             slow_guardrail_cancelled = True
-            timestamps["slow_cancelled"] = time.time()
             raise
 
     model = FakeModel()
@@ -1754,7 +1762,7 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger():
     model.set_next_output([get_text_message("hello")])
 
     with pytest.raises(InputGuardrailTripwireTriggered):
-        await Runner.run(agent, "test input")
+        await asyncio.wait_for(Runner.run(agent, "test input"), timeout=5)
 
     # Verify the fast guardrail executed
     assert fast_guardrail_executed is True, "Fast guardrail should have executed"
@@ -1762,19 +1770,6 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger():
     # Verify the slow guardrail was cancelled, not completed
     assert slow_guardrail_cancelled is True, "Slow guardrail should have been cancelled"
     assert slow_guardrail_executed is False, "Slow guardrail should NOT have completed execution"
-
-    # Verify timing: cancellation happened shortly after fast guardrail triggered
-    assert "fast_end" in timestamps
-    assert "slow_cancelled" in timestamps
-    cancellation_delay = timestamps["slow_cancelled"] - timestamps["fast_end"]
-    assert cancellation_delay >= 0, (
-        f"Slow guardrail should be cancelled after fast one completes, "
-        f"but was {cancellation_delay:.2f}s"
-    )
-    assert cancellation_delay < 0.2, (
-        f"Cancellation should happen before the slow guardrail completes, "
-        f"but took {cancellation_delay:.2f}s"
-    )
 
     # Verify agent never started
     assert model.first_turn_args is None, (
@@ -1791,17 +1786,16 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
     fast_guardrail_executed = False
     slow_guardrail_executed = False
     slow_guardrail_cancelled = False
-    timestamps = {}
+    slow_guardrail_started = asyncio.Event()
 
     @input_guardrail(run_in_parallel=False)
     async def fast_guardrail_that_triggers(
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal fast_guardrail_executed
-        timestamps["fast_start"] = time.time()
-        await asyncio.sleep(SHORT_DELAY)
+        # Trip only once the sibling is provably in flight and therefore cancellable.
+        await asyncio.wait_for(slow_guardrail_started.wait(), timeout=5)
         fast_guardrail_executed = True
-        timestamps["fast_end"] = time.time()
         return GuardrailFunctionOutput(
             output_info="fast_triggered",
             tripwire_triggered=True,
@@ -1812,18 +1806,17 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal slow_guardrail_executed, slow_guardrail_cancelled
-        timestamps["slow_start"] = time.time()
+        slow_guardrail_started.set()
         try:
-            await asyncio.sleep(MEDIUM_DELAY)
+            # Never finishes on its own, so only cancellation can end this guardrail.
+            await asyncio.Event().wait()
             slow_guardrail_executed = True
-            timestamps["slow_end"] = time.time()
             return GuardrailFunctionOutput(
                 output_info="slow_completed",
                 tripwire_triggered=False,
             )
         except asyncio.CancelledError:
             slow_guardrail_cancelled = True
-            timestamps["slow_cancelled"] = time.time()
             raise
 
     model = FakeModel()
@@ -1837,9 +1830,12 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
 
     result = Runner.run_streamed(agent, "test input")
 
-    with pytest.raises(InputGuardrailTripwireTriggered):
+    async def consume_stream() -> None:
         async for _event in result.stream_events():
             pass
+
+    with pytest.raises(InputGuardrailTripwireTriggered):
+        await asyncio.wait_for(consume_stream(), timeout=5)
 
     # Verify the fast guardrail executed
     assert fast_guardrail_executed is True, "Fast guardrail should have executed"
@@ -1847,19 +1843,6 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
     # Verify the slow guardrail was cancelled, not completed
     assert slow_guardrail_cancelled is True, "Slow guardrail should have been cancelled"
     assert slow_guardrail_executed is False, "Slow guardrail should NOT have completed execution"
-
-    # Verify timing: cancellation happened shortly after fast guardrail triggered
-    assert "fast_end" in timestamps
-    assert "slow_cancelled" in timestamps
-    cancellation_delay = timestamps["slow_cancelled"] - timestamps["fast_end"]
-    assert cancellation_delay >= 0, (
-        f"Slow guardrail should be cancelled after fast one completes, "
-        f"but was {cancellation_delay:.2f}s"
-    )
-    assert cancellation_delay < 0.2, (
-        f"Cancellation should happen before the slow guardrail completes, "
-        f"but took {cancellation_delay:.2f}s"
-    )
 
     # Verify agent never started
     assert model.first_turn_args is None, (

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -52,7 +52,7 @@ from agents import (
     trace,
 )
 from agents._public_agent import set_public_agent
-from agents.run_internal import run_loop, turn_resolution
+from agents.run_internal import run_loop, tool_execution, turn_resolution
 from agents.run_internal.agent_bindings import bind_execution_agent, bind_public_agent
 from agents.run_internal.run_loop import (
     NextStepFinalOutput,
@@ -2089,15 +2089,23 @@ async def test_multiple_tool_calls_surface_post_invoke_failure_unblocked_during_
 
 
 @pytest.mark.asyncio
-async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_sibling_error():
+async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_sibling_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
     loop = asyncio.get_running_loop()
     original_handler = loop.get_exception_handler()
     unhandled_contexts: list[dict[str, Any]] = []
+    post_invoke_started = asyncio.Event()
+
+    # Widen the post-invoke drain budget so the guardrail delay below stays well inside
+    # it. Otherwise a scheduling hiccup, not the runtime, decides which failure wins.
+    monkeypatch.setattr(tool_execution, "_FUNCTION_TOOL_POST_INVOKE_WAIT_SECONDS", 5.0)
 
     @tool_output_guardrail
     async def sleeping_tripwire_guardrail(
         _data: ToolOutputGuardrailData,
     ) -> ToolGuardrailFunctionOutput:
+        post_invoke_started.set()
         await asyncio.sleep(0.05)
         return ToolGuardrailFunctionOutput.raise_exception(output_info={"status": "sleep-tripwire"})
 
@@ -2105,6 +2113,8 @@ async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_s
         return "ok"
 
     async def _error_tool() -> str:
+        # Fail only once the sibling guardrail is provably in its post-invoke phase.
+        await post_invoke_started.wait()
         raise ValueError("boom")
 
     ok_tool = function_tool(
@@ -2135,7 +2145,7 @@ async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_s
     loop.set_exception_handler(_exception_handler)
     try:
         with pytest.raises(ToolOutputGuardrailTripwireTriggered):
-            await asyncio.wait_for(get_execute_result(agent, response), timeout=0.2)
+            await asyncio.wait_for(get_execute_result(agent, response), timeout=10)
         gc.collect()
         await asyncio.sleep(0)
     finally:
@@ -2150,13 +2160,18 @@ async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_s
 
 @pytest.mark.asyncio
 async def test_multiple_tool_calls_do_not_wait_indefinitely_for_sleeping_post_invoke_sibling():
+    post_invoke_started = asyncio.Event()
+    release_guardrail = asyncio.Event()
     guardrail_finished = asyncio.Event()
 
     @tool_output_guardrail
-    async def long_sleeping_guardrail(
+    async def blocked_post_invoke_guardrail(
         _data: ToolOutputGuardrailData,
     ) -> ToolGuardrailFunctionOutput:
-        await asyncio.sleep(0.3)
+        post_invoke_started.set()
+        # Outlast the post-invoke drain budget by construction: only the test can
+        # release this guardrail, and it does so after the sibling error propagated.
+        await release_guardrail.wait()
         guardrail_finished.set()
         return ToolGuardrailFunctionOutput.allow(output_info="done")
 
@@ -2164,13 +2179,15 @@ async def test_multiple_tool_calls_do_not_wait_indefinitely_for_sleeping_post_in
         return "ok"
 
     async def _error_tool() -> str:
+        # Fail only once the sibling guardrail is provably in its post-invoke phase.
+        await post_invoke_started.wait()
         raise ValueError("boom")
 
     ok_tool = function_tool(
         _ok_tool,
         name_override="ok_tool",
         failure_error_function=None,
-        tool_output_guardrails=[long_sleeping_guardrail],
+        tool_output_guardrails=[blocked_post_invoke_guardrail],
     )
     error_tool = function_tool(
         _error_tool,
@@ -2189,9 +2206,12 @@ async def test_multiple_tool_calls_do_not_wait_indefinitely_for_sleeping_post_in
     )
 
     with pytest.raises(UserError, match="Error running tool error_tool: boom"):
-        await asyncio.wait_for(get_execute_result(agent, response), timeout=0.2)
+        await asyncio.wait_for(get_execute_result(agent, response), timeout=5)
 
-    await asyncio.wait_for(guardrail_finished.wait(), timeout=0.5)
+    # The post-invoke sibling is still pending here, so the failure was raised without
+    # waiting for it, and it must still be allowed to finish in the background.
+    release_guardrail.set()
+    await asyncio.wait_for(guardrail_finished.wait(), timeout=5)
 
 
 @pytest.mark.asyncio
@@ -2401,7 +2421,7 @@ async def test_multiple_tool_calls_raise_late_fatal_sibling_exception_after_canc
     )
 
     with pytest.raises(ToolAborted, match=f"boom-{delay_ticks}"):
-        await asyncio.wait_for(get_execute_result(agent, response), timeout=0.2)
+        await asyncio.wait_for(get_execute_result(agent, response), timeout=5)
 
     assert sibling_cancelled.is_set()
 
@@ -2511,7 +2531,7 @@ async def test_multiple_tool_calls_report_late_cleanup_exception_from_cancelled_
     loop.set_exception_handler(_exception_handler)
     try:
         with pytest.raises(UserError, match="Error running tool error_tool: boom"):
-            await asyncio.wait_for(get_execute_result(agent, response), timeout=0.2)
+            await asyncio.wait_for(get_execute_result(agent, response), timeout=5)
 
         assert cleanup_blocked.is_set()
         release_cleanup.set()


### PR DESCRIPTION
### Summary

Eight async tests decided their assertions by racing two `asyncio.sleep` durations against each other, or against a bounded wait inside the runtime. The cushions were 20-50ms, so on a loaded machine the scheduler — not the code under test — picked the winner.

The runtime genuinely waits `_FUNCTION_TOOL_POST_INVOKE_WAIT_SECONDS = 0.1` for post-invoke siblings before propagating a tool failure, and up to `_FUNCTION_TOOL_CANCELLED_DRAIN_SECONDS = 0.25` for cancelled ones. Tests raced 0.05s and 0.3s sleeps against those budgets and guarded the calls with 0.1-0.2s timeouts, which is below the runtime's own worst case.

Under a 24-process CPU load with `pytest -n 8`, these flipped at roughly 5-20% per file run on `main`. This PR replaces each race with explicit happens-before synchronization:

- **Post-invoke drain tests** gate the failing sibling on an event set by the guardrail, so the guardrail is provably in flight when the error propagates. `...do_not_wait_indefinitely...` now blocks its guardrail on an event the test releases only after the error surfaced, so the sibling outlasts any finite drain budget by construction rather than by a 0.3s sleep. Its counterpart widens the drain budget so a scheduling hiccup cannot decide which failure wins.
- **Parallel input guardrails** trip on an event set by the tool they must not block. A regression that gates the turn now deadlocks and fails loudly instead of quietly losing a 50ms race.
- **Guardrails and model calls that exist to be cancelled** block forever instead of sleeping, so only cancellation can end them. This also removes the `cancellation_delay < 0.2` timestamp assertions that were standing in for that guarantee.

Timeouts kept in these tests are hang guards on causally guaranteed conditions, not margins. Two guards shorter than the runtime's 0.25s cancelled-sibling drain are widened for the same reason: they can fire on a healthy run.

No product code changes. `test_mixed_blocking_and_parallel_guardrails` and its streaming twin are intentionally untouched — they are handled in #4158. The two branches touch disjoint regions of `tests/test_guardrails.py` and merge cleanly in either order.

### Test plan

- Reproduced on `main` with 24 CPU-burner processes and `uv run pytest <file> -q -n 8`: `tests/test_run_step_execution.py` failed 2/35 runs; `tests/test_guardrails.py` failed 3/15 runs across 6 distinct tests.
- Same harness on this branch, 25 runs of both files: zero failures among the changed tests.
- Each changed test was verified to still catch regressions by temporarily removing the behavior it covers and confirming the test fails — the post-invoke drain, its bound, parallel-guardrail non-blocking, sibling cancellation on tripwire, sibling cancellation on non-tripwire failure, late-cleanup reporting, and late-failure merging. All reverted afterwards.
- `.agents/skills/code-change-verification/scripts/run.sh` → `code-change-verification: all commands passed.`

A few tests with similar shapes were examined and deliberately left alone because their margins are causally enforced or are themselves the thing under test — for example the sequential blocking-guardrail ordering asserts (zero margin by construction), and the `elapsed < 0.3` latency budget in `test_cancel_streaming.py`, where the discriminator is 0.1s vs 0.5s.

### Issue number

N/A — found while investigating CI flakiness.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR