### PR TITLE
fix(models): preserve streamed Anthropic thinking block boundaries

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -75,12 +75,46 @@ class StreamingState:
     # Fields for real-time function call streaming
     function_call_streaming: dict[int, bool] = field(default_factory=dict)
     ignored_tool_call_indexes: set[int] = field(default_factory=set)
-    # Store accumulated thinking text and signature for Anthropic compatibility
-    thinking_text: str = ""
-    thinking_signature: str | None = None
+    # Store the ordered Anthropic thinking block sequence for replay. Text and signatures
+    # cannot be flattened into scalars: each block carries its own signature, and a
+    # redacted_thinking block carries neither text nor signature.
+    thinking_blocks: list[dict[str, Any]] = field(default_factory=list)
     # Store provider data for all output items
     provider_data: dict[str, Any] = field(default_factory=dict)
     has_warned_unsupported_choice: bool = False
+
+    def accumulate_thinking_block(self, block: dict[str, Any]) -> None:
+        """Fold one streamed thinking delta into the ordered block sequence.
+
+        Anthropic streams a thinking block as a run of `thinking_delta` chunks terminated by a
+        single `signature_delta`, so a signature both belongs to the block being accumulated and
+        marks its end. A `redacted_thinking` block arrives whole and is kept verbatim.
+        """
+        if block.get("type") == "redacted_thinking":
+            self.thinking_blocks.append(dict(block))
+            return
+
+        thinking_text = block.get("thinking") or ""
+        signature = block.get("signature") or ""
+        if not thinking_text and not signature:
+            return
+
+        current = self._open_thinking_block()
+        if thinking_text:
+            current["thinking"] = f"{current.get('thinking', '')}{thinking_text}"
+        if signature:
+            # A signature closes the block, so later text starts a new one.
+            current["signature"] = signature
+
+    def _open_thinking_block(self) -> dict[str, Any]:
+        """Return the thinking block still accepting deltas, creating one when needed."""
+        if self.thinking_blocks:
+            last_block = self.thinking_blocks[-1]
+            if last_block.get("type") == "thinking" and "signature" not in last_block:
+                return last_block
+        new_block: dict[str, Any] = {"type": "thinking", "thinking": ""}
+        self.thinking_blocks.append(new_block)
+        return new_block
 
 
 @dataclass
@@ -578,14 +612,7 @@ class ChatCmplStreamHandler:
             if hasattr(delta, "thinking_blocks") and delta.thinking_blocks:
                 for block in delta.thinking_blocks:
                     if isinstance(block, dict):
-                        # Accumulate thinking text
-                        thinking_text = block.get("thinking", "")
-                        if thinking_text:
-                            state.thinking_text += thinking_text
-                        # Store signature if present
-                        signature = block.get("signature")
-                        if signature:
-                            state.thinking_signature = signature
+                        state.accumulate_thinking_block(block)
 
             # Handle reasoning content for reasoning summaries
             if hasattr(delta, "reasoning_content"):
@@ -1099,17 +1126,31 @@ class ChatCmplStreamHandler:
         # include Reasoning item if it exists
         if state.reasoning_content_index_and_output:
             reasoning_item = state.reasoning_content_index_and_output[1]
