### PR TITLE
fix(run): publish completed streamed guardrail results on failure paths

### DIFF
--- a/src/agents/run_internal/guardrails.py
+++ b/src/agents/run_internal/guardrails.py
@@ -67,16 +67,16 @@ async def run_input_guardrails_with_queue(
         asyncio.create_task(run_single_input_guardrail(agent, guardrail, input, context))
         for guardrail in guardrails
     ]
-    guardrail_results = []
     try:
         for done in asyncio.as_completed(guardrail_tasks):
             result = await done
-            guardrail_results.append(result)
+            # Publish into the runner-owned accumulator as each guardrail completes, so no exit
+            # path can omit results that already finished. This mirrors how the non-streamed
+            # `run_input_guardrails` records into its caller-owned sink.
+            streamed_result.input_guardrail_results = streamed_result.input_guardrail_results + [
+                result
+            ]
             if result.output.tripwire_triggered:
-                streamed_result.input_guardrail_results = (
-                    streamed_result.input_guardrail_results + guardrail_results
-                )
-                guardrail_results = []
                 streamed_result._triggered_input_guardrail_result = result
                 queue.put_nowait(result)
                 for t in guardrail_tasks:
@@ -110,10 +110,6 @@ async def run_input_guardrails_with_queue(
                 streamed_result.run_loop_task.cancel()
             streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
         raise
-
-    streamed_result.input_guardrail_results = (
-        streamed_result.input_guardrail_results + guardrail_results
-    )
 
 
 async def run_input_guardrails(

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -431,15 +431,17 @@ async def _run_output_guardrails_for_stream(
 
     try:
         return cast(list[Any], await streamed_result._output_guardrails_task)
-    except OutputGuardrailTripwireTriggered:
-        streamed_result.output_guardrail_results = (
-            streamed_result.output_guardrail_results + completed_results
-        )
-        raise
     except asyncio.CancelledError:
         raise
     except Exception as exc:
-        log_model_action_error(logger, "Unexpected error in output guardrails", exc)
+        # Publish at a single boundary so no failure path can omit results that already
+        # finished. A guardrail raising a non-tripwire error reports the same completed
+        # results a tripwire does.
+        streamed_result.output_guardrail_results = (
+            streamed_result.output_guardrail_results + completed_results
+        )
+        if not isinstance(exc, OutputGuardrailTripwireTriggered):
+            log_model_action_error(logger, "Unexpected error in output guardrails", exc)
         raise
 
 

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -2128,6 +2128,32 @@ async def test_input_guardrail_exception_reports_completed_results():
     assert _result_names(collected) == ["passes"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_in_parallel", [False, True])
+async def test_input_guardrail_exception_reports_completed_results_streamed(
+    run_in_parallel: bool,
+):
+    """A streamed guardrail raising a non-tripwire error still reports earlier results."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+    agent = Agent(
+        name="guardrail_results_agent",
+        model=model,
+        input_guardrails=_ordered_input_guardrails(
+            second_triggers=False,
+            second_raises=True,
+            run_in_parallel=run_in_parallel,
+        ),
+    )
+
+    result = Runner.run_streamed(agent, "test input")
+    with pytest.raises(RuntimeError, match="guardrail exploded"):
+        async for _ in result.stream_events():
+            pass
+
+    assert _result_names(result.input_guardrail_results) == ["passes"]
+
+
 def _ordered_output_guardrails(
     *, second_triggers: bool, second_raises: bool = False
 ) -> list[OutputGuardrail[Any]]:
@@ -2239,3 +2265,22 @@ async def test_output_guardrail_exception_reports_completed_results():
         )
 
     assert _result_names(collected) == ["passes"]
+
+
+@pytest.mark.asyncio
+async def test_output_guardrail_exception_reports_completed_results_streamed():
+    """A streamed output guardrail raising a non-tripwire error still reports earlier results."""
+    model = FakeModel()
+    model.set_next_output([get_text_message("hello")])
+    agent = Agent(
+        name="output_guardrail_results_agent",
+        model=model,
+        output_guardrails=_ordered_output_guardrails(second_triggers=False, second_raises=True),
+    )
+
+    result = Runner.run_streamed(agent, "test input")
+    with pytest.raises(RuntimeError, match="guardrail exploded"):
+        async for _ in result.stream_events():
+            pass
+
+    assert _result_names(result.output_guardrail_results) == ["passes"]


### PR DESCRIPTION
The streamed input guardrail helper buffered completed results in a local list and merged them into `RunResultStreaming.input_guardrail_results` only on the success and tripwire paths, so an input guardrail that raised a non-tripwire error discarded every sibling result that had already finished. The streamed output guardrail wrapper had the same gap, publishing completed results only when the failure was a tripwire and dropping them on any other exception. Both non-streamed siblings already record into a caller-owned sink as each guardrail completes, so this was a streaming parity gap left over from #4071 and #4090.

This publishes into the runner-owned accumulator as each input guardrail completes, and merges output guardrail results at a single failure boundary, so no exit path can omit results that already finished. That also removes the redundant success-path merge in the input helper rather than repeating the merge in each handler.

Three new tests in `tests/test_guardrails.py` cover the streamed input path in both sequential and parallel modes plus the streamed output path. On `main` all three fail with `assert [] == ['passes']`, and they pass with this change. The existing non-streamed `..._exception_reports_completed_results` tests are unaffected. `make format`, `make lint`, `make typecheck` and `make tests` are clean, apart from one unrelated flake in `test_branch_allocation_is_serialized_across_processes` that passes on its own.

Tripwire enforcement is unchanged. A tripping result is still published before any cancellation, so this only affects which passing sibling results are observable after a failure.
