### PR TITLE
fix(models): convert input_file items that reference a file_id on the Chat Completions path

### DIFF
--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -488,11 +488,20 @@ class Converter:
                 out.append(cast(ChatCompletionContentPartInputAudioParam, audio_part))
             elif isinstance(c, dict) and c.get("type") == "input_file":
                 casted_file_param = cast(ResponseInputFileParam, c)
-                if "file_data" not in casted_file_param or not casted_file_param["file_data"]:
+                # The Chat Completions file content part accepts either inline file_data or a
+                # reference to an uploaded file_id. Prefer inline data when present, otherwise
+                # fall back to the file id (the SDK's own ToolOutputFileContent emits file-id
+                # only input_file items). A file_url is not representable here.
+                file_data = casted_file_param.get("file_data")
+                file_id = casted_file_param.get("file_id")
+                if file_data:
+                    filedata = FileFile(file_data=file_data)
+                elif file_id:
+                    filedata = FileFile(file_id=file_id)
+                else:
                     raise UserError(
-                        f"Only file_data is supported for input_file {casted_file_param}"
+                        f"Only file_data or file_id is supported for input_file {casted_file_param}"
                     )
-                filedata = FileFile(file_data=casted_file_param["file_data"])
 
                 if "filename" in casted_file_param and casted_file_param["filename"]:
                     filedata["filename"] = casted_file_param["filename"]

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -691,6 +691,56 @@ def test_extract_all_content_rejects_invalid_input_audio():
         Converter.extract_all_content([audio_missing_data])
 
 
+def test_extract_all_content_supports_input_file_file_id():
+    """
+    An input_file that references an uploaded file by id is representable by the
+    Chat Completions ``file`` content part, so it must convert rather than raise.
+    """
+    content: list[dict[str, Any]] = [
+        {
+            "type": "input_file",
+            "file_id": "file-abc123",
+            "filename": "hello.txt",
+        }
+    ]
+
+    parts = Converter.extract_all_content(content)
+
+    assert parts == [
+        {
+            "type": "file",
+            "file": {"file_id": "file-abc123", "filename": "hello.txt"},
+        }
+    ]
+
+
+def test_extract_all_content_prefers_input_file_data_over_file_id():
+    """When both file_data and file_id are present, file_data is used (prior behavior)."""
+    content: list[dict[str, Any]] = [
+        {
+            "type": "input_file",
+            "file_data": "data:text/plain;base64,SGVsbG8=",
+            "file_id": "file-abc123",
+        }
+    ]
+
+    parts = Converter.extract_all_content(content)
+
+    assert parts == [
+        {
+            "type": "file",
+            "file": {"file_data": "data:text/plain;base64,SGVsbG8="},
+        }
+    ]
+
+
+def test_extract_all_content_rejects_input_file_without_data_or_id():
+    """An input_file that carries neither file_data nor file_id cannot be represented."""
+    content: list[dict[str, Any]] = [{"type": "input_file", "filename": "hello.txt"}]
+    with pytest.raises(UserError):
+        Converter.extract_all_content(content)
+
+
 def test_items_to_messages_handles_system_and_developer_roles():
     """
     Roles other than `user` (e.g. `system` and `developer`) need to be


### PR DESCRIPTION
### Summary

The Chat Completions converter (`Converter.extract_all_content`) rejected any
`input_file` content part that did not carry inline `file_data`, raising
`UserError("Only file_data is supported for input_file ...")`. But the Chat
Completions `file` content part (`openai.types.chat...FileFile`) accepts either
inline `file_data` **or** a reference to an uploaded `file_id`, so an
`input_file` that references a `file_id` is fully representable and should be
converted rather than rejected.

This also fixes an internal inconsistency: the SDK's own
`ToolOutputFileContent` emits `file_id`-only `input_file` items (see
`ItemHelpers._convert_single_tool_output_pydantic_model`). A function tool that
returns `ToolOutputFileContent(file_id=...)` therefore produced a tool output
that the SDK's own Chat Completions converter refused to convert on the next
turn.

`extract_all_content` is called on tool outputs regardless of
`preserve_tool_output_all_content` (the non-preserve branch still calls it
before filtering to text), so this `UserError` aborts the run instead of letting
the caller degrade the output.

**Fix (minimal):** prefer inline `file_data` when present, otherwise fall back
to `file_id`. Only raise when neither is present. A `file_url` remains
unrepresentable on Chat Completions and still raises, and existing `file_data`
behavior (including the `file_data`-takes-precedence and optional `filename`
handling) is unchanged.

Before:

```python
Converter.extract_all_content([{"type": "input_file", "file_id": "file-abc123"}])
# UserError: Only file_data is supported for input_file {...}
```

After:

```python
Converter.extract_all_content([{"type": "input_file", "file_id": "file-abc123"}])
# [{"type": "file", "file": {"file_id": "file-abc123"}}]
```

### Root cause

The `input_file` branch guarded on `file_data` only and raised for everything
else, predating (and never updated for) the `file_id` field that both the
Responses `input_file` param and the Chat Completions `file` part support.

### Why minimal

- One converter branch changed; no new abstractions or public API changes.
- `file_data` path, `file_data`-over-`file_id` precedence, `filename`
  forwarding, and prompt-cache-breakpoint copying are all preserved.
- `file_url` is intentionally left unsupported (not representable on Chat
  Completions) and still raises.

### Test plan

Added three focused unit tests in
`tests/models/test_openai_chatcompletions_converter.py`:

- `test_extract_all_content_supports_input_file_file_id` — converts a
  `file_id`-only `input_file` (fails on `main`, passes here).
- `test_extract_all_content_prefers_input_file_data_over_file_id` — `file_data`
  still wins when both are present.
- `test_extract_all_content_rejects_input_file_without_data_or_id` — neither
  present still raises `UserError`.

Validation commands (all pass):

- `uv run pytest tests/models/test_openai_chatcompletions_converter.py -q` → 51 passed
- `uv run pytest tests/models -q` → 695 passed
- `uv run pytest -q` → 7161 passed, 39 skipped
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → clean
- `uv run mypy . --exclude site` → Success (852 source files)
- `uv run pyright` → 0 errors

Compatibility: behavior only broadens (previously-raising inputs now convert);
no changes to items that already converted. No dependency or config changes.

### Issue number

N/A (no OpenAI API key or live service required to reproduce).

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
