### PR TITLE
fix: stop waiting on Queue.join() when the event consumer can die

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -942,7 +942,13 @@ class Agent(AgentBase, Generic[TContext]):
                                 pass
                         else:
                             await event_queue.put(None)
-                            await event_queue.join()
+                            # Wait on the dispatcher itself rather than on the queue draining.
+                            # The sentinel is the last item queued and the dispatcher only
+                            # returns after consuming it, so awaiting the task already implies
+                            # every event was handled. Waiting on `join()` instead would hang
+                            # forever when a handler raised a BaseException such as
+                            # CancelledError, because the dispatcher is then gone and the
+                            # outstanding `task_done()` calls can never arrive.
                             await dispatch_task
                     run_result = run_result_streaming
                 else:

--- a/src/agents/extensions/experimental/codex/codex_tool.py
+++ b/src/agents/extensions/experimental/codex/codex_tool.py
@@ -1115,8 +1115,13 @@ async def _consume_events(
     finally:
         if event_queue is not None:
             await event_queue.put(None)
-            await event_queue.join()
         if dispatch_task is not None:
+            # Wait on the dispatcher itself rather than on the queue draining. The sentinel is
+            # the last item queued and the dispatcher only returns after consuming it, so
+            # awaiting the task already implies every event was handled. Waiting on `join()`
+            # instead would hang forever when a handler raised a BaseException such as
+            # CancelledError, because the dispatcher is then gone and the outstanding
+            # `task_done()` calls can never arrive -- stranding the open spans below too.
             await dispatch_task
 
         # Ensure any open spans are closed even on failure.

--- a/src/agents/sandbox/memory/manager.py
+++ b/src/agents/sandbox/memory/manager.py
@@ -131,8 +131,12 @@ class SandboxMemoryGenerationManager:
                 self._ensure_worker()
                 for rollout_file in rollout_files:
                     self._queue.put_nowait(rollout_file)
-                await self._queue.join()
                 if self._worker_task is not None:
+                    # Wait on the worker rather than on the queue draining. The worker consumes
+                    # FIFO and only returns on _STOP, which is queued behind every rollout, so
+                    # awaiting it already implies each one was processed. Waiting on `join()`
+                    # instead would hang forever if the worker died on a BaseException, because
+                    # the outstanding `task_done()` calls can never arrive.
                     self._queue.put_nowait(_STOP)
                     await self._worker_task
                     self._worker_task = None

--- a/tests/extensions/experiemental/codex/test_codex_tool.py
+++ b/tests/extensions/experiemental/codex/test_codex_tool.py
@@ -2108,3 +2108,69 @@ async def test_codex_tool_argument_errors_respect_tool_data_redaction(
     else:
         assert _CODEX_TOOL_ARGUMENT_SECRET in str(error)
         assert isinstance(error.__cause__, cause_type)
+
+
+class _FatalCodexHandlerError(BaseException):
+    """A BaseException, so `_run_handler`'s `except Exception` does not catch it."""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raised",
+    [_FatalCodexHandlerError("fatal"), asyncio.CancelledError()],
+    ids=["base_exception", "cancelled_error"],
+)
+async def test_codex_tool_consume_events_does_not_hang_on_base_exception(
+    raised: BaseException,
+) -> None:
+    """A handler raising a BaseException must not strand `_consume_events`.
+
+    The dispatcher only catches `Exception`, so a BaseException such as `CancelledError`
+    terminates it. Waiting on `event_queue.join()` then waited for `task_done()` calls that
+    could never arrive, deadlocking the tool and leaving the active tracing spans unfinished.
+    """
+    events = [
+        {
+            "type": "item.completed",
+            "item": {"id": "agent-1", "type": "agent_message", "text": "done"},
+        },
+        {
+            "type": "turn.completed",
+            "usage": {"input_tokens": 1, "cached_input_tokens": 0, "output_tokens": 1},
+        },
+    ]
+
+    async def event_stream():
+        for event in events:
+            yield event
+
+    def on_stream(payload: CodexToolStreamEvent) -> None:
+        del payload
+        raise raised
+
+    context = ToolContext(
+        context=None,
+        tool_name="codex",
+        tool_call_id="call-1",
+        tool_arguments="{}",
+    )
+
+    async def invoke():
+        with trace("codex-test"):
+            return await codex_tool_module._consume_events(
+                event_stream(),
+                {"inputs": [{"type": "text", "text": "hello"}]},
+                context,
+                SimpleNamespace(id="thread-1"),
+                on_stream,
+                64,
+            )
+
+    try:
+        await asyncio.wait_for(invoke(), timeout=5)
+    except asyncio.TimeoutError:
+        pytest.fail("_consume_events deadlocked after the on_stream handler raised")
+    except _FatalCodexHandlerError:
+        pass
+    except asyncio.CancelledError:
+        pass

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -3047,3 +3047,140 @@ def test_replaced_agent_as_tool_preserves_agent_markers_for_build_agent_map() ->
     agent_map = _build_agent_map(parent_agent)
 
     assert agent_map["nested_agent"] is nested_agent
+
+
+class _FatalHandlerError(BaseException):
+    """A BaseException, so it is not caught by the on_stream handler's `except Exception`."""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raised",
+    [_FatalHandlerError("fatal"), asyncio.CancelledError()],
+    ids=["base_exception", "cancelled_error"],
+)
+async def test_agent_as_tool_streaming_does_not_hang_when_handler_raises_base_exception(
+    raised: BaseException,
+) -> None:
+    """A handler raising a BaseException must not strand the run.
+
+    The dispatcher only catches `Exception`, so a BaseException such as `CancelledError`
+    terminates it. Waiting on `event_queue.join()` then waited for `task_done()` calls that
+    could never arrive, deadlocking the tool invocation with no error and no timeout.
+    """
+    agent = Agent(
+        name="streamer",
+        model=FakeModel(
+            initial_output=[
+                ResponseOutputMessage(
+                    id="msg-fatal",
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                    content=[
+                        ResponseOutputText(
+                            annotations=[],
+                            text="streamed",
+                            type="output_text",
+                            logprobs=[],
+                        )
+                    ],
+                )
+            ]
+        ),
+    )
+
+    async def on_stream(payload: AgentToolStreamEvent) -> None:
+        del payload
+        raise raised
+
+    tool_call = ResponseFunctionToolCall(
+        id="call_fatal",
+        arguments='{"input": "go"}',
+        call_id="call-fatal",
+        name="stream_tool",
+        type="function_call",
+    )
+    tool = agent.as_tool(
+        tool_name="stream_tool",
+        tool_description="Streams events",
+        on_stream=on_stream,
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="stream_tool",
+        tool_call_id=tool_call.call_id,
+        tool_arguments=tool_call.arguments,
+        tool_call=tool_call,
+    )
+
+    # The call must settle rather than hang; whether it returns or propagates is secondary.
+    try:
+        await asyncio.wait_for(
+            tool.on_invoke_tool(tool_context, '{"input": "go"}'),
+            timeout=5,
+        )
+    except asyncio.TimeoutError:
+        pytest.fail("on_invoke_tool deadlocked after the on_stream handler raised")
+    except _FatalHandlerError:
+        pass
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_agent_as_tool_streaming_reports_every_event_before_returning() -> None:
+    """Dropping `join()` must not let the tool return before handlers have run."""
+    agent = Agent(
+        name="streamer",
+        model=FakeModel(
+            initial_output=[
+                ResponseOutputMessage(
+                    id="msg-ordered",
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                    content=[
+                        ResponseOutputText(
+                            annotations=[],
+                            text="ordered",
+                            type="output_text",
+                            logprobs=[],
+                        )
+                    ],
+                )
+            ]
+        ),
+    )
+
+    handled: list[str] = []
+
+    async def on_stream(payload: AgentToolStreamEvent) -> None:
+        # Yield control so a missing wait would let the tool return first.
+        await asyncio.sleep(0)
+        handled.append(payload["event"].type)
+
+    tool_call = ResponseFunctionToolCall(
+        id="call_ordered",
+        arguments='{"input": "go"}',
+        call_id="call-ordered",
+        name="stream_tool",
+        type="function_call",
+    )
+    tool = agent.as_tool(
+        tool_name="stream_tool",
+        tool_description="Streams events",
+        on_stream=on_stream,
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="stream_tool",
+        tool_call_id=tool_call.call_id,
+        tool_arguments=tool_call.arguments,
+        tool_call=tool_call,
+    )
+
+    output = await tool.on_invoke_tool(tool_context, '{"input": "go"}')
+
+    assert output == "ordered"
+    assert handled, "every streamed event must reach the handler before the tool returns"


