### PR TITLE
fix(models): propagate the OpenAI request ID on the Chat Completions path

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -348,7 +348,33 @@ class OpenAIChatCompletionsModel(Model):
                 output=items,
                 usage=usage,
                 response_id=None,
+                # The OpenAI SDK records the `x-request-id` header on every parsed response,
+                # so callers can inspect the same debugging handle as on the Responses path.
+                request_id=getattr(response, "_request_id", None),
             )
+
+    @staticmethod
+    def _attach_stream_request_id(response: Response, stream: Any) -> None:
+        """Copy the OpenAI request ID onto the synthesized streamed response.
+
+        The streamed Chat Completions response is built locally rather than returned by the
+        API, so the `x-request-id` header has to be carried over from the underlying HTTP
+        response. The terminal response is a `model_copy()` of this object, and that copy
+        preserves the private attribute, so `Runner` can read it back. Custom clients and
+        test doubles may yield a bare async iterator with no HTTP response attached.
+        """
+        headers = getattr(getattr(stream, "response", None), "headers", None)
+        if headers is None:
+            return
+        request_id = headers.get("x-request-id")
+        if request_id is None:
+            return
+        try:
+            response._request_id = request_id
+        except Exception:
+            # Matches the Responses adapter: a custom response object that rejects the
+            # attribute must not break the stream for a debugging field.
+            return
 
     def _attach_logprobs_to_output(
         self, output_items: list[ResponseOutputItem], logprobs: list[Logprob]
@@ -408,6 +434,8 @@ class OpenAIChatCompletionsModel(Model):
                 stream=True,
                 prompt=None,
             )
+
+            self._attach_stream_request_id(response, stream)
 
             final_response: Response | None = None
             stream_for_handler: AsyncIterator[ChatCompletionChunk]

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import httpx
 import pytest
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, omit
+from openai._models import add_request_id
 from openai.types.chat.chat_completion import ChatCompletion, Choice, ChoiceLogprobs
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
@@ -1363,3 +1364,62 @@ async def test_user_agent_header_chat_completions(override_ua):
     assert ChatCmplHelpers.get_store_param(client, model_settings) is True, (
         "Should respect explicitly set store=True"
     )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_propagates_request_id(monkeypatch) -> None:
+    """The OpenAI request ID must reach `ModelResponse.request_id` on the non-streamed path.
+
+    The OpenAI SDK records the `x-request-id` header on every parsed response object, so
+    Chat Completions runs can expose the same debugging handle as Responses runs.
+    """
+    chat = _minimal_chat_completion()
+    add_request_id(chat, "req_nonstreamed_123")
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return chat
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    resp: ModelResponse = await model.get_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert resp.request_id == "req_nonstreamed_123"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_request_id_is_none_when_absent(monkeypatch) -> None:
+    """Clients and test doubles that never set `_request_id` keep returning `None`."""
+    chat = _minimal_chat_completion()
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return chat
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    resp: ModelResponse = await model.get_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert resp.request_id is None

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -3545,3 +3545,123 @@ async def test_buffer_tool_call_stream_does_not_duplicate_tool_calls_finish() ->
     ]
     assert len(finish_choices) == 1
     assert finish_choices[0].delta.tool_calls
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_propagates_request_id(monkeypatch) -> None:
+    """The OpenAI request ID must reach the terminal streamed response.
+
+    `Runner` reads `_request_id` off the terminal response to populate
+    `ModelResponse.request_id`, so the streamed Chat Completions path has to carry the
+    `x-request-id` header from the underlying HTTP response.
+    """
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="Hello"))],
+    )
+
+    class FakeStream:
+        """Mimics `openai.AsyncStream`, which exposes the raw HTTP response."""
+
+        def __init__(self) -> None:
+            self.response = httpx.Response(
+                200,
+                headers={"x-request-id": "req_streamed_456"},
+                request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+            )
+
+        def __aiter__(self) -> AsyncIterator[ChatCompletionChunk]:
+            async def gen() -> AsyncIterator[ChatCompletionChunk]:
+                yield chunk
+
+            return gen()
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, FakeStream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    completed: ResponseCompletedEvent | None = None
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        if event.type == "response.completed":
+            completed = event
+
+    assert completed is not None
+    assert getattr(completed.response, "_request_id", None) == "req_streamed_456"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_response_without_http_response_has_no_request_id(monkeypatch) -> None:
+    """Custom clients and test doubles that yield a bare async iterator still stream."""
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="Hello"))],
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield chunk
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, fake_stream()
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    completed: ResponseCompletedEvent | None = None
+    async for event in model.stream_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    ):
+        if event.type == "response.completed":
+            completed = event
+
+    assert completed is not None
+    assert getattr(completed.response, "_request_id", None) is None


### PR DESCRIPTION
### Summary

`ModelResponse.request_id` is always `None` on the Chat Completions path, so `OpenAIChatCompletionsModel` users cannot retrieve the `x-request-id` needed to debug a request with OpenAI — the exact gap #1121 reported.

