### PR TITLE
fix(handoffs): keep empty turns in the nested conversation history

### DIFF
--- a/src/agents/handoffs/history.py
+++ b/src/agents/handoffs/history.py
@@ -429,7 +429,9 @@ def _format_transcript_item_legacy(item: TResponseInputItem) -> str:
         if isinstance(name, str) and name:
             prefix = f"{prefix} ({name})"
         content_str = _stringify_content(item.get("content"))
-        return f"{prefix}: {content_str}" if content_str else prefix
+        # Always emit the separator. A bare role has no record separator for the parser to
+        # find, so the turn is dropped when the summary is flattened on the next handoff.
+        return f"{prefix}: {content_str}"
 
     item_type = item.get("type", "item")
     rest = {k: v for k, v in item.items() if k not in ("type", "provider_data")}
@@ -535,7 +537,17 @@ def _parse_summary_line(line: str) -> TResponseInputItem | None:
 
     role_part, sep, remainder = stripped.partition(":")
     if not sep:
-        return None
+        # Summaries written before the separator was always emitted record an empty turn as
+        # a bare role, so recover those instead of dropping the turn. Restricted to a lone
+        # role token, optionally with a "(name)" suffix, so prose inside the block is still
+        # rejected rather than turning into a fabricated message.
+        if not _is_bare_role_record(stripped):
+            return None
+        role, name = _split_role_and_name(stripped)
+        recovered: dict[str, Any] = {"role": role}
+        if name:
+            recovered["name"] = name
+        return cast(TResponseInputItem, recovered)
     role_text = role_part.strip()
     if not role_text:
         return None
@@ -589,6 +601,17 @@ def _strip_transcript_item_metadata(item: TResponseInputItem) -> TResponseInputI
     from ..run_internal.items import strip_internal_input_item_metadata
 
     return strip_internal_input_item_metadata(item)
+
+
+_KNOWN_TRANSCRIPT_ROLES = frozenset({"user", "assistant", "system", "developer"})
+
+
+def _is_bare_role_record(stripped: str) -> bool:
+    """Return whether a separator-less record is a lone role, optionally with a name."""
+    candidate = stripped
+    if candidate.endswith(")") and "(" in candidate:
+        candidate = candidate[: candidate.rfind("(")].strip()
+    return candidate in _KNOWN_TRANSCRIPT_ROLES
 
 
 def _split_role_and_name(role_text: str) -> tuple[str, str | None]:

--- a/src/agents/handoffs/history.py
+++ b/src/agents/handoffs/history.py
@@ -547,6 +547,10 @@ def _parse_summary_line(line: str) -> TResponseInputItem | None:
         recovered: dict[str, Any] = {"role": role}
         if name:
             recovered["name"] = name
+        # Keep an explicit empty content. Adapters such as the Chat Completions converter
+        # only recognize a message when both keys are present, so a role-only item is not
+        # replayable.
+        recovered["content"] = ""
         return cast(TResponseInputItem, recovered)
     role_text = role_part.strip()
     if not role_text:
@@ -560,7 +564,9 @@ def _parse_summary_line(line: str) -> TResponseInputItem | None:
         legacy_typed_item = _parse_legacy_typed_item(role, content)
         if legacy_typed_item is not None:
             return legacy_typed_item
-        reconstructed["content"] = content
+    # Set content even when empty, so a turn that carried none stays a replayable message
+    # rather than a role-only item that adapters do not recognize.
+    reconstructed["content"] = content
     return cast(TResponseInputItem, reconstructed)
 
 

--- a/tests/test_handoff_history_duplication.py
+++ b/tests/test_handoff_history_duplication.py
@@ -38,7 +38,11 @@ from agents.handoffs import (
     reset_conversation_history_wrappers,
     set_conversation_history_wrappers,
 )
