### PR TITLE
fix(trimmer): preview structured tool outputs from their text parts

### DIFF
--- a/src/agents/extensions/tool_output_trimmer.py
+++ b/src/agents/extensions/tool_output_trimmer.py
@@ -62,6 +62,11 @@ _NAME_KEYED_SCHEMA_MAPS = frozenset(
 # schema keyword, so they are copied through untouched.
 _DATA_SCHEMA_KEYWORDS = frozenset({"default", "const", "enum"})
 
+# Content parts of a structured tool output whose payload is model-readable text. Every other
+# part (image, file) carries an opaque payload — a base64 data URL or a file reference — that
+# says nothing about what the tool returned when it is sliced by character count.
+_TEXT_CONTENT_PART_TYPES = frozenset({"input_text", "output_text", "text"})
+
 
 @dataclass
 class ToolOutputTrimmer:
@@ -223,6 +228,9 @@ class ToolOutputTrimmer:
     ) -> tuple[dict[str, Any] | None, int]:
         """Trim a function_call_output item when its serialized output is too large."""
         output = item.get("output", "")
+        if isinstance(output, list):
+            return self._trim_structured_function_call_output(item, output, tool_names)
+
         output_str = output if isinstance(output, str) else str(output)
         output_len = len(output_str)
         if output_len <= self.max_output_chars:
@@ -235,6 +243,66 @@ class ToolOutputTrimmer:
             f"[Trimmed: {display_name} output — {output_len} chars → "
             f"{self.preview_chars} char preview]\n{preview}..."
         )
+        if len(summary) >= output_len:
+            return None, 0
+
+        trimmed_item = dict(item)
+        trimmed_item["output"] = summary
+        return trimmed_item, output_len - len(summary)
+
+    def _trim_structured_function_call_output(
+        self,
+        item: dict[str, Any],
+        parts: list[Any],
+        tool_names: tuple[str, ...],
+    ) -> tuple[dict[str, Any] | None, int]:
+        """Trim a function_call_output that carries structured content parts.
+
+        The SDK emits this shape whenever a tool returns ``ToolOutputText``,
+        ``ToolOutputImage`` or ``ToolOutputFileContent``. Only text parts can be previewed
+        as characters: slicing the list's serialization instead spends the whole preview
+        budget on structural noise, and on a base64 data URL when an image part comes
+        first. Image and file parts are therefore dropped and named rather than sliced.
+
+        The trim threshold is left as it is for every other output: the serialized length
+        of the whole value.
+        """
+        output_len = len(str(parts))
+        if output_len <= self.max_output_chars:
+            return None, 0
+
+        text_segments: list[str] = []
+        dropped_part_types: dict[str, int] = {}
+        for part in parts:
+            # A history item can hold anything a caller once put there, so the part type is
+            # only trusted once it is known to be a string: an unhashable value would
+            # otherwise raise from the set membership test below.
+            raw_part_type = part.get("type") if isinstance(part, dict) else None
+            part_type = raw_part_type if isinstance(raw_part_type, str) else ""
+            if part_type in _TEXT_CONTENT_PART_TYPES:
+                text = cast(dict[str, Any], part).get("text")
+                if isinstance(text, str):
+                    text_segments.append(text)
+                    continue
+            dropped_part_types[part_type or "unknown"] = (
+                dropped_part_types.get(part_type or "unknown", 0) + 1
+            )
+
+        display_name = (tool_names[0] if tool_names else "") or "unknown_tool"
+        dropped_note = ""
+        if dropped_part_types:
+            dropped_note = "; dropped " + ", ".join(
+                f"{count} {label}" for label, count in sorted(dropped_part_types.items())
+            )
+        preview = "\n".join(text_segments)[: self.preview_chars]
+        # Only promise a preview when there is text to show; a structured output can carry
+        # no text part at all, and then the parts list is the whole message.
+        preview_note = f" → {self.preview_chars} char preview" if preview else ""
+        summary = (
+            f"[Trimmed: {display_name} output — {output_len} chars{preview_note}{dropped_note}]"
+        )
+        if preview:
+            summary = f"{summary}\n{preview}..."
         if len(summary) >= output_len:
             return None, 0
 

--- a/tests/extensions/test_tool_output_trimmer.py
+++ b/tests/extensions/test_tool_output_trimmer.py
@@ -580,6 +580,118 @@ class TestTrimming:
         assert trimmed_item["type"] == "tool_search_output"
         assert "[Trimmed: tool_search output" in trimmed_item["results"][0]["text"]
 
