### PR TITLE
fix(sessions): apply the reasoning item id policy to stored session history

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -523,7 +523,16 @@ class AgentRunner:
         run_config = RunConfig() if run_config is None else _coerce_run_config(run_config)
 
         is_resumed_state = isinstance(input, RunState)
-        run_state: RunState[TContext] | None = None
+        run_state: RunState[TContext] | None = (
+            cast(RunState[TContext], input) if is_resumed_state else None
+        )
+        resolved_reasoning_item_id_policy: ReasoningItemIdPolicy | None = (
+            run_config.reasoning_item_id_policy
+            if run_config.reasoning_item_id_policy is not None
+            else (run_state._reasoning_item_id_policy if run_state is not None else None)
+        )
+        if run_state is not None:
+            run_state._reasoning_item_id_policy = resolved_reasoning_item_id_policy
         starting_input = input if not is_resumed_state else None
         original_user_input: str | list[TResponseInputItem] | None = None
         session_input_items_for_persistence: list[TResponseInputItem] | None = (
@@ -533,8 +542,7 @@ class AgentRunner:
         # exactly those items (and not the full history).
         last_saved_input_snapshot_for_rewind: list[TResponseInputItem] | None = None
 
-        if is_resumed_state:
-            run_state = cast(RunState[TContext], input)
+        if is_resumed_state and run_state is not None:
             (
                 conversation_id,
                 previous_response_id,
@@ -590,6 +598,7 @@ class AgentRunner:
                     run_config.session_settings,
                     include_history_in_prepared_input=False,
                     preserve_dropped_new_items=True,
+                    reasoning_item_id_policy=resolved_reasoning_item_id_policy,
                     wrapper=context_wrapper,
                 )
                 original_input_for_state = raw_input
@@ -603,17 +612,10 @@ class AgentRunner:
                     session,
                     run_config.session_input_callback,
                     run_config.session_settings,
+                    reasoning_item_id_policy=resolved_reasoning_item_id_policy,
                     wrapper=context_wrapper,
                 )
                 original_input_for_state = prepared_input
