### PR TITLE
fix(memory): make SQLAlchemySession.pop_item atomic

### DIFF
--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -435,7 +435,16 @@ class SQLAlchemySession(SessionABC):
                         select(self._messages.c.message_data).where(self._messages.c.id == row_id)
                     )
                     row = res_data.scalar_one_or_none()
-                    await sess.execute(delete(self._messages).where(self._messages.c.id == row_id))
+                    deleted = await sess.execute(
+                        delete(self._messages).where(self._messages.c.id == row_id)
+                    )
+
+                    # The DELETE is the only atomic claim on this row: the select above can
+                    # return the same id to concurrent poppers, so treat deleting zero rows as
+                    # losing the race and look for the next item instead of handing the same
+                    # item to two callers.
+                    if deleted.rowcount == 0:
+                        continue
 
                     if row is None:
                         continue

--- a/tests/extensions/memory/test_sqlalchemy_session.py
+++ b/tests/extensions/memory/test_sqlalchemy_session.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Iterable, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -990,3 +991,39 @@ async def test_runner_with_session_settings_override(agent: Agent):
     history_items = [item for item in last_input if item.get("content") != "New question"]
     # Should have 2 history items (last two from the 10 we added)
     assert len(history_items) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_pop_item_hands_each_item_to_one_caller(
+    agent: Agent, tmp_path: Path
+) -> None:
+    """pop_item removes an item, so concurrent callers must never receive the same one.
+
+    pop_item selects the newest id, reads its payload, then deletes it in three separate
+    statements. Concurrent callers can therefore select the same id before either delete
+    lands, and both return that item while the rows they never claimed stay in the store.
+    """
+    item_count = 40
+    session_id = "concurrent_pop"
+    session = SQLAlchemySession.from_url(
+        session_id,
+        url=f"sqlite+aiosqlite:///{(tmp_path / 'concurrent_pop.db').as_posix()}",
+        create_tables=True,
+    )
+
+    await session.add_items(
+        cast(
+            list[TResponseInputItem],
+            [{"role": "user", "content": f"m{index}"} for index in range(item_count)],
+        )
+    )
+
+    popped = await asyncio.gather(*[session.pop_item() for _ in range(item_count)])
+    contents = [item.get("content") for item in popped if item is not None]
+
+    assert len(contents) == item_count
+    # Each item belongs to exactly one caller.
+    assert len(set(contents)) == item_count
+    assert sorted(cast(list[str], contents)) == sorted(f"m{index}" for index in range(item_count))
+    # And nothing is left behind by a pop that returned an item it did not delete.
+    assert await session.get_items() == []


### PR DESCRIPTION
### Summary

`SQLAlchemySession.pop_item()` picks the newest row id, reads its payload, then deletes it — three separate statements. Concurrent callers can complete the select for the same id before either delete lands, so both return that item. The second delete removes nothing, but its result is discarded, so the caller cannot tell. The rows no caller claimed are then never popped.

`pop_item` is a destructive read, so this is not a benign duplicate: an application draining a session, retrying a turn, or rewinding history processes the same item twice while other items are silently left behind.

Forty concurrent pops of a forty-item session, on `main`:

```
returned : 40
distinct : 26          <- 14 items handed to two callers, one to five
remaining: 14          <- rows nobody claimed, still in the store
```

The delete is the only statement that atomically claims a row, so this treats deleting zero rows as losing the race and continues to the next item. Checking `rowcount` keeps the existing dialect-agnostic fallback rather than requiring `DELETE ... RETURNING` support, which is what the current code comment ("Fallback for all dialects") is deliberately written around.

The SQLite backends are unaffected — they already claim the row with a single `DELETE ... RETURNING`. I verified that by running the same probe against all three backends; only the SQLAlchemy one violates the contract.

### Test plan

`tests/extensions/memory/test_sqlalchemy_session.py::test_concurrent_pop_item_hands_each_item_to_one_caller` runs 40 concurrent `pop_item()` calls against a 40-item session and asserts every item is returned exactly once and the store ends empty.

Fails on `main`, passes with the fix:

```
# main
E       AssertionError: assert 29 == 40
E        +  where 29 = len({'m11', 'm12', ...})
E        +    where ... = set(['m39', 'm34', 'm34', 'm34', 'm34', 'm34', ...])
1 failed, 34 deselected
```

Verification from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/extensions/memory/test_sqlalchemy_session.py` | 35 passed |
| `make tests` | 5769 passed |

The full-suite run was done on Windows, where some sandbox symlink and tracing/realtime timing tests fail independently of this change. I diffed the failing set against a clean `main` checkout in the same environment: the two sets are identical (58 vs 58, no differences either way).

### Issue number

Closes #4205

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`; I ran the underlying steps individually instead, with the results above.

---

@seratch — this came out of running the same concurrency contract against every session backend rather than reading one in isolation, which is why I am fairly confident the scope is exactly this one method.

One thing worth your call: `rowcount` is the minimal fix and keeps the fallback working on every dialect, but it does leave `pop_item` as three round trips per attempt. If you would rather have the atomic form where the dialect supports it, `delete(...).returning(message_data)` would collapse the read and the claim into one statement on PostgreSQL, SQLite 3.35+ and MariaDB, with this `rowcount` path kept for everything else. I did not do that here because it adds a dialect branch to a function that was deliberately written without one.
