### PR TITLE
fix(streaming): close chat completions content parts in index order

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -1146,24 +1146,19 @@ class ChatCmplStreamHandler:
         for event in cls._finish_reasoning_item(state, sequence_number):
             yield event
 
+        content_parts: list[tuple[int, ResponseOutputText | ResponseOutputRefusal]] = []
         if state.text_content_index_and_output:
-            # Send end event for this content part
-            yield ResponseContentPartDoneEvent(
-                content_index=state.text_content_index_and_output[0],
-                item_id=FAKE_RESPONSES_ID,
-                output_index=output_layout.assistant_message_output_index(state),
-                part=state.text_content_index_and_output[1],
-                type="response.content_part.done",
-                sequence_number=sequence_number.get_and_increment(),
-            )
-
+            content_parts.append(state.text_content_index_and_output)
         if state.refusal_content_index_and_output:
-            # Send end event for this content part
+            content_parts.append(state.refusal_content_index_and_output)
+        content_parts.sort(key=lambda entry: entry[0])
+
+        for content_index, content_part in content_parts:
             yield ResponseContentPartDoneEvent(
-                content_index=state.refusal_content_index_and_output[0],
+                content_index=content_index,
                 item_id=FAKE_RESPONSES_ID,
                 output_index=output_layout.assistant_message_output_index(state),
-                part=state.refusal_content_index_and_output[1],
+                part=content_part,
                 type="response.content_part.done",
                 sequence_number=sequence_number.get_and_increment(),
             )
@@ -1240,12 +1235,6 @@ class ChatCmplStreamHandler:
             # the content_part events. A refusal that opened before any text holds index 0
             # and the text holds index 1, so appending text first would contradict the
             # indexes consumers already received.
-            content_parts: list[tuple[int, ResponseOutputText | ResponseOutputRefusal]] = []
-            if state.text_content_index_and_output:
-                content_parts.append(state.text_content_index_and_output)
-            if state.refusal_content_index_and_output:
-                content_parts.append(state.refusal_content_index_and_output)
-            content_parts.sort(key=lambda entry: entry[0])
             assistant_msg.content.extend(part for _, part in content_parts)
             outputs.append(assistant_msg)
 

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -1429,7 +1429,7 @@ async def test_stream_handler_places_text_after_existing_refusal_part() -> None:
     ],
 )
 @pytest.mark.asyncio
-async def test_stream_handler_announces_assistant_message_once_for_text_and_refusal(
+async def test_stream_handler_emits_consistent_message_lifecycle_for_text_and_refusal(
     deltas: list[ChoiceDelta],
 ) -> None:
     """A message holding both a text and a refusal part is announced by a single added event."""
@@ -1471,6 +1471,9 @@ async def test_stream_handler_announces_assistant_message_once_for_text_and_refu
     part_added = [event for event in events if event.type == "response.content_part.added"]
     assert sorted(event.content_index for event in part_added) == [0, 1]
     assert {event.part.type for event in part_added} == {"output_text", "refusal"}
+    part_done = [event for event in events if event.type == "response.content_part.done"]
+    assert [event.content_index for event in part_done] == [0, 1]
+    assert [event.part.type for event in part_done] == [event.part.type for event in part_added]
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

**Component:** `src/agents/models/chatcmpl_stream_handler.py` — `ChatCmplStreamHandler.handle_stream` assistant-message finalization.

**Problem.** A Chat Completions stream that opened a refusal part before a text part announced them at `content_index` 0 and 1, but closed them in the fixed order text then refusal. Its `response.content_part.done` events therefore carried indexes `[1, 0]`, even though the corresponding `response.content_part.added` events, deltas, and completed assistant content all used `[0, 1]`.

Raw-event consumers that finalize content parts by event order could close index 1 while index 0 was still open. Text-first and single-part streams were unaffected.

**Reproduction before this change:**

`uv run pytest tests/models/test_openai_chatcompletions_stream.py -q -k consistent_message_lifecycle`

The refusal-first parameter failed with:

```text
assert [1, 0] == [0, 1]
1 failed, 1 passed, 87 deselected
```

### Root cause

The handler stored each part's assigned content index, and already sorted those `(index, part)` pairs when assembling `response.completed`, but emitted `content_part.done` through two type-specific branches in a fixed text-then-refusal order.

### Fix and scope

Build and sort the existing content-part pairs once, then reuse that list for both `content_part.done` emission and completed assistant content. This removes the duplicate finalization ordering logic without adding state, helpers, public API, or provider-specific behavior.

Text-only, refusal-only, and text-first event sequences are unchanged. Reasoning items, function calls, output indexes, sequence numbering, and completed-response ordering are unchanged.

### Test plan

- `uv run pytest tests/models/test_openai_chatcompletions_stream.py -q -k consistent_message_lifecycle` — 2 passed, 87 deselected
- `uv run pytest tests/models/test_openai_chatcompletions_stream.py -q` — 89 passed
- Focused regression repeated 10 times — 2 passed on every run
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` — all commands passed (`make format`, `make lint`, `make typecheck`, `make tests`)
- `git diff --check` — clean

No API key, paid call, live service, or networked integration test was used.

### Issue number

None — small, directly reproducible fix. This follows the both-parts scenario covered by #4236 and #4275, but addresses the `content_part.done` ordering that #4275 explicitly left out of scope.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
