### PR TITLE
fix(sandbox): keep source entry metadata when lazily loading a skill

### DIFF
--- a/src/agents/sandbox/capabilities/skills.py
+++ b/src/agents/sandbox/capabilities/skills.py
@@ -253,7 +253,13 @@ class LocalDirLazySkillSource(LazySkillSource):
                 "path": str(metadata.path).replace("\\", "/"),
             }
 
-        await LocalDir(src=src_root / metadata.path.name).apply(
+        # Materialize through a copy of the configured source so the loaded skill keeps the
+        # entry metadata (permissions, group) that the eager `from_` path already applies.
+        skill_source = self.source.model_copy(
+            update={"src": src_root / metadata.path.name},
+            deep=True,
+        )
+        await skill_source.apply(
             session,
             skill_dest,
             base_dir=Path.cwd(),

--- a/tests/sandbox/capabilities/test_skills_capability.py
+++ b/tests/sandbox/capabilities/test_skills_capability.py
@@ -20,7 +20,7 @@ from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.session.sandbox_session import SandboxSession
 from agents.sandbox.snapshot import NoopSnapshot
 from agents.sandbox.types import ExecResult, FileMode, Group, Permissions, User
-from agents.sandbox.workspace_paths import coerce_posix_path
+from agents.sandbox.workspace_paths import coerce_posix_path, sandbox_path_str
 from agents.tool import FunctionTool
 from agents.tool_context import ToolContext
 from agents.tracing import trace
@@ -583,7 +583,7 @@ class TestSkillsInstructions:
             '{"skill_name":"dynamic-skill"}',
         )
 
-        skill_dest = str(workspace_root / ".agents" / "dynamic-skill")
+        skill_dest = sandbox_path_str(workspace_root / ".agents" / "dynamic-skill")
         assert ("chmod", "0700", skill_dest) in session.commands
         assert ("chgrp", "staff", skill_dest) in session.commands
         # The configured source entry must not be repointed at the loaded skill.
@@ -615,7 +615,7 @@ class TestSkillsInstructions:
             '{"skill_name":"dynamic-skill"}',
         )
 
-        skill_dest = str(workspace_root / ".agents" / "dynamic-skill")
+        skill_dest = sandbox_path_str(workspace_root / ".agents" / "dynamic-skill")
         assert ("chmod", "0755", skill_dest) in session.commands
         assert not any(command[:1] == ("chgrp",) for command in session.commands)
 

--- a/tests/sandbox/capabilities/test_skills_capability.py
+++ b/tests/sandbox/capabilities/test_skills_capability.py
@@ -19,7 +19,7 @@ from agents.sandbox.files import EntryKind, FileEntry
 from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.session.sandbox_session import SandboxSession
 from agents.sandbox.snapshot import NoopSnapshot
-from agents.sandbox.types import ExecResult, Permissions, User
+from agents.sandbox.types import ExecResult, FileMode, Group, Permissions, User
 from agents.sandbox.workspace_paths import coerce_posix_path
 from agents.tool import FunctionTool
 from agents.tool_context import ToolContext
@@ -140,6 +140,20 @@ class _WorkspaceNotFoundSkillsSession(_SkillsSession):
             return await super().read(path, user=user)
         except FileNotFoundError as exc:
             raise WorkspaceReadNotFoundError(path=path, cause=exc) from exc
+
+
+class _ExecRecordingSkillsSession(_SkillsSession):
+    def __init__(self, manifest: Manifest) -> None:
+        super().__init__(manifest)
+        self.commands: list[tuple[str, ...]] = []
+
+    async def _exec_internal(
+        self,
+        *command: str | Path,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        self.commands.append(tuple(str(part) for part in command))
+        return await super()._exec_internal(*command, timeout=timeout)
 
 
 class _ArchiveReadErrorSkillsSession(_SkillsSession):
@@ -541,6 +555,69 @@ class TestSkillsInstructions:
         }
         loaded_skill = workspace_root / ".agents" / "dynamic-skill" / "SKILL.md"
         assert loaded_skill.read_text(encoding="utf-8") == "# dynamic skill\n"
