### PR TITLE
fix: count requests when providers omit usage

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -416,7 +416,8 @@ class AnyLLMModel(Model):
                     output_tokens_details=response.usage.output_tokens_details,
                 )
                 if response.usage
-                else Usage()
+                # The request completed, so it counts even when the provider omits usage.
+                else Usage(requests=1)
             )
 
             if tracing.include_data():
@@ -607,7 +608,8 @@ class AnyLLMModel(Model):
                     output_tokens_details=response.usage.completion_tokens_details,  # type: ignore[arg-type]
                 )
                 if response.usage
-                else Usage()
+                # The request completed, so it counts even when the provider omits usage.
+                else Usage(requests=1)
             )
 
             # Some providers signal a filtered non-streaming completion only through

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -57,6 +57,7 @@ from ...usage import (
     _attach_raw_usage_snapshot,
     _extract_raw_usage_snapshot,
     _raw_usage_snapshot,
+    mark_request_completed_without_usage,
 )
 from ...util._error_tracing import model_span_errors, record_model_error_on_span
 from ...util._json import _to_dump_compatible
@@ -482,6 +483,11 @@ class AnyLLMModel(Model):
                         final_response = chunk.response
                         if model_settings.preserve_raw_usage is True:
                             _attach_raw_usage_snapshot(chunk.response, chunk.response.usage)
+                        if final_response.usage is None:
+                            # Match the non-streaming path: the request happened even though
+                            # the provider reported no usage. Recorded without synthesizing a
+                            # usage payload, so tokens are not reported as real zeros.
+                            mark_request_completed_without_usage(final_response)
                     elif chunk_type in {"response.failed", "response.incomplete"}:
                         terminal_response = getattr(chunk, "response", None)
                         terminal_failure_error = response_terminal_failure_error(

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -60,7 +60,6 @@ from ...usage import (
     _raw_usage_snapshot,
     _requests_for_response_without_usage,
     _response_usage_to_usage,
-    _span_usage_without_provider_totals,
     model_usage_to_span_usage,
 )
 from ...util._error_tracing import model_span_errors, record_model_error_on_span
@@ -808,7 +807,7 @@ class AnyLLMModel(Model):
         elif _requests_for_response_without_usage(final_response):
             # Keep streamed tracing aligned with the non-streaming path, which records the
             # request even when the provider reports no usage.
-            span_generation.span_data.usage = _span_usage_without_provider_totals()
+            span_generation.span_data.usage = model_usage_to_span_usage(Usage(requests=1))
 
     @overload
     async def _fetch_chat_response(

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -59,7 +59,9 @@ from ...usage import (
     _mark_request_completed_without_usage,
     _raw_usage_snapshot,
     _requests_for_response_without_usage,
+    _response_usage_to_usage,
     _span_usage_without_provider_totals,
+    model_usage_to_span_usage,
 )
 from ...util._error_tracing import model_span_errors, record_model_error_on_span
 from ...util._json import _to_dump_compatible
@@ -423,6 +425,8 @@ class AnyLLMModel(Model):
                 else Usage(requests=1)
             )
 
+            span_response.span_data.usage = model_usage_to_span_usage(usage)
+
             if tracing.include_data():
                 span_response.span_data.response = response
                 span_response.span_data.input = input
@@ -511,6 +515,14 @@ class AnyLLMModel(Model):
                         yielded_terminal_event = True
                         # Populate the span before yielding the terminal event so a consumer
                         # that stops there still leaves a fully recorded span.
+                        if final_response is not None:
+                            span_response.span_data.usage = model_usage_to_span_usage(
+                                _response_usage_to_usage(final_response.usage)
+                                if final_response.usage
+                                else Usage(
+                                    requests=_requests_for_response_without_usage(final_response)
+                                )
+                            )
                         if tracing.include_data() and final_response:
                             span_response.span_data.response = final_response
                             span_response.span_data.input = input

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -56,8 +56,10 @@ from ...usage import (
     Usage,
     _attach_raw_usage_snapshot,
     _extract_raw_usage_snapshot,
+    _mark_request_completed_without_usage,
     _raw_usage_snapshot,
-    mark_request_completed_without_usage,
+    _requests_for_response_without_usage,
+    _span_usage_without_provider_totals,
 )
 from ...util._error_tracing import model_span_errors, record_model_error_on_span
 from ...util._json import _to_dump_compatible
@@ -487,7 +489,7 @@ class AnyLLMModel(Model):
                             # Match the non-streaming path: the request happened even though
                             # the provider reported no usage. Recorded without synthesizing a
                             # usage payload, so tokens are not reported as real zeros.
-                            mark_request_completed_without_usage(final_response)
+                            _mark_request_completed_without_usage(final_response)
                     elif chunk_type in {"response.failed", "response.incomplete"}:
                         terminal_response = getattr(chunk, "response", None)
                         terminal_failure_error = response_terminal_failure_error(
@@ -791,6 +793,10 @@ class AnyLLMModel(Model):
                     else {"reasoning_tokens": 0}
                 ),
             }
