### PR TITLE
fix(voice): start the dispatcher when a session ends with no turns

### DIFF
--- a/src/agents/voice/pipeline.py
+++ b/src/agents/voice/pipeline.py
@@ -136,33 +136,49 @@ class VoicePipeline:
                 transcription_session = None
                 try:
                     try:
-                        async for intro_text in self.workflow.on_start():
-                            await output._add_text(intro_text)
-                    except Exception as e:
-                        log_model_and_tool_action_warning(
-                            logger, "Voice workflow on_start failed", e
+                        emitted_intro = False
+                        try:
+                            async for intro_text in self.workflow.on_start():
+                                await output._add_text(intro_text)
+                                emitted_intro = True
+                        except Exception as e:
+                            log_model_and_tool_action_warning(
+                                logger, "Voice workflow on_start failed", e
+                            )
+
+                        if emitted_intro:
+                            # Finalize the intro turn as part of startup. Leaving it open would
+                            # hold a greeting with no sentence-final punctuation until the session
+                            # ends, or merge it into the first user turn.
+                            await output._turn_done()
+
+                        transcription_session = await self._get_stt_model().create_session(
+                            audio_input,
+                            self.config.stt_settings,
+                            self.config.trace_include_sensitive_data,
+                            self.config.trace_include_sensitive_audio_data,
                         )
 
-                    transcription_session = await self._get_stt_model().create_session(
-                        audio_input,
-                        self.config.stt_settings,
-                        self.config.trace_include_sensitive_data,
-                        self.config.trace_include_sensitive_audio_data,
-                    )
-
-                    async for input_text in transcription_session.transcribe_turns():
-                        result = self.workflow.run(input_text)
-                        async for text_event in result:
-                            await output._add_text(text_event)
-                        await output._turn_done()
-                except Exception as e:
-                    log_model_and_tool_action_error(logger, "Error processing voice turns", e)
-                    await output._add_error(e)
-                    raise
+                        async for input_text in transcription_session.transcribe_turns():
+                            result = self.workflow.run(input_text)
+                            async for text_event in result:
+                                await output._add_text(text_event)
+                            await output._turn_done()
+                    except Exception as e:
+                        # Report before closing the session below. A `close()` that also fails
+                        # would otherwise replace this exception on its way out and the consumer
+                        # would see only the cleanup error.
+                        log_model_and_tool_action_error(logger, "Error processing voice turns", e)
+                        await output._add_error(e)
+                        raise
                 finally:
                     if transcription_session is not None:
                         await transcription_session.close()
-                    await output._done()
+
+                # Only a clean run reaches here. The error path above has already queued its
+                # terminal event, and a cancelled producer has no consumer left to serve, so
+                # neither should start TTS work or wait on it.
+                await output._done()
 
         output._set_task(asyncio.create_task(process_turns()))
         return output

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -259,6 +259,11 @@ class StreamedAudioResult:
     async def _done(self):
         self._completed_session = True
         self._dispatcher_event.set()
+        # A session that produced no audio never started the dispatcher, so nothing would put
+        # the terminal event on the queue and `stream()` would wait on it forever. Start the
+        # dispatcher here so it observes the completed session and emits `session_ended`.
+        if self._dispatcher_task is None:
+            self._dispatcher_task = asyncio.create_task(self._dispatch_audio())
         await self._wait_for_completion()
 
     async def _dispatch_audio(self):
@@ -323,12 +328,14 @@ class StreamedAudioResult:
     async def stream(self) -> AsyncIterator[VoiceStreamEvent]:
         """Stream the events and audio data as they're generated."""
         saw_session_end = False
+        saw_terminal_event = False
         primary_exception: BaseException | None = None
         try:
             while True:
                 event = await self._queue.get()
                 if isinstance(event, VoiceStreamEventError):
                     self._stored_exception = event.error
+                    saw_terminal_event = True
                     log_model_and_tool_action_error(
                         logger, "Error processing voice output", event.error
                     )
@@ -340,6 +347,7 @@ class StreamedAudioResult:
                 )
                 if is_session_end:
                     saw_session_end = True
