### PR TITLE
docs: fix spelling in GPT-5 example

### DIFF
--- a/examples/basic/hello_world_gpt_5.py
+++ b/examples/basic/hello_world_gpt_5.py
@@ -14,8 +14,8 @@ from agents import Agent, ModelSettings, Runner
 
 async def main():
     agent = Agent(
-        name="Knowledgable GPT-5 Assistant",
-        instructions="You're a knowledgable assistant. You always provide an interesting answer.",
+        name="Knowledgeable GPT-5 Assistant",
+        instructions="You're a knowledgeable assistant. You always provide an interesting answer.",
         model="gpt-5.6-sol",
         model_settings=ModelSettings(
             reasoning=Reasoning(effort="low"),  # "none", "low", "medium", "high", "xhigh"


### PR DESCRIPTION
### Summary

This pull request fixes two misspellings in the GPT-5 basic example's agent name and instructions. It changes `Knowledgable`/`knowledgable` to `Knowledgeable`/`knowledgeable` without altering the example's behavior.

### Test plan

- `uvx codespell examples/basic/hello_world_gpt_5.py`
- `uv run python -m py_compile examples/basic/hello_world_gpt_5.py`
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` with Python 3.12.8
- `git diff --check`

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant (not relevant for this spelling-only change)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
