### PR TITLE
fix(memory): cap OpenAI conversation item page size at the API maximum

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -11,6 +11,11 @@ from ..items import TResponseInputItem
 from .session import SessionABC
 from .session_settings import SessionSettings, coerce_session_settings, resolve_session_limit
 
+# The Conversations items API caps its ``limit`` parameter at 100, so that parameter is a
+# per-request page size rather than the total number of items to return. The auto-paginating
+# iterator keeps fetching pages, so a session limit above the cap is satisfied by paging.
+_MAX_ITEMS_PAGE_SIZE = 100
+
 
 async def start_openai_conversations_session(openai_client: AsyncOpenAI | None = None) -> str:
     _maybe_openai_client = openai_client
@@ -96,7 +101,7 @@ class OpenAIConversationsSession(SessionABC):
         else:
             async for item in self._openai_client.conversations.items.list(
                 conversation_id=session_id,
-                limit=session_limit,
+                limit=min(session_limit, _MAX_ITEMS_PAGE_SIZE),
                 order="desc",
             ):
                 # calling model_dump() to make this serializable

--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -86,9 +86,17 @@ class OpenAIConversationsSession(SessionABC):
         self._session_id = None
 
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
-        session_id = await self._get_session_id()
-
         session_limit = resolve_session_limit(limit, self.session_settings)
+
+        # A limit of 0 is the supported "no history" request that the runner makes for
+        # RunConfig(session_settings=SessionSettings(limit=0)). The Conversations items API only
+        # accepts a page size of 1 through 100, so no request can express it. Answer it here, and
+        # do so before resolving the session id, so asking for no history does not create a remote
+        # conversation as a side effect.
+        if session_limit is not None and session_limit <= 0:
+            return []
+
+        session_id = await self._get_session_id()
 
         all_items = []
         if session_limit is None:

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -680,6 +680,11 @@ class TestOpenAIConversationsSessionSettings:
         assert session.session_settings.limit == 0
 
 
+def _contents(items: list[TResponseInputItem]) -> list[str]:
+    """Read the ``content`` of each retrieved item, which is a message here."""
+    return [cast(dict[str, Any], item)["content"] for item in items]
+
+
 class _FakeConversationItem:
     """Minimal stand-in for a Conversations item returned by the API."""
 
@@ -739,8 +744,8 @@ class TestOpenAIConversationsSessionItemPageSize:
 
         assert items.requested_limits == [_FakeConversationItems.MAX_PAGE_SIZE]
         assert len(retrieved) == 150
-        assert retrieved[0]["content"] == "m50"
-        assert retrieved[-1]["content"] == "m199"
+        assert _contents(retrieved)[0] == "m50"
+        assert _contents(retrieved)[-1] == "m199"
 
     @pytest.mark.asyncio
     async def test_get_items_forwards_limits_within_the_api_page_size(self, mock_openai_client):
@@ -753,7 +758,7 @@ class TestOpenAIConversationsSessionItemPageSize:
         retrieved = await session.get_items(limit=5)
 
         assert items.requested_limits == [5]
-        assert [item["content"] for item in retrieved] == ["m195", "m196", "m197", "m198", "m199"]
+        assert _contents(retrieved) == ["m195", "m196", "m197", "m198", "m199"]
 
     @pytest.mark.asyncio
     async def test_get_items_returns_no_history_for_a_zero_limit(self, mock_openai_client):

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -754,3 +754,47 @@ class TestOpenAIConversationsSessionItemPageSize:
 
         assert items.requested_limits == [5]
         assert [item["content"] for item in retrieved] == ["m195", "m196", "m197", "m198", "m199"]
+
+    @pytest.mark.asyncio
+    async def test_get_items_returns_no_history_for_a_zero_limit(self, mock_openai_client):
+        """A limit of 0 is the runner's no-history request, and 0 is not a valid page size."""
+        items = _FakeConversationItems(total=200)
+        mock_openai_client.conversations.items = items
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        retrieved = await session.get_items(limit=0)
+
+        assert retrieved == []
+        assert items.requested_limits == []
+
+    @pytest.mark.asyncio
+    async def test_get_items_honors_a_zero_limit_from_session_settings(self, mock_openai_client):
+        from agents.memory import SessionSettings
+
+        items = _FakeConversationItems(total=200)
+        mock_openai_client.conversations.items = items
+        session = OpenAIConversationsSession(
+            conversation_id="test_id",
+            openai_client=mock_openai_client,
+            session_settings=SessionSettings(limit=0),
+        )
+
+        retrieved = await session.get_items()
+
+        assert retrieved == []
+        assert items.requested_limits == []
+
+    @pytest.mark.asyncio
+    async def test_zero_limit_does_not_create_a_conversation(self, mock_openai_client):
+        """Asking for no history must not lazily create a remote conversation."""
+        items = _FakeConversationItems(total=200)
+        mock_openai_client.conversations.items = items
+        session = OpenAIConversationsSession(openai_client=mock_openai_client)
+
+        retrieved = await session.get_items(limit=0)
+
+        assert retrieved == []
+        assert items.requested_limits == []
+        mock_openai_client.conversations.create.assert_not_awaited()

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -678,3 +678,79 @@ class TestOpenAIConversationsSessionSettings:
 
         assert isinstance(session.session_settings, SessionSettings)
         assert session.session_settings.limit == 0
