### PR TITLE
fix(streaming): announce the chat completions assistant message once

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -814,23 +814,28 @@ class ChatCmplStreamHandler:
                             logprobs=[],
                         ),
                     )
-                    # Start a new assistant message stream
-                    assistant_item = ResponseOutputMessage(
-                        id=FAKE_RESPONSES_ID,
-                        content=[],
-                        role="assistant",
-                        type="message",
-                        status="in_progress",
-                    )
-                    if state.provider_data:
-                        assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
-                    # Notify consumers of the start of a new output message + first content part
-                    yield ResponseOutputItemAddedEvent(
-                        item=assistant_item,
-                        output_index=output_layout.assistant_message_output_index(state),
-                        type="response.output_item.added",
-                        sequence_number=sequence_number.get_and_increment(),
-                    )
+                    # A refusal part already opened this assistant message, so only the new
+                    # content part is announced here. Re-announcing the message would emit a
+                    # second response.output_item.added for an item that is already open and
+                    # is closed by a single response.output_item.done.
+                    if content_index == 0:
+                        # Start a new assistant message stream
+                        assistant_item = ResponseOutputMessage(
+                            id=FAKE_RESPONSES_ID,
+                            content=[],
+                            role="assistant",
+                            type="message",
+                            status="in_progress",
+                        )
+                        if state.provider_data:
+                            assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+                        # Notify consumers of the start of a new output message
+                        yield ResponseOutputItemAddedEvent(
+                            item=assistant_item,
+                            output_index=output_layout.assistant_message_output_index(state),
+                            type="response.output_item.added",
+                            sequence_number=sequence_number.get_and_increment(),
+                        )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.text_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,
@@ -893,23 +898,28 @@ class ChatCmplStreamHandler:
                         refusal_index,
                         ResponseOutputRefusal(refusal="", type="refusal"),
                     )
-                    # Start a new assistant message if one doesn't exist yet (in-progress)
-                    assistant_item = ResponseOutputMessage(
-                        id=FAKE_RESPONSES_ID,
-                        content=[],
-                        role="assistant",
-                        type="message",
-                        status="in_progress",
-                    )
-                    if state.provider_data:
-                        assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
-                    # Notify downstream that assistant message + first content part are starting
-                    yield ResponseOutputItemAddedEvent(
-                        item=assistant_item,
-                        output_index=output_layout.assistant_message_output_index(state),
-                        type="response.output_item.added",
-                        sequence_number=sequence_number.get_and_increment(),
-                    )
+                    # A text part already opened this assistant message, so only the new
+                    # content part is announced here. Re-announcing the message would emit a
+                    # second response.output_item.added for an item that is already open and
+                    # is closed by a single response.output_item.done.
+                    if refusal_index == 0:
+                        # Start a new assistant message if one doesn't exist yet (in-progress)
+                        assistant_item = ResponseOutputMessage(
+                            id=FAKE_RESPONSES_ID,
+                            content=[],
+                            role="assistant",
+                            type="message",
+                            status="in_progress",
+                        )
+                        if state.provider_data:
+                            assistant_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+                        # Notify downstream that the assistant message is starting
+                        yield ResponseOutputItemAddedEvent(
+                            item=assistant_item,
+                            output_index=output_layout.assistant_message_output_index(state),
+                            type="response.output_item.added",
+                            sequence_number=sequence_number.get_and_increment(),
+                        )
                     yield ResponseContentPartAddedEvent(
                         content_index=state.refusal_content_index_and_output[0],
                         item_id=FAKE_RESPONSES_ID,

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1396,6 +1396,70 @@ async def test_stream_handler_places_text_after_existing_refusal_part() -> None:
     assert assistant_item.content[1].text == "partial"
 
 
+@pytest.mark.parametrize(
+    "deltas",
+    [
+        pytest.param(
+            [
+                ChoiceDelta.model_construct(refusal="blocked"),
+                ChoiceDelta.model_construct(content="partial"),
+            ],
+            id="refusal_then_text",
+        ),
+        pytest.param(
+            [
+                ChoiceDelta.model_construct(content="partial"),
+                ChoiceDelta.model_construct(refusal="blocked"),
+            ],
+            id="text_then_refusal",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_handler_announces_assistant_message_once_for_text_and_refusal(
+    deltas: list[ChoiceDelta],
+) -> None:
+    """A message holding both a text and a refusal part is announced by a single added event."""
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=delta)],
+        )
+        for delta in deltas
+    ]
+
+    events = await _collect_handler_events(*chunks)
+
+    message_added = [
+        event
+        for event in events
+        if event.type == "response.output_item.added"
+        and isinstance(event.item, ResponseOutputMessage)
+    ]
+    message_done = [
+        event
+        for event in events
+        if event.type == "response.output_item.done"
+        and isinstance(event.item, ResponseOutputMessage)
+    ]
+    assert len(message_added) == 1
+    assert len(message_done) == 1
+    assert message_added[0].output_index == message_done[0].output_index
+
+    # The single added event still opens the message before its first content part.
+    event_types = [event.type for event in events]
+    assert event_types.index("response.output_item.added") < event_types.index(
+        "response.content_part.added"
+    )
+    # Both content parts are still announced, one each.
+    part_added = [event for event in events if event.type == "response.content_part.added"]
+    assert sorted(event.content_index for event in part_added) == [0, 1]
+    assert {event.part.type for event in part_added} == {"output_text", "refusal"}
+
+
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 async def test_stream_response_passes_strict_validation_to_stream_handler(monkeypatch) -> None:


