### PR TITLE
test: make async tool and guardrail tests deterministic

### DIFF
--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -491,11 +491,15 @@ async def test_blocking_guardrail_prevents_agent_execution_streaming():
 async def test_parallel_guardrail_may_not_prevent_tool_execution():
     tool_was_executed = False
     guardrail_executed = False
+    loop = asyncio.get_running_loop()
+    tool_executed = asyncio.Event()
 
     @function_tool
     def fast_tool() -> str:
         nonlocal tool_was_executed
         tool_was_executed = True
+        # Sync tools run in a worker thread, so signal the loop-owned event safely.
+        loop.call_soon_threadsafe(tool_executed.set)
         return "tool_executed"
 
     @input_guardrail(run_in_parallel=True)
@@ -503,7 +507,9 @@ async def test_parallel_guardrail_may_not_prevent_tool_execution():
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal guardrail_executed
-        await asyncio.sleep(LONG_DELAY)
+        # Trip only after the tool ran. If parallel guardrails gated the turn, this
+        # would deadlock instead of silently losing a wall-clock race.
+        await asyncio.wait_for(tool_executed.wait(), timeout=5)
         guardrail_executed = True
         return GuardrailFunctionOutput(
             output_info="slow_parallel_triggered",
@@ -646,7 +652,8 @@ async def test_model_error_cancels_parallel_input_guardrail_task():
     ) -> GuardrailFunctionOutput:
         guardrail_started.set()
         try:
