### PR TITLE
fix(extensions): forward prompt_cache_retention on the any-llm Responses path

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -1027,6 +1027,7 @@ class AnyLLMModel(Model):
             "stream": stream,
             "truncation": model_settings.truncation,
             "store": model_settings.store,
+            "prompt_cache_retention": model_settings.prompt_cache_retention,
             "previous_response_id": previous_response_id,
             "conversation": conversation_id,
             "include": include,

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -1179,6 +1179,65 @@ async def test_any_llm_responses_path_omits_reasoning_when_unset() -> None:
     assert provider.private_responses_calls[0]["params"].reasoning is None
 
 
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_any_llm_responses_path_forwards_prompt_cache_retention(stream: bool) -> None:
+    """`ModelSettings.prompt_cache_retention` must reach the any-llm Responses request."""
+    pytest.importorskip(
+        "any_llm",
+        reason="`any-llm-sdk` is only available when the optional dependency is installed.",
+    )
+
+    provider = _RecordingResponsesProvider(_response("Hello"))
+    model = _model_bound_to_provider(provider)
+
+    await cast(Any, model)._fetch_responses_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(prompt_cache_retention="24h"),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        previous_response_id=None,
+        conversation_id=None,
+        stream=stream,
+        prompt=None,
+    )
+
+    assert len(provider.private_responses_calls) == 1
+    assert provider.private_responses_calls[0]["params"].prompt_cache_retention == "24h"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_path_omits_prompt_cache_retention_when_unset() -> None:
+    """An unset retention stays unset instead of pinning a default on the request."""
+    pytest.importorskip(
+        "any_llm",
+        reason="`any-llm-sdk` is only available when the optional dependency is installed.",
+    )
+
+    provider = _RecordingResponsesProvider(_response("Hello"))
+    model = _model_bound_to_provider(provider)
+
+    await cast(Any, model)._fetch_responses_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        previous_response_id=None,
+        conversation_id=None,
+        stream=False,
+        prompt=None,
+    )
+
+    assert len(provider.private_responses_calls) == 1
+    assert provider.private_responses_calls[0]["params"].prompt_cache_retention is None
+
+
 def test_any_llm_provider_passes_api_override() -> None:
     pytest.importorskip(
         "any_llm",


### PR DESCRIPTION
### Summary

`AnyLLMModel` silently drops `ModelSettings.prompt_cache_retention` on its Responses path.

**Component:** `src/agents/extensions/models/any_llm_model.py` — `AnyLLMModel._fetch_responses_response()` request construction.

**Problem.** A user who sets `ModelSettings(prompt_cache_retention="24h")` and runs against an any-llm OpenAI route gets a request with no retention field. The setting is accepted, type-checks, and is silently discarded, so extended prompt-cache retention is never requested and the caller has no signal that it was ignored.

**Repro** (no API key needed — this is the shape the added tests assert):

```python
model = AnyLLMModel(model="openai/gpt-5.4-mini", api="responses")
await model.get_response(..., model_settings=ModelSettings(prompt_cache_retention="24h"), ...)
```

Before: the `ResponsesParams` handed to the provider has `prompt_cache_retention=None`.
After: it has `prompt_cache_retention="24h"`.

**Root cause.** `prompt_cache_retention` was added to `ModelSettings` in #2095 (Nov 2025) and wired into `OpenAIChatCompletionsModel` and `OpenAIResponsesModel`. `AnyLLMModel` landed later (#2706, Mar 2026) and its `request_kwargs` dict mirrors `ModelSettings` for every neighbouring OpenAI-shaped knob — `truncation`, `store`, `include`, `text`/`verbosity`, `top_logprobs`, `reasoning` — but never reads `prompt_cache_retention`. This was an omission rather than a decision: the same module's `_ANY_LLM_RESPONSES_PARAM_FIELDS` allowlist already lists `prompt_cache_retention` as a transportable any-llm `ResponsesParams` field, and `any_llm.types.responses.ResponsesParams` (any-llm 1.11.0) declares it. So the adapter already knew the parameter was supported end to end; it just never populated it.

**Why this fix is minimal.** One line, placed next to `store`, using the same `model_settings.<field>` pass-through as its neighbours. No new abstraction, no new config surface, no public API or schema change, no behavior change for any other field. Because the field is already in `_ANY_LLM_RESPONSES_PARAM_FIELDS`, both dispatch branches in `_call_any_llm_responses()` carry it correctly: it lands in `params_payload` for the private `_aresponses()` branch used whenever transport kwargs exist (the normal path, since the SDK always sends a `User-Agent`), and it is a valid `ResponsesParams` field on the public `aresponses()` branch.

**Non-goals.** The any-llm *Chat Completions* path is deliberately untouched. It fans out to non-OpenAI providers (gemini, vertexai, anthropic) and has no equivalent allowlist establishing that the parameter is transportable there, so forwarding it would widen the supported contract without evidence. `prompt_cache_options` is likewise out of scope: it is not in `_ANY_LLM_RESPONSES_PARAM_FIELDS`, so it would need separate evidence of provider support. Both remain reachable today through `ModelSettings.extra_args`.

**Compatibility.** No breaking change. `prompt_cache_retention` defaults to `None`, and `None` is the existing default of the corresponding any-llm field, so requests that do not set it are byte-for-byte unchanged — asserted directly by the second test and confirmed by the unchanged full suite.

### Test plan

Three tests added to `tests/models/test_any_llm_model.py`, using the file's existing `_RecordingResponsesProvider` / `_model_bound_to_provider` harness. No network, no API key, no sleeps.

- `test_any_llm_responses_path_forwards_prompt_cache_retention[False]` / `[True]` — the retention reaches the provider request on both the non-streamed and streamed Responses paths. Both **fail on `main`** (`AssertionError: assert None == '24h'`).
- `test_any_llm_responses_path_omits_prompt_cache_retention_when_unset` — an unset retention stays `None` rather than pinning a default. This one **passes both before and after**, proving the patch does not change the default request.

Red/green proof, at `upstream/main` `b47a0e4b`:

```
# fix reverted, tests present
$ uv run pytest tests/models/test_any_llm_model.py -q -k prompt_cache_retention
2 failed, 1 passed, 55 deselected

# fix applied
$ uv run pytest tests/models/test_any_llm_model.py -q -k prompt_cache_retention
3 passed, 55 deselected
```

Full validation run locally, all passing:

- `uv run pytest tests/models/test_any_llm_model.py -q` → `58 passed`
- `make format` → `862 files left unchanged`, `All checks passed!`
- `make lint` → `All checks passed!`
- `make typecheck` → `0 errors, 0 warnings, 0 informations`; `Success: no issues found in 849 source files`
- `make tests` → `6668 passed, 29 skipped` (parallel) and `38 passed, 5 skipped` (serial)
- `.agents/skills/code-change-verification/scripts/run.sh` → `code-change-verification: all commands passed.`
- `git diff --check` → clean

Not run: `make coverage` and `make build-docs` (no docs changed); the Python 3.10 matrix env was not built locally — the patch uses no version-specific syntax and CI covers it.

### Issue number

N/A — found by auditing `ModelSettings` field coverage across the four model adapters.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