+        elif _requests_for_response_without_usage(final_response):
+            # Keep streamed tracing aligned with the non-streaming path, which records the
+            # request even when the provider reports no usage.
+            span_generation.span_data.usage = _span_usage_without_provider_totals()
 
     @overload
     async def _fetch_chat_response(

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -289,10 +289,11 @@ class LitellmModel(Model):
                         ),
                     )
                     if response.usage
-                    else Usage()
+                    # The request completed, so it counts even when the provider omits usage.
+                    else Usage(requests=1)
                 )
             else:
-                usage = Usage()
+                usage = Usage(requests=1)
                 logger.warning("No usage information returned from Litellm")
 
             if tracing.include_data():

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -58,7 +58,13 @@ from ...tool import Tool
 from ...tracing import generation_span
 from ...tracing.span_data import GenerationSpanData
 from ...tracing.spans import Span
-from ...usage import Usage, _cache_write_tokens, _make_input_tokens_details
+from ...usage import (
+    Usage,
+    _cache_write_tokens,
+    _make_input_tokens_details,
+    _requests_for_response_without_usage,
+    _span_usage_without_provider_totals,
+)
 from ...util._error_tracing import model_span_errors
 from ...util._json import _to_dump_compatible
 
@@ -465,6 +471,12 @@ class LitellmModel(Model):
                         else {"reasoning_tokens": 0}
                     ),
                 }