-            await asyncio.sleep(LONG_DELAY)
+            # Never finishes on its own, so only cancellation can end this guardrail.
+            await asyncio.Event().wait()
             guardrail_finished.set()
             return GuardrailFunctionOutput(
                 output_info="parallel_ok",
@@ -671,7 +678,7 @@ async def test_model_error_cancels_parallel_input_guardrail_task():
 
     with patch.object(model, "get_response", side_effect=boom_get_response):
         with pytest.raises(RuntimeError, match="model boom"):
-            await Runner.run(agent, "trigger guardrail")
+            await asyncio.wait_for(Runner.run(agent, "trigger guardrail"), timeout=5)
 
     # By the time Runner.run returns, the guardrail task must already be
     # cancelled rather than left running to completion in the background.
@@ -703,7 +710,8 @@ async def test_parallel_guardrail_non_tripwire_error_not_swallowed():
     async def slow_get_response(*args, **kwargs):
         model_started.set()
         try:
-            await asyncio.sleep(LONG_DELAY)
+            # Never finishes on its own, so only cancellation can end the model call.
+            await asyncio.Event().wait()
             return await original_get_response(*args, **kwargs)
         except asyncio.CancelledError:
             model_cancelled.set()
@@ -720,7 +728,7 @@ async def test_parallel_guardrail_non_tripwire_error_not_swallowed():
 
     with patch.object(model, "get_response", side_effect=slow_get_response):
         with pytest.raises(ValueError, match="guardrail boom"):
-            await Runner.run(agent, "trigger guardrail")
+            await asyncio.wait_for(Runner.run(agent, "trigger guardrail"), timeout=5)
 
     await asyncio.wait_for(model_finished.wait(), timeout=1)
     assert model_started.is_set() is True
@@ -842,11 +850,15 @@ async def test_model_error_before_guardrail_error_preserves_stream_finalization(
 async def test_parallel_guardrail_may_not_prevent_tool_execution_streaming():
     tool_was_executed = False
     guardrail_executed = False
+    loop = asyncio.get_running_loop()
+    tool_executed = asyncio.Event()
 
     @function_tool
     def fast_tool() -> str:
         nonlocal tool_was_executed
         tool_was_executed = True
+        # Sync tools run in a worker thread, so signal the loop-owned event safely.
+        loop.call_soon_threadsafe(tool_executed.set)
         return "tool_executed"
 
     @input_guardrail(run_in_parallel=True)
@@ -854,7 +866,9 @@ async def test_parallel_guardrail_may_not_prevent_tool_execution_streaming():
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal guardrail_executed
-        await asyncio.sleep(LONG_DELAY)
+        # Trip only after the tool ran. If parallel guardrails gated the turn, this
+        # would deadlock instead of silently losing a wall-clock race.
+        await asyncio.wait_for(tool_executed.wait(), timeout=5)
         guardrail_executed = True
         return GuardrailFunctionOutput(
             output_info="slow_parallel_triggered_streaming",
@@ -1713,17 +1727,16 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger():
     fast_guardrail_executed = False
     slow_guardrail_executed = False
     slow_guardrail_cancelled = False
-    timestamps = {}
+    slow_guardrail_started = asyncio.Event()
 
     @input_guardrail(run_in_parallel=False)
     async def fast_guardrail_that_triggers(
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal fast_guardrail_executed
-        timestamps["fast_start"] = time.time()
-        await asyncio.sleep(SHORT_DELAY)
+        # Trip only once the sibling is provably in flight and therefore cancellable.
+        await asyncio.wait_for(slow_guardrail_started.wait(), timeout=5)
         fast_guardrail_executed = True
-        timestamps["fast_end"] = time.time()
         return GuardrailFunctionOutput(
             output_info="fast_triggered",
             tripwire_triggered=True,
@@ -1734,18 +1747,17 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger():
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal slow_guardrail_executed, slow_guardrail_cancelled
-        timestamps["slow_start"] = time.time()
+        slow_guardrail_started.set()
         try:
-            await asyncio.sleep(MEDIUM_DELAY)
+            # Never finishes on its own, so only cancellation can end this guardrail.
+            await asyncio.Event().wait()
             slow_guardrail_executed = True
-            timestamps["slow_end"] = time.time()
             return GuardrailFunctionOutput(
                 output_info="slow_completed",
                 tripwire_triggered=False,
             )
         except asyncio.CancelledError:
             slow_guardrail_cancelled = True
-            timestamps["slow_cancelled"] = time.time()
             raise
 
     model = FakeModel()
@@ -1758,7 +1770,7 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger():
     model.set_next_output([get_text_message("hello")])
 
     with pytest.raises(InputGuardrailTripwireTriggered):
-        await Runner.run(agent, "test input")
+        await asyncio.wait_for(Runner.run(agent, "test input"), timeout=5)
 
     # Verify the fast guardrail executed
     assert fast_guardrail_executed is True, "Fast guardrail should have executed"
@@ -1766,19 +1778,6 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger():
     # Verify the slow guardrail was cancelled, not completed
     assert slow_guardrail_cancelled is True, "Slow guardrail should have been cancelled"
     assert slow_guardrail_executed is False, "Slow guardrail should NOT have completed execution"
-
-    # Verify timing: cancellation happened shortly after fast guardrail triggered
-    assert "fast_end" in timestamps
-    assert "slow_cancelled" in timestamps
-    cancellation_delay = timestamps["slow_cancelled"] - timestamps["fast_end"]
-    assert cancellation_delay >= 0, (
-        f"Slow guardrail should be cancelled after fast one completes, "
-        f"but was {cancellation_delay:.2f}s"
-    )
-    assert cancellation_delay < 0.2, (
-        f"Cancellation should happen before the slow guardrail completes, "
-        f"but took {cancellation_delay:.2f}s"
-    )
 
     # Verify agent never started
     assert model.first_turn_args is None, (
@@ -1795,17 +1794,16 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
     fast_guardrail_executed = False
     slow_guardrail_executed = False
     slow_guardrail_cancelled = False
-    timestamps = {}
+    slow_guardrail_started = asyncio.Event()
 
     @input_guardrail(run_in_parallel=False)
     async def fast_guardrail_that_triggers(
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal fast_guardrail_executed
-        timestamps["fast_start"] = time.time()
-        await asyncio.sleep(SHORT_DELAY)
+        # Trip only once the sibling is provably in flight and therefore cancellable.
+        await asyncio.wait_for(slow_guardrail_started.wait(), timeout=5)
         fast_guardrail_executed = True
-        timestamps["fast_end"] = time.time()
         return GuardrailFunctionOutput(
             output_info="fast_triggered",
             tripwire_triggered=True,
@@ -1816,18 +1814,17 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
         ctx: RunContextWrapper[Any], agent: Agent[Any], input: str | list[TResponseInputItem]
     ) -> GuardrailFunctionOutput:
         nonlocal slow_guardrail_executed, slow_guardrail_cancelled
-        timestamps["slow_start"] = time.time()
+        slow_guardrail_started.set()
         try:
-            await asyncio.sleep(MEDIUM_DELAY)
+            # Never finishes on its own, so only cancellation can end this guardrail.
+            await asyncio.Event().wait()
             slow_guardrail_executed = True
-            timestamps["slow_end"] = time.time()
             return GuardrailFunctionOutput(
                 output_info="slow_completed",
                 tripwire_triggered=False,
             )
         except asyncio.CancelledError:
             slow_guardrail_cancelled = True
-            timestamps["slow_cancelled"] = time.time()
             raise
 
     model = FakeModel()
@@ -1841,9 +1838,12 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
 
     result = Runner.run_streamed(agent, "test input")
 
-    with pytest.raises(InputGuardrailTripwireTriggered):
+    async def consume_stream() -> None:
         async for _event in result.stream_events():
             pass
+
+    with pytest.raises(InputGuardrailTripwireTriggered):
+        await asyncio.wait_for(consume_stream(), timeout=5)
 
     # Verify the fast guardrail executed
     assert fast_guardrail_executed is True, "Fast guardrail should have executed"
@@ -1851,19 +1851,6 @@ async def test_blocking_guardrail_cancels_remaining_on_trigger_streaming():
     # Verify the slow guardrail was cancelled, not completed
     assert slow_guardrail_cancelled is True, "Slow guardrail should have been cancelled"
     assert slow_guardrail_executed is False, "Slow guardrail should NOT have completed execution"
-
-    # Verify timing: cancellation happened shortly after fast guardrail triggered
-    assert "fast_end" in timestamps
-    assert "slow_cancelled" in timestamps
-    cancellation_delay = timestamps["slow_cancelled"] - timestamps["fast_end"]
-    assert cancellation_delay >= 0, (
-        f"Slow guardrail should be cancelled after fast one completes, "
-        f"but was {cancellation_delay:.2f}s"
-    )
-    assert cancellation_delay < 0.2, (
-        f"Cancellation should happen before the slow guardrail completes, "
-        f"but took {cancellation_delay:.2f}s"
-    )
 
     # Verify agent never started
     assert model.first_turn_args is None, (

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -58,7 +58,7 @@ from agents import (
     trace,
 )
 from agents._public_agent import set_public_agent
-from agents.run_internal import run_loop, turn_resolution
+from agents.run_internal import run_loop, tool_execution, turn_resolution
 from agents.run_internal.agent_bindings import bind_execution_agent, bind_public_agent
 from agents.run_internal.run_loop import (
     NextStepFinalOutput,
@@ -2095,15 +2095,23 @@ async def test_multiple_tool_calls_surface_post_invoke_failure_unblocked_during_
 
 
 @pytest.mark.asyncio
-async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_sibling_error():
+async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_sibling_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
     loop = asyncio.get_running_loop()
     original_handler = loop.get_exception_handler()
     unhandled_contexts: list[dict[str, Any]] = []
+    post_invoke_started = asyncio.Event()
+
+    # Widen the post-invoke drain budget so the guardrail delay below stays well inside
+    # it. Otherwise a scheduling hiccup, not the runtime, decides which failure wins.
+    monkeypatch.setattr(tool_execution, "_FUNCTION_TOOL_POST_INVOKE_WAIT_SECONDS", 5.0)
 
     @tool_output_guardrail
     async def sleeping_tripwire_guardrail(
         _data: ToolOutputGuardrailData,
     ) -> ToolGuardrailFunctionOutput:
+        post_invoke_started.set()
         await asyncio.sleep(0.05)
         return ToolGuardrailFunctionOutput.raise_exception(output_info={"status": "sleep-tripwire"})
 
@@ -2111,6 +2119,8 @@ async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_s
         return "ok"
 
     async def _error_tool() -> str:
+        # Fail only once the sibling guardrail is provably in its post-invoke phase.
+        await post_invoke_started.wait()
         raise ValueError("boom")
 
     ok_tool = function_tool(
@@ -2141,7 +2151,7 @@ async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_s
     loop.set_exception_handler(_exception_handler)
     try:
         with pytest.raises(ToolOutputGuardrailTripwireTriggered):
-            await asyncio.wait_for(get_execute_result(agent, response), timeout=0.2)
+            await asyncio.wait_for(get_execute_result(agent, response), timeout=10)
         gc.collect()
         await asyncio.sleep(0)
     finally:
@@ -2156,13 +2166,18 @@ async def test_multiple_tool_calls_surface_sleeping_post_invoke_failure_before_s
 
 @pytest.mark.asyncio
 async def test_multiple_tool_calls_do_not_wait_indefinitely_for_sleeping_post_invoke_sibling():
+    post_invoke_started = asyncio.Event()
+    release_guardrail = asyncio.Event()
     guardrail_finished = asyncio.Event()
 
     @tool_output_guardrail
-    async def long_sleeping_guardrail(
+    async def blocked_post_invoke_guardrail(
         _data: ToolOutputGuardrailData,
     ) -> ToolGuardrailFunctionOutput:
-        await asyncio.sleep(0.3)
+        post_invoke_started.set()
+        # Outlast the post-invoke drain budget by construction: only the test can
+        # release this guardrail, and it does so after the sibling error propagated.
+        await release_guardrail.wait()
         guardrail_finished.set()
         return ToolGuardrailFunctionOutput.allow(output_info="done")
 
@@ -2170,13 +2185,15 @@ async def test_multiple_tool_calls_do_not_wait_indefinitely_for_sleeping_post_in
         return "ok"
 
     async def _error_tool() -> str:
+        # Fail only once the sibling guardrail is provably in its post-invoke phase.
+        await post_invoke_started.wait()
         raise ValueError("boom")
 
     ok_tool = function_tool(
         _ok_tool,
         name_override="ok_tool",
         failure_error_function=None,
-        tool_output_guardrails=[long_sleeping_guardrail],
+        tool_output_guardrails=[blocked_post_invoke_guardrail],
     )
     error_tool = function_tool(
         _error_tool,
@@ -2194,10 +2211,17 @@ async def test_multiple_tool_calls_do_not_wait_indefinitely_for_sleeping_post_in
         response_id=None,
     )
 
-    with pytest.raises(UserError, match="Error running tool error_tool: boom"):
-        await asyncio.wait_for(get_execute_result(agent, response), timeout=0.2)
+    try:
+        with pytest.raises(UserError, match="Error running tool error_tool: boom"):
+            await asyncio.wait_for(get_execute_result(agent, response), timeout=5)
+    finally:
+        # Release the detached guardrail even when the assertion fails so the test
+        # cannot leave a blocked task behind.
+        release_guardrail.set()
 
-    await asyncio.wait_for(guardrail_finished.wait(), timeout=0.5)
+    # The post-invoke sibling was still pending when the failure surfaced, and it
+    # must remain able to finish in the background.
+    await asyncio.wait_for(guardrail_finished.wait(), timeout=5)
 
 
 @pytest.mark.asyncio
@@ -2362,6 +2386,7 @@ async def test_multiple_tool_calls_drain_completed_fatal_failures_before_raising
 @pytest.mark.asyncio
 @pytest.mark.parametrize("delay_ticks", [1, 6, 20])
 async def test_multiple_tool_calls_raise_late_fatal_sibling_exception_after_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
     delay_ticks: int,
 ):
     class ToolAborted(BaseException):
@@ -2369,6 +2394,10 @@ async def test_multiple_tool_calls_raise_late_fatal_sibling_exception_after_canc
 
     sibling_ready = asyncio.Event()
     sibling_cancelled = asyncio.Event()
+
+    # Keep the cancelled-sibling drain open long enough for every parametrized
+    # scheduling step. This test covers failure arbitration, not the default budget.
+    monkeypatch.setattr(tool_execution, "_FUNCTION_TOOL_CANCELLED_DRAIN_SECONDS", 5.0)
 
     async def _error_tool_1() -> str:
         await sibling_ready.wait()
@@ -2407,7 +2436,7 @@ async def test_multiple_tool_calls_raise_late_fatal_sibling_exception_after_canc
     )
 
     with pytest.raises(ToolAborted, match=f"boom-{delay_ticks}"):
-        await asyncio.wait_for(get_execute_result(agent, response), timeout=0.2)
+        await asyncio.wait_for(get_execute_result(agent, response), timeout=5)
 
     assert sibling_cancelled.is_set()
 
@@ -2516,11 +2545,13 @@ async def test_multiple_tool_calls_report_late_cleanup_exception_from_cancelled_
 
     loop.set_exception_handler(_exception_handler)
     try:
-        with pytest.raises(UserError, match="Error running tool error_tool: boom"):
-            await asyncio.wait_for(get_execute_result(agent, response), timeout=0.2)
+        try:
+            with pytest.raises(UserError, match="Error running tool error_tool: boom"):
+                await asyncio.wait_for(get_execute_result(agent, response), timeout=5)
 
-        assert cleanup_blocked.is_set()
-        release_cleanup.set()
+            assert cleanup_blocked.is_set()
+        finally:
+            release_cleanup.set()
         await asyncio.wait_for(cleanup_finished.wait(), timeout=0.2)
         await asyncio.wait_for(late_cleanup_reported.wait(), timeout=0.5)
     finally:


### PR DESCRIPTION
This pull request improves timing-sensitive tool and guardrail tests by replacing scheduler-dependent sleeps and timestamp races with explicit causal rendezvous.

It preserves the existing synchronous function-tool, streaming, cancellation, post-invoke drain, and late-cleanup execution paths. Loop-owned events are signaled safely from worker threads, test-local drain budgets keep scheduling delays from deciding failure arbitration, and blocked cleanup work is released from `finally` blocks so failed assertions cannot leave tasks behind.

This incorporates the work from #4165 while preserving the original contributor's authorship through the commit's `Co-authored-by` trailer.
