### PR TITLE
fix(run_state): keep local shell tool outputs when restoring a RunState

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -192,7 +192,6 @@ if _missing_schema_version_summaries:
 
 _FUNCTION_OUTPUT_ADAPTER: TypeAdapter[FunctionCallOutput] = TypeAdapter(FunctionCallOutput)
 _COMPUTER_OUTPUT_ADAPTER: TypeAdapter[ComputerCallOutput] = TypeAdapter(ComputerCallOutput)
-_LOCAL_SHELL_OUTPUT_ADAPTER: TypeAdapter[LocalShellCallOutput] = TypeAdapter(LocalShellCallOutput)
 _TOOL_CALL_OUTPUT_UNION_ADAPTER: TypeAdapter[
     FunctionCallOutput | ComputerCallOutput | LocalShellCallOutput
 ] = TypeAdapter(FunctionCallOutput | ComputerCallOutput | LocalShellCallOutput)
@@ -2370,14 +2369,20 @@ def _deserialize_tool_call_output_raw_item(
         return _FUNCTION_OUTPUT_ADAPTER.validate_python(normalized_raw_item)
     if output_type == "computer_call_output":
         return _COMPUTER_OUTPUT_ADAPTER.validate_python(normalized_raw_item)
-    if output_type == "local_shell_call_output":
-        return _LOCAL_SHELL_OUTPUT_ADAPTER.validate_python(normalized_raw_item)
     if output_type == "program_output":
         try:
             return ProgramOutput(**normalized_raw_item)
         except Exception:
             return normalized_raw_item
-    if output_type in {"shell_call_output", "apply_patch_call_output", "custom_tool_call_output"}:
+    if output_type in {
+        "shell_call_output",
+        "apply_patch_call_output",
+        "custom_tool_call_output",
+        # LocalShellAction writes ``call_id`` (the key the runner pairs calls and outputs on) and
+        # no ``id``, so validating against the Responses ``LocalShellCallOutput`` shape both
+        # rejects SDK-produced items and strips ``call_id`` from API-shaped ones.
+        "local_shell_call_output",
+    }:
         return normalized_raw_item
 
     try:

--- a/tests/test_local_shell_tool.py
+++ b/tests/test_local_shell_tool.py
@@ -4,6 +4,7 @@ These confirm that LocalShellAction.execute forwards the command to the executor
 and that Runner.run executes local shell calls and records their outputs.
 """
 
+import json
 from typing import Any, cast
 
 import pytest
@@ -21,6 +22,7 @@ from agents import (
 )
 from agents.items import ToolCallOutputItem
 from agents.run_internal.run_loop import LocalShellAction, ToolRunLocalShellCall
+from agents.run_state import RunState
 
 from .fake_model import FakeModel
 from .test_responses import get_text_message
@@ -156,3 +158,112 @@ async def test_runner_executes_local_shell_calls() -> None:
 
     assert result.final_output == "shell complete"
     assert len(result.raw_responses) == 2
+
+
+def _local_shell_call() -> LocalShellCall:
+    return LocalShellCall(
+        id="lsh_test",
+        action=LocalShellCallAction(
+            command=["bash", "-c", "echo shell"],
+            env={},
+            type="exec",
+            timeout_ms=1000,
+            working_directory="/tmp",
+        ),
+        call_id="call_local_shell",
+        status="completed",
+        type="local_shell_call",
+    )
+
+
+async def _run_with_local_shell(agent: Agent[Any], model: FakeModel) -> Any:
+    model.add_multiple_turn_outputs(
+        [
+            [get_text_message("running shell"), _local_shell_call()],
+            [get_text_message("shell complete")],
+        ]
+    )
+    return await Runner.run(agent, input="please run shell")
+
+
+@pytest.mark.asyncio
+async def test_local_shell_output_survives_run_state_roundtrip() -> None:
+    """A serialized run that used a local shell tool must keep its shell output on resume."""
+    executor = RecordingLocalShellExecutor(output="shell result")
+    tool = LocalShellTool(executor=executor)
+    model = FakeModel()
+    agent = Agent(name="shell-agent", model=model, tools=[tool])
+
+    result = await _run_with_local_shell(agent, model)
+    state = result.to_state()
+    restored = await RunState.from_json(agent, json.loads(json.dumps(state.to_json())))
+
+    shell_outputs = [
+        cast(dict[str, Any], item.raw_item)
+        for item in restored._generated_items
+        if isinstance(item, ToolCallOutputItem)
+        and isinstance(item.raw_item, dict)
+        and item.raw_item.get("type") == "local_shell_call_output"
+    ]
+    assert len(shell_outputs) == 1
+    # The runner pairs calls with outputs on call_id, so it has to survive the round trip.
+    assert shell_outputs[0]["call_id"] == "call_local_shell"
+    assert shell_outputs[0]["output"] == "shell result"
+
+
+@pytest.mark.asyncio
+async def test_resumed_local_shell_run_replays_call_and_output() -> None:
+    """Resuming keeps the shell call paired with its output instead of pruning both."""
+    executor = RecordingLocalShellExecutor(output="shell result")
+    tool = LocalShellTool(executor=executor)
+    model = FakeModel()
+    agent = Agent(name="shell-agent", model=model, tools=[tool])
+
+    result = await _run_with_local_shell(agent, model)
+    serialized = json.loads(json.dumps(result.to_state().to_json()))
+
+    resumed_model = FakeModel()
+    resumed_agent = Agent(name="shell-agent", model=resumed_model, tools=[tool])
+    resumed_state = await RunState.from_json(resumed_agent, serialized)
+    resumed_model.add_multiple_turn_outputs([[get_text_message("resumed")]])
+    await Runner.run(resumed_agent, resumed_state)
+
+    replayed = [
+        entry
+        for entry in (resumed_model.last_turn_args.get("input") or [])
+        if isinstance(entry, dict)
+    ]
+    replayed_types = [entry.get("type") for entry in replayed]
+    assert "local_shell_call" in replayed_types
+    assert "local_shell_call_output" in replayed_types
+    call = next(entry for entry in replayed if entry.get("type") == "local_shell_call")
+    output = next(entry for entry in replayed if entry.get("type") == "local_shell_call_output")
+    assert call["call_id"] == output["call_id"] == "call_local_shell"
+
+
+@pytest.mark.asyncio
+async def test_api_shaped_local_shell_output_still_restores() -> None:
+    """A snapshot whose shell output carries the Responses API `id` keeps all of its fields."""
+    executor = RecordingLocalShellExecutor(output="shell result")
+    tool = LocalShellTool(executor=executor)
+    model = FakeModel()
+    agent = Agent(name="shell-agent", model=model, tools=[tool])
+
+    result = await _run_with_local_shell(agent, model)
+    serialized = json.loads(json.dumps(result.to_state().to_json()))
+    for item in serialized["generated_items"]:
+        raw_item = item.get("raw_item")
+        if isinstance(raw_item, dict) and raw_item.get("type") == "local_shell_call_output":
+            raw_item["id"] = raw_item["call_id"]
+
+    restored = await RunState.from_json(agent, serialized)
+    shell_outputs = [
+        cast(dict[str, Any], item.raw_item)
+        for item in restored._generated_items
+        if isinstance(item, ToolCallOutputItem)
+        and isinstance(item.raw_item, dict)
+        and item.raw_item.get("type") == "local_shell_call_output"
+    ]
+    assert len(shell_outputs) == 1
+    assert shell_outputs[0]["id"] == "call_local_shell"
+    assert shell_outputs[0]["call_id"] == "call_local_shell"


### PR DESCRIPTION
### Summary

**Component:** `RunState` deserialization (`_deserialize_tool_call_output_raw_item`) / `LocalShellTool` resume.

**Problem.** A run that used a `LocalShellTool` cannot be resumed: the local shell tool output is silently dropped from the restored state, and because the paired call is then an orphan, the shell call disappears too. The model never sees that the command ran.

`LocalShellAction.execute` (`run_internal/tool_actions.py`) writes the output item as:

```python
{"type": "local_shell_call_output", "call_id": call.tool_call.call_id, "output": result}
```

`call_id` is the key the runner pairs calls with outputs on — `_completed_call_ids_by_type()` in `run_internal/items.py` reads only `call_id`, and `drop_orphan_function_calls()` prunes any call whose id is not in that set.

On resume, that raw item was validated against the Responses `LocalShellCallOutput` shape, which declares `id` (required) and has no `call_id` at all. Two consequences:

1. **SDK-produced items fail validation** (`id` missing). `_deserialize_items` catches the `ValidationError`, logs `Failed to deserialize item`, and `continue`s — the output vanishes. The now-orphaned `local_shell_call` is pruned on the next turn, so both items are gone.
2. **API-shaped items lose `call_id`.** Even with `id` present, the TypedDict adapter strips unknown keys, so `call_id` is dropped and the paired call is orphaned anyway.

Before this change, resuming the run in the added test produces a model input of `["please run shell", message, message]` — no `local_shell_call`, no `local_shell_call_output`.

### Change

Deserialize `local_shell_call_output` the same way its sibling hosted-tool outputs (`shell_call_output`, `apply_patch_call_output`, `custom_tool_call_output`) are already handled: return the normalized mapping unchanged. `dict[str, Any]` is already part of the function's return type and an accepted `ToolCallOutputTypes` member, so no new shape is introduced.

This preserves whatever the producer wrote — `call_id` for SDK-produced items, and both `id` and `call_id` for API-shaped ones — which is strictly more preserving than the previous behaviour for every input.

`_LOCAL_SHELL_OUTPUT_ADAPTER` becomes unused and is removed. `LocalShellCallOutput` stays in `_TOOL_CALL_OUTPUT_UNION_ADAPTER` and in the return annotation, so no public or private signature changes.

**Why minimal / why not a producer fix.** Making `LocalShellAction` also emit `id` does not fix resume: validation still strips `call_id`, so the pairing in `drop_orphan_function_calls` still fails and the call is still pruned. Changing the runner to pair local shell items on `id` instead would touch the shared call/output pairing used by every tool family. The reader is the only place that is inconsistent with its three siblings, so that is where the fix goes.

**Compatibility.** The serialized format is unchanged, so `CURRENT_SCHEMA_VERSION` is not bumped — this only affects backward-read of persisted state, and it makes strictly more snapshots restorable than before. No public API, exception type, or hook contract changes. Streamed and non-streamed resume share this deserializer, so both paths are fixed by the same change.

**Non-goals.** Whether the Responses API itself accepts `call_id` on a `local_shell_call_output` on the wire is out of scope; this PR does not change what the SDK sends to the model, only what survives a `RunState` round trip.

### Test plan

Three tests added to `tests/test_local_shell_tool.py`, all driven through the public `Runner.run` / `RunState.from_json` path with `FakeModel` (no API key, no network):

- `test_local_shell_output_survives_run_state_roundtrip` — a real run with a `LocalShellTool`, serialized with `to_state().to_json()`, string round-tripped, and restored; asserts the `local_shell_call_output` item survives with its `call_id` and output.
- `test_resumed_local_shell_run_replays_call_and_output` — resumes that snapshot through `Runner.run` and asserts the next model input contains both the `local_shell_call` and its `local_shell_call_output` with matching `call_id`.
- `test_api_shaped_local_shell_output_still_restores` — rewrites the snapshot's shell output into the Responses API shape (adds `id`) and asserts both `id` and `call_id` survive, covering the field-stripping half of the bug.

All three fail on `upstream/main` @ `b47a0e4b` and pass after the change. The two pre-existing tests in that file pass before and after, showing the producer path is untouched:

```
# before (src/agents/run_state.py reverted)
$ uv run pytest tests/test_local_shell_tool.py -q
..FFF
E       assert 0 == 1                                    # output item dropped
E       assert 'local_shell_call' in [None, 'message', 'message']   # call pruned as orphan
E       KeyError: 'call_id'                              # call_id stripped by validation
3 failed, 2 passed

# after
$ uv run pytest tests/test_local_shell_tool.py -q
5 passed
```

Verification run from the repository root:

- `.agents/skills/code-change-verification/scripts/run.sh` — all commands passed (format, lint, typecheck, tests).
- `make format` / `make lint` — all checks passed.
- `make typecheck` — mypy: no issues in 849 source files; pyright: 0 errors, 0 warnings.
- `make tests` — 6668 passed, 29 skipped (parallel) and 38 passed, 5 skipped (serial).
- `uv run pytest tests/test_local_shell_tool.py tests/test_run_state.py tests/test_hitl_error_scenarios.py -q` run 5× — 315 passed each time, no unclosed-resource or pending-task warnings.
- `git diff --check` — clean.

Not run: `make coverage`, `make build-docs`, and the integration-test profiles (they need credentials or live services); no docs or examples are affected by this change.

### Issue number

N/A (found by auditing SDK-constructed item payloads against the generated `openai.types.responses` param models).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
