### PR TITLE
fix(voice): keep the word separator when flushing streamed sentences

### DIFF
--- a/src/agents/voice/utils.py
+++ b/src/agents/voice/utils.py
@@ -30,7 +30,12 @@ def get_sentence_based_splitter(
         if len(sentences) >= 1:
             combined_sentences = " ".join(sentences[:-1])
             if len(combined_sentences) >= min_sentence_length:
-                remaining_text_buffer = sentences[-1]
+                # Carry any trailing whitespace over to the remainder. It separates the text
+                # held back from the next streamed delta, and stripping it concatenates the
+                # next word onto the last one, so "He " followed by "arrived" is spoken as
+                # "Hearrived".
+                trailing_whitespace = text_buffer[len(text_buffer.rstrip()) :]
+                remaining_text_buffer = sentences[-1] + trailing_whitespace
                 return combined_sentences, remaining_text_buffer
         return "", text_buffer
 

--- a/tests/voice/test_utils.py
+++ b/tests/voice/test_utils.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from agents.voice import get_sentence_based_splitter
+
+
+def _stream(text: str, chunk_size: int, min_sentence_length: int = 20) -> list[str]:
+    """Feed text through the splitter the way VoiceStreamedResult._add_text does."""
+    split = get_sentence_based_splitter(min_sentence_length)
+    buffer = ""
+    spoken: list[str] = []
+    for index in range(0, len(text), chunk_size):
+        buffer += text[index : index + chunk_size]
+        chunk, buffer = split(buffer)
+        if chunk:
+            spoken.append(chunk)
+    if buffer.strip():
+        spoken.append(buffer.strip())
+    return spoken
+
+
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 5, 7, 11, 15])
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Dr. Smith went to Washington. He arrived at 3 p.m. sharp.",
+        "Hello there friend. How are you doing today? I am fine. Goodbye now.",
+        "One. Two. Three. Four. Five. Six. Seven. Eight. Nine. Ten.",
+        "A short one. Then a much longer sentence that exceeds the minimum easily.",
+    ],
+    ids=["abbreviations", "questions", "many_short", "mixed_lengths"],
+)
+def test_streamed_text_is_spoken_without_losing_or_gluing_words(text: str, chunk_size: int) -> None:
+    """Splitting must not depend on where the model's deltas happen to break.
+
+    The buffer was stripped before splitting, which also removed the trailing space that
+    separates the held-back text from the next delta. When a delta boundary landed just
+    after a space, the following word was concatenated onto the previous one, so "He "
+    plus "arrived" was spoken as "Hearrived".
+    """
+    assert " ".join(_stream(text, chunk_size)).split() == text.split()
+
+
+def test_split_preserves_the_separator_before_the_next_delta() -> None:
+    """The remainder must still end with the whitespace it was given."""
+    split = get_sentence_based_splitter(20)
+
+    spoken, remaining = split("This sentence is long enough to flush. He ")
+
+    assert spoken == "This sentence is long enough to flush."
+    # Without the trailing space, appending the next delta glues the words together.
+    assert remaining == "He "
+    assert (remaining + "arrived").split() == ["He", "arrived"]
+
+
+def test_split_leaves_the_buffer_untouched_when_nothing_is_flushed() -> None:
+    split = get_sentence_based_splitter(20)
+
+    assert split("Too short. ") == ("", "Too short. ")
+    assert split("   ") == ("", "   ")
+    assert split("") == ("", "")
+
+
+def test_split_without_trailing_whitespace_is_unchanged() -> None:
+    split = get_sentence_based_splitter(20)
+
+    assert split("This sentence is long enough to flush. He") == (
+        "This sentence is long enough to flush.",
+        "He",
+    )


### PR DESCRIPTION
### Summary

`get_sentence_based_splitter` strips the buffer before splitting, so the remainder it returns loses any trailing whitespace. `VoiceStreamedResult._add_text` appends the next model delta straight onto that remainder, so whenever a delta boundary lands just after a space the following word is concatenated onto the previous one and the TTS model speaks them as one word.

```
input : Dr. Smith went to Washington. He arrived at 3 p.m. sharp.
spoken: Dr. Smith went to Washington. Hearrived at 3 p.m. sharp.
```

Whether this happens depends only on where the model breaks its deltas, not on the text, so the same reply can be spoken correctly on one run and wrong on the next. Streaming that sentence in three-character deltas reproduces it, and across 400 randomized texts and delta sizes 51 came out with words glued together.

The fix carries the trailing whitespace over to the remainder, which keeps the separator without changing how sentences are detected. Buffers that do not end in whitespace, and buffers where nothing is flushed, produce exactly the same result as before.

### Test plan

The splitter had no tests, which is how this survived. `tests/voice/test_utils.py` adds:

- `test_streamed_text_is_spoken_without_losing_or_gluing_words`, parametrized over four texts and seven delta sizes, asserting the spoken words equal the input words. Comparing word lists rather than exact strings keeps the test about content rather than whitespace normalization.
- `test_split_preserves_the_separator_before_the_next_delta`, which pins the single-call behaviour and then appends a delta to show the words stay separate.
- `test_split_leaves_the_buffer_untouched_when_nothing_is_flushed` and `test_split_without_trailing_whitespace_is_unchanged`, covering the paths that must not change.

4 fail on `main` and pass with the fix. The other 27 pass in both runs, which is the control that the delta sizes and texts that were already correct stay correct:

```
# main
FAILED ...test_streamed_text_is_spoken_without_losing_or_gluing_words[abbreviations-3]
FAILED ...test_streamed_text_is_spoken_without_losing_or_gluing_words[abbreviations-11]
FAILED ...test_streamed_text_is_spoken_without_losing_or_gluing_words[questions-5]
FAILED ...test_split_preserves_the_separator_before_the_next_delta
4 failed, 27 passed
```

Verification from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/voice/` | 109 passed |
| `make tests` | 5850 passed |

The full suite run was done on Windows, where some sandbox symlink and tracing timing tests fail independently of this change. I diffed the failing set against a clean `main` checkout in the same environment. The only difference was `tests/mcp/test_mcp_tracing.py::test_mcp_tracing_always_hides_url_credentials`, which I then ran in isolation on both: it fails on clean `main` as well and flakes between one and two failures across runs, so it is unrelated to this change.

### Issue number

Closes #4226

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`. I ran the underlying steps individually instead, with the results above.
