### PR TITLE
fix(memory): skip conversation creation on empty add_items

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -55,13 +55,14 @@ class OpenAIConversationsSession(SessionABC):
 
         Raises:
             ValueError: If the session has not been initialized yet.
-                Call any session method (get_items, add_items, etc.) first
-                to trigger lazy initialization.
+                Call a session method that accesses the remote conversation, such as
+                get_items() or add_items() with a non-empty list, to initialize it.
         """
         if self._session_id is None:
             raise ValueError(
                 "Session ID not yet available. The session is lazily initialized "
-                "on first API call. Call get_items(), add_items(), or similar first."
+                "on first API call. Call get_items(), add_items() with a non-empty list, "
+                "or a similar method first."
             )
         return self._session_id
 
@@ -107,10 +108,10 @@ class OpenAIConversationsSession(SessionABC):
         return all_items  # type: ignore
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
-        session_id = await self._get_session_id()
         if not items:
             return
 
+        session_id = await self._get_session_id()
         await self._openai_client.conversations.items.create(
             conversation_id=session_id,
             items=items,

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -231,6 +231,31 @@ class TestOpenAIConversationsSessionBasicOperations:
         )
 
     @pytest.mark.asyncio
+    async def test_add_items_empty_does_not_create_session(self, mock_openai_client):
+        """Test that add_items with no items does not create a remote conversation."""
+        session = OpenAIConversationsSession(openai_client=mock_openai_client)
+
+        await session.add_items([])
+
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.items.create.assert_not_called()
+        with pytest.raises(ValueError, match="add_items\\(\\) with a non-empty list"):
+            _ = session.session_id
+
+    @pytest.mark.asyncio
+    async def test_add_items_empty_keeps_existing_session_id(self, mock_openai_client):
+        """Test that add_items with no items leaves an initialized session untouched."""
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        await session.add_items([])
+
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.items.create.assert_not_called()
+        assert session.session_id == "test_id"
+
+    @pytest.mark.asyncio
     async def test_pop_item_with_items(self, mock_openai_client):
         """Test popping item when items exist using method patching."""
         session = OpenAIConversationsSession(


### PR DESCRIPTION
This pull request incorporates and supersedes #4162. It fixes `OpenAIConversationsSession.add_items([])` so an empty persistence batch no longer creates a durable OpenAI Conversation.

It preserves the original fix while addressing review feedback by updating the public `session_id` guidance and adding regression coverage for both uninitialized and existing-ID sessions. The original contributor is credited as a co-author.