### PR TITLE
fix(sandbox): single-flight cached dependency factories

### DIFF
--- a/src/agents/sandbox/session/dependencies.py
+++ b/src/agents/sandbox/session/dependencies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
@@ -73,7 +74,10 @@ class Dependencies:
     def __init__(self) -> None:
         self._bindings: dict[DependencyKey, _Binding] = {}
         self._cache: dict[DependencyKey, object] = {}
+        self._pending: dict[DependencyKey, asyncio.Task[object]] = {}
+        self._active_tasks: set[asyncio.Task[object]] = set()
         self._owned_results: list[object] = []
+        self._close_task: asyncio.Task[None] | None = None
         self._closed = False
 
     @classmethod
@@ -144,6 +148,9 @@ class Dependencies:
             raise DependenciesBindingError(f"Dependency `{key}` is already bound")
         self._bindings[key] = binding
         self._cache.pop(key, None)
+        pending = self._pending.pop(key, None)
+        if pending is not None:
+            pending.cancel()
 
     async def get(self, key: DependencyKey) -> object | None:
         binding = self._bindings.get(key)
@@ -173,24 +180,92 @@ class Dependencies:
             return binding.value
 
         assert isinstance(binding, _FactoryBinding)
+        if self._closed:
+            raise DependenciesError(f"Dependencies container is closed; cannot resolve `{key}`")
         if binding.cache and key in self._cache:
             return self._cache[key]
 
+        if binding.cache:
+            task = self._pending.get(key)
+            if task is not None and task.done():
+                self._pending.pop(key, None)
+                task = None
+            if task is None:
+                task = self._create_factory_task(key, binding)
+                self._pending[key] = task
+            return await self._await_factory_task(key, binding, task, shield=True)
+
+        task = self._create_factory_task(key, binding)
+        return await self._await_factory_task(key, binding, task, shield=False)
+
+    def _create_factory_task(
+        self, key: DependencyKey, binding: _FactoryBinding
+    ) -> asyncio.Task[object]:
+        task = asyncio.create_task(self._run_factory(key, binding))
+        self._active_tasks.add(task)
+        task.add_done_callback(lambda completed: self._factory_task_done(key, completed))
+        return task
+
+    async def _run_factory(self, key: DependencyKey, binding: _FactoryBinding) -> object:
         produced = binding.factory(self)
         value = (
             await cast(Awaitable[object], produced) if inspect.isawaitable(produced) else produced
         )
 
-        if binding.cache:
-            self._cache[key] = value
         if binding.owns_result:
             self._owned_results.append(value)
+        self._raise_if_factory_invalid(key, binding)
+        if binding.cache:
+            self._cache[key] = value
         return value
 
-    async def aclose(self) -> None:
+    async def _await_factory_task(
+        self,
+        key: DependencyKey,
+        binding: _FactoryBinding,
+        task: asyncio.Task[object],
+        *,
+        shield: bool,
+    ) -> object:
+        try:
+            value = await asyncio.shield(task) if shield else await task
+        except asyncio.CancelledError:
+            if task.cancelled():
+                self._raise_if_factory_invalid(key, binding)
+            raise
+
+        self._raise_if_factory_invalid(key, binding)
+        return value
+
+    def _raise_if_factory_invalid(self, key: DependencyKey, binding: _FactoryBinding) -> None:
         if self._closed:
-            return
-        self._closed = True
+            raise DependenciesError(f"Dependencies container closed while resolving `{key}`")
+        if self._bindings.get(key) is not binding:
+            raise DependenciesBindingError(
+                f"Dependency `{key}` was rebound while its factory was resolving"
+            )
+
+    def _factory_task_done(self, key: DependencyKey, task: asyncio.Task[object]) -> None:
+        self._active_tasks.discard(task)
+        if self._pending.get(key) is task:
+            self._pending.pop(key, None)
+        if not task.cancelled():
+            task.exception()
+
+    async def aclose(self) -> None:
+        task = self._close_task
+        if task is None:
+            self._closed = True
+            task = asyncio.create_task(self._close())
+            self._close_task = task
+        await asyncio.shield(task)
+
+    async def _close(self) -> None:
+        active_tasks = tuple(self._active_tasks)
+        for task in active_tasks:
+            task.cancel()
+        if active_tasks:
+            await asyncio.gather(*active_tasks, return_exceptions=True)
 
         seen_ids: set[int] = set()
         for value in reversed(self._owned_results):
@@ -199,3 +274,8 @@ class Dependencies:
                 continue
             seen_ids.add(value_id)
             await _close_best_effort(value)
