### PR TITLE
fix(tracing): mark non-streaming agent span failures

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -72,6 +72,7 @@ from .run_internal.agent_runner_helpers import (
 )
 from .run_internal.approvals import approvals_from_step
 from .run_internal.error_handlers import (
+    attach_generic_agent_error,
     build_run_error_data,
     create_message_output_item,
     format_final_output_text,
@@ -1614,6 +1615,11 @@ class AgentRunner:
                         turn_result.new_step_items.clear()
             except BaseException as exc:
                 run_exception = exc
+                attach_generic_agent_error(
+                    current_span,
+                    exc,
+                    trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+                )
                 if isinstance(exc, AgentsException):
                     exc.run_data = RunErrorDetails(
                         input=original_input,

--- a/src/agents/run_internal/error_handlers.py
+++ b/src/agents/run_internal/error_handlers.py
@@ -8,7 +8,14 @@ from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 
 from ..agent import Agent
 from ..agent_output import _WRAPPER_DICT_KEY, AgentOutputSchema
-from ..exceptions import MaxTurnsExceeded, ModelBehaviorError, ModelRefusalError, UserError
+from ..exceptions import (
+    InputGuardrailTripwireTriggered,
+    MaxTurnsExceeded,
+    ModelBehaviorError,
+    ModelRefusalError,
+    OutputGuardrailTripwireTriggered,
+    UserError,
+)
 from ..items import (
     ItemHelpers,
     MessageOutputItem,
@@ -16,6 +23,7 @@ from ..items import (
     RunItem,
     TResponseInputItem,
 )
+from ..logger import logger
 from ..models.fake_id import FAKE_RESPONSES_ID
 from ..run_context import RunContextWrapper, TContext
 from ..run_error_handlers import (
@@ -24,10 +32,82 @@ from ..run_error_handlers import (
     RunErrorHandlerResult,
     RunErrorHandlers,
 )
+from ..tracing import Span, SpanError
+from ..util import _error_tracing
+from ..util._error_tracing import REDACTED_TRACE_ERROR_MESSAGE
 from .items import ReasoningItemIdPolicy, run_item_to_input_item
 from .turn_preparation import get_output_schema
 
 RunErrorHandlerKind = Literal["max_turns", "model_refusal", "invalid_final_output"]
+
+GENERIC_AGENT_ERROR_MESSAGE = "Error in agent run"
+UNFORMATTABLE_TRACE_ERROR_MESSAGE = "Error details are unavailable."
+
+
+def _is_generic_agent_error(exc: BaseException) -> bool:
+    """Return whether a failed run still needs the generic agent-span error.
+
+    Only ``Exception`` is eligible: the non-streaming handler also catches ``BaseException``, but
+    cancellation is not an agent failure and the streamed path never marks it. Failures that
+    already write their own agent-span error, or that a dedicated child span reports, are excluded
+    so the span keeps the more specific diagnosis.
+    """
+    if not isinstance(exc, Exception):
+        return False
+    return not isinstance(
+        exc,
+        ModelBehaviorError | InputGuardrailTripwireTriggered | OutputGuardrailTripwireTriggered,
+    )
+
+
+def _format_agent_error_detail(exc: BaseException) -> str:
+    """Stringify an exception for tracing without ever raising.
+
+    A custom exception whose ``__str__`` raises must not replace the exception the run is
+    propagating, so the formatting failure is swallowed and reported as a placeholder.
+    """
+    try:
+        return str(exc)
+    except BaseException:
+        return UNFORMATTABLE_TRACE_ERROR_MESSAGE
+
+
+def attach_generic_agent_error(
+    span: Span[Any] | None,
+    exc: BaseException,
+    *,
+    trace_include_sensitive_data: bool,
+) -> None:
+    """Mark the agent span of a failed run with the generic ``Error in agent run`` error.
+
+    This owns the whole policy shared by the streaming and non-streaming paths: eligibility,
+    preserving a more specific error already on the span, redaction, the span error payload, and
+    the attachment itself. Tracing never changes what the run raises: the exception is stringified
+    only when sensitive data is traced, and a formatting failure cannot propagate.
+    """
+    if span is None or not _is_generic_agent_error(exc):
+        return
+
+    try:
+        if span.error is not None:
+            return
+        detail = (
+            _format_agent_error_detail(exc)
+            if trace_include_sensitive_data
+            else REDACTED_TRACE_ERROR_MESSAGE
+        )
+        _error_tracing.attach_error_to_span(
+            span,
+            SpanError(message=GENERIC_AGENT_ERROR_MESSAGE, data={"error": detail}),
+        )
+    except BaseException as tracing_error:
+        try:
+            logger.warning(
+                "Failed to record a generic agent error on the span (%s)",
+                type(tracing_error).__name__,
+            )
+        except BaseException:
+            pass
 
 
 def build_run_error_data(

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -108,6 +108,7 @@ from .agent_runner_helpers import (
 )
 from .approvals import approvals_from_step
 from .error_handlers import (
+    attach_generic_agent_error,
     build_run_error_data,
     create_message_output_item,
     format_final_output_text,
@@ -285,13 +286,6 @@ async def cleanup_models_after_run(tool_use_tracker: AgentToolUseTracker) -> Non
 
 def _agent_diagnostic_extra(agent: Agent[Any]) -> dict[str, object]:
     return {"agent_name": agent.name}
-
-
-def _should_attach_generic_agent_error(exc: Exception) -> bool:
-    return not isinstance(
-        exc,
-        ModelBehaviorError | InputGuardrailTripwireTriggered | OutputGuardrailTripwireTriggered,
-    )
 
 
 async def _should_persist_stream_items(
@@ -1384,21 +1378,11 @@ async def start_streaming(
                     if await _wait_for_streamed_turn_events_and_stop_if_cancelled(streamed_result):
                         break
             except Exception as e:
-                if current_span and _should_attach_generic_agent_error(e):
-                    _error_tracing.attach_error_to_span(
-                        current_span,
-                        SpanError(
-                            message="Error in agent run",
-                            data={
-                                "error": _error_tracing.get_trace_error(
-                                    trace_include_sensitive_data=(
-                                        run_config.trace_include_sensitive_data
-                                    ),
-                                    error_message=str(e),
-                                )
-                            },
-                        ),
-                    )
+                attach_generic_agent_error(
+                    current_span,
+                    e,
+                    trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+                )
                 raise
     except AgentsException as exc:
         streamed_result.is_complete = True
@@ -1416,19 +1400,11 @@ async def start_streaming(
         )
         raise
     except Exception as e:
-        if current_span and _should_attach_generic_agent_error(e):
-            _error_tracing.attach_error_to_span(
-                current_span,
-                SpanError(
-                    message="Error in agent run",
-                    data={
-                        "error": _error_tracing.get_trace_error(
-                            trace_include_sensitive_data=run_config.trace_include_sensitive_data,
-                            error_message=str(e),
-                        )
-                    },
-                ),
-            )
+        attach_generic_agent_error(
+            current_span,
+            e,
+            trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+        )
         streamed_result.is_complete = True
         streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
         raise

--- a/tests/test_tracing_errors.py
+++ b/tests/test_tracing_errors.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from inline_snapshot import snapshot
@@ -13,11 +13,15 @@ from agents import (
     InputGuardrail,
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
+    ModelBehaviorError,
+    RunConfig,
     RunContextWrapper,
+    RunHooks,
     Runner,
     TResponseInputItem,
     _debug,
 )
+from agents.run_internal.error_handlers import attach_generic_agent_error
 
 from .fake_model import FakeModel
 from .test_responses import (
@@ -27,7 +31,7 @@ from .test_responses import (
     get_handoff_tool_call,
     get_text_message,
 )
-from .testing_processor import fetch_normalized_spans
+from .testing_processor import SPAN_PROCESSOR_TESTING, fetch_normalized_spans, fetch_span_errors
 
 
 @pytest.mark.asyncio
@@ -49,6 +53,7 @@ async def test_single_turn_model_error():
                 "children": [
                     {
                         "type": "agent",
+                        "error": {"message": "Error in agent run", "data": {"error": "test error"}},
                         "data": {
                             "name": "test_agent",
                             "handoffs": [],
@@ -102,6 +107,7 @@ async def test_multi_turn_no_handoffs():
                 "children": [
                     {
                         "type": "agent",
+                        "error": {"message": "Error in agent run", "data": {"error": "test error"}},
                         "data": {
                             "name": "test_agent",
                             "handoffs": [],
@@ -558,3 +564,212 @@ async def test_guardrail_error():
             }
         ]
     )
+
+
+SENSITIVE_ERROR_MESSAGE = "sensitive-error-detail"
+
+
+def test_run_sync_marks_agent_span_with_generic_error():
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output(ValueError("test error"))
+
+    with pytest.raises(ValueError, match="test error"):
+        Runner.run_sync(Agent(name="test_agent", model=model), input="first_test")
+
+    assert fetch_span_errors("agent") == [
+        {"message": "Error in agent run", "data": {"error": "test error"}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_span_error_matches_streamed_path():
+    """The non-streamed and streamed paths record the same agent span error."""
+    non_streamed_model = FakeModel(tracing_enabled=True)
+    non_streamed_model.set_next_output(ValueError("test error"))
+    with pytest.raises(ValueError):
+        await Runner.run(Agent(name="test_agent", model=non_streamed_model), input="first_test")
+    non_streamed_errors = fetch_span_errors("agent")
+
+    SPAN_PROCESSOR_TESTING.clear()
+
+    streamed_model = FakeModel(tracing_enabled=True)
+    streamed_model.set_next_output(ValueError("test error"))
+    result = Runner.run_streamed(Agent(name="test_agent", model=streamed_model), input="first_test")
+    with pytest.raises(ValueError):
+        async for _ in result.stream_events():
+            pass
+
+    assert non_streamed_errors == fetch_span_errors("agent")
+
+
+@pytest.mark.asyncio
+async def test_run_agent_span_error_redacts_sensitive_data():
+    model = FakeModel(tracing_enabled=False)
+    model.set_next_output(ValueError(SENSITIVE_ERROR_MESSAGE))
+
+    with pytest.raises(ValueError):
+        await Runner.run(
+            Agent(name="test_agent", model=model),
+            input="first_test",
+            run_config=RunConfig(trace_include_sensitive_data=False),
+        )
+
+    assert fetch_span_errors("agent") == [
+        {
+            "message": "Error in agent run",
+            "data": {"error": "Error details are redacted."},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_mark_agent_span_for_model_behavior_error():
+    """ModelBehaviorError is reported by the generation span, so the agent span stays clean."""
+    model = FakeModel(tracing_enabled=True)
+    model.set_next_output(ModelBehaviorError("bad model output"))
+
+    with pytest.raises(ModelBehaviorError):
+        await Runner.run(Agent(name="test_agent", model=model), input="first_test")
+
+    assert fetch_span_errors("agent") == []
+
+
+class UnformattableError(Exception):
+    """An exception whose ``__str__`` raises, like an error with a broken custom formatter."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.str_calls = 0
+
+    def __str__(self) -> str:
+        self.str_calls += 1
+        raise RuntimeError("__str__ is broken")
+
+
+class BaseExceptionUnformattableError(UnformattableError):
+    """An exception whose formatter raises outside the ``Exception`` hierarchy."""
+
+    def __str__(self) -> str:
+        self.str_calls += 1
+        raise KeyboardInterrupt("__str__ is broken")
+
+
+class RaisingHooks(RunHooks[Any]):
+    """Raises the given error from a run hook, i.e. from user code inside the agent span."""
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def on_agent_start(self, context: RunContextWrapper[Any], agent: Agent[Any]) -> None:
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_run_propagates_exception_whose_str_raises():
+    """Tracing must not replace the run exception when formatting it fails."""
+    error = UnformattableError()
+
+    with pytest.raises(UnformattableError) as exc_info:
+        await Runner.run(
+            Agent(name="test_agent", model=FakeModel(tracing_enabled=True)),
+            input="first_test",
+            hooks=RaisingHooks(error),
+        )
+
+    assert exc_info.value is error
+    assert fetch_span_errors("agent") == [
+        {"message": "Error in agent run", "data": {"error": "Error details are unavailable."}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streamed_run_propagates_exception_whose_str_raises():
+    """The streamed path shares the helper, so it keeps the same guarantee."""
+    error = UnformattableError()
+
+    result = Runner.run_streamed(
+        Agent(name="test_agent", model=FakeModel(tracing_enabled=True)),
+        input="first_test",
+        hooks=RaisingHooks(error),
+    )
+    with pytest.raises(UnformattableError) as exc_info:
+        async for _ in result.stream_events():
+            pass
+
+    assert exc_info.value is error
+    assert fetch_span_errors("agent") == [
+        {"message": "Error in agent run", "data": {"error": "Error details are unavailable."}}
+    ]
+
+
+class RecordingSpan:
+    """The subset of the span API the generic agent-error helper uses."""
+
+    def __init__(self) -> None:
+        self.error: Any = None
+
+    def set_error(self, error: Any) -> None:
+        self.error = error
+
+
+class FailingRecordingSpan:
+    """A custom span that fails while the generic error is inspected or attached."""
+
+    def __init__(self, failure_point: str) -> None:
+        self.failure_point = failure_point
+
+    @property
+    def error(self) -> Any:
+        if self.failure_point == "read":
+            raise RuntimeError("span error read failed")
+        return None
+
+    def set_error(self, error: Any) -> None:
+        raise RuntimeError("span set_error failed")
+
+
+@pytest.mark.parametrize("failure_point", ["read", "write"])
+def test_span_failure_cannot_replace_the_run_exception(failure_point: str):
+    """A custom span failure is contained so the original run exception is re-raised."""
+    original_error = ValueError("original run error")
+
+    with pytest.raises(ValueError) as exc_info:
+        try:
+            raise original_error
+        except ValueError as error:
+            attach_generic_agent_error(
+                cast(Any, FailingRecordingSpan(failure_point)),
+                error,
+                trace_include_sensitive_data=True,
+            )
+            raise
+
+    assert exc_info.value is original_error
+
+
+def test_trace_formatting_failure_cannot_replace_the_run_exception():
+    """Even a ``BaseException`` from ``__str__`` is contained at the trace-only boundary."""
+    span = RecordingSpan()
+    error = BaseExceptionUnformattableError()
+
+    attach_generic_agent_error(cast(Any, span), error, trace_include_sensitive_data=True)
+
+    assert error.str_calls == 1
+    assert span.error == {
+        "message": "Error in agent run",
+        "data": {"error": "Error details are unavailable."},
+    }
+
+
+def test_redacted_tracing_never_stringifies_the_exception():
+    """With redaction on, the detail is fixed, so the exception is never formatted at all."""
+    span = RecordingSpan()
+    error = UnformattableError()
+
+    attach_generic_agent_error(cast(Any, span), error, trace_include_sensitive_data=False)
+
+    assert error.str_calls == 0
+    assert span.error == {
+        "message": "Error in agent run",
+        "data": {"error": "Error details are redacted."},
+    }


### PR DESCRIPTION
This pull request fixes missing generic agent-span errors in non-streaming runs and brings `Runner.run()` and `Runner.run_sync()` into parity with `Runner.run_streamed()`.

It centralizes generic error attachment in one run-internal helper, preserves existing specific errors and cancellation behavior, honors sensitive-data redaction without unnecessary exception stringification, and contains formatter or custom span failures so tracing cannot replace the original application exception.

This pull request supersedes #4073 and carries forward the original contribution with co-authored credit. This pull request resolves #4070.