### PR TITLE
fix(models): resolve the any-llm default model at call time

### DIFF
--- a/src/agents/extensions/models/any_llm_provider.py
+++ b/src/agents/extensions/models/any_llm_provider.py
@@ -4,6 +4,7 @@ from ...models.default_models import get_default_model
 from ...models.interface import Model, ModelProvider
 from .any_llm_model import AnyLLMModel
 
+# This is kept for backward compatibility but using get_default_model() method is recommended.
 DEFAULT_MODEL: str = f"openai/{get_default_model()}"
 
 
@@ -28,7 +29,7 @@ class AnyLLMProvider(ModelProvider):
 
     def get_model(self, model_name: str | None) -> Model:
         return AnyLLMModel(
-            model=model_name or DEFAULT_MODEL,
+            model=model_name or f"openai/{get_default_model()}",
             api_key=self.api_key,
             base_url=self.base_url,
             api=self.api,

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -1113,6 +1113,19 @@ def test_any_llm_provider_passes_api_override() -> None:
     assert model.api == "chat_completions"
 
 
+def test_any_llm_provider_reads_default_model_at_call_time(monkeypatch: Any) -> None:
+    pytest.importorskip(
+        "any_llm",
+        reason="`any-llm-sdk` is only available when the optional dependency is installed.",
+    )
+    from agents.extensions.models.any_llm_provider import AnyLLMProvider
+
+    monkeypatch.setenv("OPENAI_DEFAULT_MODEL", "gpt-4.1")
+    provider = AnyLLMProvider()
+
+    assert cast(Any, provider.get_model(None)).model == "openai/gpt-4.1"
+
+
 def test_any_llm_reasoning_objects_prefer_content_attributes_over_iterable_pairs() -> None:
     pytest.importorskip(
         "any_llm",


### PR DESCRIPTION
`AnyLLMProvider.get_model()` falls back to the module-level `DEFAULT_MODEL` constant, which is computed once at import time from `get_default_model()`, so any `OPENAI_DEFAULT_MODEL` value set after the module is imported is ignored and the provider keeps building models for the baked-in default. The sibling `LitellmProvider` calls `get_default_model()` on every lookup and explicitly notes that its `DEFAULT_MODEL` constant is only kept for backward compatibility, so the two providers disagree about the same setting. This resolves the fallback the same way inside `get_model()` and leaves `DEFAULT_MODEL` exported unchanged. Against upstream the new test fails with `assert 'openai/gpt-5.4-mini' == 'openai/gpt-4.1'` after setting the environment variable, and it passes with the fix.