### PR TITLE
fix(models): keep url citations on the streamed chat completions path

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -44,7 +44,6 @@ from openai.types.responses import (
 from openai.types.responses.response_input_param import FunctionCallOutput, ItemReference, Message
 from openai.types.responses.response_output_text import (
     Annotation as ResponseOutputTextAnnotation,
-    AnnotationURLCitation,
 )
 from openai.types.responses.response_reasoning_item import Content, Summary
 
@@ -60,6 +59,7 @@ from ..tool import (
     ensure_function_tool_supports_responses_only_features,
     ensure_tool_choice_supports_backend,
 )
+from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
 from .reasoning_content_replay import (
     ReasoningContentReplayContext,
@@ -264,21 +264,7 @@ class Converter:
         cls, message: ChatCompletionMessage
     ) -> list[ResponseOutputTextAnnotation]:
         """Convert Chat Completions url citations into output text annotations."""
-        annotations: list[ResponseOutputTextAnnotation] = []
-        for annotation in message.annotations or []:
-            url_citation = getattr(annotation, "url_citation", None)
-            if getattr(annotation, "type", None) != "url_citation" or url_citation is None:
-                continue
-            annotations.append(
-                AnnotationURLCitation(
-                    type="url_citation",
-                    start_index=url_citation.start_index,
-                    end_index=url_citation.end_index,
-                    url=url_citation.url,
-                    title=url_citation.title,
-                )
-            )
-        return annotations
+        return ChatCmplHelpers.convert_url_citations(message.annotations)
 
     @classmethod
     def maybe_easy_input_message(cls, item: Any) -> EasyInputMessageParam | None:

--- a/src/agents/models/chatcmpl_helpers.py
+++ b/src/agents/models/chatcmpl_helpers.py
@@ -1,18 +1,35 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from contextvars import ContextVar
+from typing import Any
 
 from openai import AsyncOpenAI
 from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
-from openai.types.responses.response_output_text import Logprob, LogprobTopLogprob
+from openai.types.responses.response_output_text import (
+    Annotation as ResponseOutputTextAnnotation,
+    AnnotationURLCitation,
+    Logprob,
+    LogprobTopLogprob,
+)
 from openai.types.responses.response_text_delta_event import (
     Logprob as DeltaLogprob,
     LogprobTopLogprob as DeltaTopLogprob,
 )
+from pydantic import ValidationError
 
+from ..logger import log_model_action_debug, logger
 from ..model_settings import ModelSettings
 from ..version import __version__
 from .openai_client_utils import is_official_openai_client
+
+
+def _mapping_or_attr(source: Any, name: str) -> Any:
+    """Read a field from a value that is either a typed object or a plain mapping."""
+    if isinstance(source, Mapping):
+        return source.get(name)
+    return getattr(source, name, None)
+
 
 _USER_AGENT = f"Agents/Python {__version__}"
 HEADERS = {"User-Agent": _USER_AGENT}
@@ -99,6 +116,36 @@ class ChatCmplHelpers:
                 )
             )
         return converted
+
+    @classmethod
+    def convert_url_citations(cls, raw_annotations: Any) -> list[ResponseOutputTextAnnotation]:
+        """Convert Chat Completions url citations into output text annotations."""
+        # Providers report annotations as typed objects or as raw payloads, so validate
+        # rather than assume the declared shape.
+        if not isinstance(raw_annotations, list | tuple):
+            return []
+
+        annotations: list[ResponseOutputTextAnnotation] = []
+        for annotation in raw_annotations:
+            url_citation = _mapping_or_attr(annotation, "url_citation")
+            if _mapping_or_attr(annotation, "type") != "url_citation" or url_citation is None:
+                continue
+            try:
+                annotations.append(
+                    AnnotationURLCitation.model_validate(
+                        {
+                            "type": "url_citation",
+                            "start_index": _mapping_or_attr(url_citation, "start_index"),
+                            "end_index": _mapping_or_attr(url_citation, "end_index"),
+                            "url": _mapping_or_attr(url_citation, "url"),
+                            "title": _mapping_or_attr(url_citation, "title"),
+                        }
+                    )
+                )
+            except ValidationError as exc:
+                # A provider that reports an incomplete citation should not fail the turn.
+                log_model_action_debug(logger, "Skipping malformed url citation", exc)
+        return annotations
 
     @classmethod
     def clean_gemini_tool_call_id(cls, tool_call_id: str, model: str | None = None) -> str:

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -290,6 +290,9 @@ class ChatCmplStreamHandler:
         if hasattr(delta, "thinking_blocks") and delta.thinking_blocks:
             return True
 
