### PR TITLE
perf: speed up the test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,8 @@ The OpenAI Agents Python repository provides the Python Agents SDK, examples, an
 
 Before submitting changes, ensure relevant checks pass and extend tests when you touch code.
 
+Before adding or changing async, retry, timeout, subprocess, PTY, warning, or xdist-sensitive tests, read [Performance and determinism](tests/README.md#performance-and-determinism) and preserve the applicable behavioral and lifecycle coverage while optimizing execution.
+
 When `$code-change-verification` applies, run it to execute the required verification stack from the repository root. Rerun the full stack after applying fixes.
 
 #### Unit tests and type checking

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ tests-asyncio-stability:
 
 .PHONY: tests-parallel
 tests-parallel:
-	uv run pytest -n auto --dist loadfile -m "not serial"
+	uv run pytest -n auto --dist worksteal -m "not serial"
 
 .PHONY: tests-serial
 tests-serial:

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,31 @@ make tests
 
 `make tests` runs the shard-safe suite in parallel and then runs tests marked `serial` in a separate serial pass.
 
+## Performance and determinism
+
+Tests should wait for observable state transitions rather than elapsed wall-clock time. Preserve the behavior and lifecycle branches under test when removing waits; a faster test is not equivalent if it replaces an active state with a completed state or bypasses the production finalization path.
+
+Use these guidelines when adding or changing tests:
+
+- Use events, deterministic fakes, immediate exceptions, and narrowly scoped mocks instead of real sleeps or retry backoff when elapsed time is not the behavior under test.
+- Keep a real timeout or delay only when its duration semantics are the contract being tested. Use the smallest focused value that distinguishes the expected behavior.
+- Preserve active, completed, failure, cancellation, and cleanup coverage as applicable. Release blocked tasks and clean up sessions, processes, and other resources in `finally` blocks so failed assertions cannot hang the suite.
+- Parameterize cases that share the same setup, execution path, and assertions. Give each case a descriptive ID, and keep separate tests when their lifecycle or failure invariants differ.
+- Capture expected warnings in the narrowest test with the specific warning category and a stable message match. Do not hide unrelated warnings with a global filter.
+- Preserve subprocess isolation when import state, registration, shutdown, or interpreter lifecycle is under test. Instrument the exact side effect, such as construction or registration, instead of scanning the heap or waiting for it to occur.
+- Run independent read-only subprocess or filesystem probes with bounded concurrency when useful. Keep cases that mutate shared fixtures, scripts, environment, ports, or external services sequential.
+- Keep parallel tests shard-safe: avoid shared mutable global state, fixed writable paths, order dependence, and uncoordinated external resources. Mark a test `serial` only when isolation cannot express its required behavior.
+- Keep timing and scheduler patches local to the test context, and continue exercising the production decision, retry, finalization, or cleanup path rather than replacing it wholesale.
+
+Measure performance changes with both focused and broad runs:
+
+```bash
+uv run pytest tests/path/to/test_file.py --durations=10
+uv run pytest -n auto --dist worksteal -m "not serial" --durations=20
+```
+
+Compare test counts, skips, warnings, assertions, and lifecycle coverage as well as elapsed time. Full-suite wall-clock results depend on host load and worker scheduling, so treat repeated focused measurements as the stronger evidence for an individual optimization. Run the repository's required verification stack after the final test changes.
+
 ## Snapshots
 
 We use [inline-snapshots](https://15r10nk.github.io/inline-snapshot/latest/) for some tests. If your code adds new snapshot tests or breaks existing ones, you can fix/create them. After fixing/creating snapshots, run `make tests` again to verify the tests pass.

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -602,18 +602,14 @@ class TestBlaxelSandboxSession:
         from agents.extensions.sandbox.blaxel.sandbox import BlaxelTimeouts
 
         state = _make_state()
-        state.timeouts = BlaxelTimeouts(exec_timeout_s=1)
+        state.timeouts = BlaxelTimeouts.model_construct(exec_timeout_s=0.01)
         session = _make_session(fake_sandbox, state=state)
-
-        async def _raise_timeout(*args: object, **kw: object) -> None:
-            raise asyncio.TimeoutError
-
-        fake_sandbox.process.exec = _raise_timeout  # type: ignore[assignment]
+        fake_sandbox.process.delay = 10.0
 
         with pytest.raises(ExecTimeoutError) as exc_info:
             await session._exec_internal("sleep", "100")
 
-        assert exc_info.value.timeout_s == 1.0
+        assert exc_info.value.timeout_s == 0.01
 
     @pytest.mark.asyncio
     async def test_stop_calls_pty_terminate(self, fake_sandbox: _FakeSandboxInstance) -> None:
@@ -1729,23 +1725,14 @@ class TestPtyExec:
         from agents.extensions.sandbox.blaxel import sandbox as mod
 
         session = _make_session(fake_sandbox)
-        ws = _FakeWS()
-
-        async def _wait_for_cancellation(entry: object) -> None:
-            await asyncio.Event().wait()
+        output_msg = json.dumps({"type": "output", "data": "still running"})
+        ws = _FakeWS(messages=[_FakeWSMessage(_FakeAiohttp.WSMsgType.TEXT, output_msg)])
 
         try:
-            with (
-                patch.object(mod, "_import_aiohttp", return_value=_FakeAiohttp(ws=ws)),
-                patch.object(session, "_pty_ws_reader", side_effect=_wait_for_cancellation),
-                patch.object(
-                    session,
-                    "_collect_pty_output",
-                    new=AsyncMock(return_value=(b"", None)),
-                ),
-            ):
-                update = await session.pty_exec_start("echo", "hello")
+            with patch.object(mod, "_import_aiohttp", return_value=_FakeAiohttp(ws=ws)):
+                update = await session.pty_exec_start("echo", "hello", yield_time_s=0.01)
 
+            assert b"still running" in update.output
             assert update.process_id is not None
             assert session._pty_sessions[update.process_id].ws is ws
         finally:
@@ -1782,7 +1769,7 @@ class TestPtyExec:
         from agents.extensions.sandbox.blaxel.sandbox import BlaxelTimeouts
 
         state = _make_state()
-        state.timeouts = BlaxelTimeouts(exec_timeout_s=1)
+        state.timeouts = BlaxelTimeouts.model_construct(exec_timeout_s=0.01)
         session = _make_session(fake_sandbox, state=state)
 
         class _SlowAiohttp:
@@ -1791,7 +1778,7 @@ class TestPtyExec:
             def ClientSession(self) -> Any:
                 class _SlowSession:
                     async def ws_connect(self, url: str) -> None:
-                        raise asyncio.TimeoutError
+                        await asyncio.sleep(100)
 
                     async def close(self) -> None:
                         pass
@@ -1802,7 +1789,7 @@ class TestPtyExec:
             with pytest.raises(ExecTimeoutError) as exc_info:
                 await session.pty_exec_start("echo", "hello")
 
-        assert exc_info.value.timeout_s == 1.0
+        assert exc_info.value.timeout_s == 0.01
 
     @pytest.mark.asyncio
     async def test_pty_exec_start_connection_error(

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -29,6 +29,7 @@ from agents.sandbox.errors import (
     WorkspaceReadNotFoundError,
     WorkspaceWriteTypeError,
 )
+from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.snapshot import NoopSnapshot
 from agents.sandbox.types import ExposedPortEndpoint
 from agents.sandbox.util.tar_utils import validate_tar_bytes
@@ -351,14 +352,17 @@ class TestBlaxelSandboxSession:
 
     @pytest.mark.asyncio
     async def test_exec_transport_error(self, fake_sandbox: _FakeSandboxInstance) -> None:
+        from agents.extensions.sandbox.blaxel import sandbox as mod
+
         session = _make_session(fake_sandbox)
 
         async def _raise(*args: object, **kw: object) -> None:
             raise ConnectionError("transport error")
 
         fake_sandbox.process.exec = _raise  # type: ignore[assignment]
-        with pytest.raises(ExecTransportError) as exc_info:
-            await session._exec_internal("echo", "hello")
+        with patch.object(mod, "_import_sandbox_api_error", return_value=None):
+            with pytest.raises(ExecTransportError) as exc_info:
+                await session._exec_internal("echo", "hello")
         assert str(exc_info.value) == "Blaxel exec failed: ConnectionError: transport error"
         assert exc_info.value.context["backend"] == "blaxel"
         assert exc_info.value.context["provider_error"] == "ConnectionError: transport error"
@@ -600,7 +604,11 @@ class TestBlaxelSandboxSession:
         state = _make_state()
         state.timeouts = BlaxelTimeouts(exec_timeout_s=1)
         session = _make_session(fake_sandbox, state=state)
-        fake_sandbox.process.delay = 10.0
+
+        async def _raise_timeout(*args: object, **kw: object) -> None:
+            raise asyncio.TimeoutError
+
+        fake_sandbox.process.exec = _raise_timeout  # type: ignore[assignment]
 
         with pytest.raises(ExecTimeoutError) as exc_info:
             await session._exec_internal("sleep", "100")
@@ -1572,15 +1580,10 @@ class TestStartLifecycle:
             raise ConnectionError("mkdir failed")
 
         fake_sandbox.process.exec = _raise  # type: ignore[assignment]
-        # start() should suppress the mkdir error and call super().start().
-        # super().start() will try to materialize the manifest, which may
-        # also call process.exec. We just verify it does not raise from the
-        # initial mkdir.
-        try:
+        with patch.object(BaseSandboxSession, "start", new_callable=AsyncMock) as base_start:
             await session.start()
-        except Exception:
-            # May fail in super().start() but not from the mkdir.
-            pass
+
+        base_start.assert_awaited_once_with()
 
 
 # ---------------------------------------------------------------------------
@@ -1656,21 +1659,97 @@ class _FakeAiohttp:
 
 
 class TestPtyExec:
+    @pytest.mark.parametrize(
+        ("messages", "expected_output"),
+        [
+            pytest.param(
+                [
+                    _FakeWSMessage(
+                        _FakeAiohttp.WSMsgType.TEXT,
+                        json.dumps({"type": "output", "data": "hello from pty"}),
+                    )
+                ],
+                b"hello from pty",
+                id="text",
+            ),
+            pytest.param(
+                [
+                    _FakeWSMessage(
+                        _FakeAiohttp.WSMsgType.BINARY,
+                        json.dumps({"type": "output", "data": "binary-data"}).encode(),
+                    )
+                ],
+                b"binary-data",
+                id="binary",
+            ),
+            pytest.param(
+                [
+                    _FakeWSMessage(
+                        _FakeAiohttp.WSMsgType.TEXT,
+                        json.dumps({"Type": "output", "Data": "cap-data"}),
+                    )
+                ],
+                b"cap-data",
+                id="capitalized-keys",
+            ),
+            pytest.param(
+                [
+                    _FakeWSMessage(_FakeAiohttp.WSMsgType.TEXT, "not json"),
+                    _FakeWSMessage(
+                        _FakeAiohttp.WSMsgType.TEXT,
+                        json.dumps({"type": "output", "data": "valid"}),
+                    ),
+                ],
+                b"valid",
+                id="invalid-json-ignored",
+            ),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_pty_exec_start_success(self, fake_sandbox: _FakeSandboxInstance) -> None:
+    async def test_pty_exec_start_decodes_output_messages(
+        self,
+        fake_sandbox: _FakeSandboxInstance,
+        messages: list[_FakeWSMessage],
+        expected_output: bytes,
+    ) -> None:
         from agents.extensions.sandbox.blaxel import sandbox as mod
 
-        output_msg = json.dumps({"type": "output", "data": "hello from pty"})
-        ws = _FakeWS(messages=[_FakeWSMessage(_FakeAiohttp.WSMsgType.TEXT, output_msg)])
+        ws = _FakeWS(messages=[*messages, _FakeWSMessage(_FakeAiohttp.WSMsgType.CLOSE, "")])
         fake_aiohttp = _FakeAiohttp(ws=ws)
-
         session = _make_session(fake_sandbox)
 
         with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
             update = await session.pty_exec_start("echo", "hello", yield_time_s=0.5)
-            assert update.output is not None
-            assert b"hello from pty" in update.output
-            # process_id may be None if the reader finishes before finalize (entry.done=True).
+            assert expected_output in update.output
+
+    @pytest.mark.asyncio
+    async def test_pty_exec_start_preserves_active_session(
+        self, fake_sandbox: _FakeSandboxInstance
+    ) -> None:
+        from agents.extensions.sandbox.blaxel import sandbox as mod
+
+        session = _make_session(fake_sandbox)
+        ws = _FakeWS()
+
+        async def _wait_for_cancellation(entry: object) -> None:
+            await asyncio.Event().wait()
+
+        try:
+            with (
+                patch.object(mod, "_import_aiohttp", return_value=_FakeAiohttp(ws=ws)),
+                patch.object(session, "_pty_ws_reader", side_effect=_wait_for_cancellation),
+                patch.object(
+                    session,
+                    "_collect_pty_output",
+                    new=AsyncMock(return_value=(b"", None)),
+                ),
+            ):
+                update = await session.pty_exec_start("echo", "hello")
+
+            assert update.process_id is not None
+            assert session._pty_sessions[update.process_id].ws is ws
+        finally:
+            await session.pty_terminate_all()
 
     @pytest.mark.asyncio
     async def test_pty_exec_start_timeout(self, fake_sandbox: _FakeSandboxInstance) -> None:
@@ -1712,7 +1791,7 @@ class TestPtyExec:
             def ClientSession(self) -> Any:
                 class _SlowSession:
                     async def ws_connect(self, url: str) -> None:
-                        await asyncio.sleep(100)
+                        raise asyncio.TimeoutError
 
                     async def close(self) -> None:
                         pass
@@ -1750,8 +1829,20 @@ class TestPtyExec:
             with pytest.raises(ExecTransportError):
                 await session.pty_exec_start("echo", "hello")
 
+    @pytest.mark.parametrize(
+        ("chars", "expected_send_count"),
+        [
+            pytest.param("input\n", 1, id="input"),
+            pytest.param("", 0, id="empty"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_pty_write_stdin(self, fake_sandbox: _FakeSandboxInstance) -> None:
+    async def test_pty_write_stdin_sends_only_nonempty_input(
+        self,
+        fake_sandbox: _FakeSandboxInstance,
+        chars: str,
+        expected_send_count: int,
+    ) -> None:
         from agents.extensions.sandbox.blaxel import sandbox as mod
         from agents.extensions.sandbox.blaxel.sandbox import _BlaxelPtySessionEntry
 
@@ -1765,31 +1856,28 @@ class TestPtyExec:
         session._pty_sessions[1] = entry
         session._reserved_pty_process_ids.add(1)
 
-        with patch.object(mod, "_import_aiohttp", return_value=_FakeAiohttp()):
-            update = await session.pty_write_stdin(session_id=1, chars="input\n", yield_time_s=0.2)
+        try:
+            with (
+                patch.object(mod, "_import_aiohttp", return_value=_FakeAiohttp()),
+                patch.object(asyncio, "sleep", new=AsyncMock()),
+                patch.object(
+                    session,
+                    "_collect_pty_output",
+                    new=AsyncMock(return_value=(b"", None)),
+                ),
+            ):
+                update = await session.pty_write_stdin(
+                    session_id=1,
+                    chars=chars,
+                    yield_time_s=0.2,
+                )
+
             assert update.output is not None
-            assert len(ws._sent) == 1
-
-    @pytest.mark.asyncio
-    async def test_pty_write_stdin_empty_chars(self, fake_sandbox: _FakeSandboxInstance) -> None:
-        from agents.extensions.sandbox.blaxel import sandbox as mod
-        from agents.extensions.sandbox.blaxel.sandbox import _BlaxelPtySessionEntry
-
-        session = _make_session(fake_sandbox)
-        ws = _FakeWS()
-        entry = _BlaxelPtySessionEntry(
-            ws_session_id="empty-write",
-            ws=ws,
-            http_session=_FakeHTTPSession(ws),
-        )
-        session._pty_sessions[1] = entry
-        session._reserved_pty_process_ids.add(1)
-
-        with patch.object(mod, "_import_aiohttp", return_value=_FakeAiohttp()):
-            update = await session.pty_write_stdin(session_id=1, chars="", yield_time_s=0.2)
-            assert update.output is not None
-            # Empty chars should not send anything.
-            assert len(ws._sent) == 0
+            assert update.process_id == 1
+            assert session._pty_sessions[1] is entry
+            assert len(ws._sent) == expected_send_count
+        finally:
+            await session.pty_terminate_all()
 
     @pytest.mark.asyncio
     async def test_pty_terminate_all(self, fake_sandbox: _FakeSandboxInstance) -> None:
@@ -1825,19 +1913,6 @@ class TestPtyExec:
             assert b"something failed" in update.output
 
     @pytest.mark.asyncio
-    async def test_pty_ws_reader_binary_message(self, fake_sandbox: _FakeSandboxInstance) -> None:
-        from agents.extensions.sandbox.blaxel import sandbox as mod
-
-        output_msg = json.dumps({"type": "output", "data": "binary-data"}).encode()
-        ws = _FakeWS(messages=[_FakeWSMessage(_FakeAiohttp.WSMsgType.BINARY, output_msg)])
-        fake_aiohttp = _FakeAiohttp(ws=ws)
-        session = _make_session(fake_sandbox)
-
-        with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
-            update = await session.pty_exec_start("echo", "test", yield_time_s=0.5)
-            assert b"binary-data" in update.output
-
-    @pytest.mark.asyncio
     async def test_pty_ws_reader_close_message(self, fake_sandbox: _FakeSandboxInstance) -> None:
         from agents.extensions.sandbox.blaxel import sandbox as mod
 
@@ -1855,27 +1930,6 @@ class TestPtyExec:
         with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
             update = await session.pty_exec_start("echo", "test", yield_time_s=0.5)
             assert b"hi" in update.output
-
-    @pytest.mark.asyncio
-    async def test_pty_ws_reader_invalid_json(self, fake_sandbox: _FakeSandboxInstance) -> None:
-        from agents.extensions.sandbox.blaxel import sandbox as mod
-
-        ws = _FakeWS(
-            messages=[
-                _FakeWSMessage(_FakeAiohttp.WSMsgType.TEXT, "not json"),
-                _FakeWSMessage(
-                    _FakeAiohttp.WSMsgType.TEXT,
-                    json.dumps({"type": "output", "data": "valid"}),
-                ),
-            ]
-        )
-        fake_aiohttp = _FakeAiohttp(ws=ws)
-        session = _make_session(fake_sandbox)
-
-        with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
-            update = await session.pty_exec_start("echo", "test", yield_time_s=0.5)
-            # Invalid JSON should be silently ignored; valid output should appear.
-            assert b"valid" in update.output
 
     @pytest.mark.asyncio
     async def test_pty_ws_reader_error_type_message(
@@ -2000,32 +2054,15 @@ class TestPtyExec:
                     _FakeAiohttp.WSMsgType.TEXT,
                     json.dumps({"type": "output", "data": "quick"}),
                 ),
+                _FakeWSMessage(_FakeAiohttp.WSMsgType.CLOSE, ""),
             ]
         )
         fake_aiohttp = _FakeAiohttp(ws=ws)
         session = _make_session(fake_sandbox)
 
         with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
-            # Pass yield_time_s=None to test default (10s), but with a short timeout.
-            # We use a small timeout to not wait 10 seconds.
-            update = await session.pty_exec_start("echo", "test", yield_time_s=0.1)
+            update = await session.pty_exec_start("echo", "test")
             assert b"quick" in update.output
-
-    @pytest.mark.asyncio
-    async def test_pty_ws_reader_capital_type_keys(
-        self, fake_sandbox: _FakeSandboxInstance
-    ) -> None:
-        from agents.extensions.sandbox.blaxel import sandbox as mod
-
-        # Test the alternative capitalized key paths (Type/Data).
-        output_msg = json.dumps({"Type": "output", "Data": "cap-data"})
-        ws = _FakeWS(messages=[_FakeWSMessage(_FakeAiohttp.WSMsgType.TEXT, output_msg)])
-        fake_aiohttp = _FakeAiohttp(ws=ws)
-        session = _make_session(fake_sandbox)
-
-        with patch.object(mod, "_import_aiohttp", return_value=fake_aiohttp):
-            update = await session.pty_exec_start("echo", "test", yield_time_s=0.5)
-            assert b"cap-data" in update.output
 
     @pytest.mark.asyncio
     async def test_pty_max_output_tokens(self, fake_sandbox: _FakeSandboxInstance) -> None:
@@ -2033,7 +2070,12 @@ class TestPtyExec:
 
         long_output = "x" * 10000
         output_msg = json.dumps({"type": "output", "data": long_output})
-        ws = _FakeWS(messages=[_FakeWSMessage(_FakeAiohttp.WSMsgType.TEXT, output_msg)])
+        ws = _FakeWS(
+            messages=[
+                _FakeWSMessage(_FakeAiohttp.WSMsgType.TEXT, output_msg),
+                _FakeWSMessage(_FakeAiohttp.WSMsgType.CLOSE, ""),
+            ]
+        )
         fake_aiohttp = _FakeAiohttp(ws=ws)
         session = _make_session(fake_sandbox)
 
@@ -2554,6 +2596,7 @@ class TestFinalCoverageGaps:
                     _FakeAiohttp.WSMsgType.TEXT,
                     json.dumps({"type": "output", "data": "pruned-test"}),
                 ),
+                _FakeWSMessage(_FakeAiohttp.WSMsgType.CLOSE, ""),
             ]
         )
         fake_aiohttp = _FakeAiohttp(ws=ws)
@@ -2587,6 +2630,7 @@ class TestFinalCoverageGaps:
                     _FakeAiohttp.WSMsgType.TEXT,
                     json.dumps({"type": "output", "data": "warn-test"}),
                 ),
+                _FakeWSMessage(_FakeAiohttp.WSMsgType.CLOSE, ""),
             ]
         )
         fake_aiohttp = _FakeAiohttp(ws=ws)

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -292,7 +292,7 @@ class ConcurrentCancellationSession:
         if tool_name == "slow":
             self._slow_task = cast(asyncio.Task[CallToolResult], asyncio.current_task())
             self._slow_started.set()
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             return CallToolResult(content=[])
 
         await self._slow_started.wait()
