### PR TITLE
fix(sandbox): stop splitting Cloudflare SSE events at chunk boundaries

### DIFF
--- a/src/agents/extensions/sandbox/cloudflare/sandbox.py
+++ b/src/agents/extensions/sandbox/cloudflare/sandbox.py
@@ -231,8 +231,13 @@ class _SSELineDecoder:
                 if cr + 1 < length and raw[cr + 1 : cr + 2] == b"\n":
                     i = cr + 2
                 elif cr + 1 == length:
-                    self._buf = b"\r"
-                    lines.append(line.decode("utf-8"))
+                    # The CR is the last byte available, so it is either a lone CR
+                    # terminator or the first half of a CRLF split across chunks. Keep the
+                    # unterminated line and decide once the next chunk arrives. Emitting it
+                    # now would leave the following LF to be read as an empty line, and an
+                    # empty line dispatches the event, splitting one multi-line SSE event
+                    # into several.
+                    self._buf = raw[i:]
                     break
                 else:
                     i = cr + 1
@@ -247,11 +252,13 @@ class _SSELineDecoder:
     def flush(self) -> list[str]:
         buf = self._buf
         self._buf = b""
-        if buf == b"\r":
-            return [""]
-        if buf:
-            return [buf.decode("utf-8")]
-        return []
+        if not buf:
+            return []
+        if buf.endswith(b"\r"):
+            # A CR held back by decode() turned out to end the stream, so it is a lone CR
+            # terminator and the line it closes is the last one.
+            return [buf[:-1].decode("utf-8")]
+        return [buf.decode("utf-8")]
 
 
 class _SSEDecoder:

--- a/src/agents/extensions/sandbox/cloudflare/sandbox.py
+++ b/src/agents/extensions/sandbox/cloudflare/sandbox.py
@@ -207,12 +207,22 @@ class _ServerSentEvent:
 
 class _SSELineDecoder:
     _buf: bytes
+    _skip_leading_lf: bool
 
     def __init__(self) -> None:
         self._buf = b""
+        self._skip_leading_lf = False
 
     def decode(self, text: str) -> list[str]:
-        raw = self._buf + text.encode("utf-8")
+        data = text.encode("utf-8")
+        if self._skip_leading_lf and data:
+            # The previous chunk ended on a CR, which already terminated its line. A LF
+            # opening this chunk is the second half of that CRLF, so consume it instead of
+            # reading it as a blank line, which SSE treats as an event dispatch.
+            self._skip_leading_lf = False
+            if data.startswith(b"\n"):
+                data = data[1:]
+        raw = self._buf + data
         self._buf = b""
 
         lines: list[str] = []
@@ -231,13 +241,13 @@ class _SSELineDecoder:
                 if cr + 1 < length and raw[cr + 1 : cr + 2] == b"\n":
                     i = cr + 2
                 elif cr + 1 == length:
-                    # The CR is the last byte available, so it is either a lone CR
-                    # terminator or the first half of a CRLF split across chunks. Keep the
-                    # unterminated line and decide once the next chunk arrives. Emitting it
-                    # now would leave the following LF to be read as an empty line, and an
-                    # empty line dispatches the event, splitting one multi-line SSE event
-                    # into several.
-                    self._buf = raw[i:]
+                    # A CR is a complete line ending on its own, so deliver the line now
+                    # rather than waiting to learn whether a LF follows. Only remember that
+                    # a LF opening the next chunk belongs to this CRLF; without that, the
+                    # LF reads as a blank line and dispatches the event early, splitting one
+                    # multi-line event into several.
+                    self._skip_leading_lf = True
+                    lines.append(line.decode("utf-8"))
                     break
                 else:
                     i = cr + 1
@@ -252,12 +262,10 @@ class _SSELineDecoder:
     def flush(self) -> list[str]:
         buf = self._buf
         self._buf = b""
+        # A trailing CR already delivered its line, so there is nothing pending for it here.
+        self._skip_leading_lf = False
         if not buf:
             return []
-        if buf.endswith(b"\r"):
-            # A CR held back by decode() turned out to end the stream, so it is a lone CR
-            # terminator and the line it closes is the last one.
-            return [buf[:-1].decode("utf-8")]
         return [buf.decode("utf-8")]
 
 

--- a/tests/extensions/sandbox/test_cloudflare.py
+++ b/tests/extensions/sandbox/test_cloudflare.py
@@ -19,7 +19,11 @@ from agents.extensions.sandbox.cloudflare import (
     CloudflareSandboxSession,
     CloudflareSandboxSessionState,
 )
