### PR TITLE
docs: voice quickstart also needs sounddevice

### DIFF
--- a/docs/voice/quickstart.md
+++ b/docs/voice/quickstart.md
@@ -8,6 +8,12 @@ Make sure you've followed the base [quickstart instructions](../quickstart.md) f
 pip install 'openai-agents[voice]'
 ```
 
+The demo code below also uses [`sounddevice`](https://pypi.org/project/sounddevice/) for microphone and speaker I/O, which is not part of the `voice` extra:
+
+```bash
+pip install sounddevice
+```
+
 ## Concepts
 
 The main concept to know about is a [`VoicePipeline`][agents.voice.pipeline.VoicePipeline], which is a 3 step process:


### PR DESCRIPTION
The quickstart only says to install `openai-agents[voice]`, but the demo code at the end imports sounddevice, so a fresh install fails with ModuleNotFoundError at the last step. Added an install line for it.

(#478 hit the same thing on mac a while back.)