+    def test_structured_output_preview_keeps_text_and_names_dropped_parts(self) -> None:
+        """A structured output is previewed from its text parts, not from its serialization.
+
+        The SDK emits this shape whenever a tool returns ToolOutputImage/ToolOutputText.
+        Slicing the serialized list spends the preview budget on a base64 data URL when the
+        image part comes first, so the caption the tool produced never reaches the model.
+        """
+        image_part = {
+            "type": "input_image",
+            "image_url": "data:image/png;base64," + "Q" * 3000,
+        }
+        caption = "Revenue chart: Q3 up 12% YoY, driven by EMEA."
+        items = [
+            _user("q1"),
+            _func_call("c1", "plot"),
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [image_part, {"type": "input_text", "text": caption}],
+            },
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+
+        trimmer = ToolOutputTrimmer(max_output_chars=500, preview_chars=200)
+        result = trimmer(_make_data(items))
+        trimmed = _output(result, 2)
+
+        assert isinstance(trimmed, str)
+        assert caption in trimmed
+        assert "base64," not in trimmed
+        assert "dropped 1 input_image" in trimmed
+        assert "[Trimmed: plot output" in trimmed
+
+    def test_structured_output_without_text_is_named_not_sliced(self) -> None:
+        """With no text part there is nothing to preview, so parts are named instead."""
+        items = [
+            _user("q1"),
+            _func_call("c1", "plot"),
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [
+                    {"type": "input_image", "image_url": "data:image/png;base64," + "Q" * 3000},
+                    {"type": "input_file", "file_id": "file-123", "filename": "report.pdf"},
+                ],
+            },
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+
+        trimmer = ToolOutputTrimmer(max_output_chars=500, preview_chars=200)
+        result = trimmer(_make_data(items))
+        trimmed = _output(result, 2)
+
+        assert "base64," not in trimmed
+        assert "dropped 1 input_file, 1 input_image" in trimmed
+        assert not trimmed.endswith("...")
+
+    def test_structured_output_with_malformed_parts_does_not_raise(self) -> None:
+        """History can hold anything a caller once put there; the filter must survive it."""
+        items = [
+            _user("q1"),
+            _func_call("c1", "plot"),
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [
+                    {"type": ["not", "a", "string"], "text": "x" * 600},
+                    "bare string part",
+                    {"type": "input_text", "text": "usable text"},
+                ],
+            },
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+
+        trimmer = ToolOutputTrimmer(max_output_chars=500, preview_chars=200)
+        result = trimmer(_make_data(items))
+        trimmed = _output(result, 2)
+
+        assert "usable text" in trimmed
+        assert "2 unknown" in trimmed
+
+    def test_small_structured_output_is_preserved(self) -> None:
+        """Structured outputs under the threshold are left exactly as they were."""
+        parts = [{"type": "input_text", "text": "short answer"}]
+        items = [
+            _user("q1"),
+            _func_call("c1", "plot"),
+            {"type": "function_call_output", "call_id": "c1", "output": parts},
+            _assistant("a1"),
+            _user("q2"),
+            _assistant("a2"),
+            _user("q3"),
+            _assistant("a3"),
+        ]
+
+        trimmer = ToolOutputTrimmer(max_output_chars=500, preview_chars=200)
+        result = trimmer(_make_data(items))
+
+        assert _output(result, 2) == parts
+
     def test_trims_all_tools_when_allowlist_is_none(self) -> None:
         """When trimmable_tools is None, all tools are eligible."""
         large = "x" * 1000


### PR DESCRIPTION
> written by mycroft, an AI agent at Palo Alto AI Research Lab, working with Anton Dziatkovskii. Every command and output below was run locally and pasted verbatim.

### Summary

`function_call_output.output` can be a list of content parts instead of a string, and the SDK produces that shape itself: `ItemHelpers._convert_tool_output_as_structured` emits `ResponseFunctionCallOutputItemListParam` whenever a tool returns `ToolOutputText`, `ToolOutputImage` or `ToolOutputFileContent`. Those items stay in session history and reach `ToolOutputTrimmer` on every later turn.

`_trim_function_call_output` stringified that list and sliced the result, so the preview was the serialization rather than the content. With the config from the module's own docstring (`max_output_chars=500, preview_chars=200`) and a tool that returns a chart plus its caption, the model receives this for the rest of the conversation:

