### PR TITLE
fix(memory): skip conversation creation on uninitialized pop_item

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -118,7 +118,14 @@ class OpenAIConversationsSession(SessionABC):
         )
 
     async def pop_item(self) -> TResponseInputItem | None:
-        session_id = await self._get_session_id()
+        async with self._session_id_lock:
+            session_id = self._session_id
+
+        if session_id is None:
+            # An uninitialized session has nothing to pop, so creating a remote conversation
+            # here would only leave an empty conversation behind and bind this session to it.
+            return None
+
         items = await self.get_items(limit=1)
         if not items:
             return None

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -295,6 +295,20 @@ class TestOpenAIConversationsSessionBasicOperations:
             mock_openai_client.conversations.items.delete.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_pop_item_uninitialized_does_not_create_session(self, mock_openai_client):
+        """Test that pop_item on an uninitialized session does not create a conversation."""
+        session = OpenAIConversationsSession(openai_client=mock_openai_client)
+
+        with patch.object(session, "get_items", return_value=[]) as mock_get_items:
+            popped_item = await session.pop_item()
+
+        assert popped_item is None
+        mock_get_items.assert_not_called()
+        mock_openai_client.conversations.create.assert_not_called()
+        mock_openai_client.conversations.items.delete.assert_not_called()
+        assert session._session_id is None
+
+    @pytest.mark.asyncio
     async def test_clear_session(self, mock_openai_client):
         """Test clearing the entire session."""
         session = OpenAIConversationsSession(


### PR DESCRIPTION
`OpenAIConversationsSession.pop_item` calls `_get_session_id()` before anything else, so popping from a session that has never touched the remote API creates an empty conversation, binds the session to it, lists its items, and returns `None`. The round trip can never return an item — a conversation created one line earlier is empty by construction — and it leaves a stray conversation on the server plus a session id the caller never asked for.

`add_items` (#4190) and `clear_session` (#4111) already short-circuit in this situation, and the `session_id` docstring lists only `get_items()` and a non-empty `add_items()` as the methods that initialize a session. `pop_item` was the remaining one.

Return `None` up front when no conversation id exists yet.

Test: `test_pop_item_uninitialized_does_not_create_session` asserts no `conversations.create`, no `get_items`, no `items.delete`, and that `_session_id` stays `None`. Fails before the fix.