+
+    @pytest.mark.asyncio
+    async def test_lazy_local_dir_load_skill_applies_source_metadata(self, tmp_path: Path) -> None:
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        src_root = tmp_path / "skills"
+        skill_dir = src_root / "dynamic-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# dynamic skill\n", encoding="utf-8")
+
+        source = LocalDir(
+            src=src_root,
+            permissions=Permissions(owner=FileMode.ALL, group=0, other=0),
+            group=Group(name="staff", users=[]),
+        )
+        capability = Skills(lazy_from=LocalDirLazySkillSource(source=source))
+        manifest = capability.process_manifest(
+            _source_granted_manifest(workspace_root, source=src_root)
+        )
+        session = _ExecRecordingSkillsSession(manifest)
+        capability.bind(session)
+        tool = cast(FunctionTool, capability.tools()[0])
+
+        await tool.on_invoke_tool(
+            cast(ToolContext[object], None),
+            '{"skill_name":"dynamic-skill"}',
+        )
+
+        skill_dest = str(workspace_root / ".agents" / "dynamic-skill")
+        assert ("chmod", "0700", skill_dest) in session.commands
+        assert ("chgrp", "staff", skill_dest) in session.commands
+        # The configured source entry must not be repointed at the loaded skill.
+        assert source.src == src_root
+
+    @pytest.mark.asyncio
+    async def test_lazy_local_dir_load_skill_keeps_default_permissions(
+        self, tmp_path: Path
+    ) -> None:
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        src_root = tmp_path / "skills"
+        skill_dir = src_root / "dynamic-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# dynamic skill\n", encoding="utf-8")
+
+        capability = Skills(
+            lazy_from=LocalDirLazySkillSource(source=LocalDir(src=src_root)),
+        )
+        manifest = capability.process_manifest(
+            _source_granted_manifest(workspace_root, source=src_root)
+        )
+        session = _ExecRecordingSkillsSession(manifest)
+        capability.bind(session)
+        tool = cast(FunctionTool, capability.tools()[0])
+
+        await tool.on_invoke_tool(
+            cast(ToolContext[object], None),
+            '{"skill_name":"dynamic-skill"}',
+        )
+
+        skill_dest = str(workspace_root / ".agents" / "dynamic-skill")
+        assert ("chmod", "0755", skill_dest) in session.commands
+        assert not any(command[:1] == ("chgrp",) for command in session.commands)
 
 
 class TestSkillsLazyLoading:


### PR DESCRIPTION
### Summary

**Component:** `src/agents/sandbox/capabilities/skills.py` — `LocalDirLazySkillSource.load_skill()`, the `load_skill` tool path behind `Skills(lazy_from=...)`.

**Problem:** a lazily loaded skill directory is materialized with the SDK's *default* entry metadata instead of the metadata configured on the source entry, so `permissions` and `group` set on `LocalDirLazySkillSource.source` are silently ignored.

```python
Skills(
    lazy_from=LocalDirLazySkillSource(
        source=LocalDir(
            src=Path("skills"),
            permissions=Permissions(owner=FileMode.ALL, group=0, other=0),  # owner-only
            group=Group(name="staff", users=[]),
        )
    )
)
```

The equivalent eager configuration — `Skills(from_=LocalDir(src=..., permissions=..., group=...))` — is stored in the manifest as the user's own entry, so `BaseEntry._apply_metadata()` runs `chgrp staff` and `chmod 0700` against the skills root. The lazy path does not.

**Before / after**, observed from the commands the sandbox session receives when `load_skill` materializes a skill:

| path | commands |
|---|---|
| eager `from_` (unchanged) | `chgrp staff …`, `chmod 0700 …` |
| lazy `lazy_from` (before) | `chmod 0755 …` |
| lazy `lazy_from` (after) | `chgrp staff …`, `chmod 0700 …` |

The consequence is user-visible and security-relevant: a skills tree the caller deliberately restricted to owner-only comes back group- and world-readable/executable inside the sandbox whenever it is loaded on demand, and the configured group ownership is never applied.

