### PR TITLE
fix(memory): enforce closed state in MongoDBSession

### DIFF
--- a/src/agents/extensions/memory/mongodb_session.py
+++ b/src/agents/extensions/memory/mongodb_session.py
@@ -139,6 +139,7 @@ class MongoDBSession(SessionABC):
         )
         self._client = client
         self._owns_client = False
+        self._closed = False
 
         client.append_metadata(_DRIVER_INFO)
 
@@ -219,6 +220,11 @@ class MongoDBSession(SessionABC):
                 weakref.finalize(self._client, self._init_state.pop, self._client_id, None)
             per_client[self._init_sub_key] = True
 
+    def _check_not_closed(self) -> None:
+        """Raise if the session has already been closed."""
+        if self._closed:
+            raise RuntimeError("MongoDBSession is closed")
+
     async def _ensure_indexes(self) -> None:
         """Create required indexes the first time this (client, sub_key) is accessed.
 
@@ -226,7 +232,12 @@ class MongoDBSession(SessionABC):
         from different coroutines or event loops are safe — at most a redundant
         round-trip is issued.  The threading-lock-guarded boolean prevents that
         extra round-trip after the first call completes.
+
+        Every operation goes through here, so this is also where a closed session
+        is rejected.
         """
+        self._check_not_closed()
+
         if self._is_init_done():
             return
 
@@ -312,6 +323,10 @@ class MongoDBSession(SessionABC):
         Args:
             items: List of input items to append to the session.
         """
+        # Checked before the empty-list fast path, which would otherwise return
+        # successfully on a closed session.
+        self._check_not_closed()
+
         if not items:
             return
 
@@ -385,18 +400,32 @@ class MongoDBSession(SessionABC):
         """Close the underlying MongoDB connection.
 
         Only closes the client if this session owns it (i.e. it was created
-        via :meth:`from_uri`).  If the client was injected externally the
-        caller is responsible for managing its lifecycle.
+        via :meth:`from_uri`).  In that case the session becomes terminal and
+        subsequent operations raise ``RuntimeError``.  If the client was injected
+        externally the caller is responsible for managing its lifecycle and this
+        is a no-op.
+
+        The session is terminal from the first close attempt.  If releasing the
+        client fails or is cancelled, operations still raise and a later close()
+        retries the release, which ``AsyncMongoClient.close`` allows.
         """
-        if self._owns_client:
-            await self._client.close()
+        if not self._owns_client:
+            return
+
+        self._closed = True
+        await self._client.close()
 
     async def ping(self) -> bool:
         """Test MongoDB connectivity.
 
         Returns:
             ``True`` if the server is reachable, ``False`` otherwise.
+
+        Raises:
+            RuntimeError: If the session owns its client and has been closed.
         """
+        # Checked outside the try block; the except clause below would swallow it.
+        self._check_not_closed()
         try:
             await self._client.admin.command("ping")
             return True

--- a/tests/extensions/memory/test_mongodb_session.py
+++ b/tests/extensions/memory/test_mongodb_session.py
@@ -729,6 +729,81 @@ async def test_close_owned_client_is_closed() -> None:
         assert fake_client._closed
 
 
+def _make_owned_session(session_id: str = "owned") -> MongoDBSession:
+    """Create a from_uri session, which is the case where close() owns the client."""
+    MongoDBSession._init_state.clear()
+    with patch(
+        "agents.extensions.memory.mongodb_session.AsyncMongoClient",
+        return_value=FakeAsyncMongoClient(),
+    ):
+        return MongoDBSession.from_uri(session_id, uri="mongodb://localhost:27017", database="t")
+
+
+async def test_closed_operations_raise_runtime_error() -> None:
+    """Operations on a closed session must fail instead of running against a released client."""
+    session = _make_owned_session()
+    await session.add_items([{"role": "user", "content": "hi"}])
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await session.get_items()
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await session.add_items([{"role": "user", "content": "after close"}])
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await session.pop_item()
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await session.clear_session()
+
+
+async def test_closed_rejects_empty_add_items() -> None:
+    """add_items([]) must not bypass the closed check through the empty-list fast path."""
+    session = _make_owned_session()
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await session.add_items([])
+
+
+async def test_close_before_use_is_terminal() -> None:
+    """close() before the first operation must still be terminal."""
+    session = _make_owned_session()
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await session.get_items()
+
+
+async def test_close_is_idempotent() -> None:
+    """A second close() must be a no-op rather than raising."""
+    session = _make_owned_session()
+
+    await session.close()
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await session.get_items()
+
+
+async def test_ping_on_closed_session_raises() -> None:
+    """ping() swallows connectivity errors, so the closed check runs outside its try."""
+    session = _make_owned_session()
+    await session.close()
+
+    with pytest.raises(RuntimeError, match="MongoDBSession is closed"):
+        await session.ping()
+
+
+async def test_external_client_session_stays_usable_after_close() -> None:
+    """An injected client is the caller's to manage, so close() must not be terminal."""
+    session = _make_session()
+    assert session._owns_client is False
+
+    await session.close()
+
+    await session.add_items([{"role": "user", "content": "still works"}])
+    assert len(await session.get_items()) == 1
+
+
 # ---------------------------------------------------------------------------
 # Runner integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

