### PR TITLE
fix: make SDK exceptions survive copy and pickle

### DIFF
--- a/src/agents/exceptions.py
+++ b/src/agents/exceptions.py
@@ -118,6 +118,9 @@ class ModelRefusalError(AgentsException):
         self.refusal = refusal
         super().__init__(f"Model refused to produce output: {refusal}")
 
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (self.__class__, (self.refusal,), self.__dict__)
+
 
 class UserError(AgentsException):
     """Exception raised when the user makes an error using the SDK."""
@@ -150,6 +153,9 @@ class ToolTimeoutError(AgentsException):
         self.timeout_seconds = timeout_seconds
         super().__init__(f"Tool '{tool_name}' timed out after {timeout_seconds:g} seconds.")
 
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (self.__class__, (self.tool_name, self.timeout_seconds), self.__dict__)
+
 
 class InputGuardrailTripwireTriggered(AgentsException):
     """Exception raised when a guardrail tripwire is triggered."""
@@ -163,6 +169,9 @@ class InputGuardrailTripwireTriggered(AgentsException):
             f"Guardrail {guardrail_result.guardrail.__class__.__name__} triggered tripwire"
         )
 
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (self.__class__, (self.guardrail_result,), self.__dict__)
+
 
 class OutputGuardrailTripwireTriggered(AgentsException):
     """Exception raised when a guardrail tripwire is triggered."""
@@ -175,6 +184,9 @@ class OutputGuardrailTripwireTriggered(AgentsException):
         super().__init__(
             f"Guardrail {guardrail_result.guardrail.__class__.__name__} triggered tripwire"
         )
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (self.__class__, (self.guardrail_result,), self.__dict__)
 
 
 class ToolInputGuardrailTripwireTriggered(AgentsException):
@@ -191,6 +203,9 @@ class ToolInputGuardrailTripwireTriggered(AgentsException):
         self.output = output
         super().__init__(f"Tool input guardrail {guardrail.__class__.__name__} triggered tripwire")
 
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (self.__class__, (self.guardrail, self.output), self.__dict__)
+
 
 class ToolOutputGuardrailTripwireTriggered(AgentsException):
     """Exception raised when a tool output guardrail tripwire is triggered."""
@@ -205,3 +220,6 @@ class ToolOutputGuardrailTripwireTriggered(AgentsException):
         self.guardrail = guardrail
         self.output = output
         super().__init__(f"Tool output guardrail {guardrail.__class__.__name__} triggered tripwire")
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (self.__class__, (self.guardrail, self.output), self.__dict__)

