### PR TITLE
fix: hosted MCP approval identity

### DIFF
--- a/src/agents/_tool_identity.py
+++ b/src/agents/_tool_identity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 from typing_extensions import Required, TypedDict
@@ -17,7 +18,29 @@ FunctionToolLookupKey = (
     | NamespacedFunctionToolLookupKey
     | DeferredTopLevelFunctionToolLookupKey
 )
+HostedMCPApprovalIdentity = tuple[Literal["hosted_mcp"], str, str]
+HostedMCPApprovalCallIdentity = tuple[Literal["hosted_mcp_call"], str]
+HostedMCPApprovalQueryIdentity = tuple[Literal["hosted_mcp_query"], str, str]
+HostedMCPApprovalKey = (
+    HostedMCPApprovalIdentity | HostedMCPApprovalCallIdentity | HostedMCPApprovalQueryIdentity
+)
 NamedToolLookupKey = FunctionToolLookupKey | str
+
+
+@dataclass(frozen=True)
+class HostedMCPApprovalRequestIdentity:
+    """Validated identity fields from a hosted MCP approval request."""
+
+    request_id: str | None
+    server_label: str | None
+    tool_name: str | None
+
+    @property
+    def approval_identity(self) -> HostedMCPApprovalIdentity | None:
+        """Return the persistent identity when all required fields are available."""
+        if self.server_label is None or self.tool_name is None:
+            return None
+        return ("hosted_mcp", self.server_label, self.tool_name)
 
 
 def validate_function_tool_fallback_name(name: str) -> str:
@@ -46,6 +69,61 @@ def get_mapping_or_attr(value: Any, key: str) -> Any:
     if isinstance(value, dict):
         return value.get(key)
     return getattr(value, key, None)
+
+
+def _non_empty_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def get_hosted_mcp_approval_request_identity(
+    value: Any,
+) -> HostedMCPApprovalRequestIdentity | None:
+    """Return strictly validated identity fields for a hosted MCP approval request."""
+    raw_item = get_mapping_or_attr(value, "raw_item")
+    if raw_item is None:
+        raw_item = value
+
+    raw_type = get_mapping_or_attr(raw_item, "type")
+    if raw_type == "mcp_approval_request":
+        request = raw_item
+        request_id = _non_empty_string(get_mapping_or_attr(request, "id"))
+        tool_name = _non_empty_string(get_mapping_or_attr(request, "name"))
+    elif raw_type == "hosted_tool_call":
+        request = get_mapping_or_attr(raw_item, "provider_data")
+        if get_mapping_or_attr(request, "type") != "mcp_approval_request":
+            return None
+
+        provider_request_id = get_mapping_or_attr(request, "id")
+        if provider_request_id is None:
+            request_id = _non_empty_string(get_mapping_or_attr(raw_item, "call_id"))
+            if request_id is None:
+                request_id = _non_empty_string(get_mapping_or_attr(raw_item, "id"))
+        else:
+            request_id = _non_empty_string(provider_request_id)
+        tool_name = _non_empty_string(get_mapping_or_attr(request, "name"))
+        if tool_name is None:
+            tool_name = _non_empty_string(get_mapping_or_attr(raw_item, "name"))
+    else:
+        return None
+
+    return HostedMCPApprovalRequestIdentity(
+        request_id=request_id,
+        server_label=_non_empty_string(get_mapping_or_attr(request, "server_label")),
+        tool_name=tool_name,
+    )
+
+
+def get_tool_approval_item_call_id(value: Any) -> str | None:
+    """Return the canonical call ID for a tool approval item."""
+    hosted_request = get_hosted_mcp_approval_request_identity(value)
+    if hosted_request is not None:
+        return hosted_request.request_id
+
+    raw_item = get_mapping_or_attr(value, "raw_item")
+    if raw_item is None:
+        raw_item = value
+    call_id = get_mapping_or_attr(raw_item, "call_id") or get_mapping_or_attr(raw_item, "id")
+    return _non_empty_string(call_id)
 
 
 def tool_qualified_name(name: str | None, namespace: str | None = None) -> str | None:

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -14,7 +14,11 @@ from pydantic import BaseModel, TypeAdapter, ValidationError
 from typing_extensions import NotRequired, TypedDict
 
 from . import _debug
-from ._tool_identity import get_function_tool_approval_keys
+from ._tool_identity import (
+    get_function_tool_approval_keys,
+    get_hosted_mcp_approval_request_identity,
+    get_tool_approval_item_call_id,
+)
 from .agent_output import AgentOutputSchemaBase
 from .agent_tool_input import (
     AgentAsToolInput,
@@ -748,7 +752,7 @@ class Agent(AgentBase, Generic[TContext]):
                 has_pending = False
                 has_decision = False
                 for interruption in interruptions:
-                    call_id = interruption.call_id
+                    call_id = get_tool_approval_item_call_id(interruption)
                     if not call_id:
                         has_pending = True
                         continue
@@ -781,6 +785,15 @@ class Agent(AgentBase, Generic[TContext]):
                     *,
                     approved: bool,
                 ) -> Any | None:
+                    hosted_request = get_hosted_mcp_approval_request_identity(interruption)
+                    if hosted_request is not None and hosted_request.request_id is not None:
+                        hosted_key = hosted_request.approval_identity or (
+                            "hosted_mcp_call",
+                            hosted_request.request_id,
+                        )
+                        hosted_record = parent_context._approvals.get(hosted_key)
+                        if hosted_record is not None:
+                            return hosted_record
                     candidate_keys = list(RunContextWrapper._resolve_approval_keys(interruption))
                     for candidate_key in get_function_tool_approval_keys(
                         tool_name=RunContextWrapper._resolve_tool_name(interruption),
@@ -804,7 +817,7 @@ class Agent(AgentBase, Generic[TContext]):
                     return fallback
 
                 for interruption in interruptions:
-                    call_id = interruption.call_id
+                    call_id = get_tool_approval_item_call_id(interruption)
                     if not call_id:
                         continue
                     tool_name = RunContextWrapper._resolve_tool_name(interruption)
@@ -818,12 +831,19 @@ class Agent(AgentBase, Generic[TContext]):
                     )
                     if status is None:
                         continue
-                    approval_record = parent_context._approvals.get(approval_key)
-                    if approval_record is None:
+                    hosted_request = get_hosted_mcp_approval_request_identity(interruption)
+                    if hosted_request is not None:
                         approval_record = _find_mirrored_approval_record(
                             interruption,
                             approved=status,
                         )
+                    else:
+                        approval_record = parent_context._approvals.get(approval_key)
+                        if approval_record is None:
+                            approval_record = _find_mirrored_approval_record(
+                                interruption,
+                                approved=status,
+                            )
                     if status is True:
                         always_approve = bool(approval_record and approval_record.approved is True)
                         nested_context.approve_tool(
@@ -832,9 +852,20 @@ class Agent(AgentBase, Generic[TContext]):
                         )
                     else:
                         always_reject = bool(approval_record and approval_record.rejected is True)
+                        rejection_message = (
+                            parent_context.get_rejection_message(
+                                tool_name,
+                                call_id,
+                                tool_namespace=tool_namespace,
+                                existing_pending=interruption,
+                            )
+                            if hosted_request is not None
+                            else None
+                        )
                         nested_context.reject_tool(
                             interruption,
                             always_reject=always_reject,
+                            rejection_message=rejection_message,
                         )
 
             if isinstance(context, ToolContext) and context.tool_call is not None:

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -8,11 +8,15 @@ from typing_extensions import TypeVar
 
 from ._tool_identity import (
     FunctionToolLookupKey,
+    HostedMCPApprovalKey,
+    HostedMCPApprovalRequestIdentity,
     get_function_tool_approval_keys,
     get_function_tool_lookup_key,
+    get_hosted_mcp_approval_request_identity,
     is_reserved_synthetic_tool_namespace,
     tool_qualified_name,
 )
+from .exceptions import UserError
 from .usage import Usage
 
 if TYPE_CHECKING:
