### PR TITLE
fix(memory): enforce closed state on SQLite session empty add_items

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -170,6 +170,9 @@ class AdvancedSQLiteSession(SQLiteSession):
         Args:
             items: The items to add to the session
         """
+        # Checked before the empty-list fast path, which would otherwise return
+        # successfully on a closed session.
+        self._check_not_closed()
         if not items:
             return
 

--- a/src/agents/memory/sqlite_session.py
+++ b/src/agents/memory/sqlite_session.py
@@ -120,10 +120,14 @@ class SQLiteSession(SessionABC):
         with self._lock:
             yield self._get_connection()
 
-    def _get_connection(self) -> sqlite3.Connection:
-        """Get a database connection."""
+    def _check_not_closed(self) -> None:
+        """Raise if the session has already been closed."""
         if self._closed:
             raise RuntimeError("SQLiteSession is closed")
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Get a database connection."""
+        self._check_not_closed()
 
         if self._is_memory_db:
             # Use shared connection for in-memory database to avoid thread isolation
@@ -283,6 +287,9 @@ class SQLiteSession(SessionABC):
         Args:
             items: List of input items to add to the history
         """
+        # Checked before the empty-list fast path, which would otherwise return
+        # successfully on a closed session.
+        self._check_not_closed()
         if not items:
             return
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -328,6 +328,21 @@ async def test_add_items_failure_preserves_existing_history():
         session.close()
 
 
+async def test_advanced_sqlite_session_closed_rejects_empty_add_items():
+    """add_items([]) must not bypass the closed check through the empty-list fast path."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "closed_empty_add.db"
+        session = AdvancedSQLiteSession(
+            session_id="advanced_closed_empty_add",
+            db_path=db_path,
+            create_tables=True,
+        )
+        session.close()
+
+        with pytest.raises(RuntimeError, match="SQLiteSession is closed"):
+            await session.add_items([])
+
+
 async def test_add_items_rolls_back_partial_structure_metadata_write():
     """Partial metadata writes should roll back with the message rows in the same batch."""
     session = PartiallyFailingStructureMetadataSession(

--- a/tests/memory/test_session.py
+++ b/tests/memory/test_session.py
@@ -235,6 +235,18 @@ async def test_sqlite_session_close_closes_worker_thread_connections():
 
 
 @pytest.mark.asyncio
+async def test_sqlite_session_closed_rejects_empty_add_items():
+    """add_items([]) must not bypass the closed check through the empty-list fast path."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "closed_empty_add.db"
+        session = SQLiteSession("closed_empty_add_test", db_path)
+        session.close()
+
+        with pytest.raises(RuntimeError, match="SQLiteSession is closed"):
+            await session.add_items([])
+
+
+@pytest.mark.asyncio
 async def test_sqlite_session_memory_pop_item():
     """Test SQLiteSession pop_item functionality."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
`SQLiteSession.add_items` and `AdvancedSQLiteSession.add_items` return early on an empty list before they ever reach `_get_connection`, so `await session.add_items([])` succeeds on a session that has already been closed while every non-empty call raises `RuntimeError("SQLiteSession is closed")`. The sibling backends all order this the other way: `AsyncSQLiteSession`, `RedisSession`, and `DaprSession` call `_check_not_closed()` before the fast path, and `MongoDBSession` carries an explicit comment saying the check has to come first for exactly this reason.

This moves the closed check ahead of the empty-list fast path in both SQLite sessions and factors the existing inline check in `_get_connection` into a `_check_not_closed` helper so there is one source of truth for the error, matching the sibling shape. Nothing else changes: a closed session already raised for every other operation, and an open session is untouched.

Two regression tests, one per session class, close the session and then call `add_items([])`. Both fail on `main` with `Failed: DID NOT RAISE <class 'RuntimeError'>` and pass with this change. `make lint`, `make typecheck` (mypy and pyright, 0 errors), and the touched test modules are green.
