### PR TITLE
fix(sandbox): keep programmatic tool calling items in memory rollouts

### DIFF
--- a/src/agents/sandbox/memory/rollouts.py
+++ b/src/agents/sandbox/memory/rollouts.py
@@ -38,6 +38,8 @@ _INCLUDED_MEMORY_ITEM_TYPES = frozenset(
         "mcp_approval_request",
         "mcp_approval_response",
         "mcp_call",
+        "program",
+        "program_output",
         "shell_call",
         "shell_call_output",
         "tool_search_call",

--- a/tests/sandbox/test_memory.py
+++ b/tests/sandbox/test_memory.py
@@ -11,6 +11,8 @@ from typing import Any, cast, get_type_hints
 
 import pytest
 from openai.types.responses import ResponseCustomToolCall, ResponseFunctionToolCall
+from openai.types.responses.response_function_tool_call import CallerProgram
+from openai.types.responses.response_output_item import Program, ProgramOutput
 from openai.types.responses.response_output_message import ResponseOutputMessage
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 
@@ -33,6 +35,8 @@ from agents.items import (
     CompactionItem,
     MessageOutputItem,
     ToolApprovalItem,
+    ToolCallItem,
+    ToolCallOutputItem,
     TResponseOutputItem,
 )
 from agents.result import RunResult, RunResultStreaming
@@ -277,6 +281,120 @@ def test_build_rollout_payload_filters_developer_and_noisy_items() -> None:
         assistant_message.model_dump(exclude_unset=True),
     ]
     assert payload["final_output"] == "done"
+
+
+def test_build_rollout_payload_keeps_programmatic_tool_calling_items() -> None:
+    agent = Agent(name="test")
+    program = Program(
+        id="program_item",
+        call_id="call_prog_1",
+        code='lookup_inventory(sku="A-1")',
+        fingerprint="fingerprint",
+        type="program",
+    )
+    function_call = ResponseFunctionToolCall(
+        id="function_item",
+        call_id="call_fn_1",
+        name="lookup_inventory",
+        arguments='{"sku":"A-1"}',
+        caller=CallerProgram(type="program", caller_id="call_prog_1"),
+        type="function_call",
+    )
+    function_call_output = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call_output",
+            "call_id": "call_fn_1",
+            "output": '{"available_units":42}',
+        },
+    )
+    program_output = ProgramOutput(
+        id="program_output_item",
+        call_id="call_prog_1",
+        result='{"sku":"A-1","available_units":42}',
+        status="completed",
+        type="program_output",
+    )
+
+    payload = build_rollout_payload(
+        input="what is in stock?",
+        new_items=[
+            ToolCallItem(agent=agent, raw_item=program),
+            ToolCallItem(agent=agent, raw_item=function_call),
+            ToolCallOutputItem(agent=agent, raw_item=function_call_output, output="42"),
+            ToolCallOutputItem(agent=agent, raw_item=program_output, output="42"),
+        ],
+        final_output="done",
+        interruptions=[],
+        terminal_metadata=RolloutTerminalMetadata(
+            terminal_state="completed",
+            has_final_output=True,
+        ),
+    )
+
+    generated_items = payload["generated_items"]
+    assert [item["type"] for item in generated_items] == [
+        "program",
+        "function_call",
+        "function_call_output",
+        "program_output",
+    ]
+    # The retained function call points back at the program that issued it, so the program
+    # it names has to survive alongside it.
+    assert generated_items[1]["caller"] == {"type": "program", "caller_id": "call_prog_1"}
+    assert generated_items[0]["call_id"] == "call_prog_1"
+    assert generated_items[0]["code"] == 'lookup_inventory(sku="A-1")'
+    assert generated_items[3]["call_id"] == "call_prog_1"
+    assert generated_items[3]["result"] == '{"sku":"A-1","available_units":42}'
+
+
+def test_build_rollout_payload_keeps_program_items_from_input() -> None:
+    payload = build_rollout_payload(
+        input=[
+            cast(
+                TResponseInputItem,
+                {
+                    "type": "program",
+                    "call_id": "call_prog_1",
+                    "code": 'lookup_inventory(sku="A-1")',
+                    "fingerprint": "fingerprint",
+                },
+            ),
+            cast(
+                TResponseInputItem,
+                {
+                    "type": "program_output",
+                    "call_id": "call_prog_1",
+                    "result": '{"available_units":42}',
+                    "status": "completed",
+                },
+            ),
+        ],
+        new_items=[],
+        final_output=None,
+        interruptions=[],
+        terminal_metadata=RolloutTerminalMetadata(terminal_state="completed"),
+    )
+
+    assert [item["type"] for item in payload["input"]] == ["program", "program_output"]
+
+
+def test_build_rollout_payload_still_drops_hosted_items_outside_the_included_set() -> None:
+    """Program items are included because every other call/output pair is; hosted tool calls
+    with no output half stay out."""
+    payload = build_rollout_payload(
+        input=[
+            cast(TResponseInputItem, {"type": "file_search_call", "id": "fs_1", "queries": []}),
+            cast(TResponseInputItem, {"type": "image_generation_call", "id": "ig_1"}),
+            cast(TResponseInputItem, {"type": "program", "call_id": "call_prog_1", "code": "x()"}),
+        ],
+        new_items=[],
+        final_output=None,
+        interruptions=[],
+        terminal_metadata=RolloutTerminalMetadata(terminal_state="completed"),
+    )
+
+    assert [item["type"] for item in payload["input"]] == ["program"]
 
 
 def test_build_rollout_payload_serializes_model_interruptions_as_dicts() -> None:


