### PR TITLE
test(sandbox): cover the e2b and runloop cloud bucket mount strategies

### DIFF
--- a/tests/extensions/sandbox/test_e2b.py
+++ b/tests/extensions/sandbox/test_e2b.py
@@ -10,7 +10,7 @@ import shlex
 import tarfile
 import uuid
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import pytest
 from pydantic import Field, PrivateAttr
@@ -486,6 +486,9 @@ class _FakeMountSession(BaseSandboxSession):
         )
         self._results = list(results or [])
         self.exec_calls: list[str] = []
+        # A single ordered timeline shared with the delegate recorder further down, so
+        # that sequencing between sandbox preparation and delegation can be asserted.
+        self.events: list[str] = []
 
     async def _exec_internal(
         self,
@@ -495,6 +498,7 @@ class _FakeMountSession(BaseSandboxSession):
         _ = timeout
         cmd_str = " ".join(str(c) for c in command)
         self.exec_calls.append(cmd_str)
+        self.events.append(f"exec:{cmd_str}")
         if self._results:
             return self._results.pop(0)
         return ExecResult(stdout=b"", stderr=b"", exit_code=0)
@@ -2652,3 +2656,165 @@ async def test_e2b_pty_start_maps_missing_sandbox_not_found_to_transport_error(
     assert exc_info.value.context["provider_error"] == "The sandbox was not found: request failed"
     assert exc_info.value.context["reason"] == "_FakeNotFound"
     assert exc_info.value.retryable is False
+
+
+class _RecordingDelegate:
+    """Records delegate calls onto the session's own timeline.
+
+    Recording into ``session.events`` rather than a separate list is what makes the
+    ordering assertions real: if delegation were moved ahead of FUSE or rclone
+    preparation, the delegate entry would no longer be last in the timeline.
+    """
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.calls: list[tuple[str, RcloneMountPattern]] = []
+        recorder = self
+
+        def _make(name: str) -> Any:
+            async def _hook(self: Any, mount: Any, session: Any, *args: Any) -> list[Any]:
+                _ = (mount, args)
+                session.events.append(f"delegate:{name}")
+                recorder.calls.append((name, self.pattern))
+                return []
+
+            return _hook
+
+        for name in ("activate", "deactivate", "teardown_for_snapshot", "restore_after_snapshot"):
+            monkeypatch.setattr(InContainerMountStrategy, name, _make(name))
+
+
+def _bucket_mount() -> S3Mount:
+    return S3Mount(bucket="my-bucket", mount_strategy=E2BCloudBucketMountStrategy())
+
+
+@pytest.mark.asyncio
+async def test_e2b_ensure_fuse_raises_when_fuse_is_unavailable() -> None:
+    session = _FakeMountSession([_exec_fail()])
+
+    with pytest.raises(MountConfigError, match="FUSE support"):
+        await _ensure_fuse_support(session)
+
+    # The chmod must not run once the capability check has failed.
+    assert len(session.exec_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_e2b_ensure_fuse_raises_when_chmod_fails() -> None:
+    session = _FakeMountSession([_exec_ok(), _exec_fail()])
+
+    with pytest.raises(MountConfigError, match="/dev/fuse accessible") as exc_info:
+        await _ensure_fuse_support(session)
+
+    assert exc_info.value.context["exit_code"] == 1
+
+
+@pytest.mark.asyncio
+async def test_e2b_activate_prepares_fuse_and_rclone_before_delegating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fuse mount needs FUSE and rclone in place before the delegate runs."""
+    delegate = _RecordingDelegate(monkeypatch)
+    session = _FakeMountSession()
+    strategy = E2BCloudBucketMountStrategy()
+
+    await strategy.activate(_bucket_mount(), session, Path("/workspace/b"), Path("/tmp"))
+
+    # Delegation is the final step, after every preparation command.
+    assert session.events[-1] == "delegate:activate"
+    assert session.events.count("delegate:activate") == 1
+    prepared = session.events[:-1]
+    assert any("/dev/fuse" in event for event in prepared)
+    assert any("rclone" in event for event in prepared)
+    # The session-resolved pattern carries the fuse access args the raw pattern lacks.
+    assert "--allow-other" in delegate.calls[0][1].extra_args
+
+
+@pytest.mark.asyncio
+async def test_e2b_activate_skips_fuse_setup_for_nfs_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only fuse mounts need /dev/fuse, but every mode still needs rclone."""
+    delegate = _RecordingDelegate(monkeypatch)
+    session = _FakeMountSession()
+    strategy = E2BCloudBucketMountStrategy(pattern=RcloneMountPattern(mode="nfs"))
+
+    await strategy.activate(_bucket_mount(), session, Path("/workspace/b"), Path("/tmp"))
+
+    assert not any("/dev/fuse" in event for event in session.events)
+    assert any("rclone" in event for event in session.events)
+    # nfs still reaches the delegate, carrying the nfs pattern untouched.
+    assert session.events[-1] == "delegate:activate"
+    assert [name for name, _ in delegate.calls] == ["activate"]
+    delegated_pattern = delegate.calls[0][1]
+    assert delegated_pattern.mode == "nfs"
+    assert "--allow-other" not in delegated_pattern.extra_args
+
+
+@pytest.mark.asyncio
+async def test_e2b_restore_after_snapshot_reprepares_the_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restored sandbox may be a fresh container, so setup has to run again."""
+    delegate = _RecordingDelegate(monkeypatch)
+    session = _FakeMountSession()
+    strategy = E2BCloudBucketMountStrategy()
+
+    await strategy.restore_after_snapshot(_bucket_mount(), session, Path("/workspace/b"))
+
+    assert session.events[-1] == "delegate:restore_after_snapshot"
+    prepared = session.events[:-1]
+    assert any("/dev/fuse" in event for event in prepared)
+    assert any("rclone" in event for event in prepared)
+    assert "--allow-other" in delegate.calls[0][1].extra_args
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["deactivate", "teardown_for_snapshot"])
+async def test_e2b_teardown_paths_do_not_reinstall_tooling(
+    monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
+    """Unmounting must not try to install FUSE or rclone on the way out."""
+    delegate = _RecordingDelegate(monkeypatch)
+    session = _FakeMountSession()
+    strategy = E2BCloudBucketMountStrategy()
+
+    if method == "deactivate":
+        await strategy.deactivate(_bucket_mount(), session, Path("/workspace/b"), Path("/tmp"))
+    else:
+        await strategy.teardown_for_snapshot(_bucket_mount(), session, Path("/workspace/b"))
+
+    assert session.events == [f"delegate:{method}"]
+    assert [name for name, _ in delegate.calls] == [method]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method", ["activate", "deactivate", "teardown_for_snapshot", "restore_after_snapshot"]
+)
+async def test_e2b_strategy_rejects_a_foreign_session_before_touching_it(method: str) -> None:
+    """The session guard must run before any command is issued."""
+
+    class _WrongSession(_FakeMountSession):
+        pass
+
+    _WrongSession.__name__ = "NotAnE2BSession"
+    session = _WrongSession()
+    strategy = E2BCloudBucketMountStrategy()
+    mount = _bucket_mount()
+
+    with pytest.raises(MountConfigError, match="E2BSandboxSession"):
+        if method == "activate":
+            await strategy.activate(mount, session, Path("/w/b"), Path("/tmp"))
+        elif method == "deactivate":
+            await strategy.deactivate(mount, session, Path("/w/b"), Path("/tmp"))
+        elif method == "teardown_for_snapshot":
+            await strategy.teardown_for_snapshot(mount, session, Path("/w/b"))
+        else:
+            await strategy.restore_after_snapshot(mount, session, Path("/w/b"))
+
+    # The guard runs before anything is issued to the foreign sandbox.
+    assert session.events == []
+
+
+def test_e2b_strategy_has_no_docker_volume_driver_config() -> None:
+    assert E2BCloudBucketMountStrategy().build_docker_volume_driver_config(_bucket_mount()) is None

--- a/tests/extensions/sandbox/test_runloop_mounts.py
+++ b/tests/extensions/sandbox/test_runloop_mounts.py
@@ -10,6 +10,7 @@ import pytest
 
 from agents.sandbox import Manifest
 from agents.sandbox.entries import RcloneMountPattern, S3Mount
+from agents.sandbox.entries.mounts.base import InContainerMountStrategy
 from agents.sandbox.errors import MountConfigError
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.types import ExecResult
@@ -26,6 +27,9 @@ class _FakeRunloopMountSession(BaseSandboxSession):
         )
         self._results = list(results or [])
         self.exec_calls: list[str] = []
+        # A single ordered timeline shared with the delegate recorder below, so that
+        # sequencing between sandbox preparation and delegation can actually be asserted.
+        self.events: list[str] = []
 
     async def _exec_internal(
         self,
@@ -35,6 +39,7 @@ class _FakeRunloopMountSession(BaseSandboxSession):
         _ = timeout
         cmd_str = " ".join(str(c) for c in command)
         self.exec_calls.append(cmd_str)
+        self.events.append(f"exec:{cmd_str}")
         if self._results:
             return self._results.pop(0)
         return ExecResult(stdout=b"", stderr=b"", exit_code=0)
@@ -224,3 +229,241 @@ async def test_runloop_rclone_pattern_adds_fuse_access_args() -> None:
     pattern = await rclone_pattern_for_session(session, RcloneMountPattern(mode="fuse"))
 
     assert pattern.extra_args == ["--allow-other", "--uid", "1000", "--gid", "1000"]
+
+
+def _bucket_mount() -> S3Mount:
+    from agents.extensions.sandbox.runloop.mounts import RunloopCloudBucketMountStrategy
+
+    return S3Mount(bucket="my-bucket", mount_strategy=RunloopCloudBucketMountStrategy())
+
+
+class _RecordingDelegate:
+    """Records delegate calls onto the session's own timeline.
+
+    Recording into ``session.events`` rather than a separate list is what makes the
+    ordering assertions real: if delegation were moved ahead of FUSE or rclone
+    preparation, the delegate entry would no longer be last in the timeline.
+    """
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.calls: list[tuple[str, RcloneMountPattern]] = []
+        recorder = self
+
+        def _make(name: str) -> Any:
+            async def _hook(
+                self: Any,
+                mount: Any,
+                session: Any,
+                *args: Any,
+            ) -> list[Any]:
+                _ = (mount, args)
+                session.events.append(f"delegate:{name}")
+                recorder.calls.append((name, self.pattern))
+                return []
+
+            return _hook
+
+        for name in ("activate", "deactivate", "teardown_for_snapshot", "restore_after_snapshot"):
+            monkeypatch.setattr(InContainerMountStrategy, name, _make(name))
+
+
+@pytest.mark.asyncio
+async def test_runloop_ensure_fuse_requires_dev_fuse() -> None:
+    from agents.extensions.sandbox.runloop.mounts import _ensure_fuse_support
+
+    session = _FakeRunloopMountSession([_exec_fail()])
+
+    with pytest.raises(MountConfigError, match="FUSE support") as exc_info:
+        await _ensure_fuse_support(session)
+
+    assert exc_info.value.context["missing"] == "/dev/fuse"
+    assert len(session.exec_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_runloop_ensure_fuse_requires_the_kernel_module() -> None:
+    from agents.extensions.sandbox.runloop.mounts import _ensure_fuse_support
+
+    session = _FakeRunloopMountSession([_exec_ok(), _exec_fail()])
+
+    with pytest.raises(MountConfigError, match="FUSE support") as exc_info:
+        await _ensure_fuse_support(session)
+
+    assert exc_info.value.context["missing"] == "fuse in /proc/filesystems"
+
+
+@pytest.mark.asyncio
+async def test_runloop_ensure_fuse_requires_apt_when_fusermount_is_missing() -> None:
+    from agents.extensions.sandbox.runloop.mounts import _ensure_fuse_support
+
+    session = _FakeRunloopMountSession([_exec_ok(), _exec_ok(), _exec_fail(), _exec_fail()])
+
+    with pytest.raises(MountConfigError, match="apt-get is unavailable") as exc_info:
+        await _ensure_fuse_support(session)
+
+    assert exc_info.value.context["package"] == "fuse3"
+
+
+@pytest.mark.asyncio
+async def test_runloop_ensure_fuse_reports_a_failed_install() -> None:
+    from agents.extensions.sandbox.runloop.mounts import _ensure_fuse_support
+
+    session = _FakeRunloopMountSession(
+        [_exec_ok(), _exec_ok(), _exec_fail(), _exec_ok(), _exec_fail()]
+    )
+
+    with pytest.raises(MountConfigError, match="failed to install fuse3") as exc_info:
+        await _ensure_fuse_support(session)
+
+    assert exc_info.value.context["exit_code"] == 1
+
+
+@pytest.mark.asyncio
+async def test_runloop_ensure_fuse_raises_when_fusermount_missing_after_install() -> None:
+    from agents.extensions.sandbox.runloop.mounts import _ensure_fuse_support
+
+    session = _FakeRunloopMountSession(
+        [_exec_ok(), _exec_ok(), _exec_fail(), _exec_ok(), _exec_ok(), _exec_ok(), _exec_fail()]
+    )
+
+    with pytest.raises(MountConfigError, match="still not available"):
+        await _ensure_fuse_support(session)
+
+
+@pytest.mark.asyncio
+async def test_runloop_ensure_fuse_reports_a_failed_chmod() -> None:
+    from agents.extensions.sandbox.runloop.mounts import _ensure_fuse_support
+
+    session = _FakeRunloopMountSession(
+        [_exec_ok(), _exec_ok(), _exec_ok(), _exec_ok(), _exec_fail()]
+    )
+
+    with pytest.raises(MountConfigError, match="/dev/fuse accessible") as exc_info:
+        await _ensure_fuse_support(session)
+
+    assert exc_info.value.context["exit_code"] == 1
+
+
+@pytest.mark.asyncio
+async def test_runloop_activate_prepares_fuse_and_rclone_before_delegating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agents.extensions.sandbox.runloop.mounts import RunloopCloudBucketMountStrategy
+
+    delegate = _RecordingDelegate(monkeypatch)
+    session = _FakeRunloopMountSession()
+
+    await RunloopCloudBucketMountStrategy().activate(
+        _bucket_mount(), session, Path("/workspace/b"), Path("/tmp")
+    )
+
+    # Delegation is the final step, after every preparation command.
+    assert session.events[-1] == "delegate:activate"
+    assert session.events.count("delegate:activate") == 1
+    prepared = session.events[:-1]
+    assert any("/dev/fuse" in event for event in prepared)
+    assert any("rclone" in event for event in prepared)
+    # The delegate receives the session-resolved pattern, not the raw one.
+    assert "--allow-other" in delegate.calls[0][1].extra_args
+
+
+@pytest.mark.asyncio
+async def test_runloop_activate_skips_fuse_setup_for_nfs_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agents.extensions.sandbox.runloop.mounts import RunloopCloudBucketMountStrategy
+
+    delegate = _RecordingDelegate(monkeypatch)
+    session = _FakeRunloopMountSession()
+    strategy = RunloopCloudBucketMountStrategy(pattern=RcloneMountPattern(mode="nfs"))
+
+    await strategy.activate(_bucket_mount(), session, Path("/workspace/b"), Path("/tmp"))
+
+    assert not any("/dev/fuse" in event for event in session.events)
+    assert any("rclone" in event for event in session.events)
+    # nfs still reaches the delegate, carrying the nfs pattern untouched.
+    assert session.events[-1] == "delegate:activate"
+    assert [name for name, _ in delegate.calls] == ["activate"]
+    delegated_pattern = delegate.calls[0][1]
+    assert delegated_pattern.mode == "nfs"
+    assert "--allow-other" not in delegated_pattern.extra_args
+
+
+@pytest.mark.asyncio
+async def test_runloop_restore_after_snapshot_reprepares_the_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restored devbox may be a fresh container, so setup has to run again."""
+    from agents.extensions.sandbox.runloop.mounts import RunloopCloudBucketMountStrategy
+
+    delegate = _RecordingDelegate(monkeypatch)
+    session = _FakeRunloopMountSession()
+
+    await RunloopCloudBucketMountStrategy().restore_after_snapshot(
+        _bucket_mount(), session, Path("/workspace/b")
+    )
+
+    assert session.events[-1] == "delegate:restore_after_snapshot"
+    prepared = session.events[:-1]
+    assert any("/dev/fuse" in event for event in prepared)
+    assert any("rclone" in event for event in prepared)
+    assert "--allow-other" in delegate.calls[0][1].extra_args
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["deactivate", "teardown_for_snapshot"])
+async def test_runloop_teardown_paths_do_not_reinstall_tooling(
+    monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
+    """Unmounting must not try to install FUSE or rclone on the way out."""
+    from agents.extensions.sandbox.runloop.mounts import RunloopCloudBucketMountStrategy
+
+    delegate = _RecordingDelegate(monkeypatch)
+    session = _FakeRunloopMountSession()
+    strategy = RunloopCloudBucketMountStrategy()
+    mount = _bucket_mount()
+
+    if method == "deactivate":
+        await strategy.deactivate(mount, session, Path("/workspace/b"), Path("/tmp"))
+    else:
+        await strategy.teardown_for_snapshot(mount, session, Path("/workspace/b"))
+
+    assert session.events == [f"delegate:{method}"]
+    assert [name for name, _ in delegate.calls] == [method]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method", ["activate", "deactivate", "teardown_for_snapshot", "restore_after_snapshot"]
+)
+async def test_runloop_strategy_rejects_a_foreign_session_before_touching_it(method: str) -> None:
+    from agents.extensions.sandbox.runloop.mounts import RunloopCloudBucketMountStrategy
+
+    class _WrongSession(_FakeRunloopMountSession):
+        pass
+
+    _WrongSession.__name__ = "NotARunloopSession"
+    session = _WrongSession()
+    strategy = RunloopCloudBucketMountStrategy()
+    mount = _bucket_mount()
+
+    with pytest.raises(MountConfigError, match="RunloopSandboxSession"):
+        if method == "activate":
+            await strategy.activate(mount, session, Path("/w/b"), Path("/tmp"))
+        elif method == "deactivate":
+            await strategy.deactivate(mount, session, Path("/w/b"), Path("/tmp"))
+        elif method == "teardown_for_snapshot":
+            await strategy.teardown_for_snapshot(mount, session, Path("/w/b"))
+        else:
+            await strategy.restore_after_snapshot(mount, session, Path("/w/b"))
+
+    # The guard runs before anything is issued to the foreign sandbox.
+    assert session.events == []
+
+
+def test_runloop_strategy_has_no_docker_volume_driver_config() -> None:
+    from agents.extensions.sandbox.runloop.mounts import RunloopCloudBucketMountStrategy
+
+    assert RunloopCloudBucketMountStrategy().build_docker_volume_driver_config(_bucket_mount()) is (
+        None
+    )


### PR DESCRIPTION
### Summary

`e2b/mounts.py` and `runloop/mounts.py` were the two least covered files in the sandbox providers. Both are now at 100%.

| File | before | after |
| --- | --- | --- |
| `extensions/sandbox/e2b/mounts.py` | 62% | 100% |
| `extensions/sandbox/runloop/mounts.py` | 65% | 100% |

The gap was the strategy lifecycle. Only the session guards, the e2b FUSE happy path and rclone installation were exercised, so nothing pinned what `activate`, `deactivate`, `teardown_for_snapshot` or `restore_after_snapshot` actually do. These are also the hardest paths to exercise by hand, since reaching them normally needs a live provider account.

Behaviour now pinned, for both providers:

- The session guard runs **before any command is issued**, for all four lifecycle methods, so a foreign session cannot reach the sandbox.
- `activate` prepares FUSE and rclone **before** delegating, and hands the delegate the **session-resolved** pattern carrying `--allow-other` rather than the raw pattern.
- `nfs` mode skips FUSE preparation, still requires rclone, and reaches the delegate with the nfs pattern left untouched.
- `restore_after_snapshot` re-runs preparation, since a restored sandbox may be a fresh container.
- `deactivate` and `teardown_for_snapshot` issue no setup commands, so unmounting never tries to install tooling on the way out.
- Every failure branch of runloop's `_ensure_fuse_support`: missing `/dev/fuse`, missing kernel module, missing `apt-get`, a failed install, fusermount still absent after installing, and a failed chmod. Each asserts the error `context` so the diagnostics stay useful.

No source changes. Every assertion matches current behaviour, so this is a characterisation of what the code does today.

### Ordering is asserted on a shared timeline

Recording delegate calls separately from exec calls would not have constrained their relative order. Both fakes record into one ordered `session.events` list, and the delegate hook appends to that same list, so delegation has to be the final entry.

I checked that this is load-bearing by mutating the source and confirming the tests go red:

| mutation | result |
| --- | --- |
| runloop `activate` delegates before preparation | 2 failed |
| runloop `restore_after_snapshot` delegates before preparation | 1 failed |
| e2b `activate` + `restore_after_snapshot` delegate before preparation | 3 failed |

### Test plan

Additions to `tests/extensions/sandbox/test_runloop_mounts.py` and `tests/extensions/sandbox/test_e2b.py`. Every pre-existing test in both files is retained, and the new cases reuse the existing fake session helpers, so the optional `runloop_api_client` dependency is not imported. I verified that by blocking the module with a `sys.meta_path` hook and confirming all added cases still pass. The delegate is stubbed via `monkeypatch` on `InContainerMountStrategy` so the tests assert sequencing without needing a real mount.

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 0 errors on the touched files |
| `uv run pytest tests/extensions/sandbox/` | 768 passed, 1 skipped |
| `make tests` | 6034 passed |

The full suite run was done on Windows, where a set of sandbox symlink and tracing timing tests fail independently of this change. I diffed the failing set against clean `main` in the same environment: identical, 54 either way, with 34 more tests passing on this branch.

### Issue number

None. This is coverage work on the sandbox providers rather than a reported defect.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`. I ran the underlying steps individually instead, with the results above.
