### PR TITLE
fix(sessions): preserve required program item ids for OpenAI conversations

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -772,6 +772,8 @@ _OPENAI_CONVERSATION_ITEM_TYPES_WITH_REQUIRED_ID: frozenset[str] = frozenset(
         "mcp_approval_request",
         "mcp_call",
         "item_reference",
+        "program",
+        "program_output",
     }
 )
 

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai.types.responses.response_output_item import Program, ProgramOutput
 
-from agents import Agent, Runner, TResponseInputItem
+from agents import (
+    Agent,
+    ProgrammaticToolCallingTool,
+    Runner,
+    TResponseInputItem,
+    function_tool,
+)
 from agents.memory.openai_conversations_session import (
     OpenAIConversationsSession,
     start_openai_conversations_session,
@@ -455,6 +462,66 @@ class TestOpenAIConversationsSessionRunnerIntegration:
                 # Check that previous conversation is included
                 input_contents = [str(item.get("content", "")) for item in last_input]
                 assert any("Golden Gate Bridge" in content for content in input_contents)
+
+    @pytest.mark.asyncio
+    async def test_runner_persists_program_item_ids(self, mock_openai_client):
+        """Program items keep the id the Conversations create-item schema requires."""
+        model = FakeModel()
+        model.add_multiple_turn_outputs(
+            [
+                [
+                    Program(
+                        id="program_item",
+                        call_id="call_program",
+                        code='lookup_inventory(sku="A-1")',
+                        fingerprint="fingerprint",
+                        type="program",
+                    ),
+                ],
+                [
+                    ProgramOutput(
+                        id="program_output_item",
+                        call_id="call_program",
+                        result='{"sku":"A-1","available_units":42}',
+                        status="completed",
+                        type="program_output",
+                    ),
+                    get_text_message("done"),
+                ],
+            ]
+        )
+
+        @function_tool(allowed_callers=["programmatic"])
+        def lookup_inventory(sku: str) -> str:
+            return sku
+
+        program_agent = Agent(
+            name="inventory",
+            model=model,
+            tools=[ProgrammaticToolCallingTool(), lookup_inventory],
+        )
+        session = OpenAIConversationsSession(openai_client=mock_openai_client)
+
+        saved: list[TResponseInputItem] = []
+
+        async def record(items: list[TResponseInputItem]) -> None:
+            saved.extend(items)
+
+        with patch.object(session, "get_items", return_value=[]):
+            with patch.object(session, "add_items", side_effect=record):
+                result = await Runner.run(program_agent, "Check inventory", session=session)
+
+        assert result.final_output == "done"
+
+        saved_items = {
+            item["type"]: item
+            for item in cast(list[dict[str, Any]], saved)
+            if isinstance(item, dict) and "type" in item
+        }
+        assert saved_items["program"]["id"] == "program_item"
+        assert saved_items["program_output"]["id"] == "program_output_item"
+        # Item types whose id the Conversations schema leaves optional stay stripped.
+        assert "id" not in saved_items["message"]
 
 
 class TestOpenAIConversationsSessionErrorHandling:

--- a/tests/memory/test_session_persistence_sanitize.py
+++ b/tests/memory/test_session_persistence_sanitize.py
@@ -26,6 +26,8 @@ def _sanitize(item: dict[str, Any]) -> dict[str, Any]:
         "mcp_approval_request",
         "mcp_call",
         "item_reference",
+        "program",
+        "program_output",
     ],
 )
 def test_sanitize_preserves_ids_required_by_openai_conversation_items(item_type: str) -> None:
@@ -53,6 +55,40 @@ def test_sanitize_preserves_file_search_call_payload_id() -> None:
     assert sanitized["status"] == "completed"
 
 
+def test_sanitize_preserves_program_payload_id() -> None:
+    item = {
+        "type": "program",
+        "id": "program_abc",
+        "call_id": "call_program",
+        "code": 'lookup_inventory(sku="A-1")',
+        "fingerprint": "fingerprint",
+    }
+
+    sanitized = _sanitize(item)
+
+    assert sanitized["id"] == "program_abc"
+    assert sanitized["call_id"] == "call_program"
+    assert sanitized["code"] == 'lookup_inventory(sku="A-1")'
+    assert sanitized["fingerprint"] == "fingerprint"
+
+
+def test_sanitize_preserves_program_output_payload_id() -> None:
+    item = {
+        "type": "program_output",
+        "id": "program_output_abc",
+        "call_id": "call_program",
+        "result": '{"available_units":42}',
+        "status": "completed",
+    }
+
+    sanitized = _sanitize(item)
+
+    assert sanitized["id"] == "program_output_abc"
+    assert sanitized["call_id"] == "call_program"
+    assert sanitized["result"] == '{"available_units":42}'
+    assert sanitized["status"] == "completed"
+
+
 @pytest.mark.parametrize(
     "item",
     [
@@ -73,6 +109,14 @@ def test_sanitize_preserves_file_search_call_payload_id() -> None:
         {"type": "computer_call_output", "id": "ccout_abc", "call_id": "call_abc", "output": {}},
         {"type": "tool_search_call", "id": "ts_abc", "status": "completed"},
         {"type": "shell_call", "id": "sh_abc", "call_id": "call_abc", "action": {}},
+        {
+            "type": "function_call",
+            "id": "fc_prog",
+            "call_id": "call_abc",
+            "name": "get_weather",
+            "arguments": "{}",
+            "caller": {"type": "program", "caller_id": "call_program"},
+        },
     ],
 )
 def test_sanitize_strips_optional_or_policy_controlled_ids(item: dict[str, Any]) -> None:


### PR DESCRIPTION
### Summary