+        if getattr(delta, "annotations", None):
+            return True
+
         return False
 
     @staticmethod
@@ -870,6 +873,13 @@ class ChatCmplStreamHandler:
                         # Extend in place to avoid rebuilding the full accumulated list on
                         # every content delta, which would be O(n^2) over a long stream.
                         existing_logprobs.extend(output_logprobs)
+
+            # Handle url citations. These can arrive on the delta carrying the cited text
+            # or on a later one, so this sits outside the content branch above.
+            if state.text_content_index_and_output:
+                state.text_content_index_and_output[1].annotations.extend(
+                    ChatCmplHelpers.convert_url_citations(getattr(delta, "annotations", None))
+                )
 
             # Handle refusals (model declines to answer)
             # This is always set by the OpenAI API, but not by others e.g. LiteLLM

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -102,6 +102,50 @@ async def _collect_buffered_tool_call_chunks(
     ]
 
 
+def _url_citation(
+    url: str = "https://example.com/weather",
+    title: str = "Weather",
+    start_index: int = 0,
+    end_index: int = 22,
+) -> dict[str, Any]:
+    return {
+        "type": "url_citation",
+        "url_citation": {
+            "start_index": start_index,
+            "end_index": end_index,
+            "url": url,
+            "title": title,
+        },
+    }
+
+
+def _annotated_chunk(
+    delta_payload: dict[str, Any], finish_reason: str | None = None
+) -> ChatCompletionChunk:
+    # `annotations` is not a declared field on ChoiceDelta, so it is built through
+    # model_validate to reach the object the same way a provider payload does.
+    return ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[
+            Choice(
+                index=0,
+                delta=ChoiceDelta.model_validate(delta_payload),
+                finish_reason=cast(Any, finish_reason),
+            )
+        ],
+    )
+
+
+def _streamed_annotations(events: list[Any]) -> list[dict[str, Any]]:
+    completed = cast(ResponseCompletedEvent, events[-1])
+    message = cast(ResponseOutputMessage, completed.response.output[0])
+    text_part = cast(ResponseOutputText, message.content[0])
+    return [annotation.model_dump() for annotation in text_part.annotations]
+
+
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_dictionary", [False, True], ids=["model-settings", "dictionary"])
@@ -3665,3 +3709,133 @@ async def test_stream_response_without_http_response_has_no_request_id(monkeypat
 
     assert completed is not None
     assert getattr(completed.response, "_request_id", None) is None
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_keeps_url_citations_on_the_text_delta() -> None:
+    """Citations reported alongside the text reach the output text, as when not streaming."""
+    events = await _collect_handler_events(
+        _annotated_chunk(
+            {
+                "role": "assistant",
+                "content": "It will rain tomorrow.",
+                "annotations": [_url_citation()],
+            },
+            finish_reason="stop",
+        )
+    )
+
+    assert _streamed_annotations(events) == [
+        {
+            "type": "url_citation",
+            "start_index": 0,
+            "end_index": 22,
+            "url": "https://example.com/weather",
+            "title": "Weather",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_keeps_url_citations_reported_after_the_text() -> None:
+    """A provider may cite on a later delta, once the text the citation indexes is sent."""
+    events = await _collect_handler_events(
+        _annotated_chunk({"role": "assistant", "content": "It will rain tomorrow."}),
+        _annotated_chunk({"annotations": [_url_citation()]}, finish_reason="stop"),
+    )
+
+    assert [annotation["url"] for annotation in _streamed_annotations(events)] == [
+        "https://example.com/weather"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_accumulates_url_citations_across_deltas() -> None:
+    """Citations accumulate rather than replace, as LiteLLM does in `stream_chunk_builder`.
+
+    `delta.annotations` is undocumented, so a provider may spread citations over several
+    deltas or report them only on the last one, and accumulating keeps both cases whole.
+    A provider repeating its full list on every delta would report duplicates, which is
+    the same tradeoff LiteLLM makes.
+    """
+    events = await _collect_handler_events(
+        _annotated_chunk(
+            {
+                "role": "assistant",
+                "content": "It will rain tomorrow.",
+                "annotations": [_url_citation()],
+            }
+        ),
+        _annotated_chunk(
+            {"annotations": [_url_citation(url="https://example.com/forecast", title="Forecast")]},
+            finish_reason="stop",
+        ),
+    )
+
+    assert [annotation["url"] for annotation in _streamed_annotations(events)] == [
+        "https://example.com/weather",
+        "https://example.com/forecast",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_buffering_keeps_a_citation_only_delta() -> None:
+    """Tool call buffering must forward a delta whose only output is a citation."""
+    chunks = await _collect_buffered_tool_call_chunks(
+        _annotated_chunk({"role": "assistant", "content": "It will rain tomorrow."}),
+        _annotated_chunk({"annotations": [_url_citation()]}, finish_reason="stop"),
+    )
+    events = await _collect_handler_events(*chunks)
+
+    assert [annotation["url"] for annotation in _streamed_annotations(events)] == [
+        "https://example.com/weather"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_skips_unsupported_annotation_shapes() -> None:
+    """An unsupported or incomplete citation is dropped instead of failing the turn."""
+    other_type = {"type": "file_citation", "file_citation": {"file_id": "file-1", "index": 0}}
+    incomplete = {"type": "url_citation", "url_citation": {"url": "https://example.com/partial"}}
+    events = await _collect_handler_events(
+        _annotated_chunk(
+            {
+                "role": "assistant",
+                "content": "It will rain tomorrow.",
+                "annotations": [other_type, incomplete, _url_citation()],
+            },
+            finish_reason="stop",
+        )
+    )
+
+    assert [annotation["url"] for annotation in _streamed_annotations(events)] == [
+        "https://example.com/weather"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_ignores_annotations_that_are_not_a_sequence() -> None:
+    """The streamed field is untyped, so an unexpected shape must not fail the turn."""
+    events = await _collect_handler_events(
+        _annotated_chunk(
+            {"role": "assistant", "content": "It will rain tomorrow.", "annotations": 5},
+            finish_reason="stop",
+        )
+    )
+
+    assert _streamed_annotations(events) == []
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_drops_citations_reported_before_any_text() -> None:
+    """Citations index into text, so one reported before any text part opens is dropped."""
+    events = await _collect_handler_events(
+        _annotated_chunk({"role": "assistant", "annotations": [_url_citation()]}),
+        _annotated_chunk({"content": "It will rain tomorrow."}, finish_reason="stop"),
+    )
+
+    assert _streamed_annotations(events) == []
+    completed = cast(ResponseCompletedEvent, events[-1])
+    message = cast(ResponseOutputMessage, completed.response.output[0])
+    assert len(message.content) == 1
+    assert cast(ResponseOutputText, message.content[0]).text == "It will rain tomorrow."


### PR DESCRIPTION
### Summary

`ChatCmplStreamHandler` builds the streamed `ResponseOutputText` with a hardcoded empty annotation list and never reads `annotations` off the delta, so url citations a provider reports are dropped whenever the run streams. #4222 restored these citations on the non-streamed path, so today the same question asked of the same model returns citations through `Runner.run` and an empty annotation list through `Runner.run_streamed`, which `.agents/references/runner-lifecycle.md` requires to be equivalent.

Annotations now accumulate onto the open text part as the deltas arrive, the same way the text and its logprobs already do. A provider can report a citation on the delta that carries the cited text or on a later one, so the read sits outside the content branch, and `_delta_has_passthrough_output` now recognizes a citation-only delta so `buffer_streamed_tool_calls=True` stops discarding it. The conversion moved to `ChatCmplHelpers.convert_url_citations` next to the logprob converters that are already shared by both paths, reading both the typed objects a non-streamed message carries and the plain mappings a streamed delta carries. `Converter._convert_annotations` stays private and delegates.

Two notes for reviewers:

- `annotations` is not a declared field on `ChoiceDelta`, so it is read with `getattr` and validated, the way the handler already reads `refusal`, `reasoning_content`, `reasoning` and `thinking_blocks`. An incomplete or unsupported citation is skipped rather than failing the turn.
- Citations accumulate rather than replace, as LiteLLM does in `stream_chunk_builder`. A provider repeating its full list on every delta would report duplicates; that is the same tradeoff LiteLLM makes, and I found no documented contract either way.

### Test plan

Seven tests in `tests/models/test_openai_chatcompletions_stream.py` cover citations reported on the text delta, on a later delta, accumulated across deltas, forwarded through tool call buffering, and the unsupported cases (unsupported annotation type, incomplete citation, non-sequence payload, citation reported before any text part opens). They fail against upstream, for example:

```
assert [] == ['https://example.com/weather']
```

`.agents/skills/code-change-verification/scripts/run.sh` passes.

### Issue number

N/A — this restores streaming parity with #4222. Related to #1346, but it does not close it: that report is Perplexity through LiteLLM, which attaches citations to the non-streamed message rather than to `delta.annotations`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
