### PR TITLE
test(sandbox): cover the modal and cloudflare bucket mount strategies

### DIFF
--- a/tests/extensions/sandbox/test_cloudflare.py
+++ b/tests/extensions/sandbox/test_cloudflare.py
@@ -1664,3 +1664,163 @@ def test_sse_line_decoder_flush_emits_only_an_unterminated_line() -> None:
     partial = _SSELineDecoder()
     assert partial.decode("data: b") == []
     assert partial.flush() == ["data: b"]
+
+
+class _RecordingBucketSession:
+    """Cloudflare-shaped session that records bucket mount calls."""
+
+    def __init__(self) -> None:
+        # _resolve_mount_path() reads the manifest root off the session.
+        self.state = _make_state(manifest=Manifest(root="/workspace"))
+        self.mounted: list[dict[str, Any]] = []
+        self.unmounted: list[Path] = []
+        # A single ordered timeline, so that tests claiming an order between mount
+        # and unmount actually constrain it rather than checking two separate lists.
+        self.events: list[str] = []
+
+    async def mount_bucket(
+        self, *, bucket: str, mount_path: Path, options: dict[str, object]
+    ) -> None:
+        self.mounted.append({"bucket": bucket, "mount_path": mount_path, "options": options})
+        self.events.append(f"mount:{mount_path}")
+
+    async def unmount_bucket(self, mount_path: Path) -> None:
+        self.unmounted.append(mount_path)
+        self.events.append(f"unmount:{mount_path}")
+
+
+_RecordingBucketSession.__name__ = "CloudflareSandboxSession"
+
+
+def _cf_s3_mount(strategy: CloudflareBucketMountStrategy, **kwargs: Any) -> S3Mount:
+    defaults: dict[str, Any] = {
+        "bucket": "bucket",
+        "access_key_id": "access-key",
+        "secret_access_key": "secret-key",
+        "mount_strategy": strategy,
+    }
+    defaults.update(kwargs)
+    return S3Mount(**defaults)
+
+
+@pytest.mark.parametrize(
+    "prefix, expected",
+    [(None, None), ("", "/"), ("/", "/"), ("data", "/data/"), ("/a/b/", "/a/b/")],
+    ids=["none", "empty", "slash", "bare", "wrapped"],
+)
+def test_cloudflare_prefix_is_normalised_to_a_bounded_path(
+    prefix: str | None, expected: str | None
+) -> None:
+    assert CloudflareBucketMountStrategy._normalize_prefix(prefix) == expected
+
+
+def test_cloudflare_config_rejects_a_half_supplied_credential_pair() -> None:
+    """Mount construction validates the strategy, so the pair is checked up front."""
+    strategy = CloudflareBucketMountStrategy()
+
+    with pytest.raises(MountConfigError, match="both access_key_id and secret_access_key"):
+        _cf_s3_mount(strategy, secret_access_key=None)
+
+
+def test_cloudflare_config_rejects_an_unsupported_mount_type() -> None:
+    strategy = CloudflareBucketMountStrategy()
+
+    with pytest.raises(MountConfigError, match="not supported for this mount type"):
+        strategy._build_cloudflare_bucket_mount_config(cast(Any, Dir()))
+
+
+def test_cloudflare_request_options_carry_credentials_and_prefix() -> None:
+    strategy = CloudflareBucketMountStrategy()
+    config = strategy._build_cloudflare_bucket_mount_config(
+        _cf_s3_mount(strategy, prefix="nested", read_only=False)
+    )
+
+    options = config.to_request_options()
+
+    assert options["endpoint"] == "https://s3.amazonaws.com"
+    assert options["readOnly"] is False
+    assert options["prefix"] == "/nested/"
+    assert options["credentials"] == {
+        "accessKeyId": "access-key",
+        "secretAccessKey": "secret-key",
+    }
+
+
+def test_cloudflare_request_options_omit_absent_optional_fields() -> None:
+    strategy = CloudflareBucketMountStrategy()
+    config = strategy._build_cloudflare_bucket_mount_config(
+        S3Mount(bucket="bucket", mount_strategy=strategy)
+    )
+
+    options = config.to_request_options()
+
+    assert "prefix" not in options
+    assert "credentials" not in options
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_activate_and_deactivate_drive_the_bucket_endpoints() -> None:
+    strategy = CloudflareBucketMountStrategy()
+    mount = _cf_s3_mount(strategy, prefix="nested")
+    session = cast(Any, _RecordingBucketSession())
+
+    assert await strategy.activate(mount, session, Path("/workspace/data"), Path("/tmp")) == []
+    await strategy.deactivate(mount, session, Path("/workspace/data"), Path("/tmp"))
+
+    path = Path("/workspace/data")
+    assert session.events == [f"mount:{path}", f"unmount:{path}"]
+    assert session.mounted[0]["bucket"] == "bucket"
+    assert session.mounted[0]["options"]["prefix"] == "/nested/"
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_snapshot_hooks_unmount_then_remount_the_same_path() -> None:
+    """A snapshot must not capture a live bucket, and the mount must come back after."""
+    strategy = CloudflareBucketMountStrategy()
+    mount = _cf_s3_mount(strategy)
+    session = cast(Any, _RecordingBucketSession())
+    path = Path("/workspace/data")
+
+    await strategy.teardown_for_snapshot(mount, session, path)
+    await strategy.restore_after_snapshot(mount, session, path)
+
+    # The order is the point: unmount has to precede the remount, or the snapshot
+    # would capture a live bucket.
+    assert session.events == [f"unmount:{path}", f"mount:{path}"]
+    assert session.mounted[0]["mount_path"] == path
+    assert session.mounted[0]["bucket"] == "bucket"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method", ["activate", "deactivate", "teardown_for_snapshot", "restore_after_snapshot"]
+)
+async def test_cloudflare_strategy_rejects_a_foreign_session(method: str) -> None:
+    """Every lifecycle method must refuse a session from another backend."""
+
+    class _WrongSession(_RecordingBucketSession):
+        pass
+
+    _WrongSession.__name__ = "NotACloudflareSession"
+    session = cast(Any, _WrongSession())
+    strategy = CloudflareBucketMountStrategy()
+    mount = _cf_s3_mount(strategy)
+
+    with pytest.raises(MountConfigError, match="not supported by this sandbox backend"):
+        if method == "activate":
+            await strategy.activate(mount, session, Path("/w/d"), Path("/tmp"))
+        elif method == "deactivate":
+            await strategy.deactivate(mount, session, Path("/w/d"), Path("/tmp"))
+        elif method == "teardown_for_snapshot":
+            await strategy.teardown_for_snapshot(mount, session, Path("/w/d"))
+        else:
+            await strategy.restore_after_snapshot(mount, session, Path("/w/d"))
+
+    # The guard runs before anything reaches the foreign sandbox.
+    assert session.events == []
+
+
+def test_cloudflare_strategy_has_no_docker_volume_driver_config() -> None:
+    strategy = CloudflareBucketMountStrategy()
+
+    assert strategy.build_docker_volume_driver_config(_cf_s3_mount(strategy)) is None