@@ -58,7 +62,7 @@ class RunContextWrapper(Generic[TContext]):
     """
 
     turn_input: list[TResponseInputItem] = field(default_factory=list)
-    _approvals: dict[str, _ApprovalRecord] = field(default_factory=dict)
+    _approvals: dict[str | HostedMCPApprovalKey, _ApprovalRecord] = field(default_factory=dict)
     tool_input: Any | None = None
     """Structured input for the current agent tool run, when available."""
 
@@ -168,21 +172,39 @@ class RunContextWrapper(Generic[TContext]):
             candidate = getattr(raw, "call_id", None) or getattr(raw, "id", None)
         return RunContextWrapper._to_str_or_none(candidate)
 
-    def _get_or_create_approval_entry(self, tool_name: str) -> _ApprovalRecord:
-        approval_entry = self._approvals.get(tool_name)
+    def _get_or_create_approval_entry(
+        self,
+        approval_key: str | HostedMCPApprovalKey,
+    ) -> _ApprovalRecord:
+        approval_entry = self._approvals.get(approval_key)
         if approval_entry is None:
             approval_entry = _ApprovalRecord()
-            self._approvals[tool_name] = approval_entry
+            self._approvals[approval_key] = approval_entry
         return approval_entry
 
     def is_tool_approved(self, tool_name: str, call_id: str) -> bool | None:
         """Return True/False/None for the given tool call."""
+        hosted_query_record = self._approvals.get(("hosted_mcp_query", tool_name, call_id))
+        hosted_query_status = self._get_per_call_approval_status_for_record(
+            hosted_query_record,
+            call_id,
+        )
+        if hosted_query_status is not None:
+            return hosted_query_status
         return self._get_approval_status_for_key(tool_name, call_id)
 
     def _get_approval_status_for_key(self, approval_key: str, call_id: str) -> bool | None:
         """Return True/False/None for a concrete approval key and tool call."""
         approval_entry = self._approvals.get(approval_key)
-        if not approval_entry:
+        return self._get_approval_status_for_record(approval_entry, call_id)
+
+    @staticmethod
+    def _get_approval_status_for_record(
+        approval_entry: _ApprovalRecord | None,
+        call_id: str,
+    ) -> bool | None:
+        """Return True/False/None for an approval record and tool call."""
+        if approval_entry is None:
             return None
 
         # Check for permanent approval/rejection
@@ -210,6 +232,29 @@ class RunContextWrapper(Generic[TContext]):
         # Per-call approvals are scoped to the exact call ID, so other calls require a new decision.
         return None
 
+    def _get_per_call_approval_status_for_key(
+        self,
+        approval_key: str,
+        call_id: str,
+    ) -> bool | None:
+        """Return only exact-call decisions, ignoring sticky values on the same key."""
+        approval_entry = self._approvals.get(approval_key)
+        return self._get_per_call_approval_status_for_record(approval_entry, call_id)
+
+    @staticmethod
+    def _get_per_call_approval_status_for_record(
+        approval_entry: _ApprovalRecord | None,
+        call_id: str,
+    ) -> bool | None:
+        """Return only an exact-call decision from an approval record."""
+        if approval_entry is None:
+            return None
+        if isinstance(approval_entry.approved, list) and call_id in approval_entry.approved:
+            return True
+        if isinstance(approval_entry.rejected, list) and call_id in approval_entry.rejected:
+            return False
+        return None
+
     @staticmethod
     def _clear_rejection_message(record: _ApprovalRecord, call_id: str | None) -> None:
         if call_id is None:
@@ -234,6 +279,79 @@ class RunContextWrapper(Generic[TContext]):
             return [item for item in value if isinstance(item, str)]
         return []
 
+    @staticmethod
+    def _resolve_hosted_mcp_tool_name(
+        approval_item: ToolApprovalItem,
+        hosted_request: HostedMCPApprovalRequestIdentity,
+    ) -> str | None:
+        """Resolve a hosted MCP tool name, including persisted legacy item metadata."""
+        if hosted_request.tool_name is not None:
+            return hosted_request.tool_name
+        persisted_tool_name = getattr(approval_item, "tool_name", None)
+        if isinstance(persisted_tool_name, str) and persisted_tool_name:
+            return persisted_tool_name
+        return None
+
+    def _resolve_hosted_mcp_approval_record(
+        self,
+        approval_item: ToolApprovalItem,
+        *,
+        allow_legacy_exact: bool,
+    ) -> tuple[_ApprovalRecord | None, str | None, bool]:
+        """Resolve the authoritative hosted MCP record and whether it is exact-call-only."""
+        hosted_request = get_hosted_mcp_approval_request_identity(approval_item)
+        if hosted_request is None or hosted_request.request_id is None:
+            return None, None, True
+
+        request_id = hosted_request.request_id
+        hosted_identity = hosted_request.approval_identity
+        if hosted_identity is not None:
+            current_record = self._approvals.get(hosted_identity)
+            current_status = self._get_approval_status_for_record(current_record, request_id)
+            if current_status is not None:
+                return current_record, request_id, False
+        else:
+            current_record = self._approvals.get(("hosted_mcp_call", request_id))
+            current_status = self._get_per_call_approval_status_for_record(
+                current_record,
+                request_id,
+            )
+            if current_status is not None:
+                return current_record, request_id, True
+
+        if not allow_legacy_exact:
+            return None, request_id, True
+
+        legacy_key = self._resolve_hosted_mcp_tool_name(approval_item, hosted_request)
+        if legacy_key is None:
+            return None, request_id, True
+
+        legacy_record = self._approvals.get(legacy_key)
+        legacy_status = self._get_per_call_approval_status_for_record(legacy_record, request_id)
+        if legacy_status is None:
+            return None, request_id, True
+        return legacy_record, request_id, True
+
+    def _resolve_hosted_mcp_approval_decision(
+        self,
+        approval_item: ToolApprovalItem,
+        *,
+        allow_legacy_exact: bool = True,
+    ) -> tuple[bool | None, str | None]:
+        """Return a hosted MCP decision and its rejection message from one record."""
+        approval_record, request_id, exact_call_only = self._resolve_hosted_mcp_approval_record(
+            approval_item,
+            allow_legacy_exact=allow_legacy_exact,
+        )
+        if approval_record is None or request_id is None:
+            return None, None
+
+        if exact_call_only:
+            status = self._get_per_call_approval_status_for_record(approval_record, request_id)
+        else:
+            status = self._get_approval_status_for_record(approval_record, request_id)
+        return status, self._get_rejection_message_for_key(approval_record, request_id)
+
     def get_rejection_message(
         self,
         tool_name: str,
@@ -244,6 +362,21 @@ class RunContextWrapper(Generic[TContext]):
         tool_lookup_key: FunctionToolLookupKey | None = None,
     ) -> str | None:
         """Return a stored rejection message for a tool call if one exists."""
+        if existing_pending is not None:
+            hosted_request = get_hosted_mcp_approval_request_identity(existing_pending)
+            if hosted_request is not None:
+                _, rejection_message = self._resolve_hosted_mcp_approval_decision(existing_pending)
+                return rejection_message
+
+        hosted_query_record = self._approvals.get(("hosted_mcp_query", tool_name, call_id))
+        hosted_query_status = self._get_per_call_approval_status_for_record(
+            hosted_query_record,
+            call_id,
+        )
+        if hosted_query_status is not None:
+            assert hosted_query_record is not None
+            return self._get_rejection_message_for_key(hosted_query_record, call_id)
+
         candidates: list[str] = []
         explicit_namespace = (
             tool_namespace if isinstance(tool_namespace, str) and tool_namespace else None
@@ -315,14 +448,55 @@ class RunContextWrapper(Generic[TContext]):
         rejection_message: str | None = None,
     ) -> None:
         """Record an approval or rejection decision."""
-        approval_keys = self._resolve_approval_keys(approval_item) or ("unknown_tool",)
-        exact_approval_key = self._resolve_approval_key(approval_item)
-        call_id = self._resolve_call_id(approval_item)
-        decision_keys = (exact_approval_key,) if always or call_id is None else approval_keys
+        hosted_request = get_hosted_mcp_approval_request_identity(approval_item)
+        if hosted_request is not None:
+            call_id = hosted_request.request_id
+            if call_id is None:
+                raise UserError("Hosted MCP approval decisions require a non-empty request id.")
+            hosted_identity = hosted_request.approval_identity
+            if always and hosted_identity is None:
+                raise UserError(
+                    "Persistent hosted MCP approval decisions require a non-empty server_label "
+                    "and tool name."
+                )
+        else:
+            call_id = self._resolve_call_id(approval_item)
+            hosted_identity = None
 
-        for approval_key in decision_keys:
-            approval_entry = self._get_or_create_approval_entry(approval_key)
-            if always or call_id is None:
+        approval_entries: tuple[tuple[_ApprovalRecord, bool], ...]
+        if hosted_request is not None:
+            assert call_id is not None
+            hosted_key: HostedMCPApprovalKey
+            if hosted_identity is None:
+                hosted_key = ("hosted_mcp_call", call_id)
+            else:
+                hosted_key = hosted_identity
+            approval_entries = ((self._get_or_create_approval_entry(hosted_key), always),)
+            hosted_tool_name = self._resolve_hosted_mcp_tool_name(
+                approval_item,
+                hosted_request,
+            )
+            if hosted_tool_name is not None:
+                # Preserve exact name-based lookup without adding an authorization source.
+                approval_entries += (
+                    (
+                        self._get_or_create_approval_entry(
+                            ("hosted_mcp_query", hosted_tool_name, call_id)
+                        ),
+                        False,
+                    ),
+                )
+        else:
+            approval_keys = self._resolve_approval_keys(approval_item) or ("unknown_tool",)
+            exact_approval_key = self._resolve_approval_key(approval_item)
+            decision_keys = (exact_approval_key,) if always or call_id is None else approval_keys
+            approval_entries = tuple(
+                (self._get_or_create_approval_entry(approval_key), always)
+                for approval_key in decision_keys
+            )
+
+        for approval_entry, entry_is_sticky in approval_entries:
+            if entry_is_sticky or call_id is None:
                 approval_entry.approved = approve
                 approval_entry.rejected = [] if approve else True
                 if not approve:
@@ -384,6 +558,12 @@ class RunContextWrapper(Generic[TContext]):
         tool_lookup_key: FunctionToolLookupKey | None = None,
     ) -> bool | None:
         """Return approval status, retrying with pending item's tool name if necessary."""