+                    saw_terminal_event = True
                 yield event
                 if is_session_end:
                     break
@@ -357,7 +365,11 @@ class StreamedAudioResult:
             # Let the producer finish gracefully after terminal event delivery so any active
             # trace context can emit `trace_end` before cleanup. Await completed tasks too so a
             # terminal producer failure cannot be hidden by the preceding lifecycle event.
-            if saw_session_end and self.text_generation_task is not None:
+            #
+            # An error is a terminal event too. The producer reports it and then still has to
+            # close the transcription session, so cancelling here instead of waiting would tear
+            # that session down mid-close.
+            if saw_terminal_event and self.text_generation_task is not None:
                 try:
                     await asyncio.shield(self.text_generation_task)
                 except BaseException as exc:
@@ -388,10 +400,14 @@ class StreamedAudioResult:
             elif cleanup_exception is not None:
                 exception_to_raise = cleanup_exception
 
+            # `exc is not primary_exception` because the producer re-raises the same error it
+            # queued, so on the error path it arrives here as both. That is the outcome being
+            # preserved, not a second failure hidden behind it.
             finalization_exception_was_suppressed = any(
                 exc is not None
                 and not isinstance(exc, asyncio.CancelledError)
                 and exc is not exception_to_raise
+                and exc is not primary_exception
                 for exc in (producer_exception, cleanup_exception)
             )
             if finalization_exception_was_suppressed:

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
@@ -27,7 +27,13 @@ try:
         VoiceStreamEventLifecycle,
     )
 
-    from .fake_models import FakeStreamedAudioInput, FakeSTT, FakeTTS, FakeWorkflow
+    from .fake_models import (
+        FakeSession,
+        FakeStreamedAudioInput,
+        FakeSTT,
+        FakeTTS,
+        FakeWorkflow,
+    )
     from .helpers import extract_events
 except ImportError:
     pass
@@ -784,6 +790,332 @@ async def test_voicepipeline_streamed_audio_input() -> None:
     assert len(audio_chunks) == 2
     await fake_tts.verify_audio("out_1", audio_chunks[0])
     await fake_tts.verify_audio("out_2", audio_chunks[1])
