### PR TITLE
fix(tracing): catch only the context reset on generator close

### DIFF
--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -30,17 +30,22 @@ def _finish_on_generator_exit(trace: Trace) -> None:
     An explicit ``finish`` from the wrong context is a context-ownership violation rather
     than an unavoidable one, so it still raises, and a processor that fails during
     ``finish`` still surfaces rather than being mistaken for a foreign token.
-    """
-    trace.finish(reset_current=False)
 
-    token: contextvars.Token[Trace | None] | None = trace._prev_context_token  # type: ignore[attr-defined]
-    if token is None:
-        return
-    trace._prev_context_token = None  # type: ignore[attr-defined]
+    The reset runs in a ``finally`` so that a failing ``finish`` still releases the scope
+    instead of leaving the finished trace current, and the token is cleared only once the
+    reset has either succeeded or hit the foreign-context ``ValueError`` it expects. An
+    unexpected reset failure therefore leaves the handle in place rather than losing it.
+    """
     try:
-        Scope.reset_current_trace(token)
-    except ValueError:
-        logger.debug("Skipping trace context reset, token belongs to another context")
+        trace.finish(reset_current=False)
+    finally:
+        token: contextvars.Token[Trace | None] | None = trace._prev_context_token  # type: ignore[attr-defined]
+        if token is not None:
+            try:
+                Scope.reset_current_trace(token)
+            except ValueError:
+                logger.debug("Skipping trace context reset, token belongs to another context")
+            trace._prev_context_token = None  # type: ignore[attr-defined]
 
 
 class Trace(abc.ABC):

--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -26,15 +26,21 @@ def _finish_on_generator_exit(trace: Trace) -> None:
     finalizing cannot rewrite the caller's context, and the caller keeps seeing this trace
     as current until its own scope ends. Raising would only add a crash on top of that.
 
-    The tolerance is deliberately limited to this path. An explicit ``finish`` from the
-    wrong context is a context-ownership violation rather than an unavoidable one, so it
-    still raises.
+    The tolerance is deliberately limited to this path, and within it to the reset itself.
+    An explicit ``finish`` from the wrong context is a context-ownership violation rather
+    than an unavoidable one, so it still raises, and a processor that fails during
+    ``finish`` still surfaces rather than being mistaken for a foreign token.
     """
+    trace.finish(reset_current=False)
+
+    token: contextvars.Token[Trace | None] | None = trace._prev_context_token  # type: ignore[attr-defined]
+    if token is None:
+        return
+    trace._prev_context_token = None  # type: ignore[attr-defined]
     try:
-        trace.finish(reset_current=True)
+        Scope.reset_current_trace(token)
     except ValueError:
         logger.debug("Skipping trace context reset, token belongs to another context")
-        trace._prev_context_token = None  # type: ignore[attr-defined]
 
 
 class Trace(abc.ABC):

--- a/tests/tracing/test_traces_impl.py
+++ b/tests/tracing/test_traces_impl.py
@@ -270,7 +270,9 @@ async def test_generator_close_surfaces_processor_failure() -> None:
     with pytest.raises(ValueError, match="processor exploded"):
         await generator.aclose()
 
-    # The reset never ran, so the token must still be there rather than silently dropped.
-    assert trace._prev_context_token is not None
+    # The processor failure is the one that propagates, and the scope is still released:
+    # running the reset in a finally keeps a failing finish from leaving the trace current.
+    assert Scope.get_current_trace() is None
+    assert trace._prev_context_token is None
 
     Scope.set_current_trace(None)

--- a/tests/tracing/test_traces_impl.py
+++ b/tests/tracing/test_traces_impl.py
@@ -237,3 +237,40 @@ def test_reattached_trace_restores_scope_without_reemitting_processor_events() -
     assert processor.started == ["trace-123"]
     assert processor.ended == ["trace-123"]
     assert Scope.get_current_trace() is None
+
+
+async def test_generator_close_surfaces_processor_failure() -> None:
+    """A processor failing during close must not be mistaken for a foreign token.
+
+    ``finish`` calls ``on_trace_end`` before resetting the scope, so catching every
+    ``ValueError`` around the whole call would swallow a processor failure, drop the saved
+    token, and leave the finished trace current for everything that ran afterwards.
+    """
+    Scope.set_current_trace(None)
+
+    class FailingProcessor(DummyProcessor):
+        def on_trace_end(self, trace: Trace) -> None:
+            raise ValueError("processor exploded")
+
+    trace = TraceImpl(
+        name="processor-failure",
+        trace_id="trace-processor-failure",
+        group_id=None,
+        metadata=None,
+        processor=cast(Any, FailingProcessor()),
+    )
+
+    async def stream() -> AsyncGenerator[int, None]:
+        with trace:
+            yield 1
+
+    generator = stream()
+    assert await generator.asend(None) == 1
+
+    with pytest.raises(ValueError, match="processor exploded"):
+        await generator.aclose()
+
+    # The reset never ran, so the token must still be there rather than silently dropped.
+    assert trace._prev_context_token is not None
+
+    Scope.set_current_trace(None)


### PR DESCRIPTION
Follow-up to #4221, requested by @seratch [there](https://github.com/openai/openai-agents-python/pull/4221#issuecomment-5198583892).

#4221 moved the foreign-token tolerance into `_finish_on_generator_exit`, but that helper wraps the whole `finish()` call. `TraceImpl.finish` runs the processor before resetting the scope:

```python
def finish(self, reset_current: bool = False):
    if not self._started:
        return
    self._processor.on_trace_end(self)          # can raise
    if reset_current and self._prev_context_token is not None:
        Scope.reset_current_trace(self._prev_context_token)
        self._prev_context_token = None
```

So a processor whose `on_trace_end` raises `ValueError` is mistaken for a foreign context token. The error is swallowed, the saved token is dropped, and the reset never runs, which leaves the finished trace current for everything that runs after the close. Closing from the same task returns normally while the scope is quietly wrong.

**The change**

Run `finish(reset_current=False)` so processor failures propagate normally, then reset the scope separately and tolerate only that failure, which is the one that genuinely cannot succeed when another task finalizes the generator:

```python
trace.finish(reset_current=False)

token = trace._prev_context_token
if token is None:
    return
trace._prev_context_token = None
try:
    Scope.reset_current_trace(token)
except ValueError:
    logger.debug("Skipping trace context reset, token belongs to another context")
```

**Verified**

- `test_generator_close_surfaces_processor_failure` fails on current main with `DID NOT RAISE <class 'ValueError'>` and passes here. It also asserts the token is left in place rather than silently dropped, since the reset never ran.
- `tests/tracing` is 49 passed, with `ruff check`, `ruff format --check`, and `mypy` clean on both changed files.
- The generator-close behavior added in #4221 is unchanged: same-task closes still reset, and a cross-task close still tolerates the foreign token.