--- a/tests/extensions/sandbox/test_modal_mounts.py
+++ b/tests/extensions/sandbox/test_modal_mounts.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+
+def _stub_modal_if_missing() -> None:
+    """Make the mount strategy importable without the optional ``modal`` extra.
+
+    ``agents.extensions.sandbox.modal.__init__`` imports the backend, which does
+    ``import modal`` at module scope. ``mounts.py`` itself needs nothing from the
+    SDK, so in an environment without the extra a stub keeps these tests
+    collectable instead of failing the whole file at import time.
+    """
+    try:
+        importlib.import_module("modal")
+        return
+    except ImportError:
+        pass
+
+    modal_module = types.ModuleType("modal")
+    config_module = types.ModuleType("modal.config")
+    config_module.config = types.SimpleNamespace(get=lambda *args, **kwargs: None)  # type: ignore[attr-defined]
+    container_process_module = types.ModuleType("modal.container_process")
+    container_process_module.ContainerProcess = type("ContainerProcess", (), {})  # type: ignore[attr-defined]
+    modal_module.config = config_module  # type: ignore[attr-defined]
+    modal_module.container_process = container_process_module  # type: ignore[attr-defined]
+
+    sys.modules.setdefault("modal", modal_module)
+    sys.modules.setdefault("modal.config", config_module)
+    sys.modules.setdefault("modal.container_process", container_process_module)
+
+
+_stub_modal_if_missing()
+
+from agents.extensions.sandbox.modal.mounts import (  # noqa: E402
+    ModalCloudBucketMountStrategy,
+)
+from agents.sandbox.entries import Dir, GCSMount, R2Mount, S3Mount  # noqa: E402
+from agents.sandbox.errors import MountConfigError  # noqa: E402
+
+
+class _FakeModalSession:
+    """Modal-shaped session. The strategy only inspects its class name."""
+
+
+_FakeModalSession.__name__ = "ModalSandboxSession"
+
+
+def _s3(strategy: ModalCloudBucketMountStrategy, **kwargs: Any) -> S3Mount:
+    defaults: dict[str, Any] = {"bucket": "bucket", "mount_strategy": strategy}
+    defaults.update(kwargs)
+    return S3Mount(**defaults)
+
+
+# -- config validation -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"secret_name": ""}, "secret_name must be a non-empty string"),
+        (
+            {"secret_environment_name": "", "secret_name": "s"},
+            "secret_environment_name must be a non-empty string",
+        ),
+        (
+            {"secret_environment_name": "env"},
+            "secret_environment_name requires secret_name",
+        ),
+    ],
+    ids=["empty_secret_name", "empty_secret_env", "env_without_secret"],
+)
+def test_secret_options_are_validated(kwargs: dict[str, Any], message: str) -> None:
+    strategy = ModalCloudBucketMountStrategy(**kwargs)
+
+    with pytest.raises(MountConfigError, match=message):
+        _s3(strategy)
+
+
+@pytest.mark.parametrize(
+    "mount_factory",
+    [
+        lambda s: _s3(s, access_key_id="a", secret_access_key="b"),
+        lambda s: R2Mount(
+            bucket="bucket",
+            account_id="acct",
+            access_key_id="a",
+            secret_access_key="b",
+            mount_strategy=s,
+        ),
+        lambda s: GCSMount(bucket="bucket", access_id="a", secret_access_key="b", mount_strategy=s),
+    ],
+    ids=["s3", "r2", "gcs"],
+)
+def test_inline_credentials_cannot_be_combined_with_a_named_secret(
+    mount_factory: Any,
+) -> None:
+    """Two credential sources would be ambiguous, so the mount must be rejected."""
+    strategy = ModalCloudBucketMountStrategy(secret_name="named-secret")
+
+    with pytest.raises(MountConfigError, match="do not support both inline credentials"):
+        mount_factory(strategy)
+
+
+def test_gcs_requires_s3_compatible_credentials_without_a_secret() -> None:
+    strategy = ModalCloudBucketMountStrategy()
+
+    with pytest.raises(MountConfigError, match="require access_id and secret_access_key"):
+        GCSMount(bucket="bucket", mount_strategy=strategy)
+
+
+def test_gcs_accepts_a_named_secret_without_inline_credentials() -> None:
+    strategy = ModalCloudBucketMountStrategy(secret_name="named-secret")
+
+    mount = GCSMount(bucket="bucket", mount_strategy=strategy)
+    config = strategy._build_modal_cloud_bucket_mount_config(mount)
+
+    assert config.credentials is None
+    assert config.secret_name == "named-secret"
+    assert config.bucket_endpoint_url == "https://storage.googleapis.com"
+
+
+def test_s3_config_carries_session_token_credentials() -> None:
+    strategy = ModalCloudBucketMountStrategy()
+    mount = _s3(
+        strategy,
+        access_key_id="a",
+        secret_access_key="b",
+        session_token="t",
+        prefix="p/",
+        read_only=False,
+    )
+
+    config = strategy._build_modal_cloud_bucket_mount_config(mount)
+
+    assert config.credentials == {
+        "AWS_ACCESS_KEY_ID": "a",
+        "AWS_SECRET_ACCESS_KEY": "b",
+        "AWS_SESSION_TOKEN": "t",
+    }
+    assert config.key_prefix == "p/"
+    assert config.read_only is False
+
+
+def test_r2_config_defaults_to_the_account_endpoint() -> None:
+    strategy = ModalCloudBucketMountStrategy()
+    mount = R2Mount(bucket="bucket", account_id="acct", mount_strategy=strategy)
+
+    config = strategy._build_modal_cloud_bucket_mount_config(mount)
+
+    assert config.bucket_endpoint_url == "https://acct.r2.cloudflarestorage.com"
+    assert config.credentials is None
+
+
+def test_unsupported_mount_types_are_rejected() -> None:
+    strategy = ModalCloudBucketMountStrategy()
+
+    with pytest.raises(MountConfigError, match="not supported for this mount type"):
+        strategy._build_modal_cloud_bucket_mount_config(cast(Any, Dir()))
+
+
+# -- strategy lifecycle ----------------------------------------------------
+
+
+def test_native_snapshot_detach_is_declined_so_the_tar_fallback_is_used() -> None:
+    """Modal attaches buckets natively, so a native snapshot must not be trusted."""
+    strategy = ModalCloudBucketMountStrategy()
+
+    assert strategy.supports_native_snapshot_detach(_s3(strategy)) is False
+
+
+async def test_activate_is_a_no_op_because_modal_attaches_at_create_time() -> None:
+    """Modal attaches the bucket when the sandbox is created, so there is nothing to do."""
+    strategy = ModalCloudBucketMountStrategy()
+    session = cast(Any, _FakeModalSession())
+
+    assert await strategy.activate(_s3(strategy), session, Path("/w/d"), Path("/tmp")) == []
+    # Must accept the session rather than raise; there is no return value to check.
+    await strategy.deactivate(_s3(strategy), session, Path("/w/d"), Path("/tmp"))
+
+
+async def test_snapshot_hooks_are_no_ops() -> None:
+    """Detaching is declined above, so the snapshot hooks have nothing to unwind."""
+    strategy = ModalCloudBucketMountStrategy()
+    session = cast(Any, _FakeModalSession())
+    mount = _s3(strategy)
+
+    await strategy.teardown_for_snapshot(mount, session, Path("/w/d"))
+    await strategy.restore_after_snapshot(mount, session, Path("/w/d"))
+
+
+@pytest.mark.parametrize("method", ["activate", "deactivate"])
+async def test_activate_and_deactivate_reject_a_foreign_session(method: str) -> None:
+    class _WrongSession:
+        pass
+
+    _WrongSession.__name__ = "NotAModalSession"
+    session = cast(Any, _WrongSession())
+    strategy = ModalCloudBucketMountStrategy()
+    mount = _s3(strategy)
+
+    with pytest.raises(MountConfigError, match="not supported by this sandbox backend") as info:
+        if method == "activate":
+            await strategy.activate(mount, session, Path("/w/d"), Path("/tmp"))
+        else:
+            await strategy.deactivate(mount, session, Path("/w/d"), Path("/tmp"))
+
+    assert info.value.context["session_type"] == "NotAModalSession"
+
+
+def test_strategy_has_no_docker_volume_driver_config() -> None:
+    strategy = ModalCloudBucketMountStrategy()
+
+    assert strategy.build_docker_volume_driver_config(_s3(strategy)) is None