`_sanitize_openai_conversation_item()` strips the top-level `id` from every item it persists through `OpenAIConversationsSession` unless the item's type is listed in `_OPENAI_CONVERSATION_ITEM_TYPES_WITH_REQUIRED_ID`. That list was written in #3341 (fixing #3267, a 400 `missing items[0].id`) and enumerates the Responses input-item types whose `id` the Conversations create-item schema requires. Programmatic Tool Calling landed later, in #3833, and added two more such types — `program` and `program_output` — which were never added to the list.

So a run that uses `ProgrammaticToolCallingTool` together with an `OpenAIConversationsSession` sends its `program` and `program_output` items to `conversations.items.create` with the required `id` removed. This is the same failure #3267 reported for `file_search_call`.

**The schema is the oracle here, not an assumption.** `client.conversations.items.create(items=...)` takes `ItemCreateParams`, whose `items` is `Iterable[ResponseInputItemParam]`. In that generated union, `Program` and `ProgramOutput` both declare `id: Required[str]`:

```python
class Program(TypedDict, total=False):
    id: Required[str]
    call_id: Required[str]
    code: Required[str]
    fingerprint: Required[str]
    type: Required[Literal["program"]]

class ProgramOutput(TypedDict, total=False):
    id: Required[str]
    call_id: Required[str]
    result: Required[str]
    status: Required[Literal["completed", "incomplete"]]
    type: Required[Literal["program_output"]]
```

I diffed the whole generated `ResponseInputItemParam` union against the SDK list. Every one of the 11 listed types marks `id` as `Required`, and every unlisted type marks it `Optional` — except `program`, `program_output` (this fix), plus `message` and `reasoning`, which the function handles deliberately and separately. The list and the schema agree everywhere else, so these two are the only holes.

### Before / after

`Runner.run` with a `program` turn and an `OpenAIConversationsSession`, inspecting what reaches the session:

```
# before
SAVED: program           id=None    call_id=call_program
SAVED: program_output    id=None    call_id=call_program

# after
SAVED: program           id=program_item          call_id=call_program
SAVED: program_output    id=program_output_item   call_id=call_program
```

The same run against `SQLiteSession`, which does not sanitize, keeps `id=program_item` / `id=program_output_item` on both — so the ids are present on the raw items and it is the Conversations sanitization step that removes them.

### Why minimal

Two strings added to the existing frozenset. No new abstraction, no public API change, no serialized-format change, and no new branch in `_sanitize_openai_conversation_item()`. Sanitization only ever removes `id` and `provider_data`, so `id` was the sole required field being dropped from these items; nothing else about the payload changes.

Deliberately not widened: a `function_call` that carries `caller: {"type": "program", ...}` still has its `id` stripped, because `ResponseFunctionToolCallParam` marks `id` optional. The fix keys on the item's own type, not on program ownership. There is a regression test for that, and it passes both before and after.

### Test plan

Six tests, all through the existing public surfaces.

`tests/memory/test_openai_conversations_session.py`
- `test_runner_persists_program_item_ids` — a real `Runner.run` with `ProgrammaticToolCallingTool` and a `FakeModel` emitting `Program` then `ProgramOutput`, asserting the persisted items keep their ids and that the assistant `message` id stays stripped.

`tests/memory/test_session_persistence_sanitize.py`
- `program` and `program_output` added to the existing `test_sanitize_preserves_ids_required_by_openai_conversation_items` parametrization.
- `test_sanitize_preserves_program_payload_id` and `test_sanitize_preserves_program_output_payload_id` — full realistic payloads, mirroring the existing `file_search_call` payload test.
- A program-owned `function_call` added to `test_sanitize_strips_optional_or_policy_controlled_ids` — the boundary case, which passes before and after.

Five of the six fail on clean `main` @ `f3b6c617`, for example:

```
FAILED tests/memory/test_session_persistence_sanitize.py::test_sanitize_preserves_ids_required_by_openai_conversation_items[program]
FAILED tests/memory/test_session_persistence_sanitize.py::test_sanitize_preserves_ids_required_by_openai_conversation_items[program_output]
FAILED tests/memory/test_session_persistence_sanitize.py::test_sanitize_preserves_program_payload_id
FAILED tests/memory/test_session_persistence_sanitize.py::test_sanitize_preserves_program_output_payload_id
FAILED tests/memory/test_openai_conversations_session.py::TestOpenAIConversationsSessionRunnerIntegration::test_runner_persists_program_item_ids
5 failed, 58 passed
```

with `assert None == 'program_item'` on the end-to-end one. Red/green was proved in place by reverting only the source hunk.

Validation, all from a clean checkout of this branch:

- `uv run pytest tests/memory/test_session_persistence_sanitize.py tests/memory/test_openai_conversations_session.py -q` — red `5 failed, 58 passed`, green `63 passed`; the async test repeated 5× with no flakes.
- `uv run pytest tests/memory tests/test_programmatic_tool_calling.py -q` — `330 passed`.
- `make format` — `862 files left unchanged`. `make lint` — `All checks passed!`. `make typecheck` — mypy `no issues found in 849 source files`, pyright `0 errors, 0 warnings`.
- `make tests` and `.agents/skills/code-change-verification/scripts/run.sh` — see checkbox below.
- `git diff --check` — clean.

No API key, no network, no live service; the Conversations client is the suite's existing `AsyncMock` fixture.

Not run: `make coverage`, `make build-docs` (no docs touched), and the Python 3.10 matrix environment.

### Issue number

N/A — no filed issue. This is the same defect class as #3267 (fixed by #3341) for the item types Programmatic Tool Calling added in #3833.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
