### PR TITLE
fix(memory): reject reused branch IDs when creating a branch

### DIFF
--- a/docs/sessions/advanced_sqlite_session.md
+++ b/docs/sessions/advanced_sqlite_session.md
@@ -161,6 +161,8 @@ branch_id = await session.create_branch_from_content(
 )
 ```
 
+Branch IDs are unique for the lifetime of a session ID. Deleting a branch or clearing the session removes its conversation data but does not make previously used branch IDs available again; use a new name when creating another branch.
+
 ### Branch management
 
 ```python
@@ -251,7 +253,7 @@ The session automatically tracks message structure including:
 
 ## Database schema
 
-AdvancedSQLiteSession extends the basic SQLite schema with two additional tables:
+AdvancedSQLiteSession extends the basic SQLite schema with three additional tables:
 
 ### message_structure table
 
@@ -271,6 +273,18 @@ CREATE TABLE message_structure (
     FOREIGN KEY (message_id) REFERENCES agent_messages(id) ON DELETE CASCADE
 );
 ```
+
+### branch_reservations table
+
+```sql
+CREATE TABLE branch_reservations (
+    session_id TEXT NOT NULL,
+    branch_id TEXT NOT NULL,
+    PRIMARY KEY (session_id, branch_id)
+);
+```
+
+This table atomically reserves branch IDs, including branches whose copied prefix is empty. Reservation rows are retained after branch deletion and session clearing so stale session instances cannot merge history into a later branch that reused the same ID.
 
 ### turn_usage table
 

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -1128,85 +1128,92 @@ class AdvancedSQLiteSession(SQLiteSession):
         def _copy_sync() -> str:
             """Synchronous helper to copy messages to new branch."""
             with self._locked_connection() as conn:
-                with closing(conn.cursor()) as cursor:
-                    if new_branch_id is None:
-                        branch_id = self._generate_branch_id(cursor, from_turn_number)
-                    else:
-                        branch_id = new_branch_id
-                        if self._branch_id_exists(cursor, branch_id):
-                            raise ValueError(
-                                f"Branch '{branch_id}' already exists. Use switch_to_branch() "
-                                "to continue an existing branch."
-                            )
+                try:
+                    # Acquire SQLite's write reservation before checking the branch ID so
+                    # sessions in other processes cannot pass the same check concurrently.
+                    conn.execute("BEGIN IMMEDIATE")
+                    with closing(conn.cursor()) as cursor:
+                        if new_branch_id is None:
+                            branch_id = self._generate_branch_id(cursor, from_turn_number)
+                        else:
+                            branch_id = new_branch_id
+                            if self._branch_id_exists(cursor, branch_id):
+                                raise ValueError(
+                                    f"Branch '{branch_id}' already exists. Use switch_to_branch() "
+                                    "to continue an existing branch."
+                                )
 
-                    # Get all messages before the branch point
-                    cursor.execute(
-                        """
-                        SELECT
-                            ms.message_id,
-                            ms.message_type,
-                            ms.sequence_number,
-                            ms.user_turn_number,
-                            ms.branch_turn_number,
-                            ms.tool_name
-                        FROM message_structure ms
-                        WHERE ms.session_id = ? AND ms.branch_id = ?
-                        AND ms.branch_turn_number < ?
-                        ORDER BY ms.sequence_number
-                    """,
-                        (self.session_id, self._current_branch_id, from_turn_number),
-                    )
-
-                    messages_to_copy = cursor.fetchall()
-
-                    if messages_to_copy:
-                        # Get the max sequence number for the new inserts
+                        # Get all messages before the branch point
                         cursor.execute(
                             """
-                            SELECT COALESCE(MAX(sequence_number), 0)
-                            FROM message_structure
-                            WHERE session_id = ?
+                            SELECT
+                                ms.message_id,
+                                ms.message_type,
+                                ms.sequence_number,
+                                ms.user_turn_number,
+                                ms.branch_turn_number,
+                                ms.tool_name
+                            FROM message_structure ms
+                            WHERE ms.session_id = ? AND ms.branch_id = ?
+                            AND ms.branch_turn_number < ?
+                            ORDER BY ms.sequence_number
                         """,
-                            (self.session_id,),
+                            (self.session_id, self._current_branch_id, from_turn_number),
                         )
 
-                        seq_start = cursor.fetchone()[0]
+                        messages_to_copy = cursor.fetchall()
 
-                        # Insert copied messages with new branch_id
-                        new_structure_data = []
-                        for i, (
-                            msg_id,
-                            msg_type,
-                            _,
-                            user_turn,
-                            branch_turn,
-                            tool_name,
-                        ) in enumerate(messages_to_copy):
-                            new_structure_data.append(
-                                (
-                                    self.session_id,
-                                    msg_id,  # Same message_id (sharing the actual message data)
-                                    branch_id,
-                                    msg_type,
-                                    seq_start + i + 1,  # New sequence number
-                                    user_turn,  # Keep same global turn number
-                                    branch_turn,  # Keep same branch turn number
-                                    tool_name,
-                                )
+                        if messages_to_copy:
+                            # Get the max sequence number for the new inserts
+                            cursor.execute(
+                                """
+                                SELECT COALESCE(MAX(sequence_number), 0)
+                                FROM message_structure
+                                WHERE session_id = ?
+                            """,
+                                (self.session_id,),
                             )
 
-                        cursor.executemany(
-                            """
-                            INSERT INTO message_structure
-                            (session_id, message_id, branch_id, message_type, sequence_number,
-                             user_turn_number, branch_turn_number, tool_name)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                            new_structure_data,
-                        )
+                            seq_start = cursor.fetchone()[0]
+
+                            # Insert copied messages with new branch_id
+                            new_structure_data = []
+                            for i, (
+                                msg_id,
+                                msg_type,
+                                _,
+                                user_turn,
+                                branch_turn,
+                                tool_name,
+                            ) in enumerate(messages_to_copy):
+                                new_structure_data.append(
+                                    (
+                                        self.session_id,
+                                        msg_id,  # Same message_id (sharing the actual message data)
+                                        branch_id,
+                                        msg_type,
+                                        seq_start + i + 1,  # New sequence number
+                                        user_turn,  # Keep same global turn number
+                                        branch_turn,  # Keep same branch turn number
+                                        tool_name,
+                                    )
+                                )
+
+                            cursor.executemany(
+                                """
+                                INSERT INTO message_structure
+                                (session_id, message_id, branch_id, message_type, sequence_number,
+                                 user_turn_number, branch_turn_number, tool_name)
+                                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                            """,
+                                new_structure_data,
+                            )
 
                     conn.commit()
                     return branch_id
+                except Exception:
+                    conn.rollback()
+                    raise
 
         return await asyncio.to_thread(_copy_sync)
 

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -94,8 +94,8 @@ class AdvancedSQLiteSession(SQLiteSession):
     def _init_structure_tables(self):
         """Add structure and usage tracking tables.
 
-        Creates the message_structure and turn_usage tables with appropriate
-        indexes for conversation branching and usage analytics.
+        Creates the message_structure, branch_reservations, and turn_usage tables
+        with appropriate indexes for conversation branching and usage analytics.
         """
         with self._locked_connection() as conn:
             # Message structure with branch support
@@ -137,6 +137,8 @@ class AdvancedSQLiteSession(SQLiteSession):
                     UNIQUE(session_id, branch_id, user_turn_number)
                 )
             """)
+
+            self._ensure_branch_reservations_table(conn)
 
             # Indexes
             conn.execute("""
@@ -322,6 +324,11 @@ class AdvancedSQLiteSession(SQLiteSession):
                         message_row = cursor.fetchone()
 
                         try:
+                            # Preserve every legacy branch ID before a pop can remove its
+                            # final message_structure row. This stays inside the existing
+                            # rollback boundary for the mutation.
+                            self._ensure_branch_reservations_table(conn)
+
                             # Remove the structure row for this branch, then drop
                             # the underlying message only if no other branch
                             # references it.
@@ -382,11 +389,17 @@ class AdvancedSQLiteSession(SQLiteSession):
         rows declare an `ON DELETE CASCADE` foreign key, but SQLite does not
         enforce foreign keys unless `PRAGMA foreign_keys=ON` is set, so they must
         be deleted explicitly to avoid leaking stale structure and usage data.
+
+        Previously used branch IDs remain reserved so a stale session instance
+        cannot write into a later branch that reused the same ID.
         """
 
         def _clear_session_sync():
             with self._locked_connection() as conn:
                 try:
+                    # Backfill legacy branch IDs before clearing their only durable
+                    # identity evidence.
+                    self._ensure_branch_reservations_table(conn)
                     conn.execute(
                         f"DELETE FROM {self.messages_table} WHERE session_id = ?",
                         (self.session_id,),
@@ -813,7 +826,7 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         Args:
             turn_number: The branch turn number of the user message to branch from
-            branch_name: Optional name for the branch. Must not name a populated branch.
+            branch_name: Optional name for the branch. Must not use a previously used branch ID.
                 Auto-generated if None.
 
         Returns:
@@ -821,53 +834,23 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         Raises:
             ValueError: If turn doesn't exist, doesn't contain a user message, or
-                `branch_name` names a populated branch
+                `branch_name` has already been used in this session
         """
-        # Capture the generation before any DB work so a clear that commits
-        # while this branch is being created cannot be overwritten by the
-        # pointer update below.
-        generation = self._generation
+        # Snapshot the source branch and clear generation together. The source turn is
+        # revalidated inside the reservation transaction below.
+        with self._lock:
+            generation = self._generation
+            source_branch_id = self._current_branch_id
 
-        # Validate the turn exists and contains a user message
-        def _validate_turn():
-            """Synchronous helper to validate turn exists and contains user message."""
-            with self._locked_connection() as conn:
-                with closing(conn.cursor()) as cursor:
-                    cursor.execute(
-                        f"""
-                        SELECT am.message_data
-                        FROM message_structure ms
-                        JOIN {self.messages_table} am ON ms.message_id = am.id
-                        WHERE ms.session_id = ? AND ms.branch_id = ?
-                        AND ms.branch_turn_number = ? AND ms.message_type = 'user'
-                        """,
-                        (self.session_id, self._current_branch_id, turn_number),
-                    )
-
-                    result = cursor.fetchone()
-                    if not result:
-                        raise ValueError(
-                            f"Turn {turn_number} does not contain a user message "
-                            f"in branch '{self._current_branch_id}'"
-                        )
-
-                    message_data = result[0]
-                    try:
-                        content = json.loads(message_data).get("content", "")
-                        return content[:50] + "..." if len(content) > 50 else content
-                    except Exception:
-                        return "Unable to parse content"
-
-        turn_content = await asyncio.to_thread(_validate_turn)
-
-        # Resolve the target branch ID under the same lock that performs the copy so two
-        # creations in this process cannot select the same populated branch.
-        branch_name = await self._copy_messages_to_new_branch(branch_name, turn_number)
+        # Resolve the target branch ID under the same transaction that performs the copy
+        # so concurrent creators cannot reserve the same branch.
+        branch_name, turn_content = await self._copy_messages_to_new_branch(
+            branch_name, turn_number, source_branch_id
+        )
 
         # Switch to new branch under the lock; skipped if a clear_session has
         # committed since `generation` was captured (its reset to 'main' wins),
         # so we never point at a branch that clear removed.
-        old_branch = self._current_branch_id
         await asyncio.to_thread(self._commit_branch_pointer, branch_name, generation)
 
         if _debug.DONT_LOG_MODEL_DATA:
@@ -875,7 +858,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                 "Created branch '%s' from turn %s in '%s'",
                 branch_name,
                 turn_number,
-                old_branch,
+                source_branch_id,
             )
         else:
             self._logger.debug(
@@ -883,7 +866,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                 branch_name,
                 turn_number,
                 turn_content,
-                old_branch,
+                source_branch_id,
             )
         return branch_name
 
@@ -894,15 +877,15 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         Args:
             search_term: Text to search for in user messages.
-            branch_name: Optional name for the branch. Must not name a populated branch.
+            branch_name: Optional name for the branch. Must not use a previously used branch ID.
                 Auto-generated if None.
 
         Returns:
             The branch_id of the newly created branch.
 
         Raises:
-            ValueError: If no matching turns are found or `branch_name` names a populated
-                branch.
+            ValueError: If no matching turns are found or `branch_name` has already been used
+                in this session.
         """
         matching_turns = await self.find_turns_by_content(search_term)
         if not matching_turns:
@@ -955,6 +938,8 @@ class AdvancedSQLiteSession(SQLiteSession):
     async def delete_branch(self, branch_id: str, force: bool = False) -> None:
         """Delete a branch and all its associated data.
 
+        The branch ID remains reserved and cannot be reused in this session.
+
         Args:
             branch_id: The branch to delete.
             force: If True, allows deleting the current branch (will switch to 'main').
@@ -984,47 +969,53 @@ class AdvancedSQLiteSession(SQLiteSession):
         def _delete_sync():
             """Synchronous helper to delete branch and associated data."""
             with self._locked_connection() as conn:
-                with closing(conn.cursor()) as cursor:
-                    # First verify the branch exists
-                    cursor.execute(
-                        """
-                        SELECT COUNT(*) FROM message_structure
-                        WHERE session_id = ? AND branch_id = ?
-                    """,
-                        (self.session_id, branch_id),
-                    )
+                try:
+                    # Backfill legacy branch IDs before deleting their message structure.
+                    self._ensure_branch_reservations_table(conn)
+                    with closing(conn.cursor()) as cursor:
+                        # First verify the branch exists
+                        cursor.execute(
+                            """
+                            SELECT COUNT(*) FROM message_structure
+                            WHERE session_id = ? AND branch_id = ?
+                        """,
+                            (self.session_id, branch_id),
+                        )
 
-                    count = cursor.fetchone()[0]
-                    if count == 0:
-                        raise ValueError(f"Branch '{branch_id}' does not exist")
+                        count = cursor.fetchone()[0]
+                        if count == 0:
+                            raise ValueError(f"Branch '{branch_id}' does not exist")
 
-                    # Delete from turn_usage first (foreign key constraint)
-                    cursor.execute(
-                        """
-                        DELETE FROM turn_usage
-                        WHERE session_id = ? AND branch_id = ?
-                    """,
-                        (self.session_id, branch_id),
-                    )
+                        # Delete from turn_usage first (foreign key constraint)
+                        cursor.execute(
+                            """
+                            DELETE FROM turn_usage
+                            WHERE session_id = ? AND branch_id = ?
+                        """,
+                            (self.session_id, branch_id),
+                        )
 
-                    usage_deleted = cursor.rowcount
+                        usage_deleted = cursor.rowcount
 
-                    # Delete from message_structure
-                    cursor.execute(
-                        """
-                        DELETE FROM message_structure
-                        WHERE session_id = ? AND branch_id = ?
-                    """,
-                        (self.session_id, branch_id),
-                    )
+                        # Delete from message_structure
+                        cursor.execute(
+                            """
+                            DELETE FROM message_structure
+                            WHERE session_id = ? AND branch_id = ?
+                        """,
+                            (self.session_id, branch_id),
+                        )
 
-                    structure_deleted = cursor.rowcount
+                        structure_deleted = cursor.rowcount
 
-                    orphaned_messages_deleted = self._cleanup_orphaned_messages_sync(conn)
+                        orphaned_messages_deleted = self._cleanup_orphaned_messages_sync(conn)
 
-                    conn.commit()
+                        conn.commit()
 
-                    return usage_deleted, structure_deleted, orphaned_messages_deleted
+                        return usage_deleted, structure_deleted, orphaned_messages_deleted
+                except Exception:
+                    conn.rollback()
+                    raise
 
         usage_deleted, structure_deleted, orphaned_messages_deleted = await asyncio.to_thread(
             _delete_sync
@@ -1086,62 +1077,123 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         return await asyncio.to_thread(_list_branches_sync)
 
-    def _branch_id_exists(self, cursor: sqlite3.Cursor, branch_id: str) -> bool:
-        """Return whether the branch has any stored messages."""
-        cursor.execute(
+    def _ensure_branch_reservations_table(self, conn: sqlite3.Connection) -> None:
+        """Create the reservation table and backfill populated branches for this session."""
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS branch_reservations (
+                session_id TEXT NOT NULL,
+                branch_id TEXT NOT NULL,
+                PRIMARY KEY (session_id, branch_id)
+            )
+        """)
+        missing_branch = conn.execute(
             """
-            SELECT 1 FROM message_structure
-            WHERE session_id = ? AND branch_id = ?
+            SELECT 1
+            FROM message_structure ms
+            WHERE ms.session_id = ?
+            AND NOT EXISTS (
+                SELECT 1 FROM branch_reservations br
+                WHERE br.session_id = ms.session_id AND br.branch_id = ms.branch_id
+            )
             LIMIT 1
             """,
-            (self.session_id, branch_id),
-        )
-        return cursor.fetchone() is not None
+            (self.session_id,),
+        ).fetchone()
+        if missing_branch is not None:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO branch_reservations (session_id, branch_id)
+                SELECT DISTINCT session_id, branch_id
+                FROM message_structure
+                WHERE session_id = ?
+                """,
+                (self.session_id,),
+            )
 
-    def _generate_branch_id(self, cursor: sqlite3.Cursor, from_turn_number: int) -> str:
-        """Generate an ID that no populated branch currently uses."""
+    def _reserve_branch_id(
+        self, cursor: sqlite3.Cursor, new_branch_id: str | None, from_turn_number: int
+    ) -> str:
+        """Reserve and return a new branch ID for this session."""
+        if new_branch_id is not None:
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO branch_reservations (session_id, branch_id)
+                VALUES (?, ?)
+                """,
+                (self.session_id, new_branch_id),
+            )
+            if cursor.rowcount == 0:
+                raise ValueError(
+                    f"Branch ID '{new_branch_id}' has already been used. Choose a new branch ID."
+                )
+            return new_branch_id
+
         base_branch_id = f"branch_from_turn_{from_turn_number}_{int(time.time())}"
         branch_id = base_branch_id
         suffix = 1
-        while self._branch_id_exists(cursor, branch_id):
+        while True:
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO branch_reservations (session_id, branch_id)
+                VALUES (?, ?)
+                """,
+                (self.session_id, branch_id),
+            )
+            if cursor.rowcount == 1:
+                return branch_id
             suffix += 1
             branch_id = f"{base_branch_id}_{suffix}"
-        return branch_id
 
     async def _copy_messages_to_new_branch(
-        self, new_branch_id: str | None, from_turn_number: int
-    ) -> str:
+        self, new_branch_id: str | None, from_turn_number: int, source_branch_id: str
+    ) -> tuple[str, Any]:
         """Copy messages before the branch point to the new branch.
 
         Args:
-            new_branch_id: The ID of the new branch, or None to generate an ID not used by
-                a populated branch.
+            new_branch_id: The ID of the new branch, or None to generate an unused ID.
             from_turn_number: The turn number to copy messages up to (exclusive).
+            source_branch_id: The branch to copy messages from.
 
         Returns:
-            The resolved branch ID.
+            The resolved branch ID and a preview of the source turn content.
 
         Raises:
-            ValueError: If `new_branch_id` belongs to a populated branch.
+            ValueError: If `new_branch_id` has already been used in this session.
         """
 
-        def _copy_sync() -> str:
+        def _copy_sync() -> tuple[str, Any]:
             """Synchronous helper to copy messages to new branch."""
             with self._locked_connection() as conn:
                 try:
                     # Acquire SQLite's write reservation before checking the branch ID so
                     # sessions in other processes cannot pass the same check concurrently.
                     conn.execute("BEGIN IMMEDIATE")
+                    self._ensure_branch_reservations_table(conn)
                     with closing(conn.cursor()) as cursor:
-                        if new_branch_id is None:
-                            branch_id = self._generate_branch_id(cursor, from_turn_number)
-                        else:
-                            branch_id = new_branch_id
-                            if self._branch_id_exists(cursor, branch_id):
-                                raise ValueError(
-                                    f"Branch '{branch_id}' already exists. Use switch_to_branch() "
-                                    "to continue an existing branch."
-                                )
+                        cursor.execute(
+                            f"""
+                            SELECT am.message_data
+                            FROM message_structure ms
+                            JOIN {self.messages_table} am ON ms.message_id = am.id
+                            WHERE ms.session_id = ? AND ms.branch_id = ?
+                            AND ms.branch_turn_number = ? AND ms.message_type = 'user'
+                            """,
+                            (self.session_id, source_branch_id, from_turn_number),
+                        )
+                        result = cursor.fetchone()
+                        if result is None:
+                            raise ValueError(
+                                f"Turn {from_turn_number} does not contain a user message "
+                                f"in branch '{source_branch_id}'"
+                            )
+
+                        try:
+                            content = json.loads(result[0]).get("content", "")
+                            turn_content = content[:50] + "..." if len(content) > 50 else content
+                        except Exception:
+                            turn_content = "Unable to parse content"
+
+                        branch_id = self._reserve_branch_id(cursor, new_branch_id, from_turn_number)
 
                         # Get all messages before the branch point
                         cursor.execute(
@@ -1158,7 +1210,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                             AND ms.branch_turn_number < ?
                             ORDER BY ms.sequence_number
                         """,
-                            (self.session_id, self._current_branch_id, from_turn_number),
+                            (self.session_id, source_branch_id, from_turn_number),
                         )
 
                         messages_to_copy = cursor.fetchall()
@@ -1210,7 +1262,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                             )
 
                     conn.commit()
-                    return branch_id
+                    return branch_id, turn_content
                 except Exception:
                     conn.rollback()
                     raise

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import sqlite3
+import time
 from contextlib import closing
 from pathlib import Path
 from typing import Any, cast
@@ -812,16 +813,16 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         Args:
             turn_number: The branch turn number of the user message to branch from
-            branch_name: Optional name for the branch (auto-generated if None)
+            branch_name: Optional name for the branch. Must not name a populated branch.
+                Auto-generated if None.
 
         Returns:
             The branch_id of the newly created branch
 
         Raises:
-            ValueError: If turn doesn't exist or doesn't contain a user message
+            ValueError: If turn doesn't exist, doesn't contain a user message, or
+                `branch_name` names a populated branch
         """
-        import time
-
         # Capture the generation before any DB work so a clear that commits
         # while this branch is being created cannot be overwritten by the
         # pointer update below.
@@ -859,13 +860,9 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         turn_content = await asyncio.to_thread(_validate_turn)
 
-        # Generate branch name if not provided
-        if branch_name is None:
-            timestamp = int(time.time())
-            branch_name = f"branch_from_turn_{turn_number}_{timestamp}"
-
-        # Copy messages before the branch point to the new branch
-        await self._copy_messages_to_new_branch(branch_name, turn_number)
+        # Resolve the target branch ID under the same lock that performs the copy so two
+        # creations in this process cannot select the same populated branch.
+        branch_name = await self._copy_messages_to_new_branch(branch_name, turn_number)
 
         # Switch to new branch under the lock; skipped if a clear_session has
         # committed since `generation` was captured (its reset to 'main' wins),
@@ -897,13 +894,15 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         Args:
             search_term: Text to search for in user messages.
-            branch_name: Optional name for the branch (auto-generated if None).
+            branch_name: Optional name for the branch. Must not name a populated branch.
+                Auto-generated if None.
 
         Returns:
             The branch_id of the newly created branch.
 
         Raises:
-            ValueError: If no matching turns are found.
+            ValueError: If no matching turns are found or `branch_name` names a populated
+                branch.
         """
         matching_turns = await self.find_turns_by_content(search_term)
         if not matching_turns:
@@ -1087,18 +1086,59 @@ class AdvancedSQLiteSession(SQLiteSession):
 
         return await asyncio.to_thread(_list_branches_sync)
 
-    async def _copy_messages_to_new_branch(self, new_branch_id: str, from_turn_number: int) -> None:
+    def _branch_id_exists(self, cursor: sqlite3.Cursor, branch_id: str) -> bool:
+        """Return whether the branch has any stored messages."""
+        cursor.execute(
+            """
+            SELECT 1 FROM message_structure
+            WHERE session_id = ? AND branch_id = ?
+            LIMIT 1
+            """,
+            (self.session_id, branch_id),
+        )
+        return cursor.fetchone() is not None
+
+    def _generate_branch_id(self, cursor: sqlite3.Cursor, from_turn_number: int) -> str:
+        """Generate an ID that no populated branch currently uses."""
+        base_branch_id = f"branch_from_turn_{from_turn_number}_{int(time.time())}"
+        branch_id = base_branch_id
+        suffix = 1
+        while self._branch_id_exists(cursor, branch_id):
+            suffix += 1
+            branch_id = f"{base_branch_id}_{suffix}"
+        return branch_id
+
+    async def _copy_messages_to_new_branch(
+        self, new_branch_id: str | None, from_turn_number: int
+    ) -> str:
         """Copy messages before the branch point to the new branch.
 
         Args:
-            new_branch_id: The ID of the new branch to copy messages to.
+            new_branch_id: The ID of the new branch, or None to generate an ID not used by
+                a populated branch.
             from_turn_number: The turn number to copy messages up to (exclusive).
+
+        Returns:
+            The resolved branch ID.
+
+        Raises:
+            ValueError: If `new_branch_id` belongs to a populated branch.
         """
 
-        def _copy_sync():
+        def _copy_sync() -> str:
             """Synchronous helper to copy messages to new branch."""
             with self._locked_connection() as conn:
                 with closing(conn.cursor()) as cursor:
+                    if new_branch_id is None:
+                        branch_id = self._generate_branch_id(cursor, from_turn_number)
+                    else:
+                        branch_id = new_branch_id
+                        if self._branch_id_exists(cursor, branch_id):
+                            raise ValueError(
+                                f"Branch '{branch_id}' already exists. Use switch_to_branch() "
+                                "to continue an existing branch."
+                            )
+
                     # Get all messages before the branch point
                     cursor.execute(
                         """
@@ -1146,7 +1186,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                                 (
                                     self.session_id,
                                     msg_id,  # Same message_id (sharing the actual message data)
-                                    new_branch_id,
+                                    branch_id,
                                     msg_type,
                                     seq_start + i + 1,  # New sequence number
                                     user_turn,  # Keep same global turn number
@@ -1166,8 +1206,9 @@ class AdvancedSQLiteSession(SQLiteSession):
                         )
 
                     conn.commit()
+                    return branch_id
 
-        await asyncio.to_thread(_copy_sync)
+        return await asyncio.to_thread(_copy_sync)
 
     async def get_conversation_turns(self, branch_id: str | None = None) -> list[dict[str, Any]]:
         """Get user turns with content for easy browsing and branching decisions.

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -4,8 +4,11 @@ import asyncio
 import contextlib
 import json
 import logging
+import sqlite3
 import tempfile
 import threading
+import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import Mock, patch
@@ -648,6 +651,139 @@ async def test_branching_functionality(agent: Agent):
     assert branches_after_delete[0]["branch_id"] == "main"
 
     session.close()
+
+
+def _branch_collision_items() -> list[TResponseInputItem]:
+    """Return three user turns with assistant replies for branch collision tests."""
+    return [
+        {"role": "user", "content": "Turn one question"},
+        {"role": "assistant", "content": "Turn one answer"},
+        {"role": "user", "content": "Turn two question"},
+        {"role": "assistant", "content": "Turn two answer"},
+        {"role": "user", "content": "Turn three question"},
+        {"role": "assistant", "content": "Turn three answer"},
+    ]
+
+
+@pytest.mark.parametrize("branch_id", ["main", "existing_branch"])
+async def test_create_branch_rejects_populated_branch_id(branch_id: str):
+    """Creating a branch must not append history to a populated branch."""
+    session = AdvancedSQLiteSession(
+        session_id=f"branch_collision_{branch_id}",
+        create_tables=True,
+    )
+    items = _branch_collision_items()
+
+    try:
+        await session.add_items(items)
+        if branch_id != "main":
+            await session.create_branch_from_turn(3, branch_id)
+            await session.switch_to_branch("main")
+
+        branch_items_before = await session.get_items(branch_id=branch_id)
+
+        with pytest.raises(ValueError, match="already exists"):
+            await session.create_branch_from_turn(2, branch_id)
+
+        assert session._current_branch_id == "main"
+        assert await session.get_items(branch_id=branch_id) == branch_items_before
+        assert await session.get_items(branch_id="main") == items
+    finally:
+        session.close()
+
+
+async def test_generated_branch_ids_do_not_merge_within_the_same_second(monkeypatch):
+    """Repeated generated IDs must not merge copied branch histories."""
+    monkeypatch.setattr(time, "time", lambda: 1_700_000_000.0)
+    session = AdvancedSQLiteSession(
+        session_id="generated_branch_collision",
+        create_tables=True,
+    )
+    items = _branch_collision_items()
+
+    try:
+        await session.add_items(items)
+        first_branch = await session.create_branch_from_turn(3)
+        await session.switch_to_branch("main")
+        second_branch = await session.create_branch_from_turn(3)
+
+        assert first_branch == "branch_from_turn_3_1700000000"
+        assert second_branch == "branch_from_turn_3_1700000000_2"
+        assert await session.get_items(branch_id=first_branch) == items[:4]
+        assert await session.get_items(branch_id=second_branch) == items[:4]
+        assert await session.get_items(branch_id="main") == items
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("branch_name", [None, "shared_branch"])
+async def test_branch_allocation_is_serialized_across_sessions(
+    tmp_path: Path,
+    monkeypatch,
+    branch_name: str | None,
+):
+    """Sessions sharing one file must serialize branch ID checks and copies."""
+
+    class InstrumentedBranchCheckSession(AdvancedSQLiteSession):
+        def __init__(self, **kwargs: Any) -> None:
+            self._lock_state = threading.local()
+            super().__init__(**kwargs)
+
+        @contextlib.contextmanager
+        def _locked_connection(self) -> Iterator[sqlite3.Connection]:
+            with super()._locked_connection() as conn:
+                self._lock_state.active = True
+                try:
+                    yield conn
+                finally:
+                    self._lock_state.active = False
+
+        def _branch_id_exists(self, cursor: Any, branch_id: str) -> bool:
+            assert getattr(self._lock_state, "active", False)
+            return super()._branch_id_exists(cursor, branch_id)
+
+    monkeypatch.setattr(time, "time", lambda: 1_700_000_000.0)
+    db_path = tmp_path / "branch_allocation.db"
+    session_id = f"branch_allocation_{branch_name}"
+    first_session = InstrumentedBranchCheckSession(
+        session_id=session_id,
+        db_path=db_path,
+        create_tables=True,
+    )
+    second_session = InstrumentedBranchCheckSession(
+        session_id=session_id,
+        db_path=db_path,
+    )
+    items = _branch_collision_items()
+
+    try:
+        assert first_session._lock is second_session._lock
+        await first_session.add_items(items)
+        results = await asyncio.gather(
+            first_session.create_branch_from_turn(3, branch_name),
+            second_session.create_branch_from_turn(3, branch_name),
+            return_exceptions=True,
+        )
+
+        successful_ids = [result for result in results if isinstance(result, str)]
+        if branch_name is None:
+            assert not [result for result in results if isinstance(result, BaseException)]
+            assert sorted(successful_ids) == [
+                "branch_from_turn_3_1700000000",
+                "branch_from_turn_3_1700000000_2",
+            ]
+        else:
+            assert successful_ids == [branch_name]
+            errors = [result for result in results if isinstance(result, ValueError)]
+            assert len(errors) == 1
+            assert "already exists" in str(errors[0])
+
+        for branch_id in successful_ids:
+            assert await first_session.get_items(branch_id=branch_id) == items[:4]
+        assert await first_session.get_items(branch_id="main") == items
+    finally:
+        first_session.close()
+        second_session.close()
 
 
 async def test_delete_branch_removes_branch_only_messages():

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -670,6 +670,7 @@ def _create_branch_in_process(
     db_path: str,
     session_id: str,
     branch_name: str | None,
+    turn_number: int,
     ready: Any,
     start: Any,
     attempted: Any,
@@ -682,7 +683,7 @@ def _create_branch_in_process(
 
     class InstrumentedSession(AdvancedSQLiteSession):
         def __init__(self, **kwargs: Any) -> None:
-            self._reported_check = False
+            self._reported_reservation = False
             super().__init__(**kwargs)
 
         @contextlib.contextmanager
@@ -702,14 +703,16 @@ def _create_branch_in_process(
             with super()._locked_connection() as connection:
                 yield BeginObservableConnection(connection)
 
-        def _branch_id_exists(self, cursor: Any, branch_id: str) -> bool:
-            exists = super()._branch_id_exists(cursor, branch_id)
-            if not self._reported_check:
-                self._reported_check = True
+        def _reserve_branch_id(
+            self, cursor: Any, new_branch_id: str | None, from_turn_number: int
+        ) -> str:
+            branch_id = super()._reserve_branch_id(cursor, new_branch_id, from_turn_number)
+            if not self._reported_reservation:
+                self._reported_reservation = True
                 checked.set()
                 if hold_after_check and not release_check.wait(timeout=10):
-                    raise TimeoutError("Timed out waiting to release the branch ID check")
-            return exists
+                    raise TimeoutError("Timed out waiting to release the branch ID reservation")
+            return branch_id
 
     session = InstrumentedSession(session_id=session_id, db_path=db_path)
     try:
@@ -720,7 +723,12 @@ def _create_branch_in_process(
             "agents.extensions.memory.advanced_sqlite_session.time.time",
             return_value=1_700_000_000.0,
         ):
-            branch_id = asyncio.run(session.create_branch_from_turn(3, branch_name))
+            branch_id = asyncio.run(session.create_branch_from_turn(turn_number, branch_name))
+        branch_item: TResponseInputItem = {
+            "role": "user",
+            "content": f"{worker_name} branch item",
+        }
+        asyncio.run(session.add_items([branch_item]))
         results.put((worker_name, "success", branch_id))
     except Exception as exc:
         results.put((worker_name, "error", type(exc).__name__, str(exc)))
@@ -745,7 +753,7 @@ async def test_create_branch_rejects_populated_branch_id(branch_id: str):
 
         branch_items_before = await session.get_items(branch_id=branch_id)
 
-        with pytest.raises(ValueError, match="already exists"):
+        with pytest.raises(ValueError, match="already been used"):
             await session.create_branch_from_turn(2, branch_id)
 
         assert session._current_branch_id == "main"
@@ -779,13 +787,207 @@ async def test_generated_branch_ids_do_not_merge_within_the_same_second(monkeypa
         session.close()
 
 
-@pytest.mark.parametrize("branch_name", [None, "shared_branch"])
-async def test_branch_allocation_is_serialized_across_processes(
-    tmp_path: Path, branch_name: str | None
+async def test_failed_branch_reservation_rolls_back_and_allows_retry(tmp_path: Path):
+    """A failure after reservation must not burn the branch ID or retain a transaction."""
+
+    class FailAfterReservationSession(AdvancedSQLiteSession):
+        fail_after_reservation = True
+
+        def _reserve_branch_id(
+            self, cursor: Any, new_branch_id: str | None, from_turn_number: int
+        ) -> str:
+            branch_id = super()._reserve_branch_id(cursor, new_branch_id, from_turn_number)
+            if self.fail_after_reservation:
+                self.fail_after_reservation = False
+                raise RuntimeError("failed after reservation")
+            return branch_id
+
+    session = FailAfterReservationSession(
+        session_id="failed_branch_reservation",
+        db_path=tmp_path / "failed_branch_reservation.db",
+        create_tables=True,
+    )
+    items = _branch_collision_items()
+
+    try:
+        await session.add_items(items)
+
+        with pytest.raises(RuntimeError, match="failed after reservation"):
+            await session.create_branch_from_turn(3, "retryable_branch")
+
+        with session._locked_connection() as conn:
+            reservation_count = conn.execute(
+                """
+                SELECT COUNT(*) FROM branch_reservations
+                WHERE session_id = ? AND branch_id = ?
+                """,
+                (session.session_id, "retryable_branch"),
+            ).fetchone()[0]
+        assert reservation_count == 0
+        assert await session.get_items(branch_id="retryable_branch") == []
+        with session._connections_lock:
+            assert all(not conn.in_transaction for conn in session._connections)
+
+        assert await session.create_branch_from_turn(3, "retryable_branch") == "retryable_branch"
+        assert await session.get_items(branch_id="retryable_branch") == items[:4]
+    finally:
+        session.close()
+
+
+async def test_branch_ids_remain_reserved_after_delete_and_clear():
+    """Deleted and cleared branch IDs must not be reused by stale session instances."""
+    session = AdvancedSQLiteSession(
+        session_id="branch_reservation_tombstones",
+        create_tables=True,
+    )
+    items = _branch_collision_items()
+
+    try:
+        await session.add_items(items)
+        await session.create_branch_from_turn(3, "used_branch")
+        await session.switch_to_branch("main")
+        await session.delete_branch("used_branch")
+
+        with pytest.raises(ValueError, match="already been used"):
+            await session.create_branch_from_turn(2, "used_branch")
+
+        await session.clear_session()
+        await session.add_items(items)
+        with pytest.raises(ValueError, match="already been used"):
+            await session.create_branch_from_turn(1, "used_branch")
+    finally:
+        session.close()
+
+
+async def test_branch_reservations_migrate_existing_populated_branches(tmp_path: Path):
+    """Existing databases must backfill branch reservations before allocating IDs."""
+    db_path = tmp_path / "branch_reservation_migration.db"
+    session_id = "branch_reservation_migration"
+    items = _branch_collision_items()
+    setup_session = AdvancedSQLiteSession(
+        session_id=session_id,
+        db_path=db_path,
+        create_tables=True,
+    )
+    try:
+        await setup_session.add_items(items)
+        await setup_session.create_branch_from_turn(3, "existing_branch")
+        with setup_session._locked_connection() as conn:
+            conn.execute("DROP TABLE branch_reservations")
+            conn.commit()
+    finally:
+        setup_session.close()
+
+    session = AdvancedSQLiteSession(session_id=session_id, db_path=db_path)
+    try:
+        with pytest.raises(ValueError, match="already been used"):
+            await session.create_branch_from_turn(2, "existing_branch")
+        await session.create_branch_from_turn(1, "empty_branch")
+
+        with session._locked_connection() as conn:
+            reservations = conn.execute(
+                """
+                SELECT branch_id FROM branch_reservations
+                WHERE session_id = ?
+                ORDER BY branch_id
+                """,
+                (session_id,),
+            ).fetchall()
+        assert reservations == [("empty_branch",), ("existing_branch",), ("main",)]
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("operation", ["clear", "delete", "pop"])
+async def test_legacy_branch_ids_are_backfilled_before_destructive_operations(
+    tmp_path: Path, operation: str
 ):
-    """Processes sharing one file must serialize branch ID checks and copies."""
+    """Destructive operations must preserve IDs from databases created before reservations."""
+    db_path = tmp_path / f"legacy_branch_{operation}.db"
+    session_id = f"legacy_branch_{operation}"
+    items = _branch_collision_items()
+    setup_session = AdvancedSQLiteSession(
+        session_id=session_id,
+        db_path=db_path,
+        create_tables=True,
+    )
+    try:
+        await setup_session.add_items(items)
+        await setup_session.create_branch_from_turn(3, "legacy_branch")
+        with setup_session._locked_connection() as conn:
+            conn.execute("DROP TABLE branch_reservations")
+            conn.commit()
+    finally:
+        setup_session.close()
+
+    session = AdvancedSQLiteSession(session_id=session_id, db_path=db_path)
+    try:
+        if operation == "clear":
+            await session.clear_session()
+            await session.add_items(items)
+        elif operation == "delete":
+            await session.delete_branch("legacy_branch")
+        else:
+            await session.switch_to_branch("legacy_branch")
+            while await session.pop_item() is not None:
+                pass
+            await session.switch_to_branch("main")
+
+        with pytest.raises(ValueError, match="already been used"):
+            await session.create_branch_from_turn(2, "legacy_branch")
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("operation", ["missing_delete", "empty_pop"])
+async def test_legacy_destructive_noops_leave_database_unlocked(tmp_path: Path, operation: str):
+    """Lazy migration must not retain a writer transaction after a no-op or error."""
+    db_path = tmp_path / f"legacy_noop_{operation}.db"
+    session_id = f"legacy_noop_{operation}"
+    setup_session = AdvancedSQLiteSession(
+        session_id=session_id,
+        db_path=db_path,
+        create_tables=True,
+    )
+    try:
+        await setup_session.add_items(_branch_collision_items())
+        await setup_session.create_branch_from_turn(3, "legacy_branch")
+        if operation == "empty_pop":
+            await setup_session.switch_to_branch("main")
+            while await setup_session.pop_item() is not None:
+                pass
+        with setup_session._locked_connection() as conn:
+            conn.execute("DROP TABLE branch_reservations")
+            conn.commit()
+    finally:
+        setup_session.close()
+
+    session = AdvancedSQLiteSession(session_id=session_id, db_path=db_path)
+    contender = AdvancedSQLiteSession(session_id=f"{session_id}_contender", db_path=db_path)
+    try:
+        if operation == "missing_delete":
+            with pytest.raises(ValueError, match="does not exist"):
+                await session.delete_branch("missing_branch")
+        else:
+            assert await session.pop_item() is None
+
+        with session._connections_lock:
+            assert all(not conn.in_transaction for conn in session._connections)
+
+        await contender.add_items([{"role": "user", "content": "writer acquired"}])
+    finally:
+        contender.close()
+        session.close()
+
+
+@pytest.mark.parametrize("branch_name", [None, "shared_branch"])
+@pytest.mark.parametrize("turn_number", [1, 3])
+async def test_branch_allocation_is_serialized_across_processes(
+    tmp_path: Path, branch_name: str | None, turn_number: int
+):
+    """Processes must serialize branch reservations, including empty branches."""
     db_path = tmp_path / "branch_allocation.db"
-    session_id = f"branch_allocation_{branch_name}"
+    session_id = f"branch_allocation_{branch_name}_{turn_number}"
     setup_session = AdvancedSQLiteSession(
         session_id=session_id,
         db_path=db_path,
@@ -814,6 +1016,7 @@ async def test_branch_allocation_is_serialized_across_processes(
                     str(db_path),
                     session_id,
                     branch_name,
+                    turn_number,
                     ready,
                     start,
                     attempted,
@@ -836,8 +1039,8 @@ async def test_branch_allocation_is_serialized_across_processes(
         second_start.set()
         assert second_attempted.wait(timeout=10)
 
-        # The second process has entered branch creation, but SQLite's write reservation
-        # must keep it from checking the same ID until the first process commits.
+        # The second process has entered branch creation, but SQLite's write transaction
+        # must keep it from reserving an ID until the first process commits.
         assert not second_checked.wait(timeout=0.2)
         release_check.set()
 
@@ -850,19 +1053,24 @@ async def test_branch_allocation_is_serialized_across_processes(
         if branch_name is None:
             assert all(result[1] == "success" for result in process_results)
             assert sorted(successful_ids) == [
-                "branch_from_turn_3_1700000000",
-                "branch_from_turn_3_1700000000_2",
+                f"branch_from_turn_{turn_number}_1700000000",
+                f"branch_from_turn_{turn_number}_1700000000_2",
             ]
         else:
             assert successful_ids == [branch_name]
             errors = [result for result in process_results if result[1] == "error"]
             assert len(errors) == 1
             assert errors[0][2] == "ValueError"
-            assert "already exists" in errors[0][3]
+            assert "already been used" in errors[0][3]
 
         verification_session = AdvancedSQLiteSession(session_id=session_id, db_path=db_path)
-        for branch_id in successful_ids:
-            assert await verification_session.get_items(branch_id=branch_id) == items[:4]
+        copied_items = items[: 2 * (turn_number - 1)]
+        successful_results = [result for result in process_results if result[1] == "success"]
+        for worker_name, _, branch_id in successful_results:
+            assert await verification_session.get_items(branch_id=branch_id) == [
+                *copied_items,
+                {"role": "user", "content": f"{worker_name} branch item"},
+            ]
         assert await verification_session.get_items(branch_id="main") == items
         verification_session.close()
     finally:
@@ -2559,6 +2767,41 @@ async def test_stale_create_branch_after_clear_does_not_repoint():
         session.close()
 
 
+async def test_clear_before_branch_transaction_prevents_stale_reservation():
+    """A clear that wins before transactional validation must leave no reservation."""
+    session = AdvancedSQLiteSession(
+        session_id="clear_before_branch_transaction_test",
+        create_tables=True,
+    )
+
+    try:
+        await session.add_items(
+            [
+                {"role": "user", "content": "u1"},
+                {"role": "assistant", "content": "a1"},
+            ]
+        )
+
+        with _gate_worker("_copy_sync") as (started, real_to_thread, release):
+            task = asyncio.ensure_future(session.create_branch_from_turn(1, "stale_branch"))
+            await real_to_thread(started.wait)
+            await session.clear_session()
+            release.set()
+            with pytest.raises(ValueError, match="does not contain a user message"):
+                await task
+
+        assert session._current_branch_id == "main"
+        assert await session.list_branches() == []
+        with session._locked_connection() as conn:
+            reservations = conn.execute(
+                "SELECT branch_id FROM branch_reservations WHERE session_id = ?",
+                (session.session_id,),
+            ).fetchall()
+        assert reservations == [("main",)]
+    finally:
+        session.close()
+
+
 async def test_stale_store_run_usage_skipped_when_turn_removed_by_pop(usage_data: Usage):
     """A store_run_usage that reads a turn and then races with pop_item removing
     that turn must not reinsert usage for the now-nonexistent turn.
@@ -2688,11 +2931,13 @@ async def test_clear_session_resets_current_branch_to_main():
         await session.create_branch_from_turn(2, "branch_a")
         await session.switch_to_branch("branch_a")
         assert session._current_branch_id == "branch_a"
+        assert _count_rows(session, "branch_reservations") == 2
 
         await session.clear_session()
 
         assert session._current_branch_id == "main"
         assert await session.get_items() == []
+        assert _count_rows(session, "branch_reservations") == 2
     finally:
         session.close()
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import json
 import logging
-import sqlite3
+import multiprocessing
 import tempfile
 import threading
 import time
@@ -665,6 +665,69 @@ def _branch_collision_items() -> list[TResponseInputItem]:
     ]
 
 
+def _create_branch_in_process(
+    worker_name: str,
+    db_path: str,
+    session_id: str,
+    branch_name: str | None,
+    ready: Any,
+    start: Any,
+    attempted: Any,
+    checked: Any,
+    release_check: Any,
+    hold_after_check: bool,
+    results: Any,
+) -> None:
+    """Create a branch in a separate process with a controllable ID check."""
+
+    class InstrumentedSession(AdvancedSQLiteSession):
+        def __init__(self, **kwargs: Any) -> None:
+            self._reported_check = False
+            super().__init__(**kwargs)
+
+        @contextlib.contextmanager
+        def _locked_connection(self) -> Iterator[Any]:
+            class BeginObservableConnection:
+                def __init__(self, connection: Any) -> None:
+                    self._connection = connection
+
+                def execute(self, sql: str, parameters: Any = ()) -> Any:
+                    if sql == "BEGIN IMMEDIATE":
+                        attempted.set()
+                    return self._connection.execute(sql, parameters)
+
+                def __getattr__(self, name: str) -> Any:
+                    return getattr(self._connection, name)
+
+            with super()._locked_connection() as connection:
+                yield BeginObservableConnection(connection)
+
+        def _branch_id_exists(self, cursor: Any, branch_id: str) -> bool:
+            exists = super()._branch_id_exists(cursor, branch_id)
+            if not self._reported_check:
+                self._reported_check = True
+                checked.set()
+                if hold_after_check and not release_check.wait(timeout=10):
+                    raise TimeoutError("Timed out waiting to release the branch ID check")
+            return exists
+
+    session = InstrumentedSession(session_id=session_id, db_path=db_path)
+    try:
+        ready.set()
+        if not start.wait(timeout=10):
+            raise TimeoutError("Timed out waiting to start branch creation")
+        with patch(
+            "agents.extensions.memory.advanced_sqlite_session.time.time",
+            return_value=1_700_000_000.0,
+        ):
+            branch_id = asyncio.run(session.create_branch_from_turn(3, branch_name))
+        results.put((worker_name, "success", branch_id))
+    except Exception as exc:
+        results.put((worker_name, "error", type(exc).__name__, str(exc)))
+    finally:
+        session.close()
+
+
 @pytest.mark.parametrize("branch_id", ["main", "existing_branch"])
 async def test_create_branch_rejects_populated_branch_id(branch_id: str):
     """Creating a branch must not append history to a populated branch."""
@@ -717,73 +780,100 @@ async def test_generated_branch_ids_do_not_merge_within_the_same_second(monkeypa
 
 
 @pytest.mark.parametrize("branch_name", [None, "shared_branch"])
-async def test_branch_allocation_is_serialized_across_sessions(
-    tmp_path: Path,
-    monkeypatch,
-    branch_name: str | None,
+async def test_branch_allocation_is_serialized_across_processes(
+    tmp_path: Path, branch_name: str | None
 ):
-    """Sessions sharing one file must serialize branch ID checks and copies."""
-
-    class InstrumentedBranchCheckSession(AdvancedSQLiteSession):
-        def __init__(self, **kwargs: Any) -> None:
-            self._lock_state = threading.local()
-            super().__init__(**kwargs)
-
-        @contextlib.contextmanager
-        def _locked_connection(self) -> Iterator[sqlite3.Connection]:
-            with super()._locked_connection() as conn:
-                self._lock_state.active = True
-                try:
-                    yield conn
-                finally:
-                    self._lock_state.active = False
-
-        def _branch_id_exists(self, cursor: Any, branch_id: str) -> bool:
-            assert getattr(self._lock_state, "active", False)
-            return super()._branch_id_exists(cursor, branch_id)
-
-    monkeypatch.setattr(time, "time", lambda: 1_700_000_000.0)
+    """Processes sharing one file must serialize branch ID checks and copies."""
     db_path = tmp_path / "branch_allocation.db"
     session_id = f"branch_allocation_{branch_name}"
-    first_session = InstrumentedBranchCheckSession(
+    setup_session = AdvancedSQLiteSession(
         session_id=session_id,
         db_path=db_path,
         create_tables=True,
     )
-    second_session = InstrumentedBranchCheckSession(
-        session_id=session_id,
-        db_path=db_path,
-    )
     items = _branch_collision_items()
+    await setup_session.add_items(items)
+    setup_session.close()
+
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    release_check = context.Event()
+    processes = []
 
     try:
-        assert first_session._lock is second_session._lock
-        await first_session.add_items(items)
-        results = await asyncio.gather(
-            first_session.create_branch_from_turn(3, branch_name),
-            second_session.create_branch_from_turn(3, branch_name),
-            return_exceptions=True,
-        )
+        worker_events = []
+        for worker_name, hold_after_check in (("first", True), ("second", False)):
+            ready = context.Event()
+            start = context.Event()
+            attempted = context.Event()
+            checked = context.Event()
+            process = context.Process(
+                target=_create_branch_in_process,
+                args=(
+                    worker_name,
+                    str(db_path),
+                    session_id,
+                    branch_name,
+                    ready,
+                    start,
+                    attempted,
+                    checked,
+                    release_check,
+                    hold_after_check,
+                    results,
+                ),
+            )
+            process.start()
+            processes.append(process)
+            worker_events.append((ready, start, attempted, checked))
 
-        successful_ids = [result for result in results if isinstance(result, str)]
+        first_ready, first_start, _, first_checked = worker_events[0]
+        second_ready, second_start, second_attempted, second_checked = worker_events[1]
+        assert first_ready.wait(timeout=10)
+        first_start.set()
+        assert first_checked.wait(timeout=10)
+        assert second_ready.wait(timeout=10)
+        second_start.set()
+        assert second_attempted.wait(timeout=10)
+
+        # The second process has entered branch creation, but SQLite's write reservation
+        # must keep it from checking the same ID until the first process commits.
+        assert not second_checked.wait(timeout=0.2)
+        release_check.set()
+
+        for process in processes:
+            process.join(timeout=10)
+            assert process.exitcode == 0
+
+        process_results = [results.get(timeout=5), results.get(timeout=5)]
+        successful_ids = [result[2] for result in process_results if result[1] == "success"]
         if branch_name is None:
-            assert not [result for result in results if isinstance(result, BaseException)]
+            assert all(result[1] == "success" for result in process_results)
             assert sorted(successful_ids) == [
                 "branch_from_turn_3_1700000000",
                 "branch_from_turn_3_1700000000_2",
             ]
         else:
             assert successful_ids == [branch_name]
-            errors = [result for result in results if isinstance(result, ValueError)]
+            errors = [result for result in process_results if result[1] == "error"]
             assert len(errors) == 1
-            assert "already exists" in str(errors[0])
+            assert errors[0][2] == "ValueError"
+            assert "already exists" in errors[0][3]
 
+        verification_session = AdvancedSQLiteSession(session_id=session_id, db_path=db_path)
         for branch_id in successful_ids:
-            assert await first_session.get_items(branch_id=branch_id) == items[:4]
-        assert await first_session.get_items(branch_id="main") == items
+            assert await verification_session.get_items(branch_id=branch_id) == items[:4]
+        assert await verification_session.get_items(branch_id="main") == items
+        verification_session.close()
     finally:
-        first_session.close()
-        second_session.close()
+        release_check.set()
+        for _, start, _, _ in worker_events:
+            start.set()
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)
+        results.close()
 
 
 async def test_delete_branch_removes_branch_only_messages():


### PR DESCRIPTION
This pull request fixes branch ID reuse in `AdvancedSQLiteSession`, which could silently append messages to an existing populated branch.

It takes over and supersedes #4152, preserving the original contribution and crediting Henry Su via the commit's `Co-authored-by` trailer.

Generated branch IDs now receive a numeric suffix when a collision occurs, while explicitly reused populated branch IDs raise `ValueError` before any session state is modified.

This pull request resolves #4150.