+        if existing_pending is not None:
+            hosted_request = get_hosted_mcp_approval_request_identity(existing_pending)
+            if hosted_request is not None:
+                hosted_status, _ = self._resolve_hosted_mcp_approval_decision(existing_pending)
+                return hosted_status
+
         candidates: list[str] = []
         explicit_namespace = (
             tool_namespace if isinstance(tool_namespace, str) and tool_namespace else None
@@ -452,20 +632,61 @@ class RunContextWrapper(Generic[TContext]):
         for tool_name, record_dict in approvals.items():
             if not isinstance(tool_name, str) or not isinstance(record_dict, dict):
                 continue
-            record = _ApprovalRecord()
-            record.approved = self._restore_approval_value(record_dict.get("approved", []))
-            record.rejected = self._restore_approval_value(record_dict.get("rejected", []))
-            rejection_messages = record_dict.get("rejection_messages", {})
-            if isinstance(rejection_messages, dict):
-                record.rejection_messages = {
-                    str(call_id): message
-                    for call_id, message in rejection_messages.items()
-                    if isinstance(message, str)
-                }
-            sticky_rejection_message = record_dict.get("sticky_rejection_message")
-            if isinstance(sticky_rejection_message, str):
-                record.sticky_rejection_message = sticky_rejection_message
-            self._approvals[tool_name] = record
+            self._approvals[tool_name] = self._restore_approval_record(record_dict)
+
+    @classmethod
+    def _restore_approval_record(cls, record_dict: Mapping[str, Any]) -> _ApprovalRecord:
+        record = _ApprovalRecord()
+        record.approved = cls._restore_approval_value(record_dict.get("approved", []))
+        record.rejected = cls._restore_approval_value(record_dict.get("rejected", []))
+        rejection_messages = record_dict.get("rejection_messages", {})
+        if isinstance(rejection_messages, dict):
+            record.rejection_messages = {
+                str(call_id): message
+                for call_id, message in rejection_messages.items()
+                if isinstance(message, str)
+            }
+        sticky_rejection_message = record_dict.get("sticky_rejection_message")
+        if isinstance(sticky_rejection_message, str):
+            record.sticky_rejection_message = sticky_rejection_message
+        return record
+
+    def _rebuild_hosted_mcp_approvals(self, approvals: Any) -> None:
+        """Restore typed hosted MCP approval records from serialized state."""
+        if not isinstance(approvals, list):
+            return
+        for entry in approvals:
+            if not isinstance(entry, Mapping):
+                continue
+            identity = entry.get("identity")
+            decision = entry.get("decision")
+            if not isinstance(identity, Mapping) or not isinstance(decision, Mapping):
+                continue
+            identity_type = identity.get("type")
+            if identity_type == "server_tool":
+                server_label = identity.get("server_label")
+                tool_name = identity.get("tool_name")
+                if not isinstance(server_label, str) or not server_label:
+                    continue
+                if not isinstance(tool_name, str) or not tool_name:
+                    continue
+                key: HostedMCPApprovalKey = ("hosted_mcp", server_label, tool_name)
+            elif identity_type == "request":
+                request_id = identity.get("request_id")
+                if not isinstance(request_id, str) or not request_id:
+                    continue
+                key = ("hosted_mcp_call", request_id)
+            elif identity_type == "query":
+                tool_name = identity.get("tool_name")
+                request_id = identity.get("request_id")
+                if not isinstance(tool_name, str) or not tool_name:
+                    continue
+                if not isinstance(request_id, str) or not request_id:
+                    continue
+                key = ("hosted_mcp_query", tool_name, request_id)
+            else:
+                continue
+            self._approvals[key] = self._restore_approval_record(decision)
 
     def _fork_with_tool_input(self, tool_input: Any) -> RunContextWrapper[TContext]:
         """Create a child context that shares approvals and usage with tool input set."""

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -19,7 +19,6 @@ from openai.types.responses.response_input_item_param import (
     ComputerCallOutputAcknowledgedSafetyCheck,
 )
 from openai.types.responses.response_input_param import McpApprovalResponse
-from openai.types.responses.response_output_item import McpApprovalRequest
 
 from .. import _debug
 from .._tool_identity import (
@@ -29,6 +28,8 @@ from .._tool_identity import (
     get_function_tool_lookup_key,
     get_function_tool_lookup_key_for_call,
     get_function_tool_trace_name,
+    get_hosted_mcp_approval_request_identity,
+    get_tool_approval_item_call_id,
     get_tool_call_namespace,
     get_tool_call_trace_name,
     is_deferred_top_level_function_tool,
@@ -102,7 +103,6 @@ from .agent_bindings import AgentBindings, bind_public_agent
 from .approvals import append_approval_error_output
 from .items import (
     REJECTION_MESSAGE,
-    extract_mcp_request_id,
     extract_mcp_request_id_from_run,
     function_rejection_item,
     function_tool_error_output,
@@ -144,10 +144,8 @@ __all__ = [
     "get_trace_tool_error",
     "with_tool_function_span",
     "build_litellm_json_tool_call",
-    "process_hosted_mcp_approvals",
     "collect_manual_mcp_approvals",
     "index_approval_items_by_call_id",
-    "should_keep_hosted_mcp_item",
     "resolve_approval_status",
     "resolve_approval_interruption",
     "resolve_approval_rejection_message",
@@ -1280,68 +1278,46 @@ async def function_needs_approval(
     return bool(needs_approval)
 
 
-def process_hosted_mcp_approvals(
-    *,
-    original_pre_step_items: Sequence[RunItem],
-    mcp_approval_requests: Sequence[Any],
-    context_wrapper: RunContextWrapper[Any],
-    agent: Agent[Any],
-    append_item: Callable[[RunItem], None],
-) -> tuple[list[ToolApprovalItem], set[str]]:
-    """Filter hosted MCP outputs and merge manual approvals so only coherent items remain."""
-    hosted_mcp_approvals_by_id: dict[str, ToolApprovalItem] = {}
-    for item in original_pre_step_items:
-        if not isinstance(item, ToolApprovalItem):
-            continue
-        raw = item.raw_item
-        if not _is_hosted_mcp_approval_request(raw):
-            continue
-        request_id = extract_mcp_request_id(raw)
-        if request_id:
-            hosted_mcp_approvals_by_id[request_id] = item
-
-    pending_hosted_mcp_approvals: list[ToolApprovalItem] = []
-    pending_hosted_mcp_approval_ids: set[str] = set()
-
-    for mcp_run in mcp_approval_requests:
-        request_id = extract_mcp_request_id_from_run(mcp_run)
-        # MCP approval requests are documented to include an id used as approval_request_id.
-        # See https://platform.openai.com/docs/guides/tools-connectors-mcp#approvals
-        approval_item = hosted_mcp_approvals_by_id.get(request_id) if request_id else None
-        if not approval_item or not request_id:
-            continue
-
-        tool_name = RunContextWrapper._resolve_tool_name(approval_item)
-        approved = context_wrapper.get_approval_status(
-            tool_name=tool_name,
-            call_id=request_id,
-            existing_pending=approval_item,
-        )
-
-        if approved is not None:
-            raw_item: McpApprovalResponse = {
-                "type": "mcp_approval_response",
-                "approval_request_id": request_id,
-                "approve": approved,
-            }
-            rejection_message = context_wrapper.get_rejection_message(
-                tool_name=tool_name,
-                call_id=request_id,
-                existing_pending=approval_item,
-            )
-            if approved is False and rejection_message is not None:
-                raw_item["reason"] = rejection_message
-            ItemHelpers.copy_tool_call_caller(mcp_run.request_item, raw_item)
-            response_item = MCPApprovalResponseItem(raw_item=raw_item, agent=agent)
-            append_item(response_item)
-            continue
-
-        if approval_item not in pending_hosted_mcp_approvals:
-            pending_hosted_mcp_approvals.append(approval_item)
-        pending_hosted_mcp_approval_ids.add(request_id)
-        append_item(approval_item)
-
-    return pending_hosted_mcp_approvals, pending_hosted_mcp_approval_ids
+def _classify_hosted_mcp_pending_request(
+    pending: ToolApprovalItem,
+    current_request: Any,
+) -> Literal["reuse_pending", "use_current", "use_current_with_pending_exact", "conflict"]:
+    """Choose the safe identity source when reconciling pending and current requests."""
+    pending_identity = get_hosted_mcp_approval_request_identity(pending)
+    current_identity = get_hosted_mcp_approval_request_identity(current_request)
+    if pending_identity is None or current_identity is None:
+        return "conflict"
+    if pending_identity.request_id is None or current_identity.request_id is None:
+        return "conflict"
+    if pending_identity.request_id != current_identity.request_id:
+        return "conflict"
+    if (
+        pending_identity.server_label is not None
+        and current_identity.server_label is not None
+        and pending_identity.server_label != current_identity.server_label
+    ):
+        return "conflict"
+    pending_tool_name = RunContextWrapper._resolve_hosted_mcp_tool_name(
+        pending,
+        pending_identity,
+    )
+    if (
+        pending_tool_name is not None
+        and current_identity.tool_name is not None
+        and pending_tool_name != current_identity.tool_name
+    ):
+        return "conflict"
+    if (
+        current_identity.approval_identity is None
+        and pending_identity.approval_identity is not None
+    ):
+        return "use_current"
+    if (
+        current_identity.approval_identity is not None
+        and pending_identity.approval_identity is None
+    ):
+        return "use_current_with_pending_exact"
+    return "reuse_pending"
 
 
 def collect_manual_mcp_approvals(
@@ -1370,10 +1346,49 @@ def collect_manual_mcp_approvals(
         tool_name = RunContextWrapper._to_str_or_none(getattr(request_item, "name", None))
         tool_name = tool_name or get_mapping_or_attr(request, "mcp_tool").name
 
-        existing_pending = pending_lookup.get(request_id or "")
-        approval_status = context_wrapper.get_approval_status(
-            tool_name, request_id or "", existing_pending=existing_pending
+        current_approval_item = ToolApprovalItem(
+            agent=agent,
+            raw_item=request_item,
+            tool_name=tool_name,
         )
+        existing_pending = pending_lookup.get(request_id or "")
+        pending_resolution = (
+            _classify_hosted_mcp_pending_request(existing_pending, request_item)
+            if existing_pending is not None
+            else "use_current"
+        )
+        identity_mismatch = pending_resolution == "conflict"
+        if existing_pending is not None and pending_resolution == "reuse_pending":
+            approval_item = existing_pending
+        else:
+            approval_item = current_approval_item
+        allow_primary_legacy = (
+            existing_pending is not None
+            and not identity_mismatch
+            and pending_resolution != "use_current_with_pending_exact"
+        )
+        approval_status, rejection_message = context_wrapper._resolve_hosted_mcp_approval_decision(
+            approval_item,
+            allow_legacy_exact=allow_primary_legacy,
+        )
+        if (
+            approval_status is None
+            and existing_pending is not None
+            and pending_resolution == "use_current_with_pending_exact"
+        ):
+            approval_status, rejection_message = (
+                context_wrapper._resolve_hosted_mcp_approval_decision(
+                    existing_pending,
+                    allow_legacy_exact=True,
+                )
+            )
+        if approval_status is None and pending_resolution == "use_current_with_pending_exact":
+            approval_status, rejection_message = (
+                context_wrapper._resolve_hosted_mcp_approval_decision(
+                    current_approval_item,
+                    allow_legacy_exact=True,
+                )
+            )
 
         if approval_status is not None and request_id:
             approval_response_raw: McpApprovalResponse = {
@@ -1381,11 +1396,6 @@ def collect_manual_mcp_approvals(
                 "approval_request_id": request_id,
                 "approve": approval_status,
             }
-            rejection_message = context_wrapper.get_rejection_message(
-                tool_name,
-                request_id,
-                existing_pending=existing_pending,
-            )
             if approval_status is False and rejection_message is not None:
                 approval_response_raw["reason"] = rejection_message
             ItemHelpers.copy_tool_call_caller(request_item, approval_response_raw)
@@ -1395,14 +1405,7 @@ def collect_manual_mcp_approvals(
         if approval_status is not None:
             continue
 
-        pending.append(
-            existing_pending
-            or ToolApprovalItem(
-                agent=agent,
-                raw_item=request_item,
-                tool_name=tool_name,
-            )
-        )
+        pending.append(approval_item)
 
     return approved, pending
 
@@ -1413,27 +1416,10 @@ def index_approval_items_by_call_id(items: Sequence[RunItem]) -> dict[str, ToolA
     for item in items:
         if not isinstance(item, ToolApprovalItem):
             continue
-        call_id = extract_tool_call_id(item.raw_item)
+        call_id = get_tool_approval_item_call_id(item)
         if call_id:
             approvals[call_id] = item
     return approvals
-
-
-def should_keep_hosted_mcp_item(
-    item: RunItem,
-    *,
-    pending_hosted_mcp_approvals: Sequence[ToolApprovalItem],
-    pending_hosted_mcp_approval_ids: set[str],
-) -> bool:
-    """Keep only hosted MCP approvals that match pending requests from the provider."""
-    if not isinstance(item, ToolApprovalItem):
-        return True
-    if not _is_hosted_mcp_approval_request(item.raw_item):
-        return False
-    request_id = extract_mcp_request_id(item.raw_item)
-    return item in pending_hosted_mcp_approvals or (
-        request_id is not None and request_id in pending_hosted_mcp_approval_ids
-    )
 
 
 def _uses_programmatic_output_schema(
@@ -2603,16 +2589,3 @@ def _normalize_exit_code(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
-
-
-def _is_hosted_mcp_approval_request(raw_item: Any) -> bool:
-    """Detect hosted MCP approval request payloads emitted by the provider."""
-    if isinstance(raw_item, McpApprovalRequest):
-        return True
-    if not isinstance(raw_item, dict):
-        return False
-    provider_data = raw_item.get("provider_data", {})
-    return (
-        raw_item.get("type") == "hosted_tool_call"
-        and provider_data.get("type") == "mcp_approval_request"
-    )

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -39,6 +39,7 @@ from .._tool_identity import (
     get_function_tool_lookup_key,
     get_function_tool_lookup_key_for_call,
     get_function_tool_lookup_key_for_tool,
+    get_tool_approval_item_call_id,
     get_tool_call_namespace,
     get_tool_call_qualified_name,
     get_tool_call_trace_name,
@@ -128,6 +129,7 @@ from .items import (
     REJECTION_MESSAGE,
     NestedHistoryOwnedItem,
     apply_patch_rejection_item,
+    extract_mcp_request_id_from_run,
     function_rejection_item,
     shell_rejection_item,
 )
@@ -165,9 +167,7 @@ from .tool_execution import (
     is_apply_patch_name,
     parse_apply_patch_custom_input,
     parse_apply_patch_function_args,
-    process_hosted_mcp_approvals,
     resolve_approval_rejection_message,
-    should_keep_hosted_mcp_item,
 )
 from .tool_planning import (
     _append_mcp_callback_results,
@@ -1321,7 +1321,7 @@ async def resolve_interrupted_turn(
     ) -> Literal["approved", "pending", "rejected"]:
         has_pending = False
         for interruption in interruptions:
-            call_id = extract_tool_call_id(interruption.raw_item)
+            call_id = get_tool_approval_item_call_id(interruption)
             if not call_id:
                 has_pending = True
                 continue
@@ -1371,7 +1371,7 @@ async def resolve_interrupted_turn(
             source_item.tool_lookup_key = item.tool_lookup_key
             source_item._allow_bare_name_alias = item._allow_bare_name_alias
             item = source_item
-        call_id = extract_tool_call_id(item.raw_item)
+        call_id = get_tool_approval_item_call_id(item)
         key = call_id or f"raw:{id(item.raw_item)}"
         if key in pending_interruption_keys:
             return
@@ -1521,7 +1521,7 @@ async def resolve_interrupted_turn(
     }
 
     def _is_function_approval(approval: ToolApprovalItem) -> bool:
-        call_id = extract_tool_call_id(approval.raw_item)
+        call_id = get_tool_approval_item_call_id(approval)
         if call_id in non_function_owned_call_ids and call_id not in queued_function_call_ids:
             return False
         if get_mapping_or_attr(approval.raw_item, "type") == "function_call":
@@ -1911,12 +1911,13 @@ async def resolve_interrupted_turn(
         *(_shell_call_id_from_run(run) for run in processed_response.shell_calls),
         *(_apply_patch_call_id_from_run(run) for run in processed_response.apply_patch_calls),
         *(_custom_call_id_from_run(run) for run in processed_response.custom_tool_calls),
+        *(extract_mcp_request_id_from_run(run) for run in processed_response.mcp_approval_requests),
     }
     for original_approval in pending_approval_items:
         approval_snapshot = validated_function_approval_items.get(original_approval)
         if approval_snapshot is None:
             approval = original_approval
-            approval_call_id = extract_tool_call_id(approval.raw_item)
+            approval_call_id = get_tool_approval_item_call_id(approval)
             if approval_call_id in collector_owned_call_ids:
                 continue
             if (
@@ -2167,25 +2168,8 @@ async def resolve_interrupted_turn(
         append_item=append_if_new,
     )
 
-    (
-        pending_hosted_mcp_approvals,
-        pending_hosted_mcp_approval_ids,
-    ) = process_hosted_mcp_approvals(
-        original_pre_step_items=original_pre_step_items,
-        mcp_approval_requests=processed_response.mcp_approval_requests,
-        context_wrapper=context_wrapper,
-        agent=public_agent,
-        append_item=append_if_new,
-    )
-
-    pre_step_items = [
-        item
-        for item in original_pre_step_items
-        if should_keep_hosted_mcp_item(
-            item,
-            pending_hosted_mcp_approvals=pending_hosted_mcp_approvals,
-            pending_hosted_mcp_approval_ids=pending_hosted_mcp_approval_ids,
-        )
+    pre_step_items: list[RunItem] = [
+        item for item in original_pre_step_items if not isinstance(item, ToolApprovalItem)
     ]
 
     if rejected_function_call_ids:

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -150,7 +150,9 @@ ContextDeserializer = Callable[[Mapping[str, Any]], Any]
 # 3. to_json() always emits CURRENT_SCHEMA_VERSION.
 # 4. Forward compatibility is intentionally fail-fast (older SDKs reject newer or unsupported
 #    versions).
-CURRENT_SCHEMA_VERSION = "1.13"
+CURRENT_SCHEMA_VERSION = "1.14"
+_PROGRAMMATIC_TOOL_CALLING_MIN_SCHEMA_VERSION = "1.13"
+_HOSTED_MCP_APPROVALS_MIN_SCHEMA_VERSION = "1.14"
 # Keep this mapping in chronological order. Every schema bump must add a one-line summary here.
 SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
     "1.0": "Initial RunState snapshot format for HITL pause/resume flows.",
@@ -173,6 +175,7 @@ SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
         "Persists programmatic tool calling and nested handoff history ownership across resume "
         "flows."
     ),
+    "1.14": "Scopes hosted MCP approvals and restored requests by server label.",
 }
 SUPPORTED_SCHEMA_VERSIONS = frozenset(SCHEMA_VERSION_SUMMARIES)
 
@@ -395,6 +398,8 @@ class RunState(Generic[TContext, TAgent]):
             return {}
         approvals_dict: dict[str, dict[str, Any]] = {}
         for tool_name, record in self._context._approvals.items():
+            if not isinstance(tool_name, str):
+                continue
             approvals_dict[tool_name] = {
                 "approved": record.approved
                 if isinstance(record.approved, bool)
@@ -410,6 +415,49 @@ class RunState(Generic[TContext, TAgent]):
                     record.sticky_rejection_message
                 )
         return approvals_dict
+
+    def _serialize_hosted_mcp_approvals(self) -> list[dict[str, Any]]:
+        """Serialize hosted MCP approvals with explicit typed identities."""
+        if self._context is None:
+            return []
+        serialized: list[dict[str, Any]] = []
+        hosted_records = (
+            (identity, record)
+            for identity, record in self._context._approvals.items()
+            if isinstance(identity, tuple)
+        )
+        for identity, record in sorted(hosted_records):
+            if identity[0] == "hosted_mcp":
+                identity_data = {
+                    "type": "server_tool",
+                    "server_label": identity[1],
+                    "tool_name": identity[2],
+                }
+            elif identity[0] == "hosted_mcp_call":
+                identity_data = {
+                    "type": "request",
+                    "request_id": identity[1],
+                }
+            else:
+                identity_data = {
+                    "type": "query",
+                    "tool_name": identity[1],
+                    "request_id": identity[2],
+                }
+            decision: dict[str, Any] = {
+                "approved": record.approved
+                if isinstance(record.approved, bool)
+                else list(record.approved),
+                "rejected": record.rejected
+                if isinstance(record.rejected, bool)
+                else list(record.rejected),
+            }
+            if record.rejection_messages:
+                decision["rejection_messages"] = dict(record.rejection_messages)
+            if record.sticky_rejection_message is not None:
+                decision["sticky_rejection_message"] = record.sticky_rejection_message
+            serialized.append({"identity": identity_data, "decision": decision})
+        return serialized
 
     def _serialize_model_responses(self) -> list[dict[str, Any]]:
         """Serialize model responses."""
@@ -754,6 +802,7 @@ class RunState(Generic[TContext, TAgent]):
             raise UserError("Cannot serialize RunState: No context")
 
         approvals_dict = self._serialize_approvals()
+        hosted_mcp_approvals = self._serialize_hosted_mcp_approvals()
         model_responses = self._serialize_model_responses()
         original_input_serialized = self._serialize_original_input()
         context_payload, context_meta = self._serialize_context_payload(
@@ -771,6 +820,8 @@ class RunState(Generic[TContext, TAgent]):
         tool_input = self._serialize_tool_input(self._context.tool_input)
         if tool_input is not None:
             context_entry["tool_input"] = tool_input
+        if hosted_mcp_approvals:
+            context_entry["hosted_mcp_approvals"] = hosted_mcp_approvals
 
         agent_identity_keys_by_id = (
             _build_agent_identity_keys_by_id(cast(Agent[Any], self._starting_agent))
@@ -1721,6 +1772,18 @@ def _build_named_tool_map(
     return tool_map
 
 
+def _build_hosted_mcp_tool_map(tools: Sequence[Any]) -> dict[str, HostedMCPTool]:
+    """Build a server-label-indexed map for hosted MCP tools."""
+    tool_map: dict[str, HostedMCPTool] = {}
+    for tool in tools:
+        if not isinstance(tool, HostedMCPTool):
+            continue
+        server_label = tool.tool_config.get("server_label")
+        if isinstance(server_label, str) and server_label:
+            tool_map[server_label] = tool
+    return tool_map
+
+
 def _build_handoffs_map(current_agent: Agent[Any]) -> dict[str, Handoff[Any, Agent[Any]]]:
     """Map handoff tool names to their definitions for quick lookup."""
     handoffs_map: dict[str, Handoff[Any, Agent[Any]]] = {}
@@ -1830,7 +1893,7 @@ async def _deserialize_processed_response(
     local_shell_tools_map = _build_named_tool_map(all_tools, LocalShellTool)
     shell_tools_map = _build_named_tool_map(all_tools, ShellTool)
     apply_patch_tools_map = _build_named_tool_map(all_tools, ApplyPatchTool)
-    mcp_tools_map = _build_named_tool_map(all_tools, HostedMCPTool)
+    mcp_tools_map = _build_hosted_mcp_tool_map(all_tools)
     handoffs_map = _build_handoffs_map(current_agent)
     programmatic_tool_present = any(
         isinstance(tool, ProgrammaticToolCallingTool) for tool in all_tools
@@ -2133,8 +2196,7 @@ async def _deserialize_processed_response(
         if not mcp_tool_data:
             continue
 
-        mcp_tool_name = mcp_tool_data.get("name")
-        mcp_tool = mcp_tools_map.get(mcp_tool_name) if mcp_tool_name else None
+        mcp_tool = mcp_tools_map.get(request_item.server_label)
 
         if mcp_tool:
             _ensure_restored_tool_call_allowed(
@@ -2701,13 +2763,18 @@ async def _build_run_state_from_json(
             f"Supported versions are: {supported_versions}. "
             f"New snapshots are written as version {CURRENT_SCHEMA_VERSION}."
         )
-    if schema_version != CURRENT_SCHEMA_VERSION and _run_state_uses_programmatic_tool_calling(
-        state_json
-    ):
+    schema_major, schema_minor = (int(part) for part in schema_version.split(".", maxsplit=1))
+    programmatic_major, programmatic_minor = (
+        int(part) for part in _PROGRAMMATIC_TOOL_CALLING_MIN_SCHEMA_VERSION.split(".", maxsplit=1)
+    )
+    if (schema_major, schema_minor) < (
+        programmatic_major,
+        programmatic_minor,
+    ) and _run_state_uses_programmatic_tool_calling(state_json):
         raise UserError(
             "Run state contains Programmatic Tool Calling data but uses schema version "
             f"{schema_version}. Programmatic Tool Calling requires schema version "
-            f"{CURRENT_SCHEMA_VERSION}."
+            f"{_PROGRAMMATIC_TOOL_CALLING_MIN_SCHEMA_VERSION} or later."
         )
 
     agent_identity_map = _build_agent_identity_map(initial_agent)
@@ -2771,6 +2838,11 @@ async def _build_run_state_from_json(
         raise UserError("Serialized run state context must be a mapping. Please provide one.")
     context.usage = usage
     context._rebuild_approvals(context_data.get("approvals", {}))
+    hosted_mcp_major, hosted_mcp_minor = (
+        int(part) for part in _HOSTED_MCP_APPROVALS_MIN_SCHEMA_VERSION.split(".", maxsplit=1)
+    )
+    if (schema_major, schema_minor) >= (hosted_mcp_major, hosted_mcp_minor):
+        context._rebuild_hosted_mcp_approvals(context_data.get("hosted_mcp_approvals", []))
     serialized_tool_input = context_data.get("tool_input")
     if (
         context_override is None

--- a/src/agents/tool_context.py
+++ b/src/agents/tool_context.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from openai.types.responses import ResponseFunctionToolCall
 
-from ._tool_identity import get_tool_call_namespace, tool_trace_name
+from ._tool_identity import HostedMCPApprovalKey, get_tool_call_namespace, tool_trace_name
 from .agent_tool_state import get_agent_tool_state_scope, set_agent_tool_state_scope
 from .run_context import RunContextWrapper, TContext
 from .usage import Usage
@@ -70,7 +70,7 @@ class ToolContext(RunContextWrapper[TContext]):
         agent: AgentBase[Any] | None = None,
         run_config: RunConfig | dict[str, Any] | None = None,
         turn_input: list[TResponseInputItem] | None = None,
-        _approvals: dict[str, _ApprovalRecord] | None = None,
+        _approvals: dict[str | HostedMCPApprovalKey, _ApprovalRecord] | None = None,
         tool_input: Any | None = None,
     ) -> None:
         """Preserve the v0.7 positional constructor while accepting new context fields."""

--- a/tests/test_agent_as_tool.py
+++ b/tests/test_agent_as_tool.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 import pytest
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
+from openai.types.responses.response_output_item import McpApprovalRequest
 from pydantic import BaseModel, Field
 
 import agents._debug as _debug
@@ -1539,6 +1540,86 @@ async def test_agent_as_tool_rejected_nested_approval_resumes_run(
 
 
 @pytest.mark.asyncio
+async def test_agent_as_tool_wrapped_hosted_mcp_exact_decision_resumes_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = Agent(name="outer")
+    tool_call = make_function_tool_call(
+        "outer_tool",
+        call_id="outer-1",
+        arguments='{"input": "hello"}',
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="outer_tool",
+        tool_call_id="outer-1",
+        tool_arguments=tool_call.arguments,
+        tool_call=tool_call,
+    )
+    approval_item = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "inner-1",
+                "name": "lookup_account",
+            },
+        },
+        tool_name="lookup_account",
+    )
+
+    class DummyState:
+        def __init__(self, nested_context: ToolContext) -> None:
+            self._context = nested_context
+
+    class DummyPendingResult:
+        def __init__(self) -> None:
+            self.interruptions = [approval_item]
+            self.final_output = None
+
+        def to_state(self) -> DummyState:
+            return resume_state
+
+    class DummyResumedResult:
+        def __init__(self) -> None:
+            self.interruptions: list[ToolApprovalItem] = []
+            self.final_output = "rejected"
+
+    nested_context = ToolContext(
+        context=None,
+        tool_name=tool_call.name,
+        tool_call_id=tool_call.call_id,
+        tool_arguments=tool_call.arguments,
+        tool_call=tool_call,
+    )
+    resume_state = DummyState(nested_context)
+    pending_result = DummyPendingResult()
+    record_agent_tool_run_result(tool_call, cast(Any, pending_result))
+    tool_context.reject_tool(approval_item, rejection_message="exact denial")
+
+    resumed_result = DummyResumedResult()
+
+    async def run_resume(cls, /, starting_agent, input, **kwargs) -> DummyResumedResult:
+        assert input is resume_state
+        assert input._context is not None
+        assert input._context.is_tool_approved("lookup_account", "inner-1") is False
+        assert input._context.get_rejection_message("lookup_account", "inner-1") == "exact denial"
+        return resumed_result
+
+    monkeypatch.setattr(Runner, "run", classmethod(run_resume))
+    tool = agent.as_tool(
+        tool_name="outer_tool",
+        tool_description="Outer agent tool",
+        is_enabled=True,
+    )
+
+    output = await tool.on_invoke_tool(tool_context, tool_call.arguments)
+
+    assert output == "rejected"
+
+
+@pytest.mark.asyncio
 async def test_agent_as_tool_namespaced_nested_always_approve_stays_permanent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1622,6 +1703,156 @@ async def test_agent_as_tool_namespaced_nested_always_approve_stays_permanent(
 
     assert output == "approved"
     assert run_inputs == [resume_state]
+
+
+@pytest.mark.parametrize(
+    ("approve", "sticky", "legacy_sticky", "expected_followup"),
+    [
+        (True, True, False, True),
+        (False, True, False, False),
+        (True, False, True, None),
+        (False, False, True, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_agent_as_tool_hosted_mcp_nested_sticky_decision_stays_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+    approve: bool,
+    sticky: bool,
+    legacy_sticky: bool,
+    expected_followup: bool | None,
+) -> None:
+    agent = Agent(name="outer")
+    tool_call = make_function_tool_call(
+        "outer_tool",
+        call_id="outer-1",
+        arguments='{"input": "hello"}',
+    )
+    tool_context = ToolContext(
+        context=None,
+        tool_name="outer_tool",
+        tool_call_id="outer-1",
+        tool_arguments=tool_call.arguments,
+        tool_call=tool_call,
+    )
+    approval_item = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="inner-1",
+            type="mcp_approval_request",
+            server_label="server-a",
+            arguments="{}",
+            name="lookup_account",
+        ),
+    )
+
+    class DummyState:
+        def __init__(self, nested_context: ToolContext) -> None:
+            self._context = nested_context
+
+    class DummyPendingResult:
+        def __init__(self) -> None:
+            self.interruptions = [approval_item]
+            self.final_output = None
+
+        def to_state(self) -> DummyState:
+            return resume_state
+
+    class DummyResumedResult:
+        def __init__(self) -> None:
+            self.interruptions: list[ToolApprovalItem] = []
+            self.final_output = "resumed"
+
+    nested_context = ToolContext(
+        context=None,
+        tool_name=tool_call.name,
+        tool_call_id=tool_call.call_id,
+        tool_arguments=tool_call.arguments,
+        tool_call=tool_call,
+    )
+    resume_state = DummyState(nested_context)
+    pending_result = DummyPendingResult()
+    record_agent_tool_run_result(tool_call, cast(Any, pending_result))
+    if legacy_sticky:
+        tool_context._rebuild_approvals(  # noqa: SLF001
+            {
+                "lookup_account": {
+                    "approved": approve,
+                    "rejected": [] if approve else True,
+                    "sticky_rejection_message": None if approve else "legacy denial",
+                }
+            }
+        )
+    if approve:
+        tool_context.approve_tool(approval_item, always_approve=sticky)
+    else:
+        tool_context.reject_tool(
+            approval_item,
+            always_reject=sticky,
+            rejection_message="server-a denied",
+        )
+
+    resumed_result = DummyResumedResult()
+
+    async def run_resume(cls, /, starting_agent, input, **kwargs) -> DummyResumedResult:
+        assert input is resume_state
+        assert input._context is not None
+        assert (
+            input._context.get_approval_status(
+                "lookup_account",
+                "inner-1",
+                existing_pending=approval_item,
+            )
+            is approve
+        )
+        original_message = None if approve else "server-a denied"
+        assert (
+            input._context.get_rejection_message(
+                "lookup_account",
+                "inner-1",
+                existing_pending=approval_item,
+            )
+            == original_message
+        )
+        followup = ToolApprovalItem(
+            agent=agent,
+            raw_item=McpApprovalRequest(
+                id="inner-2",
+                type="mcp_approval_request",
+                server_label="server-a",
+                arguments="{}",
+                name="lookup_account",
+            ),
+        )
+        assert (
+            input._context.get_approval_status(
+                "lookup_account",
+                "inner-2",
+                existing_pending=followup,
+            )
+            is expected_followup
+        )
+        expected_message = "server-a denied" if expected_followup is False else None
+        assert (
+            input._context.get_rejection_message(
+                "lookup_account",
+                "inner-2",
+                existing_pending=followup,
+            )
+            == expected_message
+        )
+        return resumed_result
+
+    monkeypatch.setattr(Runner, "run", classmethod(run_resume))
+    tool = agent.as_tool(
+        tool_name="outer_tool",
+        tool_description="Outer agent tool",
+        is_enabled=True,
+    )
+
+    output = await tool.on_invoke_tool(tool_context, tool_call.arguments)
+
+    assert output == "resumed"
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -14,8 +14,10 @@ import httpx
 import pytest
 from openai import APIConnectionError, BadRequestError
 from openai.types.responses import ResponseFunctionToolCall
+from openai.types.responses.response_output_item import McpApprovalRequest
 from openai.types.responses.response_output_text import AnnotationFileCitation, ResponseOutputText
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
+from openai.types.responses.tool_param import Mcp
 from typing_extensions import TypedDict
 
 import agents._debug as _debug
@@ -88,7 +90,7 @@ from agents.run_internal.session_persistence import (
 from agents.run_internal.tool_execution import execute_approved_tools
 from agents.run_internal.tool_use_tracker import AgentToolUseTracker
 from agents.run_state import RunState
-from agents.tool import ComputerTool, FunctionToolResult, ShellTool, function_tool
+from agents.tool import ComputerTool, FunctionToolResult, HostedMCPTool, ShellTool, function_tool
 from agents.tool_context import ToolContext
 from agents.usage import Usage
 
@@ -159,7 +161,7 @@ async def run_execute_approved_tools(
 async def _run_agent_with_optional_streaming(
     agent: Agent[Any],
     *,
-    input: str | list[TResponseInputItem],
+    input: str | list[TResponseInputItem] | RunState[Any, Agent[Any]],
     streamed: bool,
     **kwargs: Any,
 ):
@@ -169,6 +171,66 @@ async def _run_agent_with_optional_streaming(
             pass
         return result
     return await Runner.run(agent, input=input, **kwargs)
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_persistent_hosted_mcp_approval_does_not_cross_servers(streamed: bool) -> None:
+    model = FakeModel()
+    server_a = HostedMCPTool(
+        tool_config=Mcp(
+            type="mcp",
+            server_label="server-a",
+            server_url="https://server-a.example/mcp",
+        )
+    )
+    server_b = HostedMCPTool(
+        tool_config=Mcp(
+            type="mcp",
+            server_label="server-b",
+            server_url="https://server-b.example/mcp",
+        )
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [
+                McpApprovalRequest(
+                    id="request-a",
+                    type="mcp_approval_request",
+                    arguments="{}",
+                    name="lookup_account",
+                    server_label="server-a",
+                )
+            ],
+            [
+                McpApprovalRequest(
+                    id="request-b",
+                    type="mcp_approval_request",
+                    arguments="{}",
+                    name="lookup_account",
+                    server_label="server-b",
+                )
+            ],
+        ]
+    )
+    agent = Agent(name="test", model=model, tools=[server_a, server_b])
+
+    first = await _run_agent_with_optional_streaming(agent, input="hello", streamed=streamed)
+    assert len(first.interruptions) == 1
+    assert first.interruptions[0].raw_item.server_label == "server-a"
+
+    state = first.to_state()
+    state.approve(first.interruptions[0], always_approve=True)
+    restored_state = await RunState.from_json(agent, state.to_json())
+
+    resumed = await _run_agent_with_optional_streaming(
+        agent,
+        input=restored_state,
+        streamed=streamed,
+    )
+
+    assert len(resumed.interruptions) == 1
+    assert resumed.interruptions[0].raw_item.server_label == "server-b"
 
 
 @pytest.mark.parametrize("surface", ["agent_tool", "handoff", "mixed"])

--- a/tests/test_run_context_approvals.py
+++ b/tests/test_run_context_approvals.py
@@ -1,8 +1,540 @@
 from __future__ import annotations
 
-from agents import Agent, RunContextWrapper
+import pytest
+from openai.types.responses.response_output_item import McpApprovalRequest
+
+from agents import Agent, RunContextWrapper, ToolApprovalItem, UserError
 
 from .utils.factories import make_tool_approval_item
+
+
+def _make_hosted_mcp_approval_item(
+    agent: Agent[None],
+    *,
+    request_id: str,
+    server_label: str,
+    tool_name: str = "lookup_account",
+) -> ToolApprovalItem:
+    return ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id=request_id,
+            type="mcp_approval_request",
+            arguments="{}",
+            name=tool_name,
+            server_label=server_label,
+        ),
+    )
+
+
+def test_hosted_mcp_permanent_approval_is_scoped_by_server_label() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    server_a = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-a-1",
+        server_label="server-a",
+    )
+    server_a_next = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-a-2",
+        server_label="server-a",
+    )
+    server_b = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-b-1",
+        server_label="server-b",
+    )
+
+    context_wrapper.approve_tool(server_a, always_approve=True)
+
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-a-2",
+            existing_pending=server_a_next,
+        )
+        is True
+    )
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-b-1",
+            existing_pending=server_b,
+        )
+        is None
+    )
+    assert context_wrapper.is_tool_approved("lookup_account", "request-a-1") is True
+    assert context_wrapper.is_tool_approved("lookup_account", "request-a-2") is None
+    assert "lookup_account" not in context_wrapper._approvals
+
+
+def test_hosted_mcp_permanent_rejection_message_is_scoped_by_server_label() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    server_a = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-a-1",
+        server_label="server-a",
+    )
+    server_a_next = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-a-2",
+        server_label="server-a",
+    )
+    server_b = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-b-1",
+        server_label="server-b",
+    )
+
+    context_wrapper.reject_tool(
+        server_a,
+        always_reject=True,
+        rejection_message="server-a denied",
+    )
+
+    assert (
+        context_wrapper.get_rejection_message(
+            "lookup_account",
+            "request-a-2",
+            existing_pending=server_a_next,
+        )
+        == "server-a denied"
+    )
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-b-1",
+            existing_pending=server_b,
+        )
+        is None
+    )
+    assert (
+        context_wrapper.get_rejection_message(
+            "lookup_account",
+            "request-b-1",
+            existing_pending=server_b,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("approved", "always"),
+    [(True, False), (True, True), (False, False), (False, True)],
+)
+def test_hosted_mcp_name_based_query_preserves_exact_call_decision(
+    approved: bool,
+    always: bool,
+) -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    approval_item = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-a-1",
+        server_label="server-a",
+    )
+
+    if approved:
+        context_wrapper.approve_tool(approval_item, always_approve=always)
+    else:
+        context_wrapper.reject_tool(
+            approval_item,
+            always_reject=always,
+            rejection_message="server-a denied",
+        )
+
+    assert context_wrapper.is_tool_approved("lookup_account", "request-a-1") is approved
+    assert context_wrapper.is_tool_approved("lookup_account", "request-a-2") is None
+    if not approved:
+        assert (
+            context_wrapper.get_rejection_message("lookup_account", "request-a-1")
+            == "server-a denied"
+        )
+
+
+def test_hosted_mcp_exact_query_precedes_colliding_function_sticky_decision() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    function_item = make_tool_approval_item(
+        agent,
+        call_id="function-call",
+        name="lookup_account",
+    )
+    hosted_item = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="hosted-call",
+        server_label="server-a",
+    )
+
+    context_wrapper.approve_tool(function_item, always_approve=True)
+    context_wrapper.reject_tool(hosted_item, rejection_message="hosted denial")
+
+    assert context_wrapper.is_tool_approved("lookup_account", "hosted-call") is False
+    assert context_wrapper.is_tool_approved("lookup_account", "function-next") is True
+    assert context_wrapper.get_rejection_message("lookup_account", "hosted-call") == "hosted denial"
+
+
+@pytest.mark.parametrize("hosted_approved", [True, False])
+def test_hosted_mcp_exact_query_does_not_inherit_function_rejection_reason(
+    hosted_approved: bool,
+) -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    function_item = make_tool_approval_item(
+        agent,
+        call_id="shared-call",
+        name="lookup_account",
+    )
+    hosted_item = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="shared-call",
+        server_label="server-a",
+    )
+
+    context_wrapper.reject_tool(function_item, rejection_message="function denial")
+    if hosted_approved:
+        context_wrapper.approve_tool(hosted_item)
+    else:
+        context_wrapper.reject_tool(hosted_item)
+
+    assert context_wrapper.is_tool_approved("lookup_account", "shared-call") is hosted_approved
+    assert context_wrapper.get_rejection_message("lookup_account", "shared-call") is None
+
+
+@pytest.mark.parametrize("approved", [True, False])
+def test_hosted_mcp_exact_query_does_not_authorize_other_server(approved: bool) -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    server_a = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="shared-request",
+        server_label="server-a",
+    )
+    server_b = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="shared-request",
+        server_label="server-b",
+    )
+
+    if approved:
+        context_wrapper.approve_tool(server_a)
+    else:
+        context_wrapper.reject_tool(server_a, rejection_message="server-a denied")
+
+    assert context_wrapper.is_tool_approved("lookup_account", "shared-request") is approved
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "shared-request",
+            existing_pending=server_b,
+        )
+        is None
+    )
+    assert (
+        context_wrapper.get_rejection_message(
+            "lookup_account",
+            "shared-request",
+            existing_pending=server_b,
+        )
+        is None
+    )
+
+
+def test_hosted_mcp_legacy_bare_name_approval_does_not_grant_access() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    pending = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-a-1",
+        server_label="server-a",
+    )
+    context_wrapper._rebuild_approvals(  # noqa: SLF001
+        {"lookup_account": {"approved": True, "rejected": []}}
+    )
+
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-a-1",
+            existing_pending=pending,
+        )
+        is None
+    )
+
+
+def test_hosted_mcp_scoped_identity_cannot_alias_legacy_tool_name() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    pending = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-a-1",
+        server_label="server-a",
+    )
+    colliding_legacy_name = '["hosted_mcp","server-a","lookup_account"]'
+    context_wrapper._rebuild_approvals(  # noqa: SLF001
+        {colliding_legacy_name: {"approved": True, "rejected": []}}
+    )
+
+    assert context_wrapper.is_tool_approved(colliding_legacy_name, "legacy-call") is True
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-a-1",
+            existing_pending=pending,
+        )
+        is None
+    )
+
+
+def test_hosted_mcp_legacy_exact_call_decisions_remain_usable() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    approved = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-approved",
+        server_label="server-a",
+    )
+    rejected = _make_hosted_mcp_approval_item(
+        agent,
+        request_id="request-rejected",
+        server_label="server-a",
+    )
+    rejected_without_raw_name = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "request-rejected",
+            },
+        },
+        tool_name="lookup_account",
+    )
+    context_wrapper._rebuild_approvals(  # noqa: SLF001
+        {
+            "lookup_account": {
+                "approved": ["request-approved"],
+                "rejected": ["request-rejected"],
+                "rejection_messages": {"request-rejected": "legacy exact denial"},
+            }
+        }
+    )
+
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-approved",
+            existing_pending=approved,
+        )
+        is True
+    )
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-rejected",
+            existing_pending=rejected,
+        )
+        is False
+    )
+    assert (
+        context_wrapper.get_rejection_message(
+            "lookup_account",
+            "request-rejected",
+            existing_pending=rejected_without_raw_name,
+        )
+        == "legacy exact denial"
+    )
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-rejected",
+            existing_pending=rejected_without_raw_name,
+        )
+        is False
+    )
+
+
+def test_hosted_mcp_persistent_decision_requires_complete_identity() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    malformed = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "name": "lookup_account",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "request-a-1",
+            },
+        },
+    )
+
+    with pytest.raises(UserError, match="non-empty server_label and tool name"):
+        context_wrapper.approve_tool(malformed, always_approve=True)
+
+
+def test_incomplete_hosted_mcp_uses_only_exact_call_decisions() -> None:
+    agent = Agent(name="test-agent")
+    malformed = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "name": "lookup_account",
+            "id": "request-a-1",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "request-a-1",
+            },
+        },
+    )
+    context_wrapper = RunContextWrapper(context=None)
+    context_wrapper._rebuild_approvals(  # noqa: SLF001
+        {
+            "lookup_account": {
+                "approved": True,
+                "rejected": True,
+                "sticky_rejection_message": "legacy denial",
+            }
+        }
+    )
+
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-a-1",
+            existing_pending=malformed,
+        )
+        is None
+    )
+    assert (
+        context_wrapper.get_rejection_message(
+            "lookup_account",
+            "request-a-1",
+            existing_pending=malformed,
+        )
+        is None
+    )
+
+    context_wrapper.approve_tool(malformed)
+    assert context_wrapper.is_tool_approved("lookup_account", "request-a-1") is True
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-a-1",
+            existing_pending=malformed,
+        )
+        is True
+    )
+
+    context_wrapper.reject_tool(malformed, rejection_message="exact denial")
+    assert context_wrapper.is_tool_approved("lookup_account", "request-a-1") is False
+    assert (
+        context_wrapper.get_approval_status(
+            "lookup_account",
+            "request-a-1",
+            existing_pending=malformed,
+        )
+        is False
+    )
+    assert (
+        context_wrapper.get_rejection_message(
+            "lookup_account",
+            "request-a-1",
+            existing_pending=malformed,
+        )
+        == "exact denial"
+    )
+
+
+def test_hosted_mcp_decision_requires_request_id() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    malformed = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "name": "lookup_account",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "server_label": "server-a",
+            },
+        },
+    )
+
+    with pytest.raises(UserError, match="non-empty request id"):
+        context_wrapper.approve_tool(malformed)
+
+    assert context_wrapper._approvals == {}  # noqa: SLF001
+
+
+@pytest.mark.parametrize("request_id", ["", 123])
+def test_hosted_mcp_invalid_request_id_does_not_mutate_approvals(request_id: object) -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    malformed = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "mcp_approval_request",
+            "id": request_id,
+            "arguments": "{}",
+            "name": "lookup_account",
+            "server_label": "server-a",
+        },
+    )
+
+    with pytest.raises(UserError, match="non-empty request id"):
+        context_wrapper.reject_tool(
+            malformed,
+            always_reject=True,
+            rejection_message="must not persist",
+        )
+
+    assert context_wrapper._approvals == {}  # noqa: SLF001
+
+
+def test_hosted_mcp_provider_invalid_request_id_does_not_fall_back_to_outer_id() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    malformed = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "call_id": "outer-id",
+            "name": "lookup_account",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": 123,
+                "server_label": "server-a",
+                "name": "lookup_account",
+            },
+        },
+    )
+
+    with pytest.raises(UserError, match="non-empty request id"):
+        context_wrapper.approve_tool(malformed)
+
+    assert context_wrapper._approvals == {}  # noqa: SLF001
+
+
+def test_hosted_mcp_request_type_is_not_used_as_missing_tool_name() -> None:
+    agent = Agent(name="test-agent")
+    context_wrapper = RunContextWrapper(context=None)
+    malformed = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "mcp_approval_request",
+            "id": "request-a-1",
+            "arguments": "{}",
+            "server_label": "server-a",
+        },
+    )
+
+    with pytest.raises(UserError, match="non-empty server_label and tool name"):
+        context_wrapper.approve_tool(malformed, always_approve=True)
+
+    assert context_wrapper._approvals == {}  # noqa: SLF001
 
 
 def test_latest_approval_decision_wins_for_call_id() -> None:

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -5520,6 +5520,37 @@ class TestRunStateSerializationEdgeCases:
             await RunState.from_json(agent, json_data)
 
     @pytest.mark.asyncio
