### PR TITLE
fix(tools): annotate the bare tool guardrail decorator overloads

### DIFF
--- a/src/agents/tool_guardrails.py
+++ b/src/agents/tool_guardrails.py
@@ -212,11 +212,11 @@ _ToolInputFuncAsync = Callable[[ToolInputGuardrailData], Awaitable[ToolGuardrail
 
 
 @overload
-def tool_input_guardrail(func: _ToolInputFuncSync): ...
+def tool_input_guardrail(func: _ToolInputFuncSync) -> ToolInputGuardrail[Any]: ...
 
 
 @overload
-def tool_input_guardrail(func: _ToolInputFuncAsync): ...
+def tool_input_guardrail(func: _ToolInputFuncAsync) -> ToolInputGuardrail[Any]: ...
 
 
 @overload
@@ -248,11 +248,11 @@ _ToolOutputFuncAsync = Callable[[ToolOutputGuardrailData], Awaitable[ToolGuardra
 
 
 @overload
-def tool_output_guardrail(func: _ToolOutputFuncSync): ...
+def tool_output_guardrail(func: _ToolOutputFuncSync) -> ToolOutputGuardrail[Any]: ...
 
 
 @overload
-def tool_output_guardrail(func: _ToolOutputFuncAsync): ...
+def tool_output_guardrail(func: _ToolOutputFuncAsync) -> ToolOutputGuardrail[Any]: ...
 
 
 @overload

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,4 +1,5 @@
 import types
+from typing import Any
 
 from typing_extensions import assert_type
 
@@ -6,6 +7,7 @@ import agents.decorators as decorators_module
 import agents.tool as tool_module
 from agents import (
     FunctionTool,
+    ToolGuardrailFunctionOutput,
     function_tool,
     input_guardrail,
     output_guardrail,
@@ -13,6 +15,12 @@ from agents import (
     tool_output_guardrail,
 )
 from agents.decorators import function_tool as decorators_function_tool, tool
+from agents.tool_guardrails import (
+    ToolInputGuardrail,
+    ToolInputGuardrailData,
+    ToolOutputGuardrail,
+    ToolOutputGuardrailData,
+)
 
 
 def test_decorator_module_preserves_existing_imports_and_identities() -> None:
@@ -40,3 +48,30 @@ def test_tool_alias_supports_bare_and_configured_decorator_forms() -> None:
     assert_type(configured_alias, FunctionTool)
     assert bare_alias.name == "bare_alias"
     assert configured_alias.name == "configured_alias"
+
+
+def test_tool_guardrail_decorators_keep_their_type_in_bare_form() -> None:
+    @tool_input_guardrail
+    def bare_input(data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow()
+
+    @tool_input_guardrail(name="configured_input")
+    def configured_input(data: ToolInputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow()
+
+    @tool_output_guardrail
+    def bare_output(data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow()
+
+    @tool_output_guardrail(name="configured_output")
+    def configured_output(data: ToolOutputGuardrailData) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow()
+
+    assert_type(bare_input, ToolInputGuardrail[Any])
+    assert_type(configured_input, ToolInputGuardrail[Any])
+    assert_type(bare_output, ToolOutputGuardrail[Any])
+    assert_type(configured_output, ToolOutputGuardrail[Any])
+    assert bare_input.get_name() == "bare_input"
+    assert configured_input.get_name() == "configured_input"
+    assert bare_output.get_name() == "bare_output"
+    assert configured_output.get_name() == "configured_output"


### PR DESCRIPTION
The two bare-call overloads of `tool_input_guardrail` and `tool_output_guardrail` declare no return type, so a guardrail written as `@tool_input_guardrail` resolves to `Any` and silently loses type checking everywhere it is used. The `input_guardrail` and `output_guardrail` decorators in `guardrail.py` annotate their equivalent two overloads with the guardrail type, and the keyword-form overload in this same file already returns `ToolInputGuardrail[Any]`, so these four were the outliers. An AST scan of `src/agents` finds these are the only four `@overload` declarations in the package with no return annotation, so this covers the whole class. The annotations match what the implementation already returns.

The new test in `tests/test_decorators.py` follows the `assert_type` pattern the file already uses for the `tool` alias. On main it fails typecheck with `Expression is of type "Any", not "ToolInputGuardrail[Any]"` for the two bare forms while the two keyword forms pass, which isolates the missing annotations. Runtime behavior is unchanged. `make lint`, `make typecheck`, and `make tests` all pass.