#1121 asked for the request ID because it was already available on API *errors* but not on successful responses. #2552 closed that for the Responses path (non-streamed and HTTP streaming) and listed its intentional non-goals — a run-level `last_request_id` API and the websocket transport. Chat Completions was not among them; it simply was not covered. `git log -S request_id -- src/agents/models/openai_chatcompletions.py` returns nothing: that file has never carried a request ID.

The OpenAI SDK makes this available uniformly — `openai/_response.py` calls `add_request_id(parsed, self.request_id)` for every parsed response, and the `openai._models` docstring uses a chat completion (`completion._request_id`) as its example. The adapter simply never read it.

**Affected component:** `src/agents/models/openai_chatcompletions.py` (`OpenAIChatCompletionsModel.get_response`, `.stream_response`).

### Current vs corrected behavior

| | before | after |
|---|---|---|
| `Runner.run(...)` + `OpenAIChatCompletionsModel` → `result.raw_responses[0].request_id` | `None` | `"req_..."` |
| `Runner.run_streamed(...)` + `OpenAIChatCompletionsModel` → `result.raw_responses[0].request_id` | `None` | `"req_..."` |
| Responses path (unchanged) | `"req_..."` | `"req_..."` |

### Root cause

Two independent omissions behind one cause — the adapter never propagates the request ID:

1. **Non-streamed:** `get_response()` builds `ModelResponse(output=..., usage=..., response_id=None)` and never reads `_request_id` off the `ChatCompletion` the SDK returned.
2. **Streamed:** the terminal streamed response is synthesized locally in `_fetch_response()` rather than returned by the API, so it carries no HTTP metadata. `Runner` already reads `getattr(terminal_response, "_request_id", None)` generically (`run_internal/run_loop.py`), so nothing downstream needed changing — the header just never got attached.

### Implementation

- `get_response()` passes `request_id=getattr(response, "_request_id", None)`.
- `stream_response()` calls a new `_attach_stream_request_id()` that copies `x-request-id` from the stream's underlying HTTP response onto the synthesized `Response`. The terminal event is a `model_copy()` of that object and pydantic preserves the private attribute, so `Runner` reads it back through the existing generic path.

**Why this is minimal:** no public API, signature, or serialization change — `ModelResponse.request_id` and `RunState` persistence (schema 1.4) already exist and are unchanged. No downstream file is touched. Both accessors degrade to `None` for custom clients and test doubles that expose no HTTP response, matching the compatibility approach #2552 took for `with_streaming_response`.

### Regression tests

`tests/models/test_openai_chatcompletions.py`
- `test_get_response_propagates_request_id` — request ID reaches `ModelResponse.request_id`.
- `test_get_response_request_id_is_none_when_absent` — boundary: no `_request_id` still yields `None`.

`tests/models/test_openai_chatcompletions_stream.py`
- `test_stream_response_propagates_request_id` — terminal streamed response carries `_request_id`.
- `test_stream_response_without_http_response_has_no_request_id` — boundary: a bare async iterator (the shape existing tests and custom clients use) still streams, with no request ID.

The two propagation tests fail on `main` (`assert None == 'req_nonstreamed_123'` / `assert None == 'req_streamed_456'`) and pass with this change; the two boundary tests pass both before and after, pinning the no-op case.

End-to-end coverage already exists and is unchanged: `test_streamed_run_exposes_request_id_on_raw_responses` (added by #2552) asserts terminal `_request_id` → `result.raw_responses[0].request_id`, which is the linkage the streamed half of this fix feeds.

### Execution modes covered

Non-streamed `get_response` and streamed `stream_response`, which are the two modes this adapter exposes.

### Non-goals

- **`LitellmModel` / `AnyLLMModel`** also leave `request_id` unset. Their underlying clients are not OpenAI clients and do not expose the `x-request-id` contract, so populating it there would be speculative rather than a fix.
- No run-level `last_request_id` API, and no change to the websocket transport — both were declared out of scope by #2552 and remain so.

### Test plan

Run from the repository root on `b47a0e4`:

```
uv run pytest tests/models/test_openai_chatcompletions.py tests/models/test_openai_chatcompletions_stream.py -k request_id -q
```
Before: `2 failed, 2 passed, 117 deselected`. After: `4 passed, 117 deselected`.

```
uv run pytest tests/models/test_openai_chatcompletions.py tests/models/test_openai_chatcompletions_stream.py -q   # 121 passed
make format      # 862 files left unchanged; All checks passed!
make lint        # All checks passed!
make typecheck   # 0 errors, 0 warnings, 0 informations (849 source files)
make tests       # 6669 passed, 29 skipped; serial stage 38 passed, 5 skipped
bash .agents/skills/code-change-verification/scripts/run.sh
git diff --check # clean
```

No OpenAI API key, network access, or paid model call is needed for any of the above; the tests patch `_fetch_response`.

### Issue number

Follow-up to #1121, which #2552 fixed for the Responses path only.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
