### PR TITLE
fix(run_state): keep current_step interruptions with an unknown agent name

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -3052,6 +3052,7 @@ async def _build_run_state_from_json(
                 item_data,
                 agent_map=agent_map,
                 agent_identity_map=agent_identity_map,
+                fallback_agent=current_agent,
             )
             if approval_item is not None:
                 interruptions.append(approval_item)

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -2737,6 +2737,27 @@ class TestDeserializeHelpers:
         assert interruptions[0].agent.name == "InnerAgent"
         assert interruptions[0].raw_item.name == "sensitive_tool"  # type: ignore[union-attr]
 
+    async def test_current_step_interruption_survives_unresolvable_agent_name(self):
+        """current_step interruptions must restore like their last_processed_response twins."""
+        agent = Agent(name="MainAgent")
+        # The approval was raised by an agent the restored graph no longer exposes by name,
+        # for example because the application renamed it between snapshots.
+        approval_item = ToolApprovalItem(
+            agent=Agent(name="RenamedAgent"),
+            raw_item=make_function_tool_call("sensitive_tool", call_id="call-1"),
+        )
+        state = make_state_with_interruptions(agent, [approval_item], original_input="test")
+        state._last_processed_response = make_processed_response(interruptions=[approval_item])
+
+        restored = await RunState.from_string(agent, state.to_string())
+
+        assert restored._last_processed_response is not None
+        assert len(restored._last_processed_response.interruptions) == 1
+        interruptions = restored.get_interruptions()
+        assert len(interruptions) == 1
+        assert interruptions[0].agent is agent
+        assert interruptions[0].raw_item.name == "sensitive_tool"  # type: ignore[union-attr]
+
     @pytest.mark.parametrize("drop_mode", ["disabled", "removed", "malformed_call"])
     async def test_nested_agent_tool_state_survives_when_earlier_function_is_dropped(
         self, drop_mode: str


### PR DESCRIPTION
`from_json` restores the same approval items twice: once under `last_processed_response.interruptions` and once under `current_step.data.interruptions`. The first call passes `fallback_agent=current_agent`, the second does not, so an approval whose agent name is missing from the restored graph resolves to `None` and is silently skipped.

The result is a `RunState` that still reports an interrupted step while `get_interruptions()` returns an empty list, so the caller can never approve or reject and the state cannot be resumed. Nothing is logged. Agent references are serialized by name unless the graph has duplicate names, so any rename between snapshot and resume hits this.

Pass the same fallback on both paths.

Test round-trips a state whose interruption names an agent outside the restored graph and asserts `get_interruptions()` matches `last_processed_response.interruptions`. Fails before the fix.
