### PR TITLE
fix: compute G.711 audio length for typed and mapping format spellings

### DIFF
--- a/src/agents/realtime/_util.py
+++ b/src/agents/realtime/_util.py
@@ -1,20 +1,48 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+
+from openai.types.realtime.realtime_audio_formats import AudioPCMA, AudioPCMU
+
 from .config import RealtimeAudioFormat
 
 PCM16_SAMPLE_RATE_HZ = 24_000
 PCM16_SAMPLE_WIDTH_BYTES = 2
 G711_SAMPLE_RATE_HZ = 8_000
 
+# Every spelling of the two G.711 families accepted across the SDK: the legacy session-config
+# names, the GA wire-format names, and their bare suffixes. Kept in sync with the session
+# normalizer in `audio_formats.to_realtime_audio_format`.
+_G711_FORMAT_NAMES = frozenset(
+    {"g711_ulaw", "g711_alaw", "audio/pcmu", "audio/pcma", "pcmu", "pcma"}
+)
+
+
+def _is_g711_format(format: RealtimeAudioFormat | None) -> bool:
+    """Whether the format is G.711 (8 kHz, one byte per sample) in any of its spellings.
+
+    The format may arrive as a legacy string (``"g711_ulaw"``), a GA wire-format mapping
+    (``{"type": "audio/pcmu"}``), or a typed ``AudioPCMU`` / ``AudioPCMA`` object, depending on
+    how the session was configured and which path delivered it.
+    """
+    if isinstance(format, str):
+        return format.lower() in _G711_FORMAT_NAMES or format.lower().startswith("g711")
+    if isinstance(format, AudioPCMU | AudioPCMA):
+        return True
+    if isinstance(format, Mapping):
+        format_type = format.get("type")
+        return isinstance(format_type, str) and format_type.lower() in _G711_FORMAT_NAMES
+    format_type = getattr(format, "type", None)
+    return isinstance(format_type, str) and format_type.lower() in _G711_FORMAT_NAMES
+
 
 def calculate_audio_length_ms(format: RealtimeAudioFormat | None, audio_bytes: bytes) -> float:
     if not audio_bytes:
         return 0.0
 
-    normalized_format = format.lower() if isinstance(format, str) else None
-
-    if normalized_format and normalized_format.startswith("g711"):
+    if _is_g711_format(format):
         return (len(audio_bytes) / G711_SAMPLE_RATE_HZ) * 1000
 
+    # PCM16 at 24 kHz, which also serves as the fallback for unknown formats.
     samples = len(audio_bytes) / PCM16_SAMPLE_WIDTH_BYTES
     return (samples / PCM16_SAMPLE_RATE_HZ) * 1000

--- a/tests/realtime/test_playback_tracker.py
+++ b/tests/realtime/test_playback_tracker.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from openai.types.realtime.realtime_audio_formats import AudioPCM, AudioPCMA, AudioPCMU
 
 from agents.realtime._default_tracker import ModelAudioTracker
 from agents.realtime.model import RealtimePlaybackTracker
@@ -259,3 +260,48 @@ class TestPlaybackTracker:
         # Test None format (defaults to PCM)
         none_length = calculate_audio_length_ms(None, pcm_bytes)
         assert none_length == pytest.approx(expected_pcm, rel=0, abs=1e-6)