@@ -384,6 +384,7 @@ class DummyStreamableHttpServer(MCPServerStreamableHttp):
             params={"url": "https://example.test/mcp"},
             client_session_timeout_seconds=None,
             max_retry_attempts=0,
+            retry_backoff_seconds_base=0,
         )
         self.session = cast(ClientSession, shared_session)
         self._isolated_session = cast(ClientSession, isolated_session)
@@ -597,7 +598,7 @@ class OverlapTrackingSession:
         self.in_flight += 1
         self.max_in_flight = max(self.max_in_flight, self.in_flight)
         try:
-            await asyncio.sleep(0.02)
+            await asyncio.sleep(0)
             yield
         finally:
             self.in_flight -= 1

--- a/tests/sandbox/test_session_utils.py
+++ b/tests/sandbox/test_session_utils.py
@@ -6,6 +6,7 @@ import shlex
 import subprocess
 import sys
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -353,17 +354,24 @@ def test_read_path_probe_resolves_symlinks_before_classifying_missing(tmp_path: 
         )
         return result.returncode
 
-    assert probe(dangling) == 1
-    assert probe(invalid_target) == 2
-    assert probe(dangling_parent / "child") == 1
-    assert probe(invalid_parent / "child") == 2
-    assert probe(loop) == 2
-    assert probe(newline_link) == 0
-    assert probe(workspace / "[a]") == 1
-    assert probe(workspace / "?") == 1
-    assert probe(workspace / "*") == 1
-    assert probe(workspace.joinpath(*symlink_parts, "missing")) == 2
-    assert probe(workspace / ("x" * 256)) == 2
+    probe_cases = [
+        (dangling, 1),
+        (invalid_target, 2),
+        (dangling_parent / "child", 1),
+        (invalid_parent / "child", 2),
+        (loop, 2),
+        (newline_link, 0),
+        (workspace / "[a]", 1),
+        (workspace / "?", 1),
+        (workspace / "*", 1),
+        (workspace.joinpath(*symlink_parts, "missing"), 2),
+        (workspace / ("x" * 256), 2),
+    ]
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = executor.map(probe, (path for path, _expected in probe_cases))
+
+    for (path, expected), actual in zip(probe_cases, results, strict=True):
+        assert actual == expected, f"unexpected probe result for {path}"
 
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1,9 +1,10 @@
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from enum import Enum
 from typing import Annotated, Any, Literal
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
+from pydantic.json_schema import PydanticJsonSchemaWarning
 from typing_extensions import TypedDict
 
 from agents import RunContextWrapper, function_tool