-from agents.extensions.sandbox.cloudflare.sandbox import _CloudflarePtyProcessEntry
+from agents.extensions.sandbox.cloudflare.sandbox import (
+    _CloudflarePtyProcessEntry,
+    _SSEDecoder,
+    _SSELineDecoder,
+)
 from agents.sandbox.entries import Dir, GCSMount, R2Mount, S3Mount
 from agents.sandbox.errors import (
     ConfigurationError,
@@ -1567,3 +1571,66 @@ async def test_cloudflare_shutdown_logs_respect_tool_data_policy(
     )
     assert has_detail is not redacted
     assert response.read_calls == (0 if redacted else 1)
+
+
+def _decode_in_chunks(stream: str, size: int) -> list[str]:
+    decoder = _SSELineDecoder()
+    lines: list[str] = []
+    for index in range(0, len(stream), size):
+        lines.extend(decoder.decode(stream[index : index + size]))
+    lines.extend(decoder.flush())
+    return lines
+
+
+def _events(lines: list[str]) -> list[tuple[str, str]]:
+    decoder = _SSEDecoder()
+    collected: list[tuple[str, str]] = []
+    for line in lines:
+        event = decoder.decode(line)
+        if event is not None:
+            collected.append((event.event, event.data))
+    return collected
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [
+        "data: a\ndata: b\n\n",
+        "data: a\r\ndata: b\r\n\r\n",
+        "data: a\rdata: b\r\r",
+        "data: a\r\ndata: b\n\r\n",
+        "data:\r\n\r\n",
+        "data: a\r",
+        "\r\n",
+    ],
+    ids=["lf", "crlf", "cr", "mixed", "empty_data", "trailing_cr", "bare_crlf"],
+)
+def test_sse_line_decoder_matches_splitlines_for_every_chunk_boundary(stream: str) -> None:
+    """Line splitting must not depend on how the transport chunks the stream.
+
+    A chunk that ends on a CR cannot be classified yet: the next chunk may start with LF,
+    and CRLF is a single terminator. Emitting the line early left that LF to be read as a
+    blank line, and a blank line dispatches an SSE event.
+    """
+    expected = stream.splitlines()
+    for size in range(1, len(stream) + 1):
+        assert _decode_in_chunks(stream, size) == expected, f"chunk size {size}"
+
+
+def test_sse_event_is_not_split_when_crlf_straddles_a_chunk_boundary() -> None:
+    """One multi-line event must stay one event regardless of chunking."""
+    stream = "data: a\r\ndata: b\r\n\r\n"
+
+    whole = _events(_decode_in_chunks(stream, len(stream)))
+    assert whole == [("message", "a\nb")]
+
+    for size in range(1, len(stream) + 1):
+        assert _events(_decode_in_chunks(stream, size)) == whole, f"chunk size {size}"
+
+
+def test_sse_line_decoder_flush_does_not_emit_a_phantom_line_for_a_trailing_cr() -> None:
+    """A stream ending on a lone CR closes its line without adding a blank one."""
+    decoder = _SSELineDecoder()
+
+    assert decoder.decode("data: a\r") == []
+    assert decoder.flush() == ["data: a"]

--- a/tests/extensions/sandbox/test_cloudflare.py
+++ b/tests/extensions/sandbox/test_cloudflare.py
@@ -1628,9 +1628,39 @@ def test_sse_event_is_not_split_when_crlf_straddles_a_chunk_boundary() -> None:
         assert _events(_decode_in_chunks(stream, size)) == whole, f"chunk size {size}"
 
 
-def test_sse_line_decoder_flush_does_not_emit_a_phantom_line_for_a_trailing_cr() -> None:
-    """A stream ending on a lone CR closes its line without adding a blank one."""
+def test_sse_line_decoder_delivers_a_cr_terminated_line_immediately() -> None:
+    """A CR is a complete line ending, so the line must not wait for the next chunk.
+
+    Holding it back to learn whether a LF follows would delay every CR-terminated line
+    until more bytes arrive or the stream ends.
+    """
     decoder = _SSELineDecoder()
 
