### PR TITLE
fix(realtime): clean up failed connection attempts

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -547,6 +547,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
         self.model = DEFAULT_REALTIME_MODEL
         self._websocket: ClientConnection | None = None
         self._websocket_task: asyncio.Task[None] | None = None
+        self._connection_attempt_active = False
         self._response_create_tasks: set[asyncio.Task[None]] = set()
         self._user_input_lock = asyncio.Lock()
         self._listeners: list[RealtimeModelListener] = []
@@ -579,56 +580,65 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
 
     async def connect(self, options: RealtimeModelConfig) -> None:
         """Establish a connection to the model and keep it alive."""
+        assert not self._connection_attempt_active, "Already connected"
         assert self._websocket is None, "Already connected"
         assert self._websocket_task is None, "Already connected"
+        self._connection_attempt_active = True
 
-        model_settings: RealtimeSessionModelSettings = options.get("initial_model_settings", {})
+        try:
+            model_settings: RealtimeSessionModelSettings = options.get("initial_model_settings", {})
 
-        self._playback_tracker = options.get("playback_tracker", None)
+            self._playback_tracker = options.get("playback_tracker", None)
 
-        call_id = options.get("call_id")
-        model_name = model_settings.get("model_name")
-        if call_id and model_name:
-            error_message = (
-                "Cannot specify both `call_id` and `model_name` "
-                "when attaching to an existing realtime call."
+            call_id = options.get("call_id")
+            model_name = model_settings.get("model_name")
+            if call_id and model_name:
+                error_message = (
+                    "Cannot specify both `call_id` and `model_name` "
+                    "when attaching to an existing realtime call."
+                )
+                raise UserError(error_message)
+
+            if model_name:
+                self.model = model_name
+
+            self._call_id = call_id
+            api_key = await get_api_key(options.get("api_key"))
+
+            if "tracing" in model_settings:
+                self._tracing_config = model_settings["tracing"]
+            else:
+                self._tracing_config = "auto"
+
+            if call_id:
+                url = options.get("url", f"wss://api.openai.com/v1/realtime?call_id={call_id}")
+            else:
+                url = options.get("url", f"wss://api.openai.com/v1/realtime?model={self.model}")
+
+            headers: dict[str, str] = {}
+            if options.get("headers") is not None:
+                # For customizing request headers
+                headers.update(options["headers"])
+            else:
+                # OpenAI's Realtime API
+                if not api_key:
+                    raise UserError("API key is required but was not provided.")
+
+                headers.update({"Authorization": f"Bearer {api_key}"})
+
+            self._websocket = await self._create_websocket_connection(
+                url=url,
+                headers=headers,
+                transport_config=self._transport_config,
             )
-            raise UserError(error_message)
-
-        if model_name:
-            self.model = model_name
-
-        self._call_id = call_id
-        api_key = await get_api_key(options.get("api_key"))
-
-        if "tracing" in model_settings:
-            self._tracing_config = model_settings["tracing"]
-        else:
-            self._tracing_config = "auto"
-
-        if call_id:
-            url = options.get("url", f"wss://api.openai.com/v1/realtime?call_id={call_id}")
-        else:
-            url = options.get("url", f"wss://api.openai.com/v1/realtime?model={self.model}")
-
-        headers: dict[str, str] = {}
-        if options.get("headers") is not None:
-            # For customizing request headers
-            headers.update(options["headers"])
-        else:
-            # OpenAI's Realtime API
-            if not api_key:
-                raise UserError("API key is required but was not provided.")
-
-            headers.update({"Authorization": f"Bearer {api_key}"})
-
-        self._websocket = await self._create_websocket_connection(
-            url=url,
-            headers=headers,
-            transport_config=self._transport_config,
-        )
-        self._websocket_task = asyncio.create_task(self._listen_for_messages())
-        await self._update_session_config(model_settings)
+            try:
+                self._websocket_task = asyncio.create_task(self._listen_for_messages())
+                await self._update_session_config(model_settings)
+            except BaseException:
+                await self.close()
+                raise
+        finally:
+            self._connection_attempt_active = False
 
     async def _create_websocket_connection(
         self,

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -580,9 +580,13 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
 
     async def connect(self, options: RealtimeModelConfig) -> None:
         """Establish a connection to the model and keep it alive."""
-        assert not self._connection_attempt_active, "Already connected"
-        assert self._websocket is None, "Already connected"
-        assert self._websocket_task is None, "Already connected"
+        if (
+            self._connection_attempt_active
+            or self._websocket is not None
+            or self._websocket_task is not None
+        ):
+            raise AssertionError("Already connected")
+        previous_model = self.model
         self._connection_attempt_active = True
 
         try:
@@ -635,8 +639,17 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 self._websocket_task = asyncio.create_task(self._listen_for_messages())
                 await self._update_session_config(model_settings)
             except BaseException:
-                await self.close()
+                try:
+                    await self.close()
+                except BaseException:
+                    logger.warning(
+                        "Failed to clean up after Realtime connection setup failure",
+                        exc_info=True,
+                    )
                 raise
+        except BaseException:
+            self.model = previous_model
+            raise
         finally:
             self._connection_attempt_active = False
 
@@ -1229,18 +1242,36 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
         """Close the session."""
         try:
             await self._cancel_response_create_tasks()
+            cleanup_error: BaseException | None = None
+
             if self._websocket:
-                await self._websocket.close()
-                self._websocket = None
+                try:
+                    await self._websocket.close()
+                except BaseException as exc:
+                    cleanup_error = exc
+                finally:
+                    self._websocket = None
+
             if self._websocket_task:
                 self._websocket_task.cancel()
                 try:
                     await self._websocket_task
                 except asyncio.CancelledError:
                     pass
-                self._websocket_task = None
+                except BaseException as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+                finally:
+                    self._websocket_task = None
             else:
-                await self._release_response_waiters()
+                try:
+                    await self._release_response_waiters()
+                except BaseException as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+
+            if cleanup_error is not None:
+                raise cleanup_error
         finally:
             self._clear_response_audio_indexes()
 

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -345,9 +345,13 @@ class TestConnectionLifecycle(TestOpenAIRealtimeWebSocketModel):
     @pytest.mark.asyncio
     async def test_connect_session_config_failure_releases_websocket(self, model, mock_websocket):
         """A failed initial session update must release the connection."""
+        default_model = model.model
         invalid_config: RealtimeModelConfig = {
             "api_key": "test-key",
-            "initial_model_settings": {"tools": [WebSearchTool()]},
+            "initial_model_settings": {
+                "model_name": "failed-model",
+                "tools": [WebSearchTool()],
+            },
         }
 
         async def async_websocket(*args, **kwargs):
@@ -359,11 +363,43 @@ class TestConnectionLifecycle(TestOpenAIRealtimeWebSocketModel):
 
             assert model._websocket is None
             assert model._websocket_task is None
+            assert model.model == default_model
             mock_websocket.close.assert_awaited_once()
 
             await model.connect({"api_key": "test-key"})
             assert mock_connect.call_count == 2
+            assert mock_connect.call_args_list[1].args[0].endswith(f"?model={default_model}")
 
+        await model.close()
+
+    @pytest.mark.asyncio
+    async def test_connect_preserves_setup_error_when_websocket_close_fails(
+        self, model, mock_websocket
+    ):
+        """A cleanup failure must not mask the initial session update error."""
+        mock_websocket.close.side_effect = RuntimeError("close failed")
+        retry_websocket = AsyncMock()
+        connections = iter((mock_websocket, retry_websocket))
+
+        async def async_websocket(*args, **kwargs):
+            return next(connections)
+
+        invalid_config: RealtimeModelConfig = {
+            "api_key": "test-key",
+            "initial_model_settings": {"tools": [WebSearchTool()]},
+        }
+
+        with patch("websockets.connect", side_effect=async_websocket):
+            with pytest.raises(UserError, match="Must be a function tool"):
+                await model.connect(invalid_config)
+
+            assert model._websocket is None
+            assert model._websocket_task is None
+            mock_websocket.close.assert_awaited_once()
+
+            await model.connect({"api_key": "test-key"})
+
+        assert model._websocket is retry_websocket
         await model.close()
 
     @pytest.mark.asyncio

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -10,7 +10,7 @@ import pytest
 import websockets
 from pydantic import TypeAdapter
 
-from agents import Agent, function_tool
+from agents import Agent, WebSearchTool, function_tool
 from agents.exceptions import UserError
 from agents.handoffs import handoff
 from agents.realtime.model import RealtimeModelConfig, RealtimePlaybackTracker
@@ -341,6 +341,61 @@ class TestConnectionLifecycle(TestOpenAIRealtimeWebSocketModel):
         # Verify internal state remains clean after failure
         assert model._websocket is None
         assert model._websocket_task is None
+
+    @pytest.mark.asyncio
+    async def test_connect_session_config_failure_releases_websocket(self, model, mock_websocket):
+        """A failed initial session update must release the connection."""
+        invalid_config: RealtimeModelConfig = {
+            "api_key": "test-key",
+            "initial_model_settings": {"tools": [WebSearchTool()]},
+        }
+
+        async def async_websocket(*args, **kwargs):
+            return mock_websocket
+
+        with patch("websockets.connect", side_effect=async_websocket) as mock_connect:
+            with pytest.raises(UserError, match="Must be a function tool"):
+                await model.connect(invalid_config)
+
+            assert model._websocket is None
+            assert model._websocket_task is None
+            mock_websocket.close.assert_awaited_once()
+
+            await model.connect({"api_key": "test-key"})
+            assert mock_connect.call_count == 2
+
+        await model.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_connect_is_rejected_before_acquiring_another_websocket(
+        self, model, mock_websocket
+    ):
+        """A connection attempt must own the model before its first suspension point."""
+        connection_started = asyncio.Event()
+        allow_connection = asyncio.Event()
+
+        async def async_websocket(*args, **kwargs):
+            connection_started.set()
+            await allow_connection.wait()
+            return mock_websocket
+
+        config: RealtimeModelConfig = {"api_key": "test-key"}
+        with patch("websockets.connect", side_effect=async_websocket) as mock_connect:
+            first_connect = asyncio.create_task(model.connect(config))
+            try:
+                await asyncio.wait_for(connection_started.wait(), timeout=1)
+
+                with pytest.raises(AssertionError, match="Already connected"):
+                    await model.connect(config)
+
+                mock_connect.assert_called_once()
+            finally:
+                allow_connection.set()
+
+            await asyncio.wait_for(first_connect, timeout=1)
+
+        assert model._websocket is mock_websocket
+        await model.close()
 
     @pytest.mark.asyncio
     async def test_connect_with_empty_transport_config(self, mock_websocket):


### PR DESCRIPTION
This pull request takes over and supersedes #4161, which identified a leaked WebSocket and listener task when the initial Realtime session update fails.

It preserves the original cleanup and regression coverage while adding a connection-attempt ownership guard. This prevents overlapping `connect()` calls from acquiring or replacing connection state while another attempt is in progress. Failed initialization now leaves the model reusable without changing successful connection or SIP behavior.

The original contributor is credited through the commit's `Co-authored-by` trailer.