### PR DESCRIPTION
### Summary

Sandbox memory rollouts silently drop Programmatic Tool Calling items.

`_should_include_memory_item()` in `src/agents/sandbox/memory/rollouts.py` keeps an item only when its `type` is listed in `_INCLUDED_MEMORY_ITEM_TYPES` (an explicit `_EXCLUDED_MEMORY_ITEM_TYPES` set names the types that are deliberately dropped; everything else falls through to dropped). That set lists **both halves of every call/output pair in `_TOOL_CALL_TO_OUTPUT_TYPE`** (`run_internal/items.py`) — `function_call`, `custom_tool_call`, `shell_call`, `apply_patch_call`, `computer_call`, `local_shell_call`, `tool_search_call` and their outputs — plus `web_search_call`, `mcp_call`, `mcp_approval_request`, `mcp_approval_response`.

The one pair missing is `program` / `program_output`.

The set was written in #2889 (2026-04-15) and has not been edited since. Programmatic Tool Calling added the `program` and `program_output` item types later, in #3833 (2026-07-17), and this call site was not updated — so a run that uses `ProgrammaticToolCallingTool` writes a rollout with the program code and the program result removed.

The rollout is the raw evidence that phase-one/phase-two memory generation reads, so the loss is not cosmetic. Worse, the filter is inconsistent with itself: the `function_call` items a program issues **are** retained, and each one carries `caller: {"type": "program", "caller_id": ...}` pointing at a `program` item that was just removed. The stored rollout therefore contains dangling caller references.

Before, for a single programmatic turn (`program` → `function_call` → `function_call_output` → `program_output`):

```
generated_items: ["function_call", "function_call_output"]
  function_call.caller = {"type": "program", "caller_id": "call_prog_1"}   # target not in the rollout
```

After:

```
generated_items: ["program", "function_call", "function_call_output", "program_output"]
```

**Fix:** add `"program"` and `"program_output"` to the existing frozenset. Two strings — no new branch, no new helper, no public API or stored-format change.

**Deliberately not widened.** `file_search_call`, `code_interpreter_call`, `mcp_list_tools` and `hosted_tool_call` are also absent from the set, but they are not part of the contract this change asserts: the claim here is only that every call/output pair the SDK knows how to pair should survive into the rollout, and `program` is the sole pair that does not. `image_generation_call` stays excluded via `_EXCLUDED_MEMORY_ITEM_TYPES`. There is a boundary test covering exactly this.

### Test plan

Three tests added to `tests/sandbox/test_memory.py`:

- `test_build_rollout_payload_keeps_programmatic_tool_calling_items` — a full programmatic turn as `RunItem`s (`Program`, a `function_call` carrying `CallerProgram`, its output, `ProgramOutput`). Asserts all four survive in order, that the program's `code` and the program output's `result` are preserved, and that the retained `function_call.caller` resolves to a `program` item that is present.
- `test_build_rollout_payload_keeps_program_items_from_input` — the same types arriving on the `input` side, which goes through the same filter.
- `test_build_rollout_payload_still_drops_hosted_items_outside_the_included_set` — boundary: `file_search_call` and `image_generation_call` are still dropped while `program` is kept, so the narrow scope is pinned.

All three fail on `upstream/main` @ `f3b6c617` and pass with the change; verified by reverting only the source hunk and re-running (`3 failed, 3 passed` → `6 passed`). The three pre-existing `build_rollout_payload` tests pass unchanged in both states.

Commands run:

- `uv run pytest tests/sandbox/test_memory.py -q` → `73 passed`
- `uv run pytest tests/sandbox tests/test_programmatic_tool_calling.py -q` → `1130 passed, 2 skipped`
- `make format` → `862 files left unchanged`
- `make lint` → `All checks passed!`
- `make typecheck` → mypy and pyright clean (exit 0)
- `make tests` → `6744 passed, 29 skipped` (parallel) + `77 passed, 5 skipped` (serial)
- `git diff --check` → clean

No API key, no network, no live service.

Not run: `make coverage`, `make build-docs`, the Python 3.10 matrix, and the integration-test profiles.

One unrelated flake seen while validating: `tests/extensions/memory/test_advanced_sqlite_session.py::test_branch_allocation_is_serialized_across_processes` fails intermittently (~1 in 5) under CPU contention at `assert first_ready.wait(timeout=10)`, a fixed wall-clock wait on a `multiprocessing.Event`. It reproduces with this change reverted and is not in this change's import graph; `make tests` is green on this branch when the machine is idle.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