-            # Store thinking text in content and signature in encrypted_content
-            if state.thinking_text:
-                # Add thinking text as a Content object
-                if not reasoning_item.content:
-                    reasoning_item.content = []
-                reasoning_item.content.append(
-                    Content(text=state.thinking_text, type="reasoning_text")
-                )
-            # Store signature in encrypted_content
-            if state.thinking_signature:
-                reasoning_item.encrypted_content = state.thinking_signature
+            if state.thinking_blocks:
+                # The normalized reasoning fields below cannot represent per-block signatures,
+                # empty thinking text, or redacted_thinking blocks. Keep the complete provider
+                # sequence as the replay source of truth while retaining those released fields
+                # as derived data, matching the non-streaming converter.
+                reasoning_provider_data = dict(getattr(reasoning_item, "provider_data", None) or {})
+                reasoning_provider_data["thinking_blocks"] = [
+                    dict(block) for block in state.thinking_blocks
+                ]
+                reasoning_item.provider_data = reasoning_provider_data  # type: ignore[attr-defined]
+
+                # Retain the released normalized representation for callers and legacy replay.
+                signatures: list[str] = []
+                for block in state.thinking_blocks:
+                    thinking_text = block.get("thinking") or ""
+                    if thinking_text:
+                        if not reasoning_item.content:
+                            reasoning_item.content = []
+                        reasoning_item.content.append(
+                            Content(text=thinking_text, type="reasoning_text")
+                        )
+                    if signature := block.get("signature"):
+                        signatures.append(signature)
+                if signatures:
+                    reasoning_item.encrypted_content = "\n".join(signatures)
             outputs.append(reasoning_item)
 
         outputs.extend(output_layout.function_calls_before_message(state))

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -37,6 +37,7 @@ from openai.types.responses import (
 from agents import Agent, Runner, function_tool
 from agents.exceptions import ModelBehaviorError, UserError
 from agents.model_settings import ModelSettings
+from agents.models.chatcmpl_converter import Converter
 from agents.models.chatcmpl_stream_handler import (
     ChatCmplStreamHandler,
     Part,
@@ -884,8 +885,135 @@ async def test_stream_handler_preserves_thinking_blocks_with_reasoning_summary()
     assert isinstance(reasoning_item, ResponseReasoningItem)
     assert reasoning_item.summary[0].text == "summary"
     assert reasoning_item.content
-    assert cast(Any, reasoning_item.content[0]).text == "hidden one hidden two"
-    assert reasoning_item.encrypted_content == "sig-2"
+    # Each block keeps its own signature: merging the text would leave the pair unverifiable.
+    assert [cast(Any, part).text for part in reasoning_item.content] == [
+        "hidden one ",
+        "hidden two",
+    ]
+    assert reasoning_item.encrypted_content == "sig-1\nsig-2"
+    assert cast(Any, reasoning_item).provider_data["thinking_blocks"] == [
+        {"type": "thinking", "thinking": "hidden one ", "signature": "sig-1"},
+        {"type": "thinking", "thinking": "hidden two", "signature": "sig-2"},
+    ]
+
+
+def _thinking_chunk(**delta_kwargs: Any) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="anthropic/claude-4-opus",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta.model_construct(**delta_kwargs))],
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_segments_thinking_blocks_at_signature_deltas() -> None:
+    """A streamed block ends at its signature_delta, so each block keeps its own signature.
+
+    Anthropic streams a thinking block as a run of `thinking_delta` chunks terminated by one
+    `signature_delta`. Accumulating the text into a single scalar merged interleaved blocks and
+    kept only the last signature, which cannot be verified against the merged text on replay.
+    """
+    events = await _collect_handler_events(
+        _thinking_chunk(reasoning_content="summary"),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "step ", "signature": ""}]
+        ),
+        _thinking_chunk(thinking_blocks=[{"type": "thinking", "thinking": "one", "signature": ""}]),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "", "signature": "SIG-1"}]
+        ),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "step two", "signature": ""}]
+        ),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "", "signature": "SIG-2"}]
+        ),
+    )
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    reasoning_item = completed_event.response.output[0]
+    assert isinstance(reasoning_item, ResponseReasoningItem)
+    assert cast(Any, reasoning_item).provider_data["thinking_blocks"] == [
+        {"type": "thinking", "thinking": "step one", "signature": "SIG-1"},
+        {"type": "thinking", "thinking": "step two", "signature": "SIG-2"},
+    ]
+    assert reasoning_item.encrypted_content == "SIG-1\nSIG-2"
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_preserves_redacted_thinking_blocks() -> None:
+    """A redacted_thinking block carries neither text nor signature and was dropped entirely.
+
+    Anthropic requires redacted blocks to be replayed unmodified during tool-use continuation,
+    and the normalized content/encrypted_content pair cannot represent them.
+    """
+    events = await _collect_handler_events(
+        _thinking_chunk(reasoning_content="summary"),
+        _thinking_chunk(thinking_blocks=[{"type": "redacted_thinking", "data": "REDACTED-BLOB"}]),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "visible", "signature": ""}]
+        ),
+        _thinking_chunk(thinking_blocks=[{"type": "thinking", "thinking": "", "signature": "SIG"}]),
+    )
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    reasoning_item = completed_event.response.output[0]
+    assert isinstance(reasoning_item, ResponseReasoningItem)
+    assert cast(Any, reasoning_item).provider_data["thinking_blocks"] == [
+        {"type": "redacted_thinking", "data": "REDACTED-BLOB"},
+        {"type": "thinking", "thinking": "visible", "signature": "SIG"},
+    ]
+    # The redacted block contributes no reasoning_text and no signature.
+    assert [cast(Any, part).text for part in (reasoning_item.content or [])] == ["visible"]
+    assert reasoning_item.encrypted_content == "SIG"
+
+
+@pytest.mark.asyncio
+async def test_streamed_thinking_blocks_replay_through_the_converter() -> None:
+    """End-to-end: a streamed Anthropic response must replay as the same ordered blocks.
+
+    This covers the streaming counterpart of the non-streaming replay path, so a signed block
+    survives item serialization and reaches the outbound request unchanged.
+    """
+    events = await _collect_handler_events(
+        _thinking_chunk(reasoning_content="summary"),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "alpha", "signature": ""}]
+        ),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "", "signature": "SIG-A"}]
+        ),
+        _thinking_chunk(thinking_blocks=[{"type": "redacted_thinking", "data": "BLOB"}]),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "beta", "signature": ""}]
+        ),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "", "signature": "SIG-B"}]
+        ),
+        _thinking_chunk(content="visible answer"),
+    )
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    stored_items = [item.model_dump() for item in completed_event.response.output]
+
+    messages = Converter.items_to_messages(
+        cast(Any, stored_items),
+        model="anthropic/claude-4-opus",
+        preserve_thinking_blocks=True,
+    )
+
+    assistant_messages = [msg for msg in messages if msg.get("role") == "assistant"]
+    assert len(assistant_messages) == 1
+    # The complete sequence replays through LiteLLM's native assistant thinking_blocks field,
+    # which round-trips redacted blocks and per-block signatures unchanged.
+    assert cast(Any, assistant_messages[0])["thinking_blocks"] == [
+        {"type": "thinking", "thinking": "alpha", "signature": "SIG-A"},
+        {"type": "redacted_thinking", "data": "BLOB"},
+        {"type": "thinking", "thinking": "beta", "signature": "SIG-B"},
+    ]
+    assert assistant_messages[0].get("content") == "visible answer"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Follow-up to #4157, which fixed thinking-block replay for the non-streaming converter and noted that "streaming has the same lossy behavior and can be tracked separately". This applies the same source-of-truth model to `ChatCmplStreamHandler`.

