### PR TITLE
fix: skip remote history for zero session limit

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -81,9 +81,11 @@ class OpenAIConversationsSession(SessionABC):
         self._session_id = None
 
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
-        session_id = await self._get_session_id()
-
         session_limit = resolve_session_limit(limit, self.session_settings)
+        if session_limit == 0:
+            return []
+
+        session_id = await self._get_session_id()
 
         all_items = []
         if session_limit is None:

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -13,6 +13,7 @@ from agents.memory.openai_conversations_session import (
     OpenAIConversationsSession,
     start_openai_conversations_session,
 )
+from agents.memory.session_settings import SessionSettings
 from tests.fake_model import FakeModel
 from tests.test_responses import get_text_message
 
@@ -195,6 +196,29 @@ class TestOpenAIConversationsSessionLifecycle:
 
 class TestOpenAIConversationsSessionBasicOperations:
     """Test basic CRUD operations with simple mocking."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("limit", "session_settings"),
+        [
+            pytest.param(0, None, id="explicit-limit"),
+            pytest.param(None, SessionSettings(limit=0), id="session-settings"),
+        ],
+    )
+    async def test_get_items_zero_limit_skips_remote_conversation(
+        self,
+        mock_openai_client,
+        limit: int | None,
+        session_settings: SessionSettings | None,
+    ):
+        session = OpenAIConversationsSession(
+            openai_client=mock_openai_client,
+            session_settings=session_settings,
+        )
+
+        assert await session.get_items(limit=limit) == []
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.items.list.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_items_simple(self, mock_openai_client):


### PR DESCRIPTION
### Summary

This pull request fixes `OpenAIConversationsSession.get_items()` when the effective session history limit is zero.

The Agents SDK session contract uses `limit=0` to disable history retrieval, but this backend forwarded zero to `conversations.items.list`. The Conversations API only accepts limits from 1 to 100, so the call failed instead of returning no history. The method now resolves the effective limit before initializing a remote conversation and returns an empty list locally when it is zero.

This preserves the existing behavior for positive limits and `None`, and avoids creating an otherwise unused remote conversation.

API reference: https://developers.openai.com/api/reference/python/resources/conversations/subresources/items/methods/list

### Test plan

- `uv run pytest -q tests/memory/test_openai_conversations_session.py` (`37 passed`)
- `uv run ruff check src/agents/memory/openai_conversations_session.py tests/memory/test_openai_conversations_session.py`
- `uv run mypy src/agents/memory/openai_conversations_session.py`
- `git diff --check`

The repository-wide verification script was not run locally; this PR remains Draft while CI supplies the broader regression signal.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