@@ -1101,31 +1102,38 @@ _ELEMENTWISE_DEFAULT = _ElementwiseEqual()
 _ALWAYS_EQUAL_DEFAULT = _AlwaysEqual()
 
 
-def test_default_with_elementwise_eq_does_not_crash():
-    """Defaults must be compared to the inspect sentinel by identity: a numpy-style
-    default whose ``==`` returns a non-boolean container used to crash schema creation."""
+def _function_with_elementwise_default(x: int, value: Any = _ELEMENTWISE_DEFAULT) -> int:
+    return x
 
-    def score(x: int, weights: Any = _ELEMENTWISE_DEFAULT) -> int:
-        return x
 
-    fs = function_schema(score, strict_json_schema=False)
-    assert "weights" not in fs.params_json_schema.get("required", [])
+def _function_with_always_equal_default(x: int, value: Any = _ALWAYS_EQUAL_DEFAULT) -> int:
+    return x
+
+
+@pytest.mark.parametrize(
+    ("func", "default_type"),
+    [
+        pytest.param(
+            _function_with_elementwise_default,
+            _ElementwiseEqual,
+            id="elementwise-equality",
+        ),
+        pytest.param(
+            _function_with_always_equal_default,
+            _AlwaysEqual,
+            id="always-true-equality",
+        ),
+    ],
+)
+def test_default_equality_is_not_used_for_sentinel_comparison(
+    func: Callable[..., Any], default_type: type[Any]
+) -> None:
+    """Defaults with non-boolean or always-true equality remain optional and are preserved."""
+    with pytest.warns(PydanticJsonSchemaWarning, match="is not JSON serializable"):
+        fs = function_schema(func, strict_json_schema=False)
+
+    assert fs.params_json_schema.get("required", []) == ["x"]
 
     parsed = fs.params_pydantic_model(x=1)
     args, kwargs = fs.to_call_args(parsed)
