### PR TITLE
fix(tracing): release the span scope when a generator is closed

### DIFF
--- a/src/agents/tracing/spans.py
+++ b/src/agents/tracing/spans.py
@@ -28,6 +28,28 @@ class SpanError(TypedDict):
     data: dict[str, Any] | None
 
 
+def _finish_on_generator_exit(span: Span[Any]) -> None:
+    """Finish a span whose ``with`` block is unwinding because of ``GeneratorExit``.
+
+    A generator closed from the task that advanced it resets normally, which is the common
+    case. An abandoned async generator is instead finalized from whichever task happens to
+    run its ``aclose``, so the body resumes in a context that never set the token and
+    ``ContextVar.reset`` raises ``ValueError``. Nothing can be done about that from here:
+    a ``Token`` is only valid in the ``Context`` that created it, so the task doing the
+    finalizing cannot rewrite the caller's context, and the caller keeps seeing this span
+    as current until its own scope ends. Raising would only add a crash on top of that.
+
+    The tolerance is deliberately limited to this path. An explicit ``finish`` from the
+    wrong context is a context-ownership violation rather than an unavoidable one, so it
+    still raises.
+    """
+    try:
+        span.finish(reset_current=True)
+    except ValueError:
+        logger.debug("Skipping span context reset, token belongs to another context")
+        span._prev_span_token = None  # type: ignore[attr-defined]
+
+
 class Span(abc.ABC, Generic[TSpanData]):
     """Base class for representing traceable operations with timing and context.
 
@@ -230,12 +252,10 @@ class NoOpSpan(Span[TSpanData]):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        reset_current = True
         if exc_type is GeneratorExit:
-            logger.debug("GeneratorExit, skipping span reset")
-            reset_current = False
-
-        self.finish(reset_current=reset_current)
+            _finish_on_generator_exit(self)
+        else:
+            self.finish(reset_current=True)
 
     def set_error(self, error: SpanError) -> None:
         pass
@@ -339,12 +359,10 @@ class SpanImpl(Span[TSpanData]):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        reset_current = True
         if exc_type is GeneratorExit:
-            logger.debug("GeneratorExit, skipping span reset")
-            reset_current = False
-
-        self.finish(reset_current=reset_current)
+            _finish_on_generator_exit(self)
+        else:
+            self.finish(reset_current=True)
 
     def set_error(self, error: SpanError) -> None:
         self._error = error

--- a/src/agents/tracing/spans.py
+++ b/src/agents/tracing/spans.py
@@ -39,15 +39,21 @@ def _finish_on_generator_exit(span: Span[Any]) -> None:
     finalizing cannot rewrite the caller's context, and the caller keeps seeing this span
     as current until its own scope ends. Raising would only add a crash on top of that.
 
-    The tolerance is deliberately limited to this path. An explicit ``finish`` from the
-    wrong context is a context-ownership violation rather than an unavoidable one, so it
-    still raises.
+    The tolerance is deliberately limited to this path, and within it to the reset itself.
+    An explicit ``finish`` from the wrong context is a context-ownership violation rather
+    than an unavoidable one, so it still raises, and a processor that fails during
+    ``finish`` still surfaces rather than being mistaken for a foreign token.
     """
+    span.finish(reset_current=False)
+
+    token: contextvars.Token[Span[Any] | None] | None = span._prev_span_token  # type: ignore[attr-defined]
+    if token is None:
+        return
+    span._prev_span_token = None  # type: ignore[attr-defined]
     try:
-        span.finish(reset_current=True)
+        Scope.reset_current_span(token)
     except ValueError:
         logger.debug("Skipping span context reset, token belongs to another context")
-        span._prev_span_token = None  # type: ignore[attr-defined]
 
 
 class Span(abc.ABC, Generic[TSpanData]):