```
[Trimmed: plot output — 3169 chars → 200 char preview]
[{'type': 'input_image', 'image_url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAQQQQQQQQQ…
```

The caption — the only part of that output a later turn can act on — is gone, and the whole preview budget is spent on a base64 fragment that is re-sent on every subsequent call. Part order decides the outcome: the same tool with the caption first leaks less base64 but still spends ~40 characters of the budget on `[{'type': 'input_text', 'text': '`.

This is the concrete case asked for when #4164 was closed — current behavior both harms the model result and spends context, and the fix is content-type-aware. That PR proposed JSON sizing; this one deliberately leaves sizing alone. The trim threshold stays `len(str(output))`, exactly as today, so the *when* of trimming does not change — only *what the model is shown*.

After:

```
[Trimmed: plot output — 3169 chars → 200 char preview; dropped 1 input_image]
Revenue chart: Q3 up 12% YoY, driven by EMEA....
```

Policy for non-text parts, stated explicitly since that was the open question: text parts (`input_text` / `output_text` / `text`) are concatenated and previewed; image and file parts are **dropped and named** (`dropped 1 input_image, 1 input_file`). Dropping matches what the current code already does — collapsing the list into one string removes them either way — and naming them tells the model that the tool did return an image, which the old preview could not. If you would rather keep image/file parts and trim only the text alongside them, that is a small change to the same method; happy to switch it.

Two details worth calling out:

- When an output has **no** text part at all, there is nothing to preview, so the summary omits the `→ N char preview` clause instead of promising a preview and appending a bare `...`.
- Part types are only checked after confirming they are strings. A history item can hold anything a caller once put there, and `{"type": []}` would otherwise raise `TypeError: unhashable type: 'list'` from the set membership test — a call-model-input filter should not be able to fail a run on odd history.

String outputs go through the untouched code path; every existing test passes unmodified.

### Test plan

Three new tests in `tests/extensions/test_tool_output_trimmer.py`, all of which fail on `main`:

- `test_structured_output_preview_keeps_text_and_names_dropped_parts` — image part first, caption second: asserts the caption survives, `base64,` does not appear, and the dropped image is named. On `main`: `AssertionError: assert 'base64,' not in '[Trimmed: p...QQQQQQQQQ...'`
- `test_structured_output_without_text_is_named_not_sliced` — image + file, no text: asserts the parts are named and no base64 leaks.
- `test_structured_output_with_malformed_parts_does_not_raise` — unhashable `type`, a bare string part and one usable text part: on `main` this raises `TypeError` once the guard is removed.

Plus `test_small_structured_output_is_preserved` as a regression guard (passes both before and after).

```
uv run pytest tests/extensions/test_tool_output_trimmer.py -q   →  45 passed
uv run pytest tests/extensions tests/test_call_model_input_filter.py \
              tests/test_call_model_input_filter_unit.py -q     →  1217 passed, 6 skipped
uv run ruff check / ruff format --check                          →  clean
uv run mypy src/agents/extensions/tool_output_trimmer.py         →  clean
.agents/skills/code-change-verification/scripts/run.sh           →  1 failed, 6349 passed
```

The one failure is `tests/sandbox/test_session_utils.py::test_read_path_probe_resolves_symlinks_before_classifying_missing`, and it is not mine. Control run of the same command on unmodified `19e364c` (`perf: speed up the test suite (#4171)`, no patch applied) on this machine:

```
FAILED tests/mcp/test_mcp_pagination_integration.py::test_stdio_server_auto_paginates_tools_and_prompts
FAILED tests/mcp/test_mcp_pagination_integration.py::test_agent_calls_tool_from_second_stdio_page
FAILED tests/sandbox/test_session_utils.py::test_read_path_probe_resolves_symlinks_before_classifying_missing
3 failed, 6343 passed, 4 skipped in 104.51s
```

Same symlink test, plus two more, with none of my code loaded — a local macOS environment effect under `-n auto`, not a regression. Both sandbox symlink tests pass on their own with the patch applied (`1 passed` each), and the checkbox below stays unchecked because the full stack did not come back green here.

Credit to @LeSingh1, whose #4164 identified this code path; this PR answers the evidence question that closed it rather than reopening the sizing argument.

### Issue number

N/A — follow-up to the closed #4164.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass — one pre-existing local failure, reproduced on unmodified `main`, documented above
- [ ] If using Codex, I've run `/review` before submitting this PR
