### PR TITLE
fix: keep FunctionTool subclasses copyable

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 import asyncio
 import copy
-import dataclasses
 import functools
 import inspect
 import json
@@ -600,15 +599,18 @@ class FunctionTool:
         _validate_function_tool_timeout_config(self)
 
     def __copy__(self) -> FunctionTool:
-        copied_tool = dataclasses.replace(self)
-        dataclass_field_names = {tool_field.name for tool_field in dataclasses.fields(FunctionTool)}
-        for tool_field in dataclasses.fields(FunctionTool):
-            if tool_field.init:
-                continue
-            setattr(copied_tool, tool_field.name, getattr(self, tool_field.name))
-        for attr_name, attr_value in self.__dict__.items():
-            if attr_name not in dataclass_field_names:
-                setattr(copied_tool, attr_name, attr_value)
+        # Rebuild the instance state directly instead of re-running the constructor, so
+        # FunctionTool subclasses that define their own __init__ signature stay copyable.
+        copied_tool = object.__new__(type(self))
+        copied_tool.__dict__.update(self.__dict__)
+        # A subclass may pass one of its own bound methods as the invoker, e.g.
+        # on_invoke_tool=self._invoke. Copying the __dict__ carries that binding over
+        # unchanged, so the copy would run against the original instance's state.
+        invoker = copied_tool.__dict__.get("on_invoke_tool")
+        invoker_func = getattr(invoker, "__func__", None)
+        if invoker_func is not None and getattr(invoker, "__self__", None) is self:
+            copied_tool.on_invoke_tool = invoker_func.__get__(copied_tool, type(copied_tool))
+        copied_tool.__post_init__()
         return copied_tool
 
 

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -820,6 +820,80 @@ async def test_shallow_copied_function_tool_normal_failure_uses_copied_policy() 
     assert cast(Any, copied_tool).custom_state is custom_state
 
 
+@dataclasses.dataclass(init=False)
+class _CustomConstructorFunctionTool(FunctionTool):
+    """FunctionTool subclass with its own constructor, like the sandbox shell tools."""
+
+    session: Any = dataclasses.field(init=False, repr=False, compare=False)
+
+    def __init__(self, *, session: Any) -> None:
+        self.session = session
+        super().__init__(
+            name="custom_constructor_tool",
+            description="Tool with a custom constructor.",
+            params_json_schema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": False,
+            },
+            on_invoke_tool=self._invoke,
+        )
+
+    async def _invoke(self, _ctx: ToolContext[Any], raw_input: str) -> str:
+        # Reads instance state so a copy that is still bound to the original is visible.
+        return f"{self.session}:{raw_input}"
+
+
+def _tool_context(tool: FunctionTool) -> ToolContext[Any]:
+    return ToolContext(None, tool_name=tool.name, tool_call_id="1", tool_arguments="{}")
+
+
+@pytest.mark.asyncio
+async def test_shallow_copy_supports_function_tool_subclass_constructors() -> None:
+    session = object()
+    original_tool = _CustomConstructorFunctionTool(session=session)
+
+    copied_tool = copy.copy(original_tool)
+
+    assert isinstance(copied_tool, _CustomConstructorFunctionTool)
+    assert copied_tool is not original_tool
+    assert copied_tool.session is session
+    assert copied_tool.name == original_tool.name
+    assert await copied_tool.on_invoke_tool(_tool_context(copied_tool), "{}") == f"{session}:{{}}"
+
+
+@pytest.mark.asyncio
+async def test_shallow_copied_subclass_invoker_uses_the_copied_instance_state() -> None:
+    original_tool = _CustomConstructorFunctionTool(session="original-session")
+
+    copied_tool = copy.copy(original_tool)
+    copied_tool.session = "copied-session"
+
+    # The subclass passes its own bound method as the invoker, so the copy must be
+    # rebound; otherwise it keeps reading the original instance's session.
+    assert await copied_tool.on_invoke_tool(_tool_context(copied_tool), "{}") == (
+        "copied-session:{}"
+    )
+    assert await original_tool.on_invoke_tool(_tool_context(original_tool), "{}") == (
+        "original-session:{}"
+    )
+
+
+def test_tool_namespace_supports_function_tool_subclass_constructors() -> None:
+    original_tool = _CustomConstructorFunctionTool(session=object())
+
+    namespaced_tool = tool_namespace(
+        name="workspace",
+        description="Workspace tools.",
+        tools=[original_tool],
+    )[0]
+
+    assert isinstance(namespaced_tool, _CustomConstructorFunctionTool)
+    assert namespaced_tool.qualified_name == "workspace.custom_constructor_tool"
+    assert original_tool.qualified_name == "custom_constructor_tool"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("copy_style", ["replace", "shallow_copy"])
 async def test_copied_function_tool_invalid_input_uses_current_name(copy_style: str) -> None:


### PR DESCRIPTION
`FunctionTool.__copy__` rebuilt the tool with `dataclasses.replace(self)`, which calls the concrete class constructor with every dataclass field. A `FunctionTool` subclass that defines its own `__init__` signature therefore raises `TypeError: __init__() got an unexpected keyword argument 'name'` on `copy.copy()`, and `tool_namespace()` raises the same error because it copies each tool before attaching namespace metadata.

The SDK's own sandbox tools hit this — `ExecCommandTool` and `WriteStdinTool` in `agents/sandbox/capabilities/tools/shell_tool.py` are `@dataclass(init=False)` `FunctionTool` subclasses with keyword-only constructors, so neither can be copied or grouped into a namespace.

Copy the instance state onto a fresh object of the same type and re-run `__post_init__` instead. That keeps every effect of the old path — invoker rebinding, the `allowed_callers` copy, the `params_json_schema` deep copy and strictification, `output_json_schema` normalization, and timeout validation — while also carrying non-field attributes across, which the old manual loop handled separately.

Tests cover `copy.copy()` and `tool_namespace()` on a subclass with a custom constructor.