+
+
+class _FakeConversationItem:
+    """Minimal stand-in for a Conversations item returned by the API."""
+
+    def __init__(self, index: int) -> None:
+        self._index = index
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        return {"id": f"item_{self._index}", "role": "user", "content": f"m{self._index}"}
+
+
+class _FakeConversationItems:
+    """Records the requested page size and rejects values the API does not accept."""
+
+    MAX_PAGE_SIZE = 100
+
+    def __init__(self, total: int) -> None:
+        self._total = total
+        self.requested_limits: list[int | None] = []
+
+    def list(
+        self,
+        *,
+        conversation_id: str,
+        order: str,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        self.requested_limits.append(limit)
+
+        async def _iterate() -> Any:
+            if limit is not None and not 1 <= limit <= self.MAX_PAGE_SIZE:
+                raise ValueError(
+                    f"Invalid 'limit': expected a value between 1 and {self.MAX_PAGE_SIZE}, "
+                    f"but got {limit} instead."
+                )
+            # The auto-paginating iterator hides page boundaries from callers, so it
+            # yields every stored item regardless of the per-request page size.
+            indexes = range(self._total)
+            for index in reversed(indexes) if order == "desc" else indexes:
+                yield _FakeConversationItem(index)
+
+        return _iterate()
+
+
+class TestOpenAIConversationsSessionItemPageSize:
+    """The session limit must not be forwarded as the Conversations items page size."""
+
+    @pytest.mark.asyncio
+    async def test_get_items_pages_when_limit_exceeds_api_page_size(self, mock_openai_client):
+        items = _FakeConversationItems(total=200)
+        mock_openai_client.conversations.items = items
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        retrieved = await session.get_items(limit=150)
+
+        assert items.requested_limits == [_FakeConversationItems.MAX_PAGE_SIZE]
+        assert len(retrieved) == 150
+        assert retrieved[0]["content"] == "m50"
+        assert retrieved[-1]["content"] == "m199"
+
+    @pytest.mark.asyncio
+    async def test_get_items_forwards_limits_within_the_api_page_size(self, mock_openai_client):
+        items = _FakeConversationItems(total=200)
+        mock_openai_client.conversations.items = items
+        session = OpenAIConversationsSession(
+            conversation_id="test_id", openai_client=mock_openai_client
+        )
+
+        retrieved = await session.get_items(limit=5)
+
+        assert items.requested_limits == [5]
+        assert [item["content"] for item in retrieved] == ["m195", "m196", "m197", "m198", "m199"]


### PR DESCRIPTION
`OpenAIConversationsSession.get_items` passed the caller's `limit` straight through as the Conversations items API page size. The OpenAI client documents that parameter as "A limit on the number of objects to be returned. Limit can range between 1 and 100", so it is a per-request page size rather than a total, and any session limit above 100 raised an error instead of returning items while every other session backend simply returns the requested number.

This caps the page size at the API maximum and lets the auto-paginating iterator page until the requested number of items is collected, so the `Session` protocol behaves the same across backends.

The same parameter bound also rules out `limit=0`, which is the supported "no history" request the runner makes for `RunConfig(session_settings=SessionSettings(limit=0))` and which `SQLiteSession` already answers locally. So `get_items` now resolves the session limit first and returns an empty list for any non-positive value, before resolving the session id, so asking for no history does not create a remote conversation as a side effect.

Regression tests in `tests/memory/test_openai_conversations_session.py` cover the paging case, the small-limit case that must still be forwarded verbatim, the zero limit from both the call argument and `SessionSettings`, and the no-lazy-create behavior. On `main` four of the five fail, three with `ValueError: Invalid 'limit': expected a value between 1 and 100`. `make lint`, `make typecheck` and `tests/memory` are green.
