### PR TITLE
fix: detect RunContextWrapper subclasses as the tool context parameter

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -283,6 +283,16 @@ def _extract_field_info_from_metadata(metadata: tuple[Any, ...]) -> FieldInfo | 
     return None
 
 
+def _is_run_context_annotation(annotation: Any) -> bool:
+    """Whether an annotation refers to RunContextWrapper or one of its subclasses.
+
+    ToolContext and AgentHookContext are SDK subclasses, and the docs tell callers the SDK may
+    hand them a specialized subclass, so subclasses have to count as context too.
+    """
+    origin = get_origin(annotation) or annotation
+    return isinstance(origin, type) and issubclass(origin, RunContextWrapper | ToolContext)
+
+
 def function_schema(
     func: Callable[..., Any],
     docstring_style: DocstringStyle | None = None,
@@ -356,8 +366,7 @@ def function_schema(
         # Prefer the evaluated type hint if available
         ann = type_hints.get(first_name, first_param.annotation)
         if ann is not inspect._empty:
-            origin = get_origin(ann) or ann
-            if origin is RunContextWrapper or origin is ToolContext:
+            if _is_run_context_annotation(ann):
                 takes_context = True  # Mark that the function takes context
             else:
                 filtered_params.append((first_name, first_param))
@@ -368,8 +377,7 @@ def function_schema(
     for name, param in params[1:]:
         ann = type_hints.get(name, param.annotation)
         if ann is not inspect._empty:
-            origin = get_origin(ann) or ann
-            if origin is RunContextWrapper or origin is ToolContext:
+            if _is_run_context_annotation(ann):
                 raise UserError(
                     f"RunContextWrapper/ToolContext param found at non-first position in function"
                     f" {func.__name__}"

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -1137,3 +1137,32 @@ def test_default_equality_is_not_used_for_sentinel_comparison(
     parsed = fs.params_pydantic_model(x=1)
     args, kwargs = fs.to_call_args(parsed)
     assert isinstance((args + list(kwargs.values()))[-1], default_type)
+
+
+class _CustomContext(RunContextWrapper[str]):
+    """A caller-defined context, like the specialized subclasses the SDK itself passes."""
+
+
+def function_with_context_subclass(ctx: _CustomContext, a: int, b: int = 5):
+    return a + b
+
+
+def test_function_with_context_subclass() -> None:
+    func_schema = function_schema(function_with_context_subclass)
+
+    assert func_schema.takes_context
+    assert "ctx" not in func_schema.params_json_schema.get("properties", {})
+
+    context = _CustomContext(context="test")
+    parsed = func_schema.params_pydantic_model(**{"a": 1, "b": 2})
+    args, kwargs_dict = func_schema.to_call_args(parsed)
+    assert function_with_context_subclass(context, *args, **kwargs_dict) == 3
+
+
+def function_with_context_subclass_at_non_first_position(a: int, ctx: _CustomContext):
+    return a
+
+
+def test_context_subclass_at_non_first_position_raises() -> None:
+    with pytest.raises(UserError, match="param found at non-first position"):
+        function_schema(function_with_context_subclass_at_non_first_position)


### PR DESCRIPTION
`function_schema` identifies the context parameter with `origin is RunContextWrapper or origin is ToolContext`. `ToolContext` is a `RunContextWrapper` subclass that had to be added by hand; the SDK ships another one in `AgentHookContext`, and `docs/context.md` tells callers the SDK may hand them a specialized subclass.

Annotating a tool's first parameter with any other subclass leaves `takes_context` `False`. The context is then advertised to the model as a tool parameter, and `to_call_args` passes the model's value into the context slot. Under the default strict schema it fails earlier with an unrelated `additionalProperties` error instead. The non-first-position guard misses the same annotations, so its intended `UserError` never fires.

Match `RunContextWrapper` subclasses rather than exact types. Existing behavior for `RunContextWrapper[T]`, `ToolContext`, and non-context first parameters is unchanged.