The streamed path accumulated Anthropic extended thinking into two scalars:

```python
thinking_text: str = ""
thinking_signature: str | None = None
...
state.thinking_text += thinking_text        # every block appended to one string
state.thinking_signature = signature        # every block overwrote the last
```

Anthropic streams a thinking block as a run of `thinking_delta` chunks terminated by a single `signature_delta`, and interleaved thinking emits several such blocks per turn. Flattening them means a turn with N signed blocks replays as **one** block whose text is every block concatenated and whose signature is only the last one — a pair Anthropic cannot verify. `redacted_thinking` blocks, which carry neither `thinking` nor `signature`, were dropped entirely even though Anthropic requires them to be replayed unmodified during tool-use continuation.

Given a realistic stream (`alpha` → `SIG-1`, a redacted block, `beta` → `SIG-2`):

| | before | after |
| --- | --- | --- |
| reasoning text | `['alphabeta']` | `['alpha', 'beta']` |
| `encrypted_content` | `'SIG-2'` (SIG-1 lost) | `'SIG-1\nSIG-2'` |
| redacted block | dropped | preserved in order |

The fix replaces the two scalars with the ordered block sequence, segmenting on `signature_delta` (a signature both belongs to the block being accumulated and closes it), and publishes it as `provider_data["thinking_blocks"]` — the same replay source of truth #4157 introduced, so streamed turns now flow through LiteLLM's native assistant `thinking_blocks` field. The released `content` / `encrypted_content` fields are retained as derived data for callers and legacy histories.