+            elif final_response is not None and _requests_for_response_without_usage(
+                final_response
+            ):
+                # Keep streamed tracing aligned with the non-streaming path, which records the
+                # request even when the provider reports no usage.
+                span_generation.span_data.usage = _span_usage_without_provider_totals()
 
     @overload
     async def _fetch_response(

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -63,7 +63,7 @@ from ...usage import (
     _cache_write_tokens,
     _make_input_tokens_details,
     _requests_for_response_without_usage,
-    _span_usage_without_provider_totals,
+    model_usage_to_span_usage,
 )
 from ...util._error_tracing import model_span_errors
 from ...util._json import _to_dump_compatible
@@ -486,7 +486,7 @@ class LitellmModel(Model):
         elif _requests_for_response_without_usage(final_response):
             # Keep streamed tracing aligned with the non-streaming path, which records the
             # request even when the provider reports no usage.
-            span_generation.span_data.usage = _span_usage_without_provider_totals()
+            span_generation.span_data.usage = model_usage_to_span_usage(Usage(requests=1))
 
     @overload
     async def _fetch_response(

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -431,6 +431,12 @@ class LitellmModel(Model):
                     if chunk.type == "response.completed":
                         final_response = chunk.response
                         yielded_terminal_event = True
+                        # Populate the span before yielding, because a caller that stops
+                        # consuming at the terminal event closes this generator and never
+                        # resumes it, which would leave the span without usage.
+                        self._populate_stream_generation_span(
+                            span_generation, final_response, tracing
+                        )
 
                     yield chunk
             except asyncio.CancelledError:
@@ -451,32 +457,36 @@ class LitellmModel(Model):
                         else:
                             raise
 
-            if tracing.include_data() and final_response:
-                span_generation.span_data.output = [final_response.model_dump()]
+    @staticmethod
+    def _populate_stream_generation_span(
+        span_generation: Span[GenerationSpanData],
+        final_response: Response,
+        tracing: ModelTracing,
+    ) -> None:
+        if tracing.include_data():
+            span_generation.span_data.output = [final_response.model_dump()]
 
-            if final_response and final_response.usage:
-                span_generation.span_data.usage = {
-                    "requests": 1,
-                    "input_tokens": final_response.usage.input_tokens,
-                    "output_tokens": final_response.usage.output_tokens,
-                    "total_tokens": final_response.usage.total_tokens,
-                    "input_tokens_details": (
-                        final_response.usage.input_tokens_details.model_dump()
-                        if final_response.usage.input_tokens_details
-                        else {"cached_tokens": 0, "cache_write_tokens": 0}
-                    ),
-                    "output_tokens_details": (
-                        final_response.usage.output_tokens_details.model_dump()
-                        if final_response.usage.output_tokens_details
-                        else {"reasoning_tokens": 0}
-                    ),
-                }
-            elif final_response is not None and _requests_for_response_without_usage(
-                final_response
-            ):
-                # Keep streamed tracing aligned with the non-streaming path, which records the
-                # request even when the provider reports no usage.
-                span_generation.span_data.usage = _span_usage_without_provider_totals()
+        if final_response.usage:
+            span_generation.span_data.usage = {
+                "requests": 1,
+                "input_tokens": final_response.usage.input_tokens,
+                "output_tokens": final_response.usage.output_tokens,
+                "total_tokens": final_response.usage.total_tokens,
+                "input_tokens_details": (
+                    final_response.usage.input_tokens_details.model_dump()
+                    if final_response.usage.input_tokens_details
+                    else {"cached_tokens": 0, "cache_write_tokens": 0}
+                ),
+                "output_tokens_details": (
+                    final_response.usage.output_tokens_details.model_dump()
+                    if final_response.usage.output_tokens_details
+                    else {"reasoning_tokens": 0}
+                ),
+            }
+        elif _requests_for_response_without_usage(final_response):
+            # Keep streamed tracing aligned with the non-streaming path, which records the
+            # request even when the provider reports no usage.
+            span_generation.span_data.usage = _span_usage_without_provider_totals()
 
     @overload
     async def _fetch_response(

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -56,6 +56,7 @@ from ..usage import (
     _cache_write_tokens,
     _extract_raw_usage_snapshot,
     _make_input_tokens_details,
+    mark_request_completed_without_usage,
 )
 from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
@@ -1285,6 +1286,11 @@ class ChatCmplStreamHandler:
         )
         if preserve_raw_usage:
             _attach_raw_usage_snapshot(final_response, raw_usage)
+        if usage is None:
+            # The stream reached a terminal response, so a request was made even though the
+            # provider reported no usage. Record that without inventing a usage payload, so
+            # the raw usage snapshot stays absent and tokens are not reported as real zeros.
+            mark_request_completed_without_usage(final_response)
 
         yield ResponseCompletedEvent(
             response=final_response,

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -56,7 +56,7 @@ from ..usage import (
     _cache_write_tokens,
     _extract_raw_usage_snapshot,
     _make_input_tokens_details,
-    mark_request_completed_without_usage,
+    _mark_request_completed_without_usage,
 )
 from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
@@ -1290,7 +1290,7 @@ class ChatCmplStreamHandler:
             # The stream reached a terminal response, so a request was made even though the
             # provider reported no usage. Record that without inventing a usage payload, so
             # the raw usage snapshot stays absent and tokens are not reported as real zeros.
-            mark_request_completed_without_usage(final_response)
+            _mark_request_completed_without_usage(final_response)
 
         yield ResponseCompletedEvent(
             response=final_response,

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -471,6 +471,12 @@ class OpenAIChatCompletionsModel(Model):
                     if chunk.type == "response.completed":
                         final_response = chunk.response
                         yielded_terminal_event = True
+                        # Populate the span before yielding, because a caller that stops
+                        # consuming at the terminal event closes this generator and never
+                        # resumes it, which would leave the span without usage.
+                        self._populate_stream_generation_span(
+                            span_generation, final_response, tracing
+                        )
 
                     yield chunk
             except asyncio.CancelledError:
@@ -491,32 +497,36 @@ class OpenAIChatCompletionsModel(Model):
                         else:
                             raise
 
-            if tracing.include_data() and final_response:
-                span_generation.span_data.output = [final_response.model_dump()]
+    @staticmethod
+    def _populate_stream_generation_span(
+        span_generation: Span[GenerationSpanData],
+        final_response: Response,
+        tracing: ModelTracing,
+    ) -> None:
+        if tracing.include_data():
+            span_generation.span_data.output = [final_response.model_dump()]
 
-            if final_response and final_response.usage:
-                span_generation.span_data.usage = {
-                    "requests": 1,
-                    "input_tokens": final_response.usage.input_tokens,
-                    "output_tokens": final_response.usage.output_tokens,
-                    "total_tokens": final_response.usage.total_tokens,
-                    "input_tokens_details": (
-                        final_response.usage.input_tokens_details.model_dump()
-                        if final_response.usage.input_tokens_details
-                        else {"cached_tokens": 0, "cache_write_tokens": 0}
-                    ),
-                    "output_tokens_details": (
-                        final_response.usage.output_tokens_details.model_dump()
-                        if final_response.usage.output_tokens_details
-                        else {"reasoning_tokens": 0}
-                    ),
-                }
-            elif final_response is not None and _requests_for_response_without_usage(
-                final_response
-            ):
-                # Keep streamed tracing aligned with the non-streaming path, which records the
-                # request even when the provider reports no usage.
-                span_generation.span_data.usage = _span_usage_without_provider_totals()
+        if final_response.usage:
+            span_generation.span_data.usage = {
+                "requests": 1,
+                "input_tokens": final_response.usage.input_tokens,
+                "output_tokens": final_response.usage.output_tokens,
+                "total_tokens": final_response.usage.total_tokens,
+                "input_tokens_details": (
+                    final_response.usage.input_tokens_details.model_dump()
+                    if final_response.usage.input_tokens_details
+                    else {"cached_tokens": 0, "cache_write_tokens": 0}
+                ),
+                "output_tokens_details": (
+                    final_response.usage.output_tokens_details.model_dump()
+                    if final_response.usage.output_tokens_details
+                    else {"reasoning_tokens": 0}
+                ),
+            }
+        elif _requests_for_response_without_usage(final_response):
+            # Keep streamed tracing aligned with the non-streaming path, which records the
+            # request even when the provider reports no usage.
+            span_generation.span_data.usage = _span_usage_without_provider_totals()
 
     def _handle_unsupported_server_managed_conversation_state(
         self,

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -35,7 +35,7 @@ from ..usage import (
     Usage,
     _raw_usage_snapshot,
     _requests_for_response_without_usage,
-    _span_usage_without_provider_totals,
+    model_usage_to_span_usage,
 )
 from ..util._error_tracing import model_span_errors
 from ..util._json import _to_dump_compatible
@@ -526,7 +526,7 @@ class OpenAIChatCompletionsModel(Model):
         elif _requests_for_response_without_usage(final_response):
             # Keep streamed tracing aligned with the non-streaming path, which records the
             # request even when the provider reports no usage.
-            span_generation.span_data.usage = _span_usage_without_provider_totals()
+            span_generation.span_data.usage = model_usage_to_span_usage(Usage(requests=1))
 
     def _handle_unsupported_server_managed_conversation_state(
         self,

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -31,7 +31,12 @@ from ..tool import Tool
 from ..tracing import generation_span
 from ..tracing.span_data import GenerationSpanData
 from ..tracing.spans import Span
-from ..usage import Usage, _raw_usage_snapshot
+from ..usage import (
+    Usage,
+    _raw_usage_snapshot,
+    _requests_for_response_without_usage,
+    _span_usage_without_provider_totals,
+)
 from ..util._error_tracing import model_span_errors
 from ..util._json import _to_dump_compatible
 from ._openai_retry import get_openai_retry_advice
@@ -506,6 +511,12 @@ class OpenAIChatCompletionsModel(Model):
                         else {"reasoning_tokens": 0}
                     ),
                 }
+            elif final_response is not None and _requests_for_response_without_usage(
+                final_response
+            ):
+                # Keep streamed tracing aligned with the non-streaming path, which records the
+                # request even when the provider reports no usage.
+                span_generation.span_data.usage = _span_usage_without_provider_totals()
 
     def _handle_unsupported_server_managed_conversation_state(
         self,

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -291,7 +291,8 @@ class OpenAIChatCompletionsModel(Model):
                     output_tokens_details=response.usage.completion_tokens_details,  # type: ignore[arg-type]
                 )
                 if response.usage
-                else Usage()
+                # The request completed, so it counts even when the provider omits usage.
+                else Usage(requests=1)
             )
 
             # Some providers signal a filtered non-streaming completion only through

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -79,7 +79,12 @@ from ..tracing import Span, SpanError, agent_span, get_current_trace, task_span,
 from ..tracing.config import include_task_and_turn_spans
 from ..tracing.model_tracing import get_model_tracing_impl
 from ..tracing.span_data import AgentSpanData, TaskSpanData
-from ..usage import Usage, _extract_raw_usage_snapshot, _response_usage_to_usage
+from ..usage import (
+    Usage,
+    _extract_raw_usage_snapshot,
+    _response_usage_to_usage,
+    requests_for_response_without_usage,
+)
 from ..util import _coro, _error_tracing
 from ..util._asyncio_tasks import gather_with_cancel
 from .agent_bindings import AgentBindings, bind_public_agent
@@ -1725,7 +1730,9 @@ async def run_single_turn_streamed(
                 (
                     _response_usage_to_usage(terminal_response.usage)
                     if terminal_response.usage
-                    else Usage()
+                    # Defaults to zero requests, so adapters that fold several provider
+                    # responses into one and report counts separately are not double-counted.
+                    else Usage(requests=requests_for_response_without_usage(terminal_response))
                 ),
                 stream_failed_retry_attempts[0],
             )

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -82,8 +82,8 @@ from ..tracing.span_data import AgentSpanData, TaskSpanData
 from ..usage import (
     Usage,
     _extract_raw_usage_snapshot,
+    _requests_for_response_without_usage,
     _response_usage_to_usage,
-    requests_for_response_without_usage,
 )
 from ..util import _coro, _error_tracing
 from ..util._asyncio_tasks import gather_with_cancel
@@ -1732,7 +1732,7 @@ async def run_single_turn_streamed(
                     if terminal_response.usage
                     # Defaults to zero requests, so adapters that fold several provider
                     # responses into one and report counts separately are not double-counted.
-                    else Usage(requests=requests_for_response_without_usage(terminal_response))
+                    else Usage(requests=_requests_for_response_without_usage(terminal_response))
                 ),
                 stream_failed_retry_attempts[0],
             )

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -322,22 +322,6 @@ def _mark_request_completed_without_usage(response: Any) -> None:
     object.__setattr__(response, _REQUEST_WITHOUT_USAGE_ATTR, True)
 
 
-def _span_usage_without_provider_totals() -> dict[str, Any]:
-    """Span usage for a response that completed without any provider usage payload.
-
-    The request is recorded so streamed and non-streaming tracing agree, while every token
-    total stays at zero because the provider genuinely reported none.
-    """
-    return {
-        "requests": 1,
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "total_tokens": 0,
-        "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
-        "output_tokens_details": {"reasoning_tokens": 0},
-    }
-
-
 def _requests_for_response_without_usage(response: Any) -> int:
     """How many requests a usage-less response represents.
 

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -313,7 +313,7 @@ class Usage:
 _REQUEST_WITHOUT_USAGE_ATTR = "_agents_sdk_request_completed_without_usage"
 
 
-def mark_request_completed_without_usage(response: Any) -> None:
+def _mark_request_completed_without_usage(response: Any) -> None:
     """Record that a response completed even though the provider reported no usage.
 
     Adapters call this instead of synthesizing a zero-filled usage payload, so the raw
@@ -322,7 +322,23 @@ def mark_request_completed_without_usage(response: Any) -> None:
     object.__setattr__(response, _REQUEST_WITHOUT_USAGE_ATTR, True)
 
 
-def requests_for_response_without_usage(response: Any) -> int:
+def _span_usage_without_provider_totals() -> dict[str, Any]:
+    """Span usage for a response that completed without any provider usage payload.
+
+    The request is recorded so streamed and non-streaming tracing agree, while every token
+    total stays at zero because the provider genuinely reported none.
+    """
+    return {
+        "requests": 1,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
+        "output_tokens_details": {"reasoning_tokens": 0},
+    }
+
+
+def _requests_for_response_without_usage(response: Any) -> int:
     """How many requests a usage-less response represents.
 
     Defaults to zero so adapters that multiplex several provider responses into one

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -310,6 +310,27 @@ class Usage:
             self.request_usage_entries.append(request_usage)
 
 
+_REQUEST_WITHOUT_USAGE_ATTR = "_agents_sdk_request_completed_without_usage"
+
+
+def mark_request_completed_without_usage(response: Any) -> None:
+    """Record that a response completed even though the provider reported no usage.
+
+    Adapters call this instead of synthesizing a zero-filled usage payload, so the raw
+    provider usage stays absent while the request itself is still counted.
+    """
+    object.__setattr__(response, _REQUEST_WITHOUT_USAGE_ATTR, True)
+
+
+def requests_for_response_without_usage(response: Any) -> int:
+    """How many requests a usage-less response represents.
+
+    Defaults to zero so adapters that multiplex several provider responses into one
+    response, and report their counts separately, are not double-counted.
+    """
+    return 1 if getattr(response, _REQUEST_WITHOUT_USAGE_ATTR, False) else 0
+
+
 def _response_usage_to_usage(response_usage: Any) -> Usage:
     """Convert Responses API usage, including adapter-supplied per-request details."""
     request_usages = getattr(response_usage, "_agents_sdk_request_usages", None)

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -1919,3 +1919,85 @@ async def test_any_llm_responses_stream_lets_in_flight_close_finish_after_cancel
     finally:
         release.set()
         task.cancel()
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_counts_request_when_usage_is_absent(monkeypatch) -> None:
+    """The AnyLLM Responses stream must count its request like the non-streaming path.
+
+    `get_response` already reports one request when the provider omits usage. The streaming
+    path went through the run loop's usage-less fallback and reported zero, so the same call
+    was counted differently depending only on whether it was streamed.
+    """
+    completed = _response("Hello")
+    completed.usage = None
+
+    async def response_stream() -> AsyncIterator[ResponseCompletedEvent]:
+        yield ResponseCompletedEvent(
+            type="response.completed", response=completed, sequence_number=1
+        )
+
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=response_stream())
+    module, _ = _import_any_llm_module(monkeypatch, provider)
+
+    events = [
+        event
+        async for event in module.AnyLLMModel(model="openai/gpt-5.4-mini").stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+    ]
+
+    from agents.usage import requests_for_response_without_usage
+
+    terminal = events[-1]
+    assert isinstance(terminal, ResponseCompletedEvent)
+    # No usage payload is synthesized, so token counts are not reported as real zeros.
+    assert terminal.response.usage is None
+    assert requests_for_response_without_usage(terminal.response) == 1
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_any_llm_responses_stream_with_usage_is_not_marked(monkeypatch) -> None:
+    """A response that did report usage must not also be counted by the usage-less path."""
+
+    async def response_stream() -> AsyncIterator[ResponseCompletedEvent]:
+        yield ResponseCompletedEvent(
+            type="response.completed", response=_response("Hello"), sequence_number=1
+        )
+
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=response_stream())
+    module, _ = _import_any_llm_module(monkeypatch, provider)
+
+    events = [
+        event
+        async for event in module.AnyLLMModel(model="openai/gpt-5.4-mini").stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+    ]
+
+    from agents.usage import requests_for_response_without_usage
+
+    terminal = events[-1]
+    assert isinstance(terminal, ResponseCompletedEvent)
+    assert terminal.response.usage is not None
+    assert requests_for_response_without_usage(terminal.response) == 0

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -1957,13 +1957,13 @@ async def test_any_llm_responses_stream_counts_request_when_usage_is_absent(monk
         )
     ]
 
-    from agents.usage import requests_for_response_without_usage
+    from agents.usage import _requests_for_response_without_usage
 
     terminal = events[-1]
     assert isinstance(terminal, ResponseCompletedEvent)
     # No usage payload is synthesized, so token counts are not reported as real zeros.
     assert terminal.response.usage is None
-    assert requests_for_response_without_usage(terminal.response) == 1
+    assert _requests_for_response_without_usage(terminal.response) == 1
 
 
 @pytest.mark.allow_call_model_methods
@@ -1995,9 +1995,9 @@ async def test_any_llm_responses_stream_with_usage_is_not_marked(monkeypatch) ->
         )
     ]
 
-    from agents.usage import requests_for_response_without_usage
+    from agents.usage import _requests_for_response_without_usage
 
     terminal = events[-1]
     assert isinstance(terminal, ResponseCompletedEvent)
     assert terminal.response.usage is not None
-    assert requests_for_response_without_usage(terminal.response) == 0
+    assert _requests_for_response_without_usage(terminal.response) == 0

--- a/tests/models/test_litellm_usage_requests.py
+++ b/tests/models/test_litellm_usage_requests.py
@@ -1,0 +1,45 @@
+import litellm
+import pytest
+from litellm.types.utils import Choices, Message, ModelResponse
+
+from agents.extensions.models.litellm_model import LitellmModel
+from agents.model_settings import ModelSettings
+from agents.models.interface import ModelTracing
+
+
+async def _get_response(monkeypatch, *, response: ModelResponse):
+    async def fake_acompletion(model, messages=None, **kwargs):
+        return response
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    return await LitellmModel(model="test-model").get_response(
+        system_instructions=None,
+        input=[],
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+
+
+def _response_without_usage() -> ModelResponse:
+    response = ModelResponse(
+        choices=[Choices(index=0, message=Message(role="assistant", content="ok"))]
+    )
+    # LiteLLM providers that report nothing leave usage unset or None.
+    response.usage = None  # type: ignore[attr-defined]
+    return response
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_request_is_counted_when_litellm_reports_no_usage(monkeypatch) -> None:
+    """The call happened, so it counts, even though no token counts came back."""
+    resp = await _get_response(monkeypatch, response=_response_without_usage())
+
+    assert resp.usage.requests == 1
+    assert resp.usage.input_tokens == 0
+    assert resp.usage.output_tokens == 0
+    assert resp.usage.total_tokens == 0

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -760,8 +760,9 @@ async def test_get_response_with_refusal(monkeypatch) -> None:
     refusal_part = resp.output[0].content[0]
     assert isinstance(refusal_part, ResponseOutputRefusal)
     assert refusal_part.refusal == "No thanks"
-    # With no usage from the completion, usage defaults to zeros.
-    assert resp.usage.requests == 0
+    # With no usage from the completion, token counts default to zeros, but the request itself
+    # still happened and is counted.
+    assert resp.usage.requests == 1
     assert resp.usage.input_tokens == 0
     assert resp.usage.output_tokens == 0
     assert resp.usage.input_tokens_details.cached_tokens == 0
@@ -1504,3 +1505,48 @@ async def test_get_response_request_id_is_none_when_absent(monkeypatch) -> None:
     )
 
     assert resp.request_id is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_request_is_counted_when_provider_omits_usage(monkeypatch) -> None:
+    """A completed call counts as one request even when the provider reports no usage.
+
+    Some OpenAI-compatible providers and gateways return no `usage` block. Counting those as
+    zero requests understates `Usage.requests`, which is documented as the number of requests
+    made to the LLM API, and is inconsistent with the retry path, which already forces the
+    successful attempt to count via `max(usage.requests, 1)`.
+    """
+    msg = ChatCompletionMessage(role="assistant", content="hello")
+    chat = ChatCompletion(
+        id="resp-id",
+        created=0,
+        model="fake",
+        object="chat.completion",
+        choices=[Choice(index=0, finish_reason="stop", message=msg)],
+        usage=None,
+    )
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        return chat
+
+    monkeypatch.setattr(OpenAIChatCompletionsModel, "_fetch_response", patched_fetch_response)
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+    resp: ModelResponse = await model.get_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert resp.usage.requests == 1
+    # Token counts stay at zero, since the provider genuinely did not report them.
+    assert resp.usage.input_tokens == 0
+    assert resp.usage.output_tokens == 0
+    assert resp.usage.total_tokens == 0

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -3916,3 +3916,82 @@ async def test_stream_handler_drops_citations_reported_before_any_text() -> None
     message = cast(ResponseOutputMessage, completed.response.output[0])
     assert len(message.content) == 1
     assert cast(ResponseOutputText, message.content[0]).text == "It will rain tomorrow."
+
+
+def _usageless_stream_patch(usage: CompletionUsage | None = None):
+    """Patch `_fetch_response` with a stream whose only chunk carries `usage`."""
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(content="Hello"))],
+        usage=usage,
+    )
+
+    async def fake_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield chunk
+
+    async def patched_fetch_response(self, *args, **kwargs):
+        resp = Response(
+            id="resp-id",
+            created_at=0,
+            model="fake-model",
+            object="response",
+            output=[],
+            tool_choice="none",
+            tools=[],
+            parallel_tool_calls=False,
+        )
+        return resp, fake_stream()
+
+    return patched_fetch_response
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_streamed_run_counts_request_when_provider_omits_usage(monkeypatch) -> None:
+    """A stream that never carries a usage chunk still made a request.
+
+    Providers without `stream_options.include_usage` finish the stream with no usage payload.
+    The run must still report the request, while token counts stay at zero because the
+    provider genuinely did not report them.
+    """
+    monkeypatch.setattr(
+        OpenAIChatCompletionsModel, "_fetch_response", _usageless_stream_patch(usage=None)
+    )
+    agent = Agent(name="test", model=OpenAIProvider(use_responses=False).get_model("gpt-4"))
+
+    result = Runner.run_streamed(agent, "hi")
+    completed: ResponseCompletedEvent | None = None
+    async for event in result.stream_events():
+        raw = getattr(event, "data", None)
+        if isinstance(raw, ResponseCompletedEvent):
+            completed = raw
+
+    assert result.context_wrapper.usage.requests == 1
+    assert result.context_wrapper.usage.total_tokens == 0
+    # No usage payload is synthesized, so nothing reports token counts that never arrived.
+    assert completed is not None
+    assert completed.response.usage is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_streamed_run_does_not_double_count_when_usage_is_present(monkeypatch) -> None:
+    """The usage-less path must not add a second request when usage did arrive."""
+    monkeypatch.setattr(
+        OpenAIChatCompletionsModel,
+        "_fetch_response",
+        _usageless_stream_patch(
+            usage=CompletionUsage(completion_tokens=5, prompt_tokens=7, total_tokens=12)
+        ),
+    )
+    agent = Agent(name="test", model=OpenAIProvider(use_responses=False).get_model("gpt-4"))
+
+    result = Runner.run_streamed(agent, "hi")
+    async for _ in result.stream_events():
+        pass
+
+    assert result.context_wrapper.usage.requests == 1
+    assert result.context_wrapper.usage.total_tokens == 12

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -4033,3 +4033,41 @@ async def test_streamed_span_records_the_request_when_provider_omits_usage(monke
     assert generation.span_data.usage["requests"] == 1
     # The provider reported no tokens, so every total stays at zero.
     assert generation.span_data.usage["total_tokens"] == 0
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_stream_span_is_recorded_for_a_consumer_that_stops_at_the_terminal_event(
+    monkeypatch,
+) -> None:
+    """A caller that stops at `response.completed` closes the generator.
+
+    Anything recorded only after the yield loop never runs for such a consumer, so the span
+    has to be populated before the terminal event is handed out.
+    """
+    monkeypatch.setattr(
+        OpenAIChatCompletionsModel, "_fetch_response", _usageless_stream_patch(usage=None)
+    )
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    with trace(workflow_name="test"):
+        stream = model.stream_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.ENABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+        async for event in stream:
+            if event.type == "response.completed":
+                break  # stop consuming, as a caller watching for the terminal event would
+        await stream.aclose()
+
+    generation = next(s for s in fetch_ordered_spans() if s.span_data.type == "generation")
+    assert generation.span_data.usage is not None
+    assert generation.span_data.usage["requests"] == 1

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -34,7 +34,7 @@ from openai.types.responses import (
     ResponseReasoningItem,
 )
 
-from agents import Agent, Runner, function_tool
+from agents import Agent, Runner, function_tool, trace
 from agents.exceptions import ModelBehaviorError, UserError
 from agents.model_settings import ModelSettings
 from agents.models.chatcmpl_converter import Converter
@@ -50,6 +50,7 @@ from agents.models.chatcmpl_stream_handler import (
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
+from tests.testing_processor import fetch_ordered_spans
 from tests.utils.simple_session import SimpleListSession
 
 
@@ -3995,3 +3996,40 @@ async def test_streamed_run_does_not_double_count_when_usage_is_present(monkeypa
 
     assert result.context_wrapper.usage.requests == 1
     assert result.context_wrapper.usage.total_tokens == 12
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_streamed_span_records_the_request_when_provider_omits_usage(monkeypatch) -> None:
+    """Streamed tracing must record the request the same way the non-streaming path does.
+
+    Non-streaming writes a span usage object with `requests: 1` when the provider reports no
+    usage. Streaming used to omit span usage entirely, so the run reported one request while
+    the model span showed none.
+    """
+    monkeypatch.setattr(
+        OpenAIChatCompletionsModel, "_fetch_response", _usageless_stream_patch(usage=None)
+    )
+    model = OpenAIProvider(use_responses=False).get_model("gpt-4")
+
+    with trace(workflow_name="test"):
+        async for _ in model.stream_response(
+            system_instructions=None,
+            input="",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.ENABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        ):
+            pass
+
+    spans = fetch_ordered_spans()
+    generation = next(s for s in spans if s.span_data.type == "generation")
+    assert generation.span_data.usage is not None
+    assert generation.span_data.usage["requests"] == 1
+    # The provider reported no tokens, so every total stays at zero.
+    assert generation.span_data.usage["total_tokens"] == 0

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -4063,10 +4063,11 @@ async def test_stream_span_is_recorded_for_a_consumer_that_stops_at_the_terminal
             conversation_id=None,
             prompt=None,
         )
-        async for event in stream:
+        stream_agen = cast(Any, stream)
+        async for event in stream_agen:
             if event.type == "response.completed":
                 break  # stop consuming, as a caller watching for the terminal event would
-        await stream.aclose()
+        await stream_agen.aclose()
 
     generation = next(s for s in fetch_ordered_spans() if s.span_data.type == "generation")
     assert generation.span_data.usage is not None


### PR DESCRIPTION
This pull request takes over and completes the work started in #4281.

It counts completed model requests when providers omit usage across OpenAI Chat Completions, LiteLLM, and AnyLLM while preserving absent raw usage and Hosted Multi-Agent request accounting. It also aligns streamed tracing with non-streaming behavior, records span usage before terminal events are yielded, fixes the terminal-event test typing failure, and reuses the canonical usage-to-span serializer.
