### PR TITLE
fix(mcp): derive streamable HTTP retry backoff from backoffs taken

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -2102,6 +2102,11 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
         try:
             self._validate_required_parameters(tool_name=tool_name, arguments=arguments)
             retries_used = 0
+            # `retries_used` measures the retry budget, not elapsed backoffs: it is
+            # deliberately not advanced while `max_retry_attempts` is -1, and a single
+            # isolated-session retry charges it twice. Count backoffs separately so the
+            # delay follows the configured schedule in both cases.
+            backoffs_taken = 0
             first_attempt = True
             while True:
                 if not first_attempt and self.max_retry_attempts != -1:
@@ -2125,12 +2130,14 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                         if exc.__cause__ is not None:
                             raise exc.__cause__ from exc
                         raise
-                    backoff = self.retry_backoff_seconds_base * (2 ** (retries_used - 1))
+                    backoff = self.retry_backoff_seconds_base * (2**backoffs_taken)
+                    backoffs_taken += 1
                     await asyncio.sleep(backoff)
                 except Exception:
                     if self.max_retry_attempts != -1 and retries_used >= self.max_retry_attempts:
                         raise
-                    backoff = self.retry_backoff_seconds_base * (2**retries_used)
+                    backoff = self.retry_backoff_seconds_base * (2**backoffs_taken)
+                    backoffs_taken += 1
                     await asyncio.sleep(backoff)
                 first_attempt = False
         except httpx.HTTPStatusError as e:

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -696,3 +696,57 @@ async def test_streamable_http_serializes_call_tool_with_prompt_requests(prompt_
         assert isinstance(results[1], GetPromptResult)
     assert shared_session.max_in_flight == 1
     assert isolated_session.call_tool_attempts == 0
+
+
+class FlakyRuntimeErrorSession:
+    """Fails with an error that does not qualify for an isolated-session retry."""
+
+    def __init__(self, failures: int):
+        self.failures = failures
+        self.call_tool_attempts = 0
+
+    async def call_tool(self, tool_name, arguments, meta=None):
+        self.call_tool_attempts += 1
+        if self.call_tool_attempts <= self.failures:
+            raise RuntimeError("transient failure")
+        return CallToolResult(content=[])
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_backoff_grows_with_unlimited_retries(monkeypatch):
+    delays: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+
+    shared_session = FlakyRuntimeErrorSession(failures=3)
+    server = DummyStreamableHttpServer(shared_session, TimeoutSession())
+    server.max_retry_attempts = -1
+    server.retry_backoff_seconds_base = 1.0
+
+    await server.call_tool("tool", None)
+
+    assert delays == [1.0, 2.0, 4.0]
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_backoff_matches_generic_schedule_on_isolated_retry(monkeypatch):
+    delays: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+
+    shared_session = TimeoutSession("shared timed out")
+    isolated_session = TimeoutSession("isolated timed out")
+    server = DummyStreamableHttpServer(shared_session, isolated_session)
+    server.max_retry_attempts = 6
+    server.retry_backoff_seconds_base = 1.0
+
+    with pytest.raises(httpx.TimeoutException, match="shared timed out"):
+        await server.call_tool("tool", None)
+
+    assert delays == [1.0, 2.0, 4.0]


### PR DESCRIPTION
### Summary

`MCPServerStreamableHttp.call_tool` replaces the shared retry loop with its own, and takes the backoff exponent from `retries_used` — a retry *budget* counter rather than a count of backoffs already taken. The two disagree in both directions:

- `retries_used` is only advanced at the top of the loop when `max_retry_attempts != -1`. So with `max_retry_attempts = -1` ("retry indefinitely") the generic `except Exception` path evaluates `retry_backoff_seconds_base * 2**0` on every pass and the delay never grows — an unreachable server is retried at a flat interval forever.
- One isolated-session retry charges `retries_used` twice, once at the top of the loop and once in the `_IsolatedSessionRetryFailed` handler. With a finite budget the delay then quadruples per sleep: `1s, 4s, 16s` instead of `1s, 2s, 4s`.

`.agents/references/local-mcp-server-lifecycle.md` states that generic `list_tools()` / `call_tool()` retries "use the configured attempt count and backoff", and `_run_with_retries` — the schedule every other retry path in this file follows — is `base * 2 ** (attempts - 1)` over actual attempts. This change makes the streamable HTTP override agree with it by counting backoffs in a dedicated local and using that as the exponent. Budget accounting, attempt counts, and isolated-session retry eligibility are unchanged.

### Test plan

Two tests added to `tests/mcp/test_client_session_retries.py`, both patching `asyncio.sleep` to record the delay sequence:

- `test_streamable_http_backoff_grows_with_unlimited_retries` — `max_retry_attempts = -1`, expects `[1.0, 2.0, 4.0]`. On unmodified `main` it records `[1.0, 1.0, 1.0]`.
- `test_streamable_http_backoff_matches_generic_schedule_on_isolated_retry` — finite budget with an isolated-session retry, expects `[1.0, 2.0, 4.0]`. On unmodified `main` it records `[1.0, 4.0, 16.0]`.

Both were confirmed failing against unmodified `main` before the fix and passing after it.

`.agents/skills/code-change-verification/scripts/run.sh`: `make format`, `make lint` and `make typecheck` pass. `make tests` reports a single failure, `tests/test_run_step_execution.py::test_multiple_tool_calls_raise_late_fatal_sibling_exception_after_cancellation[20]`, which is pre-existing and unrelated to this change: it reproduces identically on unmodified `main` at 19e364c under the same `pytest -n auto --dist worksteal -m "not serial"` invocation, and passes when that test is run on its own. I have left the "all verification steps pass" box unchecked for that reason.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