`MongoDBSession.close()` releases the client but records nothing, so a closed session keeps working. This applies the rule [#4035](https://github.com/openai/openai-agents-python/pull/4035) established and [#4109](https://github.com/openai/openai-agents-python/pull/4109) extended, to the last session backend that does not follow it.

#4035's summary states the contract: *"SQLiteSession makes close() terminal: it sets `_closed` under the session lock, and every operation re-checks that flag inside the same lock."* It fixed Redis and Dapr; #4109 fixed `AsyncSQLiteSession`. `MongoDBSession` is now the only backend left that defines `close()` without it — `SQLAlchemySession`, `EncryptedSession` and `OpenAIConversationsSession` define no `close()` at all, so this closes the class.

What goes wrong today, for a `from_uri` session that owns its client:

```python
session = MongoDBSession.from_uri("s", uri="mongodb://localhost:27017")
await session.add_items([...])
await session.close()          # client released
await session.get_items()      # still returns history
await session.add_items([...]) # still writes
```

Every operation runs against a released client instead of raising. `close()` before first use is not terminal either, and `ping()` reports connectivity for a session that has none.

The fix mirrors #4035 and #4109. `close()` marks the session terminal before releasing the client, and the check goes in `_ensure_indexes()` — the one path `get_items`, `add_items`, `pop_item` and `clear_session` all share, so it is a single insertion rather than four. `add_items` also checks before its empty-list fast path, the same gap #4035 closed for Redis. `ping()` checks outside its `try`, since its `except Exception` would otherwise swallow the `RuntimeError`; that comment is lifted from `RedisSession.ping` which had the identical trap. The injected-client case stays a no-op and stays usable, matching `RedisSession`: if you passed the client in, its lifecycle is yours.

**One judgment call, and it is why this backend was skipped before.** The siblings hang the flag on a per-session `asyncio.Lock`. This class deliberately has none, and says why:

> *Only a threading.Lock (never an asyncio.Lock) touches the registry. asyncio.Lock is bound to the event loop that first acquires it; reusing one across loops raises RuntimeError.*

So I did not import that pattern. `close()` sets a plain boolean before awaiting the release, which is a single atomic store and needs no lock, and it does not null the client out — so unlike `AsyncSQLiteSession` there is no attribute for a concurrent operation to trip over, and no `_client_released` flag is needed because `AsyncMongoClient.close()` tolerates repeated calls. That also means a failed or cancelled release leaves the session terminal and a later `close()` simply retries. Adding a lock or a second flag here would be machinery with no requirement behind it.

**Out of scope, named so it is clear it was seen and not missed:** the `session_limit <= 0` divergence across backends is untouched — that is a design question you have already declined twice ([#3244](https://github.com/openai/openai-agents-python/pull/3244), [#3960](https://github.com/openai/openai-agents-python/issues/3960)), and nothing here needs it settled.

### Test plan

Six tests added to `tests/extensions/memory/test_mongodb_session.py`, all run against unpatched code first:

- `test_closed_operations_raise_runtime_error` — `get_items`, `add_items`, `pop_item`, `clear_session`
- `test_closed_rejects_empty_add_items` — the empty-list fast path
- `test_close_before_use_is_terminal`
- `test_close_is_idempotent`
- `test_ping_on_closed_session_raises`
- `test_external_client_session_stays_usable_after_close` — **passes both before and after by design**; it exists to hold the ownership branch that did *not* change

Fail-first: `5 failed, 3 passed, 35 deselected` on unpatched code, the five being the new closed-state assertions and the three being the two pre-existing `close()` tests plus the ownership test above. After: `43 passed` in that file.

Full stack:

- `make format` — 844 files unchanged
- `make lint` — clean
- `make typecheck` — pyright 0 errors; mypy clean on `.venv_313` (593 source files). On the default 3.11 env mypy reports the pre-existing `tests/test_run_step_execution.py:1466: Module has no attribute "eager_task_factory"`, which is unrelated to this diff and present on `main`.
- `make tests` — `6090 passed, 8 skipped` + `38 passed` serial. `main` is `6084 passed`, so +6, which are the six tests added. Zero regressions.

**One thing I want to flag rather than bury.** An earlier full-suite run of mine showed a single failure in `tests/sandbox/test_runtime.py::test_remote_realpath_guard_fails_closed_on_symlink_cycle`. It passes in isolation, the whole file passes under `-n auto` on clean `main`, the full suite is green on clean `main`, and the full suite is green on re-run with this change. So it is intermittent under parallelism and not this diff — but I hit it once, so someone else will, and I would rather say so than quietly re-run until green. It was seen once before, in #4109.

I did not run `.agents/skills/code-change-verification/scripts/run.sh` to completion: it pins typecheck to the default 3.11 env and runs mypy and pyright in parallel with the full suite, which wedges this machine past a sensible time budget. I ran the four stages individually instead, as above, and have left that box unchecked.

### Issue number

n/a

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
