### PR TITLE
fix(sessions): strip placeholder item IDs before Conversations persistence

### DIFF
--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -30,6 +30,7 @@ from ..memory import (
 )
 from ..memory.openai_conversations_session import OpenAIConversationsSession
 from ..memory.session import _call_session_method, _get_session_wrapper
+from ..models.fake_id import FAKE_RESPONSES_ID
 from ..run_context import RunContextWrapper
 from ..run_state import RunState
 from .items import (
@@ -794,11 +795,15 @@ def _sanitize_openai_conversation_item(item: TResponseInputItem) -> TResponseInp
     persisted through the Conversations API. Reasoning items also need their server
     identity or encrypted content to remain persistable. Other item IDs remain stripped
     so replayed messages, function calls, and tool outputs do not carry stale provider IDs.
+
+    ``FAKE_RESPONSES_ID`` is the SDK's own placeholder for providers that assign no item ID,
+    so it is never a server identity and is stripped from every item type.
     """
     if isinstance(item, dict):
         clean_item = cast(dict[str, Any], strip_internal_input_item_metadata(item))
-        if clean_item.get("type") != "reasoning" and not _openai_conversation_item_requires_id(
-            clean_item
+        if clean_item.get("id") == FAKE_RESPONSES_ID or (
+            clean_item.get("type") != "reasoning"
+            and not _openai_conversation_item_requires_id(clean_item)
         ):
             clean_item.pop("id", None)
         clean_item.pop("provider_data", None)

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -64,6 +64,7 @@ from agents.items import (
     TResponseInputItem,
 )
 from agents.lifecycle import RunHooks
+from agents.models.fake_id import FAKE_RESPONSES_ID
 from agents.run import AgentRunner, get_default_agent_runner, set_default_agent_runner
 from agents.run_config import _default_trace_include_sensitive_data
 from agents.run_internal.agent_bindings import bind_public_agent
@@ -3923,6 +3924,99 @@ async def test_save_result_to_openai_conversation_keeps_reasoning_encrypted_cont
     assert len(session.saved_items) == 1
     saved_reasoning = cast(dict[str, Any], session.saved_items[0])
     assert saved_reasoning["encrypted_content"] == "encrypted"
+
+
+@pytest.mark.asyncio
+async def test_save_result_to_openai_conversation_drops_placeholder_id_reasoning_item() -> None:
+    class DummyOpenAIConversationsSession(OpenAIConversationsSession):
+        def __init__(self) -> None:
+            self.saved_items: list[TResponseInputItem] = []
+
+        async def _get_session_id(self) -> str:
+            return "conv_test"
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            self.saved_items.extend(items)
+
+        async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+            return []
+
+        async def pop_item(self) -> TResponseInputItem | None:
+            return None
+
+        async def clear_session(self) -> None:
+            return None
+
+    session = DummyOpenAIConversationsSession()
+    agent = Agent(name="agent", model=FakeModel())
+    # Chat Completions providers have no server-assigned reasoning ID, so the SDK stamps its
+    # own placeholder. That placeholder is not a server identity, so the item is no more
+    # persistable than one with no ID at all.
+    placeholder_reasoning = ReasoningItem(
+        agent=agent,
+        raw_item=ResponseReasoningItem(
+            type="reasoning",
+            id=FAKE_RESPONSES_ID,
+            summary=[Summary(text="thinking", type="summary_text")],
+        ),
+    )
+
+    saved_count = await save_result_to_session(
+        session,
+        [],
+        cast(list[RunItem], [placeholder_reasoning]),
+        None,
+    )
+
+    assert saved_count == 1
+    assert session.saved_items == []
+
+
+@pytest.mark.asyncio
+async def test_save_result_to_openai_conversation_strips_placeholder_reasoning_id() -> None:
+    class DummyOpenAIConversationsSession(OpenAIConversationsSession):
+        def __init__(self) -> None:
+            self.saved_items: list[TResponseInputItem] = []
+
+        async def _get_session_id(self) -> str:
+            return "conv_test"
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            self.saved_items.extend(items)
+
+        async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
+            return []
+
+        async def pop_item(self) -> TResponseInputItem | None:
+            return None
+
+        async def clear_session(self) -> None:
+            return None
+
+    session = DummyOpenAIConversationsSession()
+    agent = Agent(name="agent", model=FakeModel())
+    placeholder_reasoning = ReasoningItem(
+        agent=agent,
+        raw_item=ResponseReasoningItem(
+            type="reasoning",
+            id=FAKE_RESPONSES_ID,
+            summary=[],
+            encrypted_content="encrypted",
+        ),
+    )
+
+    saved_count = await save_result_to_session(
+        session,
+        [],
+        cast(list[RunItem], [placeholder_reasoning]),
+        None,
+    )
+
+    assert saved_count == 1
+    assert len(session.saved_items) == 1
+    saved_reasoning = cast(dict[str, Any], session.saved_items[0])
+    assert saved_reasoning["encrypted_content"] == "encrypted"
+    assert "id" not in saved_reasoning
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

**Component:** `src/agents/run_internal/session_persistence.py` — `_sanitize_openai_conversation_item`, the sanitizer applied to every item saved through `OpenAIConversationsSession`.

**Problem.** Providers reached through the Chat Completions shape assign no item ID, so the SDK stamps its own placeholder: `Converter.message_to_output_items` and `ChatCmplStreamHandler` build every reasoning item with `id=FAKE_RESPONSES_ID` (`"__fake_id__"`). When that run stores history with `OpenAIConversationsSession`, the sanitizer strips IDs from messages, function calls and tool outputs, but deliberately keeps them on reasoning items — reasoning items need their server identity to remain persistable. The placeholder is not a server identity, so it survived and `client.conversations.items.create(...)` was sent a reasoning item whose `id` is `"__fake_id__"`.

`_is_unpersistable_for_openai_conversation` already encodes the intended rule ("a reasoning item with no server identity and no encrypted content must not be persisted"), but a placeholder ID passes its `not item.get("id")` test, so the guard never fires for these items.

**Repro** (no API key needed; the placeholder ID is exactly what the Chat Completions converter emits):

```python
session = OpenAIConversationsSession(...)   # add_items captured
agent = Agent(name="a", model=FakeModel())
model.set_next_output([
    ResponseReasoningItem(type="reasoning", id=FAKE_RESPONSES_ID,
                          summary=[Summary(text="thinking", type="summary_text")]),
    get_text_message("hi"),
])
await Runner.run(agent, input="hello", session=session)
```

Before — the placeholder is posted to the Conversations API:

```
[{'content': 'hello', 'role': 'user'},
 {'id': '__fake_id__', 'summary': [{'text': 'thinking', 'type': 'summary_text'}], 'type': 'reasoning'},
 {'content': [...], 'role': 'assistant', 'status': 'completed', 'type': 'message'}]
```

After — the item without a real identity is dropped by the existing unpersistable check:

```
[{'content': 'hello', 'role': 'user'},
 {'content': [...], 'role': 'assistant', 'status': 'completed', 'type': 'message'}]
```

This is the same placeholder-leak class as #4266 on the Responses request path (`_clean_item_for_openai` deletes `FAKE_RESPONSES_ID`), and the same symptom users hit in #2293 (`Invalid 'input[1].id': '__fake_id__'`). The Conversations persistence path never got the equivalent treatment.

**Root cause.** The ID-retention decision looks only at the item *type*, never at whether the ID is a real provider identity, so the SDK's own sentinel is treated as one.

**Fix + why minimal.** One condition in `_sanitize_openai_conversation_item`: an ID equal to `FAKE_RESPONSES_ID` is dropped for every item type. Nothing else moves — the sanitizer already runs before the unpersistable filter and before fingerprinting, so a placeholder-only reasoning item now falls into the existing "no identity" branch and is dropped, while one that also carries `encrypted_content` is still stored, just without the fabricated ID (matching the already-tested behavior for an encrypted reasoning item with no ID at all).

**Non-goals.** No change to which item types keep a genuine server ID, to reasoning-item persistence policy, to the Responses request path, or to any public API.

**Compatibility.** Behavior-only, and only for items carrying the SDK's internal sentinel; a caller cannot legitimately depend on `"__fake_id__"` reaching the OpenAI Conversations API.

### Test plan

Two regression tests in `tests/test_agent_runner.py`, next to the existing reasoning-persistence tests, both red on `main` for the right reason and green after:

- `test_save_result_to_openai_conversation_drops_placeholder_id_reasoning_item` — placeholder ID, no encrypted content → not sent. Pre-fix failure: `Left contains one more item: {'id': '__fake_id__', 'summary': [...], 'type': 'reasoning'}`.
- `test_save_result_to_openai_conversation_strips_placeholder_reasoning_id` — placeholder ID plus `encrypted_content` → still sent, without the ID. Pre-fix failure: `assert 'id' not in {'encrypted_content': 'encrypted', 'id': '__fake_id__', ...}`.

Existing boundary coverage kept: a real `rs_...` ID is still preserved (`..._preserves_reasoning_id_when_policy_is_omit`), an ID-less reasoning item is still dropped, and an encrypted ID-less one is still stored.

Verification run from the repository root on a clean checkout of this branch:

```
.agents/skills/code-change-verification/scripts/run.sh   # all commands passed
```

which covers:

```
make format        # ruff format → 864 files left unchanged; ruff check --fix → All checks passed!
make lint          # ruff check → All checks passed!
make typecheck     # pyright 0 errors, 0 warnings; mypy Success: no issues found in 851 source files
make tests         # 7066 passed, 28 skipped; serial suite 77 passed, 11 skipped
```

`uv run pytest tests/test_agent_runner.py` was also run three times back to back (201 passed each time) to confirm the new tests are order- and repeat-stable. No snapshots changed.

### Issue number

N/A — found while auditing the placeholder-ID handling added in #4266 against the Conversations persistence path. Related: #4266, #2293.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
