### PR TITLE
fix(streaming): add the chat completions assistant message once per turn

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -814,23 +814,26 @@ class ChatCmplStreamHandler:
                             logprobs=[],
                         ),
                     )
-                    # Start a new assistant message stream
-                    assistant_item = ResponseOutputMessage(
-                        id=FAKE_RESPONSES_ID,
-                        content=[],
-                        role="assistant",
-                        type="message",
-                        status="in_progress",
-                    )
-                    if state.provider_data:
-                        assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
-                    # Notify consumers of the start of a new output message + first content part
-                    yield ResponseOutputItemAddedEvent(
-                        item=assistant_item,
-                        output_index=output_layout.assistant_message_output_index(state),
-                        type="response.output_item.added",
-                        sequence_number=sequence_number.get_and_increment(),
-                    )
+                    # Start a new assistant message stream. A refusal part may have already
+                    # announced it; text and refusal share one ResponseOutputMessage, which
+                    # gets a single output_item.done, so it must only be added once.
+                    if not state.refusal_content_index_and_output:
+                        assistant_item = ResponseOutputMessage(
+                            id=FAKE_RESPONSES_ID,
+                            content=[],
+                            role="assistant",
+                            type="message",
+                            status="in_progress",
+                        )
+                        if state.provider_data:
+                            assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+                        # Notify consumers of the start of a new output message
+                        yield ResponseOutputItemAddedEvent(
+                            item=assistant_item,
+                            output_index=output_layout.assistant_message_output_index(state),
+                            type="response.output_item.added",
+                            sequence_number=sequence_number.get_and_increment(),
+                        )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.text_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
@@ -893,23 +896,26 @@ class ChatCmplStreamHandler:
                         refusal_index,
                         ResponseOutputRefusal(refusal="", type="refusal"),
                     )
-                    # Start a new assistant message if one doesn't exist yet (in-progress)
-                    assistant_item = ResponseOutputMessage(
-                        id=FAKE_RESPONSES_ID,
-                        content=[],
-                        role="assistant",
-                        type="message",
-                        status="in_progress",
-                    )
-                    if state.provider_data:
-                        assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
-                    # Notify downstream that assistant message + first content part are starting
-                    yield ResponseOutputItemAddedEvent(
-                        item=assistant_item,
-                        output_index=output_layout.assistant_message_output_index(state),
-                        type="response.output_item.added",
-                        sequence_number=sequence_number.get_and_increment(),
-                    )
+                    # Start a new assistant message if one doesn't exist yet (in-progress).
+                    # A text part may have already announced it; both parts belong to the same
+                    # ResponseOutputMessage, so it must only be added once.
+                    if not state.text_content_index_and_output:
+                        assistant_item = ResponseOutputMessage(
+                            id=FAKE_RESPONSES_ID,
+                            content=[],
+                            role="assistant",
+                            type="message",
+                            status="in_progress",
+                        )
+                        if state.provider_data:
+                            assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+                        # Notify downstream that the assistant message is starting
+                        yield ResponseOutputItemAddedEvent(
+                            item=assistant_item,
+                            output_index=output_layout.assistant_message_output_index(state),
+                            type="response.output_item.added",
+                            sequence_number=sequence_number.get_and_increment(),
+                        )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.refusal_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -589,6 +589,37 @@ async def test_stream_handler_keeps_empty_choice_usage_chunks() -> None:
     assert completed_event.response.usage.total_tokens == 3
 
 
+@pytest.mark.parametrize("refusal_first", [False, True])
+@pytest.mark.asyncio
+async def test_stream_handler_adds_the_assistant_message_once_for_text_and_refusal(
+    refusal_first: bool,
+) -> None:
+    """Text and a refusal share one ResponseOutputMessage, so it gets one added event."""
+    text_chunk = _chunk_with([Choice(index=0, delta=ChoiceDelta(content="hi"))])
+    refusal_chunk = _chunk_with([Choice(index=0, delta=ChoiceDelta(refusal="nope"))])
+    chunks = (refusal_chunk, text_chunk) if refusal_first else (text_chunk, refusal_chunk)
+
+    events = await _collect_handler_events(*chunks)
+
+    message_added = [
+        event
+        for event in events
+        if event.type == "response.output_item.added"
+        and isinstance(event.item, ResponseOutputMessage)
+    ]
+    message_done = [
+        event
+        for event in events
+        if event.type == "response.output_item.done"
+        and isinstance(event.item, ResponseOutputMessage)
+    ]
+    assert len(message_added) == len(message_done) == 1
+
+    completed = events[-1]
+    assert isinstance(completed, ResponseCompletedEvent)
+    assert len(completed.response.output) == 1
+
+
 @pytest.mark.asyncio
 async def test_stream_handler_rejects_multiple_choices_in_strict_mode() -> None:
     chunk = ChatCompletionChunk(


### PR DESCRIPTION
Text deltas and refusal deltas each announce their own `response.output_item.added` for the assistant message. A turn that carries both emits two added events for a single `ResponseOutputMessage` and only one `output_item.done`, since both parts are assembled into one message for `response.completed`.

The refusal branch's comment says it starts a message "if one doesn't exist yet", but its guard only checks whether the refusal part exists, not whether the message was already announced by the text branch. The text branch has the mirror-image gap.

The non-streamed converter puts an `output_text` and a `refusal` on the same message, so this is a supported shape, not a malformed stream.

Announce the message from whichever part opens first; the second part emits only its own `content_part.added`. Test covers both orderings.
