### PR TITLE
fix: redact model output from JSON validation errors

### DIFF
--- a/src/agents/util/_json.py
+++ b/src/agents/util/_json.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from pydantic import TypeAdapter, ValidationError
 from typing_extensions import TypeVar
 
+from .. import _debug
 from ..exceptions import ModelBehaviorError
 from ..tracing import SpanError
 from ._error_tracing import attach_error_to_current_span
@@ -32,9 +33,16 @@ def validate_json(
                 data={},
             )
         )
-        raise ModelBehaviorError(
-            f"Invalid JSON when parsing {json_str} for {type_adapter}; {e}"
-        ) from e
+        if not _debug.DONT_LOG_MODEL_DATA:
+            raise ModelBehaviorError(
+                f"Invalid JSON when parsing {json_str} for {type_adapter}; {e}"
+            ) from e
+
+    # Only reachable when the model-data policy suppressed the detailed error above. This is
+    # raised outside the except block on purpose: chaining it would keep the ValidationError
+    # reachable through __cause__ and __context__, and that error embeds the offending model
+    # output in its own message.
+    raise ModelBehaviorError(f"Invalid JSON when parsing model output for {type_adapter}")
 
 
 def _to_dump_compatible(obj: Any) -> Any:

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 from openai import AsyncOpenAI
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 import agents._debug as _debug
 from agents import (
@@ -31,9 +31,11 @@ from agents import (
     OpenAIResponsesModel,
     RunConfig,
     RunContextWrapper,
+    Runner,
     function_tool,
     trace,
 )
+from agents.agent_output import AgentOutputSchema
 from agents.logger import (
     log_model_action_debug,
     log_model_action_error,
@@ -56,6 +58,10 @@ from agents.tracing.processor_interface import TracingProcessor
 from agents.tracing.provider import SynchronousMultiTracingProcessor
 from agents.tracing.spans import Span
 from agents.tracing.traces import Trace
+from agents.util._json import validate_json
+
+from .fake_model import FakeModel
+from .test_responses import get_text_message
 
 _SECRET = "super secret prompt content"
 
@@ -858,3 +864,85 @@ async def test_agent_tool_validation_error_preserves_diagnostics_when_tool_data_
     error = exc_info.value
     assert _TOOL_ARGUMENT_SECRET in str(error)
     assert isinstance(error.__cause__, ValidationError)
+
+
+_MODEL_OUTPUT_SECRET = "SECRET_MODEL_OUTPUT_123"
+
+
+class _RequiredOutput(BaseModel):
+    answer: str
+    count: int
+
+
+def _output_schema() -> AgentOutputSchema:
+    return AgentOutputSchema(_RequiredOutput)
+
+
+def test_output_schema_validation_error_redacts_payload_when_model_data_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The model output must not reach the error when model-data logging is disabled.
+
+    The message embedded the raw JSON, and the chained ValidationError carries the same
+    payload again in its own ``input_value``, so both have to go.
+    """
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+
+    with pytest.raises(ModelBehaviorError) as exc_info:
+        _output_schema().validate_json(payload)
+
+    error = exc_info.value
+    assert _MODEL_OUTPUT_SECRET not in str(error)
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
+def test_output_schema_validation_error_preserves_diagnostics_when_model_data_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+
+    with pytest.raises(ModelBehaviorError) as exc_info:
+        _output_schema().validate_json(payload)
+
+    error = exc_info.value
+    assert _MODEL_OUTPUT_SECRET in str(error)
+    assert isinstance(error.__cause__, ValidationError)
+
+
+def test_handoff_input_validation_error_redacts_payload_when_model_data_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Handoff arguments are model output too, so they follow the same policy."""
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+
+    with pytest.raises(ModelBehaviorError) as exc_info:
+        validate_json(payload, TypeAdapter(_RequiredOutput), partial=False)
+
+    error = exc_info.value
+    assert _MODEL_OUTPUT_SECRET not in str(error)
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
+@pytest.mark.asyncio
+async def test_run_surfaces_redacted_output_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End to end: a run whose model output fails validation must not leak it."""
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+
+    model = FakeModel()
+    agent = Agent(name="A", model=model, output_type=_RequiredOutput)
+    model.set_next_output([get_text_message(f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}')])
+
+    with pytest.raises(ModelBehaviorError) as exc_info:
+        await Runner.run(agent, "go")
+
+    error = exc_info.value
+    assert _MODEL_OUTPUT_SECRET not in str(error)
+    assert error.__cause__ is None
+    assert error.__context__ is None


### PR DESCRIPTION
### Summary

`agents.util._json.validate_json` formats the offending model output into its `ModelBehaviorError` message and chains the pydantic `ValidationError`, which repeats the same payload in its own `input_value`. Neither is gated on `_debug.DONT_LOG_MODEL_DATA`, which is `True` by default, so structured output that fails schema validation reaches the exception, its cause chain, and any traceback the application logs.

This is the model side of the tool argument redaction in #4182, and one change covers the three callers that pass model generated JSON: output schema validation (any agent with an `output_type`), handoff input validation, and its realtime equivalent.

Before, with the default flag:

```
message: Invalid JSON when parsing {"answer": "SUPER_SECRET_VALUE_9f3a"} for TypeAdapter(Structured); 1 validation error for Structured
count
  Field required [type=missing, input_value={'answer': 'SUPER_SECRET_VALUE_9f3a'}, input_type=dict]
cause  : ValidationError
```

After:

```
message: Invalid JSON when parsing model output for TypeAdapter(Structured)
cause  : None
```

The fix follows the same shape as #4182: keep the detailed error when the flag allows it, and otherwise raise outside the `except` block so neither `__cause__` nor `__context__` keeps the `ValidationError` reachable. Suppressing only the message would not be enough, because the chained error carries the payload independently.

Scope notes:

- Diagnostics are unchanged with `OPENAI_AGENTS_DONT_LOG_MODEL_DATA=0`: same message, same chained `ValidationError`.
- The `SpanError` raised alongside already used `data={}`, so tracing was correct and is untouched.
- `DONT_LOG_MODEL_DATA` is the right flag for all three callers because the payload is LLM output in every case, including handoff arguments.

### Test plan

Four tests in `tests/test_error_logging_redaction.py`, alongside the existing #4182 cases:

- `test_output_schema_validation_error_redacts_payload_when_model_data_disabled`
- `test_output_schema_validation_error_preserves_diagnostics_when_model_data_enabled`
- `test_handoff_input_validation_error_redacts_payload_when_model_data_disabled`
- `test_run_surfaces_redacted_output_validation_error`, an end to end run through `Runner.run`

Each redaction test asserts the payload is absent from the message and that `__cause__` and `__context__` are both `None`, so the check cannot pass by suppressing the message alone.

Three fail on `main` and pass with the fix. The diagnostics test passes in both runs, which is the control that the flag still enables the detailed error:

```
# main
FAILED tests/test_error_logging_redaction.py::test_output_schema_validation_error_redacts_payload_when_model_data_disabled
FAILED tests/test_error_logging_redaction.py::test_handoff_input_validation_error_redacts_payload_when_model_data_disabled
FAILED tests/test_error_logging_redaction.py::test_run_surfaces_redacted_output_validation_error
3 failed, 1 passed, 67 deselected
```

Verification from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/test_error_logging_redaction.py` | 71 passed |
| `make tests` | 5805 passed |

The full suite run was done on Windows, where some sandbox symlink and tracing timing tests fail independently of this change. I diffed the failing set against a clean `main` checkout in the same environment. This branch has one fewer failure than the baseline, and the difference is `test_tracing_errors_streamed.py::test_max_turns_exceeded`, a timing test that flakes on `main` on its own. Nothing else differs in either direction.

### Issue number

Closes #4207

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`. I ran the underlying steps individually instead, with the results above.