### PR DESCRIPTION
### Summary

Three streaming dispatchers hand user events to a background consumer task and then wait on `asyncio.Queue.join()` before returning. Each wraps the user callback in `except Exception`, so a `BaseException` escapes and ends the consumer. The outstanding `task_done()` calls can then never arrive, and `join()` blocks forever — the run hangs with no exception and no timeout.

`asyncio.CancelledError` is the realistic trigger: any `asyncio.timeout()`, `wait_for`, or task cancellation inside a user's handler raises one.

The `join()` is also redundant in all three cases. The sentinel is the last item queued and the consumer only returns after consuming it, so awaiting the consumer task already implies every event was handled — and it surfaces a dead consumer instead of waiting on it. Each fix is therefore a removal, not a new mechanism.

| Site | Impact |
| --- | --- |
| `Agent.as_tool(on_stream=...)` | tool invocation hangs permanently |
| `codex_tool._consume_events()` | hangs, **and** strands active tracing spans — `span.finish()` runs after the join |
| `sandbox/memory/manager.flush()` | hangs before phase-two consolidation |

Ordinary `Exception`s from handlers are unaffected: they stay logged and swallowed exactly as before.

This is the same failure shape as #4170, which added an error sentinel so the STT waiters could not hang on a dead websocket listener.

