### PR TITLE
fix(run_state): make to_json repeatable

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -769,8 +769,10 @@ class RunState(Generic[TContext, TAgent]):
                 seen_call_ids.add(call_id)
             generated_items.append(new_item)
 
-        if current_merge_marker is not None:
-            self._generated_items_last_processed_marker = current_merge_marker
+        # The merge result is local, so the marker must not be recorded here: doing so would make
+        # the next call take the already-merged shortcut above and return the unmerged
+        # `_generated_items`. Only callers that actually store the merged list mark it, via
+        # `_mark_generated_items_merged_with_last_processed`.
         return generated_items
 
     def to_json(

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -1411,6 +1411,30 @@ class TestRunState:
         ]
 
     @pytest.mark.asyncio
+    async def test_to_json_is_repeatable(self):
+        """to_json() must not lose merged items when it is called more than once."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="AgentRepeatedSerialization")
+        state = make_state(agent, context=context, original_input="input", max_turns=2)
+
+        state._generated_items = []
+        state._last_processed_response = make_processed_response(
+            new_items=[
+                MessageOutputItem(
+                    raw_item=make_message_output(message_id="msg-processed", text="processed"),
+                    agent=agent,
+                ),
+            ]
+        )
+
+        first = state.to_json()
+        second = state.to_json()
+
+        assert [item["type"] for item in first["generated_items"]] == ["message_output_item"]
+        assert second["generated_items"] == first["generated_items"]
+        assert second["generated_session_item_indexes"] == first["generated_session_item_indexes"]
+
+    @pytest.mark.asyncio
     async def test_anonymous_tool_search_items_not_duplicated_across_round_trip(self):
         """Ensure already-merged anonymous tool_search items do not grow across round-trips."""
         context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})


### PR DESCRIPTION
`_merge_generated_items_with_processed` builds the merged item list locally but also recorded the merge marker on the instance. The merged list is never stored back into `_generated_items`, so the next call takes the "already merged" shortcut and returns the unmerged list.

`to_json()` and `to_string()` therefore return different snapshots on the second call, and the second one silently drops every item that only exists in `last_processed_response.new_items`. Logging the state and then persisting it is enough to store a lossy snapshot.

Only callers that actually keep the merged list should mark it; the run loop already does that via `_mark_generated_items_merged_with_last_processed`, which is what the existing anonymous-tool-search dedupe test relies on.

Test asserts two consecutive `to_json()` calls agree. Fails before the fix.
