### PR TITLE
fix: reject free-form objects in strict schemas instead of silently emptying them

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -237,6 +237,14 @@ def create_static_tool_filter(
     return filter_dict
 
 
+def _declares_object_type(schema: dict[str, Any]) -> bool:
+    """Whether a schema states it is an object, rather than leaving its type unstated."""
+    declared_type = schema.get("type")
+    return declared_type == "object" or (
+        isinstance(declared_type, list) and "object" in declared_type
+    )
+
+
 class MCPUtil:
     """Set of utilities for interop between MCP and Agents SDK tools."""
 
@@ -549,14 +557,22 @@ class MCPUtil:
             # non-strict. Convert a separate copy so the non-strict fallback keeps
             # the original schema intact.
             strict_source = copy.deepcopy(schema)
-            if not declared_properties:
+            if not declared_properties and _declares_object_type(strict_source):
                 # Convert what the server actually sent. The synthetic ``properties: {}`` above
                 # is an OpenAI-spec accommodation, not a statement by the server that the tool
                 # takes no arguments, so leaving it in would let a free-form root be closed as
-                # an empty object instead of falling back to non-strict.
+                # an empty object instead of falling back to non-strict. Only an explicit object
+                # root is exposed this way; a schema that does not declare its type keeps the
+                # historical no-argument treatment rather than changing meaning here.
                 strict_source.pop("properties", None)
             try:
-                schema = ensure_strict_json_schema(strict_source)
+                converted = ensure_strict_json_schema(strict_source)
+                if "properties" not in converted:
+                    # Restore the shape the OpenAI spec wants. Only reachable when the root was
+                    # already closed by the server, e.g. ``additionalProperties: false``.
+                    converted["properties"] = {}
+                    converted.setdefault("required", [])
+                schema = converted
                 is_strict = True
             except Exception as e:
                 if _debug.DONT_LOG_TOOL_DATA:

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -237,12 +237,13 @@ def create_static_tool_filter(
     return filter_dict
 
 
-def _declares_object_type(schema: dict[str, Any]) -> bool:
-    """Whether a schema states it is an object, rather than leaving its type unstated."""
+def _is_strict_object_root(schema: dict[str, Any]) -> bool:
+    """Whether a converted schema is the closed object envelope a strict tool needs."""
     declared_type = schema.get("type")
-    return declared_type == "object" or (
+    is_object = declared_type == "object" or (
         isinstance(declared_type, list) and "object" in declared_type
     )
+    return is_object and schema.get("additionalProperties") is False
 
 
 class MCPUtil:
@@ -557,16 +558,22 @@ class MCPUtil:
             # non-strict. Convert a separate copy so the non-strict fallback keeps
             # the original schema intact.
             strict_source = copy.deepcopy(schema)
-            if not declared_properties and _declares_object_type(strict_source):
+            if not declared_properties:
                 # Convert what the server actually sent. The synthetic ``properties: {}`` above
                 # is an OpenAI-spec accommodation, not a statement by the server that the tool
-                # takes no arguments, so leaving it in would let a free-form root be closed as
-                # an empty object instead of falling back to non-strict. Only an explicit object
-                # root is exposed this way; a schema that does not declare its type keeps the
-                # historical no-argument treatment rather than changing meaning here.
+                # takes no arguments, so leaving it in would let a free-form root, including one
+                # reached through a composed root such as ``allOf``, be closed as an empty
+                # object instead of falling back to non-strict.
                 strict_source.pop("properties", None)
             try:
                 converted = ensure_strict_json_schema(strict_source)
+                if not _is_strict_object_root(converted):
+                    # Without the shim a root that never declared its type converts to something
+                    # that is not a strict object envelope. Serve the original instead of
+                    # sending the provider a strict schema it cannot use.
+                    raise UserError(
+                        "strict conversion did not produce an object root for this MCP schema"
+                    )
                 if "properties" not in converted:
                     # Restore the shape the OpenAI spec wants. Only reachable when the root was
                     # already closed by the server, e.g. ``additionalProperties: false``.

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -583,6 +583,14 @@ class MCPUtil:
                         "strict conversion did not produce an object root for this MCP schema"
                     )
                 if "properties" not in converted:
+                    stale_required = converted.get("required")
+                    if isinstance(stale_required, list) and stale_required:
+                        # The root requires keys it never declares. Restoring the empty
+                        # properties shim would serve a strict schema whose required names
+                        # are all forbidden, so serve the original non-strict instead.
+                        raise UserError(
+                            "strict conversion left required names with no declared properties"
+                        )
                     # Restore the shape the OpenAI spec wants. Only reachable when the root was
                     # already closed by the server, e.g. ``additionalProperties: false``.
                     converted["properties"] = {}

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -238,19 +238,14 @@ def create_static_tool_filter(
 
 
 def _is_strict_object_root(schema: dict[str, Any]) -> bool:
-    """Whether a converted schema is the closed object envelope a strict tool needs.
-
-    A root that never declared its type but is already closed still describes an object, so it
-    is normalized here rather than rejected.
-    """
+    """Whether a converted schema is the closed object envelope a strict tool needs."""
     if schema.get("additionalProperties") is not False:
         return False
     declared_type = schema.get("type")
-    if declared_type is None:
-        schema["type"] = "object"
-        return True
-    return declared_type == "object" or (
-        isinstance(declared_type, list) and "object" in declared_type
+    return (
+        declared_type is None
+        or declared_type == "object"
+        or (isinstance(declared_type, list) and "object" in declared_type)
     )
 
 
@@ -575,6 +570,11 @@ class MCPUtil:
                 strict_source.pop("properties", None)
             try:
                 converted = ensure_strict_json_schema(strict_source)
+                if _is_strict_object_root(converted) and converted.get("type") is None:
+                    # A root that never declared its type but is already closed still
+                    # describes an object; normalize it explicitly here, on the copy this
+                    # branch owns, rather than inside the predicate.
+                    converted["type"] = "object"
                 if not _is_strict_object_root(converted):
                     # Without the shim a root that never declared its type converts to something
                     # that is not a strict object envelope. Serve the original instead of

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -238,12 +238,20 @@ def create_static_tool_filter(
 
 
 def _is_strict_object_root(schema: dict[str, Any]) -> bool:
-    """Whether a converted schema is the closed object envelope a strict tool needs."""
+    """Whether a converted schema is the closed object envelope a strict tool needs.
+
+    A root that never declared its type but is already closed still describes an object, so it
+    is normalized here rather than rejected.
+    """
+    if schema.get("additionalProperties") is not False:
+        return False
     declared_type = schema.get("type")
-    is_object = declared_type == "object" or (
+    if declared_type is None:
+        schema["type"] = "object"
+        return True
+    return declared_type == "object" or (
         isinstance(declared_type, list) and "object" in declared_type
     )
-    return is_object and schema.get("additionalProperties") is False
 
 
 class MCPUtil:

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -538,7 +538,8 @@ class MCPUtil:
         schema, is_strict = copy.deepcopy(tool_input_schema(tool)), False
 
         # MCP spec doesn't require the inputSchema to have `properties`, but OpenAI spec does.
-        if "properties" not in schema:
+        declared_properties = "properties" in schema
+        if not declared_properties:
             schema["properties"] = {}
 
         if convert_schemas_to_strict:
@@ -547,8 +548,15 @@ class MCPUtil:
             # ``additionalProperties: false``) on a schema we still serve as
             # non-strict. Convert a separate copy so the non-strict fallback keeps
             # the original schema intact.
+            strict_source = copy.deepcopy(schema)
+            if not declared_properties:
+                # Convert what the server actually sent. The synthetic ``properties: {}`` above
+                # is an OpenAI-spec accommodation, not a statement by the server that the tool
+                # takes no arguments, so leaving it in would let a free-form root be closed as
+                # an empty object instead of falling back to non-strict.
+                strict_source.pop("properties", None)
             try:
-                schema = ensure_strict_json_schema(copy.deepcopy(schema))
+                schema = ensure_strict_json_schema(strict_source)
                 is_strict = True
             except Exception as e:
                 if _debug.DONT_LOG_TOOL_DATA:

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -126,7 +126,14 @@ _CONTENT_SHAPING_KEYWORDS = frozenset(
 def _is_unclosable_object(json_schema: dict[str, object]) -> bool:
     """Whether closing this object with ``additionalProperties: false`` would change meaning."""
     typ = json_schema.get("type")
-    is_object = typ == "object" or (is_list(typ) and "object" in typ)
+    declared_properties = json_schema.get("properties")
+    # A typeless schema with a properties map is normalized to an object by the conversion
+    # walk, so the precomputed registries must see it the same way.
+    is_object = (
+        typ == "object"
+        or (is_list(typ) and "object" in typ)
+        or (typ is None and is_dict(declared_properties))
+    )
     if not is_object or "additionalProperties" in json_schema:
         return False
     if _allows_only_the_empty_object(json_schema):
@@ -196,6 +203,10 @@ def _resolves_to_free_form_definition(
 
 _DEFINITION_CONTAINER_KEYS = ("$defs", "definitions")
 
+# Keywords whose values are data literals, not schemas. A literal such as
+# `{"const": {"type": "object"}}` must never have its value mistaken for a schema node.
+_LITERAL_VALUE_KEYWORDS = frozenset({"const", "default", "enum", "examples"})
+
 
 def _iter_schema_nodes(root: object, *, limit: int) -> list[dict[str, object]]:
     """Every dict node in the tree, cycle-safe and bounded like the conversion itself."""
@@ -217,7 +228,7 @@ def _iter_schema_nodes(root: object, *, limit: int) -> list[dict[str, object]]:
             )
         if is_dict(node):
             nodes.append(node)
-            stack.extend(node.values())
+            stack.extend(value for key, value in node.items() if key not in _LITERAL_VALUE_KEYWORDS)
         elif is_list(node):
             stack.extend(node)
     return nodes
@@ -252,7 +263,9 @@ def _precompute_definition_registries(root: dict[str, object], budget: _NodeBudg
         # shape this definition's value, so they are excluded from its interior.
         interior: list[dict[str, object]] = []
         stack: list[object] = [
-            value for key, value in entry.items() if key not in _DEFINITION_CONTAINER_KEYS
+            value
+            for key, value in entry.items()
+            if key not in _DEFINITION_CONTAINER_KEYS and key not in _LITERAL_VALUE_KEYWORDS
         ]
         seen: set[int] = set()
         while stack:
@@ -265,7 +278,7 @@ def _precompute_definition_registries(root: dict[str, object], budget: _NodeBudg
                 stack.extend(
                     value
                     for key, value in interior_node.items()
-                    if key not in _DEFINITION_CONTAINER_KEYS
+                    if key not in _DEFINITION_CONTAINER_KEYS and key not in _LITERAL_VALUE_KEYWORDS
                 )
             elif is_list(interior_node):
                 stack.extend(interior_node)
@@ -402,21 +415,31 @@ def _ensure_strict_json_schema(
     # object types
     # { 'type': 'object', 'properties': { 'a':  {...} } }
     if is_dict(properties):
-        declared_required = json_schema.get("required")
-        if (
-            "$ref" not in json_schema
-            and is_list(declared_required)
-            and any(name not in properties for name in declared_required)
-        ):
-            # The object requires keys it never declares, so their values are unconstrained.
-            # Strict mode needs required to be a subset of properties with everything else
-            # forbidden, so conversion would silently drop the requirement and forbid the key.
-            if in_definitions:
-                if budget.definition_stack:
-                    budget.tainted_definition_ids.add(budget.definition_stack[-1])
-            else:
-                raise UserError(_FREE_FORM_OBJECT_ERROR)
-        json_schema["required"] = list(properties.keys())
+        all_of_value = json_schema.get("allOf")
+        merge_is_pending = "$ref" in json_schema or (
+            is_list(all_of_value) and len(all_of_value) == 1
+        )
+        if merge_is_pending:
+            # A `$ref` or single-entry `allOf` merge will land more properties on this node
+            # and re-enter, so required handling must wait for the merged shape. Overwriting
+            # now would also destroy the original `required` before it can be judged.
+            pass
+        else:
+            declared_required = json_schema.get("required")
+            if is_list(declared_required) and any(
+                name not in properties for name in declared_required
+            ):
+                # The object requires keys it never declares, so their values are
+                # unconstrained. Strict mode needs required to be a subset of properties with
+                # everything else forbidden, so conversion would silently drop the requirement
+                # and forbid the key.
+                if in_definitions:
+                    if budget.definition_stack:
+                        budget.tainted_definition_ids.add(budget.definition_stack[-1])
+                else:
+                    raise UserError(_FREE_FORM_OBJECT_ERROR)
+        if not merge_is_pending:
+            json_schema["required"] = list(properties.keys())
         json_schema["properties"] = {
             key: _ensure_strict_json_schema(
                 prop_schema,

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -97,12 +97,28 @@ _CONTENT_SHAPING_KEYWORDS = frozenset(
         "if",
         "not",
         "oneOf",
+        "maxProperties",
+        "minProperties",
         "patternProperties",
         "propertyNames",
         "then",
         "unevaluatedProperties",
     }
 )
+
+
+def _is_unclosable_object(json_schema: dict[str, object]) -> bool:
+    """Whether closing this object with ``additionalProperties: false`` would change meaning."""
+    typ = json_schema.get("type")
+    is_object = typ == "object" or (is_list(typ) and "object" in typ)
+    if not is_object or "additionalProperties" in json_schema:
+        return False
+    if _allows_only_the_empty_object(json_schema):
+        return False
+    declared = json_schema.get("properties")
+    if not is_dict(declared):
+        return True
+    return not declared and _shapes_contents_without_properties(json_schema)
 
 
 def _shapes_contents_without_properties(json_schema: dict[str, object]) -> bool:
@@ -121,6 +137,7 @@ def _ensure_strict_json_schema(
     root: dict[str, object],
     budget: _NodeBudget | None = None,
     in_definitions: bool = False,
+    free_form_refs: set[str] | None = None,
 ) -> dict[str, Any]:
     if not is_dict(json_schema):
         raise TypeError(f"Expected {json_schema} to be a dictionary; path={path}")
@@ -129,11 +146,17 @@ def _ensure_strict_json_schema(
     # exponentially and exhaust CPU and memory.
     if budget is None:
         budget = _NodeBudget(_MAX_SCHEMA_NODES)
+    if free_form_refs is None:
+        free_form_refs = set()
     budget.spend()
 
     defs = json_schema.get("$defs")
     if is_dict(defs):
         for def_name, def_schema in defs.items():
+            if is_dict(def_schema) and _is_unclosable_object(def_schema):
+                # Remember it before the walk below closes it, so a bare `$ref` that points
+                # here can be rejected rather than silently narrowed to the empty object.
+                free_form_refs.add(f"#/$defs/{def_name}")
             _ensure_strict_json_schema(
                 def_schema,
                 path=(*path, "$defs", def_name),
@@ -145,6 +168,10 @@ def _ensure_strict_json_schema(
     definitions = json_schema.get("definitions")
     if is_dict(definitions):
         for definition_name, definition_schema in definitions.items():
+            if is_dict(definition_schema) and _is_unclosable_object(definition_schema):
+                # Remember it before the walk below closes it, so a bare `$ref` that points
+                # here can be rejected rather than silently narrowed to the empty object.
+                free_form_refs.add(f"#/definitions/{definition_name}")
             _ensure_strict_json_schema(
                 definition_schema,
                 path=(*path, "definitions", definition_name),
@@ -181,6 +208,7 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 in_definitions=in_definitions,
+                free_form_refs=free_form_refs,
             )
             for key, prop_schema in properties.items()
         }
@@ -190,7 +218,12 @@ def _ensure_strict_json_schema(
     items = json_schema.get("items")
     if is_dict(items):
         json_schema["items"] = _ensure_strict_json_schema(
-            items, path=(*path, "items"), root=root, budget=budget, in_definitions=in_definitions
+            items,
+            path=(*path, "items"),
+            root=root,
+            budget=budget,
+            in_definitions=in_definitions,
+            free_form_refs=free_form_refs,
         )
 
     # unions
@@ -203,6 +236,7 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 in_definitions=in_definitions,
+                free_form_refs=free_form_refs,
             )
             for i, variant in enumerate(any_of)
         ]
@@ -222,6 +256,7 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 in_definitions=in_definitions,
+                free_form_refs=free_form_refs,
             )
             for i, variant in enumerate(one_of)
         ]
@@ -243,7 +278,12 @@ def _ensure_strict_json_schema(
             json_schema.pop("allOf")
             json_schema.update(entry)
             return _ensure_strict_json_schema(
-                json_schema, path=path, root=root, budget=budget, in_definitions=in_definitions
+                json_schema,
+                path=path,
+                root=root,
+                budget=budget,
+                in_definitions=in_definitions,
+                free_form_refs=free_form_refs,
             )
         else:
             json_schema["allOf"] = [
@@ -269,6 +309,10 @@ def _ensure_strict_json_schema(
     # so we unravel the ref
     # `{"type": "string", "description": "my description"}`
     ref = json_schema.get("$ref")
+    if isinstance(ref, str) and ref in free_form_refs and not has_more_than_n_keys(json_schema, 1):
+        # A bare `$ref` is never inlined, so the strict schema would keep pointing at a
+        # definition that has since been closed into the empty object.
+        raise UserError(_FREE_FORM_OBJECT_ERROR)
     if ref and has_more_than_n_keys(json_schema, 1):
         assert isinstance(ref, str), f"Received non-string $ref - {ref}"
 
@@ -287,7 +331,12 @@ def _ensure_strict_json_schema(
         # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied
         # we call `_ensure_strict_json_schema` again to fix the inlined schema and ensure it's valid
         return _ensure_strict_json_schema(
-            json_schema, path=path, root=root, budget=budget, in_definitions=in_definitions
+            json_schema,
+            path=path,
+            root=root,
+            budget=budget,
+            in_definitions=in_definitions,
+            free_form_refs=free_form_refs,
         )
 
     # Decide whether this object can be closed only once the normalizations above have run, so

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -28,39 +28,12 @@ _ADDITIONAL_PROPERTIES_ERROR = (
 )
 
 _FREE_FORM_OBJECT_ERROR = (
-    "Strict JSON schemas cannot express a free-form object. An object that declares no "
-    "properties and no additionalProperties accepts arbitrary keys, which strict mode does "
-    "not support. Describe the expected properties, or update the function or output tool to "
-    "not use a strict schema."
+    "Strict JSON schemas cannot express this object. An object that declares no properties at "
+    "its own level and no explicit additionalProperties: false accepts arbitrary keys, which "
+    "strict mode does not support. Describe the expected properties, set additionalProperties "
+    "to false if the empty object really is the only valid value, or update the function or "
+    "output tool to not use a strict schema."
 )
-
-# Keywords that constrain what an object may contain. An object schema carrying none of these
-# places no restriction on its keys, so it is free-form. ``additionalProperties`` is handled by
-# the caller, which only consults this helper when the keyword is absent.
-_OBJECT_SHAPE_KEYWORDS = frozenset(
-    {
-        "$ref",
-        "allOf",
-        "anyOf",
-        "const",
-        "dependentSchemas",
-        "else",
-        "enum",
-        "if",
-        "not",
-        "oneOf",
-        "patternProperties",
-        "properties",
-        "propertyNames",
-        "then",
-        "unevaluatedProperties",
-    }
-)
-
-
-def _is_free_form_object(json_schema: dict[str, object]) -> bool:
-    """Whether an object schema places no restriction at all on its keys."""
-    return not any(keyword in json_schema for keyword in _OBJECT_SHAPE_KEYWORDS)
 
 
 class _NodeBudget:
@@ -151,17 +124,7 @@ def _ensure_strict_json_schema(
     elif typ is None and json_schema.get("additionalProperties", False) is not False:
         raise UserError(_ADDITIONAL_PROPERTIES_ERROR)
     is_object = typ == "object" or (is_list(typ) and "object" in typ)
-    if is_object and "additionalProperties" not in json_schema:
-        # An object that constrains nothing is a free-form object: any keys are allowed.
-        # Strict mode cannot express that, and defaulting to ``additionalProperties: false``
-        # here would silently narrow it to "the empty object is the only valid value", so the
-        # model could never send any content. Fail the same way an explicit
-        # ``additionalProperties: true`` does, which lets callers that can degrade (such as
-        # MCP tool conversion) fall back to serving the schema as non-strict.
-        if _is_free_form_object(json_schema):
-            raise UserError(_FREE_FORM_OBJECT_ERROR)
-        json_schema["additionalProperties"] = False
-    elif (
+    if (
         is_object
         and "additionalProperties" in json_schema
         # Compare with ``is not False`` rather than truthiness: OpenAPI/MCP schemas often use
@@ -265,6 +228,22 @@ def _ensure_strict_json_schema(
         # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied
         # we call `_ensure_strict_json_schema` again to fix the inlined schema and ensure it's valid
         return _ensure_strict_json_schema(json_schema, path=path, root=root, budget=budget)
+
+    # Decide whether this object can be closed only once the normalizations above have run, so
+    # that a `$ref` or a single-entry `allOf` has already had the chance to lift `properties` up
+    # to this level. Both of those paths re-enter this function and are handled by the return
+    # statements above rather than reaching here.
+    if is_object and "additionalProperties" not in json_schema:
+        if "properties" not in json_schema:
+            # Nothing at this level says which keys are allowed, so the object accepts any of
+            # them. Closing it with `additionalProperties: false` would silently narrow it to
+            # "the empty object is the only valid value", or, for a composed wrapper such as
+            # `anyOf`/multi-branch `allOf`/`enum`/`const`, would reject the very values the
+            # branches describe. Fail the same way an explicit `additionalProperties: true`
+            # does, so callers that can degrade (such as MCP tool conversion) fall back to
+            # serving the schema as non-strict.
+            raise UserError(_FREE_FORM_OBJECT_ERROR)
+        json_schema["additionalProperties"] = False
 
     return json_schema
 

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -205,7 +205,7 @@ _DEFINITION_CONTAINER_KEYS = ("$defs", "definitions")
 
 # Keywords whose values are data literals, not schemas. A literal such as
 # `{"const": {"type": "object"}}` must never have its value mistaken for a schema node.
-_LITERAL_VALUE_KEYWORDS = frozenset({"const", "default", "enum", "examples"})
+_LITERAL_VALUE_KEYWORDS = frozenset({"const", "default", "enum", "example", "examples"})
 
 
 def _iter_schema_nodes(root: object, *, limit: int) -> list[dict[str, object]]:
@@ -239,6 +239,36 @@ def _node_is_unshaped_ref(node: dict[str, object]) -> bool:
     return isinstance(node.get("$ref"), str) and not _siblings_supply_the_shape(
         {key: value for key, value in node.items() if key != "$ref"}
     )
+
+
+def _effective_definition_view(
+    entry: dict[str, object], *, root: dict[str, object]
+) -> dict[str, object]:
+    """What a definition will look like once the converter's normalizations run.
+
+    The walk merges a single-entry `allOf` onto its node and inlines a `$ref` that has
+    siblings, so classifying the raw shape would call definitions free-form that end up
+    perfectly strictable. This mirrors those merges on a copy, without mutating anything.
+    """
+    view = dict(entry)
+    for _ in range(_MAX_SCHEMA_NODES):
+        all_of = view.get("allOf")
+        if is_list(all_of) and len(all_of) == 1 and is_dict(all_of[0]):
+            branch = all_of[0]
+            view.pop("allOf")
+            view = {**view, **branch}
+            continue
+        ref = view.get("$ref")
+        if isinstance(ref, str) and has_more_than_n_keys(view, 1):
+            target = _resolve_ref_chain(ref, root=root)
+            if not is_dict(target):
+                break
+            view.pop("$ref")
+            # Sibling keys take priority over the referenced schema, as in the real merge.
+            view = {**target, **view}
+            continue
+        break
+    return view
 
 
 def _precompute_definition_registries(root: dict[str, object], budget: _NodeBudget) -> None:
@@ -284,7 +314,8 @@ def _precompute_definition_registries(root: dict[str, object], budget: _NodeBudg
                 stack.extend(interior_node)
         interior_nodes[id(entry)] = interior
 
-        if _is_unclosable_object(entry):
+        entry_view = _effective_definition_view(entry, root=root)
+        if "$ref" not in entry_view and _is_unclosable_object(entry_view):
             budget.free_form_definition_ids.add(id(entry))
         for node in interior:
             if _is_unclosable_object(node):
@@ -308,7 +339,8 @@ def _precompute_definition_registries(root: dict[str, object], budget: _NodeBudg
             entry_id = id(entry)
             if entry_id in budget.tainted_definition_ids:
                 continue
-            root_ref = entry.get("$ref")
+            entry_view = _effective_definition_view(entry, root=root)
+            root_ref = entry_view.get("$ref")
             if isinstance(root_ref, str) and entry_id not in budget.free_form_definition_ids:
                 target = _resolve_ref_chain(root_ref, root=root)
                 if target is not None:
@@ -318,7 +350,7 @@ def _precompute_definition_registries(root: dict[str, object], budget: _NodeBudg
                         changed = True
                         continue
                     if id(target) in budget.free_form_definition_ids and _node_is_unshaped_ref(
-                        entry
+                        entry_view
                     ):
                         budget.free_form_definition_ids.add(entry_id)
                         changed = True
@@ -360,10 +392,8 @@ def _ensure_strict_json_schema(
     defs = json_schema.get("$defs")
     if is_dict(defs):
         for def_name, def_schema in defs.items():
-            if is_dict(def_schema) and _is_unclosable_object(def_schema):
-                # Remember it before the walk below closes it, so a `$ref` that points here
-                # can be handled rather than silently narrowed to the empty object.
-                budget.free_form_definition_ids.add(id(def_schema))
+            # Classification comes from the precomputed registries, which read the
+            # untouched tree and account for the merges this walk is about to perform.
             budget.definition_stack.append(id(def_schema))
             try:
                 _ensure_strict_json_schema(
@@ -379,10 +409,8 @@ def _ensure_strict_json_schema(
     definitions = json_schema.get("definitions")
     if is_dict(definitions):
         for definition_name, definition_schema in definitions.items():
-            if is_dict(definition_schema) and _is_unclosable_object(definition_schema):
-                # Remember it before the walk below closes it, so a `$ref` that points here
-                # can be handled rather than silently narrowed to the empty object.
-                budget.free_form_definition_ids.add(id(definition_schema))
+            # Classification comes from the precomputed registries, which read the
+            # untouched tree and account for the merges this walk is about to perform.
             budget.definition_stack.append(id(definition_schema))
             try:
                 _ensure_strict_json_schema(

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -27,6 +27,41 @@ _ADDITIONAL_PROPERTIES_ERROR = (
     "to not use a strict schema."
 )
 
+_FREE_FORM_OBJECT_ERROR = (
+    "Strict JSON schemas cannot express a free-form object. An object that declares no "
+    "properties and no additionalProperties accepts arbitrary keys, which strict mode does "
+    "not support. Describe the expected properties, or update the function or output tool to "
+    "not use a strict schema."
+)
+
+# Keywords that constrain what an object may contain. An object schema carrying none of these
+# places no restriction on its keys, so it is free-form. ``additionalProperties`` is handled by
+# the caller, which only consults this helper when the keyword is absent.
+_OBJECT_SHAPE_KEYWORDS = frozenset(
+    {
+        "$ref",
+        "allOf",
+        "anyOf",
+        "const",
+        "dependentSchemas",
+        "else",
+        "enum",
+        "if",
+        "not",
+        "oneOf",
+        "patternProperties",
+        "properties",
+        "propertyNames",
+        "then",
+        "unevaluatedProperties",
+    }
+)
+
+
+def _is_free_form_object(json_schema: dict[str, object]) -> bool:
+    """Whether an object schema places no restriction at all on its keys."""
+    return not any(keyword in json_schema for keyword in _OBJECT_SHAPE_KEYWORDS)
+
 
 class _NodeBudget:
     """Tracks the remaining schema-node expansion budget across the recursion."""
@@ -117,6 +152,14 @@ def _ensure_strict_json_schema(
         raise UserError(_ADDITIONAL_PROPERTIES_ERROR)
     is_object = typ == "object" or (is_list(typ) and "object" in typ)
     if is_object and "additionalProperties" not in json_schema:
+        # An object that constrains nothing is a free-form object: any keys are allowed.
+        # Strict mode cannot express that, and defaulting to ``additionalProperties: false``
+        # here would silently narrow it to "the empty object is the only valid value", so the
+        # model could never send any content. Fail the same way an explicit
+        # ``additionalProperties: true`` does, which lets callers that can degrade (such as
+        # MCP tool conversion) fall back to serving the schema as non-strict.
+        if _is_free_form_object(json_schema):
+            raise UserError(_FREE_FORM_OBJECT_ERROR)
         json_schema["additionalProperties"] = False
     elif (
         is_object

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -46,8 +46,15 @@ class _NodeBudget:
     def __init__(self, limit: int) -> None:
         self.remaining = limit
         # Definitions that were free-form before the definition walk closed them, recorded by
-        # object identity so nested `$defs` need no path bookkeeping.
+        # object identity so nested `$defs` need no path bookkeeping. A `$ref` to one of these
+        # is salvageable when its siblings supply the shape.
         self.free_form_definition_ids: set[int] = set()
+        # Definitions whose interior holds a free-form node at a value position. No sibling
+        # merge can reach inside the referenced subtree, so a `$ref` to one of these is never
+        # salvageable.
+        self.tainted_definition_ids: set[int] = set()
+        # Identity of the definition currently being walked, innermost last.
+        self.definition_stack: list[int] = []
 
     def spend(self) -> None:
         self.remaining -= 1
@@ -98,6 +105,8 @@ _CONTENT_SHAPING_KEYWORDS = frozenset(
         "allOf",
         "anyOf",
         "const",
+        "dependencies",
+        "dependentRequired",
         "dependentSchemas",
         "else",
         "enum",
@@ -152,15 +161,37 @@ def _siblings_supply_the_shape(siblings: dict[str, object]) -> bool:
     return _allows_only_the_empty_object(siblings)
 
 
+def _resolve_ref_chain(ref: str, *, root: dict[str, object]) -> object | None:
+    """Resolve a ref, following alias definitions that are themselves a lone `$ref`."""
+    seen: set[str] = set()
+    current = ref
+    while current not in seen:
+        seen.add(current)
+        try:
+            resolved = resolve_ref(root=root, ref=current)
+        except Exception:
+            # Unresolvable refs keep their historical handling; they are not this check's concern.
+            return None
+        if not is_dict(resolved):
+            return None
+        next_ref = resolved.get("$ref")
+        if isinstance(next_ref, str) and not has_more_than_n_keys(resolved, 1):
+            current = next_ref
+            continue
+        return resolved
+    return None
+
+
 def _resolves_to_free_form_definition(
     ref: str, *, root: dict[str, object], budget: _NodeBudget
 ) -> bool:
-    try:
-        resolved = resolve_ref(root=root, ref=ref)
-    except Exception:
-        # Unresolvable refs keep their historical handling; they are not this check's concern.
+    resolved = _resolve_ref_chain(ref, root=root)
+    if resolved is None:
         return False
-    return id(resolved) in budget.free_form_definition_ids
+    return (
+        id(resolved) in budget.free_form_definition_ids
+        or id(resolved) in budget.tainted_definition_ids
+    )
 
 
 def _ensure_strict_json_schema(
@@ -187,13 +218,17 @@ def _ensure_strict_json_schema(
                 # Remember it before the walk below closes it, so a `$ref` that points here
                 # can be handled rather than silently narrowed to the empty object.
                 budget.free_form_definition_ids.add(id(def_schema))
-            _ensure_strict_json_schema(
-                def_schema,
-                path=(*path, "$defs", def_name),
-                root=root,
-                budget=budget,
-                in_definitions=True,
-            )
+            budget.definition_stack.append(id(def_schema))
+            try:
+                _ensure_strict_json_schema(
+                    def_schema,
+                    path=(*path, "$defs", def_name),
+                    root=root,
+                    budget=budget,
+                    in_definitions=True,
+                )
+            finally:
+                budget.definition_stack.pop()
 
     definitions = json_schema.get("definitions")
     if is_dict(definitions):
@@ -202,13 +237,17 @@ def _ensure_strict_json_schema(
                 # Remember it before the walk below closes it, so a `$ref` that points here
                 # can be handled rather than silently narrowed to the empty object.
                 budget.free_form_definition_ids.add(id(definition_schema))
-            _ensure_strict_json_schema(
-                definition_schema,
-                path=(*path, "definitions", definition_name),
-                root=root,
-                budget=budget,
-                in_definitions=True,
-            )
+            budget.definition_stack.append(id(definition_schema))
+            try:
+                _ensure_strict_json_schema(
+                    definition_schema,
+                    path=(*path, "definitions", definition_name),
+                    root=root,
+                    budget=budget,
+                    in_definitions=True,
+                )
+            finally:
+                budget.definition_stack.pop()
 
     typ = json_schema.get("type")
     properties = json_schema.get("properties")
@@ -230,6 +269,20 @@ def _ensure_strict_json_schema(
     # object types
     # { 'type': 'object', 'properties': { 'a':  {...} } }
     if is_dict(properties):
+        declared_required = json_schema.get("required")
+        if (
+            "$ref" not in json_schema
+            and is_list(declared_required)
+            and any(name not in properties for name in declared_required)
+        ):
+            # The object requires keys it never declares, so their values are unconstrained.
+            # Strict mode needs required to be a subset of properties with everything else
+            # forbidden, so conversion would silently drop the requirement and forbid the key.
+            if in_definitions:
+                if budget.definition_stack:
+                    budget.tainted_definition_ids.add(budget.definition_stack[-1])
+            else:
+                raise UserError(_FREE_FORM_OBJECT_ERROR)
         json_schema["required"] = list(properties.keys())
         json_schema["properties"] = {
             key: _ensure_strict_json_schema(
@@ -352,6 +405,10 @@ def _ensure_strict_json_schema(
         # (chained refs), we preserve it for the recursive expansion below instead of
         # silently dropping it.
         json_schema.pop("$ref")
+        if id(resolved) in budget.tainted_definition_ids:
+            # The free-form node is inside the referenced subtree, out of reach of any
+            # sibling merge, so this reference can never be made strict.
+            raise UserError(_FREE_FORM_OBJECT_ERROR)
         if id(resolved) in budget.free_form_definition_ids and not _siblings_supply_the_shape(
             json_schema
         ):
@@ -376,6 +433,20 @@ def _ensure_strict_json_schema(
     # that a `$ref` or a single-entry `allOf` has already had the chance to lift `properties` up
     # to this level. Both of those paths re-enter this function and are handled by the return
     # statements above rather than reaching here.
+    if is_object and "additionalProperties" not in json_schema and in_definitions:
+        is_definition_root = bool(
+            budget.definition_stack and budget.definition_stack[-1] == id(json_schema)
+        )
+        if (
+            not is_definition_root
+            and _is_unclosable_object(json_schema)
+            and budget.definition_stack
+        ):
+            # A free-form node at a value position inside a definition can never be salvaged:
+            # a sibling merge at the `$ref` site only reshapes the top level, not the interior.
+            # Record the enclosing definition so any reference to it falls back.
+            budget.tainted_definition_ids.add(budget.definition_stack[-1])
+
     if is_object and "additionalProperties" not in json_schema and not in_definitions:
         # A definition is a template rather than a value position: a broad base is routinely
         # narrowed by the keys a `$ref` site supplies, and an unreferenced one has no effect at

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -74,9 +74,9 @@ def ensure_strict_json_schema(
     """
     if schema == {}:
         return copy.deepcopy(_EMPTY_SCHEMA)
-    converted = _ensure_strict_json_schema(
-        schema, path=(), root=schema, budget=_NodeBudget(_MAX_SCHEMA_NODES)
-    )
+    budget = _NodeBudget(_MAX_SCHEMA_NODES)
+    _precompute_definition_registries(schema, budget)
+    converted = _ensure_strict_json_schema(schema, path=(), root=schema, budget=budget)
     return _ensure_strict_root(converted)
 
 
@@ -194,6 +194,138 @@ def _resolves_to_free_form_definition(
     )
 
 
+_DEFINITION_CONTAINER_KEYS = ("$defs", "definitions")
+
+
+def _iter_schema_nodes(root: object, *, limit: int) -> list[dict[str, object]]:
+    """Every dict node in the tree, cycle-safe and bounded like the conversion itself."""
+    nodes: list[dict[str, object]] = []
+    stack: list[object] = [root]
+    seen: set[int] = set()
+    count = 0
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        count += 1
+        if count > limit:
+            raise UserError(
+                "JSON schema is too large to convert to a strict schema. This can happen when a "
+                "schema expands `$ref`s exponentially, which may indicate a malformed or "
+                "malicious schema."
+            )
+        if is_dict(node):
+            nodes.append(node)
+            stack.extend(node.values())
+        elif is_list(node):
+            stack.extend(node)
+    return nodes
+
+
+def _node_is_unshaped_ref(node: dict[str, object]) -> bool:
+    """A `$ref` node whose sibling keys do not shape or close the referenced object."""
+    return isinstance(node.get("$ref"), str) and not _siblings_supply_the_shape(
+        {key: value for key, value in node.items() if key != "$ref"}
+    )
+
+
+def _precompute_definition_registries(root: dict[str, object], budget: _NodeBudget) -> None:
+    """Populate the free-form and tainted registries before anything is walked or mutated.
+
+    Populating during the definition walk is order-dependent: an alias that appears before
+    its target would be inlined and closed while the target is still unrecorded. This pass
+    reads the untouched tree, seeds both registries from what each definition says on its
+    own, then iterates alias and interior references to a fixpoint, so declaration order
+    cannot matter.
+    """
+    definition_entries: list[dict[str, object]] = []
+    for node in _iter_schema_nodes(root, limit=_MAX_SCHEMA_NODES):
+        for container_key in _DEFINITION_CONTAINER_KEYS:
+            container = node.get(container_key)
+            if is_dict(container):
+                definition_entries.extend(entry for entry in container.values() if is_dict(entry))
+
+    interior_nodes: dict[int, list[dict[str, object]]] = {}
+    for entry in definition_entries:
+        # A definition's own nested definition containers are separate templates and do not
+        # shape this definition's value, so they are excluded from its interior.
+        interior: list[dict[str, object]] = []
+        stack: list[object] = [
+            value for key, value in entry.items() if key not in _DEFINITION_CONTAINER_KEYS
+        ]
+        seen: set[int] = set()
+        while stack:
+            interior_node = stack.pop()
+            if id(interior_node) in seen:
+                continue
+            seen.add(id(interior_node))
+            if is_dict(interior_node):
+                interior.append(interior_node)
+                stack.extend(
+                    value
+                    for key, value in interior_node.items()
+                    if key not in _DEFINITION_CONTAINER_KEYS
+                )
+            elif is_list(interior_node):
+                stack.extend(interior_node)
+        interior_nodes[id(entry)] = interior
+
+        if _is_unclosable_object(entry):
+            budget.free_form_definition_ids.add(id(entry))
+        for node in interior:
+            if _is_unclosable_object(node):
+                budget.tainted_definition_ids.add(id(entry))
+                break
+            required = node.get("required")
+            properties = node.get("properties")
+            if (
+                "$ref" not in node
+                and is_dict(properties)
+                and is_list(required)
+                and any(name not in properties for name in required)
+            ):
+                budget.tainted_definition_ids.add(id(entry))
+                break
+
+    changed = True
+    while changed:
+        changed = False
+        for entry in definition_entries:
+            entry_id = id(entry)
+            if entry_id in budget.tainted_definition_ids:
+                continue
+            root_ref = entry.get("$ref")
+            if isinstance(root_ref, str) and entry_id not in budget.free_form_definition_ids:
+                target = _resolve_ref_chain(root_ref, root=root)
+                if target is not None:
+                    if id(target) in budget.tainted_definition_ids:
+                        # No sibling merge reaches inside the referenced subtree.
+                        budget.tainted_definition_ids.add(entry_id)
+                        changed = True
+                        continue
+                    if id(target) in budget.free_form_definition_ids and _node_is_unshaped_ref(
+                        entry
+                    ):
+                        budget.free_form_definition_ids.add(entry_id)
+                        changed = True
+            for node in interior_nodes[entry_id]:
+                if node is entry:
+                    continue
+                node_ref = node.get("$ref")
+                if not isinstance(node_ref, str):
+                    continue
+                target = _resolve_ref_chain(node_ref, root=root)
+                if target is None:
+                    continue
+                if id(target) in budget.tainted_definition_ids or (
+                    id(target) in budget.free_form_definition_ids and _node_is_unshaped_ref(node)
+                ):
+                    budget.tainted_definition_ids.add(entry_id)
+                    changed = True
+                    break
+
+
 def _ensure_strict_json_schema(
     json_schema: object,
     *,
@@ -209,6 +341,7 @@ def _ensure_strict_json_schema(
     # exponentially and exhaust CPU and memory.
     if budget is None:
         budget = _NodeBudget(_MAX_SCHEMA_NODES)
+        _precompute_definition_registries(root, budget)
     budget.spend()
 
     defs = json_schema.get("$defs")
@@ -389,9 +522,15 @@ def _ensure_strict_json_schema(
     ref = json_schema.get("$ref")
     if isinstance(ref, str) and not has_more_than_n_keys(json_schema, 1):
         if _resolves_to_free_form_definition(ref, root=root, budget=budget):
-            # A bare `$ref` is never inlined, so the strict schema would keep pointing at a
-            # definition that the walk above has since closed into the empty object.
-            raise UserError(_FREE_FORM_OBJECT_ERROR)
+            if in_definitions:
+                # Inside a template this only matters if something references the template,
+                # so record it rather than failing a possibly unreferenced definition.
+                if budget.definition_stack:
+                    budget.tainted_definition_ids.add(budget.definition_stack[-1])
+            else:
+                # A bare `$ref` is never inlined, so the strict schema would keep pointing at
+                # a definition that the walk above has since closed into the empty object.
+                raise UserError(_FREE_FORM_OBJECT_ERROR)
     if ref and has_more_than_n_keys(json_schema, 1):
         assert isinstance(ref, str), f"Received non-string $ref - {ref}"
 
@@ -405,11 +544,19 @@ def _ensure_strict_json_schema(
         # (chained refs), we preserve it for the recursive expansion below instead of
         # silently dropping it.
         json_schema.pop("$ref")
-        if id(resolved) in budget.tainted_definition_ids:
+        reference_cannot_be_strict = id(resolved) in budget.tainted_definition_ids or (
+            id(resolved) in budget.free_form_definition_ids
+            and not _siblings_supply_the_shape(json_schema)
+        )
+        if reference_cannot_be_strict and in_definitions:
+            # Same as the bare-ref case: a template is only a problem once referenced.
+            if budget.definition_stack:
+                budget.tainted_definition_ids.add(budget.definition_stack[-1])
+        elif id(resolved) in budget.tainted_definition_ids:
             # The free-form node is inside the referenced subtree, out of reach of any
             # sibling merge, so this reference can never be made strict.
             raise UserError(_FREE_FORM_OBJECT_ERROR)
-        if id(resolved) in budget.free_form_definition_ids and not _siblings_supply_the_shape(
+        elif id(resolved) in budget.free_form_definition_ids and not _siblings_supply_the_shape(
             json_schema
         ):
             # The definition was free-form, so the keys alongside the `$ref` must supply the

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -84,12 +84,43 @@ def _ensure_strict_root(schema: dict[str, Any]) -> dict[str, Any]:
 
 
 # Adapted from https://github.com/openai/openai-python/blob/main/src/openai/lib/_pydantic.py
+# Keywords that describe an object's contents somewhere other than its own `properties` map.
+# An empty `properties` map next to one of these is not a statement that the object is empty.
+_CONTENT_SHAPING_KEYWORDS = frozenset(
+    {
+        "allOf",
+        "anyOf",
+        "const",
+        "dependentSchemas",
+        "else",
+        "enum",
+        "if",
+        "not",
+        "oneOf",
+        "patternProperties",
+        "propertyNames",
+        "then",
+        "unevaluatedProperties",
+    }
+)
+
+
+def _shapes_contents_without_properties(json_schema: dict[str, object]) -> bool:
+    return any(keyword in json_schema for keyword in _CONTENT_SHAPING_KEYWORDS)
+
+
+def _allows_only_the_empty_object(json_schema: dict[str, object]) -> bool:
+    """Whether the schema already forbids every key, so closing it changes nothing."""
+    return json_schema.get("maxProperties") == 0
+
+
 def _ensure_strict_json_schema(
     json_schema: object,
     *,
     path: tuple[str, ...],
     root: dict[str, object],
     budget: _NodeBudget | None = None,
+    in_definitions: bool = False,
 ) -> dict[str, Any]:
     if not is_dict(json_schema):
         raise TypeError(f"Expected {json_schema} to be a dictionary; path={path}")
@@ -104,7 +135,11 @@ def _ensure_strict_json_schema(
     if is_dict(defs):
         for def_name, def_schema in defs.items():
             _ensure_strict_json_schema(
-                def_schema, path=(*path, "$defs", def_name), root=root, budget=budget
+                def_schema,
+                path=(*path, "$defs", def_name),
+                root=root,
+                budget=budget,
+                in_definitions=True,
             )
 
     definitions = json_schema.get("definitions")
@@ -115,6 +150,7 @@ def _ensure_strict_json_schema(
                 path=(*path, "definitions", definition_name),
                 root=root,
                 budget=budget,
+                in_definitions=True,
             )
 
     typ = json_schema.get("type")
@@ -140,7 +176,11 @@ def _ensure_strict_json_schema(
         json_schema["required"] = list(properties.keys())
         json_schema["properties"] = {
             key: _ensure_strict_json_schema(
-                prop_schema, path=(*path, "properties", key), root=root, budget=budget
+                prop_schema,
+                path=(*path, "properties", key),
+                root=root,
+                budget=budget,
+                in_definitions=in_definitions,
             )
             for key, prop_schema in properties.items()
         }
@@ -150,7 +190,7 @@ def _ensure_strict_json_schema(
     items = json_schema.get("items")
     if is_dict(items):
         json_schema["items"] = _ensure_strict_json_schema(
-            items, path=(*path, "items"), root=root, budget=budget
+            items, path=(*path, "items"), root=root, budget=budget, in_definitions=in_definitions
         )
 
     # unions
@@ -158,7 +198,11 @@ def _ensure_strict_json_schema(
     if is_list(any_of):
         json_schema["anyOf"] = [
             _ensure_strict_json_schema(
-                variant, path=(*path, "anyOf", str(i)), root=root, budget=budget
+                variant,
+                path=(*path, "anyOf", str(i)),
+                root=root,
+                budget=budget,
+                in_definitions=in_definitions,
             )
             for i, variant in enumerate(any_of)
         ]
@@ -173,7 +217,11 @@ def _ensure_strict_json_schema(
             existing_any_of = []
         json_schema["anyOf"] = existing_any_of + [
             _ensure_strict_json_schema(
-                variant, path=(*path, "oneOf", str(i)), root=root, budget=budget
+                variant,
+                path=(*path, "oneOf", str(i)),
+                root=root,
+                budget=budget,
+                in_definitions=in_definitions,
             )
             for i, variant in enumerate(one_of)
         ]
@@ -194,11 +242,17 @@ def _ensure_strict_json_schema(
             # declares `properties`, would look like a free-form object and be rejected.
             json_schema.pop("allOf")
             json_schema.update(entry)
-            return _ensure_strict_json_schema(json_schema, path=path, root=root, budget=budget)
+            return _ensure_strict_json_schema(
+                json_schema, path=path, root=root, budget=budget, in_definitions=in_definitions
+            )
         else:
             json_schema["allOf"] = [
                 _ensure_strict_json_schema(
-                    entry, path=(*path, "allOf", str(i)), root=root, budget=budget
+                    entry,
+                    path=(*path, "allOf", str(i)),
+                    root=root,
+                    budget=budget,
+                    in_definitions=in_definitions,
                 )
                 for i, entry in enumerate(all_of)
             ]
@@ -232,14 +286,24 @@ def _ensure_strict_json_schema(
         json_schema.update({**resolved, **json_schema})
         # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied
         # we call `_ensure_strict_json_schema` again to fix the inlined schema and ensure it's valid
-        return _ensure_strict_json_schema(json_schema, path=path, root=root, budget=budget)
+        return _ensure_strict_json_schema(
+            json_schema, path=path, root=root, budget=budget, in_definitions=in_definitions
+        )
 
     # Decide whether this object can be closed only once the normalizations above have run, so
     # that a `$ref` or a single-entry `allOf` has already had the chance to lift `properties` up
     # to this level. Both of those paths re-enter this function and are handled by the return
     # statements above rather than reaching here.
-    if is_object and "additionalProperties" not in json_schema:
-        if "properties" not in json_schema:
+    if is_object and "additionalProperties" not in json_schema and not in_definitions:
+        # A definition is a template rather than a value position: a broad base is routinely
+        # narrowed by the keys a `$ref` site supplies, and an unreferenced one has no effect at
+        # all. Judging one on its own would reject schemas that are perfectly strictable once
+        # inlined, so definitions keep the historical behaviour and are closed below.
+        declared = json_schema.get("properties")
+        if _allows_only_the_empty_object(json_schema):
+            # Already constrained to the empty object, so closing it changes nothing.
+            pass
+        elif not is_dict(declared):
             # Nothing at this level says which keys are allowed, so the object accepts any of
             # them. Closing it with `additionalProperties: false` would silently narrow it to
             # "the empty object is the only valid value", or, for a composed wrapper such as
@@ -248,6 +312,12 @@ def _ensure_strict_json_schema(
             # does, so callers that can degrade (such as MCP tool conversion) fall back to
             # serving the schema as non-strict.
             raise UserError(_FREE_FORM_OBJECT_ERROR)
+        elif not declared and _shapes_contents_without_properties(json_schema):
+            # An empty `properties` map next to a keyword that describes the contents some
+            # other way is not a declaration that the object is empty.
+            raise UserError(_FREE_FORM_OBJECT_ERROR)
+
+    if is_object and "additionalProperties" not in json_schema:
         json_schema["additionalProperties"] = False
 
     return json_schema

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -183,12 +183,17 @@ def _ensure_strict_json_schema(
     all_of = json_schema.get("allOf")
     if is_list(all_of):
         if len(all_of) == 1:
-            json_schema.update(
-                _ensure_strict_json_schema(
-                    all_of[0], path=(*path, "allOf", "0"), root=root, budget=budget
+            entry = all_of[0]
+            if not is_dict(entry):
+                raise TypeError(
+                    f"Expected {entry} to be a dictionary; path={(*path, 'allOf', '0')}"
                 )
-            )
+            # Merge the single branch before converting it, then re-enter. Converting the branch
+            # on its own first would judge it in isolation, so a branch that constrains nothing
+            # by itself, such as a redundant `{"type": "object"}` next to a parent that already
+            # declares `properties`, would look like a free-form object and be rejected.
             json_schema.pop("allOf")
+            json_schema.update(entry)
             return _ensure_strict_json_schema(json_schema, path=path, root=root, budget=budget)
         else:
             json_schema["allOf"] = [

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -37,10 +37,17 @@ _FREE_FORM_OBJECT_ERROR = (
 
 
 class _NodeBudget:
-    """Tracks the remaining schema-node expansion budget across the recursion."""
+    """Carries per-conversion state: the node budget and the free-form definition registry.
+
+    Riding on this object rather than a separate parameter guarantees every recursive call
+    sees the same registry, since the budget must already reach every call for the DoS bound.
+    """
 
     def __init__(self, limit: int) -> None:
         self.remaining = limit
+        # Definitions that were free-form before the definition walk closed them, recorded by
+        # object identity so nested `$defs` need no path bookkeeping.
+        self.free_form_definition_ids: set[int] = set()
 
     def spend(self) -> None:
         self.remaining -= 1
@@ -127,7 +134,33 @@ def _shapes_contents_without_properties(json_schema: dict[str, object]) -> bool:
 
 def _allows_only_the_empty_object(json_schema: dict[str, object]) -> bool:
     """Whether the schema already forbids every key, so closing it changes nothing."""
-    return json_schema.get("maxProperties") == 0
+    if json_schema.get("maxProperties") == 0:
+        return True
+    if json_schema.get("const") == {}:
+        return True
+    enum = json_schema.get("enum")
+    return is_list(enum) and bool(enum) and all(entry == {} for entry in enum)
+
+
+def _siblings_supply_the_shape(siblings: dict[str, object]) -> bool:
+    """Whether the keys alongside a `$ref` to a free-form definition close or shape it."""
+    declared = siblings.get("properties")
+    if is_dict(declared) and declared:
+        return True
+    if "additionalProperties" in siblings:
+        return True
+    return _allows_only_the_empty_object(siblings)
+
+
+def _resolves_to_free_form_definition(
+    ref: str, *, root: dict[str, object], budget: _NodeBudget
+) -> bool:
+    try:
+        resolved = resolve_ref(root=root, ref=ref)
+    except Exception:
+        # Unresolvable refs keep their historical handling; they are not this check's concern.
+        return False
+    return id(resolved) in budget.free_form_definition_ids
 
 
 def _ensure_strict_json_schema(
@@ -137,7 +170,6 @@ def _ensure_strict_json_schema(
     root: dict[str, object],
     budget: _NodeBudget | None = None,
     in_definitions: bool = False,
-    free_form_refs: set[str] | None = None,
 ) -> dict[str, Any]:
     if not is_dict(json_schema):
         raise TypeError(f"Expected {json_schema} to be a dictionary; path={path}")
@@ -146,17 +178,15 @@ def _ensure_strict_json_schema(
     # exponentially and exhaust CPU and memory.
     if budget is None:
         budget = _NodeBudget(_MAX_SCHEMA_NODES)
-    if free_form_refs is None:
-        free_form_refs = set()
     budget.spend()
 
     defs = json_schema.get("$defs")
     if is_dict(defs):
         for def_name, def_schema in defs.items():
             if is_dict(def_schema) and _is_unclosable_object(def_schema):
-                # Remember it before the walk below closes it, so a bare `$ref` that points
-                # here can be rejected rather than silently narrowed to the empty object.
-                free_form_refs.add(f"#/$defs/{def_name}")
+                # Remember it before the walk below closes it, so a `$ref` that points here
+                # can be handled rather than silently narrowed to the empty object.
+                budget.free_form_definition_ids.add(id(def_schema))
             _ensure_strict_json_schema(
                 def_schema,
                 path=(*path, "$defs", def_name),
@@ -169,9 +199,9 @@ def _ensure_strict_json_schema(
     if is_dict(definitions):
         for definition_name, definition_schema in definitions.items():
             if is_dict(definition_schema) and _is_unclosable_object(definition_schema):
-                # Remember it before the walk below closes it, so a bare `$ref` that points
-                # here can be rejected rather than silently narrowed to the empty object.
-                free_form_refs.add(f"#/definitions/{definition_name}")
+                # Remember it before the walk below closes it, so a `$ref` that points here
+                # can be handled rather than silently narrowed to the empty object.
+                budget.free_form_definition_ids.add(id(definition_schema))
             _ensure_strict_json_schema(
                 definition_schema,
                 path=(*path, "definitions", definition_name),
@@ -208,7 +238,6 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 in_definitions=in_definitions,
-                free_form_refs=free_form_refs,
             )
             for key, prop_schema in properties.items()
         }
@@ -223,7 +252,6 @@ def _ensure_strict_json_schema(
             root=root,
             budget=budget,
             in_definitions=in_definitions,
-            free_form_refs=free_form_refs,
         )
 
     # unions
@@ -236,7 +264,6 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 in_definitions=in_definitions,
-                free_form_refs=free_form_refs,
             )
             for i, variant in enumerate(any_of)
         ]
@@ -256,7 +283,6 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 in_definitions=in_definitions,
-                free_form_refs=free_form_refs,
             )
             for i, variant in enumerate(one_of)
         ]
@@ -283,7 +309,6 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 in_definitions=in_definitions,
-                free_form_refs=free_form_refs,
             )
         else:
             json_schema["allOf"] = [
@@ -309,10 +334,11 @@ def _ensure_strict_json_schema(
     # so we unravel the ref
     # `{"type": "string", "description": "my description"}`
     ref = json_schema.get("$ref")
-    if isinstance(ref, str) and ref in free_form_refs and not has_more_than_n_keys(json_schema, 1):
-        # A bare `$ref` is never inlined, so the strict schema would keep pointing at a
-        # definition that has since been closed into the empty object.
-        raise UserError(_FREE_FORM_OBJECT_ERROR)
+    if isinstance(ref, str) and not has_more_than_n_keys(json_schema, 1):
+        if _resolves_to_free_form_definition(ref, root=root, budget=budget):
+            # A bare `$ref` is never inlined, so the strict schema would keep pointing at a
+            # definition that the walk above has since closed into the empty object.
+            raise UserError(_FREE_FORM_OBJECT_ERROR)
     if ref and has_more_than_n_keys(json_schema, 1):
         assert isinstance(ref, str), f"Received non-string $ref - {ref}"
 
@@ -326,6 +352,14 @@ def _ensure_strict_json_schema(
         # (chained refs), we preserve it for the recursive expansion below instead of
         # silently dropping it.
         json_schema.pop("$ref")
+        if id(resolved) in budget.free_form_definition_ids and not _siblings_supply_the_shape(
+            json_schema
+        ):
+            # The definition was free-form, so the keys alongside the `$ref` must supply the
+            # shape. An empty `properties` map or a bare annotation does not, and the merged
+            # result would inherit the `additionalProperties: false` the walk added and be
+            # silently narrowed to the empty object.
+            raise UserError(_FREE_FORM_OBJECT_ERROR)
         # properties from the json schema take priority over the ones on the `$ref`
         json_schema.update({**resolved, **json_schema})
         # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied
@@ -336,7 +370,6 @@ def _ensure_strict_json_schema(
             root=root,
             budget=budget,
             in_definitions=in_definitions,
-            free_form_refs=free_form_refs,
         )
 
     # Decide whether this object can be closed only once the normalizations above have run, so

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -2395,3 +2395,40 @@ async def test_composed_and_enum_object_args_keep_their_non_strict_meaning(wrapp
     assert function_tool.strict_json_schema is False
     # Served exactly as the server described it, so the branches still match.
     assert function_tool.params_json_schema["properties"]["field"] == wrapper
+
+
+@pytest.mark.asyncio
+async def test_already_closed_root_keeps_the_openai_properties_shape():
+    """A server-closed root must still be served with the `properties` key OpenAI expects."""
+    server = FakeMCPServer()
+    tool = MCPTool(name="closed", inputSchema={"type": "object", "additionalProperties": False})
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema["properties"] == {}
+    assert function_tool.params_json_schema["required"] == []
+    assert function_tool.params_json_schema["additionalProperties"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "input_schema",
+    [{"description": "Test tool"}, {}],
+    ids=["annotation-only", "empty"],
+)
+async def test_typeless_root_keeps_its_no_argument_treatment(input_schema):
+    """Only a declared object root is exposed as free-form.
+
+    A schema that never states its type is left on the historical no-argument path rather than
+    having its meaning changed here, and it must not be served as a strict non-object schema.
+    """
+    server = FakeMCPServer()
+    tool = MCPTool(name="t", inputSchema=input_schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema["type"] == "object"
+    assert function_tool.params_json_schema["properties"] == {}
+    assert function_tool.params_json_schema["additionalProperties"] is False

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -2338,6 +2338,60 @@ async def test_fully_specified_object_args_still_convert_to_strict():
     function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
 
     assert function_tool.strict_json_schema is True
-    assert (
-        function_tool.params_json_schema["properties"]["options"]["additionalProperties"] is False
+    options = function_tool.params_json_schema["properties"]["options"]
+    assert options["additionalProperties"] is False
+
+
+@pytest.mark.asyncio
+async def test_free_form_root_schema_falls_back_to_non_strict():
+    """A root that declares no properties is free-form, not a no-argument tool.
+
+    `to_function_tool` adds a synthetic `properties: {}` because the OpenAI spec wants one.
+    That accommodation must not be read back as the server saying the tool takes no arguments,
+    which would close a free-form root into "call me with no arguments".
+    """
+    server = FakeMCPServer()
+    tool = MCPTool(name="passthrough", inputSchema={"type": "object"})
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert "additionalProperties" not in function_tool.params_json_schema
+
+
+@pytest.mark.asyncio
+async def test_declared_empty_properties_root_still_converts_to_strict():
+    """A server that explicitly declares `properties: {}` does mean "no arguments"."""
+    server = FakeMCPServer()
+    tool = MCPTool(name="ping", inputSchema={"type": "object", "properties": {}})
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema["additionalProperties"] is False
+    assert function_tool.params_json_schema["required"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        {"type": "object", "anyOf": [{"properties": {"a": {"type": "string"}}}]},
+        {"type": "object", "enum": [{"a": 1}]},
+        {"type": "object", "const": {"a": 1}},
+    ],
+    ids=["composed-wrapper", "object-enum", "object-const"],
+)
+async def test_composed_and_enum_object_args_keep_their_non_strict_meaning(wrapper):
+    """Wrappers that describe contents elsewhere must be served unchanged, not closed."""
+    server = FakeMCPServer()
+    tool = MCPTool(
+        name="set_properties",
+        inputSchema={"type": "object", "properties": {"field": wrapper}},
     )
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    # Served exactly as the server described it, so the branches still match.
+    assert function_tool.params_json_schema["properties"]["field"] == wrapper

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -2287,3 +2287,57 @@ def test_to_function_tool_description_falls_back_to_mcp_title():
 
     assert function_tool.description == "Search Docs"
     assert function_tool._mcp_title == "Search Docs"
+
+
+@pytest.mark.asyncio
+async def test_free_form_object_arg_falls_back_to_non_strict_schema():
+    """A free-form object arg must stay usable rather than becoming "empty object only".
+
+    Strict conversion cannot express `{"type": "object"}` with no properties. Forcing
+    `additionalProperties: false` onto it would leave the model able to send only `{}`, so the
+    tool silently loses the ability to carry any data. Conversion must fail and the server must
+    fall back to the original schema.
+    """
+    server = FakeMCPServer()
+    tool = MCPTool(
+        name="set_properties",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "target": {"type": "string"},
+                "keys_and_values": {"type": "object", "description": "key/value pairs"},
+            },
+            "required": ["target", "keys_and_values"],
+        },
+    )
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    keys_and_values = function_tool.params_json_schema["properties"]["keys_and_values"]
+    # The free-form object is served as-is, so arbitrary keys remain valid.
+    assert "additionalProperties" not in keys_and_values
+
+
+@pytest.mark.asyncio
+async def test_fully_specified_object_args_still_convert_to_strict():
+    """The fallback above must not stop ordinary schemas from becoming strict."""
+    server = FakeMCPServer()
+    tool = MCPTool(
+        name="set_properties",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "target": {"type": "string"},
+                "options": {"type": "object", "properties": {"visible": {"type": "boolean"}}},
+            },
+            "required": ["target", "options"],
+        },
+    )
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert (
+        function_tool.params_json_schema["properties"]["options"]["additionalProperties"] is False
+    )

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -2478,3 +2478,22 @@ async def test_typeless_but_closed_root_is_normalized_to_a_strict_envelope():
     assert function_tool.params_json_schema["type"] == "object"
     assert function_tool.params_json_schema["properties"] == {}
     assert function_tool.params_json_schema["additionalProperties"] is False
+
+
+@pytest.mark.asyncio
+async def test_closed_root_with_undeclared_required_falls_back():
+    """Restoring the properties shim must not manufacture an unsatisfiable strict schema.
+
+    The root is closed but requires a key it never declares. Serving it strict would forbid
+    the very key it requires, so the original is served non-strict instead.
+    """
+    server = FakeMCPServer()
+    tool = MCPTool(
+        name="t",
+        inputSchema={"type": "object", "additionalProperties": False, "required": ["a"]},
+    )
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema["required"] == ["a"]

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -2412,19 +2412,10 @@ async def test_already_closed_root_keeps_the_openai_properties_shape():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "input_schema",
-    [{"description": "Test tool"}, {}],
-    ids=["annotation-only", "empty"],
-)
-async def test_typeless_root_keeps_its_no_argument_treatment(input_schema):
-    """Only a declared object root is exposed as free-form.
-
-    A schema that never states its type is left on the historical no-argument path rather than
-    having its meaning changed here, and it must not be served as a strict non-object schema.
-    """
+async def test_empty_root_schema_still_converts_to_a_no_argument_tool():
+    """An entirely empty schema keeps its long-standing no-argument treatment."""
     server = FakeMCPServer()
-    tool = MCPTool(name="t", inputSchema=input_schema)
+    tool = MCPTool(name="t", inputSchema={})
 
     function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
 
@@ -2432,3 +2423,44 @@ async def test_typeless_root_keeps_its_no_argument_treatment(input_schema):
     assert function_tool.params_json_schema["type"] == "object"
     assert function_tool.params_json_schema["properties"] == {}
     assert function_tool.params_json_schema["additionalProperties"] is False
+
+
+@pytest.mark.asyncio
+async def test_annotation_only_root_falls_back_instead_of_faking_an_envelope():
+    """A schema that never declares an object cannot be served as a strict object.
+
+    Without the synthetic `properties`, conversion produces something that is not a closed
+    object envelope. Serving that as strict would hand the provider a schema it cannot use, so
+    the original is served non-strict instead.
+    """
+    server = FakeMCPServer()
+    tool = MCPTool(name="t", inputSchema={"description": "Test tool"})
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema["description"] == "Test tool"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "input_schema",
+    [
+        {"allOf": [{"type": "object"}]},
+        {"allOf": [{"type": "object", "enum": [{"a": 1}]}]},
+    ],
+    ids=["composed-free-form-root", "composed-enum-root"],
+)
+async def test_composed_root_without_a_declared_type_falls_back(input_schema):
+    """The synthetic `properties: {}` must not close a root reached through composition.
+
+    These declare no top-level `type`, so the shim would otherwise look like the server saying
+    the tool takes no arguments, and the composed meaning would be lost.
+    """
+    server = FakeMCPServer()
+    tool = MCPTool(name="t", inputSchema=input_schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema["allOf"] == input_schema["allOf"]

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -2464,3 +2464,17 @@ async def test_composed_root_without_a_declared_type_falls_back(input_schema):
 
     assert function_tool.strict_json_schema is False
     assert function_tool.params_json_schema["allOf"] == input_schema["allOf"]
+
+
+@pytest.mark.asyncio
+async def test_typeless_but_closed_root_is_normalized_to_a_strict_envelope():
+    """A root that is already closed describes an object even without declaring `type`."""
+    server = FakeMCPServer()
+    tool = MCPTool(name="t", inputSchema={"additionalProperties": False})
+
+    function_tool = MCPUtil.to_function_tool(tool, server, convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema["type"] == "object"
+    assert function_tool.params_json_schema["properties"] == {}
+    assert function_tool.params_json_schema["additionalProperties"] is False

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -362,3 +362,67 @@ def test_ref_expansion_bomb_is_rejected():
     }
     with pytest.raises(UserError):
         ensure_strict_json_schema(schema)
+
+
+def test_free_form_object_property_is_rejected_instead_of_silently_emptied():
+    # A property declared only as `{"type": "object"}` accepts arbitrary keys. Defaulting it to
+    # `additionalProperties: false` would narrow it to "the empty object is the only valid
+    # value", so the model could never send any content for it.
+    schema = {
+        "type": "object",
+        "properties": {
+            "target": {"type": "string"},
+            "keysAndValues": {"type": "object", "description": "key/value pairs"},
+        },
+    }
+
+    with pytest.raises(UserError, match="free-form object"):
+        ensure_strict_json_schema(schema)
+
+
+def test_free_form_object_root_is_rejected():
+    with pytest.raises(UserError, match="free-form object"):
+        ensure_strict_json_schema({"type": "object"})
+
+
+def test_object_with_empty_properties_stays_strict():
+    # A tool that takes no arguments is not free-form: it declares that it has no properties.
+    result = ensure_strict_json_schema({"type": "object", "properties": {}})
+
+    assert result == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+    }
+
+
+def test_explicit_additional_properties_false_object_is_preserved():
+    # An explicit `additionalProperties: false` is the caller stating the empty object really is
+    # the only valid value, so it must keep working.
+    result = ensure_strict_json_schema(
+        {
+            "type": "object",
+            "properties": {"a": {"type": "object", "additionalProperties": False}},
+        }
+    )
+
+    assert result["properties"]["a"] == {"type": "object", "additionalProperties": False}
+
+
+@pytest.mark.parametrize(
+    "shaped",
+    [
+        {"type": "object", "allOf": [{"properties": {"a": {"type": "string"}}}]},
+        {"type": "object", "anyOf": [{"properties": {"a": {"type": "string"}}}]},
+        {"type": "object", "patternProperties": {"^x": {"type": "string"}}},
+        {"type": "object", "enum": [{"a": 1}]},
+    ],
+    ids=["allOf", "anyOf", "patternProperties", "enum"],
+)
+def test_object_shaped_by_other_keywords_is_not_treated_as_free_form(shaped):
+    # These constrain the object without using `properties`, so they are not free-form and must
+    # still convert rather than raise.
+    result = ensure_strict_json_schema({"type": "object", "properties": {"a": shaped}})
+
+    assert result["properties"]["a"]["additionalProperties"] is False

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -785,3 +785,84 @@ def test_alias_to_a_shaped_target_converts_in_either_order():
     )
 
     assert result["$defs"]["Inner"]["additionalProperties"] is False
+
+
+@pytest.mark.parametrize(
+    "literal_keyword",
+    [
+        {"const": {"type": "object"}},
+        {"enum": [{"type": "object"}]},
+        {"default": {"type": "object"}},
+    ],
+    ids=["const", "enum", "default"],
+)
+def test_literal_values_inside_definitions_are_not_mistaken_for_schemas(literal_keyword):
+    # `{"type": "object"}` here is a data value, not a schema node, so it must not taint the
+    # definition that contains it.
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {
+                "D": {
+                    # `tag` is a bare literal node: no type, no properties, just the value.
+                    "type": "object",
+                    "properties": {"tag": literal_keyword},
+                }
+            },
+            "type": "object",
+            "properties": {"f": {"$ref": "#/$defs/D"}},
+        }
+    )
+
+    assert result["$defs"]["D"]["additionalProperties"] is False
+
+
+def test_required_supplied_by_a_single_allof_branch_still_converts():
+    # The merge lands the branch's properties on this node and re-enters, so the
+    # required-subset judgment has to wait for the merged shape.
+    result = ensure_strict_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "f": {
+                    "type": "object",
+                    "properties": {},
+                    "required": ["a"],
+                    "allOf": [{"properties": {"a": {"type": "string"}}}],
+                }
+            },
+        }
+    )
+
+    field = result["properties"]["f"]
+    assert field["required"] == ["a"]
+    assert field["properties"] == {"a": {"type": "string"}}
+
+
+def test_required_not_supplied_by_the_branch_is_still_rejected():
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "f": {
+                        "type": "object",
+                        "properties": {},
+                        "required": ["a"],
+                        "allOf": [{"properties": {"b": {"type": "string"}}}],
+                    }
+                },
+            }
+        )
+
+
+def test_typeless_definition_with_shaping_keywords_is_registered():
+    # The conversion walk normalizes typeless-with-properties to an object, so the
+    # precomputed registries must classify it the same way.
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            {
+                "$defs": {"Base": {"properties": {}, "propertyNames": {"pattern": "^x"}}},
+                "type": "object",
+                "properties": {"f": {"$ref": "#/$defs/Base"}},
+            }
+        )

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -866,3 +866,56 @@ def test_typeless_definition_with_shaping_keywords_is_registered():
                 "properties": {"f": {"$ref": "#/$defs/Base"}},
             }
         )
+
+
+def test_allof_shaped_definition_is_classified_after_normalization():
+    # The converter merges a single-entry allOf onto the definition, so classifying the raw
+    # shape would call a strictable definition free-form.
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {
+                "Base": {"type": "object", "allOf": [{"properties": {"a": {"type": "string"}}}]}
+            },
+            "type": "object",
+            "properties": {"f": {"$ref": "#/$defs/Base"}},
+        }
+    )
+
+    base = result["$defs"]["Base"]
+    assert base["properties"] == {"a": {"type": "string"}}
+    assert base["additionalProperties"] is False
+
+
+def test_ref_shaped_definition_is_classified_after_normalization():
+    # Same for a definition whose properties arrive through a `$ref` sibling.
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {
+                "Base": {"type": "object", "$ref": "#/$defs/S", "description": "d"},
+                "S": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+            "type": "object",
+            "properties": {"f": {"$ref": "#/$defs/Base"}},
+        }
+    )
+
+    assert result["$defs"]["Base"]["properties"] == {"a": {"type": "string"}}
+
+
+def test_singular_example_annotation_is_not_read_as_a_schema():
+    # OpenAPI's singular `example` has no validation effect, so an object literal under it
+    # must not be mistaken for a nested free-form schema.
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {
+                "D": {
+                    "type": "object",
+                    "properties": {"tag": {"type": "string", "example": {"type": "object"}}},
+                }
+            },
+            "type": "object",
+            "properties": {"f": {"$ref": "#/$defs/D"}},
+        }
+    )
+
+    assert result["$defs"]["D"]["additionalProperties"] is False

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -490,3 +490,62 @@ def test_redundant_single_entry_allof_branch_does_not_block_conversion():
     assert result["required"] == ["a"]
     assert result["additionalProperties"] is False
     assert "allOf" not in result
+
+
+def test_broad_definition_narrowed_at_the_ref_site_still_converts():
+    # The definition is free-form on its own, but the `$ref` site supplies the shape. Judging
+    # the definition in isolation would reject a schema that is strictable once inlined.
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {"Base": {"type": "object"}},
+            "type": "object",
+            "properties": {"f": {"$ref": "#/$defs/Base", "properties": {"a": {"type": "string"}}}},
+        }
+    )
+
+    field = result["properties"]["f"]
+    assert field["properties"] == {"a": {"type": "string"}}
+    assert field["required"] == ["a"]
+    assert field["additionalProperties"] is False
+
+
+def test_unreferenced_free_form_definition_does_not_block_conversion():
+    # An unused definition has no validation effect, so it must not abort the conversion.
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {"Unused": {"type": "object"}},
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+        }
+    )
+
+    assert result["properties"] == {"a": {"type": "string"}}
+    assert result["additionalProperties"] is False
+
+
+def test_max_properties_zero_object_is_closed_rather_than_rejected():
+    # This already forbids every key, so closing it preserves the meaning exactly.
+    result = ensure_strict_json_schema(
+        {"type": "object", "properties": {"f": {"type": "object", "maxProperties": 0}}}
+    )
+
+    assert result["properties"]["f"]["additionalProperties"] is False
+    assert result["properties"]["f"]["maxProperties"] == 0
+
+
+@pytest.mark.parametrize(
+    "keyword_schema",
+    [
+        {"propertyNames": {"pattern": "^x"}},
+        {"patternProperties": {"^x": {"type": "string"}}},
+        {"enum": [{"a": 1}]},
+    ],
+    ids=["propertyNames", "patternProperties", "enum"],
+)
+def test_empty_properties_map_beside_a_shaping_keyword_is_not_closed(keyword_schema):
+    # An empty `properties` map next to a keyword that describes the contents another way is
+    # not a declaration that the object is empty, so closing it would reject valid values.
+    field = {"type": "object", "properties": {}, **keyword_schema}
+
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema({"type": "object", "properties": {"f": field}})

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -653,3 +653,86 @@ def test_empty_object_literals_are_closed_rather_than_rejected(literal):
     )
 
     assert result["properties"]["f"]["additionalProperties"] is False
+
+
+def test_free_form_field_inside_a_referenced_definition_taints_the_reference():
+    # A sibling merge at the `$ref` site only reshapes the top level, so a free-form node
+    # inside the referenced subtree can never be salvaged, with or without siblings.
+    def fresh_schema(ref_site: dict[str, object]) -> dict[str, object]:
+        # Conversion mutates in place, so each call needs its own copy of the definition.
+        return {
+            "$defs": {"M": {"type": "object", "properties": {"x": {"type": "object"}}}},
+            "type": "object",
+            "properties": {"f": ref_site},
+        }
+
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(fresh_schema({"$ref": "#/$defs/M"}))
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            fresh_schema({"$ref": "#/$defs/M", "properties": {"y": {"type": "string"}}})
+        )
+
+
+def test_unreferenced_definition_with_a_free_form_field_stays_harmless():
+    # The taint only matters when something references the definition.
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {"M": {"type": "object", "properties": {"x": {"type": "object"}}}},
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+        }
+    )
+
+    assert result["properties"] == {"a": {"type": "string"}}
+
+
+def test_alias_definition_chains_are_followed_to_their_target():
+    # `$defs.Outer` is just a `$ref` to `Inner`, so a reference to `Outer` must be judged by
+    # what `Inner` is.
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            {
+                "$defs": {"Outer": {"$ref": "#/$defs/Inner"}, "Inner": {"type": "object"}},
+                "type": "object",
+                "properties": {"f": {"$ref": "#/$defs/Outer"}},
+            }
+        )
+
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {
+                "Outer": {"$ref": "#/$defs/Inner"},
+                "Inner": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+            "type": "object",
+            "properties": {"f": {"$ref": "#/$defs/Outer"}},
+        }
+    )
+    assert result["$defs"]["Inner"]["additionalProperties"] is False
+
+
+def test_required_names_outside_declared_properties_are_rejected():
+    # Strict mode needs `required` to be a subset of `properties`; conversion would otherwise
+    # silently drop the requirement and forbid the key it referred to.
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {"f": {"type": "object", "properties": {}, "required": ["a"]}},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "dependency_keyword",
+    [{"dependentRequired": {"a": ["b"]}}, {"dependencies": {"a": ["b"]}}],
+    ids=["dependentRequired", "draft-07-dependencies"],
+)
+def test_dependency_keywords_keep_an_empty_properties_object_open(dependency_keyword):
+    # Dependencies only fire when keys are present, so the object still accepts keys and an
+    # empty `properties` map is not a declaration that it is empty.
+    field = {"type": "object", "properties": {}, **dependency_keyword}
+
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema({"type": "object", "properties": {"f": field}})

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -572,3 +572,84 @@ def test_bounded_object_with_empty_properties_is_not_closed(bound):
 
     with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
         ensure_strict_json_schema({"type": "object", "properties": {"f": field}})
+
+
+def test_allof_branch_with_a_bare_ref_to_a_free_form_definition_is_rejected():
+    # The branch is converted on its own, so the tracked definitions must be visible there
+    # too; otherwise the closed definition silently rejects keys the intersection accepted.
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            {
+                "$defs": {"Base": {"type": "object"}},
+                "type": "object",
+                "properties": {
+                    "f": {
+                        "type": "object",
+                        "properties": {"a": {"type": "string"}},
+                        "allOf": [
+                            {"$ref": "#/$defs/Base"},
+                            {"properties": {"b": {"type": "string"}}},
+                        ],
+                    }
+                },
+            }
+        )
+
+
+def test_bare_ref_to_a_nested_free_form_definition_is_rejected():
+    # Identity-based tracking needs no path bookkeeping, so nesting must make no difference.
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            {
+                "$defs": {
+                    "Outer": {
+                        "$defs": {"Inner": {"type": "object"}},
+                        "type": "object",
+                        "properties": {"x": {"type": "string"}},
+                    }
+                },
+                "type": "object",
+                "properties": {"f": {"$ref": "#/$defs/Outer/$defs/Inner"}},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "siblings, expected",
+    [
+        ({"properties": {}}, "rejected"),
+        ({"description": "d"}, "rejected"),
+        ({"properties": {"a": {"type": "string"}}}, "converted"),
+    ],
+    ids=["empty-properties", "annotation-only", "real-properties"],
+)
+def test_ref_to_a_free_form_definition_requires_siblings_that_supply_the_shape(siblings, expected):
+    # The merged result inherits the close the definition walk added, so the final decision
+    # cannot catch this; the merge site has to judge whether the siblings shape the object.
+    schema = {
+        "$defs": {"Base": {"type": "object"}},
+        "type": "object",
+        "properties": {"f": {"$ref": "#/$defs/Base", **siblings}},
+    }
+
+    if expected == "rejected":
+        with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+            ensure_strict_json_schema(schema)
+    else:
+        result = ensure_strict_json_schema(schema)
+        assert result["properties"]["f"]["required"] == ["a"]
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [{"properties": {}, "const": {}}, {"enum": [{}]}],
+    ids=["const-empty", "enum-empty"],
+)
+def test_empty_object_literals_are_closed_rather_than_rejected(literal):
+    # These already constrain the value to the empty object, so closing preserves meaning
+    # exactly, like maxProperties: 0.
+    result = ensure_strict_json_schema(
+        {"type": "object", "properties": {"f": {"type": "object", **literal}}}
+    )
+
+    assert result["properties"]["f"]["additionalProperties"] is False

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -549,3 +549,26 @@ def test_empty_properties_map_beside_a_shaping_keyword_is_not_closed(keyword_sch
 
     with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
         ensure_strict_json_schema({"type": "object", "properties": {"f": field}})
+
+
+def test_bare_ref_to_a_free_form_definition_is_rejected():
+    # A bare `$ref` is never inlined, so closing the definition would leave the strict schema
+    # pointing at an object that now accepts only `{}`.
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            {
+                "$defs": {"Base": {"type": "object"}},
+                "type": "object",
+                "properties": {"f": {"$ref": "#/$defs/Base"}},
+            }
+        )
+
+
+@pytest.mark.parametrize("bound", [{"maxProperties": 1}, {"minProperties": 1}], ids=["max", "min"])
+def test_bounded_object_with_empty_properties_is_not_closed(bound):
+    # A bound on the number of keys says arbitrary keys are expected, so an empty `properties`
+    # map is not a declaration that the object is empty.
+    field = {"type": "object", "properties": {}, **bound}
+
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema({"type": "object", "properties": {"f": field}})

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -736,3 +736,52 @@ def test_dependency_keywords_keep_an_empty_properties_object_open(dependency_key
 
     with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
         ensure_strict_json_schema({"type": "object", "properties": {"f": field}})
+
+
+def test_alias_declared_before_its_free_form_target_is_still_caught():
+    # The registries are precomputed from the untouched tree, so declaration order between an
+    # alias and its target cannot matter. Populating them during the walk missed this: the
+    # alias was inlined and closed before its target was ever recorded.
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema(
+            {
+                "$defs": {
+                    "Outer": {"$ref": "#/$defs/Inner", "description": "d"},
+                    "Inner": {"type": "object"},
+                },
+                "type": "object",
+                "properties": {"f": {"$ref": "#/$defs/Outer"}},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "defs",
+    [
+        {"Outer": {"$ref": "#/$defs/Inner", "description": "d"}, "Inner": {"type": "object"}},
+        {"Inner": {"type": "object"}, "Outer": {"$ref": "#/$defs/Inner"}},
+    ],
+    ids=["annotated-alias-first", "bare-alias-last"],
+)
+def test_unreferenced_aliases_to_free_form_targets_stay_harmless(defs):
+    # A template is only a problem once something references it, in either declaration order.
+    result = ensure_strict_json_schema(
+        {"$defs": defs, "type": "object", "properties": {"a": {"type": "string"}}}
+    )
+
+    assert result["properties"] == {"a": {"type": "string"}}
+
+
+def test_alias_to_a_shaped_target_converts_in_either_order():
+    result = ensure_strict_json_schema(
+        {
+            "$defs": {
+                "Outer": {"$ref": "#/$defs/Inner", "description": "d"},
+                "Inner": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+            "type": "object",
+            "properties": {"f": {"$ref": "#/$defs/Outer"}},
+        }
+    )
+
+    assert result["$defs"]["Inner"]["additionalProperties"] is False

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -376,12 +376,12 @@ def test_free_form_object_property_is_rejected_instead_of_silently_emptied():
         },
     }
 
-    with pytest.raises(UserError, match="free-form object"):
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
         ensure_strict_json_schema(schema)
 
 
 def test_free_form_object_root_is_rejected():
-    with pytest.raises(UserError, match="free-form object"):
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
         ensure_strict_json_schema({"type": "object"})
 
 
@@ -411,18 +411,65 @@ def test_explicit_additional_properties_false_object_is_preserved():
 
 
 @pytest.mark.parametrize(
-    "shaped",
+    "wrapper, accepted_by_original",
     [
-        {"type": "object", "allOf": [{"properties": {"a": {"type": "string"}}}]},
-        {"type": "object", "anyOf": [{"properties": {"a": {"type": "string"}}}]},
-        {"type": "object", "patternProperties": {"^x": {"type": "string"}}},
-        {"type": "object", "enum": [{"a": 1}]},
+        ({"type": "object", "anyOf": [{"properties": {"a": {"type": "string"}}}]}, {"a": "x"}),
+        (
+            {
+                "type": "object",
+                "allOf": [
+                    {"properties": {"a": {"type": "string"}}},
+                    {"properties": {"b": {"type": "string"}}},
+                ],
+            },
+            {"a": "x", "b": "y"},
+        ),
+        ({"type": "object", "enum": [{"a": 1}]}, {"a": 1}),
+        ({"type": "object", "const": {"a": 1}}, {"a": 1}),
+        ({"type": "object", "patternProperties": {"^x": {"type": "string"}}}, {"xy": "v"}),
+        ({"type": "object", "propertyNames": {"pattern": "^x"}}, {"xy": "v"}),
     ],
-    ids=["allOf", "anyOf", "patternProperties", "enum"],
+    ids=["anyOf", "multi-allOf", "enum", "const", "patternProperties", "propertyNames"],
 )
-def test_object_shaped_by_other_keywords_is_not_treated_as_free_form(shaped):
-    # These constrain the object without using `properties`, so they are not free-form and must
-    # still convert rather than raise.
-    result = ensure_strict_json_schema({"type": "object", "properties": {"a": shaped}})
+def test_composed_object_wrappers_are_not_closed(wrapper, accepted_by_original):
+    # These describe their contents somewhere other than a `properties` map at this level.
+    # Closing the wrapper with `additionalProperties: false` would reject the very values the
+    # branches describe, so conversion must fail and let the caller stay non-strict.
+    del accepted_by_original  # documents why closing the wrapper is wrong
 
-    assert result["properties"]["a"]["additionalProperties"] is False
+    with pytest.raises(UserError, match="Strict JSON schemas cannot express"):
+        ensure_strict_json_schema({"type": "object", "properties": {"f": wrapper}})
+
+
+def test_single_entry_allof_is_normalized_before_the_check():
+    # A single-entry `allOf` is merged into its parent, which lifts `properties` to this level,
+    # so it must still convert rather than be treated as unclosable.
+    result = ensure_strict_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "f": {"type": "object", "allOf": [{"properties": {"a": {"type": "string"}}}]}
+            },
+        }
+    )
+
+    field = result["properties"]["f"]
+    assert field["properties"] == {"a": {"type": "string"}}
+    assert field["additionalProperties"] is False
+    assert field["required"] == ["a"]
+
+
+def test_ref_to_an_object_is_normalized_before_the_check():
+    # `$ref` unravelling also lifts `properties` up, so a referenced object still converts.
+    result = ensure_strict_json_schema(
+        {
+            "type": "object",
+            "$defs": {"S": {"type": "object", "properties": {"a": {"type": "string"}}}},
+            "properties": {"f": {"$ref": "#/$defs/S", "description": "d"}},
+        }
+    )
+
+    field = result["properties"]["f"]
+    assert field["description"] == "d"
+    assert field["additionalProperties"] is False
+    assert field["required"] == ["a"]

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -473,3 +473,20 @@ def test_ref_to_an_object_is_normalized_before_the_check():
     assert field["description"] == "d"
     assert field["additionalProperties"] is False
     assert field["required"] == ["a"]
+
+
+def test_redundant_single_entry_allof_branch_does_not_block_conversion():
+    # The parent already declares the properties; the branch adds nothing on its own. Judging
+    # that branch in isolation would call it free-form and reject an otherwise strictable object.
+    result = ensure_strict_json_schema(
+        {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "allOf": [{"type": "object"}],
+        }
+    )
+
+    assert result["properties"] == {"a": {"type": "string"}}
+    assert result["required"] == ["a"]
+    assert result["additionalProperties"] is False
+    assert "allOf" not in result


### PR DESCRIPTION
### Summary

An object schema that declares no `properties` and no `additionalProperties` accepts arbitrary keys. Strict conversion defaulted it to `additionalProperties: false`, which narrows it to "the empty object is the only valid value". The tool is then handed to the model as strict, with a parameter that can never carry any content, and nothing reports a problem.

```python
{"type": "object", "properties": {
    "target":        {"type": "string"},
    "keysAndValues": {"type": "object", "description": "key/value pairs"}}}
```

`keysAndValues` comes out of `ensure_strict_json_schema` as:

```python
{"type": "object", "description": "key/value pairs", "additionalProperties": False}
```

Validating candidate values against that:

| value | result |
| --- | --- |
| `{}` | accepted |
| `{"visible": false}` | rejected, `Additional properties are not allowed` |
| `{"a": 1, "b": "x"}` | rejected |

The parameter is required, and the only value it can hold is `{}`.

### Why this is inconsistent rather than just a strict-mode limitation

The same intent is already handled correctly when it arrives spelled differently. A Python tool annotated `dict[str, Any]` makes Pydantic emit `additionalProperties: true`, and that path raises `UserError` today:

```
UserError: additionalProperties should not be set for object types...
```

Only schemas that arrive *without* the keyword were silently narrowed. That is the common shape from MCP servers and hand-written schemas, so the loud path covers the case users are least likely to hit and the silent path covers the case they are most likely to hit.

### Fix

Treat a free-form object the same way as an explicit `additionalProperties: true` and raise `UserError`.

That choice is what makes this a real fix rather than a different error. MCP tool conversion already falls back to serving the original schema as non-strict when strict conversion raises:

```python
try:
    schema = ensure_strict_json_schema(copy.deepcopy(schema))
    is_strict = True
except Exception as e:
    logger.info("Error converting MCP schema to strict mode: %s", e)
```

So affected MCP tools go back to accepting arbitrary keys:

| | `strict_json_schema` | `{}` | `{"visible": false}` |
| --- | --- | --- | --- |
| before | `True` | accepted | **rejected** |
| after | `False` | accepted | accepted |

Function tools and output types now get an actionable error instead of a tool that silently cannot receive data.

An object counts as free-form only when it carries none of the keywords that constrain its contents, so these are unaffected:

- `properties: {}`, a no-argument tool, still converts to a strict empty object
- an explicit `additionalProperties: false` is preserved, since that is the caller stating the empty object really is the only valid value
- objects shaped by `$ref`, `allOf`, `anyOf`, `oneOf`, `patternProperties`, `propertyNames`, `enum`, `const` and friends still convert normally

### Issue number

Matches the symptom in #1681, where nested object arguments came back flattened. That report concluded the model was ignoring a correct schema. The schema the model received actually required that parameter to be empty, so there was no way to express the nested value.

### Test plan

Three tests fail without the source change and pass with it:

- `test_free_form_object_property_is_rejected_instead_of_silently_emptied`
- `test_free_form_object_root_is_rejected`
- `test_free_form_object_arg_falls_back_to_non_strict_schema`, which asserts the user-visible outcome, that the MCP tool is served non-strict and keeps accepting arbitrary keys

Seven more pin the cases that must keep working, and pass both with and without the change: empty `properties`, explicit `additionalProperties: false`, objects shaped by `allOf` / `anyOf` / `patternProperties` / `enum`, and ordinary nested objects still converting to strict.

| Command | Result |
| --- | --- |
| `make format` / `make lint` | clean, all checks passed |
| `make mypy` | 5 errors, all pre-existing on `main`, none in the touched files |
| `make pyright` | 0 errors on the touched files |
| `uv run pytest tests/test_strict_schema.py tests/mcp/` | 124 passed |
| `make tests` | 6131 passed |

The full suite was run on Windows, where a set of sandbox symlink and tracing timing tests fail regardless of this change. I diffed the failing set against `main` at the same commit: no new failures. The one test that differed between runs, `tests/test_tracing.py::test_simple_tracing`, fails 5 out of 5 times on unmodified `main` when run in isolation, so it is part of that pre-existing set rather than something this change introduced.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a bash script that shells out to `make`. I ran the underlying steps individually instead, with the results above.
