### PR TITLE
fix(extensions): surface content filter refusals on the any_llm chat path

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -592,6 +592,19 @@ class AnyLLMModel(Model):
                 else Usage()
             )
 
+            # Some providers signal a filtered non-streaming completion only through
+            # finish_reason="content_filter" and an otherwise empty message. Preserve
+            # that terminal signal as a refusal instead of returning an empty output.
+            if (
+                message is not None
+                and first_choice is not None
+                and first_choice.finish_reason == "content_filter"
+                and not message.content
+                and not message.refusal
+                and not message.tool_calls
+            ):
+                message.refusal = "Response withheld by the provider's content filter."
+
             if tracing.include_data():
                 span_generation.span_data.output = (
                     [message.model_dump()] if message is not None else []

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -17,7 +17,12 @@ from openai.types.chat import (
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, ChoiceDelta
 from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
-from openai.types.responses import Response, ResponseCompletedEvent, ResponseOutputMessage
+from openai.types.responses import (
+    Response,
+    ResponseCompletedEvent,
+    ResponseOutputMessage,
+    ResponseOutputRefusal,
+)
 from openai.types.responses.response_created_event import ResponseCreatedEvent
 from openai.types.responses.response_error_event import ResponseErrorEvent
 from openai.types.responses.response_failed_event import ResponseFailedEvent
@@ -440,6 +445,82 @@ async def test_any_llm_chat_path_is_used_when_responses_are_unsupported(monkeypa
     assert response.output[0].content[0].text == "Hello"
     assert response.usage.input_tokens_details.cached_tokens == 2
     assert getattr(response.usage.input_tokens_details, "cache_write_tokens", None) == 4
+
+
+def _content_filtered_chat_completion(content: str) -> ChatCompletion:
+    completion = _chat_completion(content)
+    completion.choices[0].finish_reason = "content_filter"
+    return completion
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_path_surfaces_content_filter_refusal(monkeypatch) -> None:
+    """A filtered turn must become a refusal instead of an empty output."""
+    provider = FakeAnyLLMProvider(
+        supports_responses=False,
+        chat_response=_content_filtered_chat_completion(""),
+    )
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    response = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    refusals = [
+        content
+        for item in response.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert refusals, f"expected a refusal item, got: {response.output}"
+    assert refusals[0].refusal
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_path_content_filter_keeps_real_content(monkeypatch) -> None:
+    """A filtered turn that still carries text keeps the text and gains no refusal."""
+    provider = FakeAnyLLMProvider(
+        supports_responses=False,
+        chat_response=_content_filtered_chat_completion("here is the answer"),
+    )
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+    response = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    refusals = [
+        content
+        for item in response.output
+        if isinstance(item, ResponseOutputMessage)
+        for content in item.content
+        if isinstance(content, ResponseOutputRefusal)
+    ]
+    assert not refusals
+    assert response.output[0].content[0].text == "here is the answer"
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
Some providers signal a blocked non-streaming completion only with `finish_reason="content_filter"` and an otherwise empty message, with no `refusal` field set. On the any_llm chat completions path that message converts to zero output items, so the caller sees a turn that is indistinguishable from a normal empty response and an agent loop can retry it forever.

Both siblings already handle this. `OpenAIChatCompletionsModel.get_response` in `src/agents/models/openai_chatcompletions.py` synthesizes a refusal for exactly this shape, and `LitellmModel` does the same for its provider-specific field. The any_llm streaming path is already covered too, because it delegates to the shared `ChatCmplStreamHandler`, which raises the same refusal on a terminal `content_filter` chunk. Only the any_llm non-streaming path was missing it, so the same provider behaves differently depending on whether you stream.

This copies the OpenAI check verbatim, including its guards: the refusal is synthesized only when the message has no content, no existing refusal, and no tool calls, so a `content_filter` that still carried output is left alone. Two regression tests cover both cases. The empty one fails on `main` with `AssertionError: expected a refusal item, got: []` and passes with this change, and the non-empty one passes either way to pin the guard. `make lint` and `make typecheck` (mypy and pyright, 0 errors) are green, and `tests/models/test_any_llm_model.py` is 55 passed.
