### PR TITLE
fix(models): surface non-streaming content-filter refusals

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -306,6 +306,19 @@ class OpenAIChatCompletionsModel(Model):
                 "output_tokens_details": usage.output_tokens_details.model_dump(),
             }
 
+            # Some providers signal a filtered non-streaming completion only through
+            # finish_reason="content_filter" and an otherwise empty message. Preserve
+            # that terminal signal as a refusal instead of returning an empty output.
+            if (
+                message is not None
+                and first_choice is not None
+                and first_choice.finish_reason == "content_filter"
+                and not message.content
+                and not message.refusal
+                and not message.tool_calls
+            ):
+                message.refusal = "Response withheld by the provider's content filter."
+
             # Build provider_data for provider_specific_fields
             provider_data = {"model": self.model}
             if message is not None and hasattr(response, "id"):

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -293,18 +293,6 @@ class OpenAIChatCompletionsModel(Model):
                 if response.usage
                 else Usage()
             )
-            if tracing.include_data():
-                span_generation.span_data.output = (
-                    [message.model_dump()] if message is not None else []
-                )
-            span_generation.span_data.usage = {
-                "requests": usage.requests,
-                "input_tokens": usage.input_tokens,
-                "output_tokens": usage.output_tokens,
-                "total_tokens": usage.total_tokens,
-                "input_tokens_details": usage.input_tokens_details.model_dump(),
-                "output_tokens_details": usage.output_tokens_details.model_dump(),
-            }
 
             # Some providers signal a filtered non-streaming completion only through
             # finish_reason="content_filter" and an otherwise empty message. Preserve
@@ -318,6 +306,19 @@ class OpenAIChatCompletionsModel(Model):
                 and not message.tool_calls
             ):
                 message.refusal = "Response withheld by the provider's content filter."
+
+            if tracing.include_data():
+                span_generation.span_data.output = (
+                    [message.model_dump()] if message is not None else []
+                )
+            span_generation.span_data.usage = {
+                "requests": usage.requests,
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "total_tokens": usage.total_tokens,
+                "input_tokens_details": usage.input_tokens_details.model_dump(),
+                "output_tokens_details": usage.output_tokens_details.model_dump(),
+            }
 
             # Build provider_data for provider_specific_fields
             provider_data = {"model": self.model}

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -46,11 +46,13 @@ from agents import (
     Runner,
     __version__,
     generation_span,
+    trace,
 )
 from agents.exceptions import UserError
 from agents.models._retry_runtime import provider_managed_retries_disabled
 from agents.models.chatcmpl_helpers import HEADERS_OVERRIDE, ChatCmplHelpers
 from agents.models.fake_id import FAKE_RESPONSES_ID
+from tests.testing_processor import fetch_ordered_spans
 
 
 def _minimal_chat_completion(content: str = "ok") -> ChatCompletion:
