### PR TITLE
fix(run): apply the reasoning item id policy to error handler run data

### DIFF
--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1914,6 +1914,7 @@ async def run_single_turn_streamed(
         server_manages_conversation=server_conversation_tracker is not None,
         event_queue=streamed_result._event_queue,
         before_side_effects=raise_if_input_guardrail_tripwire_known,
+        reasoning_item_id_policy=reasoning_item_id_policy,
     )
 
     items_to_filter = session_items_for_turn(single_step_result)
@@ -2060,6 +2061,7 @@ async def run_single_turn(
         error_handlers=error_handlers,
         tool_use_tracker=tool_use_tracker,
         server_manages_conversation=server_conversation_tracker is not None,
+        reasoning_item_id_policy=reasoning_item_id_policy,
     )
 
 

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -128,6 +128,7 @@ from .error_handlers import (
 from .items import (
     REJECTION_MESSAGE,
     NestedHistoryOwnedItem,
+    ReasoningItemIdPolicy,
     apply_patch_rejection_item,
     extract_mcp_request_id_from_run,
     function_rejection_item,
@@ -422,6 +423,7 @@ async def _resolve_invalid_final_output(
     new_response: ModelResponse,
     new_items: list[RunItem],
     context_wrapper: RunContextWrapper[TContext],
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
 ) -> tuple[Any, MessageOutputItem | None] | None:
     redacted = _is_error_data_redacted(error) or _debug.DONT_LOG_MODEL_DATA
     run_error_data = build_run_error_data(
@@ -429,6 +431,7 @@ async def _resolve_invalid_final_output(
         new_items=new_items,
         raw_responses=[new_response],
         last_agent=public_agent,
+        reasoning_item_id_policy=reasoning_item_id_policy,
     )
     _detach_data_redacted_error_traceback(error)
     safe_error: UserError | None = None
@@ -771,6 +774,7 @@ async def execute_tools_and_side_effects(
     run_config: RunConfig,
     error_handlers: RunErrorHandlers[TContext] | None = None,
     server_manages_conversation: bool = False,
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
 ) -> SingleStepResult:
     """Run one turn of the loop, coordinating tools, approvals, guardrails, and handoffs."""
     public_agent = bindings.public_agent
@@ -910,6 +914,7 @@ async def execute_tools_and_side_effects(
                     new_items=pre_step_items + new_step_items,
                     raw_responses=[new_response],
                     last_agent=public_agent,
+                    reasoning_item_id_policy=reasoning_item_id_policy,
                 )
                 handler_result = await resolve_run_error_handler_result(
                     error_handlers=error_handlers,
@@ -956,6 +961,7 @@ async def execute_tools_and_side_effects(
                                 new_response=new_response,
                                 new_items=pre_step_items + new_step_items,
                                 context_wrapper=context_wrapper,
+                                reasoning_item_id_policy=reasoning_item_id_policy,
                             )
                             if resolved_handler_output is None:
                                 raise
@@ -972,6 +978,7 @@ async def execute_tools_and_side_effects(
                             new_response=new_response,
                             new_items=pre_step_items + new_step_items,
                             context_wrapper=context_wrapper,
+                            reasoning_item_id_policy=reasoning_item_id_policy,
                         )
                         if resolved_handler_output is None:
                             raise validation_error
@@ -989,6 +996,7 @@ async def execute_tools_and_side_effects(
                         new_response=new_response,
                         new_items=pre_step_items + new_step_items,
                         context_wrapper=context_wrapper,
+                        reasoning_item_id_policy=reasoning_item_id_policy,
                     )
                     if resolved_handler_output is None:
                         return SingleStepResult(
@@ -2991,6 +2999,7 @@ async def get_single_step_result_from_response(
     server_manages_conversation: bool = False,
     event_queue: asyncio.Queue[StreamEvent | QueueCompleteSentinel] | None = None,
     before_side_effects: Callable[[], Awaitable[None]] | None = None,
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
 ) -> SingleStepResult:
     item_agent = bindings.public_agent
     processed_response = process_model_response(
@@ -3033,4 +3042,5 @@ async def get_single_step_result_from_response(
         run_config=run_config,
         error_handlers=error_handlers,
         server_manages_conversation=server_manages_conversation,
+        reasoning_item_id_policy=reasoning_item_id_policy,
     )

--- a/tests/test_invalid_final_output_handler.py
+++ b/tests/test_invalid_final_output_handler.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 from openai.types.responses import ResponseOutputMessage
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
 from pydantic import BaseModel
 
 import agents._debug as _debug
@@ -16,6 +17,7 @@ from agents import (
     MessageOutputItem,
     ModelBehaviorError,
     OutputGuardrail,
+    RunConfig,
     RunContextWrapper,
     RunErrorHandlerInput,
     RunErrorHandlerResult,
@@ -374,3 +376,57 @@ async def test_invalid_final_output_fallback_does_not_retry_or_replay_tools(
     assert final_output == FinalOutput(summary="safe fallback")
     assert side_effects == ["once"]
     assert len(model.turn_outputs) == 2
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_error_handler_run_data_honors_reasoning_item_id_policy(streamed: bool) -> None:
+    """`omit` must strip reasoning ids from the run data every handler kind receives."""
+    captured: dict[str, list[TResponseInputItem]] = {}
+
+    def handler(data: RunErrorHandlerInput[None]) -> FinalOutput:
+        captured["history"] = list(data.run_data.history)
+        return FinalOutput(summary="safe fallback")
+
+    model = FakeModel(
+        initial_output=[
+            ResponseReasoningItem(
+                id="rs_invalid_final_output",
+                type="reasoning",
+                summary=[Summary(text="Thinking...", type="summary_text")],
+            ),
+            get_text_message("not valid json"),
+        ]
+    )
+    agent = Agent(name="test", model=model, output_type=FinalOutput)
+    error_handlers: RunErrorHandlers[None] = {"invalid_final_output": handler}
+    run_config = RunConfig(reasoning_item_id_policy="omit")
+
+    if streamed:
+        streamed_result = Runner.run_streamed(
+            agent,
+            input="user_message",
+            error_handlers=error_handlers,
+            run_config=run_config,
+        )
+        async for _ in streamed_result.stream_events():
+            pass
+        final_output = streamed_result.final_output
+    else:
+        final_output = (
+            await Runner.run(
+                agent,
+                input="user_message",
+                error_handlers=error_handlers,
+                run_config=run_config,
+            )
+        ).final_output
+
+    assert final_output == FinalOutput(summary="safe fallback")
+    reasoning_items = [
+        item
+        for item in captured["history"]
+        if isinstance(item, dict) and item.get("type") == "reasoning"
+    ]
+    assert reasoning_items
+    assert all("id" not in item for item in reasoning_items)

--- a/tests/test_max_turns.py
+++ b/tests/test_max_turns.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
@@ -12,6 +13,7 @@ from agents import (
     MaxTurnsExceeded,
     MessageOutputItem,
     ModelRefusalError,
+    RunConfig,
     RunErrorHandlerResult,
     Runner,
     SQLiteSession,
@@ -210,6 +212,43 @@ async def test_non_streamed_refusal_handler_can_skip_history():
 
     assert result.final_output == "safe fallback"
     assert ItemHelpers.text_message_outputs(result.new_items) == ""
+
+
+@pytest.mark.asyncio
+async def test_non_streamed_refusal_handler_run_data_honors_reasoning_item_id_policy():
+    """`omit` must strip reasoning ids from the run data the refusal handler receives."""
+    model = FakeModel(
+        initial_output=[
+            ResponseReasoningItem(
+                id="rs_refusal",
+                type="reasoning",
+                summary=[Summary(text="Thinking...", type="summary_text")],
+            ),
+            get_refusal_message("I cannot help with that request."),
+        ]
+    )
+    agent = Agent(name="test_1", model=model)
+    captured: dict[str, list] = {}
+
+    def handler(data):
+        captured["history"] = list(data.run_data.history)
+        return "safe fallback"
+
+    result = await Runner.run(
+        agent,
+        input="user_message",
+        error_handlers={"model_refusal": handler},
+        run_config=RunConfig(reasoning_item_id_policy="omit"),
+    )
+
+    assert result.final_output == "safe fallback"
+    reasoning_items = [
+        item
+        for item in captured["history"]
+        if isinstance(item, dict) and item.get("type") == "reasoning"
+    ]
+    assert reasoning_items
+    assert all("id" not in item for item in reasoning_items)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`build_run_error_data` accepts `reasoning_item_id_policy` so that `RunErrorData.history` and `.output` match the history the runner would actually replay. The `max_turns` call sites in `run.py` and `run_loop.py` pass it; the `model_refusal` and `invalid_final_output` call sites in `turn_resolution.py` never did.

With `RunConfig(reasoning_item_id_policy="omit")` a `max_turns` handler therefore receives reasoning items with their ids stripped, while a `model_refusal` or `invalid_final_output` handler receives them intact. A handler that does the natural thing and feeds `run_data.history` into a follow-up run succeeds under one error kind and gets a provider 400 under the other.

Thread the resolved policy from both run loops through `get_single_step_result_from_response` and `execute_tools_and_side_effects` to the two remaining call sites. The resolved value is used rather than `run_config` alone so resumed runs keep the policy stored on the `RunState`.

Tests: one refusal-path test and one parametrized streamed/non-streamed `invalid_final_output` test, all failing before the fix.