### PR DESCRIPTION
### Summary

**Component:** `src/agents/models/chatcmpl_stream_handler.py` — `ChatCmplStreamHandler.handle_stream`, the assistant-message content-part branches.

**Problem.** A Chat Completions stream whose assistant message carries *both* a text part and a refusal part emits **two** `response.output_item.added` events for that single message, and only one `response.output_item.done`. Both content-part openers (`delta.content` and `delta.refusal`) unconditionally construct a fresh in-progress `ResponseOutputMessage` and announce it, even when the sibling part already opened that same message at the same `output_index`.

The both-parts case is not hypothetical: the handler explicitly supports it — each branch offsets its `content_index` by the sibling part (`content_index += 1` / `refusal_index += 1`), and #4236 just landed to make the completed response respect those indexes. Non-OpenAI providers routed through this handler (LiteLLM, any-llm, and other OpenAI-compatible chat backends, which all share `ChatCmplStreamHandler`) are where a `content` delta and a `refusal` delta arrive in the same turn.

**Impact.** Consumers of the raw streamed events (`raw_response_event`) that track open output items keyed by `output_index` see an item opened twice and closed once. Reconstructing the response from the raw stream yields a duplicate assistant message, or leaves one item permanently open. The Responses API — which this handler emulates — emits exactly one `response.output_item.added` per output item. `RunResult` is unaffected, because it reads the final `response.completed` payload.

**Repro (before this change):**

```python
events = await ChatCmplStreamHandler.handle_stream(response, stream)  # refusal chunk, then content chunk
```

```
response.created
response.output_item.added      output_index=0 item=message   <-- 1st
response.content_part.added     content_index=0 part=refusal
response.refusal.delta
response.output_item.added      output_index=0 item=message   <-- 2nd, same item
response.content_part.added     content_index=1 part=output_text
response.output_text.delta
...
response.output_item.done       output_index=0 item=message   <-- only one done
```

The same duplication happens in the mirror order (content chunk, then refusal chunk).

**After:** exactly one `response.output_item.added`, still emitted before the first `response.content_part.added`; both content parts are still announced with their existing indexes.

### Root cause

Each opener owns "announce the message" as well as "announce my content part". The message is only ever opened by whichever content part comes first, so the second opener must announce only its content part.

### Fix and why it is minimal

Guard the `ResponseOutputItemAddedEvent` in both branches on the content index that was just computed two lines above: index `0` means no sibling part has opened this message yet, so this branch is the one that opens it. No new state field, no new helper, no change to `content_index` assignment, to the `content_part.added` events, to the delta events, or to the completed response. The diff is one `if` in each branch plus the re-indentation of the block it now wraps.

Deliberately unchanged:

- The synthesized content-filter refusal near the end of `handle_stream` already runs only when neither part opened, so it keeps its single announcement.
- Text-only and refusal-only streams (the overwhelmingly common shapes) emit a byte-identical event sequence.
- Multi-part `content_part.done` emission order. In the refusal-then-text case those two events are still emitted text-first (index 1 before index 0). That is a separate ordering question from the duplicate-announcement defect fixed here, and I left it out to keep this change to one behavior. Happy to send it separately if you'd like it.

### Test plan

New regression test `test_stream_handler_announces_assistant_message_once_for_text_and_refusal`, parametrized over both orders (`refusal_then_text`, `text_then_refusal`). It asserts one message `added`, one message `done`, matching `output_index`, that the single `added` still precedes the first `content_part.added`, and that both content parts are still announced at indexes `0` and `1`.

- Fails on `upstream/main` for the right reason, both parameters: `AssertionError: assert 2 == 1` on the count of message `added` events.
- Passes with this change.

Commands run from the repository root at `8b810bc4`:

- `uv run pytest tests/models/test_openai_chatcompletions_stream.py -q` — **89 passed** (87 pre-existing + the 2 new parameters), no existing assertion changed.
- `uv run pytest -n auto --maxprocesses=9 --dist worksteal -m "not serial" -q` — **6819 passed, 29 skipped**.
- `make tests-serial` — passed.
- `make lint` (`uv run ruff check`) — `All checks passed!`.
- `make format` — no reformatting needed for the changed files.
- `make typecheck` (`mypy` + `pyright`) — passed.
- `git diff --check` — clean.

Verification note: an earlier run of `.agents/skills/code-change-verification/scripts/run.sh` hit one failure in `tests/extensions/memory/test_advanced_sqlite_session.py::test_branch_allocation_is_serialized_across_processes[1-shared_branch]`, a multiprocessing `Event.wait(timeout=30)` in a test unrelated to this change. It passes in isolation (4 passed) and in the full parallel suite above; it timed out only while `make lint` and `make typecheck` were saturating the machine in parallel. No code in this PR is reachable from that test.

### Issue number

None — reporting and fixing directly, per the repository's guidance for small fixes. Follows up on the same both-parts scenario addressed by #4236.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
