### PR TITLE
fix(streaming): assemble chat completions content parts in content index order

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -1205,10 +1205,17 @@ class ChatCmplStreamHandler:
             )
             if state.provider_data:
                 assistant_msg.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+            # Assemble the parts in the order of the content indexes already announced by
+            # the content_part events. A refusal that opened before any text holds index 0
+            # and the text holds index 1, so appending text first would contradict the
+            # indexes consumers already received.
+            content_parts: list[tuple[int, ResponseOutputText | ResponseOutputRefusal]] = []
             if state.text_content_index_and_output:
-                assistant_msg.content.append(state.text_content_index_and_output[1])
+                content_parts.append(state.text_content_index_and_output)
             if state.refusal_content_index_and_output:
-                assistant_msg.content.append(state.refusal_content_index_and_output[1])
+                content_parts.append(state.refusal_content_index_and_output)
+            content_parts.sort(key=lambda entry: entry[0])
+            assistant_msg.content.extend(part for _, part in content_parts)
             outputs.append(assistant_msg)
 
             # send a ResponseOutputItemDone for the assistant message

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1326,6 +1326,13 @@ async def test_stream_handler_places_text_after_existing_refusal_part() -> None:
 
     events = await _collect_handler_events(*chunks)
 
+    refusal_part_added = next(
+        event
+        for event in events
+        if event.type == "response.content_part.added"
+        and isinstance(event.part, ResponseOutputRefusal)
+    )
+    assert refusal_part_added.content_index == 0
     text_part_added = next(
         event
         for event in events
@@ -1337,10 +1344,12 @@ async def test_stream_handler_places_text_after_existing_refusal_part() -> None:
     completed_event = next(event for event in events if event.type == "response.completed")
     assistant_item = completed_event.response.output[0]
     assert isinstance(assistant_item, ResponseOutputMessage)
-    assert isinstance(assistant_item.content[0], ResponseOutputText)
-    assert isinstance(assistant_item.content[1], ResponseOutputRefusal)
-    assert assistant_item.content[0].text == "partial"
-    assert assistant_item.content[1].refusal == "blocked"
+    # The completed content must line up with the content indexes announced above: the
+    # refusal opened first at index 0 and the text followed at index 1.
+    assert isinstance(assistant_item.content[0], ResponseOutputRefusal)
+    assert isinstance(assistant_item.content[1], ResponseOutputText)
+    assert assistant_item.content[0].refusal == "blocked"
+    assert assistant_item.content[1].text == "partial"
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
`ChatCmplStreamHandler` assigns content indexes in the order the parts open: a refusal delta that arrives before any text delta gets `content_index=0` and the later text gets `content_index=1`. The completed assistant message, however, always appended the text part first and the refusal second, so `response.completed` contradicted the `content_part.added`, `output_text.delta`, and `refusal.delta` events consumers had already received. A consumer that uses `content_index` to index into the finished message's `content` list reads the wrong part.

The fix sorts the two parts by their already-assigned content index before appending them. Text-first streams are unchanged because the text part already holds index 0 there, so this only affects the refusal-before-text ordering that was inconsistent to begin with.

`tests/models/test_openai_chatcompletions_stream.py::test_stream_handler_places_text_after_existing_refusal_part` already streams a refusal chunk followed by a text chunk and already asserts that the text part is announced at `content_index == 1`. It then asserted the contradictory completed layout, which is the bug rather than intended behavior, so this updates it to require the completed content to line up with the announced indexes and adds the matching assertion that the refusal was announced at index 0. It fails on `main` with `AssertionError: assert False, where False = isinstance(ResponseOutputText(...), ResponseOutputRefusal)` and passes with this change.

`make lint` and `make typecheck` (mypy and pyright, 0 errors) are green, and the full suite is 6672 passed with 32 skipped. This is a refile of #3822 by @felmonon, which the stale bot closed for inactivity rather than on the merits. It is also the ordering issue @AmirF194 explicitly scoped out of #3757, calling it a separate pre-existing bug on main, so #4177 landing did not cover it.