### PR TITLE
fix(memory): release SQLite engine config entries when engines are collected

### DIFF
--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import weakref
 from typing import Any, ClassVar
 
 from sqlalchemy import (
@@ -63,6 +64,10 @@ class SQLAlchemySession(SessionABC):
 
     _table_init_locks: ClassVar[dict[tuple[str, str, str], threading.Lock]] = {}
     _table_init_locks_guard: ClassVar[threading.Lock] = threading.Lock()
+    # Keyed on id(engine.sync_engine) so two distinct engines that happen to compare equal
+    # never share a cache entry.  A weakref.finalize callback removes the entry when the sync
+    # engine is garbage collected, preventing stale id() values from being reused by a future
+    # engine that has not been configured yet.
     _sqlite_configured_engines: ClassVar[set[int]] = set()
     _sqlite_configured_engines_guard: ClassVar[threading.Lock] = threading.Lock()
     _SQLITE_BUSY_TIMEOUT_MS: ClassVar[int] = 5000
@@ -109,6 +114,9 @@ class SQLAlchemySession(SessionABC):
                     cursor.close()
 
             cls._sqlite_configured_engines.add(engine_key)
+            # Drop the entry once the sync engine goes away so a later engine allocated at the
+            # same address is still configured instead of being treated as already configured.
+            weakref.finalize(engine.sync_engine, cls._sqlite_configured_engines.discard, engine_key)
 
     @staticmethod
     def _is_sqlite_lock_error(exc: OperationalError) -> bool:

--- a/tests/extensions/memory/test_sqlalchemy_session.py
+++ b/tests/extensions/memory/test_sqlalchemy_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
 import threading
 from collections.abc import Iterable, Sequence
@@ -990,3 +991,44 @@ async def test_runner_with_session_settings_override(agent: Agent):
     history_items = [item for item in last_input if item.get("content") != "New question"]
     # Should have 2 history items (last two from the 10 we added)
     assert len(history_items) == 2
+
+
+async def test_sqlite_configuration_registry_releases_collected_engines(tmp_path):
+    """The SQLite configuration registry must not keep ids of collected engines."""
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'sqlite_registry_release.db'}"
+    session = SQLAlchemySession.from_url(
+        "sqlite_registry_release",
+        url=db_url,
+        create_tables=True,
+    )
+    engine = session.engine
+    engine_key = id(engine.sync_engine)
+    assert engine_key in SQLAlchemySession._sqlite_configured_engines
+
+    await engine.dispose()
+    del session
+    del engine
+    gc.collect()
+
+    # A later engine can be allocated at the same address, so a stale entry would make the
+    # SQLite PRAGMA setup silently skipped for an engine that was never configured.
+    assert engine_key not in SQLAlchemySession._sqlite_configured_engines
+
+
+async def test_sqlite_configuration_registry_does_not_grow_unbounded(tmp_path):
+    """Short-lived SQLite sessions must not accumulate registry entries."""
+    baseline = len(SQLAlchemySession._sqlite_configured_engines)
+
+    for index in range(25):
+        db_url = f"sqlite+aiosqlite:///{tmp_path / f'sqlite_registry_growth_{index}.db'}"
+        session = SQLAlchemySession.from_url(
+            f"sqlite_registry_growth_{index}",
+            url=db_url,
+            create_tables=True,
+        )
+        await session.add_items([{"role": "user", "content": f"turn {index}"}])
+        await session.engine.dispose()
+        del session
+        gc.collect()
+
+    assert len(SQLAlchemySession._sqlite_configured_engines) == baseline


### PR DESCRIPTION
`SQLAlchemySession._configure_sqlite_engine` remembers that an engine already has the SQLite `connect` listener by storing `id(engine.sync_engine)` in a class-level set, but that set holds no reference to the engine, so the entry outlives the object. CPython reuses addresses, so a later engine allocated at the same address takes the early return and never gets `PRAGMA busy_timeout` or `PRAGMA journal_mode = WAL`, which is exactly the configuration `_run_sqlite_write_with_retry` exists to complement. The same set also grows for the lifetime of the process, which `from_url` makes easy to hit because it creates and discards an engine per session.

This registers a `weakref.finalize` callback that discards the entry when the sync engine is collected, matching the guard `MongoDBSession` already documents for its own `id()`-keyed registry. Two regression tests cover it: one asserts the entry is gone after the engine is collected, and one asserts the registry returns to its baseline size after 25 short-lived `from_url` sessions. Both fail on main and pass with the fix, and `uv run pytest tests/extensions/memory/test_sqlalchemy_session.py` is green at 36 passed along with `make format`, `make lint`, and `make typecheck`.