### PR TITLE
fix(run): copy raw_responses when building a RunState

### DIFF
--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -131,7 +131,7 @@ def _populate_state_from_result(
         snapshot_refs,
     )
     state._nested_history_owned_session_item_refs = live_refs
-    state._model_responses = result.raw_responses
+    state._model_responses = list(result.raw_responses)
     state._input_guardrail_results = result.input_guardrail_results
     state._output_guardrail_results = result.output_guardrail_results
     state._tool_input_guardrail_results = result.tool_input_guardrail_results

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -3178,6 +3178,27 @@ class TestRunStateResumption:
         assert result2.final_output == "Second response"
 
     @pytest.mark.asyncio
+    async def test_resume_from_run_state_does_not_mutate_source_result(self):
+        """Resuming from a state must not append to the raw_responses already returned."""
+        model = FakeModel()
+        agent = Agent(name="TestAgent", model=model)
+
+        model.set_next_output([get_text_message("First response")])
+        result1 = await Runner.run(agent, "First input")
+        assert len(result1.raw_responses) == 1
+
+        state = result1.to_state()
+
+        model.set_next_output([get_text_message("Second response")])
+        result2 = await Runner.run(agent, state)
+
+        # The second run accumulates on top of the first, but the RunResult that was
+        # already handed back to the caller must keep only its own response.
+        assert len(result2.raw_responses) == 2
+        assert len(result1.raw_responses) == 1
+        assert result1.raw_responses is not result2.raw_responses
+
+    @pytest.mark.asyncio
     async def test_resume_from_run_state_with_context(self):
         """Test resuming a run from a RunState with context override."""
         model = FakeModel()


### PR DESCRIPTION
`to_state()` assigns `result.raw_responses` straight onto the new `RunState`, so the state and the already-returned `RunResult` share one list object. Resuming that state through `Runner.run()` appends the next turn's `ModelResponse` onto that shared list, which silently grows the `raw_responses` of a `RunResult` the caller was handed earlier. The assignment one line above it in the same function copies with `list(result.new_items)`, and the resume block in `run.py` copies `session_items` and the three guardrail result lists out of the run state the same way, so this line was the lone outlier. The fix copies the list.

This is distinct from #3924, which was closed because it changed the `_model_input_items` fallback branch that is unreachable for SDK-created results. This line is not branch guarded and reproduces through the plain public API. On main the new test fails with `assert 2 == 1`, because `result1.raw_responses` grows from one response to two after a second `Runner.run()` resumes the state. The streamed path is unaffected because `run_loop.py` rebinds `streamed_result.raw_responses` to a newly concatenated list rather than appending in place, so only the `Runner.run()` resume path shows the bug. `make lint`, `make typecheck`, and `make tests` all pass.