**Root cause:** `load_skill()` built a brand-new entry rather than reusing the configured one:

```python
await LocalDir(src=src_root / metadata.path.name).apply(...)
```

`LocalDir` inherits `description`, `ephemeral`, `group` and `permissions` from `BaseEntry`, and `apply()` reads `self.group` / `self.permissions` in `_apply_metadata()`. Constructing a fresh `LocalDir` with only `src` therefore resets every one of those fields to its default (`0755`, no group). Only `src` actually has to differ between the configured source (the skills root) and the per-skill materialization (one skill subdirectory).

Present since the original Sandbox Agents commit (`2d665c9a`, #2889); the line has not been touched since.

**Fix + why minimal:** copy the configured source and repoint only `src`, so the entry stays the single source of truth for its own metadata:

```python
skill_source = self.source.model_copy(
    update={"src": src_root / metadata.path.name},
    deep=True,
)
await skill_source.apply(...)
```

Nothing else moves. `model_copy` also preserves a `LocalDir` subclass, and any field added to `BaseEntry` later is carried automatically instead of needing a new keyword here. `deep=True` keeps the caller's `Permissions` model from being aliased by the throwaway copy; the added test asserts the caller's `source.src` is left pointing at the skills root.

**Non-goals:** no new configuration surface. There is still no way to give an individual lazy skill different metadata from its source entry, and per-file modes inside the copied directory are unchanged. The `user is not None` branch in `LocalDir.apply()` still skips `_apply_metadata()` exactly as before.

**Compatibility:** the only behavior change is on the lazy `load_skill` path, and only when the caller configured non-default `permissions` or `group` on the source entry. A default `LocalDirLazySkillSource(source=LocalDir(src=...))` still produces `chmod 0755` and no `chgrp`; that is pinned by a test so the default is not silently altered.

### Test plan

Two tests in `tests/sandbox/capabilities/test_skills_capability.py`, next to the existing lazy-materialization coverage, plus a small `_ExecRecordingSkillsSession` that records the commands the fake session receives (it delegates to the existing `_SkillsSession._exec_internal`):

- `test_lazy_local_dir_load_skill_applies_source_metadata` — configured `permissions=0700` and `group=staff` produce `chmod 0700` and `chgrp staff` on the loaded skill directory, and the caller's `source.src` is unchanged.
- `test_lazy_local_dir_load_skill_keeps_default_permissions` — boundary: an unconfigured source still yields `chmod 0755` and no `chgrp`.

Red/green proved by toggling **only** `src/agents/sandbox/capabilities/skills.py` (test file untouched):

- before the fix: `1 failed, 40 passed` — `AssertionError: assert ('chmod', '0700', '…/workspace/.agents/dynamic-skill') in [('chmod', '0755', '…/workspace/.agents/dynamic-skill')]`
- after the fix: `41 passed`

The default-permissions test passes both before and after, confirming it pins existing behavior rather than the fix.

Verification commands and results (all run from the repository root, on the rebased branch):

- `bash .agents/skills/code-change-verification/scripts/run.sh` — all commands passed (`make format` 864 files unchanged, `make lint`, `make typecheck`, `make tests`).
- `make format` — 864 files left unchanged; `make lint` — all checks passed.
- `make typecheck` — mypy: no issues in 851 source files; pyright: 0 errors, 0 warnings.
- `make tests` — 7066 passed, 28 skipped (parallel); 77 passed, 11 skipped (serial).
- `uv run pytest tests/sandbox/capabilities/test_skills_capability.py -q -W error::RuntimeWarning` run three consecutive times — 41 passed each time, no warnings.
- `git diff --check` — clean.

No API key, paid call, or live service is needed: the tests drive the `load_skill` function tool against the existing in-repo fake sandbox session and a `tmp_path` skills tree.

Not run: `make coverage`, `make build-docs` (no docs or coverage-config changes in this PR).

### Issue number

N/A — found by auditing the lazy skill source against the eager `from_` path.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
