### PR TITLE
docs: correct nonexistent guardrail type names

### DIFF
--- a/examples/agent_patterns/README.md
+++ b/examples/agent_patterns/README.md
@@ -50,7 +50,7 @@ See the [`parallelization.py`](./parallelization.py) file for an example of this
 
 Related to parallelization, you often want to run input guardrails to make sure the inputs to your agents are valid. For example, if you have a customer support agent, you might want to make sure that the user isn't trying to ask for help with a math problem.
 
-You can definitely do this without any special Agents SDK features by using parallelization, but we support a special guardrail primitive. Guardrails can have a "tripwire" - if the tripwire is triggered, the agent execution will immediately stop and a `GuardrailTripwireTriggered` exception will be raised.
+You can definitely do this without any special Agents SDK features by using parallelization, but we support a special guardrail primitive. Guardrails can have a "tripwire" - if the tripwire is triggered, the agent execution will immediately stop and an `InputGuardrailTripwireTriggered` or `OutputGuardrailTripwireTriggered` exception will be raised.
 
 This is really useful for latency: for example, you might have a very fast model that runs the guardrail and a slow model that runs the actual agent. You wouldn't want to wait for the slow model to finish, so guardrails let you quickly reject invalid inputs.
 

--- a/src/agents/guardrail.py
+++ b/src/agents/guardrail.py
@@ -78,8 +78,8 @@ class InputGuardrail(Generic[TContext]):
     You can use the `@input_guardrail()` decorator to turn a function into an `InputGuardrail`, or
     create an `InputGuardrail` manually.
 
-    Guardrails return a `GuardrailResult`. If `result.tripwire_triggered` is `True`,
-    the agent's execution will immediately stop, and
+    Guardrail functions return a `GuardrailFunctionOutput`. If its `tripwire_triggered` field is
+    `True`, the agent's execution will immediately stop, and
     an `InputGuardrailTripwireTriggered` exception will be raised
     """
 
@@ -88,8 +88,8 @@ class InputGuardrail(Generic[TContext]):
         MaybeAwaitable[GuardrailFunctionOutput],
     ]
     """A function that receives the agent input and the context, and returns a
-     `GuardrailResult`. The result marks whether the tripwire was triggered, and can optionally
-     include information about the guardrail's output.
+     `GuardrailFunctionOutput`. The output marks whether the tripwire was triggered, and can
+     optionally include information about the guardrail's output.
     """
 
     name: str | None = None
@@ -138,8 +138,8 @@ class OutputGuardrail(Generic[TContext]):
     You can use the `@output_guardrail()` decorator to turn a function into an `OutputGuardrail`,
     or create an `OutputGuardrail` manually.
 
-    Guardrails return a `GuardrailResult`. If `result.tripwire_triggered` is `True`, an
-    `OutputGuardrailTripwireTriggered` exception will be raised.
+    Guardrail functions return a `GuardrailFunctionOutput`. If its `tripwire_triggered` field is
+    `True`, an `OutputGuardrailTripwireTriggered` exception will be raised.
     """
 
     guardrail_function: Callable[
@@ -147,8 +147,8 @@ class OutputGuardrail(Generic[TContext]):
         MaybeAwaitable[GuardrailFunctionOutput],
     ]
     """A function that receives the final agent, its output, and the context, and returns a
-     `GuardrailResult`. The result marks whether the tripwire was triggered, and can optionally
-     include information about the guardrail's output.
+     `GuardrailFunctionOutput`. The output marks whether the tripwire was triggered, and can
+     optionally include information about the guardrail's output.
     """
 
     name: str | None = None

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -528,7 +528,8 @@ class RunResultStreaming(RunResultBase):
 
     The streaming method will raise:
     - A MaxTurnsExceeded exception if the agent exceeds the max_turns limit.
-    - A GuardrailTripwireTriggered exception if a guardrail is tripped.
+    - A tripwire exception if a guardrail is tripped, e.g. InputGuardrailTripwireTriggered
+      or OutputGuardrailTripwireTriggered.
     """
 
     current_agent: Agent[Any]
@@ -802,7 +803,8 @@ class RunResultStreaming(RunResultBase):
 
         This will raise:
         - A MaxTurnsExceeded exception if the agent exceeds the max_turns limit.
-        - A GuardrailTripwireTriggered exception if a guardrail is tripped.
+        - A tripwire exception if a guardrail is tripped, e.g. InputGuardrailTripwireTriggered
+          or OutputGuardrailTripwireTriggered.
         """
         consumer_registered = False
         registered_consumer_task: asyncio.Task[Any] | None = None

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -236,8 +236,8 @@ class Runner:
         In two cases, the agent may raise an exception:
 
           1. If the max_turns is exceeded, a MaxTurnsExceeded exception is raised unless handled.
-          2. If a guardrail tripwire is triggered, a GuardrailTripwireTriggered
-             exception is raised.
+          2. If a guardrail tripwire is triggered, the matching tripwire exception is raised,
+             e.g. InputGuardrailTripwireTriggered or OutputGuardrailTripwireTriggered.
 
         Note:
             Only the first agent's input guardrails are run.
@@ -325,8 +325,8 @@ class Runner:
         In two cases, the agent may raise an exception:
 
           1. If the max_turns is exceeded, a MaxTurnsExceeded exception is raised unless handled.
-          2. If a guardrail tripwire is triggered, a GuardrailTripwireTriggered
-             exception is raised.
+          2. If a guardrail tripwire is triggered, the matching tripwire exception is raised,
+             e.g. InputGuardrailTripwireTriggered or OutputGuardrailTripwireTriggered.
 
         Note:
             Only the first agent's input guardrails are run.
@@ -405,8 +405,8 @@ class Runner:
         In two cases, the agent may raise an exception:
 
           1. If the max_turns is exceeded, a MaxTurnsExceeded exception is raised unless handled.
-          2. If a guardrail tripwire is triggered, a GuardrailTripwireTriggered
-             exception is raised.
+          2. If a guardrail tripwire is triggered, the matching tripwire exception is raised,
+             e.g. InputGuardrailTripwireTriggered or OutputGuardrailTripwireTriggered.
 
         Note:
             Only the first agent's input guardrails are run.


### PR DESCRIPTION
### Summary

`Runner.run`, `run_sync`, `run_streamed` and `RunResultStreaming.stream_events` tell you to catch `GuardrailTripwireTriggered`, and `InputGuardrail` / `OutputGuardrail` say a guardrail returns a `GuardrailResult`. Neither type exists. `exceptions.py` defines only the `Input`, `Output`, `ToolInput` and `ToolOutput` tripwire variants, so that `except` clause raises `NameError`, and guardrail functions return `GuardrailFunctionOutput`, which is also where `tripwire_triggered` lives. `examples/agent_patterns/README.md` names the same missing exception, so it goes with them.

The replacement exception wording stays non-exhaustive, since tool guardrails raise the `Tool*` variants from the same runs; `docs/guardrails.md` covers all four.

### Test plan

Docstrings and one line of example prose, no runtime change, which `AGENTS.md` puts under the docs-only skip for `$code-change-verification`. Grepping for either name now finds only symbols that actually exist.

### Issue number

N/A