@@ -173,7 +175,9 @@ async def test_get_response_with_text_message(monkeypatch) -> None:
 
 
 async def _get_response_for_choice(
-    monkeypatch: pytest.MonkeyPatch, choice: Choice
+    monkeypatch: pytest.MonkeyPatch,
+    choice: Choice,
+    tracing: ModelTracing = ModelTracing.DISABLED,
 ) -> ModelResponse:
     chat = ChatCompletion(
         id="resp-id",
@@ -195,7 +199,7 @@ async def _get_response_for_choice(
         tools=[],
         output_schema=None,
         handoffs=[],
-        tracing=ModelTracing.DISABLED,
+        tracing=tracing,
         previous_response_id=None,
         conversation_id=None,
         prompt=None,
@@ -220,6 +224,31 @@ async def test_get_response_surfaces_empty_content_filter_as_refusal(monkeypatch
     assert isinstance(resp.output[0].content[0], ResponseOutputRefusal)
     assert (
         resp.output[0].content[0].refusal == "Response withheld by the provider's content filter."
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_traces_synthesized_content_filter_refusal(monkeypatch) -> None:
+    with trace(workflow_name="content-filter-refusal"):
+        await _get_response_for_choice(
+            monkeypatch,
+            Choice(
+                index=0,
+                finish_reason="content_filter",
+                message=ChatCompletionMessage(role="assistant", content=None),
+            ),
+            tracing=ModelTracing.ENABLED,
+        )
+
+    generation_spans = [
+        span for span in fetch_ordered_spans() if span.span_data.type == "generation"
+    ]
+    assert len(generation_spans) == 1
+    exported_span = generation_spans[0].export()
+    assert exported_span is not None
+    assert exported_span["span_data"]["output"][0]["refusal"] == (
+        "Response withheld by the provider's content filter."
     )
 
 

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -172,6 +172,127 @@ async def test_get_response_with_text_message(monkeypatch) -> None:
     assert resp.response_id is None
 
 
+async def _get_response_for_choice(
+    monkeypatch: pytest.MonkeyPatch, choice: Choice
+) -> ModelResponse:
+    chat = ChatCompletion(
+        id="resp-id",
+        created=0,
+        model="fake",
+        object="chat.completion",
+        choices=[choice],
+    )
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return chat
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    return await model.get_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_surfaces_empty_content_filter_as_refusal(monkeypatch) -> None:
+    resp = await _get_response_for_choice(
+        monkeypatch,
+        Choice(
+            index=0,
+            finish_reason="content_filter",
+            message=ChatCompletionMessage(role="assistant", content=None),
+        ),
+    )
+
+    assert len(resp.output) == 1
+    assert isinstance(resp.output[0], ResponseOutputMessage)
+    assert len(resp.output[0].content) == 1
+    assert isinstance(resp.output[0].content[0], ResponseOutputRefusal)
+    assert (
+        resp.output[0].content[0].refusal == "Response withheld by the provider's content filter."
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("message", "expected_output_type", "expected_content_type"),
+    [
+        (
+            ChatCompletionMessage(role="assistant", content="partial"),
+            ResponseOutputMessage,
+            ResponseOutputText,
+        ),
+        (
+            ChatCompletionMessage(role="assistant", content=None, refusal="provider refusal"),
+            ResponseOutputMessage,
+            ResponseOutputRefusal,
+        ),
+        (
+            ChatCompletionMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ChatCompletionMessageFunctionToolCall(
+                        id="call-1",
+                        type="function",
+                        function=Function(name="do_thing", arguments="{}"),
+                    )
+                ],
+            ),
+            ResponseFunctionToolCall,
+            None,
+        ),
+    ],
+)
+async def test_get_response_preserves_nonempty_content_filter_output(
+    monkeypatch,
+    message: ChatCompletionMessage,
+    expected_output_type: type[object],
+    expected_content_type: type[object] | None,
+) -> None:
+    resp = await _get_response_for_choice(
+        monkeypatch,
+        Choice(index=0, finish_reason="content_filter", message=message),
+    )
+
+    assert len(resp.output) == 1
+    assert isinstance(resp.output[0], expected_output_type)
+    if expected_content_type is not None:
+        assert isinstance(resp.output[0], ResponseOutputMessage)
+        assert len(resp.output[0].content) == 1
+        assert isinstance(resp.output[0].content[0], expected_content_type)
+    if isinstance(resp.output[0], ResponseOutputMessage) and isinstance(
+        resp.output[0].content[0], ResponseOutputRefusal
+    ):
+        assert resp.output[0].content[0].refusal == "provider refusal"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_preserves_empty_nonfiltered_output(monkeypatch) -> None:
+    resp = await _get_response_for_choice(
+        monkeypatch,
+        Choice(
+            index=0,
+            finish_reason="stop",
+            message=ChatCompletionMessage(role="assistant", content=None),
+        ),
+    )
+
+    assert resp.output == []
+
+
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request takes over the fix originally proposed in #4159.

It fixes non-streaming Chat Completions responses that report `finish_reason="content_filter"` but contain no text, refusal, or tool calls. It converts that otherwise empty provider signal into the same explicit `ResponseOutputRefusal` used by the streaming and LiteLLM paths, while preserving partial text, provider-supplied refusals, tool calls, and ordinary empty completions.

The original contributor is credited through the commit's `Co-authored-by` trailer.