-from agents.handoffs.history import _get_nested_history_owned_items
+from agents.handoffs.history import (
+    _extract_nested_history_transcript,
+    _get_nested_history_owned_items,
+    get_conversation_history_wrappers,
+)
 from agents.items import (
     HandoffCallItem,
     HandoffOutputItem,
@@ -2298,3 +2302,111 @@ async def test_first_nested_handoff_after_restore_uses_explicit_occurrence_linea
     expected_occurrences = 2 if legacy_snapshot else 1
     assert replay_types.count("tool_search_call") == expected_occurrences
     assert replay_types.count("tool_search_output") == expected_occurrences
+
+
+@pytest.mark.parametrize(
+    "empty_item",
+    [
+        {"role": "user", "content": ""},
+        {"role": "assistant", "content": ""},
+        {"role": "user", "content": None},
+        {"role": "user", "name": "bob", "content": ""},
+    ],
+    ids=["user_empty", "assistant_empty", "user_none", "named_empty"],
+)
+def test_nested_history_keeps_turns_with_no_content(empty_item: dict[str, Any]) -> None:
+    """A turn with no content must survive being summarized and flattened again.
+
+    An empty turn was rendered as a bare role with no separator, and the parser that
+    flattens the summary on the next handoff requires one, so the turn was dropped. The
+    next agent then saw a transcript with a turn missing, which also breaks the
+    user/assistant alternation.
+    """
+    history = (
+        {"role": "user", "content": "first question"},
+        empty_item,
+        {"role": "user", "content": "second question"},
+    )
+    data = HandoffInputData(
+        input_history=cast(Any, history),
+        pre_handoff_items=(),
+        new_items=(),
+        run_context=None,
+    )
+
+    nested = nest_handoff_history(data)
+    transcript = _extract_nested_history_transcript(cast(Any, nested.input_history)[0])
+
+    assert transcript is not None
+    assert len(transcript) == len(history)
+    assert [item.get("role") for item in transcript] == ["user", empty_item["role"], "user"]
+
+
+def test_nested_history_survives_repeated_handoffs() -> None:
+    """Flattening and re-nesting must not shed the empty turn on each hop."""
+    history = (
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": ""},
+        {"role": "user", "content": "second question"},
+    )
+    data = HandoffInputData(
+        input_history=cast(Any, history),
+        pre_handoff_items=(),
+        new_items=(),
+        run_context=None,
+    )
+
+    nested = nest_handoff_history(data)
+    for _ in range(3):
+        nested = nest_handoff_history(nested)
+        transcript = _extract_nested_history_transcript(cast(Any, nested.input_history)[0])
+        assert transcript is not None
+        assert len(transcript) == len(history)
+
+
+def test_bare_role_record_from_an_older_summary_is_recovered() -> None:
+    """Summaries written before the separator was always emitted must still flatten."""
+    start_marker, end_marker = get_conversation_history_wrappers()
+    legacy = {
+        "role": "assistant",
+        "content": "\n".join(
+            [
+                "For context, here is the conversation so far between the user and the "
+                "previous agent:",
+                start_marker,
+                "1. user: first question",
+                "2. assistant",
+                "3. user: second question",
+                end_marker,
+            ]
+        ),
+    }
+
+    transcript = _extract_nested_history_transcript(cast(Any, legacy))
+
+    assert transcript is not None
+    assert [item.get("role") for item in transcript] == ["user", "assistant", "user"]
+
+
+def test_prose_inside_the_summary_block_is_still_rejected() -> None:
+    """The bare-role recovery must not turn arbitrary text into a fabricated turn."""
+    start_marker, end_marker = get_conversation_history_wrappers()
+    with_prose = {
+        "role": "assistant",
+        "content": "\n".join(
+            [
+                "For context, here is the conversation so far between the user and the "
+                "previous agent:",
+                start_marker,
+                "1. user: first question",
+                "some stray prose with no separator",
+                "3. user: second question",
+                end_marker,
+            ]
+        ),
+    }
+
+    transcript = _extract_nested_history_transcript(cast(Any, with_prose))
+
+    assert transcript is not None
+    assert [item.get("role") for item in transcript] == ["user", "user"]

--- a/tests/test_handoff_history_duplication.py
+++ b/tests/test_handoff_history_duplication.py
@@ -53,6 +53,7 @@ from agents.items import (
     ToolCallOutputItem,
     TResponseInputItem,
 )
+from agents.models.chatcmpl_converter import Converter
 from agents.result import RunResult, RunResultStreaming
 from agents.run_internal.items import (
     NestedHistoryOwnedItem,
@@ -2389,7 +2390,11 @@ def test_bare_role_record_from_an_older_summary_is_recovered() -> None:
 
 
 def test_prose_inside_the_summary_block_is_still_rejected() -> None:
-    """The bare-role recovery must not turn arbitrary text into a fabricated turn."""
+    """The bare-role recovery must not turn arbitrary text into a fabricated turn.
+
+    The prose is numbered so it becomes its own record. An unnumbered line is folded into
+    the previous record as continuation text and never reaches the rejection branch.
+    """
     start_marker, end_marker = get_conversation_history_wrappers()
     with_prose = {
         "role": "assistant",
@@ -2399,7 +2404,7 @@ def test_prose_inside_the_summary_block_is_still_rejected() -> None:
                 "previous agent:",
                 start_marker,
                 "1. user: first question",
-                "some stray prose with no separator",
+                "2. some stray prose with no separator",
                 "3. user: second question",
                 end_marker,
             ]
@@ -2410,3 +2415,63 @@ def test_prose_inside_the_summary_block_is_still_rejected() -> None:
 
     assert transcript is not None
     assert [item.get("role") for item in transcript] == ["user", "user"]
+    assert [item.get("content") for item in transcript] == [
+        "first question",
+        "second question",
+    ]
+
+
+def test_recovered_empty_turn_keeps_explicit_content() -> None:
+    """A recovered turn must carry content, not just a role.
+
+    Adapters such as the Chat Completions converter only recognize a message when both
+    keys are present, so a role-only item is not replayable.
+    """
+    start_marker, end_marker = get_conversation_history_wrappers()
+    legacy = {
+        "role": "assistant",
+        "content": "\n".join(
+            [
+                "For context, here is the conversation so far between the user and the "
+                "previous agent:",
+                start_marker,
+                "1. user: first question",
+                "2. assistant",
+                "3. assistant: ",
+                end_marker,
+            ]
+        ),
+    }
+
+    transcript = _extract_nested_history_transcript(cast(Any, legacy))
+
+    assert transcript is not None
+    # Both the recovered bare role and the separator-only record keep empty content.
+    assert transcript[1] == {"role": "assistant", "content": ""}
+    assert transcript[2] == {"role": "assistant", "content": ""}
+
+
+def test_second_pass_nesting_keeps_empty_turns_provider_valid() -> None:
+    """After a second handoff the empty turn must still convert for a real adapter."""
+    history = (
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": ""},
+        {"role": "user", "content": "second question"},
+    )
+    data = HandoffInputData(
+        input_history=cast(Any, history),
+        pre_handoff_items=(),
+        new_items=(),
+        run_context=None,
+    )
+
+    nested = nest_handoff_history(nest_handoff_history(data))
+    transcript = _extract_nested_history_transcript(cast(Any, nested.input_history)[0])
+
+    assert transcript is not None
+    assert transcript[1] == {"role": "assistant", "content": ""}
+
+    # The reconstructed transcript must convert through a supported adapter.
+    messages = Converter.items_to_messages(cast(Any, transcript))
+    assert [message["role"] for message in messages] == ["user", "assistant", "user"]
+    assert messages[1].get("content") == ""


### PR DESCRIPTION
### Summary

`nest_handoff_history` summarizes the previous transcript into an assistant message, and the next handoff flattens that summary back into items so history does not nest repeatedly. A turn with no content was rendered as a bare role, with the `role: content` separator omitted. The parser splits each record on that separator and discards anything without one, so the turn was dropped.

```
original turns: 3   ['user', 'assistant', 'user']
nested turns  : 2   ['user', 'user']
```

The next agent receives a transcript with a turn missing, and the user/assistant alternation is broken. The turn stays lost across further handoffs. This affects `content=""` and `content=None`, for any role, with or without a `name`. Whitespace content and non-string content such as `[]` were unaffected, because those take a different formatting path.

The fix emits the separator unconditionally, so the record parses like every other one. Summaries written before this change still contain bare roles, so the parser also recovers a separator-less record when it is a lone known role, optionally with a `(name)` suffix. That is deliberately narrow: prose inside the block is still rejected rather than becoming a fabricated turn, and a test pins that.

### Test plan

Added to `tests/test_handoff_history_duplication.py`:

- `test_nested_history_keeps_turns_with_no_content`, parametrized over `content=""` for user and assistant, `content=None`, and a named turn, asserting the turn count and the role sequence survive.
- `test_nested_history_survives_repeated_handoffs`, nesting four times to show the turn is not shed on each hop.
- `test_bare_role_record_from_an_older_summary_is_recovered`, covering a summary written before this change.
- `test_prose_inside_the_summary_block_is_still_rejected`, the guard on the recovery.

6 fail on `main` and pass with the fix. The prose test passes in both runs, which is the control that the recovery is narrow rather than accepting anything without a separator:

```
# main
FAILED ...test_nested_history_keeps_turns_with_no_content[user_empty]
FAILED ...test_nested_history_keeps_turns_with_no_content[assistant_empty]
FAILED ...test_nested_history_keeps_turns_with_no_content[user_none]
FAILED ...test_nested_history_keeps_turns_with_no_content[named_empty]
FAILED ...test_nested_history_survives_repeated_handoffs
FAILED ...test_bare_role_record_from_an_older_summary_is_recovered
6 failed, 1 passed, 83 deselected
```

Verification from the repository root:

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 1 error, pre-existing on `main` (`src/agents/sandbox/util/tar_utils.py:161`) |
| `uv run pytest tests/test_handoff_history_duplication.py` | 90 passed |
| `uv run pytest tests/test_extension_filters.py tests/test_run_step_processing.py tests/test_agent_runner.py` | 338 passed with the file above |
| `make tests` | 5825 passed |

The full suite run was done on Windows, where some sandbox symlink and tracing timing tests fail independently of this change. I diffed the failing set against a clean `main` checkout in the same environment. The only difference was `tests/test_tracing_errors.py::test_multiple_final_output_doesnt_error`, which I then ran in isolation on both: it fails three times out of three on clean `main` as well, so it is pre-existing and unrelated.

### Issue number

Closes #4229

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`. I ran the underlying steps individually instead, with the results above.
