### PR TITLE
fix(streaming): open a chunkless chat completions stream with response.created

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -1064,6 +1064,18 @@ class ChatCmplStreamHandler:
                             sequence_number=sequence_number.get_and_increment(),
                         )
 
+        # A provider can return a 200 whose stream carries no chunks at all, and
+        # buffer_tool_call_stream can also swallow every chunk. `response.created` is only
+        # emitted from inside the loop, so open the stream here rather than let the terminal
+        # event arrive without one.
+        if not state.started:
+            state.started = True
+            yield ResponseCreatedEvent(
+                response=response,
+                type="response.created",
+                sequence_number=sequence_number.get_and_increment(),
+            )
+
         # Content-filter refusal with no emitted output: synthesize a refusal so
         # the completed response carries a ResponseOutputRefusal rather than an
         # empty turn. Only when nothing else was produced (text / refusal / tool

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -590,6 +590,19 @@ async def test_stream_handler_keeps_empty_choice_usage_chunks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_handler_opens_a_chunkless_stream() -> None:
+    """A provider stream that yields no chunks still has to start with response.created."""
+    events = [
+        event
+        async for event in ChatCmplStreamHandler.handle_stream(
+            _empty_response(), cast(Any, _empty_chat_completion_stream())
+        )
+    ]
+
+    assert [event.type for event in events] == ["response.created", "response.completed"]
+
+
+@pytest.mark.asyncio
 async def test_stream_handler_rejects_multiple_choices_in_strict_mode() -> None:
     chunk = ChatCompletionChunk(
         id="chunk-id",


### PR DESCRIPTION
`handle_stream` emits `response.created` from inside its chunk loop but emits `response.completed` unconditionally after it. A provider stream that yields no chunks — or one whose chunks are all swallowed by `buffer_tool_call_stream`, which returns without yielding when it never sees a last chunk — ends with a terminal event that no `created` opened. Consumers that initialize per-response state on `created` see `completed` first.

Emit the created event after the loop when nothing started the stream. Non-empty streams are unaffected: they still emit it on the first chunk.

The existing "nothing was produced" tests already assert `["response.created", "response.completed"]`; the new test covers the zero-chunk case.
