### PR TITLE
fix(chatcmpl): reject truncated function calls

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -605,6 +605,15 @@ class AnyLLMModel(Model):
             ):
                 message.refusal = "Response withheld by the provider's content filter."
 
+            ChatCmplHelpers.raise_if_tool_calls_truncated(
+                first_choice.finish_reason if first_choice is not None else None,
+                has_function_tool_calls=bool(
+                    message is not None
+                    and message.tool_calls
+                    and any(tool_call.type == "function" for tool_call in message.tool_calls)
+                ),
+            )
+
             if tracing.include_data():
                 span_generation.span_data.output = (
                     [message.model_dump()] if message is not None else []

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -295,6 +295,18 @@ class LitellmModel(Model):
                 usage = Usage()
                 logger.warning("No usage information returned from Litellm")
 
+            message_tool_calls = getattr(message, "tool_calls", None) if message else None
+            ChatCmplHelpers.raise_if_tool_calls_truncated(
+                getattr(first_choice, "finish_reason", None) if first_choice else None,
+                has_function_tool_calls=bool(
+                    message_tool_calls
+                    and any(
+                        getattr(tool_call, "type", None) == "function"
+                        for tool_call in message_tool_calls
+                    )
+                ),
+            )
+
             if tracing.include_data():
                 span_generation.span_data.output = (
                     [message.model_dump()] if message is not None else []

--- a/src/agents/models/chatcmpl_helpers.py
+++ b/src/agents/models/chatcmpl_helpers.py
@@ -10,6 +10,7 @@ from openai.types.responses.response_text_delta_event import (
     LogprobTopLogprob as DeltaTopLogprob,
 )
 
+from ..exceptions import ModelBehaviorError
 from ..model_settings import ModelSettings
 from ..version import __version__
 from .openai_client_utils import is_official_openai_client
@@ -23,6 +24,20 @@ HEADERS_OVERRIDE: ContextVar[dict[str, str] | None] = ContextVar(
 
 
 class ChatCmplHelpers:
+    @classmethod
+    def raise_if_tool_calls_truncated(
+        cls,
+        finish_reason: str | None,
+        *,
+        has_function_tool_calls: bool,
+    ) -> None:
+        """Reject function tool calls that the provider explicitly truncated."""
+        if finish_reason == "length" and has_function_tool_calls:
+            raise ModelBehaviorError(
+                "Chat Completions response was truncated while generating tool calls "
+                "(finish_reason='length')."
+            )
+
     @classmethod
     def is_openai(cls, client: AsyncOpenAI) -> bool:
         return is_official_openai_client(client)

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -430,6 +430,11 @@ class ChatCmplStreamHandler:
                         "but did not include any streamed tool call deltas."
                     )
 
+                ChatCmplHelpers.raise_if_tool_calls_truncated(
+                    choice.finish_reason,
+                    has_function_tool_calls=bool(buffered_calls),
+                )
+
                 if has_passthrough_output:
                     passthrough_choices.append(choice)
                 elif choice.finish_reason == "content_filter":
@@ -600,6 +605,7 @@ class ChatCmplStreamHandler:
         # empty delta and no refusal field. Track it so we can synthesize an
         # explicit refusal after the stream if nothing else was emitted.
         saw_content_filter = False
+        saw_length = False
         async for chunk in stream:
             if not state.started:
                 state.started = True
@@ -642,6 +648,8 @@ class ChatCmplStreamHandler:
 
             if choice.finish_reason == "content_filter":
                 saw_content_filter = True
+            elif choice.finish_reason == "length":
+                saw_length = True
 
             if not choice.delta:
                 continue
@@ -1053,6 +1061,11 @@ class ChatCmplStreamHandler:
                             type="response.function_call_arguments.delta",
                             sequence_number=sequence_number.get_and_increment(),
                         )
+
+        ChatCmplHelpers.raise_if_tool_calls_truncated(
+            "length" if saw_length else None,
+            has_function_tool_calls=bool(state.function_calls),
+        )
 
         # Content-filter refusal with no emitted output: synthesize a refusal so
         # the completed response carries a ResponseOutputRefusal rather than an

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -307,6 +307,15 @@ class OpenAIChatCompletionsModel(Model):
             ):
                 message.refusal = "Response withheld by the provider's content filter."
 