--- a/tests/test_exception_copying.py
+++ b/tests/test_exception_copying.py
@@ -1,0 +1,115 @@
+"""Verify that SDK exceptions survive copy and pickle round-trips.
+
+`BaseException.__reduce__` rebuilds an exception with `type(exc)(*exc.args)`, so an
+exception whose `__init__` takes more parameters than it forwards to `super().__init__`
+cannot be copied or pickled. Anything that moves an exception across a process boundary
+(multiprocessing pools, task queues, workflow engines) relies on this working.
+"""
+
+from __future__ import annotations
+
+import copy
+import pickle
+from typing import Any
+
+import pytest
+
+from agents import (
+    Agent,
+    AgentsException,
+    GuardrailFunctionOutput,
+    InputGuardrail,
+    InputGuardrailResult,
+    InputGuardrailTripwireTriggered,
+    MaxTurnsExceeded,
+    MCPToolCancellationError,
+    ModelBehaviorError,
+    ModelRefusalError,
+    OutputGuardrail,
+    OutputGuardrailResult,
+    OutputGuardrailTripwireTriggered,
+    RunContextWrapper,
+    ToolGuardrailFunctionOutput,
+    ToolInputGuardrail,
+    ToolInputGuardrailTripwireTriggered,
+    ToolOutputGuardrail,
+    ToolOutputGuardrailTripwireTriggered,
+    ToolTimeoutError,
+    UserError,
+)
+
+
+def _guardrail_function(
+    context: RunContextWrapper[Any], agent: Agent[Any], data: Any
+) -> GuardrailFunctionOutput:
+    return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+
+def _tool_guardrail_function(data: Any) -> ToolGuardrailFunctionOutput:
+    return ToolGuardrailFunctionOutput(output_info=None)
+
+
+def _input_guardrail_result() -> InputGuardrailResult:
+    return InputGuardrailResult(
+        guardrail=InputGuardrail(guardrail_function=_guardrail_function),
+        output=GuardrailFunctionOutput(output_info="blocked", tripwire_triggered=True),
+    )
+
+
+def _output_guardrail_result() -> OutputGuardrailResult:
+    return OutputGuardrailResult(
+        guardrail=OutputGuardrail(guardrail_function=_guardrail_function),
+        agent_output="final",
+        agent=Agent(name="test"),
+        output=GuardrailFunctionOutput(output_info="blocked", tripwire_triggered=True),
+    )
+
+
+def _exception_cases() -> list[AgentsException]:
+    return [
+        UserError("bad usage"),
+        MaxTurnsExceeded("too many turns"),
+        ModelBehaviorError("bad model output"),
+        MCPToolCancellationError("cancelled"),
+        ModelRefusalError("cannot help"),
+        ToolTimeoutError("my_tool", 1.5),
+        InputGuardrailTripwireTriggered(_input_guardrail_result()),
+        OutputGuardrailTripwireTriggered(_output_guardrail_result()),
+        ToolInputGuardrailTripwireTriggered(
+            ToolInputGuardrail(guardrail_function=_tool_guardrail_function),
+            ToolGuardrailFunctionOutput(output_info="blocked"),
+        ),
+        ToolOutputGuardrailTripwireTriggered(
+            ToolOutputGuardrail(guardrail_function=_tool_guardrail_function),
+            ToolGuardrailFunctionOutput(output_info="blocked"),
+        ),
+    ]
+
+
+@pytest.mark.parametrize("error", _exception_cases(), ids=lambda error: type(error).__name__)
+def test_sdk_exceptions_can_be_copied(error: AgentsException) -> None:
+    copied = copy.copy(error)
+
+    assert type(copied) is type(error)
+    assert str(copied) == str(error)
+    for name, value in vars(error).items():
+        assert getattr(copied, name) is value
+
+
+def test_tool_timeout_error_survives_copy_with_its_fields() -> None:
+    error = ToolTimeoutError("my_tool", 1.5)
+
+    copied = copy.copy(error)
+
+    assert copied.tool_name == "my_tool"
+    assert copied.timeout_seconds == 1.5
+    assert str(copied) == "Tool 'my_tool' timed out after 1.5 seconds."
+
+
+def test_tool_timeout_error_survives_pickle() -> None:
+    restored = pickle.loads(pickle.dumps(ToolTimeoutError("my_tool", 1.5)))
+
+    assert isinstance(restored, ToolTimeoutError)
+    assert restored.tool_name == "my_tool"
+    assert restored.timeout_seconds == 1.5
+    assert restored.run_data is None


### PR DESCRIPTION
`BaseException.__reduce__` rebuilds an exception with `type(exc)(*exc.args)`, so an exception whose `__init__` takes parameters it doesn't forward to `super().__init__` can't be reconstructed.

`ToolTimeoutError`, `InputGuardrailTripwireTriggered`, `OutputGuardrailTripwireTriggered`, `ToolInputGuardrailTripwireTriggered` and `ToolOutputGuardrailTripwireTriggered` all raise `TypeError` or `AttributeError` under `copy.copy()` and `pickle.loads()`. `ModelRefusalError` rebuilds but re-prefixes its own message, so a copied instance reads `Model refused to produce output: Model refused to produce output: ...`.

The other exceptions in the module are fine because they pass the same value to both the attribute and `super().__init__`.

This gives the six a `__reduce__` that rebuilds from the stored constructor arguments and restores the instance dict, so moving an exception across a process boundary (multiprocessing pools, task queues, workflow engines) keeps working. The guardrail tripwire errors are the ones users most often catch and re-raise, so they matter most here.