+    async def test_schema_1_13_accepts_programmatic_tool_calling_items(self):
+        agent = Agent(name="TestAgent", tools=[ProgrammaticToolCallingTool()])
+        state: RunState[Any, Agent[Any]] = make_state(
+            agent,
+            context=RunContextWrapper(context={}),
+            original_input="test",
+        )
+        state._model_responses = [
+            ModelResponse(
+                output=[
+                    Program(
+                        id="program_item",
+                        call_id="call_program",
+                        code="lookup()",
+                        fingerprint="fingerprint",
+                        type="program",
+                    )
+                ],
+                usage=Usage(),
+                response_id="response_1",
+            )
+        ]
+        json_data = state.to_json()
+        json_data["$schemaVersion"] = "1.13"
+
+        restored = await RunState.from_json(agent, json_data)
+
+        assert restored._schema_version == "1.13"
+        assert restored._model_responses[0].output[0].type == "program"
+
+    @pytest.mark.asyncio
     async def test_previous_schema_ignores_program_like_arbitrary_context(self):
         agent = Agent(name="TestAgent")
         state = make_state(
@@ -5555,6 +5586,7 @@ class TestRunStateSerializationEdgeCases:
                 "1.10",
                 "1.11",
                 "1.12",
+                "1.13",
                 CURRENT_SCHEMA_VERSION,
             }
         )
