### PR TITLE
fix(models): strip placeholder item IDs without provider_data on the Responses path

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -916,17 +916,20 @@ class OpenAIResponsesModel(Model):
         This data transformation does not always guarantee that items from other provider
         interactions are accepted by the OpenAI Responses API.
 
-        Only items with truthy provider_data are processed.
         This function handles the following incompatibilities:
         - provider_data: Removes fields specific to other providers (e.g., Gemini, Claude).
         - Fake IDs: Removes temporary IDs (FAKE_RESPONSES_ID) that should not be sent to OpenAI.
         - Reasoning items: Filters out provider-specific reasoning items entirely.
         """
-        # Early return optimization: if no item has provider_data, return unchanged.
-        has_provider_data = any(
-            isinstance(item, dict) and item.get("provider_data") for item in list_input
+        # Early return optimization: skip the copy when nothing needs cleaning. Placeholder IDs
+        # are emitted without provider_data by several SDK paths, so they have to be checked
+        # independently of it.
+        needs_cleaning = any(
+            isinstance(item, dict)
+            and (item.get("provider_data") or item.get("id") == FAKE_RESPONSES_ID)
+            for item in list_input
         )
-        if not has_provider_data:
+        if not needs_cleaning:
             return list_input
 
         result = []

--- a/tests/models/test_remove_openai_responses_api_incompatible_fields.py
+++ b/tests/models/test_remove_openai_responses_api_incompatible_fields.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 
+from agents import Agent, ModelSettings
+from agents.items import TResponseInputItem
 from agents.models.fake_id import FAKE_RESPONSES_ID
 from agents.models.openai_responses import OpenAIResponsesModel
+from agents.run_internal.error_handlers import create_message_output_item
 
 
 @pytest.fixture
@@ -91,6 +94,23 @@ class TestRemoveOpenAIResponsesAPIIncompatibleFields:
         assert "id" not in result[0]
         assert result[0]["content"] == "hello"
 
+    def test_removes_fake_responses_id_without_provider_data(self, model: OpenAIResponsesModel):
+        """Placeholder IDs are stripped even when no item carries provider_data.
+
+        Several SDK paths build output items with FAKE_RESPONSES_ID and no provider_data, so
+        the placeholder cannot be assumed to travel alongside it.
+        """
+        list_input = [
+            {"role": "user", "content": "hi"},
+            {"type": "message", "id": FAKE_RESPONSES_ID, "content": "hello"},
+        ]
+
+        result = model._remove_openai_responses_api_incompatible_fields(list_input)
+
+        assert len(result) == 2
+        assert "id" not in result[1]
+        assert result[1]["content"] == "hello"
+
     def test_preserves_real_ids(self, model: OpenAIResponsesModel):
         """Real IDs (not FAKE_RESPONSES_ID) should be preserved."""
         list_input = [
@@ -160,3 +180,26 @@ class TestRemoveOpenAIResponsesAPIIncompatibleFields:
         assert result[3]["content"] == "The weather is 72F"
         assert "id" not in result[3]
         assert "provider_data" not in result[3]
+
+    def test_request_payload_drops_sdk_generated_placeholder_ids(
+        self, model: OpenAIResponsesModel
+    ) -> None:
+        """A replayed SDK-built assistant message must not send its placeholder ID upstream."""
+        message = create_message_output_item(
+            Agent(name="test"), "the run error handler final output"
+        ).raw_item
+
+        create_kwargs = model._build_response_create_kwargs(
+            system_instructions=None,
+            input=[
+                {"role": "user", "content": "hi"},
+                cast(TResponseInputItem, message.model_dump()),
+            ],
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+        )
+
+        assert message.id == FAKE_RESPONSES_ID
+        assert "id" not in create_kwargs["input"][1]


### PR DESCRIPTION
`_remove_openai_responses_api_incompatible_fields` returns the input list unchanged unless some item carries `provider_data`. The per-item cleaner it guards also strips `FAKE_RESPONSES_ID`, and that placeholder does not always travel with `provider_data` — `create_message_output_item` in the run error handlers builds its message with the placeholder id and nothing else.

Replaying such an item sends `id="__fake_id__"` to the Responses API, which rejects the request with `Invalid 'input[N].id'. Expected an ID that begins with 'msg'`.

Check for placeholder ids alongside `provider_data` when deciding whether the list needs cleaning. Lists that need neither are still returned as-is.

Adds a unit test for the placeholder-without-`provider_data` case and one asserting the built request payload drops the id.
