### PR TITLE
feat: use GPT-5.6 Luna as the default model

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -338,7 +338,7 @@ class Agent(AgentBase, Generic[TContext]):
     """The model implementation to use when invoking the LLM.
 
     By default, if not set, the agent will use the default model configured in
-    `agents.models.get_default_model()` (currently "gpt-5.4-mini").
+    `agents.models.get_default_model()` (currently "gpt-5.6-luna").
     """
 
     model_settings: ModelSettings = field(default_factory=get_default_model_settings)

--- a/src/agents/models/default_models.py
+++ b/src/agents/models/default_models.py
@@ -100,7 +100,7 @@ def get_default_model() -> str:
     """
     Returns the default model name.
     """
-    return os.getenv(OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME, "gpt-5.4-mini").lower()
+    return os.getenv(OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME, "gpt-5.6-luna").lower()
 
 
 def get_default_model_settings(model: str | None = None) -> ModelSettings:

--- a/tests/models/test_default_models.py
+++ b/tests/models/test_default_models.py
@@ -23,8 +23,8 @@ def _gpt_5_default_settings(
     return ModelSettings(reasoning=Reasoning(effort=reasoning_effort), verbosity="low")
 
 
-def test_default_model_is_gpt_5_4_mini():
-    assert get_default_model() == "gpt-5.4-mini"
+def test_default_model_is_gpt_5_6_luna():
+    assert get_default_model() == "gpt-5.6-luna"
     assert is_gpt_5_default() is True
     assert gpt_5_reasoning_settings_required(get_default_model()) is True
     assert get_default_model_settings() == _gpt_5_default_settings("none")


### PR DESCRIPTION
This pull request updates the Agents SDK default model from `gpt-5.4-mini` to `gpt-5.6-luna`.

Following the Luna pricing update, both models were reevaluated from scratch across 20 example-derived Agents SDK scenarios using the same script from https://github.com/openai/openai-agents-python/pull/3147. All figures below are drawn exclusively from three-session dataset.

The evaluation covered text and structured output, function tools, tool and output guardrails, streaming, handoffs, agents as tools, parallel orchestration, conversation continuation, image and PDF inputs, file outputs, and multi-agent workflows.

Both models used `reasoning.effort: "none"`, `text.verbosity: "low"`, and the same token ceiling. Each session used fresh agents, excluded warm-ups, alternated model execution order between attempts, and did not use a prompt cache key.

### Functional results

Across the three complete sessions:

| Result | `gpt-5.4-mini` | `gpt-5.6-luna` |
|---|---:|---:|
| Measured attempts | 276 | 276 |
| Successful checks | 275 | 276 |
| Success rate | 99.6% | 100% |

Luna matched or exceeded `gpt-5.4-mini` across the primary evaluation. Both models completed all 267 checks outside the multi-agent story workflow successfully.

The only primary failure was one `gpt-5.4-mini` attempt in the story workflow's model-graded quality gate. Because this creative workflow showed variability, it was evaluated in three additional interleaved control batches:

| Story workflow | `gpt-5.4-mini` | `gpt-5.6-luna` |
|---|---:|---:|
| Primary sessions | 8/9 | 9/9 |
| Additional control | 9/9 | 7/9 |
| Combined | 17/18 | 16/18 |

Including the focused control, the overall result was 284/285 for `gpt-5.4-mini` and 283/285 for Luna, or 99.6% versus 99.3%. The difference was one check out of 285 and was limited to the stochastic creative-story quality gate.

No failures occurred for factual or constrained responses, structured output, streaming, tools, guardrails, handoffs, parallel orchestration, conversation state, image/PDF inputs, or file handling.

### Usage and cost

The primary three-session workload produced the same number of API requests for both models, while Luna used fewer tokens:

| Metric | `gpt-5.4-mini` | `gpt-5.6-luna` | Difference |
|---|---:|---:|---:|
| API requests | 498 | 498 | 0% |
| Input tokens | 53,994 | 52,978 | -1.9% |
| Output tokens | 10,704 | 10,345 | -3.4% |
| Total tokens | 64,698 | 63,323 | -2.1% |

Under the current [Standard API pricing](https://developers.openai.com/api/docs/pricing), Luna's input and output token rates are both approximately 73.3% lower:

| Price per 1M tokens | `gpt-5.4-mini` | `gpt-5.6-luna` |
|---|---:|---:|
| Input | `$0.75` | `$0.20` |
| Output | `$4.50` | `$1.20` |

Using the uncached Standard rates as a conservative estimate, the measured workload cost approximately:

| Model | Estimated cost |
|---|---:|
| `gpt-5.4-mini` | `$0.088664` |
| `gpt-5.6-luna` | `$0.023010` |

Luna reduced the estimated workload cost by approximately 74.0%.

### Response-time comparison

Latency was measured on a machine shared with other tasks, so the results are presented as directional relative averages rather than absolute timings.

For each session and workflow, mean latency was calculated and normalized with `gpt-5.4-mini` set to `1.00`. The table averages those normalized results across the three fresh sessions. Lower values are faster.

| Workflow group | `gpt-5.4-mini` | `gpt-5.6-luna` |
|---|---:|---:|
| Text and structured output | 1.00 | 1.06 |
| Tools and guardrails | 1.00 | 1.02 |
| Handoffs and orchestration | 1.00 | 1.06 |
| Conversations and files | 1.00 | 1.15 |
| Overall average | 1.00 | 1.07 |

Luna's normalized mean latency was approximately 7% higher overall and remained in the same general response-time range. Both models had double-digit-second outliers caused by shared-environment variability; none were excluded.

Taken together, the fresh results show near-equivalent functional behavior, slightly lower token usage, comparable response performance, and a substantial cost-efficiency improvement. The observed functional difference was one stochastic creative-quality check out of 285, while Luna reduced the measured workload cost by approximately 74.0%. This supports using Luna as the SDK default.

The change only affects the fallback used when no model is specified. Explicit agent models, run-level model overrides, and the `OPENAI_DEFAULT_MODEL` environment variable continue to take precedence. The existing default settings of `reasoning.effort: "none"` and `text.verbosity: "low"` are unchanged.