### PR TITLE
fix(sandbox): encode Blaxel terminal WebSocket URL query values

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Literal, cast
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlencode, urlsplit
 
 from pydantic import BaseModel, Field
 
@@ -1280,15 +1280,32 @@ def _build_ws_url(
 ) -> str:
     """Build the WebSocket URL for a Blaxel terminal session."""
     base = sandbox_url.rstrip("/")
-    ws_base = base.replace("https://", "wss://").replace("http://", "ws://")
-    return (
-        f"{ws_base}/terminal/ws"
-        f"?token={token}"
-        f"&cols={cols}"
-        f"&rows={rows}"
-        f"&sessionId={session_id}"
-        f"&workingDir={cwd}"
+    # Rewrite only the scheme. `replace` would also rewrite an occurrence inside the path,
+    # such as a proxied URL.
+    if base.startswith("https://"):
+        ws_base = f"wss://{base.removeprefix('https://')}"
+    elif base.startswith("http://"):
+        ws_base = f"ws://{base.removeprefix('http://')}"
+    else:
+        ws_base = base
+    # Percent-encode the values. The workspace path and session id are caller-controlled and
+    # may contain characters that are structural in a query string, so interpolating them
+    # raw lets a path such as `/w/a&rows=1` add or override parameters, and lets a `#`
+    # silently truncate the rest into a fragment. A `+` in a token would also decode back as
+    # a space.
+    # `/` stays literal because it is legal in a query value and keeps paths readable.
+    query = urlencode(
+        {
+            "token": token,
+            "cols": cols,
+            "rows": rows,
+            "sessionId": session_id,
+            "workingDir": cwd,
+        },
+        quote_via=quote,
+        safe="/",
     )
+    return f"{ws_base}/terminal/ws?{query}"
 
 
 __all__ = [

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -934,6 +934,64 @@ class TestHelpers:
         assert "sessionId=sess-1" in url
         assert "workingDir=/workspace" in url
 
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("cwd", "/workspace/my project"),
+            ("cwd", "/workspace/a&rows=9999"),
+            ("cwd", "/workspace/a#b"),
+            ("cwd", "/workspace/café"),
+            ("token", "ab+cd/ef=="),
+            ("session_id", "a&b"),
+        ],
+        ids=["space", "ampersand", "hash", "non_ascii", "token_plus", "session_amp"],
+    )
+    def test_build_ws_url_percent_encodes_query_values(self, field: str, value: str) -> None:
+        """Caller-controlled values must survive the round trip intact.
+
+        The workspace path and session id can contain characters that are structural in a
+        query string. Interpolating them raw let a path such as `/w/a&rows=1` append or
+        override parameters, let a `#` truncate the rest into a fragment, and let a `+` in a
+        token decode back as a space.
+        """
+        from urllib.parse import parse_qs, urlsplit
+
+        from agents.extensions.sandbox.blaxel.sandbox import _build_ws_url
+
+        kwargs: dict[str, Any] = {
+            "sandbox_url": "https://test.bl.run",
+            "token": "tok123",
+            "session_id": "sess-1",
+            "cwd": "/workspace",
+        }
+        kwargs[field] = value
+
+        url = _build_ws_url(**kwargs)
+        parts = urlsplit(url)
+        query = parse_qs(parts.query, keep_blank_values=True)
+
+        assert parts.fragment == ""
+        assert " " not in url
+        assert query["token"] == [kwargs["token"]]
+        assert query["sessionId"] == [kwargs["session_id"]]
+        assert query["workingDir"] == [kwargs["cwd"]]
+        # A structural character in a value must not add or override a parameter.
+        assert query["rows"] == ["24"]
+        assert query["cols"] == ["80"]
+
+    def test_build_ws_url_rewrites_only_the_scheme(self) -> None:
+        """`replace` also rewrote an occurrence inside the path, such as a proxied URL."""
+        from agents.extensions.sandbox.blaxel.sandbox import _build_ws_url
+
+        url = _build_ws_url(
+            sandbox_url="https://test.bl.run/proxy/http://inner",
+            token="t",
+            session_id="s",
+            cwd="/workspace",
+        )
+
+        assert url.startswith("wss://test.bl.run/proxy/http://inner/terminal/ws?")
+
     def test_extract_preview_url(self) -> None:
         from agents.extensions.sandbox.blaxel.sandbox import _extract_preview_url
 


### PR DESCRIPTION
### Summary

`_build_ws_url` in the Blaxel provider interpolated the token, session id and working directory straight into the terminal WebSocket query string. Those values are caller controlled, and the working directory is ordinary user configuration (the manifest workspace root), so characters that are structural in a query string changed the URL rather than travelling inside it.

| input | before | after |
| --- | --- | --- |
| `cwd="/workspace/a&rows=9999"` | `workingDir=/workspace/a`, `rows=9999` | `workingDir` intact, `rows=24` |
| `cwd="/workspace/a#b"` | remainder dropped as a fragment | intact |
| `cwd="/workspace/my project"` | raw space, invalid URL | encoded |
| `token="ab+cd/ef=="` | decodes to `ab cd/ef==` | intact |
| `sandbox_url=".../proxy/http://inner"` | `.../proxy/ws://inner` | prefix only |

The `&` case is the sharpest: a path can append or override parameters, silently replacing the terminal row count. The `+` case corrupts any standard base64 credential, since `+` decodes back as a space.

The scheme rewrite had the same shape of problem. `str.replace` rewrote every occurrence rather than the prefix.

The fix uses `urllib.parse.urlencode` for the query and matches the prefix handling already used by the equivalent Cloudflare helper `_ws_pty_url`. `/` is kept literal via `quote_via=quote, safe="/"`, because it is legal in a query value and keeps paths readable, so the emitted URL is unchanged for values that contain nothing needing encoding.

### Test plan

Added to `tests/extensions/sandbox/test_blaxel.py`:

- `test_build_ws_url_percent_encodes_query_values`, parametrized over a space, `&`, `#`, non-ASCII, a `+` token and an `&` session id. Each asserts the value round trips through `parse_qs`, that no fragment appears, and that `rows` and `cols` keep their real values so an injected parameter cannot pass unnoticed.
- `test_build_ws_url_rewrites_only_the_scheme`.

6 fail on `main` and pass with the fix. The pre-existing `test_build_ws_url` and the non-ASCII case pass in both runs, the former confirming the URL shape is unchanged for ordinary input and the latter confirming the tests are not simply rejecting any encoding difference:

```
# main
FAILED ...test_build_ws_url_percent_encodes_query_values[space]
FAILED ...test_build_ws_url_percent_encodes_query_values[ampersand]
FAILED ...test_build_ws_url_percent_encodes_query_values[hash]
FAILED ...test_build_ws_url_percent_encodes_query_values[token_plus]
FAILED ...test_build_ws_url_percent_encodes_query_values[session_amp]
FAILED ...test_build_ws_url_rewrites_only_the_scheme
6 failed, 3 passed, 229 deselected
```

Verification from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/extensions/sandbox/test_blaxel.py` | 237 passed, 1 skipped |
| `make tests` | 5834 passed |

The full suite run was done on Windows, where some sandbox symlink and tracing timing tests fail independently of this change. I diffed the failing set against a clean `main` checkout in the same environment and the two sets are identical, 54 versus 54, with no differences in either direction.

### Issue number

Closes #4216

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`. I ran the underlying steps individually instead, with the results above.
