### PR TITLE
fix(tracing): name streamed task spans after the run's own workflow

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1972,6 +1972,7 @@ class AgentRunner:
                 conversation_id=conversation_id,
                 session=session,
                 run_state=run_state,
+                trace_workflow_name=trace_workflow_name,
                 is_resumed_state=is_resumed_state,
                 sandbox_runtime=sandbox_runtime,
             )

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -606,6 +606,7 @@ async def start_streaming(
     session: Session | None,
     run_state: RunState[TContext] | None = None,
     *,
+    trace_workflow_name: str,
     is_resumed_state: bool = False,
     sandbox_runtime: SandboxRuntime[TContext] | None = None,
 ):
@@ -628,10 +629,9 @@ async def start_streaming(
             auto_previous_response_id=auto_previous_response_id,
         )
 
-    current_trace = streamed_result.trace or get_current_trace()
     use_task_and_turn_spans = include_task_and_turn_spans(run_config.tracing)
     current_task_span: Span[TaskSpanData] | None = (
-        task_span(name=current_trace.name) if current_trace and use_task_and_turn_spans else None
+        task_span(name=trace_workflow_name) if use_task_and_turn_spans else None
     )
     if current_task_span:
         current_task_span.start(mark_as_current=True)

--- a/tests/test_agent_tracing.py
+++ b/tests/test_agent_tracing.py
@@ -993,6 +993,31 @@ async def test_wrapped_streaming_run_creates_root_task_span():
 
 
 @pytest.mark.asyncio
+async def test_wrapped_run_task_span_uses_run_workflow_name():
+    def _make_agent() -> Agent[None]:
+        return Agent(
+            name="test_agent",
+            model=FakeModel(initial_output=[get_text_message("first_test")]),
+        )
+
+    run_config = RunConfig(workflow_name="inner_workflow")
+
+    with trace(workflow_name="outer_workflow"):
+        await Runner.run(_make_agent(), input="first_test", run_config=run_config)
+        result = Runner.run_streamed(_make_agent(), input="first_test", run_config=run_config)
+        async for _ in result.stream_events():
+            pass
+
+    task_spans = [span.export() for span in fetch_ordered_spans() if span.span_data.type == "task"]
+    # A task span names one Runner invocation, so both runs must use their own workflow name
+    # rather than the enclosing trace's name.
+    assert [span["span_data"]["data"]["name"] for span in task_spans if span] == [
+        "inner_workflow",
+        "inner_workflow",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_wrapped_streaming_run_can_disable_task_and_turn_spans():
     agent = Agent(
         name="test_agent",


### PR DESCRIPTION
### Summary

A task span represents one top-level `Runner` invocation. The non-streaming path names it from the workflow name resolved for that run; the streaming path named it from `streamed_result.trace or get_current_trace()`.

Those two agree only when the run creates its own trace. Inside an existing trace `create_trace_for_run` returns `None`, so `streamed_result.trace` is `None` and the streamed run fell back to the **enclosing** trace's name. An orchestration trace that fans out several streamed sub-runs therefore gets task spans all labelled with the orchestrator's workflow name — indistinguishable from each other and from the outer trace — while the same code run non-streamed labels them correctly. `RunConfig(workflow_name=...)` is effectively ignored for streamed runs nested in a trace.

This passes the already-resolved workflow name into `start_streaming` and uses it, which also drops a `current_trace` guard the non-streaming path never had (that variable existed only to supply the name, and its `None` branch is unreachable — `create_trace_for_run` returns `None` only when `get_current_trace()` is truthy).

`start_streaming` lives in `agents.run_internal` and is not a public export, so the new keyword-only argument is not a public API change. No persisted schema or wire format is affected; only exported telemetry changes, and it changes toward the documented semantics and toward the non-streamed path.

Present in released v0.19.2.

### Test plan

- New `tests/test_agent_tracing.py::test_wrapped_run_task_span_uses_run_workflow_name` runs the same agent non-streamed and streamed inside one outer trace and asserts both task spans use the run's own workflow name. It fails on `main` with `At index 1 diff: 'outer_workflow' != 'inner_workflow'` and passes with this change.
- `uv run pytest tests/test_agent_tracing.py tests/tracing` → 72 passed.
- `bash .agents/skills/code-change-verification/scripts/run.sh` → all commands passed.

### Issue number

N/A — found while auditing tracing parity between the streamed and non-streamed runners.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR