### PR TITLE
fix: defer non-stream session saves until output guardrails

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -14,6 +14,7 @@ from .exceptions import (
     AgentsException,
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
+    OutputGuardrailTripwireTriggered,
     RunErrorDetails,
     UserError,
 )
@@ -61,6 +62,7 @@ from .run_internal.agent_runner_helpers import (
     resolve_processed_response,
     resolve_resumed_context,
     resolve_trace_settings,
+    save_final_turn_items_after_guardrails,
     save_turn_items_if_needed,
     should_cancel_parallel_model_task_on_input_guardrail_trip,
     snapshot_usage,
@@ -85,6 +87,7 @@ from .run_internal.oai_conversation import OpenAIServerConversationTracker
 from .run_internal.prompt_cache_key import PromptCacheKeyResolver
 from .run_internal.run_grouping import resolve_run_grouping_id
 from .run_internal.run_loop import (
+    _retained_items_for_blocked_output,
     cleanup_models_after_run,
     get_all_tools,
     get_output_schema,
@@ -1378,15 +1381,6 @@ class AgentRunner:
 
                     items_to_save_turn = list(turn_session_items)
                     if not isinstance(turn_result.next_step, NextStepInterruption):
-                        # When resuming a turn we have already persisted the tool_call items;
-                        if (
-                            is_resumed_state
-                            and run_state
-                            and run_state._current_turn_persisted_item_count > 0
-                        ):
-                            items_to_save_turn = [
-                                item for item in items_to_save_turn if item.type != "tool_call_item"
-                            ]
                         if session_persistence_enabled:
                             output_call_ids = {
                                 item.raw_item.get("call_id")
@@ -1418,7 +1412,9 @@ class AgentRunner:
                                     )
                                 ):
                                     items_to_save_turn.append(item)
-                            if items_to_save_turn:
+                            if items_to_save_turn and not isinstance(
+                                turn_result.next_step, NextStepFinalOutput
+                            ):
                                 logger.debug(
                                     "Persisting turn items (types=%s)",
                                     [item.type for item in items_to_save_turn],
@@ -1452,13 +1448,48 @@ class AgentRunner:
 
                     try:
                         if isinstance(turn_result.next_step, NextStepFinalOutput):
-                            await run_output_guardrails(
-                                current_agent.output_guardrails
-                                + (run_config.output_guardrails or []),
-                                current_agent,
-                                turn_result.next_step.output,
-                                context_wrapper,
-                                output_guardrail_results,
+                            try:
+                                await run_output_guardrails(
+                                    current_agent.output_guardrails
+                                    + (run_config.output_guardrails or []),
+                                    current_agent,
+                                    turn_result.next_step.output,
+                                    context_wrapper,
+                                    output_guardrail_results,
+                                )
+                            except OutputGuardrailTripwireTriggered:
+                                await save_final_turn_items_after_guardrails(
+                                    session=session,
+                                    run_state=run_state,
+                                    session_persistence_enabled=session_persistence_enabled,
+                                    input_guardrail_results=input_guardrail_results,
+                                    items=_retained_items_for_blocked_output(items_to_save_turn),
+                                    response_id=turn_result.model_response.response_id,
+                                    store=store_setting,
+                                )
+                                raise
+                            except (Exception, asyncio.CancelledError):
+                                # Preserve the released non-stream behavior for guardrail errors
+                                # and cancellation: the completed final turn remains replayable.
+                                await save_final_turn_items_after_guardrails(
+                                    session=session,
+                                    run_state=run_state,
+                                    session_persistence_enabled=session_persistence_enabled,
+                                    input_guardrail_results=input_guardrail_results,
+                                    items=items_to_save_turn,
+                                    response_id=turn_result.model_response.response_id,
+                                    store=store_setting,
+                                )
+                                raise
+
+                            await save_final_turn_items_after_guardrails(
+                                session=session,
+                                run_state=run_state,
+                                session_persistence_enabled=session_persistence_enabled,
+                                input_guardrail_results=input_guardrail_results,
+                                items=items_to_save_turn,
+                                response_id=turn_result.model_response.response_id,
+                                store=store_setting,
                             )
 
                             # Ensure starting_input is not None and not RunState
@@ -1489,15 +1520,6 @@ class AgentRunner:
                                 result._current_turn_persisted_item_count = (
                                     run_state._current_turn_persisted_item_count
                                 )
-                            await save_turn_items_if_needed(
-                                session=session,
-                                run_state=run_state,
-                                session_persistence_enabled=session_persistence_enabled,
-                                input_guardrail_results=input_guardrail_results,
-                                items=session_items_for_turn(turn_result),
-                                response_id=turn_result.model_response.response_id,
-                                store=store_setting,
-                            )
                             result._original_input = copy_input_items(original_input)
                             return _finalize_result(result)
                         elif isinstance(turn_result.next_step, NextStepInterruption):

--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -40,7 +40,7 @@ from .run_steps import (
     NextStepRunAgain,
     ProcessedResponse,
 )
-from .session_persistence import save_result_to_session
+from .session_persistence import save_result_to_session, save_resumed_turn_items
 from .tool_use_tracker import AgentToolUseTracker, serialize_tool_use_tracker
 
 __all__ = [
@@ -59,6 +59,7 @@ __all__ = [
     "resolve_trace_settings",
     "resolve_processed_response",
     "resolve_resumed_context",
+    "save_final_turn_items_after_guardrails",
     "save_turn_items_if_needed",
     "should_cancel_parallel_model_task_on_input_guardrail_trip",
     "update_run_state_for_interruption",
@@ -480,6 +481,41 @@ async def save_turn_items_if_needed(
     if input_guardrails_triggered(input_guardrail_results):
         return
     if run_state is not None and run_state._current_turn_persisted_item_count > 0:
+        return
+    await save_result_to_session(
+        session,
+        [],
+        list(items),
+        run_state,
+        response_id=response_id,
+        store=store,
+    )
+
+
+async def save_final_turn_items_after_guardrails(
+    *,
+    session: Session | None,
+    run_state: RunState | None,
+    session_persistence_enabled: bool,
+    input_guardrail_results: list[InputGuardrailResult],
+    items: list[RunItem],
+    response_id: str | None,
+    store: bool | None = None,
+) -> None:
+    """Persist deferred final-turn items without skipping a partially persisted resumed turn."""
+    if not session_persistence_enabled or not items:
+        return
+    if input_guardrails_triggered(input_guardrail_results):
+        return
+    if run_state is not None and run_state._current_turn_persisted_item_count > 0:
+        run_state._current_turn_persisted_item_count = await save_resumed_turn_items(
+            session=session,
+            items=items,
+            persisted_count=run_state._current_turn_persisted_item_count,
+            response_id=response_id,
+            reasoning_item_id_policy=run_state._reasoning_item_id_policy,
+            store=store,
+        )
         return
     await save_result_to_session(
         session,

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -3863,6 +3863,9 @@ async def test_session_persists_only_new_step_items(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(
         "agents.run_internal.session_persistence.save_result_to_session", save_wrapper
     )
+    monkeypatch.setattr(
+        "agents.run_internal.agent_runner_helpers.save_result_to_session", save_wrapper
+    )
     monkeypatch.setattr("agents.run.run_single_turn", fake_run_single_turn)
     monkeypatch.setattr("agents.run_internal.run_loop.run_single_turn", fake_run_single_turn)
     monkeypatch.setattr("agents.run.run_output_guardrails", fake_run_output_guardrails)
@@ -3913,6 +3916,201 @@ async def test_output_guardrail_tripwire_triggered_causes_exception():
 
     with pytest.raises(OutputGuardrailTripwireTriggered):
         await Runner.run(agent, input="user_message")
+
+
+def test_output_guardrail_tripwire_does_not_save_assistant_message_to_session_sync() -> None:
+    def guardrail_function(
+        _context: RunContextWrapper[Any], _agent: Agent[Any], _agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    session = SimpleListSession()
+    model = FakeModel()
+    model.set_next_output([get_text_message("should_not_be_saved")])
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+    )
+
+    with pytest.raises(OutputGuardrailTripwireTriggered):
+        Runner.run_sync(agent, input="user_message", session=session)
+
+    items = asyncio.run(session.get_items())
+    assert [
+        cast(dict[str, Any], item).get("type") or cast(dict[str, Any], item).get("role")
+        for item in items
+    ] == ["user"]
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_error_preserves_final_output_in_session() -> None:
+    def guardrail_function(
+        _context: RunContextWrapper[Any], _agent: Agent[Any], _agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        raise RuntimeError("guardrail failed")
+
+    session = SimpleListSession()
+    model = FakeModel()
+    model.set_next_output([get_text_message("preserved_on_guardrail_error")])
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+    )
+
+    with pytest.raises(RuntimeError, match="guardrail failed"):
+        await Runner.run(agent, input="user_message", session=session)
+
+    items = await session.get_items()
+    assert [
+        cast(dict[str, Any], item).get("type") or cast(dict[str, Any], item).get("role")
+        for item in items
+    ] == ["user", "message"]
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_cancellation_preserves_final_output_in_session() -> None:
+    guardrail_started = asyncio.Event()
+
+    async def guardrail_function(
+        _context: RunContextWrapper[Any], _agent: Agent[Any], _agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        guardrail_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    session = SimpleListSession()
+    model = FakeModel()
+    model.set_next_output([get_text_message("preserved_on_guardrail_cancellation")])
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+    )
+
+    run_task = asyncio.create_task(Runner.run(agent, input="user_message", session=session))
+    await guardrail_started.wait()
+    run_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    items = await session.get_items()
+    assert [
+        cast(dict[str, Any], item).get("type") or cast(dict[str, Any], item).get("role")
+        for item in items
+    ] == ["user", "message"]
+
+
+@pytest.mark.asyncio
+async def test_resumed_final_output_persists_once_after_passing_output_guardrail() -> None:
+    def guardrail_function(
+        _context: RunContextWrapper[Any], _agent: Agent[Any], _agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    @function_tool
+    def foo(a: str) -> str:
+        return f"result:{a}"
+
+    session = SimpleListSession()
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("foo", json.dumps({"a": "b"}))])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[foo],
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+    )
+
+    streamed = Runner.run_streamed(agent, input="user_message", session=session)
+    async for event in streamed.stream_events():
+        if event.type == "run_item_stream_event" and event.name == "tool_output":
+            streamed.cancel(mode="after_turn")
+
+    items_before_resume = await session.get_items()
+    state = streamed.to_state()
+    state._current_turn_persisted_item_count = 2
+
+    model.set_next_output([get_text_message("accepted_final")])
+    resumed = await Runner.run(agent, state, session=session)
+    assert resumed.final_output == "accepted_final"
+
+    items_after_resume = await session.get_items()
+    assert items_after_resume[: len(items_before_resume)] == items_before_resume
+    assistant_messages = [
+        item
+        for item in items_after_resume
+        if cast(dict[str, Any], item).get("role") == "assistant"
+        and cast(dict[str, Any], item).get("type") == "message"
+    ]
+    assert len(assistant_messages) == 1
+    content = cast(dict[str, Any], assistant_messages[0]).get("content")
+    assert isinstance(content, list)
+    assert any(isinstance(part, dict) and part.get("text") == "accepted_final" for part in content)
+
+
+@pytest.mark.parametrize("tripwire_triggered", [False, True])
+@pytest.mark.asyncio
+async def test_resumed_final_tool_persists_call_and_output_after_output_guardrail(
+    tripwire_triggered: bool,
+) -> None:
+    def guardrail_function(
+        _context: RunContextWrapper[Any], _agent: Agent[Any], _agent_output: Any
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(
+            output_info=None,
+            tripwire_triggered=tripwire_triggered,
+        )
+
+    @function_tool(name_override="commit_tool")
+    def commit_tool() -> str:
+        return "committed-result"
+
+    session = SimpleListSession()
+    model = FakeModel()
+    model.set_next_output([get_function_tool_call("commit_tool", "{}", call_id="call-first")])
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[commit_tool],
+        output_guardrails=[OutputGuardrail(guardrail_function=guardrail_function)],
+    )
+
+    streamed = Runner.run_streamed(agent, input="user_message", session=session)
+    async for event in streamed.stream_events():
+        if event.type == "run_item_stream_event" and event.name == "tool_output":
+            streamed.cancel(mode="after_turn")
+
+    state = streamed.to_state()
+    assert state._current_turn_persisted_item_count == 2
+
+    agent.tool_use_behavior = "stop_on_first_tool"
+    model.set_next_output([get_function_tool_call("commit_tool", "{}", call_id="call-second")])
+
+    if tripwire_triggered:
+        with pytest.raises(OutputGuardrailTripwireTriggered):
+            await Runner.run(agent, state, session=session)
+    else:
+        result = await Runner.run(agent, state, session=session)
+        assert result.final_output == "committed-result"
+
+    assert state._current_turn_persisted_item_count == 4
+    items = await session.get_items()
+    assert [
+        (
+            cast(dict[str, Any], item).get("type") or cast(dict[str, Any], item).get("role"),
+            cast(dict[str, Any], item).get("call_id"),
+        )
+        for item in items
+    ] == [
+        ("user", None),
+        ("function_call", "call-first"),
+        ("function_call_output", "call-first"),
+        ("function_call", "call-second"),
+        ("function_call_output", "call-second"),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -2152,13 +2152,10 @@ async def test_stop_on_first_tool_final_persists_committed_tool_items_on_tripwir
     ]
 
 
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
 @pytest.mark.asyncio
-async def test_streamed_blocked_message_final_output_is_not_persisted() -> None:
-    """Control for the committed-tool case: a rejected message is still withheld from the session.
-
-    Streamed-only on purpose. The non-streamed path persists a turn before its output guardrails
-    run, so it keeps the rejected message today; that difference is out of scope here.
-    """
+async def test_blocked_message_final_output_is_not_persisted(mode: str) -> None:
+    """Control for the committed-tool case: a rejected message is withheld from the session."""
 
     def output_guardrail(
         _context: RunContextWrapper[Any],
@@ -2177,16 +2174,20 @@ async def test_streamed_blocked_message_final_output_is_not_persisted() -> None:
     session = SimpleListSession()
 
     with pytest.raises(OutputGuardrailTripwireTriggered):
-        result = Runner.run_streamed(agent, "user_message", session=session)
-        await consume_stream(result)
+        if mode == "non_streamed":
+            await Runner.run(agent, "user_message", session=session)
+        else:
+            result = Runner.run_streamed(agent, "user_message", session=session)
+            await consume_stream(result)
 
     saved_items = await session.get_items()
     saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
     assert saved == ["user"]
 
 
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
 @pytest.mark.asyncio
-async def test_streamed_blocked_final_persists_tool_items_but_not_the_message() -> None:
+async def test_blocked_final_persists_tool_items_but_not_the_message(mode: str) -> None:
     """A mixed final turn splits: the tool record is kept, the blocked message is not."""
 
     @function_tool(name_override="commit_tool")
@@ -2216,8 +2217,11 @@ async def test_streamed_blocked_final_persists_tool_items_but_not_the_message() 
     session = SimpleListSession()
 
     with pytest.raises(OutputGuardrailTripwireTriggered):
-        result = Runner.run_streamed(agent, "Use commit_tool", session=session)
-        await consume_stream(result)
+        if mode == "non_streamed":
+            await Runner.run(agent, "Use commit_tool", session=session)
+        else:
+            result = Runner.run_streamed(agent, "Use commit_tool", session=session)
+            await consume_stream(result)
 
     saved_items = await session.get_items()
     saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
@@ -2282,7 +2286,7 @@ async def test_mixed_final_turn_session_order_and_committed_items(
     saved_items = await session.get_items()
     saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
 
-    if tripwire and mode == "streamed":
+    if tripwire:
         # The undeliverable message is withheld; the tool that already ran is not.
         assert saved == ["user", "function_call", "function_call_output"]
     else:
@@ -2368,8 +2372,11 @@ async def test_blocked_tool_final_keeps_reasoning_context_with_the_committed_cal
     assert replayed == ["reasoning", "function_call", "function_call_output"]
 
 
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
 @pytest.mark.asyncio
-async def test_blocked_tool_final_drops_reasoning_tied_to_the_rejected_message() -> None:
+async def test_blocked_tool_final_drops_reasoning_tied_to_the_rejected_message(
+    mode: str,
+) -> None:
     """Only the reasoning tied to a retained call survives; the message's reasoning goes with it.
 
     The turn is `reasoning_for_message -> message -> reasoning_for_call -> function_call`. A
@@ -2377,10 +2384,7 @@ async def test_blocked_tool_final_drops_reasoning_tied_to_the_rejected_message()
     whenever the turn happens to contain a tool call would leave the rejected message's reasoning
     dangling in the next request.
 
-    Streamed only: on a tripwire the non-streamed path persists the whole turn - the rejected
-    message included - which predates this change and is a separate bug (see the PR discussion).
     """
-    mode = "streamed"
 
     @function_tool(name_override="commit_tool")
     def commit_tool() -> str:


### PR DESCRIPTION
This pull request fixes non-streamed session persistence so assistant output rejected by an output guardrail is not replayed on later turns.

It supersedes the closed #3998. That PR identified the underlying bug, but its branch diverged from current main after #4148 established the shared blocked-output retention behavior, and its split-save approach could lose or reorder mixed final-turn items.

This replacement reuses the retention policy from #4148, persists accepted final turns as one ordered batch, retains committed tool and reasoning records when a tripwire fires, and keeps resumed `RunState` persistence counts exact. It also preserves the released behavior for ordinary guardrail errors and cancellation.