**Deliberately out of scope:** the reasoning item is still only created when `reasoning_content` is non-empty (`chatcmpl_stream_handler.py:620`). A turn whose only output is a `redacted_thinking` block therefore still produces no reasoning item. Fixing that means emitting an `output_item.added` event where none exists today, which changes the streamed event sequence, so it belongs in its own change. Non-streaming already handles this case via `if reasoning_content or thinking_blocks`.

### Test plan

`tests/models/test_openai_chatcompletions_stream.py`:

- `test_stream_handler_segments_thinking_blocks_at_signature_deltas` — delta-by-delta stream, two blocks keep their own signatures.
- `test_stream_handler_preserves_redacted_thinking_blocks` — redacted block survives in order and contributes no text or signature.
- `test_streamed_thinking_blocks_replay_through_the_converter` — end-to-end: streamed response → item serialization → `items_to_messages`, asserting the outbound assistant message carries the exact ordered blocks. This is the streaming counterpart of the raw-response-to-outbound-request coverage requested in the #4155 review.
- `test_stream_handler_preserves_thinking_blocks_with_reasoning_summary` — updated; it previously asserted the merged text `"hidden one hidden two"` and the single trailing signature `"sig-2"`, which is the lossy behavior this change removes.

All four fail on `main` and pass with the fix:

```
FAILED ...::test_stream_handler_preserves_thinking_blocks_with_reasoning_summary
FAILED ...::test_stream_handler_segments_thinking_blocks_at_signature_deltas
FAILED ...::test_stream_handler_preserves_redacted_thinking_blocks
FAILED ...::test_streamed_thinking_blocks_replay_through_the_converter
4 failed, 64 passed
```

Verification from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/models/` | 643 passed |
| `make tests` | 5648 passed |

The full-suite run was done on Windows, where a set of sandbox symlink tests and some tracing/realtime timing tests fail independently of this change. I diffed the failing set against a clean `main` checkout in the same environment and the two sets are identical (56 vs 56, no differences either way).

Block shapes were taken from the locked LiteLLM 1.83.0 runtime: `AnthropicChatCompletion._handle_content_block_delta` emits `{"type": "thinking", "thinking": <text or "">, "signature": <sig or "">}` per delta, and `_handle_redacted_thinking_content` emits `{"type": "redacted_thinking", "data": ...}` into the same `thinking_blocks` list.

### Issue number

Follow-up to #4157; behavior called out in the #4155 review.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`; I ran the underlying steps individually instead, with the results above.

---

@seratch — picking up the streaming half you flagged on #4155, and I took the two points from that review seriously: the source of truth here is the complete ordered `thinking_blocks` sequence rather than the normalized pair, and the coverage is an end-to-end streamed-response-to-outbound-request assertion rather than a unit expectation.

One thing worth your call. I segment blocks on `signature_delta`, since that is what terminates a block in Anthropic's stream. That is correct for `thinking`, but it means a provider that emits thinking deltas without ever sending a signature yields a single open block. Anthropic always signs, so this holds for the real transform, but if you would rather key segmentation off an explicit block index I can rework it — LiteLLM does not currently surface one on the delta, so it would need a change there first. I also left the `reasoning_content`-gated reasoning item creation alone for the reason in the summary; happy to fold that in if you would rather have it here than in a separate change.
