### PR TITLE
fix(tracing): release the span scope when a span is finished twice

### DIFF
--- a/src/agents/tracing/spans.py
+++ b/src/agents/tracing/spans.py
@@ -326,10 +326,12 @@ class SpanImpl(Span[TSpanData]):
     def finish(self, reset_current: bool = False) -> None:
         if self.ended_at is not None:
             logger.warning("Span already finished")
-            return
+        else:
+            self._ended_at = util.time_iso()
+            self._processor.on_span_end(self)
 
-        self._ended_at = util.time_iso()
-        self._processor.on_span_end(self)
+        # The span scope is released even for a repeated finish, otherwise an ended
+        # span stays current and later spans are nested under it.
         if reset_current and self._prev_span_token is not None:
             Scope.reset_current_span(self._prev_span_token)
             self._prev_span_token = None

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -14,6 +14,7 @@ from agents.tracing import (
     custom_span,
     function_span,
     generation_span,
+    get_current_span,
     handoff_span,
     set_trace_processors,
     trace,
@@ -405,6 +406,19 @@ async def test_multiple_span_start_finish_doesnt_crash():
             span.start()
 
         span.finish()
+
+
+async def test_finishing_a_span_twice_still_releases_the_span_scope():
+    with trace(workflow_name="test", trace_id="123", group_id="456"):
+        with custom_span(name="span_1") as span:
+            # Ending a span early, for example to keep cleanup work out of its
+            # timing, must not stop the context manager from releasing the scope.
+            span.finish()
+
+        assert get_current_span() is None
+
+        with custom_span(name="span_2") as sibling:
+            assert sibling.parent_id is None
 
 
 async def test_noop_parent_is_noop_child():


### PR DESCRIPTION
`SpanImpl.finish` returned early as soon as `ended_at` was set, so a second `finish` never reset the context token that `start(mark_as_current=True)` saved. Ending a span manually inside its `with` block, for example to keep cleanup work out of the span timing, therefore leaves the ended span installed as the current span after the block exits, and every span created later in that context is nested under a span that already ended. `NoOpSpan.finish` has no such early return and already releases the token on a repeated call, so the disabled and enabled paths disagreed.

The fix keeps the existing "Span already finished" warning and the guard against a duplicate `on_span_end`, and only moves the scope release out of the early-return path. Fail-before proof on `origin/main`: the new test fails at `assert get_current_span() is None` with `assert <agents.tracing.spans.SpanImpl object at 0x10bf94950> is None`, alongside the expected `WARNING openai.agents:spans.py:328 Span already finished`. With the fix the test passes and so do the 185 tests across `tests/tracing/`, `tests/test_tracing.py`, `tests/test_trace_processor.py`, `tests/test_agent_tracing.py`, `tests/test_tracing_errors.py`, `tests/test_tracing_errors_streamed.py` and `tests/test_responses_tracing.py`.
