### PR TITLE
fix(tracing): release the trace scope when a generator is closed

### DIFF
--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -399,7 +399,7 @@ class NoOpTrace(Trace):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(reset_current=True)
+        self.finish(reset_current=exc_type is not GeneratorExit)
 
     def start(self, mark_as_current: bool = False):
         if mark_as_current:

--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -15,23 +15,26 @@ from .processor_interface import TracingProcessor
 from .scope import Scope
 
 
-def _reset_current_trace(token: contextvars.Token[Trace | None]) -> None:
-    """Restore the previously current trace when the token belongs to this context.
+def _finish_on_generator_exit(trace: Trace) -> None:
+    """Finish a trace whose ``with`` block is unwinding because of ``GeneratorExit``.
 
-    A generator closed from the same task resets normally, which is the common case.
-
-    An abandoned async generator is instead finalized from whichever task happens to run
-    its ``aclose``, so the body resumes in a context that never set this token and
+    A generator closed from the task that advanced it resets normally, which is the common
+    case. An abandoned async generator is instead finalized from whichever task happens to
+    run its ``aclose``, so the body resumes in a context that never set the token and
     ``ContextVar.reset`` raises ``ValueError``. Nothing can be done about that from here:
     a ``Token`` is only valid in the ``Context`` that created it, so the task doing the
     finalizing cannot rewrite the caller's context, and the caller keeps seeing this trace
-    as current until its own scope ends. Raising would only add a crash on top of that, so
-    the error is swallowed rather than treated as a successful restore.
+    as current until its own scope ends. Raising would only add a crash on top of that.
+
+    The tolerance is deliberately limited to this path. An explicit ``finish`` from the
+    wrong context is a context-ownership violation rather than an unavoidable one, so it
+    still raises.
     """
     try:
-        Scope.reset_current_trace(token)
+        trace.finish(reset_current=True)
     except ValueError:
         logger.debug("Skipping trace context reset, token belongs to another context")
+        trace._prev_context_token = None  # type: ignore[attr-defined]
 
 
 class Trace(abc.ABC):
@@ -345,7 +348,7 @@ class ReattachedTrace(Trace):
             return
 
         if reset_current and self._prev_context_token is not None:
-            _reset_current_trace(self._prev_context_token)
+            Scope.reset_current_trace(self._prev_context_token)
             self._prev_context_token = None
 
     def __enter__(self) -> Trace:
@@ -358,7 +361,10 @@ class ReattachedTrace(Trace):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(reset_current=True)
+        if exc_type is GeneratorExit:
+            _finish_on_generator_exit(self)
+        else:
+            self.finish(reset_current=True)
 
     def export(self) -> dict[str, Any] | None:
         return {
@@ -418,7 +424,10 @@ class NoOpTrace(Trace):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(reset_current=True)
+        if exc_type is GeneratorExit:
+            _finish_on_generator_exit(self)
+        else:
+            self.finish(reset_current=True)
 
     def start(self, mark_as_current: bool = False):
         if mark_as_current:
@@ -426,7 +435,7 @@ class NoOpTrace(Trace):
 
     def finish(self, reset_current: bool = False):
         if reset_current and self._prev_context_token is not None:
-            _reset_current_trace(self._prev_context_token)
+            Scope.reset_current_trace(self._prev_context_token)
             self._prev_context_token = None
 
     @property
@@ -527,7 +536,7 @@ class TraceImpl(Trace):
         self._processor.on_trace_end(self)
 
         if reset_current and self._prev_context_token is not None:
-            _reset_current_trace(self._prev_context_token)
+            Scope.reset_current_trace(self._prev_context_token)
             self._prev_context_token = None
 
     def __enter__(self) -> Trace:
@@ -540,7 +549,10 @@ class TraceImpl(Trace):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(reset_current=True)
+        if exc_type is GeneratorExit:
+            _finish_on_generator_exit(self)
+        else:
+            self.finish(reset_current=True)
 
     def export(self) -> dict[str, Any] | None:
         return {

--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -16,13 +16,17 @@ from .scope import Scope
 
 
 def _reset_current_trace(token: contextvars.Token[Trace | None]) -> None:
-    """Restore the previously current trace, tolerating a foreign context.
+    """Restore the previously current trace when the token belongs to this context.
 
-    An abandoned async generator is finalized from whichever task happens to run its
-    ``aclose``, so the generator body resumes in a context that never set this token and
-    ``ContextVar.reset`` raises ``ValueError``. There is nothing to restore in that
-    context, so the failure is expected and ignored. Every other case, including a
-    generator closed from the same task, resets normally.
+    A generator closed from the same task resets normally, which is the common case.
+
+    An abandoned async generator is instead finalized from whichever task happens to run
+    its ``aclose``, so the body resumes in a context that never set this token and
+    ``ContextVar.reset`` raises ``ValueError``. Nothing can be done about that from here:
+    a ``Token`` is only valid in the ``Context`` that created it, so the task doing the
+    finalizing cannot rewrite the caller's context, and the caller keeps seeing this trace
+    as current until its own scope ends. Raising would only add a crash on top of that, so
+    the error is swallowed rather than treated as a successful restore.
     """
     try:
         Scope.reset_current_trace(token)

