### PR TITLE
fix(sandbox): restore archived file modes when extracting a workspace tar

### DIFF
--- a/src/agents/sandbox/util/tar_utils.py
+++ b/src/agents/sandbox/util/tar_utils.py
@@ -424,12 +424,15 @@ def safe_extract_tarfile(
         fd = os.open(dest, flags, 0o600)
         try:
             with os.fdopen(fd, "wb") as out:
-                if hasattr(os, "fchmod"):
-                    # Restore the archived permissions on the open descriptor so a workspace
-                    # snapshot round-trip keeps executable scripts executable without
-                    # re-resolving the path.
-                    os.fchmod(out.fileno(), _restored_regular_file_mode(member.mode))
                 shutil.copyfileobj(fileobj, out)
+                out.flush()
+                if hasattr(os, "fchmod"):
+                    # Restore the archived permissions so a workspace snapshot round-trip keeps
+                    # executable scripts executable. This runs on the still-open descriptor,
+                    # after the payload is written and flushed: the file keeps its private
+                    # creation mode while it holds partial data, and a failed copy leaves the
+                    # partial file at 0o600 instead of its final readable/executable mode.
+                    os.fchmod(out.fileno(), _restored_regular_file_mode(member.mode))
         finally:
             try:
                 fileobj.close()

--- a/src/agents/sandbox/util/tar_utils.py
+++ b/src/agents/sandbox/util/tar_utils.py
@@ -212,6 +212,21 @@ def should_skip_tar_member(
     return any(_is_within(rel, prefix) for rel in rel_variants for prefix in prefixes)
 
 
+def _restored_regular_file_mode(mode: int) -> int:
+    """Return the permission bits to restore for an extracted regular file.
+
+    This mirrors the mode policy of the standard library's ``tarfile`` ``data`` filter, which
+    this extractor replaces: setuid, setgid, sticky and group/other write bits are dropped,
+    execute bits are kept only when the owner had them, and the owner is always left able to
+    read and write the file.
+    """
+
+    restored = mode & 0o755
+    if not restored & 0o100:
+        restored &= ~0o111
+    return restored | 0o600
+
+
 def _ensure_no_symlink_parents(*, root: Path, dest: Path, check_leaf: bool = True) -> None:
     """
     Ensure that no existing parent directory in `dest` is a symlink.
@@ -409,6 +424,11 @@ def safe_extract_tarfile(
         fd = os.open(dest, flags, 0o600)
         try:
             with os.fdopen(fd, "wb") as out:
+                if hasattr(os, "fchmod"):
+                    # Restore the archived permissions on the open descriptor so a workspace
+                    # snapshot round-trip keeps executable scripts executable without
+                    # re-resolving the path.
+                    os.fchmod(out.fileno(), _restored_regular_file_mode(member.mode))
                 shutil.copyfileobj(fileobj, out)
         finally:
             try:

--- a/tests/sandbox/test_tar_utils.py
+++ b/tests/sandbox/test_tar_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import io
 import os
+import stat
+import sys
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,9 +42,11 @@ def _dir(name: str) -> _Member:
     return _Member(member)
 
 
-def _file(name: str, payload: bytes = b"payload") -> _Member:
+def _file(name: str, payload: bytes = b"payload", mode: int | None = None) -> _Member:
     member = tarfile.TarInfo(name)
     member.size = len(payload)
+    if mode is not None:
+        member.mode = mode
     return _Member(member, payload)
 
 
@@ -393,3 +397,60 @@ def test_validate_tar_bytes_ignores_skipped_unsafe_member() -> None:
         _tar_bytes(_symlink(".runtime/escape", "/tmp/outside")),
         skip_rel_paths=[Path(".runtime")],
     )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes are Unix-specific")
+@pytest.mark.parametrize(
+    ("archived_mode", "expected_mode"),
+    [
+        pytest.param(0o755, 0o755, id="executable-script"),
+        pytest.param(0o644, 0o644, id="plain-file"),
+        pytest.param(0o600, 0o600, id="owner-only-file"),
+        pytest.param(0o700, 0o700, id="owner-only-executable"),
+        pytest.param(0o444, 0o644, id="read-only-file-stays-owner-writable"),
+        pytest.param(0o000, 0o600, id="unreadable-file-stays-owner-readable"),
+        pytest.param(0o777, 0o755, id="group-and-other-write-dropped"),
+        pytest.param(0o655, 0o644, id="execute-without-owner-execute-dropped"),
+        pytest.param(0o4755, 0o755, id="setuid-dropped"),
+        pytest.param(0o2755, 0o755, id="setgid-dropped"),
+        pytest.param(0o1755, 0o755, id="sticky-dropped"),
+    ],
+)
+def test_safe_extract_tarfile_restores_regular_file_modes(
+    tmp_path: Path,
+    archived_mode: int,
+    expected_mode: int,
+) -> None:
+    raw = _tar_bytes(_file("run.sh", b"#!/bin/sh\n", mode=archived_mode))
+
+    _safe_extract(raw, tmp_path)
+
+    assert stat.S_IMODE((tmp_path / "run.sh").stat().st_mode) == expected_mode
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes are Unix-specific")
+def test_safe_extract_tarfile_keeps_workspace_scripts_executable(tmp_path: Path) -> None:
+    raw = _tar_bytes(
+        _dir("."),
+        _dir("./bin"),
+        _file("./bin/start", b"#!/bin/sh\necho hi\n", mode=0o755),
+        _file("./README.md", b"# readme\n", mode=0o644),
+    )
+
+    _safe_extract(raw, tmp_path)
+
+    assert os.access(tmp_path / "bin" / "start", os.X_OK)
+    assert not os.access(tmp_path / "README.md", os.X_OK)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes are Unix-specific")
+def test_safe_extract_tarfile_restores_mode_when_replacing_an_existing_file(
+    tmp_path: Path,
+) -> None:
+    _safe_extract(_tar_bytes(_file("run.sh", b"v1\n", mode=0o644)), tmp_path)
+    assert stat.S_IMODE((tmp_path / "run.sh").stat().st_mode) == 0o644
+
+    _safe_extract(_tar_bytes(_file("run.sh", b"v2\n", mode=0o755)), tmp_path)
+
+    assert (tmp_path / "run.sh").read_bytes() == b"v2\n"
+    assert stat.S_IMODE((tmp_path / "run.sh").stat().st_mode) == 0o755

--- a/tests/sandbox/test_tar_utils.py
+++ b/tests/sandbox/test_tar_utils.py
@@ -454,3 +454,38 @@ def test_safe_extract_tarfile_restores_mode_when_replacing_an_existing_file(
 
     assert (tmp_path / "run.sh").read_bytes() == b"v2\n"
     assert stat.S_IMODE((tmp_path / "run.sh").stat().st_mode) == 0o755
+
+
+class _FailingPayload:
+    """A member payload that yields one chunk and then fails, like a truncated read."""
+
+    def __init__(self, chunk: bytes) -> None:
+        self._chunk: bytes | None = chunk
+
+    def read(self, size: int = -1) -> bytes:
+        if self._chunk is None:
+            raise OSError("payload stream failed")
+        chunk, self._chunk = self._chunk, None
+        return chunk
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes are Unix-specific")
+def test_safe_extract_tarfile_keeps_a_partially_written_file_private(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = _tar_bytes(_file("run.sh", b"#!/bin/sh\necho hi\n", mode=0o755))
+
+    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:*") as tar:
+        monkeypatch.setattr(tar, "extractfile", lambda member: _FailingPayload(b"#!/bin/sh\n"))
+
+        with pytest.raises(OSError, match="payload stream failed"):
+            safe_extract_tarfile(tar, root=tmp_path)
+
+    dest = tmp_path / "run.sh"
+    assert dest.read_bytes() == b"#!/bin/sh\n"
+    assert stat.S_IMODE(dest.stat().st_mode) == 0o600
+    assert not os.access(dest, os.X_OK)


### PR DESCRIPTION
### Summary

**Component:** `src/agents/sandbox/util/tar_utils.py` — `safe_extract_tarfile()`, the workspace-tar extractor used by `UnixLocalSandbox.hydrate_workspace()`.

**Problem:** `safe_extract_tarfile` creates every regular file with a hardcoded `0o600` and never applies the archived member mode. A `persist_workspace()` → `hydrate_workspace()` round trip therefore rewrites every file in the restored workspace to owner-read/write only. Executable scripts in the workspace — a checked-in `./bin/start`, a `.venv/bin/*` wrapper, `node_modules/.bin/*` — come back non-executable, so shell commands that worked before the snapshot fail after the restore with a permission error.

**Repro (no key, no live service):**

```python
import io, os, stat, tarfile, tempfile
from pathlib import Path
from agents.sandbox.util.tar_utils import safe_extract_tarfile

with tempfile.TemporaryDirectory() as td:
    src = Path(td) / "src"
    src.mkdir()
    script = src / "run.sh"
    script.write_text("#!/bin/sh\necho hi\n")
    script.chmod(0o755)

    buf = io.BytesIO()
    with tarfile.open(fileobj=buf, mode="w") as tar:
        tar.add(src, arcname=".")          # member mode is 0o755
    buf.seek(0)

    dest = Path(td) / "dest"
    with tarfile.open(fileobj=buf, mode="r:*") as tar:
        safe_extract_tarfile(tar, root=dest, allow_external_symlink_targets=False)

    print(oct(stat.S_IMODE((dest / "run.sh").stat().st_mode)))  # 0o600
    print(os.access(dest / "run.sh", os.X_OK))                  # False
```

**Before:** `0o600`, `os.access(..., os.X_OK)` is `False`.
**After:** `0o755`, `os.access(..., os.X_OK)` is `True`.

**Root cause:** `_write_file()` passes `0o600` as the creation mode to `os.open()` and stops there. That value is only meant to keep the file private while it is being written; nothing ever restores `member.mode`. The custom extractor exists to enforce a stricter containment policy than `TarFile.extractall()`, and when it replaced the stdlib path it also dropped the stdlib's mode handling.

**Fix:** apply the archived mode with `os.fchmod()` on the still-open descriptor, **after** `shutil.copyfileobj()` completes and the buffer is flushed. The file therefore keeps its private `0o600` creation mode for as long as it may hold partial data: a concurrent reader never sees a half-written file through its final readable/executable mode, and a copy that fails partway (interrupted input, full disk) leaves the partial file at `0o600` rather than at those permissions. The mode is sanitized with the same policy the standard library's `tarfile` `data` filter applies to regular files, which is the policy this extractor replaced:

* `mode & 0o755` — setuid, setgid, sticky and group/other write bits are dropped, so an untrusted archive cannot plant a setuid binary or a world-writable file.
* execute bits are cleared unless the owner had `0o100`.
* `| 0o600` — the owner always keeps read and write access.

**Why minimal:**

* One helper plus one call, in the one place regular files are written. No change to validation, traversal, symlink or hardlink policy, or to any public signature.
* Directory and symlink modes are deliberately left alone. That matches the same stdlib `data` filter ("Ignore mode for directories & symlinks"), and it avoids the ordering hazard of applying a restrictive archived directory mode before that directory's children are extracted.
* `os.fchmod` is applied to the open descriptor rather than the path, so it cannot follow a path that changed after `os.open(..., O_EXCL | O_NOFOLLOW)` succeeded, and no extra `stat`/`chmod` round trip on the path is introduced.
* Guarded by `hasattr(os, "fchmod")`, mirroring the existing `hasattr(os, "O_NOFOLLOW")` guard two lines above, because `os.fchmod` is Unix-only and this suite runs in the Windows CI job.

**Non-goals:** the zip/source-archive materialization path in `sandbox/session/archive_extraction.py`, directory and symlink modes, and ownership (uid/gid) restoration — the stdlib `data` filter drops ownership too, and doing otherwise would need privileges the extractor does not have.

### Test plan

New tests in `tests/sandbox/test_tar_utils.py`, all skipped on Windows via `sys.platform == "win32"` because they assert POSIX permission bits (the existing suite already runs unskipped on Windows, so the new cases had to opt out rather than the file):

* `test_safe_extract_tarfile_restores_regular_file_modes` — 11 parametrized cases pinning the sanitizing policy: `0o755→0o755`, `0o644→0o644`, `0o600→0o600`, `0o700→0o700`, `0o444→0o644` (owner stays writable), `0o000→0o600` (owner stays readable), `0o777→0o755` (group/other write dropped), `0o655→0o644` (execute without owner-execute dropped), and `0o4755`/`0o2755`/`0o1755 → 0o755` (setuid/setgid/sticky dropped).
* `test_safe_extract_tarfile_keeps_workspace_scripts_executable` — the real-world symptom: a nested `./bin/start` stays executable and a sibling `README.md` does not become executable.
* `test_safe_extract_tarfile_restores_mode_when_replacing_an_existing_file` — the replace path (`_prepare_replaceable_leaf` unlinks, then re-creates), extracting `0o644` and then `0o755` over it.
* `test_safe_extract_tarfile_keeps_a_partially_written_file_private` — the failure path. `tar.extractfile` is patched to return a payload that yields one chunk and then raises, so the copy fails mid-write; the test asserts the partial bytes did land, that the destination is still `0o600`, and that it is not executable.

`_file()` in that test module gained an optional `mode` argument; every existing call site is unchanged.

Red/green was verified twice, by toggling only `src/agents/sandbox/util/tar_utils.py` with the tests already in place:

* against `upstream/main`: **11 failed, 37 passed** → **49 passed**. The three mode cases that pass in both directions (`0o600`, and the two clamped-to-`0o600` boundaries) are kept as boundary coverage.
* against the earlier ordering in this PR (`fchmod` before the copy): `test_safe_extract_tarfile_keeps_a_partially_written_file_private` fails with `assert 0o755 == 0o600` on the partially written file, and passes once the `fchmod` moved after the copy and flush.

Validation, all from a clean worktree branched at `upstream/main` (`237716cf`), Python 3.12.13, macOS:

* `uv run pytest tests/sandbox/test_tar_utils.py -q` → 49 passed (run 3× consecutively, identical)
* `uv run pytest tests/sandbox -q` → 1005 passed, 2 skipped
* `make format` → 864 files left unchanged; `ruff check --fix` all checks passed
* `make lint` → all checks passed
* `make typecheck` → mypy: no issues in 851 source files; pyright: 0 errors, 0 warnings
* `make tests` → 7078 passed, 28 skipped; serial suite 77 passed, 11 skipped, 55 deselected
* `bash .agents/skills/code-change-verification/scripts/run.sh` → all commands passed
* `git diff --check` → clean

Not run: `make coverage` and `make build-docs` (no docs touched); the Windows CI job — the new tests skip there by construction and the runtime change is behind `hasattr(os, "fchmod")`, but the Windows behavior itself is unverified locally.

### Issue number

None — found by reading `safe_extract_tarfile` against the stdlib `tarfile` filter policy it replaced.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
