### PR TITLE
fix(run): cancel sibling work after concurrent failures

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -97,6 +97,7 @@ from ..tracing.model_tracing import get_model_tracing_impl
 from ..tracing.span_data import AgentSpanData, TaskSpanData
 from ..usage import Usage, _response_usage_to_usage
 from ..util import _coro, _error_tracing
+from ..util._asyncio_tasks import gather_with_cancel
 from .agent_bindings import AgentBindings, bind_public_agent
 from .agent_runner_helpers import (
     apply_resumed_conversation_settings,
@@ -1544,7 +1545,7 @@ async def run_single_turn_streamed(
             _approvals=context_wrapper._approvals,
             turn_input=turn_input,
         )
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_agent_start(agent_hook_context, public_agent),
             (
                 public_agent.hooks.on_start(agent_hook_context, public_agent)
@@ -1558,7 +1559,7 @@ async def run_single_turn_streamed(
     streamed_result.current_agent = public_agent
     streamed_result._current_agent_output_schema = get_output_schema(public_agent)
 
-    system_prompt, prompt_config = await asyncio.gather(
+    system_prompt, prompt_config = await gather_with_cancel(
         execution_agent.get_system_prompt(context_wrapper),
         execution_agent.get_prompt(context_wrapper),
     )
@@ -1642,7 +1643,7 @@ async def run_single_turn_streamed(
         # explicitly rewind this state before replaying a failed request.
         server_conversation_tracker.mark_input_as_sent(filtered.input)
 
-    await asyncio.gather(
+    await gather_with_cancel(
         hooks.on_llm_start(context_wrapper, public_agent, filtered.instructions, filtered.input),
         (
             public_agent.hooks.on_llm_start(
@@ -1879,7 +1880,7 @@ async def run_single_turn_streamed(
 
     if final_response is not None:
         context_wrapper.usage.add(final_response.usage)
-        await asyncio.gather(
+        await gather_with_cancel(
             (
                 public_agent.hooks.on_llm_end(context_wrapper, public_agent, final_response)
                 if public_agent.hooks
@@ -1993,7 +1994,7 @@ async def run_single_turn(
             _approvals=context_wrapper._approvals,
             turn_input=turn_input,
         )
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_agent_start(agent_hook_context, public_agent),
             (
                 public_agent.hooks.on_start(agent_hook_context, public_agent)
@@ -2002,7 +2003,7 @@ async def run_single_turn(
             ),
         )
 
-    system_prompt, prompt_config = await asyncio.gather(
+    system_prompt, prompt_config = await gather_with_cancel(
         execution_agent.get_system_prompt(context_wrapper),
         execution_agent.get_prompt(context_wrapper),
     )
@@ -2100,7 +2101,7 @@ async def get_new_response(
     if server_conversation_tracker is not None:
         server_conversation_tracker.mark_input_as_sent(filtered.input)
 
-    await asyncio.gather(
+    await gather_with_cancel(
         hooks.on_llm_start(context_wrapper, public_agent, filtered.instructions, filtered.input),
         (
             public_agent.hooks.on_llm_start(
@@ -2180,7 +2181,7 @@ async def get_new_response(
 
     context_wrapper.usage.add(new_response.usage)
 
-    await asyncio.gather(
+    await gather_with_cancel(
         (
             public_agent.hooks.on_llm_end(context_wrapper, public_agent, new_response)
             if public_agent.hooks

--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -5,7 +5,6 @@ functions and approval plumbing live in tool_execution.py.
 
 from __future__ import annotations
 
-import asyncio
 import copy
 import dataclasses
 import inspect
@@ -40,6 +39,7 @@ from ..tool_context import ToolContext
 from ..tracing import SpanError
 from ..util import _coro
 from ..util._approvals import evaluate_needs_approval_setting
+from ..util._asyncio_tasks import gather_with_cancel
 from ..util._custom_data import maybe_extract_custom_data
 from .items import apply_patch_rejection_item, shell_rejection_item
 from .tool_execution import (
@@ -126,7 +126,7 @@ class ComputerAction:
                 tool=action.computer_tool, run_context=context_wrapper
             )
             agent_hooks = agent.hooks
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_start(context_wrapper, agent, action.computer_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, action.computer_tool)
@@ -177,7 +177,7 @@ class ComputerAction:
                 ),
             )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output)
@@ -393,7 +393,7 @@ class LocalShellAction:
     ) -> RunItem:
         """Run a local shell tool call and wrap the result as a ToolCallOutputItem."""
         agent_hooks = agent.hooks
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool),
             (
                 agent_hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool)
@@ -409,7 +409,7 @@ class LocalShellAction:
         output = call.local_shell_tool.executor(request)
         result = await output if inspect.isawaitable(output) else output
 
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result),
             (
                 agent_hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result)
@@ -498,7 +498,7 @@ class ShellAction:
                     rejection_message=rejection_message,
                 )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_start(context_wrapper, agent, shell_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, shell_tool)
@@ -572,7 +572,7 @@ class ShellAction:
                     output_text = output_text[:max_output_length]
                 log_tool_action_error("Shell executor failed", exc)
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text)
@@ -702,7 +702,7 @@ class CustomToolAction:
                     ),
                 )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_start(tool_context, agent, custom_tool),
                 (
                     agent_hooks.on_tool_start(tool_context, agent, custom_tool)
@@ -749,7 +749,7 @@ class CustomToolAction:
                 ),
             )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_end(tool_context, agent, custom_tool, output_text),
                 (
                     agent_hooks.on_tool_end(tool_context, agent, custom_tool, output_text)
@@ -889,7 +889,7 @@ class ApplyPatchAction:
                     rejection_message=rejection_message,
                 )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_start(context_wrapper, agent, apply_patch_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, apply_patch_tool)
@@ -966,7 +966,7 @@ class ApplyPatchAction:
                 ),
             )
 
-            await asyncio.gather(
+            await gather_with_cancel(
                 hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text)

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -602,7 +602,7 @@ async def initialize_computer_tools(
         tool for tool in computer_tools if _computer_tool_uses_run_scoped_initializer(tool)
     }
 
-    resolved_computers = await asyncio.gather(
+    resolved_computers = await gather_with_cancel(
         *(resolve_computer(tool=tool, run_context=context_wrapper) for tool in computer_tools)
     )
     resolved_by_tool = dict(zip(computer_tools, resolved_computers, strict=True))
@@ -1456,6 +1456,7 @@ class _FunctionToolBatchExecutor:
         context_wrapper: RunContextWrapper[Any],
         config: RunConfig,
         isolate_parallel_failures: bool | None,
+        sibling_category_failure: asyncio.Event | None,
     ) -> None:
         self.execution_agent = bindings.execution_agent
         self.public_agent = bindings.public_agent
@@ -1466,6 +1467,7 @@ class _FunctionToolBatchExecutor:
         self.isolate_parallel_failures = (
             len(tool_runs) > 1 if isolate_parallel_failures is None else isolate_parallel_failures
         )
+        self.sibling_category_failure = sibling_category_failure
         self.tool_input_guardrail_results: list[ToolInputGuardrailResult] = []
         self.tool_output_guardrail_results: list[ToolOutputGuardrailResult] = []
         self.tool_state_scope_id = get_agent_tool_state_scope(context_wrapper)
@@ -1516,7 +1518,10 @@ class _FunctionToolBatchExecutor:
         except asyncio.CancelledError as exc:
             if self.propagating_failure is exc:
                 raise
-            self._cancel_pending_tasks_for_parent_cancellation()
+            if self.sibling_category_failure is not None and self.sibling_category_failure.is_set():
+                await self._drain_pending_tasks_for_sibling_category_failure()
+            else:
+                self._cancel_pending_tasks_for_parent_cancellation()
             raise
 
         return (
@@ -1634,6 +1639,30 @@ class _FunctionToolBatchExecutor:
             failure_sources_by_task=post_invoke_failure_sources,
             timeout_seconds=_FUNCTION_TOOL_POST_INVOKE_WAIT_SECONDS,
         )
+
+    async def _drain_pending_tasks_for_sibling_category_failure(self) -> None:
+        """Settle nested function tasks after another tool category fails."""
+        cancellable_tasks, post_invoke_tasks = self._partition_pending_tasks()
+        self.teardown_cancelled_tasks.update(cancellable_tasks)
+        _cancel_function_tool_tasks(cancellable_tasks)
+
+        try:
+            _, remaining_cancelled_tasks = await self._drain_cancelled_tasks(cancellable_tasks)
+            _, remaining_post_invoke_tasks = await self._wait_post_invoke_tasks(post_invoke_tasks)
+        except BaseException:
+            self._cancel_pending_tasks_for_parent_cancellation()
+            self.pending_tasks = set()
+            raise
+
+        _attach_function_tool_task_result_callbacks(
+            remaining_cancelled_tasks,
+            message_for_exception=_background_cleanup_task_exception_message,
+        )
+        _attach_function_tool_task_result_callbacks(
+            remaining_post_invoke_tasks,
+            message_for_exception=_background_post_invoke_task_exception_message,
+        )
+        self.pending_tasks = set()
 
     def _cancel_pending_tasks_for_parent_cancellation(self) -> None:
         self.teardown_cancelled_tasks.update(self.pending_tasks)
@@ -1862,7 +1891,7 @@ class _FunctionToolBatchExecutor:
             self.schema_bypassed_tool_runs.add(id(task_state.tool_run))
             return rejected_message
 
-        await asyncio.gather(
+        await gather_with_cancel(
             self.hooks.on_tool_start(tool_context, self.public_agent, func_tool),
             (
                 agent_hooks.on_tool_start(tool_context, self.public_agent, func_tool)
@@ -1978,7 +2007,7 @@ class _FunctionToolBatchExecutor:
         if custom_data:
             self.custom_data_by_tool_run[id(task_state.tool_run)] = custom_data
 
-        await asyncio.gather(
+        await gather_with_cancel(
             self.hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result),
             (
                 agent_hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result)
@@ -2134,6 +2163,7 @@ async def execute_function_tool_calls(
     context_wrapper: RunContextWrapper[Any],
     config: RunConfig,
     isolate_parallel_failures: bool | None = None,
+    sibling_category_failure: asyncio.Event | None = None,
 ) -> tuple[
     list[FunctionToolResult], list[ToolInputGuardrailResult], list[ToolOutputGuardrailResult]
 ]:
@@ -2145,6 +2175,7 @@ async def execute_function_tool_calls(
         context_wrapper=context_wrapper,
         config=config,
         isolate_parallel_failures=isolate_parallel_failures,
+        sibling_category_failure=sibling_category_failure,
     ).execute()
 
 

--- a/src/agents/run_internal/tool_planning.py
+++ b/src/agents/run_internal/tool_planning.py
@@ -25,6 +25,7 @@ from ..items import (
 from ..run_context import RunContextWrapper
 from ..tool import FunctionTool, MCPToolApprovalRequest, get_function_tool_origin
 from ..tool_guardrails import ToolInputGuardrailResult, ToolOutputGuardrailResult
+from ..util._asyncio_tasks import gather_with_cancel
 from .agent_bindings import AgentBindings
 from .run_steps import (
     ToolRunApplyPatchCall,
@@ -136,7 +137,7 @@ async def execute_mcp_approval_requests(
         )
 
     tasks = [run_single_approval(approval_request) for approval_request in approval_requests]
-    return await asyncio.gather(*tasks)
+    return list(await gather_with_cancel(*tasks))
 
 
 def _build_tool_output_index(items: Sequence[RunItem]) -> set[tuple[str, str]]:
@@ -582,6 +583,7 @@ async def _execute_tool_plan(
         )
     )
     if parallel:
+        sibling_category_failure = asyncio.Event()
         (
             (function_results, tool_input_guardrail_results, tool_output_guardrail_results),
             computer_results,
@@ -589,7 +591,7 @@ async def _execute_tool_plan(
             shell_results,
             apply_patch_results,
             local_shell_results,
-        ) = await asyncio.gather(
+        ) = await gather_with_cancel(
             execute_function_tool_calls(
                 bindings=bindings,
                 tool_runs=plan.function_runs,
@@ -597,6 +599,7 @@ async def _execute_tool_plan(
                 context_wrapper=context_wrapper,
                 config=run_config,
                 isolate_parallel_failures=isolate_function_tool_failures,
+                sibling_category_failure=sibling_category_failure,
             ),
             execute_computer_actions(
                 public_agent=public_agent,
@@ -633,6 +636,7 @@ async def _execute_tool_plan(
                 context_wrapper=context_wrapper,
                 config=run_config,
             ),
+            on_child_failure=sibling_category_failure.set,
         )
     else:
         (

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -107,6 +107,7 @@ from ..tool_guardrails import ToolInputGuardrailResult, ToolOutputGuardrailResul
 from ..tracing import SpanError, handoff_span
 from ..util import _coro, _error_tracing
 from ..util._approvals import evaluate_needs_approval_setting
+from ..util._asyncio_tasks import gather_with_cancel
 from .agent_bindings import AgentBindings
 from .error_handlers import (
     build_run_error_data,
@@ -330,7 +331,7 @@ async def run_final_output_hooks(
         turn_input=context_wrapper.turn_input,
     )
 
-    await asyncio.gather(
+    await gather_with_cancel(
         hooks.on_agent_end(agent_hook_context, agent, final_output),
         agent.hooks.on_end(agent_hook_context, agent, final_output)
         if agent.hooks
@@ -553,7 +554,7 @@ async def execute_handoffs(
             )
         )
 
-        await asyncio.gather(
+        await gather_with_cancel(
             hooks.on_handoff(
                 context=context_wrapper,
                 from_agent=public_agent,

--- a/src/agents/util/_asyncio_tasks.py
+++ b/src/agents/util/_asyncio_tasks.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar, overload
 
 T = TypeVar("T")
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+T6 = TypeVar("T6")
+
+
+def _consume_future_exception(future: asyncio.Future[Any]) -> None:
+    """Retrieve a completed future's exception without changing its result semantics."""
+    try:
+        future.exception()
+    except asyncio.CancelledError:
+        pass
 
 
 @overload
@@ -15,6 +26,8 @@ async def gather_with_cancel(
     awaitable_1: Awaitable[T1],
     awaitable_2: Awaitable[T2],
     /,
+    *,
+    on_child_failure: Callable[[], None] | None = None,
 ) -> tuple[T1, T2]: ...
 
 
@@ -24,18 +37,73 @@ async def gather_with_cancel(
     awaitable_2: Awaitable[T2],
     awaitable_3: Awaitable[T3],
     /,
+    *,
+    on_child_failure: Callable[[], None] | None = None,
 ) -> tuple[T1, T2, T3]: ...
 
 
 @overload
-async def gather_with_cancel(*awaitables: Awaitable[T]) -> tuple[T, ...]: ...
+async def gather_with_cancel(
+    awaitable_1: Awaitable[T1],
+    awaitable_2: Awaitable[T2],
+    awaitable_3: Awaitable[T3],
+    awaitable_4: Awaitable[T4],
+    /,
+    *,
+    on_child_failure: Callable[[], None] | None = None,
+) -> tuple[T1, T2, T3, T4]: ...
 
 
-async def gather_with_cancel(*awaitables: Awaitable[Any]) -> tuple[Any, ...]:
+@overload
+async def gather_with_cancel(
+    awaitable_1: Awaitable[T1],
+    awaitable_2: Awaitable[T2],
+    awaitable_3: Awaitable[T3],
+    awaitable_4: Awaitable[T4],
+    awaitable_5: Awaitable[T5],
+    /,
+    *,
+    on_child_failure: Callable[[], None] | None = None,
+) -> tuple[T1, T2, T3, T4, T5]: ...
+
+
+@overload
+async def gather_with_cancel(
+    awaitable_1: Awaitable[T1],
+    awaitable_2: Awaitable[T2],
+    awaitable_3: Awaitable[T3],
+    awaitable_4: Awaitable[T4],
+    awaitable_5: Awaitable[T5],
+    awaitable_6: Awaitable[T6],
+    /,
+    *,
+    on_child_failure: Callable[[], None] | None = None,
+) -> tuple[T1, T2, T3, T4, T5, T6]: ...
+
+
+@overload
+async def gather_with_cancel(
+    *awaitables: Awaitable[T],
+    on_child_failure: Callable[[], None] | None = None,
+) -> tuple[T, ...]: ...
+
+
+async def gather_with_cancel(
+    *awaitables: Awaitable[Any],
+    on_child_failure: Callable[[], None] | None = None,
+) -> tuple[Any, ...]:
     """Gather awaitables, cancelling and draining siblings when one raises."""
     tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
+    gather_future = asyncio.gather(*tasks)
+    gather_future.add_done_callback(_consume_future_exception)
     try:
-        return tuple(await asyncio.gather(*tasks))
+        await asyncio.wait((gather_future,))
+        try:
+            return tuple(gather_future.result())
+        except BaseException:
+            if on_child_failure is not None:
+                on_child_failure()
+            raise
     except BaseException:
         for task in tasks:
             if not task.done():

--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+from typing import Any
+
 import pytest
 from openai import omit
 
 from agents import Agent, Prompt, RunConfig, RunContextWrapper, Runner
 from agents.models.interface import Model, ModelProvider
 from agents.models.openai_responses import OpenAIResponsesModel
+from agents.prompts import GenerateDynamicPromptData
 
 from .fake_model import FakeModel, get_response_obj
 from .test_responses import get_text_message
@@ -142,3 +146,75 @@ async def test_agent_prompt_with_default_model_omits_model_and_tools_parameters(
     assert called_kwargs["prompt"] == expected_prompt
     assert called_kwargs["model"] is omit
     assert called_kwargs["tools"] is omit
+
+
+@pytest.mark.asyncio
+async def test_run_cancels_sibling_instructions_when_prompt_resolution_fails() -> None:
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_instructions(_ctx: RunContextWrapper[Any], _agent: Agent[Any]) -> str:
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return "unreachable"
+
+    async def failing_prompt(_data: GenerateDynamicPromptData) -> Prompt:
+        await slow_started.wait()
+        raise RuntimeError("prompt resolution failed")
+
+    agent = Agent(
+        name="prompt-agent",
+        model=FakeModel(),
+        instructions=slow_instructions,
+        prompt=failing_prompt,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt resolution failed"):
+        await Runner.run(agent, input="hi")
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_streamed_cancels_sibling_instructions_when_prompt_resolution_fails() -> None:
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_finished = asyncio.Event()
+
+    async def slow_instructions(_ctx: RunContextWrapper[Any], _agent: Agent[Any]) -> str:
+        slow_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        finally:
+            slow_finished.set()
+        return "unreachable"
+
+    async def failing_prompt(_data: GenerateDynamicPromptData) -> Prompt:
+        await slow_started.wait()
+        raise RuntimeError("prompt resolution failed")
+
+    agent = Agent(
+        name="prompt-agent",
+        model=FakeModel(),
+        instructions=slow_instructions,
+        prompt=failing_prompt,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt resolution failed"):
+        result = Runner.run_streamed(agent, input="hi")
+        async for _event in result.stream_events():
+            pass
+
+    assert slow_cancelled.is_set()
+    assert slow_finished.is_set()

--- a/tests/test_asyncio_tasks.py
+++ b/tests/test_asyncio_tasks.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agents.util._asyncio_tasks import gather_with_cancel
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [RuntimeError, asyncio.CancelledError])
+async def test_gather_with_cancel_reports_child_failure_before_cancelling_siblings(
+    error_type: type[BaseException],
+) -> None:
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    child_failure_reported = asyncio.Event()
+
+    async def sibling() -> None:
+        sibling_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+
+    async def fail_after_sibling_starts() -> None:
+        await sibling_started.wait()
+        raise error_type("child failed")
+
+    with pytest.raises(error_type):
+        await gather_with_cancel(
+            sibling(),
+            fail_after_sibling_starts(),
+            on_child_failure=child_failure_reported.set,
+        )
+
+    assert child_failure_reported.is_set()
+    assert sibling_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_gather_with_cancel_does_not_report_parent_cancellation_as_child_failure() -> None:
+    children_started = 0
+    all_children_started = asyncio.Event()
+    child_failure_reported = asyncio.Event()
+    loop_errors: list[dict[str, object]] = []
+    loop = asyncio.get_running_loop()
+    previous_exception_handler = loop.get_exception_handler()
+
+    async def child() -> None:
+        nonlocal children_started
+        children_started += 1
+        if children_started == 2:
+            all_children_started.set()
+        await asyncio.Event().wait()
+
+    loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+    try:
+        task = asyncio.create_task(
+            gather_with_cancel(
+                child(),
+                child(),
+                on_child_failure=child_failure_reported.set,
+            )
+        )
+        await all_children_started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_exception_handler)
+
+    assert not child_failure_reported.is_set()
+    assert loop_errors == []

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -3713,6 +3713,7 @@ async def test_execute_tool_plan_drains_function_tools_on_sibling_failure() -> N
             await asyncio.sleep(0)
             tool_unwound.set()
             raise
+        return "unreachable"
 
     async def reject_once_tool_is_running(_data: Any) -> bool:
         await tool_started.wait()
@@ -3859,6 +3860,7 @@ async def test_execute_tool_plan_parent_cancellation_does_not_wait_for_function_
             await allow_cleanup_exit.wait()
             cleanup_finished.set()
             raise
+        return "unreachable"
 
     agent: Agent[Any] = Agent(name="test", tools=[slow_tool])
     plan = ToolExecutionPlan(
@@ -3919,6 +3921,7 @@ async def test_execute_tool_plan_parent_cancellation_interrupts_sibling_failure_
             await allow_cleanup_exit.wait()
             cleanup_finished.set()
             raise RuntimeError("late cleanup failure") from None
+        return "unreachable"
 
     async def reject_once_tool_is_running(_data: Any) -> bool:
         await tool_started.wait()

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -12,6 +12,11 @@ from typing import Any, cast
 
 import pytest
 from openai.types.responses import ResponseFunctionToolCall
+from openai.types.responses.response_computer_tool_call import (
+    ActionScreenshot,
+    PendingSafetyCheck,
+    ResponseComputerToolCall,
+)
 from openai.types.responses.response_output_item import McpApprovalRequest
 from openai.types.responses.response_output_message import ResponseOutputMessage
 from openai.types.responses.response_output_refusal import ResponseOutputRefusal
@@ -21,6 +26,7 @@ from agents import (
     Agent,
     AgentBase,
     ApplyPatchTool,
+    ComputerTool,
     FunctionTool,
     HostedMCPTool,
     MCPApprovalRequestItem,
@@ -3618,3 +3624,362 @@ async def test_execute_tools_emits_hosted_mcp_rejection_reason_from_explicit_mes
     assert responses[0].raw_item["approve"] is False
     assert responses[0].raw_item["approval_request_id"] == "mcp-approval-reject-reason"
     assert responses[0].raw_item["reason"] == "Denied by policy"
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_plan_cancels_sibling_category_on_failure() -> None:
+    from agents.run_internal.tool_planning import ToolExecutionPlan, _execute_tool_plan
+
+    from .test_computer_tool_lifecycle import FakeComputer
+
+    shell_started = asyncio.Event()
+    shell_cancelled = asyncio.Event()
+    shell_finished = asyncio.Event()
+
+    async def blocking_executor(_request: Any) -> str:
+        shell_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            shell_cancelled.set()
+            raise
+        finally:
+            shell_finished.set()
+        return "unreachable"
+
+    async def reject_once_shell_is_running(_data: Any) -> bool:
+        await shell_started.wait()
+        return False
+
+    shell_tool = ShellTool(executor=blocking_executor)
+    computer_tool = ComputerTool(
+        computer=FakeComputer(), on_safety_check=reject_once_shell_is_running
+    )
+    agent: Agent[Any] = Agent(name="test", tools=[shell_tool, computer_tool])
+    plan = ToolExecutionPlan(
+        shell_calls=[
+            ToolRunShellCall(
+                tool_call=cast(Any, make_shell_call("shell-1", commands=["sleep 1000"])),
+                shell_tool=shell_tool,
+            )
+        ],
+        computer_actions=[
+            ToolRunComputerAction(
+                tool_call=ResponseComputerToolCall(
+                    id="computer-1",
+                    type="computer_call",
+                    call_id="computer-1",
+                    action=ActionScreenshot(type="screenshot"),
+                    pending_safety_checks=[
+                        PendingSafetyCheck(id="sc-1", code="malicious", message="nope")
+                    ],
+                    status="completed",
+                ),
+                computer_tool=computer_tool,
+            )
+        ],
+    )
+
+    with pytest.raises(UserError, match="safety check was not acknowledged"):
+        await _execute_tool_plan(
+            plan=plan,
+            bindings=bind_public_agent(agent),
+            hooks=RunHooks[Any](),
+            context_wrapper=RunContextWrapper(context=None),
+            run_config=RunConfig(),
+        )
+
+    assert shell_cancelled.is_set()
+    assert shell_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_plan_drains_function_tools_on_sibling_failure() -> None:
+    from agents.run_internal.tool_planning import ToolExecutionPlan, _execute_tool_plan
+
+    from .test_computer_tool_lifecycle import FakeComputer
+
+    tool_started = asyncio.Event()
+    tool_cancelled = asyncio.Event()
+    tool_unwound = asyncio.Event()
+
+    @function_tool
+    async def slow_tool() -> str:
+        tool_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            tool_cancelled.set()
+            await asyncio.sleep(0)
+            tool_unwound.set()
+            raise
+
+    async def reject_once_tool_is_running(_data: Any) -> bool:
+        await tool_started.wait()
+        return False
+
+    computer_tool = ComputerTool(
+        computer=FakeComputer(), on_safety_check=reject_once_tool_is_running
+    )
+    agent: Agent[Any] = Agent(name="test", tools=[slow_tool, computer_tool])
+    plan = ToolExecutionPlan(
+        function_runs=[
+            ToolRunFunction(
+                tool_call=ResponseFunctionToolCall(
+                    id="fn-1",
+                    call_id="fn-1",
+                    name="slow_tool",
+                    arguments="{}",
+                    type="function_call",
+                ),
+                function_tool=cast(Any, slow_tool),
+            )
+        ],
+        computer_actions=[
+            ToolRunComputerAction(
+                tool_call=ResponseComputerToolCall(
+                    id="computer-1",
+                    type="computer_call",
+                    call_id="computer-1",
+                    action=ActionScreenshot(type="screenshot"),
+                    pending_safety_checks=[
+                        PendingSafetyCheck(id="sc-1", code="malicious", message="nope")
+                    ],
+                    status="completed",
+                ),
+                computer_tool=computer_tool,
+            )
+        ],
+    )
+
+    with pytest.raises(UserError, match="safety check was not acknowledged"):
+        await _execute_tool_plan(
+            plan=plan,
+            bindings=bind_public_agent(agent),
+            hooks=RunHooks[Any](),
+            context_wrapper=RunContextWrapper(context=None),
+            run_config=RunConfig(),
+        )
+
+    assert tool_cancelled.is_set()
+    assert tool_unwound.is_set()
+
+
+class _SlowToolEndHooks(RunHooks[Any]):
+    def __init__(self, started: asyncio.Event, finished: asyncio.Event) -> None:
+        self.started = started
+        self.finished = finished
+
+    async def on_tool_end(self, context: Any, agent: Any, tool: Any, result: Any) -> None:
+        self.started.set()
+        await asyncio.sleep(0.05)
+        self.finished.set()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_plan_preserves_function_tool_post_invoke_work() -> None:
+    from agents.run_internal.tool_planning import ToolExecutionPlan, _execute_tool_plan
+
+    from .test_computer_tool_lifecycle import FakeComputer
+
+    post_invoke_started = asyncio.Event()
+    post_invoke_finished = asyncio.Event()
+
+    @function_tool
+    async def quick_tool() -> str:
+        return "ok"
+
+    async def reject_once_post_invoke_is_running(_data: Any) -> bool:
+        await post_invoke_started.wait()
+        return False
+
+    computer_tool = ComputerTool(
+        computer=FakeComputer(), on_safety_check=reject_once_post_invoke_is_running
+    )
+    agent: Agent[Any] = Agent(name="test", tools=[quick_tool, computer_tool])
+    plan = ToolExecutionPlan(
+        function_runs=[
+            ToolRunFunction(
+                tool_call=ResponseFunctionToolCall(
+                    id="fn-1",
+                    call_id="fn-1",
+                    name="quick_tool",
+                    arguments="{}",
+                    type="function_call",
+                ),
+                function_tool=cast(Any, quick_tool),
+            )
+        ],
+        computer_actions=[
+            ToolRunComputerAction(
+                tool_call=ResponseComputerToolCall(
+                    id="computer-1",
+                    type="computer_call",
+                    call_id="computer-1",
+                    action=ActionScreenshot(type="screenshot"),
+                    pending_safety_checks=[
+                        PendingSafetyCheck(id="sc-1", code="malicious", message="nope")
+                    ],
+                    status="completed",
+                ),
+                computer_tool=computer_tool,
+            )
+        ],
+    )
+
+    with pytest.raises(UserError, match="safety check was not acknowledged"):
+        await _execute_tool_plan(
+            plan=plan,
+            bindings=bind_public_agent(agent),
+            hooks=_SlowToolEndHooks(post_invoke_started, post_invoke_finished),
+            context_wrapper=RunContextWrapper(context=None),
+            run_config=RunConfig(),
+        )
+
+    assert post_invoke_started.is_set()
+    assert post_invoke_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_plan_parent_cancellation_does_not_wait_for_function_cleanup() -> None:
+    from agents.run_internal.tool_planning import ToolExecutionPlan, _execute_tool_plan
+
+    tool_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+    allow_cleanup_exit = asyncio.Event()
+
+    @function_tool
+    async def slow_tool() -> str:
+        tool_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await allow_cleanup_exit.wait()
+            cleanup_finished.set()
+            raise
+
+    agent: Agent[Any] = Agent(name="test", tools=[slow_tool])
+    plan = ToolExecutionPlan(
+        function_runs=[
+            ToolRunFunction(
+                tool_call=ResponseFunctionToolCall(
+                    id="fn-1",
+                    call_id="fn-1",
+                    name="slow_tool",
+                    arguments="{}",
+                    type="function_call",
+                ),
+                function_tool=cast(Any, slow_tool),
+            )
+        ]
+    )
+    execution_task = asyncio.create_task(
+        _execute_tool_plan(
+            plan=plan,
+            bindings=bind_public_agent(agent),
+            hooks=RunHooks[Any](),
+            context_wrapper=RunContextWrapper(context=None),
+            run_config=RunConfig(),
+        )
+    )
+    await tool_started.wait()
+
+    execution_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(execution_task, timeout=0.1)
+
+    await cleanup_started.wait()
+    allow_cleanup_exit.set()
+    await cleanup_finished.wait()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_plan_parent_cancellation_interrupts_sibling_failure_drain() -> None:
+    from agents.run_internal.tool_planning import ToolExecutionPlan, _execute_tool_plan
+
+    from .test_computer_tool_lifecycle import FakeComputer
+
+    tool_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    allow_cleanup_exit = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+    loop_errors: list[dict[str, object]] = []
+    loop = asyncio.get_running_loop()
+    previous_exception_handler = loop.get_exception_handler()
+
+    @function_tool
+    async def slow_tool() -> str:
+        tool_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await allow_cleanup_exit.wait()
+            cleanup_finished.set()
+            raise RuntimeError("late cleanup failure") from None
+
+    async def reject_once_tool_is_running(_data: Any) -> bool:
+        await tool_started.wait()
+        return False
+
+    computer_tool = ComputerTool(
+        computer=FakeComputer(), on_safety_check=reject_once_tool_is_running
+    )
+    agent: Agent[Any] = Agent(name="test", tools=[slow_tool, computer_tool])
+    plan = ToolExecutionPlan(
+        function_runs=[
+            ToolRunFunction(
+                tool_call=ResponseFunctionToolCall(
+                    id="fn-1",
+                    call_id="fn-1",
+                    name="slow_tool",
+                    arguments="{}",
+                    type="function_call",
+                ),
+                function_tool=cast(Any, slow_tool),
+            )
+        ],
+        computer_actions=[
+            ToolRunComputerAction(
+                tool_call=ResponseComputerToolCall(
+                    id="computer-1",
+                    type="computer_call",
+                    call_id="computer-1",
+                    action=ActionScreenshot(type="screenshot"),
+                    pending_safety_checks=[
+                        PendingSafetyCheck(id="sc-1", code="malicious", message="nope")
+                    ],
+                    status="completed",
+                ),
+                computer_tool=computer_tool,
+            )
+        ],
+    )
+
+    loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+    try:
+        execution_task = asyncio.create_task(
+            _execute_tool_plan(
+                plan=plan,
+                bindings=bind_public_agent(agent),
+                hooks=RunHooks[Any](),
+                context_wrapper=RunContextWrapper(context=None),
+                run_config=RunConfig(),
+            )
+        )
+        await cleanup_started.wait()
+
+        execution_task.cancel()
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await execution_task
+        finally:
+            allow_cleanup_exit.set()
+        await asyncio.wait_for(cleanup_finished.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_exception_handler)
+
+    assert loop_errors == []


### PR DESCRIPTION
This pull request takes over the core fix proposed in https://github.com/openai/openai-agents-python/pull/4142.

It ensures that when one SDK-owned concurrent run operation fails, its sibling operations are cancelled and drained before the original error is propagated. For parallel tool execution, it also carries the sibling-category failure signal into nested function-tool execution so existing bounded cleanup and post-invoke settlement behavior can complete while keeping parent cancellation prompt.

The implementation narrows the original approach by reusing the existing cancellation and function-tool lifecycle machinery without introducing global cancellation context or new public APIs. It preserves successful result ordering, streaming and non-streaming parity, and Python 3.10 compatibility.

The original contributor is credited through the commit's `Co-authored-by` trailer.