--- a/tests/tracing/test_spans_impl.py
+++ b/tests/tracing/test_spans_impl.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator, Callable
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -123,5 +123,40 @@ async def test_explicit_finish_from_another_context_still_raises(
             span.finish(reset_current=True)
 
     await asyncio.create_task(finish_elsewhere())
+
+    Scope.set_current_span(None)
+
+
+async def test_generator_close_surfaces_processor_failure() -> None:
+    """A processor failing during close must not be mistaken for a foreign token.
+
+    ``finish`` calls ``on_span_end`` before resetting the scope, so catching every
+    ``ValueError`` around the whole call would swallow a processor failure, drop the saved
+    token, and leave the finished span current for everything that ran afterwards.
+    """
+    Scope.set_current_span(None)
+
+    class FailingProcessor(DummyProcessor):
+        def on_span_end(self, span: Span[Any]) -> None:
+            raise ValueError("processor exploded")
+
+    span = SpanImpl(
+        trace_id="trace-processor-failure",
+        span_id="span-processor-failure",
+        parent_id=None,
+        processor=cast(Any, FailingProcessor()),
+        span_data=AgentSpanData(name="processor-failure"),
+        tracing_api_key=None,
+    )
+
+    async def stream() -> AsyncGenerator[int, None]:
+        with span:
+            yield 1
+
+    generator = stream()
+    assert await generator.asend(None) == 1
+
+    with pytest.raises(ValueError, match="processor exploded"):
+        await generator.aclose()
 
     Scope.set_current_span(None)

--- a/tests/tracing/test_spans_impl.py
+++ b/tests/tracing/test_spans_impl.py
@@ -1,0 +1,127 @@
+import asyncio
+from collections.abc import AsyncGenerator, Callable
+from typing import Any
+
+import pytest
+
+from agents.tracing.processor_interface import TracingProcessor
+from agents.tracing.scope import Scope
+from agents.tracing.span_data import AgentSpanData, SpanData
+from agents.tracing.spans import NoOpSpan, Span, SpanImpl
+from agents.tracing.traces import Trace
+
+
+class DummyProcessor(TracingProcessor):
+    def __init__(self) -> None:
+        self.started: list[str] = []
+        self.ended: list[str] = []
+
+    def on_trace_start(self, trace: Trace) -> None:
+        return None
+
+    def on_trace_end(self, trace: Trace) -> None:
+        return None
+
+    def on_span_start(self, span: Span[Any]) -> None:
+        self.started.append(span.span_id)
+
+    def on_span_end(self, span: Span[Any]) -> None:
+        self.ended.append(span.span_id)
+
+    def shutdown(self) -> None:
+        return None
+
+    def force_flush(self) -> None:
+        return None
+
+
+def _new_no_op_span() -> Span[SpanData]:
+    return NoOpSpan(AgentSpanData(name="generator-exit"))
+
+
+def _new_span_impl() -> Span[SpanData]:
+    return SpanImpl(
+        trace_id="trace-generator-exit",
+        span_id="span-generator-exit",
+        parent_id=None,
+        processor=DummyProcessor(),
+        span_data=AgentSpanData(name="generator-exit"),
+        tracing_api_key=None,
+    )
+
+
+_SPAN_FACTORIES = [_new_no_op_span, _new_span_impl]
+
+
+def _spanned_stream(new_span: Callable[[], Span[SpanData]]) -> AsyncGenerator[int, None]:
+    async def stream() -> AsyncGenerator[int, None]:
+        with new_span():
+            yield 1
+            yield 2
+
+    return stream()
+
+
+@pytest.mark.parametrize("new_span", _SPAN_FACTORIES)
+async def test_generator_close_in_the_same_task_releases_the_span_scope(
+    new_span: Callable[[], Span[SpanData]],
+) -> None:
+    """Closing a generator from the task that advanced it must restore the caller's span.
+
+    ``GeneratorExit`` unwinds the ``with`` block, but the token saved by ``start`` is still
+    valid here because the body resumes in the caller's own context. Skipping the reset
+    would leave the closed span current and nest every later span under it.
+    """
+    Scope.set_current_span(None)
+
+    generator = _spanned_stream(new_span)
+    assert await generator.asend(None) == 1
+    await generator.aclose()
+
+    assert Scope.get_current_span() is None
+
+
+@pytest.mark.parametrize("new_span", _SPAN_FACTORIES)
+async def test_generator_close_from_another_task_does_not_raise(
+    new_span: Callable[[], Span[SpanData]],
+) -> None:
+    """Abandoned async generators are finalized from whichever task runs ``aclose``.
+
+    The body then resumes in a context that never set the token, so ``ContextVar.reset``
+    raises ``ValueError``. That reset cannot succeed from there, and the caller keeps
+    seeing the span as current, so closing must at least not raise on top of it.
+    Disabled tracing must behave the same as enabled tracing here.
+    """
+    Scope.set_current_span(None)
+
+    generator = _spanned_stream(new_span)
+    assert await generator.asend(None) == 1
+    await asyncio.create_task(generator.aclose())
+
+    # The caller's own context still holds the span, which is the documented residue of
+    # finalizing from another task. Clear it so later tests do not inherit it.
+    Scope.set_current_span(None)
+
+
+@pytest.mark.parametrize("new_span", _SPAN_FACTORIES)
+async def test_explicit_finish_from_another_context_still_raises(
+    new_span: Callable[[], Span[SpanData]],
+) -> None:
+    """Only ``GeneratorExit`` cleanup tolerates a foreign token.
+
+    An explicit ``finish`` from a context that never set the token is a context-ownership
+    violation rather than an unavoidable one, so it must surface instead of silently
+    discarding the saved token.
+    """
+    Scope.set_current_span(None)
+
+    span = new_span()
+    span.start(mark_as_current=True)
+
+    async def finish_elsewhere() -> None:
+        with pytest.raises(ValueError):
+            span.finish(reset_current=True)
+
+    await asyncio.create_task(finish_elsewhere())
+
+    Scope.set_current_span(None)


### PR DESCRIPTION
`SpanImpl.__exit__` and `NoOpSpan.__exit__` passed `reset_current=False` whenever the `with` block unwound on `GeneratorExit`, so closing a generator from the task that advanced it left the ended span current and nested every span opened afterwards under it. The token saved by `start` is still valid on that path, because the generator body resumes in the caller's own context, so the reset both can and should run.

#4221 made exactly this correction at the trace level for `TraceImpl`, `ReattachedTrace`, and `NoOpTrace`, and the span level was left behind. This restores the pairing, with the tolerance narrowed to the reset itself: `finish` runs without the reset, and only `Scope.reset_current_span` is guarded, since that is the one call that can raise on a foreign token. Guarding the whole `finish` would swallow a processor that raises `ValueError` from `on_span_end`, which propagates on `main` today, so that would be a new regression rather than a fix.

Fail-before evidence, in both directions. With `src/agents/tracing/spans.py` reverted to `main` and the new tests kept, `test_generator_close_in_the_same_task_releases_the_span_scope` fails for both parameters with `assert <agents.tracing.spans.SpanImpl object at 0x...> is None`, giving 2 failed and 5 passed. With the helper written as a single `try` around the whole `finish` call instead, `test_generator_close_surfaces_processor_failure` fails with `Failed: DID NOT RAISE <class 'ValueError'>`. The committed form gives 7 passed, and the full suite plus `make lint` and `make typecheck` are green.