+            ChatCmplHelpers.raise_if_tool_calls_truncated(
+                first_choice.finish_reason if first_choice is not None else None,
+                has_function_tool_calls=bool(
+                    message is not None
+                    and message.tool_calls
+                    and any(tool_call.type == "function" for tool_call in message.tool_calls)
+                ),
+            )
+
             if tracing.include_data():
                 span_generation.span_data.output = (
                     [message.model_dump()] if message is not None else []

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -447,6 +447,32 @@ async def test_any_llm_chat_path_is_used_when_responses_are_unsupported(monkeypa
     assert getattr(response.usage.input_tokens_details, "cache_write_tokens", None) == 4
 
 
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_chat_path_rejects_length_terminated_function_tool_call(
+    monkeypatch,
+) -> None:
+    completion = _chat_completion_with_tool_call(thought_signature="sig-123")
+    completion.choices[0].finish_reason = "length"
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=completion)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+
+
 def _content_filtered_chat_completion(content: str) -> ChatCompletion:
     completion = _chat_completion(content)
     completion.choices[0].finish_reason = "content_filter"

--- a/tests/models/test_litellm_content_filter.py
+++ b/tests/models/test_litellm_content_filter.py
@@ -3,6 +3,7 @@ import pytest
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
 from openai.types.responses import ResponseOutputMessage, ResponseOutputRefusal
 
+from agents.exceptions import ModelBehaviorError
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
@@ -87,3 +88,42 @@ async def test_normal_stop_is_unaffected(monkeypatch):
         if isinstance(content, ResponseOutputRefusal)
     ]
     assert not refusals
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_length_terminated_function_tool_call_is_rejected(monkeypatch):
+    """A syntactically valid partial function call must not be executed."""
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        msg = Message(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "exec_command",
+                        "arguments": '{"cmd":"true"}',
+                    },
+                }
+            ],
+        )
+        choice = Choices(index=0, finish_reason="length", message=msg)
+        return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    model = LitellmModel(model="test-model")
+
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await model.get_response(
+            system_instructions=None,
+            input=[],
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+        )

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import httpx
 import pytest
@@ -49,7 +49,7 @@ from agents import (
     generation_span,
     trace,
 )
-from agents.exceptions import UserError
+from agents.exceptions import ModelBehaviorError, UserError
 from agents.models._retry_runtime import provider_managed_retries_disabled
 from agents.models.chatcmpl_helpers import HEADERS_OVERRIDE, ChatCmplHelpers
 from agents.models.fake_id import FAKE_RESPONSES_ID
