### PR TITLE
fix(memory): reject an existing branch id in create_branch_from_turn

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -863,6 +863,11 @@ class AdvancedSQLiteSession(SQLiteSession):
         if branch_name is None:
             timestamp = int(time.time())
             branch_name = f"branch_from_turn_{turn_number}_{timestamp}"
+        elif await self._branch_exists(branch_name):
+            raise ValueError(
+                f"Branch '{branch_name}' already exists in session '{self.session_id}'. "
+                "Pass a different branch_name, or omit it to generate one."
+            )
 
         # Copy messages before the branch point to the new branch
         await self._copy_messages_to_new_branch(branch_name, turn_number)
@@ -1086,6 +1091,25 @@ class AdvancedSQLiteSession(SQLiteSession):
                     return branches
 
         return await asyncio.to_thread(_list_branches_sync)
+
+    async def _branch_exists(self, branch_id: str) -> bool:
+        """Whether any message in this session is already tagged with ``branch_id``."""
+
+        def _branch_exists_sync() -> bool:
+            with self._locked_connection() as conn:
+                with closing(conn.cursor()) as cursor:
+                    cursor.execute(
+                        """
+                        SELECT 1
+                        FROM message_structure
+                        WHERE session_id = ? AND branch_id = ?
+                        LIMIT 1
+                        """,
+                        (self.session_id, branch_id),
+                    )
+                    return cursor.fetchone() is not None
+
+        return await asyncio.to_thread(_branch_exists_sync)
 
     async def _copy_messages_to_new_branch(self, new_branch_id: str, from_turn_number: int) -> None:
         """Copy messages before the branch point to the new branch.

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -182,6 +182,32 @@ async def test_create_branch_logging_respects_model_data_policy(monkeypatch, red
         session.close()
 
 
+async def test_create_branch_rejects_existing_branch_id():
+    session = AdvancedSQLiteSession(session_id="s4150", create_tables=True)
+    try:
+        await session.add_items(
+            [
+                {"role": "user", "content": "one"},
+                {"role": "assistant", "content": "a"},
+                {"role": "user", "content": "two"},
+                {"role": "assistant", "content": "b"},
+            ]
+        )
+        await session.create_branch_from_turn(2, "dup")
+        # Return to a branch where turn 2 still resolves, so the only thing
+        # left for the second call to object to is the duplicate branch id.
+        await session.switch_to_branch("main")
+        before = {b["branch_id"]: b["message_count"] for b in await session.list_branches()}
+
+        with pytest.raises(ValueError, match="already exists"):
+            await session.create_branch_from_turn(2, "dup")
+
+        after = {b["branch_id"]: b["message_count"] for b in await session.list_branches()}
+        assert after == before, "a rejected branch creation must not modify any branch"
+    finally:
+        session.close()
+
+
 async def test_advanced_session_respects_custom_table_names():
     """AdvancedSQLiteSession should consistently use configured table names."""
     session = AdvancedSQLiteSession(


### PR DESCRIPTION
Closes #4150.

### Problem

`create_branch_from_turn()` passes `branch_name` straight through to `_copy_messages_to_new_branch()`, which unconditionally inserts `message_structure` rows tagged with that id. Passing the id of a branch that already exists merges the copied turns into it and then switches to it. There is no error, and afterwards the two histories cannot be told apart.

### Change

Check the id before copying and raise `ValueError`. The method's docstring already documents `ValueError` as its failure mode, so this uses the existing contract rather than introducing a new one. A generated name is unaffected, since it embeds a timestamp.

### Verification

- Test added to `tests/extensions/memory/test_advanced_sqlite_session.py`. It asserts both halves: that the second call raises, and that branch message counts are unchanged afterwards, so a rejected call cannot have partially written.
- Confirmed the test fails without the source change (1 failed, 67 passed) and passes with it (68 passed).
- The assertion matches on `"already exists"`. An earlier version of this test passed for the wrong reason: after the first call the session is on the new branch, where the requested turn no longer resolves, so turn validation raised `ValueError` on its own. Switching back to `main` first isolates the duplicate-id condition.
- `ruff check` and `ruff format --check` clean on both files.
