### PR TITLE
fix(models): keep url citations when converting chat completions output

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -42,6 +42,10 @@ from openai.types.responses import (
     ResponseReasoningItemParam,
 )
 from openai.types.responses.response_input_param import FunctionCallOutput, ItemReference, Message
+from openai.types.responses.response_output_text import (
+    Annotation as ResponseOutputTextAnnotation,
+    AnnotationURLCitation,
+)
 from openai.types.responses.response_reasoning_item import Content, Summary
 
 from ..agent_output import AgentOutputSchemaBase
@@ -199,7 +203,10 @@ class Converter:
         if message.content:
             message_item.content.append(
                 ResponseOutputText(
-                    text=message.content, type="output_text", annotations=[], logprobs=[]
+                    text=message.content,
+                    type="output_text",
+                    annotations=cls._convert_annotations(message),
+                    logprobs=[],
                 )
             )
         if message.refusal:
@@ -251,6 +258,27 @@ class Converter:
                         )
 
         return items
+
+    @classmethod
+    def _convert_annotations(
+        cls, message: ChatCompletionMessage
+    ) -> list[ResponseOutputTextAnnotation]:
+        """Convert Chat Completions url citations into output text annotations."""
+        annotations: list[ResponseOutputTextAnnotation] = []
+        for annotation in message.annotations or []:
+            url_citation = getattr(annotation, "url_citation", None)
+            if getattr(annotation, "type", None) != "url_citation" or url_citation is None:
+                continue
+            annotations.append(
+                AnnotationURLCitation(
+                    type="url_citation",
+                    start_index=url_citation.start_index,
+                    end_index=url_citation.end_index,
+                    url=url_citation.url,
+                    title=url_citation.title,
+                )
+            )
+        return annotations
 
     @classmethod
     def maybe_easy_input_message(cls, item: Any) -> EasyInputMessageParam | None:

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -29,6 +29,7 @@ from typing import Any, Literal, cast
 import pytest
 from openai import omit
 from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageFunctionToolCall
+from openai.types.chat.chat_completion_message import Annotation, AnnotationURLCitation
 from openai.types.chat.chat_completion_message_custom_tool_call import (
     ChatCompletionMessageCustomToolCall,
     Custom,
@@ -71,6 +72,40 @@ def test_message_to_output_items_with_text_only():
     text_part = cast(ResponseOutputText, message_item.content[0])
     assert text_part.type == "output_text"
     assert text_part.text == "Hello"
+
+
+def test_message_to_output_items_keeps_url_citation_annotations():
+    """
+    URL citations reported on the Chat Completions message should survive as
+    output text annotations, the same way the Responses API reports them.
+    """
+    msg = ChatCompletionMessage(
+        role="assistant",
+        content="It will rain tomorrow.",
+        annotations=[
+            Annotation(
+                type="url_citation",
+                url_citation=AnnotationURLCitation(
+                    start_index=0,
+                    end_index=22,
+                    url="https://example.com/weather",
+                    title="Weather",
+                ),
+            )
+        ],
+    )
+    items = Converter.message_to_output_items(msg)
+    message_item = cast(ResponseOutputMessage, items[0])
+    text_part = cast(ResponseOutputText, message_item.content[0])
+    assert [annotation.model_dump() for annotation in text_part.annotations] == [
+        {
+            "end_index": 22,
+            "start_index": 0,
+            "title": "Weather",
+            "type": "url_citation",
+            "url": "https://example.com/weather",
+        }
+    ]
 
 
 def test_message_to_output_items_with_refusal():


### PR DESCRIPTION
`Converter.message_to_output_items()` builds the `ResponseOutputText` with a hardcoded `annotations=[]`, so url citations that the provider reports on the Chat Completions message are silently dropped and callers see an empty annotation list. The Responses sibling surfaces the same citations because it returns provider output items untouched, and the LiteLLM adapter already normalizes `annotations` onto the message through `convert_annotations_to_openai` for a consumer that never reads them. This maps `url_citation` annotations onto the output text and skips annotation types the Responses shape cannot represent. Against upstream the new test fails with `assert [] == [{'end_index': 22, 'start_index': 0, 'title': 'Weather', 'type': 'url_citation', ...}]`, and it passes with the fix.