+
+
+def _never_complete(text: str) -> tuple[str, str]:
+    """A splitter that never returns a complete sentence, so everything stays buffered."""
+    return "", text
+
+
+class _RecordingTTS(FakeTTS):
+    """Records every text handed to TTS so a test can assert no work was started."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.texts: list[str] = []
+
+    async def run(self, text: str, settings: TTSModelSettings) -> AsyncIterator[bytes]:
+        self.texts.append(text)
+        yield np.zeros(2, dtype=np.int16).tobytes()
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_streamed_audio_input_without_turns() -> None:
+    # Zero turns. The session still has to end, otherwise `stream()` waits on the queue forever.
+
+    fake_stt = FakeSTT([])
+    workflow = FakeWorkflow()
+    fake_tts = FakeTTS()
+    pipeline = VoicePipeline(workflow=workflow, stt_model=fake_stt, tts_model=fake_tts)
+
+    streamed_audio_input = await FakeStreamedAudioInput.get(count=0)
+
+    result = await pipeline.run(streamed_audio_input)
+    # The timeout bounds the failure mode under test, which is a stream that never terminates.
+    events, audio_chunks = await asyncio.wait_for(extract_events(result), timeout=5)
+    assert events == ["session_ended"]
+    assert audio_chunks == []
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_delivers_on_start_output_during_startup() -> None:
+    # A greeting belongs to startup, so it must reach the consumer while the transcription
+    # session is still open rather than being held until the session ends.
+
+    intro_delivered = asyncio.Event()
+
+    class GatedSession(FakeSession):
+        async def transcribe_turns(self) -> AsyncIterator[str]:
+            # Released only once the greeting has been fully delivered. If the intro turn were
+            # left open until session end, this would never be released and the test times out.
+            await intro_delivered.wait()
+            for t in self.outputs:
+                yield t
+
+    class GatedSTT(FakeSTT):
+        async def create_session(self, *args: Any, **kwargs: Any) -> GatedSession:
+            session = GatedSession()
+            session.outputs = self.outputs
+            return session
+
+    class GreetingWorkflow(FakeWorkflow):
+        async def on_start(self) -> AsyncIterator[str]:
+            yield "Hello there"
+
+    config = VoicePipelineConfig(
+        tts_settings=TTSModelSettings(buffer_size=1, text_splitter=_never_complete)
+    )
+    pipeline = VoicePipeline(
+        workflow=GreetingWorkflow(),
+        stt_model=GatedSTT([]),
+        tts_model=_RecordingTTS(),
+        config=config,
+    )
+    result = await pipeline.run(await FakeStreamedAudioInput.get(count=0))
+
+    events: list[str] = []
+
+    async def consume() -> None:
+        async for event in result.stream():
+            if event.type == "voice_stream_event_lifecycle":
+                events.append(event.event)
+                if event.event == "turn_ended":
+                    intro_delivered.set()
+            elif event.type == "voice_stream_event_audio":
+                events.append("audio")
+
+    await asyncio.wait_for(consume(), timeout=5)
+
+    assert events == ["turn_started", "audio", "turn_ended", "session_ended"]
+    assert cast(_RecordingTTS, pipeline.tts_model).texts == ["Hello there"]
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_on_start_output_is_its_own_turn() -> None:
+    # The same guarantee as the test above, but with a transcription session that produces a turn
+    # immediately rather than waiting for the greeting to be delivered. Nothing serializes the two,
+    # so this pins that the greeting is finalized as its own turn and the first user response still
+    # gets its own turn_started rather than being folded into an intro that is still open.
+
+    class ImmediateSession(FakeSession):
+        async def transcribe_turns(self) -> AsyncIterator[str]:
+            yield "hello"
+
+    class ImmediateSTT(FakeSTT):
+        async def create_session(self, *args: Any, **kwargs: Any) -> ImmediateSession:
+            return ImmediateSession()
+
+    class GreetingWorkflow(FakeWorkflow):
+        async def on_start(self) -> AsyncIterator[str]:
+            yield "Hello there"
+
+        async def run(self, _: str) -> AsyncIterator[str]:
+            yield "the reply"
+
+    recording_tts = _RecordingTTS()
+    config = VoicePipelineConfig(
+        tts_settings=TTSModelSettings(buffer_size=1, text_splitter=_never_complete)
+    )
+    pipeline = VoicePipeline(
+        workflow=GreetingWorkflow(),
+        stt_model=ImmediateSTT([]),
+        tts_model=recording_tts,
+        config=config,
+    )
+    result = await pipeline.run(await FakeStreamedAudioInput.get(count=1))
+
+    events, _ = await asyncio.wait_for(extract_events(result), timeout=5)
+
+    assert events == [
+        "turn_started",
+        "audio",
+        "turn_ended",
+        "turn_started",
+        "audio",
+        "turn_ended",
+        "session_ended",
+    ]
+    assert recording_tts.texts == ["Hello there", "the reply"]
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_failed_turn_closes_the_session_without_further_tts() -> None:
+    # A failing turn must still close the transcription session, and must not send the text it
+    # had buffered to TTS. The consumer stops at the error, so that audio is unobservable.
+
+    closed = asyncio.Event()
+
+    class ClosingSession(FakeSession):
+        async def close(self) -> None:
+            closed.set()
+
+    class ClosingSTT(FakeSTT):
+        async def create_session(self, *args: Any, **kwargs: Any) -> ClosingSession:
+            session = ClosingSession()
+            session.outputs = self.outputs
+            return session
+
+    error = RuntimeError("workflow blew up")
+
+    class FailingWorkflow(FakeWorkflow):
+        async def run(self, _: str) -> AsyncIterator[str]:
+            yield "partial"
+            raise error
+
+    recording_tts = _RecordingTTS()
+    config = VoicePipelineConfig(
+        tts_settings=TTSModelSettings(buffer_size=1, text_splitter=_never_complete)
+    )
+    pipeline = VoicePipeline(
+        workflow=FailingWorkflow(),
+        stt_model=ClosingSTT(["hello"]),
+        tts_model=recording_tts,
+        config=config,
+    )
+    result = await pipeline.run(await FakeStreamedAudioInput.get(count=1))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await asyncio.wait_for(extract_events(result), timeout=5)
+
+    assert exc_info.value is error
+    assert closed.is_set()
+    assert recording_tts.texts == []
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_error_waits_for_the_session_close_before_cleanup() -> None:
+    # An error is a terminal event, but the producer still has to close the transcription session
+    # after reporting it. `stream()` has to wait for that instead of cancelling the producer, or
+    # the session is torn down mid-close.
+
+    turn_error = RuntimeError("workflow blew up")
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    close_finished = asyncio.Event()
+
+    class BlockingCloseSession(FakeSession):
+        async def close(self) -> None:
+            close_started.set()
+            await release_close.wait()
+            close_finished.set()
+
+    class BlockingCloseSTT(FakeSTT):
+        async def create_session(self, *args: Any, **kwargs: Any) -> BlockingCloseSession:
+            session = BlockingCloseSession()
+            session.outputs = self.outputs
+            return session
+
+    class FailingWorkflow(FakeWorkflow):
+        async def run(self, _: str) -> AsyncIterator[str]:
+            yield "partial"
+            raise turn_error
+
+    recording_tts = _RecordingTTS()
+    config = VoicePipelineConfig(
+        tts_settings=TTSModelSettings(buffer_size=1, text_splitter=_never_complete)
+    )
+    pipeline = VoicePipeline(
+        workflow=FailingWorkflow(),
+        stt_model=BlockingCloseSTT(["hello"]),
+        tts_model=recording_tts,
+        config=config,
+    )
+    result = await pipeline.run(await FakeStreamedAudioInput.get(count=1))
+
+    consumer = asyncio.create_task(extract_events(result))
+    await asyncio.wait_for(close_started.wait(), timeout=5)
+
+    # The consumer has the error and is inside its finally. It must be parked on the producer
+    # rather than cancelling it, so the close is still running and neither side has finished.
+    await asyncio.sleep(0)
+    producer = result.text_generation_task
+    assert producer is not None
+    assert not producer.cancelled()
+    assert not producer.done()
+    assert not consumer.done()
+
+    release_close.set()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await asyncio.wait_for(consumer, timeout=5)
+
+    assert exc_info.value is turn_error
+    assert close_finished.is_set()
+    assert recording_tts.texts == []
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_failing_close_does_not_replace_the_turn_error() -> None:
+    # When a turn fails and closing the transcription session fails too, the consumer must still
+    # see the error that actually broke the run, not the cleanup error that followed it.
+
+    turn_error = RuntimeError("workflow blew up")
+    close_error = RuntimeError("close blew up")
+
+    class FailingCloseSession(FakeSession):
+        async def close(self) -> None:
+            raise close_error
+
+    class FailingCloseSTT(FakeSTT):
+        async def create_session(self, *args: Any, **kwargs: Any) -> FailingCloseSession:
+            session = FailingCloseSession()
+            session.outputs = self.outputs
+            return session
+
+    class FailingWorkflow(FakeWorkflow):
+        async def run(self, _: str) -> AsyncIterator[str]:
+            raise turn_error
+            yield ""
+
+    pipeline = VoicePipeline(
+        workflow=FailingWorkflow(),
+        stt_model=FailingCloseSTT(["hello"]),
+        tts_model=FakeTTS(),
+    )
+    result = await pipeline.run(await FakeStreamedAudioInput.get(count=1))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await asyncio.wait_for(extract_events(result), timeout=5)
+
+    assert exc_info.value is turn_error
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_cancelled_consumer_closes_the_session_without_further_tts() -> None:
+    # Cancelling the consumer tears down the producer. The transcription session still has to be
+    # closed, and the turn the producer had open must not be sent to TTS on the way out.
+
+    closed = asyncio.Event()
+    buffered = asyncio.Event()
+
+    class ClosingSession(FakeSession):
+        async def transcribe_turns(self) -> AsyncIterator[str]:
+            yield "hello"
+            await asyncio.Event().wait()
+
+        async def close(self) -> None:
+            closed.set()
+
+    class ClosingSTT(FakeSTT):
+        async def create_session(self, *args: Any, **kwargs: Any) -> ClosingSession:
+            return ClosingSession()
+
+    class BufferingWorkflow(FakeWorkflow):
+        async def run(self, _: str) -> AsyncIterator[str]:
+            yield "partial"
+            buffered.set()
+            await asyncio.Event().wait()
+
+    recording_tts = _RecordingTTS()
+    config = VoicePipelineConfig(
+        tts_settings=TTSModelSettings(buffer_size=1, text_splitter=_never_complete)
+    )
+    pipeline = VoicePipeline(
+        workflow=BufferingWorkflow(),
+        stt_model=ClosingSTT([]),
+        tts_model=recording_tts,
+        config=config,
+    )
+    result = await pipeline.run(await FakeStreamedAudioInput.get(count=1))
+
+    consumer = asyncio.create_task(extract_events(result))
+    await asyncio.wait_for(buffered.wait(), timeout=5)
+    consumer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await consumer
+
+    assert closed.is_set()
+    assert recording_tts.texts == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

A streamed voice session that produces no audio never terminates. `_dispatch_audio` is the only thing that puts `session_ended` on the queue, and it is only started once a turn has text to synthesize, so a session with zero turns leaves `stream()` waiting on the queue forever.

`_done()` now starts the dispatcher when the session finished without one.

The rest of the change is the lifecycle around that, in `_run_multi_turn`:

- Output emitted by `on_start()` is finalized as part of startup, right after the startup block. It used to stay in an open turn, so a greeting without sentence-final punctuation was held until the session ended or folded into the first user turn.
- The transcription session is closed from a `finally`, and that `finally` runs after the `except` has reported the error. Closing before the report meant a failing `close()` replaced the error the consumer actually needed.
- `_done()` is called only after the producer completes cleanly. An error has already queued its terminal event and a cancelled producer has no consumer left, so neither should start TTS work or wait on it.
- In `stream()`, the graceful producer wait now treats an error as terminal, not just `session_ended`. The producer still has to close the transcription session after reporting an error, so cleanup would otherwise cancel it mid-close.

### Test plan

Six tests in `tests/voice/test_pipeline.py`, all through the public pipeline:

- `..._streamed_audio_input_without_turns` covers the zero-turn hang.
- `..._delivers_on_start_output_during_startup` gates the transcription session on the greeting reaching the consumer.
- `..._on_start_output_is_its_own_turn` pins the same guarantee with a session that yields immediately, so nothing serializes the two.
- `..._error_waits_for_the_session_close_before_cleanup` blocks inside `close()` and asserts the producer is not cancelled, then that cleanup completes, the workflow error reaches the consumer, and no TTS work started.
- `..._failing_close_does_not_replace_the_turn_error` fails the turn and the close, and asserts the consumer gets the turn error.
- `..._cancelled_consumer_closes_the_session_without_further_tts` cancels the consumer and asserts the session still closes with no TTS work.