+
+    @pytest.mark.parametrize(
+        "audio_format",
+        [
+            AudioPCMU(type="audio/pcmu"),
+            AudioPCMA(type="audio/pcma"),
+            {"type": "audio/pcmu"},
+            {"type": "audio/pcma"},
+            "audio/pcmu",
+            "audio/pcma",
+        ],
+        ids=["typed-ulaw", "typed-alaw", "mapping-ulaw", "mapping-alaw", "str-ulaw", "str-alaw"],
+    )
+    def test_g711_length_is_correct_for_every_format_spelling(self, audio_format):
+        """G.711 is one byte per sample at 8 kHz regardless of how the format is spelled.
+
+        Only the legacy `"g711_*"` strings were recognized, so the GA wire-format mapping and
+        the typed objects fell through to PCM16 math: 2 bytes per sample at 24 kHz, a 6x
+        shorter duration. That skews playback and interruption tracking for telephony
+        sessions, which are exactly the sessions that use G.711.
+        """
+        from agents.realtime._util import calculate_audio_length_ms
+
+        # 8000 bytes of G.711 is exactly one second of audio.
+        assert calculate_audio_length_ms(audio_format, b"\x00" * 8000) == 1000.0
+
+    @pytest.mark.parametrize(
+        "audio_format",
+        [AudioPCM(type="audio/pcm", rate=24000), {"type": "audio/pcm"}, "audio/pcm"],
+        ids=["typed", "mapping", "str"],
+    )
+    def test_pcm_spellings_keep_pcm16_math(self, audio_format):
+        from agents.realtime._util import calculate_audio_length_ms
+
+        # 48000 bytes of PCM16 at 24 kHz is exactly one second of audio.
+        assert calculate_audio_length_ms(audio_format, b"\x00" * 48000) == 1000.0
+
+    def test_playback_tracker_measures_g711_with_a_typed_format(self):
+        """End to end: a tracker configured with the GA typed format reports 8 kHz progress."""
+        playback_tracker = RealtimePlaybackTracker()
+        playback_tracker.set_audio_format(AudioPCMU(type="audio/pcmu"))
+
+        playback_tracker.on_play_bytes("item_1", 0, b"\x00" * 4000)
+
+        assert playback_tracker.get_state()["elapsed_ms"] == 500.0


### PR DESCRIPTION
### Summary

`calculate_audio_length_ms` only recognizes G.711 when the format arrives as a legacy string starting with `"g711"`. The same format in any other spelling the SDK accepts falls through to PCM16 math, 2 bytes per sample at 24 kHz instead of 1 byte per sample at 8 kHz, which reports a 6x shorter duration:

| format shape | expected for 8000 bytes | reported before |
| --- | --- | --- |
| `"g711_ulaw"` / `"g711_alaw"` | 1000 ms | 1000 ms |
| `{"type": "audio/pcmu"}` / `{"type": "audio/pcma"}` | 1000 ms | **166.67 ms** |
| `AudioPCMU` / `AudioPCMA` typed objects | 1000 ms | **166.67 ms** |

### Who hits it

Both consumers of this function:

- `ModelAudioTracker` gets its format from the websocket session normalizer. `_normalize_audio_format` reports a mapping config as its raw type string, so a session configured with the GA wire form `{"type": "audio/pcmu"}` reaches the calculator as `"audio/pcmu"` and takes the wrong branch.
- `RealtimePlaybackTracker.set_audio_format` is public API accepting the full `RealtimeAudioFormat` union, so user code passing the typed objects gets the same wrong math on `on_play_bytes`.

The consequence is that playback position and interruption timing are skewed 6x for telephony sessions, which are exactly the sessions that use G.711.

### Fix

The calculator now recognizes every spelling the SDK accepts for the two G.711 families: legacy strings, bare suffixes (`"pcmu"`), wire-format names (`"audio/pcmu"`), the GA mapping form, and the typed objects. PCM16 at 24 kHz remains the fallback for unknown formats, so nothing else changes behaviour.

Dispatch is inline rather than delegated to `to_realtime_audio_format` because the function runs per audio delta on the hot path, and the session normalizer logs and constructs typed objects per call. The recognized name set carries a comment tying it to that normalizer so the two stay aligned.

#3196 identified this same gap; it was closed for inactivity with an invitation to revisit in a new PR, so this supersedes it with a same-file fix and regression coverage.

### Test plan

Ten new tests in `tests/realtime/test_playback_tracker.py`, next to the existing format test:

- `test_g711_length_is_correct_for_every_format_spelling`, parametrized over the six spellings; all six fail before the fix
- `test_playback_tracker_measures_g711_with_a_typed_format`, end to end through the public tracker; fails before the fix
- `test_pcm_spellings_keep_pcm16_math`, pinning that PCM stays on 24 kHz math either way

| Command | Result |
| --- | --- |
| `make format` / `make lint` | clean |
| `make mypy` / `make pyright` | 0 issues in the touched files |
| `uv run pytest tests/realtime/test_playback_tracker.py` | 21 passed |
| `make tests` | 6377 passed |

Run on Windows, where a fixed set of sandbox and tracing tests fail regardless of this change; the failing set is identical to `main` at the same commit.

### Issue number

Supersedes #3196.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script shells out to `make`; I ran the underlying steps individually, with the results above.