### Test plan

New regression tests, each parametrized over a custom `BaseException` and `asyncio.CancelledError`:

- `tests/test_agent_as_tool.py::test_agent_as_tool_streaming_does_not_hang_when_handler_raises_base_exception`
- `tests/extensions/experiemental/codex/test_codex_tool.py::test_codex_tool_consume_events_does_not_hang_on_base_exception`

Plus `test_agent_as_tool_streaming_reports_every_event_before_returning`, which pins the property that made dropping `join()` safe: the handler still observes every event before the tool returns. It awaits inside the handler so a missing wait would let the tool return first.

On `main` the four hang tests fail on the 5s guard; with the fix the same selection drops from **10.9s to 0.4s**:

```
# main
FAILED ...test_agent_as_tool_streaming_does_not_hang_when_handler_raises_base_exception[base_exception]
FAILED ...test_agent_as_tool_streaming_does_not_hang_when_handler_raises_base_exception[cancelled_error]
2 failed, 1 passed, 55 deselected in 10.94s

# with fix
3 passed, 55 deselected in 0.42s
```

Verification from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/test_agent_as_tool.py tests/extensions/experiemental/codex/` | 190 passed |
| `make tests` | 5648 passed |

The full-suite run was done on Windows, where some sandbox symlink and tracing/realtime timing tests fail independently of this change. I diffed the failing set against a clean `main` checkout in the same environment: the two sets are identical (56 vs 56, no differences either way).

**One verification gap, stated plainly:** `tests/sandbox/test_memory.py` cannot be collected on Windows (`ImportError: UnixLocalSandbox is not supported on Windows`), so I could not execute a regression test for the `sandbox/memory/manager.py` site locally and did not add one I could not run. I did reproduce the deadlock for that site structurally — driving its exact worker/queue/sentinel shape, the worker dies on a `BaseException` and `join()` blocks with two unfinished items — and the change there is the same removal as the other two. Happy to add a test for it if you would rather have one, or to drop that hunk from this PR and leave it for someone who can run the file.

### Issue number

Closes #4198

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`; I ran the underlying steps individually instead, with the results above.

---

@seratch — this is the same shape you fixed for the STT listener in #4170, so I went looking for siblings of that pattern and these three were the ones where a consumer death can strand a `Queue.join()`.

Worth your call on one point: dropping `join()` means a `BaseException` from a handler now propagates out of the tool instead of hanging, which is a behavior change at that boundary even though the previous behavior was an unrecoverable hang. If you would rather keep handler failures fully contained, the alternative is widening the wrapper to `except BaseException` and re-raising `CancelledError` only — I did not do that because swallowing cancellation is usually worse than surfacing it.
