### PR TITLE
fix(realtime): preserve falsey custom models

### DIFF
--- a/src/agents/realtime/runner.py
+++ b/src/agents/realtime/runner.py
@@ -43,7 +43,7 @@ class RealtimeRunner:
         """
         self._starting_agent = starting_agent
         self._config = config
-        self._model = model or OpenAIRealtimeWebSocketModel()
+        self._model = model if model is not None else OpenAIRealtimeWebSocketModel()
 
     async def run(
         self, *, context: TContext | None = None, model_config: RealtimeModelConfig | None = None

--- a/tests/realtime/test_runner.py
+++ b/tests/realtime/test_runner.py
@@ -56,6 +56,19 @@ def mock_model():
 
 
 @pytest.mark.asyncio
+async def test_run_preserves_falsey_custom_model(mock_agent: Mock):
+    class FalseyRealtimeModel(MockRealtimeModel):
+        def __bool__(self) -> bool:
+            return False
+
+    model = FalseyRealtimeModel()
+
+    session = await RealtimeRunner(mock_agent, model=model).run()
+
+    assert session.model is model
+
+
+@pytest.mark.asyncio
 async def test_run_creates_session_with_no_settings(
     mock_agent: Mock, mock_model: MockRealtimeModel
 ):


### PR DESCRIPTION
### Summary

This pull request fixes `RealtimeRunner` so an explicitly supplied custom `RealtimeModel` is preserved even when the model object is falsey.

Previously, `RealtimeRunner.__init__` selected its model with a truthiness fallback. A valid custom model whose class defines `__bool__` or `__len__` to return a falsey value was silently replaced by `OpenAIRealtimeWebSocketModel`, contrary to the constructor contract that the default is used only when no model is provided.

The fix changes the fallback to an explicit `None` check. The public signature, ordinary truthy-model behavior, default behavior for `None`, session lifecycle, and provider interfaces are unchanged. Documentation was not changed because this restores the existing documented contract rather than introducing new behavior.

Duplicate checks covered open and closed issues and pull requests, the contributor's prior pull-request history, repository history/blame, and related TODOs. No matching report or in-flight fix was found. No issue was opened because this is a small, self-contained correctness fix.

### Test plan

- Added `test_run_preserves_falsey_custom_model`, which asserts the session retains the exact supplied model instance.
- Before the fix, `UV_CACHE_DIR=/tmp/oai-agents-uv-cache UV_PYTHON=3.12 uv run pytest tests/realtime/test_runner.py::test_run_preserves_falsey_custom_model -q` failed with the default `OpenAIRealtimeWebSocketModel` replacing the falsey model.
- After the fix, the same focused command passed (`1 passed`).
- `UV_CACHE_DIR=/tmp/oai-agents-uv-cache UV_PYTHON=3.12 uv run pytest tests/realtime/test_runner.py -q` passed (`8 passed`).
- The focused regression was repeated five times; every run passed.
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` passed all repository gates: `make format` (864 files unchanged), `make lint` (passed), `make tests` (passed in 46s), and `make typecheck` (passed in 201s).
- An independent zero-base final review found no correctness, compatibility, lifecycle, or test-coverage findings on the verified fingerprint.

No API key, paid service, network model request, or live Realtime connection was used.

### Issue number

N/A — no existing issue was found, and no issue is required for this focused fix.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
