### PR TITLE
fix(mcp): build the active server list without re-consuming the iterable

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -169,7 +169,7 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
         connect_in_parallel: bool = False,
     ) -> None:
         self._all_servers = list(servers)
-        self._active_servers = list(servers)
+        self._active_servers = list(self._all_servers)
         self.connect_timeout_seconds = connect_timeout_seconds
         self.cleanup_timeout_seconds = cleanup_timeout_seconds
         self.drop_failed_servers = drop_failed_servers

--- a/tests/mcp/test_mcp_server_manager.py
+++ b/tests/mcp/test_mcp_server_manager.py
@@ -833,3 +833,38 @@ async def test_manager_async_with_cleans_cancelled_server_when_unsuppressed() ->
     assert server.cleanup_calls == 1
     assert cancelled_server.cleanup_calls == 1
     assert cancelled_server.resource_open is False
+
+
+def test_manager_accepts_one_shot_iterables() -> None:
+    server_a = FlakyServer(failures=0)
+    server_b = FlakyServer(failures=0)
+
+    manager = MCPServerManager(iter([server_a, server_b]))
+
+    assert manager.all_servers == [server_a, server_b]
+    assert manager.active_servers == [server_a, server_b]
+
+
+@pytest.mark.asyncio
+async def test_manager_connects_servers_from_a_one_shot_iterable() -> None:
+    server_a = CleanupAwareServer()
+    server_b = CleanupAwareServer()
+
+    async with MCPServerManager(server for server in (server_a, server_b)) as manager:
+        assert manager.active_servers == [server_a, server_b]
+        assert server_a.connect_calls == 1
+        assert server_b.connect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_manager_restores_one_shot_iterable_servers_after_a_failed_connect() -> None:
+    server = FlakyServer(failures=1)
+
+    manager = MCPServerManager(iter([server]), strict=True, drop_failed_servers=False)
+
+    with pytest.raises(RuntimeError):
+        await manager.connect_all()
+
+    # drop_failed_servers=False keeps failed servers active, so the restored list must match
+    # what an equivalent list argument produces.
+    assert manager.active_servers == [server]


### PR DESCRIPTION
`MCPServerManager.__init__` accepts `Iterable[MCPServer]` but calls `list(servers)` twice, so a generator or any other one-shot iterable is already exhausted by the second call and `_active_servers` starts out empty. `_all_servers` is populated correctly by the first pass, so the second list should be built from it rather than from the caller's iterable again.

The empty list is observable straight after construction, and it also survives a real operation: when `connect_all` fails, the `drop_failed_servers=False` restore path replays the list captured at entry, so `active_servers` ends up empty where an equivalent `list` argument leaves it intact. After a successful `connect_all` the value is masked, because `_refresh_active_servers` rebuilds it from `_all_servers`.

Fail-before evidence: with `src/agents/mcp/manager.py` reverted to `main` and the new tests kept, `test_manager_accepts_one_shot_iterables` and `test_manager_restores_one_shot_iterable_servers_after_a_failed_connect` both fail with `assert [] == [<tests.mcp.test_mcp_server_manager.FlakyServer object at 0x...>]`. The third new test covers the successful `async with` path and passes either way, so it is a regression guard rather than a reproducer. With the fix all 62 tests in `tests/mcp/test_mcp_server_manager.py` pass, and `make lint` and `make typecheck` are green.
