### PR TITLE
fix(run): keep tool guardrail results when a resumed run interrupts again

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1015,6 +1015,12 @@ class AgentRunner:
                                 append_model_response_if_new(
                                     model_responses, turn_result.model_response
                                 )
+                                tool_input_guardrail_results.extend(
+                                    turn_result.tool_input_guardrail_results
+                                )
+                                tool_output_guardrail_results.extend(
+                                    turn_result.tool_output_guardrail_results
+                                )
                                 processed_response_for_state = resolve_processed_response(
                                     run_state=run_state,
                                     processed_response=turn_result.processed_response,
@@ -1035,12 +1041,8 @@ class AgentRunner:
                                     model_responses=model_responses,
                                     current_agent=current_agent,
                                     input_guardrail_results=input_guardrail_results,
-                                    tool_input_guardrail_results=(
-                                        turn_result.tool_input_guardrail_results
-                                    ),
-                                    tool_output_guardrail_results=(
-                                        turn_result.tool_output_guardrail_results
-                                    ),
+                                    tool_input_guardrail_results=tool_input_guardrail_results,
+                                    tool_output_guardrail_results=tool_output_guardrail_results,
                                     context_wrapper=context_wrapper,
                                     interruptions=approvals_from_step(turn_result.next_step),
                                     processed_response=processed_response_for_state,

--- a/tests/test_runner_guardrail_resume.py
+++ b/tests/test_runner_guardrail_resume.py
@@ -1,13 +1,19 @@
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
+from openai.types.responses import ResponseFunctionToolCall
 
 import agents.run as run_module
 from agents import Agent, Runner
 from agents.guardrail import GuardrailFunctionOutput, InputGuardrail, InputGuardrailResult
-from agents.items import ModelResponse
+from agents.items import ModelResponse, ToolApprovalItem
 from agents.run_context import RunContextWrapper
-from agents.run_internal.run_steps import NextStepFinalOutput, SingleStepResult
+from agents.run_internal.run_steps import (
+    NextStepFinalOutput,
+    NextStepInterruption,
+    SingleStepResult,
+)
 from agents.run_state import RunState
 from agents.tool_guardrails import (
     AllowBehavior,
@@ -142,6 +148,132 @@ async def test_runner_resume_preserves_guardrail_results(monkeypatch: pytest.Mon
     assert [res.guardrail.get_name() for res in result.input_guardrail_results] == [
         "state_input_guardrail"
     ]
+    assert [res.guardrail.get_name() for res in result.tool_input_guardrail_results] == [
+        "state_tool_input_guardrail",
+        "new_tool_input_guardrail",
+    ]
+    assert [res.guardrail.get_name() for res in result.tool_output_guardrail_results] == [
+        "state_tool_output_guardrail",
+        "new_tool_output_guardrail",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_resume_preserves_guardrail_results_on_reinterruption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resumed run that interrupts again must keep the tool guardrail results it carried in."""
+    agent = Agent(name="agent", model=FakeModel())
+    context_wrapper: RunContextWrapper[dict[str, Any]] = RunContextWrapper(context={})
+
+    tool_input_guardrail: ToolInputGuardrail[Any] = ToolInputGuardrail(
+        guardrail_function=lambda data: ToolGuardrailFunctionOutput(
+            output_info={"source": "state"},
+            behavior=AllowBehavior(type="allow"),
+        ),
+        name="state_tool_input_guardrail",
+    )
+    tool_output_guardrail: ToolOutputGuardrail[Any] = ToolOutputGuardrail(
+        guardrail_function=lambda data: ToolGuardrailFunctionOutput(
+            output_info={"source": "state"},
+            behavior=AllowBehavior(type="allow"),
+        ),
+        name="state_tool_output_guardrail",
+    )
+    initial_tool_input_result = ToolInputGuardrailResult(
+        guardrail=tool_input_guardrail,
+        output=ToolGuardrailFunctionOutput(
+            output_info={"source": "state"},
+            behavior=AllowBehavior(type="allow"),
+        ),
+    )
+    initial_tool_output_result = ToolOutputGuardrailResult(
+        guardrail=tool_output_guardrail,
+        output=ToolGuardrailFunctionOutput(
+            output_info={"source": "state"},
+            behavior=AllowBehavior(type="allow"),
+        ),
+    )
+
+    model_response = ModelResponse(output=[], usage=Usage(), response_id="resp-interrupted")
+    processed_response = cast(Any, SimpleNamespace(tools_used=[], new_items=[]))
+
+    run_state = RunState(
+        context=context_wrapper,
+        original_input="hello",
+        starting_agent=agent,
+        max_turns=3,
+    )
+    run_state._tool_input_guardrail_results = [initial_tool_input_result]
+    run_state._tool_output_guardrail_results = [initial_tool_output_result]
+    run_state._model_responses = [model_response]
+    run_state._last_processed_response = processed_response
+
+    pending_approval = ToolApprovalItem(
+        agent=agent,
+        raw_item=ResponseFunctionToolCall(
+            id="call-pending",
+            call_id="call-pending",
+            name="pending_tool",
+            arguments="{}",
+            type="function_call",
+        ),
+    )
+    run_state._current_step = NextStepInterruption(interruptions=[pending_approval])
+
+    new_tool_input_result = ToolInputGuardrailResult(
+        guardrail=ToolInputGuardrail(
+            guardrail_function=lambda data: ToolGuardrailFunctionOutput(
+                output_info={"source": "new"},
+                behavior=AllowBehavior(type="allow"),
+            ),
+            name="new_tool_input_guardrail",
+        ),
+        output=ToolGuardrailFunctionOutput(
+            output_info={"source": "new"},
+            behavior=AllowBehavior(type="allow"),
+        ),
+    )
+    new_tool_output_result = ToolOutputGuardrailResult(
+        guardrail=ToolOutputGuardrail(
+            guardrail_function=lambda data: ToolGuardrailFunctionOutput(
+                output_info={"source": "new"},
+                behavior=AllowBehavior(type="allow"),
+            ),
+            name="new_tool_output_guardrail",
+        ),
+        output=ToolGuardrailFunctionOutput(
+            output_info={"source": "new"},
+            behavior=AllowBehavior(type="allow"),
+        ),
+    )
+
+    async def fake_resolve_interrupted_turn(**_: object) -> SingleStepResult:
+        return SingleStepResult(
+            original_input="hello",
+            model_response=model_response,
+            pre_step_items=[],
+            new_step_items=[],
+            next_step=NextStepInterruption(interruptions=[pending_approval]),
+            tool_input_guardrail_results=[new_tool_input_result],
+            tool_output_guardrail_results=[new_tool_output_result],
+        )
+
+    async def fake_get_all_tools(*_: object, **__: object) -> list[object]:
+        return []
+
+    async def fake_initialize_computer_tools(
+        *args: object, tools: list[object], **kwargs: object
+    ) -> list[object]:
+        return tools
+
+    monkeypatch.setattr(run_module, "resolve_interrupted_turn", fake_resolve_interrupted_turn)
+    monkeypatch.setattr(run_module, "get_all_tools", fake_get_all_tools)
+    monkeypatch.setattr(run_module, "initialize_computer_tools", fake_initialize_computer_tools)
+
+    result = await Runner.run(agent, run_state)
+
+    assert result.interruptions
     assert [res.guardrail.get_name() for res in result.tool_input_guardrail_results] == [
         "state_tool_input_guardrail",
         "new_tool_input_guardrail",


### PR DESCRIPTION
When a resumed run interrupts a second time, every tool guardrail result carried over from the previous run is lost. The resumed interruption branch in `AgentRunner.run` builds its `RunResult` from the turn-local `turn_result.tool_input_guardrail_results` and `turn_result.tool_output_guardrail_results`, then returns immediately, so it never reaches the run-wide `extend` a few lines below. Those run-wide lists are the ones hydrated from `RunState._tool_input_guardrail_results` and `_tool_output_guardrail_results` at the top of the run, so the carried-over results are silently dropped.

The non-resumed interruption path in the same function already passes the accumulated lists, and the streamed path accumulates them too since #4097, so this branch was the outlier. The fix extends the accumulated lists with the turn's results and passes those, matching both siblings. The new test in `tests/test_runner_guardrail_resume.py` mirrors the existing resume test in that file but ends in a second interruption instead of a final output. On main it fails with `assert ['new_tool_input_guardrail'] == ['state_tool_input_guardrail', 'new_tool_input_guardrail']`, and the existing final-output test keeps passing, which isolates the failure to the re-interruption path. `make lint`, `make typecheck`, and `make tests` all pass.