@@ -740,7 +740,72 @@ async def test_get_response_with_tool_call(monkeypatch) -> None:
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
-async def test_get_response_rejects_custom_tool_call_in_strict_mode(monkeypatch) -> None:
+async def test_get_response_rejects_length_terminated_tool_call(monkeypatch) -> None:
+    tool_call = ChatCompletionMessageFunctionToolCall(
+        id="call-id",
+        type="function",
+        function=Function(name="do_thing", arguments='{"cmd":"unterminated'),
+    )
+
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await _get_response_for_choice(
+            monkeypatch,
+            Choice(
+                index=0,
+                finish_reason="length",
+                message=ChatCompletionMessage(role="assistant", tool_calls=[tool_call]),
+            ),
+        )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_preserves_length_terminated_text(monkeypatch) -> None:
+    response = await _get_response_for_choice(
+        monkeypatch,
+        Choice(
+            index=0,
+            finish_reason="length",
+            message=ChatCompletionMessage(role="assistant", content="partial text"),
+        ),
+    )
+
+    assert len(response.output) == 1
+    assert isinstance(response.output[0], ResponseOutputMessage)
+    assert isinstance(response.output[0].content[0], ResponseOutputText)
+    assert response.output[0].content[0].text == "partial text"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_get_response_preserves_default_handling_for_length_terminated_custom_tool_call(
+    monkeypatch,
+) -> None:
+    tool_call = ChatCompletionMessageCustomToolCall(
+        id="tool1",
+        type="custom",
+        custom=Custom(name="raw_tool", input="payload"),
+    )
+
+    response = await _get_response_for_choice(
+        monkeypatch,
+        Choice(
+            index=0,
+            finish_reason="length",
+            message=ChatCompletionMessage(role="assistant", tool_calls=[tool_call]),
+        ),
+    )
+
+    assert response.output == []
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finish_reason", ["tool_calls", "length"])
+async def test_get_response_rejects_custom_tool_call_in_strict_mode(
+    monkeypatch,
+    finish_reason: Literal["tool_calls", "length"],
+) -> None:
     tool_call = ChatCompletionMessageCustomToolCall(
         id="tool1",
         type="custom",
@@ -752,7 +817,7 @@ async def test_get_response_rejects_custom_tool_call_in_strict_mode(monkeypatch)
         created=0,
         model="fake",
         object="chat.completion",
-        choices=[Choice(index=0, finish_reason="tool_calls", message=msg)],
+        choices=[Choice(index=0, finish_reason=finish_reason, message=msg)],
         usage=None,
     )
 

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -546,6 +546,103 @@ async def test_stream_handler_keeps_empty_choice_usage_chunks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_handler_rejects_length_terminated_tool_call() -> None:
+    tool_call_delta = ChoiceDeltaToolCall(
+        index=0,
+        id="call-id",
+        function=ChoiceDeltaToolCallFunction(
+            name="exec_command",
+            arguments='{"cmd":"unterminated',
+        ),
+        type="function",
+    )
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[tool_call_delta]))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
+        ),
+    ]
+    events: list[Any] = []
+
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        async for event in ChatCmplStreamHandler.handle_stream(
+            _empty_response(), cast(Any, _completion_stream(*chunks))
+        ):
+            events.append(event)
+
+    assert "response.output_item.done" not in [event.type for event in events]
+    assert "response.completed" not in [event.type for event in events]
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_preserves_length_terminated_text() -> None:
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[
+            Choice(
+                index=0,
+                delta=ChoiceDelta(content="partial text"),
+                finish_reason="length",
+            )
+        ],
+    )
+
+    events = await _collect_handler_events(chunk)
+
+    completed_event = next(event for event in events if event.type == "response.completed")
+    assert isinstance(completed_event, ResponseCompletedEvent)
+    message = completed_event.response.output[0]
+    assert isinstance(message, ResponseOutputMessage)
+    assert isinstance(message.content[0], ResponseOutputText)
+    assert message.content[0].text == "partial text"
+
+
+@pytest.mark.asyncio
+async def test_buffer_tool_call_stream_rejects_length_terminated_tool_call() -> None:
+    tool_call_delta = ChoiceDeltaToolCall(
+        index=0,
+        id="call-id",
+        function=ChoiceDeltaToolCallFunction(
+            name="exec_command",
+            arguments='{"cmd":"unterminated',
+        ),
+        type="function",
+    )
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(tool_calls=[tool_call_delta]))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="length")],
+        ),
+    ]
+
+    with pytest.raises(ModelBehaviorError, match="finish_reason='length'"):
+        await _collect_buffered_tool_call_chunks(*chunks)
+
+
+@pytest.mark.asyncio
 async def test_stream_handler_rejects_multiple_choices_in_strict_mode() -> None:
     chunk = ChatCompletionChunk(
         id="chunk-id",


### PR DESCRIPTION
### Summary

This pull request fixes Chat Completions adapters finalizing function tool calls that the provider explicitly truncated with `finish_reason="length"`.

The shared Chat Completions terminal check now raises `ModelBehaviorError` before conversion or completion events in:

- OpenAI Chat Completions non-streaming responses
- LiteLLM non-streaming responses
- AnyLLM Chat Completions non-streaming responses
- direct streamed tool calls
- buffered streamed tool calls

This prevents partial arguments from reaching tool execution even when the accumulated fragment happens to be valid JSON. Existing behavior remains unchanged for length-terminated text, custom tool calls, normally completed function calls, and providers that omit terminal finish reasons.

### Test plan

- Added regression coverage for non-streaming, direct streaming, and buffered streaming paths.
- Added valid-JSON truncation cases for LiteLLM and AnyLLM to verify the terminal reason—not JSON parsing—drives rejection.
- Ran `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` with formatting, lint, mypy, pyright, and the full test suite passing.

### Issue number

Related to #3861.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
