### PR TITLE
perf: add source-only typecheck target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ lint:
 
 .PHONY: mypy
 mypy: 
-	uv run mypy . --exclude site
+	uv run mypy $(if $(TYPECHECK_SRC_ONLY),src,.) --exclude site
 
 .PHONY: pyright
 pyright:
-	uv run pyright --project pyrightconfig.json
+	uv run pyright --project pyrightconfig.json $(if $(TYPECHECK_SRC_ONLY),src,)
 
 .PHONY: typecheck
 typecheck:
@@ -39,6 +39,10 @@ typecheck:
 	wait $$mypy_pid; \
 	wait $$pyright_pid; \
 	trap - EXIT
+
+.PHONY: typecheck-src
+typecheck-src:
+	@$(MAKE) typecheck TYPECHECK_SRC_ONLY=1
 
 .PHONY: tests
 tests: tests-parallel tests-serial


### PR DESCRIPTION
This pull request adds a source-only type-checking target for faster implementation-time feedback. `make typecheck-src` runs mypy and pyright against `src` through the existing parallel type-checking pipeline, while `make typecheck` retains its full validation scope for final verification and CI.

As a local cold-cache reference, limiting mypy to `src` reduced its runtime from 255 seconds to 138 seconds, approximately 46%. These timings were collected while other tasks were running, so they should be treated as directional rather than a controlled CI benchmark.