@@ -7506,4 +7538,323 @@ async def test_resume_nested_agent_as_tool_with_context_override() -> None:
     # Nested post-resume model turns must keep accruing on the parent usage object.
     assert resumed.context_wrapper.usage.input_tokens == (
         usage_before_resume + nested_turn_usage.input_tokens
+    )
+
+
+@pytest.mark.asyncio
+async def test_hosted_mcp_approval_request_restores_matching_server_tool() -> None:
+    server_a = HostedMCPTool(
+        tool_config=Mcp(
+            type="mcp",
+            server_label="server-a",
+            server_url="https://server-a.example/mcp",
+        )
+    )
+    server_b = HostedMCPTool(
+        tool_config=Mcp(
+            type="mcp",
+            server_label="server-b",
+            server_url="https://server-b.example/mcp",
+        )
+    )
+    agent = Agent(name="test", tools=[server_a, server_b])
+    request_item = McpApprovalRequest(
+        id="request-a",
+        type="mcp_approval_request",
+        arguments="{}",
+        name="lookup_account",
+        server_label="server-a",
+    )
+    context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+    state = make_state(agent, context=context)
+    state._last_processed_response = make_processed_response(
+        mcp_approval_requests=[
+            ToolRunMCPApprovalRequest(
+                request_item=request_item,
+                mcp_tool=server_a,
+            )
+        ]
+    )
+
+    restored = await RunState.from_json(agent, state.to_json())
+
+    assert restored._last_processed_response is not None
+    restored_requests = restored._last_processed_response.mcp_approval_requests
+    assert len(restored_requests) == 1
+    assert restored_requests[0].mcp_tool is server_a
+
+
+@pytest.mark.asyncio
+async def test_hosted_mcp_approval_round_trip_uses_typed_identity_records() -> None:
+    agent = Agent(name="test")
+    context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+    state = make_state(agent, context=context)
+    approval = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="request-a",
+            type="mcp_approval_request",
+            arguments="{}",
+            name="lookup_account",
+            server_label="server-a",
+        ),
+    )
+    state.approve(approval, always_approve=True)
+
+    serialized = state.to_json()
+
+    assert serialized["context"]["approvals"] == {}
+    assert serialized["context"]["hosted_mcp_approvals"] == [
+        {
+            "identity": {
+                "type": "server_tool",
+                "server_label": "server-a",
+                "tool_name": "lookup_account",
+            },
+            "decision": {"approved": True, "rejected": []},
+        },
+        {
+            "identity": {
+                "type": "query",
+                "tool_name": "lookup_account",
+                "request_id": "request-a",
+            },
+            "decision": {"approved": ["request-a"], "rejected": []},
+        },
+    ]
+    restored = await RunState.from_json(agent, serialized)
+
+    assert restored._context is not None
+    assert restored._context.is_tool_approved("lookup_account", "request-a") is True
+    assert restored._context.is_tool_approved("lookup_account", "request-next") is None
+    assert (
+        restored._context.get_approval_status(
+            "lookup_account",
+            "request-next",
+            existing_pending=ToolApprovalItem(
+                agent=agent,
+                raw_item=McpApprovalRequest(
+                    id="request-next",
+                    type="mcp_approval_request",
+                    arguments="{}",
+                    name="lookup_account",
+                    server_label="server-a",
+                ),
+            ),
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_incomplete_hosted_mcp_query_round_trip_preserves_exact_decision() -> None:
+    agent = Agent(name="test")
+    context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+    state = make_state(agent, context=context)
+    approval = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "request-a",
+            },
+        },
+        tool_name="lookup_account",
+    )
+    state.reject(approval, rejection_message="exact denial")
+
+    serialized = state.to_json()
+
+    assert serialized["context"]["hosted_mcp_approvals"] == [
+        {
+            "identity": {
+                "type": "request",
+                "request_id": "request-a",
+            },
+            "decision": {
+                "approved": [],
+                "rejected": ["request-a"],
+                "rejection_messages": {"request-a": "exact denial"},
+            },
+        },
+        {
+            "identity": {
+                "type": "query",
+                "tool_name": "lookup_account",
+                "request_id": "request-a",
+            },
+            "decision": {
+                "approved": [],
+                "rejected": ["request-a"],
+                "rejection_messages": {"request-a": "exact denial"},
+            },
+        },
+    ]
+    restored = await RunState.from_json(agent, serialized)
+
+    assert restored._context is not None
+    assert restored._context.is_tool_approved("lookup_account", "request-a") is False
+    assert restored._context.get_rejection_message("lookup_account", "request-a") == "exact denial"
+    assert restored._context.is_tool_approved("lookup_account", "request-next") is None
+
+
+@pytest.mark.asyncio
+async def test_hosted_mcp_rejection_query_round_trip_does_not_cross_servers() -> None:
+    agent = Agent(name="test")
+    context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+    state = make_state(agent, context=context)
+    server_a = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="shared-request",
+            type="mcp_approval_request",
+            arguments="{}",
+            name="lookup_account",
+            server_label="server-a",
+        ),
+    )
+    server_b = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="shared-request",
+            type="mcp_approval_request",
+            arguments="{}",
+            name="lookup_account",
+            server_label="server-b",
+        ),
+    )
+    state.reject(server_a, rejection_message="server-a denied")
+
+    restored = await RunState.from_json(agent, state.to_json())
+
+    assert restored._context is not None
+    assert restored._context.is_tool_approved("lookup_account", "shared-request") is False
+    assert (
+        restored._context.get_rejection_message("lookup_account", "shared-request")
+        == "server-a denied"
+    )
+    assert (
+        restored._context.get_approval_status(
+            "lookup_account",
+            "shared-request",
+            existing_pending=server_b,
+        )
+        is None
+    )
+    assert (
+        restored._context.get_rejection_message(
+            "lookup_account",
+            "shared-request",
+            existing_pending=server_b,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_1_13_ignores_typed_hosted_mcp_approval_records() -> None:
+    agent = Agent(name="test")
+    context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+    state = make_state(agent, context=context)
+    approval = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="request-a",
+            type="mcp_approval_request",
+            arguments="{}",
+            name="lookup_account",
+            server_label="server-a",
+        ),
+    )
+    state.approve(approval, always_approve=True)
+    serialized = state.to_json()
+    serialized["$schemaVersion"] = "1.13"
+
+    restored = await RunState.from_json(agent, serialized)
+
+    assert restored._context is not None
+    assert (
+        restored._context.get_approval_status(
+            "lookup_account",
+            "request-next",
+            existing_pending=ToolApprovalItem(
+                agent=agent,
+                raw_item=McpApprovalRequest(
+                    id="request-next",
+                    type="mcp_approval_request",
+                    arguments="{}",
+                    name="lookup_account",
+                    server_label="server-a",
+                ),
+            ),
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_1_13_hosted_mcp_exact_call_decisions_remain_usable() -> None:
+    agent = Agent(name="test")
+    context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+    context._rebuild_approvals(  # noqa: SLF001
+        {
+            "lookup_account": {
+                "approved": ["request-approved"],
+                "rejected": ["request-rejected"],
+                "rejection_messages": {"request-rejected": "legacy exact denial"},
+            }
+        }
+    )
+    state = make_state(agent, context=context)
+    serialized = state.to_json()
+    serialized["$schemaVersion"] = "1.13"
+
+    restored = await RunState.from_json(agent, serialized)
+
+    assert restored._context is not None
+    approved = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="request-approved",
+            type="mcp_approval_request",
+            arguments="{}",
+            name="lookup_account",
+            server_label="server-a",
+        ),
+    )
+    rejected = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "request-rejected",
+            },
+        },
+        tool_name="lookup_account",
+    )
+    assert (
+        restored._context.get_approval_status(
+            "lookup_account",
+            "request-approved",
+            existing_pending=approved,
+        )
+        is True
+    )
+    assert (
+        restored._context.get_approval_status(
+            "lookup_account",
+            "request-rejected",
+            existing_pending=rejected,
+        )
+        is False
+    )
+    assert (
+        restored._context.get_rejection_message(
+            "lookup_account",
+            "request-rejected",
+            existing_pending=rejected,
+        )
+        == "legacy exact denial"
     )