+
+        self._pending.clear()
+        self._active_tasks.clear()
+        self._cache.clear()
+        self._owned_results.clear()

--- a/tests/sandbox/test_dependencies.py
+++ b/tests/sandbox/test_dependencies.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from agents.sandbox.session import (
     Dependencies,
     DependenciesBindingError,
+    DependenciesError,
     DependenciesMissingDependencyError,
 )
+
+_EAGER_TASK_FACTORY = getattr(asyncio, "eager_task_factory", None)
 
 
 class _AsyncClosable:
@@ -15,6 +20,20 @@ class _AsyncClosable:
 
     async def aclose(self) -> None:
         self.calls += 1
+
+
+class _BlockingAsyncClosable:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.completed = False
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def aclose(self) -> None:
+        self.calls += 1
+        self.started.set()
+        await self.release.wait()
+        self.completed = True
 
 
 class _AsyncCloseMethod:
@@ -100,6 +119,245 @@ async def test_dependencies_cached_factory_resolves_once() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dependencies_cached_factory_resolves_once_concurrently() -> None:
+    dependencies = Dependencies()
+    key = "tests.concurrent_cached_factory"
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def _factory(_dependencies: Dependencies) -> _AsyncClosable:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return _AsyncClosable()
+
+    dependencies.bind_factory(key, _factory, cache=True, owns_result=True)
+    tasks = [asyncio.create_task(dependencies.require(key)) for _ in range(3)]
+
+    await started.wait()
+    release.set()
+    values = await asyncio.gather(*tasks)
+
+    assert calls == 1
+    assert values[0] is values[1] is values[2]
+
+    await dependencies.aclose()
+    assert isinstance(values[0], _AsyncClosable)
+    assert values[0].calls == 1
+
+
+@pytest.mark.asyncio
+async def test_dependencies_cached_factory_survives_waiter_cancellation() -> None:
+    dependencies = Dependencies()
+    key = "tests.cancelled_waiter"
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def _factory(_dependencies: Dependencies) -> object:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return object()
+
+    dependencies.bind_factory(key, _factory, cache=True)
+    cancelled_waiter = asyncio.create_task(dependencies.require(key))
+    surviving_waiter = asyncio.create_task(dependencies.require(key))
+
+    await started.wait()
+    cancelled_waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled_waiter
+
+    release.set()
+    value = await surviving_waiter
+
+    assert calls == 1
+    assert await dependencies.require(key) is value
+
+
+@pytest.mark.asyncio
+async def test_dependencies_cached_factory_failure_allows_retry() -> None:
+    dependencies = Dependencies()
+    key = "tests.failed_factory_retry"
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def _factory(_dependencies: Dependencies) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            await release.wait()
+            raise RuntimeError("factory failed")
+        return "recovered"
+
+    dependencies.bind_factory(key, _factory, cache=True)
+    first = asyncio.create_task(dependencies.require(key))
+    second = asyncio.create_task(dependencies.require(key))
+
+    await started.wait()
+    release.set()
+
+    for task in (first, second):
+        with pytest.raises(RuntimeError, match="factory failed"):
+            await task
+
+    assert await dependencies.require(key) == "recovered"
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_dependencies_rebind_before_factory_starts_cleans_up_task() -> None:
+    dependencies = Dependencies()
+    key = "tests.rebind_before_start"
+    factory_started = asyncio.Event()
+
+    async def _factory(_dependencies: Dependencies) -> object:
+        factory_started.set()
+        return object()
+
+    dependencies.bind_factory(key, _factory, cache=True)
+    stale_resolve = asyncio.create_task(dependencies.require(key))
+
+    def _rebind() -> None:
+        dependencies.bind_factory(
+            key, lambda _dependencies: "replacement", cache=True, overwrite=True
+        )
+
+    asyncio.get_running_loop().call_soon(_rebind)
+    await asyncio.sleep(0)
+
+    with pytest.raises(DependenciesBindingError, match="rebound"):
+        await stale_resolve
+    assert not factory_started.is_set()
+    assert await dependencies.require(key) == "replacement"
+
+    await asyncio.sleep(0)
+    assert not dependencies._pending
+    assert not dependencies._active_tasks
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(_EAGER_TASK_FACTORY is None, reason="requires Python 3.12+")
+async def test_dependencies_eager_factory_failure_allows_retry() -> None:
+    dependencies = Dependencies()
+    key = "tests.eager_failed_factory_retry"
+    calls = 0
+
+    async def _factory(_dependencies: Dependencies) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("factory failed")
+        return "recovered"
+
+    loop = asyncio.get_running_loop()
+    previous_task_factory = loop.get_task_factory()
+    loop.set_task_factory(_EAGER_TASK_FACTORY)
+    try:
+        dependencies.bind_factory(key, _factory, cache=True)
+        with pytest.raises(RuntimeError, match="factory failed"):
+            await dependencies.require(key)
+        assert await dependencies.require(key) == "recovered"
+    finally:
+        loop.set_task_factory(previous_task_factory)
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_dependencies_rebind_preserves_aliased_stale_result_until_close() -> None:
+    dependencies = Dependencies()
+    key = "tests.rebind_aliased_result"
+    started = asyncio.Event()
+    value = _AsyncClosable()
+
+    async def _factory(_dependencies: Dependencies) -> _AsyncClosable:
+        started.set()
+        try:
+            await asyncio.Future()
+            raise AssertionError("Unreachable")
+        except asyncio.CancelledError:
+            return value
+
+    dependencies.bind_factory(key, _factory, cache=True, owns_result=True)
+    stale_resolve = asyncio.create_task(dependencies.require(key))
+
+    await started.wait()
+    dependencies.bind_factory(
+        key,
+        lambda _dependencies: value,
+        cache=True,
+        overwrite=True,
+        owns_result=True,
+    )
+
+    with pytest.raises(DependenciesBindingError, match="rebound"):
+        await stale_resolve
+    assert await dependencies.require(key) is value
+    assert value.calls == 0
+
+    await dependencies.aclose()
+    assert value.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_dependencies_close_cleans_up_owned_in_flight_result() -> None:
+    dependencies = Dependencies()
+    key = "tests.close_in_flight"
+    started = asyncio.Event()
+    produced: list[_AsyncClosable] = []
+
+    async def _factory(_dependencies: Dependencies) -> _AsyncClosable:
+        started.set()
+        try:
+            await asyncio.Future()
+            raise AssertionError("Unreachable")
+        except asyncio.CancelledError:
+            value = _AsyncClosable()
+            produced.append(value)
+            return value
+
+    dependencies.bind_factory(key, _factory, cache=True, owns_result=True)
+    resolve_task = asyncio.create_task(dependencies.require(key))
+
+    await started.wait()
+    await dependencies.aclose()
+
+    with pytest.raises(DependenciesError, match="closed"):
+        await resolve_task
+    assert len(produced) == 1
+    assert produced[0].calls == 1
+
+
+@pytest.mark.asyncio
+async def test_dependencies_close_before_waiter_resumes_rejects_closed_result() -> None:
+    dependencies = Dependencies()
+    key = "tests.close_before_waiter_resumes"
+    produced = asyncio.Event()
+    value = _AsyncClosable()
+
+    async def _factory(_dependencies: Dependencies) -> _AsyncClosable:
+        produced.set()
+        return value
+
+    dependencies.bind_factory(key, _factory, cache=True, owns_result=True)
+    resolve_task = asyncio.create_task(dependencies.require(key))
+
+    await produced.wait()
+    await dependencies.aclose()
+
+    with pytest.raises(DependenciesError, match="closed"):
+        await resolve_task
+    assert value.calls == 1
+
+
+@pytest.mark.asyncio
 async def test_dependencies_uncached_factory_resolves_every_time() -> None:
     dependencies = Dependencies()
     key = "tests.uncached_factory"
@@ -154,6 +412,27 @@ async def test_dependencies_aclose_closes_owned_results_and_is_idempotent() -> N
     assert isinstance(v2, _AsyncCloseMethod) and v2.calls == 1
     assert isinstance(v3a, _SyncClosable) and v3a.calls == 1
     assert isinstance(v3b, _SyncClosable) and v3b.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_dependencies_aclose_continues_after_waiter_cancellation() -> None:
+    dependencies = Dependencies()
+    key = "tests.cancelled_close"
+    value = _BlockingAsyncClosable()
+    dependencies.bind_factory(key, lambda _dependencies: value, owns_result=True)
+    _ = await dependencies.require(key)
+
+    close_waiter = asyncio.create_task(dependencies.aclose())
+    await value.started.wait()
+    close_waiter.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await close_waiter
+
+    value.release.set()
+    await dependencies.aclose()
+    assert value.calls == 1
+    assert value.completed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request takes over and completes the original work in #3935 by @cosin2077.

It fixes cached sandbox dependency factories so concurrent requests for the same key share one in-flight initialization and cached result. It also keeps shared initialization alive when an individual waiter is cancelled, allows failed factories to be retried, and prevents rebind or shutdown races from returning disposed dependencies or closing aliased owned resources prematurely.