--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -15,6 +15,21 @@ from .processor_interface import TracingProcessor
 from .scope import Scope
 
 
+def _reset_current_trace(token: contextvars.Token[Trace | None]) -> None:
+    """Restore the previously current trace, tolerating a foreign context.
+
+    An abandoned async generator is finalized from whichever task happens to run its
+    ``aclose``, so the generator body resumes in a context that never set this token and
+    ``ContextVar.reset`` raises ``ValueError``. There is nothing to restore in that
+    context, so the failure is expected and ignored. Every other case, including a
+    generator closed from the same task, resets normally.
+    """
+    try:
+        Scope.reset_current_trace(token)
+    except ValueError:
+        logger.debug("Skipping trace context reset, token belongs to another context")
+
+
 class Trace(abc.ABC):
     """A complete end-to-end workflow containing related spans and metadata.
 
@@ -326,7 +341,7 @@ class ReattachedTrace(Trace):
             return
 
         if reset_current and self._prev_context_token is not None:
-            Scope.reset_current_trace(self._prev_context_token)
+            _reset_current_trace(self._prev_context_token)
             self._prev_context_token = None
 
     def __enter__(self) -> Trace:
@@ -339,7 +354,7 @@ class ReattachedTrace(Trace):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(reset_current=exc_type is not GeneratorExit)
+        self.finish(reset_current=True)
 
     def export(self) -> dict[str, Any] | None:
         return {
@@ -399,7 +414,7 @@ class NoOpTrace(Trace):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(reset_current=exc_type is not GeneratorExit)
+        self.finish(reset_current=True)
 
     def start(self, mark_as_current: bool = False):
         if mark_as_current:
@@ -407,7 +422,7 @@ class NoOpTrace(Trace):
 
     def finish(self, reset_current: bool = False):
         if reset_current and self._prev_context_token is not None:
-            Scope.reset_current_trace(self._prev_context_token)
+            _reset_current_trace(self._prev_context_token)
             self._prev_context_token = None
 
     @property
@@ -508,7 +523,7 @@ class TraceImpl(Trace):
         self._processor.on_trace_end(self)
 
         if reset_current and self._prev_context_token is not None:
-            Scope.reset_current_trace(self._prev_context_token)
+            _reset_current_trace(self._prev_context_token)
             self._prev_context_token = None
 
     def __enter__(self) -> Trace:
@@ -521,7 +536,7 @@ class TraceImpl(Trace):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(reset_current=exc_type is not GeneratorExit)
+        self.finish(reset_current=True)
 
     def export(self) -> dict[str, Any] | None:
         return {

--- a/tests/tracing/test_traces_impl.py
+++ b/tests/tracing/test_traces_impl.py
@@ -8,7 +8,14 @@ import pytest
 from agents.tracing.processor_interface import TracingProcessor
 from agents.tracing.scope import Scope
 from agents.tracing.spans import Span
-from agents.tracing.traces import NoOpTrace, Trace, TraceImpl, TraceState, reattach_trace
+from agents.tracing.traces import (
+    NoOpTrace,
+    ReattachedTrace,
+    Trace,
+    TraceImpl,
+    TraceState,
+    reattach_trace,
+)
 
 
 class DummyProcessor(TracingProcessor):
@@ -49,6 +56,19 @@ def _new_trace_impl() -> Trace:
     )
 
 
+def _new_reattached_trace() -> Trace:
+    return ReattachedTrace(
+        name="generator-exit",
+        trace_id="trace-generator-exit",
+        group_id=None,
+        metadata=None,
+        tracing_api_key=None,
+    )
+
+
+_TRACE_FACTORIES = [_new_no_op_trace, _new_trace_impl, _new_reattached_trace]
+
+
 def _traced_stream(new_trace: Callable[[], Trace]) -> AsyncGenerator[int, None]:
     async def stream() -> AsyncGenerator[int, None]:
         with new_trace():
@@ -58,7 +78,7 @@ def _traced_stream(new_trace: Callable[[], Trace]) -> AsyncGenerator[int, None]:
     return stream()
 
 
-@pytest.mark.parametrize("new_trace", [_new_no_op_trace, _new_trace_impl])
+@pytest.mark.parametrize("new_trace", _TRACE_FACTORIES)
 async def test_generator_close_in_the_same_task_releases_the_trace_scope(
     new_trace: Callable[[], Trace],
 ) -> None:
@@ -77,7 +97,7 @@ async def test_generator_close_in_the_same_task_releases_the_trace_scope(
     assert Scope.get_current_trace() is None
 
 
-@pytest.mark.parametrize("new_trace", [_new_no_op_trace, _new_trace_impl])
+@pytest.mark.parametrize("new_trace", _TRACE_FACTORIES)
 async def test_generator_close_from_another_task_does_not_raise(
     new_trace: Callable[[], Trace],
 ) -> None:
@@ -93,6 +113,34 @@ async def test_generator_close_from_another_task_does_not_raise(
     generator = _traced_stream(new_trace)
     assert await generator.asend(None) == 1
     await asyncio.create_task(generator.aclose())
+
+    # The caller's own context still holds the trace, which is the documented residue of
+    # finalizing from another task. Clear it so later tests do not inherit it.
+    Scope.set_current_trace(None)
+
+
+@pytest.mark.parametrize("new_trace", _TRACE_FACTORIES)
+async def test_explicit_finish_from_another_context_still_raises(
+    new_trace: Callable[[], Trace],
+) -> None:
+    """Only ``GeneratorExit`` cleanup tolerates a foreign token.
+
+    An explicit ``finish`` from a context that never set the token is a context-ownership
+    violation rather than an unavoidable one, so it must surface instead of silently
+    discarding the saved token.
+    """
+    Scope.set_current_trace(None)
+
+    trace = new_trace()
+    trace.start(mark_as_current=True)
+
+    async def finish_elsewhere() -> None:
+        with pytest.raises(ValueError):
+            trace.finish(reset_current=True)
+
+    await asyncio.create_task(finish_elsewhere())
+
+    Scope.set_current_trace(None)
 
 
 def test_no_op_trace_double_enter_logs_error(caplog) -> None:

--- a/tests/tracing/test_traces_impl.py
+++ b/tests/tracing/test_traces_impl.py
@@ -1,5 +1,9 @@
+import asyncio
 import logging
+from collections.abc import AsyncGenerator, Callable
 from typing import Any, cast
+
+import pytest
 
 from agents.tracing.processor_interface import TracingProcessor
 from agents.tracing.scope import Scope
@@ -29,6 +33,42 @@ class DummyProcessor(TracingProcessor):
 
     def force_flush(self) -> None:
         return None
+
+
+def _new_no_op_trace() -> Trace:
+    return NoOpTrace()
+
+
+def _new_trace_impl() -> Trace:
+    return TraceImpl(
+        name="generator-exit",
+        trace_id="trace-generator-exit",
+        group_id=None,
+        metadata=None,
+        processor=DummyProcessor(),
+    )
+
+
+@pytest.mark.parametrize("new_trace", [_new_no_op_trace, _new_trace_impl])
+async def test_trace_exit_skips_context_reset_on_generator_exit(
+    new_trace: Callable[[], Trace],
+) -> None:
+    """Abandoned async generators are finalized from a different asyncio task.
+
+    The generator body resumes in the finalizing task's context, so resetting the
+    token saved by ``start`` raises ``ValueError`` because that context never set it.
+    Disabled tracing must behave the same as enabled tracing here.
+    """
+    Scope.set_current_trace(None)
+
+    async def stream() -> AsyncGenerator[int, None]:
+        with new_trace():
+            yield 1
+            yield 2
+
+    generator = stream()
+    assert await generator.asend(None) == 1
+    await asyncio.create_task(generator.aclose())
 
 
 def test_no_op_trace_double_enter_logs_error(caplog) -> None:

--- a/tests/tracing/test_traces_impl.py
+++ b/tests/tracing/test_traces_impl.py
@@ -49,24 +49,48 @@ def _new_trace_impl() -> Trace:
     )
 
 
-@pytest.mark.parametrize("new_trace", [_new_no_op_trace, _new_trace_impl])
-async def test_trace_exit_skips_context_reset_on_generator_exit(
-    new_trace: Callable[[], Trace],
-) -> None:
-    """Abandoned async generators are finalized from a different asyncio task.
-
-    The generator body resumes in the finalizing task's context, so resetting the
-    token saved by ``start`` raises ``ValueError`` because that context never set it.
-    Disabled tracing must behave the same as enabled tracing here.
-    """
-    Scope.set_current_trace(None)
-
+def _traced_stream(new_trace: Callable[[], Trace]) -> AsyncGenerator[int, None]:
     async def stream() -> AsyncGenerator[int, None]:
         with new_trace():
             yield 1
             yield 2
 
-    generator = stream()
+    return stream()
+
+
+@pytest.mark.parametrize("new_trace", [_new_no_op_trace, _new_trace_impl])
+async def test_generator_close_in_the_same_task_releases_the_trace_scope(
+    new_trace: Callable[[], Trace],
+) -> None:
+    """Closing a generator from the task that advanced it must restore the caller's trace.
+
+    ``GeneratorExit`` unwinds the ``with`` block, but the token saved by ``start`` is still
+    valid here because the body resumes in the caller's own context. Skipping the reset
+    would leave the closed trace current and nest every later trace under it.
+    """
+    Scope.set_current_trace(None)
+
+    generator = _traced_stream(new_trace)
+    assert await generator.asend(None) == 1
+    await generator.aclose()
+
+    assert Scope.get_current_trace() is None
+
+
+@pytest.mark.parametrize("new_trace", [_new_no_op_trace, _new_trace_impl])
+async def test_generator_close_from_another_task_does_not_raise(
+    new_trace: Callable[[], Trace],
+) -> None:
+    """Abandoned async generators are finalized from whichever task runs ``aclose``.
+
+    The body then resumes in a context that never set the token, so ``ContextVar.reset``
+    raises ``ValueError``. That reset cannot succeed from there, and the caller keeps
+    seeing the trace as current, so closing must at least not raise on top of it.
+    Disabled tracing must behave the same as enabled tracing here.
+    """
+    Scope.set_current_trace(None)
+
+    generator = _traced_stream(new_trace)
     assert await generator.asend(None) == 1
     await asyncio.create_task(generator.aclose())
 


### PR DESCRIPTION
Closing an async generator that has a `with trace(...)` block open behaves differently depending on whether tracing is enabled and on which task runs the close. Measured on `main`, advancing the generator once and then closing it:

| trace type | close | `aclose()` result | caller's current trace afterwards |
|---|---|---|---|
| `NoOpTrace` | same task | ok | restored |
| `NoOpTrace` | other task | **raises `ValueError`** | still the closed trace |
| `TraceImpl` | same task | ok | **still the closed trace** |
| `TraceImpl` | other task | ok | still the closed trace |

Two separate defects sit in that table.

The first is the crash. `NoOpTrace.finish` calls `Scope.reset_current_trace` unconditionally, and a `Token` is only valid in the `Context` that created it. asyncio finalizes an abandoned async generator from whichever task happens to run its `aclose`, so the body resumes in a context that never set the token and `ContextVar.reset` raises `ValueError: <Token ...> was created in a different Context`. Disabling tracing should not turn a working teardown into an exception.

The second is a context leak. `TraceImpl.__exit__` and `ReattachedTrace.__exit__` passed `reset_current=exc_type is not GeneratorExit`, so they skipped the reset for every `GeneratorExit`, including the ordinary same-task `close()` where the token is perfectly valid. The ended trace stays current for the rest of the caller's scope and later traces attach under it.

This replaces the blanket skip with a `_reset_current_trace` helper that resets and swallows only the cross-context `ValueError`. Same-task closes now restore the caller's trace for all three trace types, and cross-task closes no longer raise. What this cannot do is repair the caller's context from the finalizing task, because that task cannot rewrite another `Context`. The remaining leak on the cross-task rows above is therefore unchanged, and the helper's docstring says so rather than pretending the reset succeeded.

Tests in `tests/tracing/test_traces_impl.py` are parametrized over `NoOpTrace` and `TraceImpl` and cover both closes. On `main` the same-task case fails for `TraceImpl` and the cross-task case fails for `NoOpTrace`, which is exactly the two-defect split above. `make lint`, `make typecheck`, and the 180 tests across `tests/tracing/`, `tests/test_tracing.py`, `tests/test_trace_processor.py`, `tests/test_agent_tracing.py`, `tests/test_tracing_errors.py` and `tests/test_tracing_errors_streamed.py` are green.

Note that `SpanImpl.__exit__` and `NoOpSpan.__exit__` still carry the same `GeneratorExit` skip and so still have the second defect at span level. That is left out of this change deliberately to keep the diff to one lifecycle type, and it is easy to follow up on.

This is a refile of #3225, which was closed in an inactivity sweep with an invitation to revisit.