-    assert isinstance((args + list(kwargs.values()))[-1], _ElementwiseEqual)
-
-
-def test_default_with_always_true_eq_stays_optional():
-    """A default whose ``__eq__`` answers True used to be mistaken for the no-default
-    sentinel, silently marking the parameter required and discarding the default."""
-
-    def strip(text: str, punctuation: Any = _ALWAYS_EQUAL_DEFAULT) -> str:
-        return text
-
-    fs = function_schema(strip, strict_json_schema=False)
-    assert fs.params_json_schema.get("required", []) == ["text"]
-
-    parsed = fs.params_pydantic_model(text="hi")
-    args, kwargs = fs.to_call_args(parsed)
-    assert isinstance((args + list(kwargs.values()))[-1], _AlwaysEqual)
+    assert isinstance((args + list(kwargs.values()))[-1], default_type)

--- a/tests/tracing/test_import_side_effects.py
+++ b/tests/tracing/test_import_side_effects.py
@@ -36,20 +36,27 @@ def _run_python(script: str) -> dict[str, object]:
 def test_import_agents_has_no_tracing_side_effects() -> None:
     payload = _run_python(
         """
-import gc
 import json
 import httpx
 
-clients_before = sum(1 for obj in gc.get_objects() if isinstance(obj, httpx.Client))
+client_init_calls = 0
+original_client_init = httpx.Client.__init__
+
+def tracking_client_init(self, *args, **kwargs):
+    global client_init_calls
+    client_init_calls += 1
+    original_client_init(self, *args, **kwargs)
+
+httpx.Client.__init__ = tracking_client_init
+
 import agents  # noqa: F401
 from agents.tracing import processors as tracing_processors
 from agents.tracing import setup as tracing_setup
-clients_after = sum(1 for obj in gc.get_objects() if isinstance(obj, httpx.Client))
 
 print(
     json.dumps(
         {
-            "client_delta": clients_after - clients_before,
+            "client_init_calls": client_init_calls,
             "provider_initialized": tracing_setup.GLOBAL_TRACE_PROVIDER is not None,
             "exporter_initialized": tracing_processors._global_exporter is not None,
             "processor_initialized": tracing_processors._global_processor is not None,
@@ -60,7 +67,7 @@ print(
 """
     )
 
-    assert payload["client_delta"] == 0
+    assert payload["client_init_calls"] == 0
     assert payload["provider_initialized"] is False
     assert payload["exporter_initialized"] is False
     assert payload["processor_initialized"] is False


### PR DESCRIPTION
This pull request improves test-suite performance while preserving and, in some cases, strengthening existing behavioral coverage.

It updates pytest-xdist scheduling from `loadfile` to `worksteal`, consolidates related cases with parameterization, replaces unnecessary wall-clock waits with deterministic test doubles, and runs independent read-only shell probes concurrently. It also captures the two expected Pydantic non-serializable-default warnings locally instead of emitting them during the full test run.

Local results on the same machine included:

- Non-serial full suite: 53.85s → 28.71s, approximately 47% faster. This measurement is load-dependent.
- Blaxel test file: 5.24s → 1.14s.
- Import side-effect tests: 10.60s → 5.55s.
- Read-path shell probe: 1.46s → 0.75s.
- MCP retry tests: eliminated two fixed one-second backoff waits; the full file now runs in 0.14s.
- Test warnings: 2 → 0.

The final verification completed successfully with formatting, linting, type checking, parallel tests, and the serial test pass.