-    assert decoder.decode("data: a\r") == []
-    assert decoder.flush() == ["data: a"]
+    assert decoder.decode("data: a\r") == ["data: a"]
+    # The LF is the second half of that CRLF, not a blank line, so it yields nothing.
+    assert decoder.decode("\n") == []
+    assert decoder.flush() == []
+
+
+def test_sse_line_decoder_dispatches_a_cr_only_blank_line_without_more_input() -> None:
+    """A CR-only blank line must dispatch its event without another chunk or EOF."""
+    decoder = _SSELineDecoder()
+    sse = _SSEDecoder()
+
+    lines = decoder.decode("data: a\r\r")
+
+    assert lines == ["data: a", ""]
+    events = [event for event in (sse.decode(line) for line in lines) if event is not None]
+    assert [(event.event, event.data) for event in events] == [("message", "a")]
+
+
+def test_sse_line_decoder_flush_emits_only_an_unterminated_line() -> None:
+    """A stream ending on a lone CR already delivered its line, so flush adds nothing."""
+    decoder = _SSELineDecoder()
+
+    assert decoder.decode("data: a\r") == ["data: a"]
+    assert decoder.flush() == []
+
+    partial = _SSELineDecoder()
+    assert partial.decode("data: b") == []
+    assert partial.flush() == ["data: b"]


### PR DESCRIPTION
### Summary

The Cloudflare Worker's server-sent event stream is split into lines by a hand-rolled decoder that classifies a chunk ending on CR immediately: it emits the line and keeps a bare CR as the buffer. A CR at the end of the available bytes cannot be classified yet, because the next chunk may begin with LF and CRLF is a single terminator. The stored CR is then read as the start of a new line, so the following LF produces a blank line, and a blank line dispatches an SSE event. One multi-line event arrives as several.

Transport chunk boundaries are arbitrary, so which events an application receives depended on how the response happened to be framed rather than on its content:

```
stream = "data: a\r\ndata: b\r\n\r\n"

one chunk        ['data: a', 'data: b', '']          -> [('message', 'a\nb')]
split on the CR  ['data: a', '', 'data: b', '', '']  -> [('message', 'a'), ('message', 'b')]
```

`flush()` had the matching problem and appended a blank line for a stream ending on CR. The CR-only and trailing-CR shapes were also wrong when decoded in a single call, independently of chunking.

The decoder is adapted from the httpx line decoder, which defers a trailing CR into the next iteration and documents that it matches `str.splitlines()`. This restores that behavior: keep the unterminated line, CR included, until the next chunk decides, and let `flush` close the pending line instead of adding a blank one.

Measured against `str.splitlines()` as the oracle:

| | before | after |
| --- | --- | --- |
| stream shapes disagreeing at some chunk size | 6 of 7 | 0 of 7 |
| randomized streams whose events changed with chunking | 191 of 400 | 0 of 400 |

### Test plan

The decoders had no tests, which is how this survived. Added to `tests/extensions/sandbox/test_cloudflare.py`:

- `test_sse_line_decoder_matches_splitlines_for_every_chunk_boundary`, parametrized over LF, CRLF, CR, mixed, empty-data, trailing-CR and bare-CRLF streams, asserting agreement with `str.splitlines()` at every chunk size from 1 to the full length.
- `test_sse_event_is_not_split_when_crlf_straddles_a_chunk_boundary`, asserting the decoded events are identical for every chunk size.
- `test_sse_line_decoder_flush_does_not_emit_a_phantom_line_for_a_trailing_cr`.

8 fail on `main` and pass with the fix. The LF-only case passes in both runs, which is the control confirming the tests are not simply rejecting the decoder wholesale:

```
# main
FAILED ...test_sse_line_decoder_matches_splitlines_for_every_chunk_boundary[crlf]
FAILED ...test_sse_line_decoder_matches_splitlines_for_every_chunk_boundary[cr]
FAILED ...test_sse_line_decoder_matches_splitlines_for_every_chunk_boundary[mixed]
FAILED ...test_sse_line_decoder_matches_splitlines_for_every_chunk_boundary[empty_data]
FAILED ...test_sse_line_decoder_matches_splitlines_for_every_chunk_boundary[trailing_cr]
FAILED ...test_sse_line_decoder_matches_splitlines_for_every_chunk_boundary[bare_crlf]
FAILED ...test_sse_event_is_not_split_when_crlf_straddles_a_chunk_boundary
FAILED ...test_sse_line_decoder_flush_does_not_emit_a_phantom_line_for_a_trailing_cr
8 failed, 3 passed, 68 deselected
```

Verification from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/extensions/sandbox/test_cloudflare.py` | 79 passed |
| `make tests` | 5827 passed |

The full suite run was done on Windows, where some sandbox symlink and tracing timing tests fail independently of this change. I diffed the failing set against a clean `main` checkout in the same environment and the two sets are identical, 54 versus 54, with no differences in either direction.

### Issue number

Closes #4214

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`. I ran the underlying steps individually instead, with the results above.