-
-        resolved_reasoning_item_id_policy: ReasoningItemIdPolicy | None = (
-            run_config.reasoning_item_id_policy
-            if run_config.reasoning_item_id_policy is not None
-            else (run_state._reasoning_item_id_policy if run_state is not None else None)
-        )
-        if run_state is not None:
-            run_state._reasoning_item_id_policy = resolved_reasoning_item_id_policy
 
         # Check whether to enable OpenAI server-managed conversation
         if (

--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -60,6 +60,7 @@ __all__ = [
     "REJECTION_MESSAGE",
     "TOOL_CALL_SESSION_DESCRIPTION_KEY",
     "TOOL_CALL_SESSION_TITLE_KEY",
+    "apply_reasoning_item_id_policy",
     "copy_input_items",
     "drop_orphan_function_calls",
     "ensure_input_item_format",
@@ -695,6 +696,16 @@ def strip_internal_input_item_metadata(item: TResponseInputItem) -> TResponseInp
     cleaned.pop(TOOL_CALL_SESSION_DESCRIPTION_KEY, None)
     cleaned.pop(TOOL_CALL_SESSION_TITLE_KEY, None)
     return cast(TResponseInputItem, cleaned)
+
+
+def apply_reasoning_item_id_policy(
+    items: list[TResponseInputItem],
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None,
+) -> list[TResponseInputItem]:
+    """Apply the reasoning item ID policy to already-converted input items."""
+    if not _should_omit_reasoning_item_ids(reasoning_item_id_policy):
+        return items
+    return [_without_reasoning_item_id(item) for item in items]
 
 
 def _should_omit_reasoning_item_ids(reasoning_item_id_policy: ReasoningItemIdPolicy | None) -> bool:

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -779,6 +779,7 @@ async def start_streaming(
                 run_config.session_settings,
                 include_history_in_prepared_input=not server_manages_conversation,
                 preserve_dropped_new_items=True,
+                reasoning_item_id_policy=resolved_reasoning_item_id_policy,
                 wrapper=context_wrapper,
             )
             streamed_result.input = prepared_input

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -36,6 +36,7 @@ from .items import (
     NestedHistoryOwnedItem,
     NestedHistoryOwnedItemRef,
     ReasoningItemIdPolicy,
+    apply_reasoning_item_id_policy,
     copy_input_items,
     deduplicate_input_items_preferring_latest,
     digest_input_item,
@@ -206,6 +207,7 @@ async def prepare_input_with_session(
     *,
     include_history_in_prepared_input: bool = True,
     preserve_dropped_new_items: bool = False,
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
     wrapper: RunContextWrapper[Any] | None = None,
 ) -> tuple[str | list[TResponseInputItem], list[TResponseInputItem]]:
     """Prepare model input from session history plus the new turn input.
@@ -242,6 +244,13 @@ async def prepare_input_with_session(
     converted_history = [
         strip_internal_input_item_metadata(ensure_input_item_format(item)) for item in history
     ]
+    if not is_openai_conversation_session:
+        # History written before the caller opted into "omit" still carries server-assigned
+        # reasoning IDs. Apply the policy on read too, the same way `save_result_to_session`
+        # applies it on write, so replaying that history cannot 404 on a stale `rs_...` ID.
+        converted_history = apply_reasoning_item_id_policy(
+            converted_history, reasoning_item_id_policy
+        )
 
     new_input_list = [
         ensure_input_item_format(item) for item in ItemHelpers.input_to_new_input_list(input)

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import httpx
 import pytest
-from openai import APIConnectionError, BadRequestError
+from openai import APIConnectionError, BadRequestError, NotFoundError
 from openai.types.responses import ResponseFunctionToolCall
 from openai.types.responses.response_output_item import McpApprovalRequest
 from openai.types.responses.response_output_text import AnnotationFileCitation, ResponseOutputText
@@ -1229,6 +1229,89 @@ async def test_call_model_input_filter_can_reintroduce_reasoning_ids() -> None:
     history_reasoning = _find_reasoning_input_item(result.to_input_list())
     assert history_reasoning is not None
     assert "id" not in history_reasoning
+
+
+class _RevokedReasoningIdModel(FakeModel):
+    """FakeModel that 404s like the Responses API when a revoked reasoning ID is replayed."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.revoked_reasoning_ids: set[str] = set()
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        *args: Any,
+        **kwargs: Any,
+    ) -> ModelResponse:
+        if isinstance(input, list):
+            for item in input:
+                if not isinstance(item, dict) or item.get("type") != "reasoning":
+                    continue
+                item_id = item.get("id")
+                if item_id in self.revoked_reasoning_ids:
+                    message = f"Item with id '{item_id}' not found."
+                    body = {"error": {"message": message, "type": "invalid_request_error"}}
+                    raise NotFoundError(
+                        message,
+                        response=httpx.Response(
+                            404,
+                            request=httpx.Request("POST", "https://api.openai.com/v1/responses"),
+                            json=body,
+                        ),
+                        body=body,
+                    )
+        return await super().get_response(system_instructions, input, *args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_omit_policy_strips_reasoning_ids_already_stored_in_the_session() -> None:
+    """Adopting `omit` must also cover reasoning IDs a session recorded before it was set.
+
+    Reproduces https://github.com/openai/openai-agents-python/issues/2020: a triage agent hands
+    off, its empty-summary reasoning item is persisted to the session, the server later drops the
+    item, and every later turn of that conversation fails with
+    `404 Item with id 'rs_...' not found`.
+    """
+    model = _RevokedReasoningIdModel()
+    specialist = Agent(name="specialist", model=model)
+    triage = Agent(name="triage", model=model, handoffs=[specialist])
+
+    session = SQLiteSession("issue-2020")
+
+    # Turn 1 predates the mitigation, so the session records the reasoning ID.
+    model.add_multiple_turn_outputs(
+        [
+            [
+                ResponseReasoningItem(id="rs_triage", type="reasoning", summary=[]),
+                get_handoff_tool_call(specialist),
+            ],
+            [get_text_message("handled")],
+        ]
+    )
+    first = await Runner.run(triage, input="hello", session=session)
+    assert first.final_output == "handled"
+    stored_reasoning = _find_reasoning_input_item(await session.get_items())
+    assert stored_reasoning is not None
+    assert stored_reasoning.get("id") == "rs_triage"
+
+    # The server no longer resolves that reasoning item.
+    model.revoked_reasoning_ids.add("rs_triage")
+
+    # Turn 2 opts into the documented mitigation for this failure.
+    model.add_multiple_turn_outputs([[get_text_message("done")]])
+    second = await Runner.run(
+        triage,
+        input="anything else?",
+        session=session,
+        run_config=RunConfig(reasoning_item_id_policy="omit"),
+    )
+
+    assert second.final_output == "done"
+    replayed_reasoning = _find_reasoning_input_item(model.last_turn_args.get("input"))
+    assert replayed_reasoning is not None
+    assert "id" not in replayed_reasoning
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 import httpx
 import pytest
-from openai import APIConnectionError, BadRequestError
+from openai import APIConnectionError, BadRequestError, NotFoundError
 from openai.types.responses import (
     ResponseCompletedEvent,
     ResponseErrorEvent,
@@ -36,6 +36,7 @@ from agents import (
     OutputGuardrailTripwireTriggered,
     RunContextWrapper,
     Runner,
+    SQLiteSession,
     ToolGuardrailFunctionOutput,
     ToolInputGuardrailData,
     ToolOutputGuardrailData,
@@ -828,6 +829,90 @@ async def test_streamed_reasoning_item_id_policy_omits_follow_up_reasoning_ids()
     history_reasoning = _find_reasoning_input_item(result.to_input_list())
     assert history_reasoning is not None
     assert "id" not in history_reasoning
+
+
+class _StreamedRevokedReasoningIdModel(FakeModel):
+    """FakeModel that 404s like the Responses API when a revoked reasoning ID is replayed."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.revoked_reasoning_ids: set[str] = set()
+
+    def stream_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncIterator[TResponseStreamEvent]:
+        if isinstance(input, list):
+            for item in input:
+                if not isinstance(item, dict) or item.get("type") != "reasoning":
+                    continue
+                item_id = item.get("id")
+                if item_id in self.revoked_reasoning_ids:
+                    message = f"Item with id '{item_id}' not found."
+                    body = {"error": {"message": message, "type": "invalid_request_error"}}
+                    raise NotFoundError(
+                        message,
+                        response=httpx.Response(
+                            404,
+                            request=httpx.Request("POST", "https://api.openai.com/v1/responses"),
+                            json=body,
+                        ),
+                        body=body,
+                    )
+        return super().stream_response(system_instructions, input, *args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_streamed_omit_policy_strips_reasoning_ids_already_stored_in_the_session() -> None:
+    """Adopting `omit` must also cover reasoning IDs a session recorded before it was set.
+
+    Streaming counterpart of the non-streamed regression test for
+    https://github.com/openai/openai-agents-python/issues/2020.
+    """
+    model = _StreamedRevokedReasoningIdModel()
+    specialist = Agent(name="specialist", model=model)
+    triage = Agent(name="triage", model=model, handoffs=[specialist])
+    session = SQLiteSession("issue-2020-streamed")
+
+    # Turn 1 predates the mitigation, so the session records the reasoning ID.
+    model.add_multiple_turn_outputs(
+        [
+            [
+                ResponseReasoningItem(id="rs_triage", type="reasoning", summary=[]),
+                get_handoff_tool_call(specialist),
+            ],
+            [get_text_message("handled")],
+        ]
+    )
+    first = Runner.run_streamed(triage, input="hello", session=session)
+    async for _ in first.stream_events():
+        pass
+    assert first.final_output == "handled"
+    stored_reasoning = _find_reasoning_input_item(await session.get_items())
+    assert stored_reasoning is not None
+    assert stored_reasoning.get("id") == "rs_triage"
+
+    # The server no longer resolves that reasoning item.
+    model.revoked_reasoning_ids.add("rs_triage")
+
+    # Turn 2 opts into the documented mitigation for this failure.
+    model.add_multiple_turn_outputs([[get_text_message("done")]])
+    second = Runner.run_streamed(
+        triage,
+        input="anything else?",
+        session=session,
+        run_config=RunConfig(reasoning_item_id_policy="omit"),
+    )
+    async for _ in second.stream_events():
+        pass
+
+    assert second.final_output == "done"
+    replayed_reasoning = _find_reasoning_input_item(model.last_turn_args.get("input"))
+    assert replayed_reasoning is not None
+    assert "id" not in replayed_reasoning
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`save_result_to_session` applies `reasoning_item_id_policy` when writing run items to a non-Conversations session. `prepare_input_with_session` never applies it when reading that history back.

Reasoning ids recorded before the caller set `reasoning_item_id_policy="omit"` are therefore replayed on every later turn of the same conversation. The documented mitigation cannot rescue a session that already holds a stale `rs_...` id — the row is never rewritten, and it survives restarts in the SQLite file.

That is the shape reported in #2020: a triage agent hands off, its empty-summary reasoning item lands in a `SQLiteSession`, the server later stops resolving the id, and every subsequent turn fails with `404 Item with id 'rs_...' not found`.

Apply the policy to session history on read too, skipping `OpenAIConversationsSession` exactly as the write path does. Runs that leave `reasoning_item_id_policy` unset are unchanged.

Two things worth flagging rather than leaving you to find them:

- This does not close #2020. The reporters were not using `omit`, so it does not make the default `preserve` path safe — it makes the documented mitigation actually work on a conversation that is already poisoned. Marking it `Refs` rather than `Fixes` for that reason.
- I checked the broader claim first and could not support it. With `omit` set from the start, I could not leak a reasoning id through any public path I tried: session + handoff, streamed and non-streamed, nested handoff history, `handoff_input_filter`, `session_input_callback`, `SessionSettings(limit=...)`, approval interrupt with `RunState` resume, `max_turns`, `agent.as_tool()`, and `to_input_list()` round-trip. So the unconditional-strip approach in #3514/#3582/#4013 still looks wrong, and this is deliberately narrower.

The `run.py` change is mechanical — it hoists the existing policy resolution above the session prep so it can be passed in. `run_state` is always `None` at those two call sites, so it could pass `run_config.reasoning_item_id_policy` directly and shrink that file to two lines. I went with the version that does not rely on an unstated invariant; happy to switch.

Tests: a non-streamed and a streamed regression test drive `Runner.run` / `Runner.run_streamed` with a real `SQLiteSession` and a real handoff against a model that raises `openai.NotFoundError` on the revoked id. Both fail before the fix with the error from the issue rather than an internal assertion.

Refs #2020
