### PR TITLE
fix(mcp): keep MCP error content when structured output is enabled

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -763,8 +763,10 @@ class MCPUtil:
             logger.debug("MCP tool %s returned %s", tool_name_for_display, result)
 
         # If structured content is requested and available, use it exclusively. Results the
-        # server flagged as errors keep their content, because that is where the error text
-        # lives and structured content is not a valid output payload for a failed call.
+        # server flagged as errors keep their content instead, because that is where the
+        # actionable failure text lives. MCP permits `structuredContent` alongside
+        # `isError`, so this is an error-content precedence policy in this SDK rather than
+        # the structured payload being invalid for a failed call.
         tool_output: ToolOutput
         structured_content = result_structured_content(result)
         if server.use_structured_content and structured_content and not result_is_error(result):

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -762,10 +762,12 @@ class MCPUtil:
         else:
             logger.debug("MCP tool %s returned %s", tool_name_for_display, result)
 
-        # If structured content is requested and available, use it exclusively
+        # If structured content is requested and available, use it exclusively. Results the
+        # server flagged as errors keep their content, because that is where the error text
+        # lives and structured content is not a valid output payload for a failed call.
         tool_output: ToolOutput
         structured_content = result_structured_content(result)
-        if server.use_structured_content and structured_content:
+        if server.use_structured_content and structured_content and not result_is_error(result):
             tool_output = json.dumps(structured_content)
         else:
             tool_output_list: list[ToolOutputItem] = []

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1890,11 +1890,18 @@ class StructuredContentTestServer(FakeMCPServer):
         self.use_structured_content = use_structured_content
         self._test_content: list[Any] = []
         self._test_structured_content: dict[str, Any] | None = None
+        self._test_is_error: bool | None = None
 
-    def set_test_result(self, content: list[Any], structured_content: dict[str, Any] | None = None):
+    def set_test_result(
+        self,
+        content: list[Any],
+        structured_content: dict[str, Any] | None = None,
+        is_error: bool | None = None,
+    ):
         """Set the content and structured content that will be returned by call_tool."""
         self._test_content = content
         self._test_structured_content = structured_content
+        self._test_is_error = is_error
 
     async def call_tool(
         self,
@@ -1905,8 +1912,13 @@ class StructuredContentTestServer(FakeMCPServer):
         """Return test result with specified content and structured content."""
         self.tool_calls.append(tool_name)
 
+        extra: dict[str, Any] = {}
+        if self._test_is_error is not None:
+            extra["isError"] = self._test_is_error
         return CallToolResult(
-            content=self._test_content, structuredContent=self._test_structured_content
+            content=self._test_content,
+            structuredContent=self._test_structured_content,
+            **extra,
         )
 
 
@@ -1999,6 +2011,46 @@ async def test_structured_content_handling(
 
     result = await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
     assert result == expected_output
+
+
+@pytest.mark.asyncio
+async def test_structured_content_skipped_for_error_results():
+    """A result flagged as an error keeps the content that carries the error text."""
+
+    server = StructuredContentTestServer(use_structured_content=True)
+    server.add_tool("failing_tool", {})
+    server.set_test_result(
+        [TextContent(text="database connection refused", type="text")],
+        {"answer": 42},
+        is_error=True,
+    )
+
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="failing_tool", inputSchema={})
+
+    result = await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
+
+    assert result == {"type": "text", "text": "database connection refused"}
+
+
+@pytest.mark.asyncio
+async def test_structured_content_used_for_non_error_results():
+    """An explicit isError=False result still prefers structured content."""
+
+    server = StructuredContentTestServer(use_structured_content=True)
+    server.add_tool("ok_tool", {})
+    server.set_test_result(
+        [TextContent(text="ignored", type="text")],
+        {"answer": 42},
+        is_error=False,
+    )
+
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="ok_tool", inputSchema={})
+
+    result = await MCPUtil.invoke_mcp_tool(server, tool, ctx, "{}")
+
+    assert result == '{"answer": 42}'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When a local MCP server returns a `CallToolResult` with `isError` set, the actionable failure text lives in `content`. `MCPUtil.invoke_mcp_tool` only checked `server.use_structured_content` before serializing `structuredContent` and returning it exclusively, so a server constructed with `use_structured_content=True` had its error text silently replaced by the structured payload and the model saw what looked like a successful result.

MCP permits `structuredContent` alongside `isError`, so this is not a case of an invalid payload. It is a precedence policy in this SDK: for results the server flagged as errors, the error content wins over the structured payload, and every other case keeps the existing behavior, including the `isError=False` path.

The TypeScript SDK already does this and covers it with the "preserves MCP error content when structured output is enabled" test, so this brings the Python SDK back in line.

Two regression tests are added: `test_structured_content_skipped_for_error_results` fails on main with `assert '{"answer": 42}' == {'text': 'database connection refused', 'type': 'text'}` and passes with the fix, and `test_structured_content_used_for_non_error_results` pins the unchanged path. `uv run pytest tests/mcp` is green at 377 passed and 24 skipped, along with `make format`, `make lint`, and `make typecheck`.