--- a/tests/test_run_step_execution.py
+++ b/tests/test_run_step_execution.py
@@ -3409,6 +3409,490 @@ async def test_execute_tools_surfaces_hosted_mcp_interruptions_without_callback(
     )
 
 
+def test_manual_hosted_mcp_approval_does_not_reuse_stale_pending_identity():
+    server_b = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-b",
+            "server_url": "https://server-b.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server_b])
+    pending_a = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="shared-request",
+            type="mcp_approval_request",
+            server_label="server-a",
+            arguments="{}",
+            name="lookup_account",
+        ),
+    )
+    current_b = McpApprovalRequest(
+        id="shared-request",
+        type="mcp_approval_request",
+        server_label="server-b",
+        arguments="{}",
+        name="lookup_account",
+    )
+    request_run = ToolRunMCPApprovalRequest(request_item=current_b, mcp_tool=server_b)
+    context_wrapper = make_context_wrapper()
+    context_wrapper._rebuild_approvals(  # noqa: SLF001
+        {"lookup_account": {"approved": ["shared-request"], "rejected": []}}
+    )
+
+    approved, pending = tool_execution.collect_manual_mcp_approvals(
+        agent=agent,
+        requests=[request_run],
+        context_wrapper=context_wrapper,
+        existing_pending_by_call_id={"shared-request": pending_a},
+    )
+
+    assert approved == []
+    assert len(pending) == 1
+    assert pending[0].raw_item is current_b
+
+
+def test_hosted_mcp_approval_does_not_reuse_legacy_name_for_a_different_current_tool():
+    server = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-a",
+            "server_url": "https://server-a.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server])
+    pending_lookup = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "shared-request",
+                "server_label": "server-a",
+            },
+        },
+        tool_name="lookup_account",
+    )
+    current_delete = McpApprovalRequest(
+        id="shared-request",
+        type="mcp_approval_request",
+        server_label="server-a",
+        arguments="{}",
+        name="delete_account",
+    )
+    request_run = ToolRunMCPApprovalRequest(request_item=current_delete, mcp_tool=server)
+    context_wrapper = make_context_wrapper()
+    context_wrapper._rebuild_approvals(  # noqa: SLF001
+        {"lookup_account": {"approved": ["shared-request"], "rejected": []}}
+    )
+
+    responses, pending = tool_execution.collect_manual_mcp_approvals(
+        agent=agent,
+        requests=[request_run],
+        context_wrapper=context_wrapper,
+        existing_pending_by_call_id={"shared-request": pending_lookup},
+    )
+
+    assert responses == []
+    assert len(pending) == 1
+    assert pending[0].raw_item is current_delete
+
+
+def test_manual_hosted_mcp_approval_uses_current_scoped_decision_after_identity_conflict():
+    server_b = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-b",
+            "server_url": "https://server-b.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server_b])
+    pending_a = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="shared-request",
+            type="mcp_approval_request",
+            server_label="server-a",
+            arguments="{}",
+            name="lookup_account",
+        ),
+    )
+    current_b = McpApprovalRequest(
+        id="shared-request",
+        type="mcp_approval_request",
+        server_label="server-b",
+        arguments="{}",
+        name="lookup_account",
+    )
+    current_b_approval = ToolApprovalItem(agent=agent, raw_item=current_b)
+    context_wrapper = make_context_wrapper()
+    context_wrapper.approve_tool(current_b_approval, always_approve=True)
+
+    approved, pending = tool_execution.collect_manual_mcp_approvals(
+        agent=agent,
+        requests=[ToolRunMCPApprovalRequest(request_item=current_b, mcp_tool=server_b)],
+        context_wrapper=context_wrapper,
+        existing_pending_by_call_id={"shared-request": pending_a},
+    )
+
+    assert pending == []
+    assert len(approved) == 1
+    assert approved[0].raw_item["approve"] is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_interrupted_turn_uses_current_scoped_hosted_mcp_decision():
+    server_b = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-b",
+            "server_url": "https://server-b.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server_b])
+    pending_a = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="shared-request",
+            type="mcp_approval_request",
+            server_label="server-a",
+            arguments="{}",
+            name="lookup_account",
+        ),
+    )
+    current_b = McpApprovalRequest(
+        id="shared-request",
+        type="mcp_approval_request",
+        server_label="server-b",
+        arguments="{}",
+        name="lookup_account",
+    )
+    context_wrapper = make_context_wrapper()
+    context_wrapper.approve_tool(
+        ToolApprovalItem(agent=agent, raw_item=current_b),
+        always_approve=True,
+    )
+    processed_response = make_processed_response(
+        new_items=[MCPApprovalRequestItem(raw_item=current_b, agent=agent)],
+        mcp_approval_requests=[
+            ToolRunMCPApprovalRequest(request_item=current_b, mcp_tool=server_b)
+        ],
+    )
+
+    result = await turn_resolution.resolve_interrupted_turn(
+        bindings=_bind_agent(agent),
+        original_input="test",
+        original_pre_step_items=[pending_a],
+        new_response=ModelResponse(output=[], usage=Usage(), response_id="resp"),
+        processed_response=processed_response,
+        hooks=RunHooks(),
+        context_wrapper=context_wrapper,
+        run_config=RunConfig(),
+    )
+
+    assert not isinstance(result.next_step, NextStepInterruption)
+    responses = [
+        item
+        for item in result.new_step_items
+        if isinstance(item, MCPApprovalResponseItem)
+        and item.raw_item.get("approval_request_id") == "shared-request"
+    ]
+    assert len(responses) == 1
+    assert all(item.raw_item["approve"] is True for item in responses)
+    assert not any(
+        isinstance(item, ToolApprovalItem)
+        and getattr(item.raw_item, "server_label", None) == "server-a"
+        for item in result.new_step_items
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_interrupted_turn_keeps_callback_owned_hosted_mcp_request_out_of_pending():
+    callback_tool = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-a",
+            "server_url": "https://server-a.example/mcp",
+        },
+        on_approval_request=lambda request: {"approve": True},
+    )
+    agent = make_agent(tools=[callback_tool])
+    request = McpApprovalRequest(
+        id="callback-request",
+        type="mcp_approval_request",
+        server_label="server-a",
+        arguments="{}",
+        name="lookup_account",
+    )
+    pending = ToolApprovalItem(agent=agent, raw_item=request)
+    processed_response = make_processed_response(
+        new_items=[MCPApprovalRequestItem(raw_item=request, agent=agent)],
+        mcp_approval_requests=[
+            ToolRunMCPApprovalRequest(request_item=request, mcp_tool=callback_tool)
+        ],
+    )
+
+    result = await turn_resolution.resolve_interrupted_turn(
+        bindings=_bind_agent(agent),
+        original_input="test",
+        original_pre_step_items=[pending],
+        new_response=ModelResponse(output=[], usage=Usage(), response_id="resp"),
+        processed_response=processed_response,
+        hooks=RunHooks(),
+        context_wrapper=make_context_wrapper(),
+        run_config=RunConfig(),
+    )
+
+    assert not isinstance(result.next_step, NextStepInterruption)
+    responses = [
+        item
+        for item in result.new_step_items
+        if isinstance(item, MCPApprovalResponseItem)
+        and item.raw_item.get("approval_request_id") == "callback-request"
+    ]
+    assert len(responses) == 1
+    assert responses[0].raw_item["approve"] is True
+    assert not any(isinstance(item, ToolApprovalItem) for item in result.pre_step_items)
+    assert not any(isinstance(item, ToolApprovalItem) for item in result.new_step_items)
+
+
+def test_manual_hosted_mcp_approval_keeps_incomplete_exact_call_decision():
+    server_a = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-a",
+            "server_url": "https://server-a.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server_a])
+    pending_unknown = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "shared-request",
+                "name": "lookup_account",
+            },
+        },
+    )
+    current = McpApprovalRequest(
+        id="shared-request",
+        type="mcp_approval_request",
+        server_label="server-a",
+        arguments="{}",
+        name="lookup_account",
+    )
+    request_run = ToolRunMCPApprovalRequest(request_item=current, mcp_tool=server_a)
+    context_wrapper = make_context_wrapper()
+    context_wrapper.approve_tool(pending_unknown)
+
+    approved, pending = tool_execution.collect_manual_mcp_approvals(
+        agent=agent,
+        requests=[request_run],
+        context_wrapper=context_wrapper,
+        existing_pending_by_call_id={"shared-request": pending_unknown},
+    )
+
+    assert pending == []
+    assert len(approved) == 1
+    assert approved[0].raw_item["approve"] is True
+
+
+def test_manual_hosted_mcp_approval_prefers_complete_current_scoped_identity():
+    server_a = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-a",
+            "server_url": "https://server-a.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server_a])
+    pending_partial = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "shared-request",
+                "name": "lookup_account",
+            },
+        },
+        tool_name="lookup_account",
+    )
+    current = McpApprovalRequest(
+        id="shared-request",
+        type="mcp_approval_request",
+        server_label="server-a",
+        arguments="{}",
+        name="lookup_account",
+    )
+    context_wrapper = make_context_wrapper()
+    context_wrapper._rebuild_hosted_mcp_approvals(  # noqa: SLF001
+        [
+            {
+                "identity": {
+                    "type": "server_tool",
+                    "server_label": "server-a",
+                    "tool_name": "lookup_account",
+                },
+                "decision": {"approved": True, "rejected": []},
+            }
+        ]
+    )
+
+    approved, pending = tool_execution.collect_manual_mcp_approvals(
+        agent=agent,
+        requests=[ToolRunMCPApprovalRequest(request_item=current, mcp_tool=server_a)],
+        context_wrapper=context_wrapper,
+        existing_pending_by_call_id={"shared-request": pending_partial},
+    )
+
+    assert pending == []
+    assert len(approved) == 1
+    assert approved[0].raw_item["approve"] is True
+
+
+def test_manual_hosted_mcp_approval_does_not_apply_legacy_exact_without_pending():
+    server_b = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-b",
+            "server_url": "https://server-b.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server_b])
+    current = McpApprovalRequest(
+        id="shared-request",
+        type="mcp_approval_request",
+        server_label="server-b",
+        arguments="{}",
+        name="lookup_account",
+    )
+    context_wrapper = make_context_wrapper()
+    context_wrapper._rebuild_approvals(  # noqa: SLF001
+        {"lookup_account": {"approved": ["shared-request"], "rejected": []}}
+    )
+
+    approved, pending = tool_execution.collect_manual_mcp_approvals(
+        agent=agent,
+        requests=[ToolRunMCPApprovalRequest(request_item=current, mcp_tool=server_b)],
+        context_wrapper=context_wrapper,
+    )
+
+    assert approved == []
+    assert len(pending) == 1
+    assert pending[0].raw_item is current
+
+
+@pytest.mark.asyncio
+async def test_resolve_interrupted_turn_prefers_wrapped_pending_exact_over_legacy():
+    server_a = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-a",
+            "server_url": "https://server-a.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server_a])
+    pending_partial = ToolApprovalItem(
+        agent=agent,
+        raw_item={
+            "type": "hosted_tool_call",
+            "provider_data": {
+                "type": "mcp_approval_request",
+                "id": "shared-request",
+                "name": "lookup_account",
+            },
+        },
+        tool_name="lookup_account",
+    )
+    current = McpApprovalRequest(
+        id="shared-request",
+        type="mcp_approval_request",
+        server_label="server-a",
+        arguments="{}",
+        name="lookup_account",
+    )
+    context_wrapper = make_context_wrapper()
+    context_wrapper._rebuild_approvals(  # noqa: SLF001
+        {"lookup_account": {"approved": ["shared-request"], "rejected": []}}
+    )
+    context_wrapper.reject_tool(pending_partial, rejection_message="new exact denial")
+    processed_response = make_processed_response(
+        new_items=[MCPApprovalRequestItem(raw_item=current, agent=agent)],
+        mcp_approval_requests=[ToolRunMCPApprovalRequest(request_item=current, mcp_tool=server_a)],
+    )
+
+    result = await turn_resolution.resolve_interrupted_turn(
+        bindings=_bind_agent(agent),
+        original_input="test",
+        original_pre_step_items=[pending_partial],
+        new_response=ModelResponse(output=[], usage=Usage(), response_id="resp"),
+        processed_response=processed_response,
+        hooks=RunHooks(),
+        context_wrapper=context_wrapper,
+        run_config=RunConfig(),
+    )
+
+    assert not isinstance(result.next_step, NextStepInterruption)
+    responses = [
+        item
+        for item in result.new_step_items
+        if isinstance(item, MCPApprovalResponseItem)
+        and item.raw_item.get("approval_request_id") == "shared-request"
+    ]
+    assert len(responses) == 1
+    assert responses[0].raw_item["approve"] is False
+    assert responses[0].raw_item["reason"] == "new exact denial"
+    assert not any(isinstance(item, ToolApprovalItem) for item in result.pre_step_items)
+    assert not any(isinstance(item, ToolApprovalItem) for item in result.new_step_items)
+
+
+def test_incomplete_current_hosted_mcp_request_does_not_reuse_scoped_pending_identity():
+    server_a = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "server-a",
+            "server_url": "https://server-a.example/mcp",
+        }
+    )
+    agent = make_agent(tools=[server_a])
+    pending_complete = ToolApprovalItem(
+        agent=agent,
+        raw_item=McpApprovalRequest(
+            id="shared-request",
+            type="mcp_approval_request",
+            server_label="server-a",
+            arguments="{}",
+            name="lookup_account",
+        ),
+    )
+    current_incomplete = McpApprovalRequest.model_construct(
+        id="shared-request",
+        type="mcp_approval_request",
+        arguments="{}",
+    )
+    request_run = ToolRunMCPApprovalRequest(
+        request_item=current_incomplete,
+        mcp_tool=server_a,
+    )
+    context_wrapper = make_context_wrapper()
+    context_wrapper.approve_tool(pending_complete, always_approve=True)
+
+    approved, manual_pending = tool_execution.collect_manual_mcp_approvals(
+        agent=agent,
+        requests=[request_run],
+        context_wrapper=context_wrapper,
+        existing_pending_by_call_id={"shared-request": pending_complete},
+    )
+
+    assert approved == []
+    assert len(manual_pending) == 1
+    assert manual_pending[0].raw_item is current_incomplete
+
+
 @pytest.mark.asyncio
 async def test_execute_tools_uses_public_agent_for_hosted_mcp_interruptions():
     """Hosted MCP approval items should expose the public agent when execution uses a clone."""


### PR DESCRIPTION
This pull request fixes hosted MCP persistent approval decisions being reused across different servers when those servers expose a tool with the same name. It keys sticky approvals, rejections, and messages by both server label and tool name, resolves restored requests against the matching hosted MCP server, and persists the scoped identity through RunState schema 1.14 while continuing to read older snapshots conservatively. Legacy bare-name hosted MCP approvals do not grant access after resume, so affected calls prompt again; function-tool approvals and existing public call shapes remain unchanged.