### PR DESCRIPTION
### Summary

Completes coverage of the sandbox provider mount strategies, following #4240 which did e2b and runloop.

| File | before | after |
| --- | --- | --- |
| `extensions/sandbox/modal/mounts.py` | 78% | 100% |
| `extensions/sandbox/cloudflare/mounts.py` | 85% | 100% |

Config building was already tested for both. The gap was the strategy lifecycle and the error branches, which normally need a live provider account to reach.

**Cloudflare**

- `activate` and `deactivate` drive `mount_bucket` and `unmount_bucket` with the resolved mount path and the built request options.
- The snapshot hooks unmount and then remount the same path, so a snapshot cannot capture a live bucket and the mount returns afterwards.
- All four lifecycle methods reject a session from another backend, asserted by checking that no bucket call was made rather than only that it raised.
- Prefix normalisation across `None`, empty, bare and wrapped forms, a half-supplied credential pair, and an unsupported mount type.

**Modal**

- `supports_native_snapshot_detach` is `False`, which is what routes snapshots through `_native_snapshot_requires_tar_fallback` instead of trusting a native snapshot taken while a bucket is attached. That link was previously unpinned, so it is worth having a test on it.
- `activate` and the snapshot hooks are no-ops, because Modal attaches buckets at sandbox create time, and `activate` and `deactivate` still reject a foreign session.
- Secret option validation, and the rule that inline credentials cannot be combined with a named secret, for s3, r2 and gcs.

No source changes. Every assertion matches current behaviour, so this is a characterisation of what the code does today.

### Test plan

New `tests/extensions/sandbox/test_modal_mounts.py`, following the existing `test_blaxel_mounts.py` convention, plus additions to `tests/extensions/sandbox/test_cloudflare.py`. Cloudflare uses a recording session that captures `mount_bucket` and `unmount_bucket` calls on a single ordered timeline, so the tests assert an exact call sequence rather than checking two independent lists. Modal's strategy only inspects the session class name, so a bare stand-in is enough; the file stubs the optional `modal` SDK when it is absent, since the package `__init__` imports the backend at module scope and would otherwise fail collection.

| Command | Result |
| --- | --- |
| `make format` | clean |
| `make lint` | all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 0 errors on the touched files |
| `uv run pytest tests/extensions/sandbox/` | 773 passed, 1 skipped |
| `make tests` | 6035 passed |

The full suite run was done on Windows, where a set of sandbox symlink and tracing timing tests fail independently of this change. I diffed the failing set against clean `main` in the same environment: no new failures, with 35 more tests passing here.

### Issue number

None. This is coverage work on the sandbox providers rather than a reported defect.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`. I ran the underlying steps individually instead, with the results above.
