### PR TITLE
fix(extensions): keep an assistant turn whose tool call cannot be split

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -1477,6 +1477,7 @@ class AnyLLMModel(Model):
             role = original_message.get("role")
             if role == "assistant" and original_message.get("tool_calls"):
                 tool_calls = original_message.get("tool_calls", [])
+                emitted_split = False
                 if isinstance(tool_calls, list):
                     for tool_call in tool_calls:
                         if not isinstance(tool_call, dict):
@@ -1490,12 +1491,19 @@ class AnyLLMModel(Model):
                             tool_result_index, tool_result_message = tool_result_messages[tool_id]
                             fixed_messages.append(tool_call_message)
                             fixed_messages.append(tool_result_message)
+                            emitted_split = True
                             used_indices.add(tool_call_messages[tool_id][0])
                             used_indices.add(tool_result_index)
                         elif tool_id in tool_call_messages:
                             _, tool_call_message = tool_call_messages[tool_id]
                             fixed_messages.append(tool_call_message)
+                            emitted_split = True
                             used_indices.add(tool_call_messages[tool_id][0])
+                if not emitted_split:
+                    # No split could be built, e.g. a tool call carrying no id or a tool_calls
+                    # value that is not a list. Keep the turn rather than dropping it, the same
+                    # way an unmatched tool result below is kept.
+                    fixed_messages.append(original_message)
                 used_indices.add(index)
             elif role == "tool":
                 if index not in paired_tool_result_indices:

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -823,6 +823,7 @@ class LitellmModel(Model):
             if role == "assistant" and original_message.get("tool_calls"):
                 # Process each tool call in this assistant message
                 tool_calls = original_message.get("tool_calls", [])
+                emitted_split = False
                 if isinstance(tool_calls, list):
                     for tool_call in tool_calls:
                         if isinstance(tool_call, dict):
@@ -838,6 +839,7 @@ class LitellmModel(Model):
 
                                 fixed_messages.append(tool_call_msg)
                                 fixed_messages.append(tool_result_msg)
+                                emitted_split = True
 
                                 # Mark both as used
                                 used_indices.add(tool_call_messages[tool_id][0])
@@ -846,7 +848,14 @@ class LitellmModel(Model):
                                 # Tool call without result - add just the tool call
                                 _, tool_call_msg = tool_call_messages[tool_id]
                                 fixed_messages.append(tool_call_msg)
+                                emitted_split = True
                                 used_indices.add(tool_call_messages[tool_id][0])
+
+                if not emitted_split:
+                    # No split could be built, e.g. a tool call carrying no id or a tool_calls
+                    # value that is not a list. Keep the turn rather than dropping it, the same
+                    # way an unmatched tool result below is kept.
+                    fixed_messages.append(original_message)
 
                 used_indices.add(i)  # Mark original multi-tool message as used
 

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -1912,3 +1912,39 @@ async def test_any_llm_responses_stream_lets_in_flight_close_finish_after_cancel
     finally:
         release.set()
         task.cancel()
+
+
+def test_any_llm_split_keeps_assistant_turn_without_a_usable_tool_call(monkeypatch) -> None:
+    """A tool call that produces no split must not take the assistant message with it.
+
+    The tool-result branch of the same loop already preserves results it cannot pair, so a
+    tool call carrying no id - or a malformed tool_calls value - has to keep its message.
+    """
+    provider = FakeAnyLLMProvider(supports_responses=False)
+    module, _ = _import_any_llm_module(monkeypatch, provider)
+    AnyLLMModel = module.AnyLLMModel
+
+    model = AnyLLMModel(model="anthropic/claude-3-5-sonnet")
+
+    idless: list[Any] = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "let me check",
+            "tool_calls": [
+                {"id": "", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ],
+        },
+        {"role": "user", "content": "thanks"},
+    ]
+    result = model._fix_tool_message_ordering(idless)
+    assert [message["role"] for message in result] == ["user", "assistant", "user"]
+    assert result[1]["content"] == "let me check"
+
+    malformed: list[Any] = [
+        {"role": "assistant", "content": "A", "tool_calls": {"id": "call_1"}},
+        {"role": "user", "content": "B"},
+    ]
+    result = model._fix_tool_message_ordering(malformed)
+    assert [message["role"] for message in result] == ["assistant", "user"]
+    assert result[0]["content"] == "A"

--- a/tests/models/test_extended_thinking_message_order.py
+++ b/tests/models/test_extended_thinking_message_order.py
@@ -352,3 +352,43 @@ class TestExtendedThinkingMessageOrder:
         assert result[6]["role"] == "tool"  # Orphaned result (preserved)
         assert result[6]["tool_call_id"] == "call_orphan"
         assert result[7]["role"] == "user"  # End
+
+    def test_tool_call_without_id_keeps_the_assistant_turn(self):
+        """An unusable tool call must not take the assistant message down with it.
+
+        The tool-result branch already preserves results it cannot pair, so a tool call
+        that produces no split has to keep its original message too.
+        """
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "Hello"},
+            cast(
+                Any,
+                {
+                    "role": "assistant",
+                    "content": "let me check",
+                    "tool_calls": [
+                        {"id": "", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+                    ],
+                },
+            ),
+            {"role": "user", "content": "Thanks"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        assert [message["role"] for message in result] == ["user", "assistant", "user"]
+        assert result[1]["content"] == "let me check"
+
+    def test_non_list_tool_calls_keep_the_assistant_turn(self):
+        """A malformed tool_calls value must not delete the assistant message either."""
+        messages: list[ChatCompletionMessageParam] = [
+            cast(Any, {"role": "assistant", "content": "A", "tool_calls": {"id": "call_1"}}),
+            {"role": "user", "content": "B"},
+        ]
+
+        model = LitellmModel("test-model")
+        result = model._fix_tool_message_ordering(messages)
+
+        assert [message["role"] for message in result] == ["assistant", "user"]
+        assert result[0]["content"] == "A"


### PR DESCRIPTION
`_fix_tool_message_ordering` rewrites an assistant message carrying `tool_calls` into one message per call, then marks the original consumed. It only builds a split for tool calls with a usable id, and it has no fallback when `tool_calls` is not a list. An assistant turn whose tool call has an empty or missing id therefore contributes nothing and is dropped, taking its text and thinking blocks out of the conversation.

The tool-result branch of the same loop keeps results it cannot pair, so silently losing the turn is not the intended behavior.

Fall back to the original message when no split was emitted. A turn with a mix of usable and unusable ids still splits as before. Both the LiteLLM and any-llm copies of the routine have the defect, so both are fixed.
