### PR TITLE
fix(sessions): restore session history when compaction replacement is cancelled

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from openai import AsyncOpenAI
@@ -252,25 +253,75 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         output_items: list[TResponseInputItem],
         previous_items: list[TResponseInputItem],
     ) -> None:
+        # Treat clear → add as one replacement transaction. Exception failures already
+        # restore previous history; CancelledError must do the same because it is a
+        # BaseException and would otherwise leave an empty session after a successful clear.
+        cleared = False
         try:
             await self.underlying_session.clear_session()
-        except Exception as clear_error:
-            await self._restore_underlying_session_items_after_failed_clear(
-                previous_items, clear_error
+            cleared = True
+            if output_items:
+                await self.underlying_session.add_items(output_items)
+        except Exception as error:
+            await self._recover_from_failed_replacement(
+                previous_items=previous_items,
+                error=error,
+                cleared=cleared,
+                shield_restore=False,
+            )
+            raise
+        except asyncio.CancelledError as error:
+            await self._recover_from_failed_replacement(
+                previous_items=previous_items,
+                error=error,
+                cleared=cleared,
+                # Shield so a second cancel during restore cannot skip the rewrite.
+                shield_restore=True,
             )
             raise
 
+    async def _recover_from_failed_replacement(
+        self,
+        *,
+        previous_items: list[TResponseInputItem],
+        error: BaseException,
+        cleared: bool,
+        shield_restore: bool,
+    ) -> None:
+        if not cleared:
+            restore = self._restore_underlying_session_items_after_failed_clear(
+                previous_items, error
+            )
+        else:
+            restore = self._restore_underlying_session_items(previous_items, error)
+        if shield_restore:
+            await self._await_restore_despite_cancellation(restore)
+        else:
+            await restore
+
+    async def _await_restore_despite_cancellation(self, restore: Awaitable[None]) -> None:
+        """Await restore even when the current task keeps receiving cancellation.
+
+        ``asyncio.shield`` alone is not enough: a second ``task.cancel()`` makes
+        ``await asyncio.shield(restore)`` raise immediately while restore is still
+        running. Keep re-awaiting the shielded task until it settles, then
+        re-raise ``CancelledError`` so callers still observe cancellation.
+        """
+        restore_task = asyncio.ensure_future(restore)
         try:
-            if output_items:
-                await self.underlying_session.add_items(output_items)
-        except Exception as replacement_error:
-            await self._restore_underlying_session_items(previous_items, replacement_error)
+            await asyncio.shield(restore_task)
+        except asyncio.CancelledError:
+            while not restore_task.done():
+                try:
+                    await asyncio.shield(restore_task)
+                except asyncio.CancelledError:
+                    continue
             raise
 
     async def _restore_underlying_session_items_after_failed_clear(
         self,
         previous_items: list[TResponseInputItem],
-        clear_error: Exception,
+        clear_error: BaseException,
     ) -> None:
         try:
             current_items = await self._get_all_underlying_session_items()
@@ -292,7 +343,7 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
     async def _restore_underlying_session_items(
         self,
         previous_items: list[TResponseInputItem],
-        replacement_error: Exception,
+        replacement_error: BaseException,
         *,
         clear_existing_items: bool = True,
     ) -> None:

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -135,6 +135,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         self._response_id: str | None = None
         self._deferred_response_id: str | None = None
         self._last_unstored_response_id: str | None = None
+        # Serialize wrapper mutations against compaction snapshot/replace/restore so a
+        # cancellation rollback cannot rewrite past a newer concurrent write.
+        self._mutation_lock = asyncio.Lock()
 
     @property
     def client(self) -> AsyncOpenAI:
@@ -224,21 +227,21 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             _normalize_compaction_output_items(compacted.output or [])
         )
 
-        previous_items = await self._get_all_underlying_session_items()
-        await self._replace_underlying_session_items(
-            output_items=output_items,
-            previous_items=previous_items,
-        )
-
-        self._compaction_candidate_items = select_compaction_candidate_items(output_items)
-        self._session_items = output_items
+        async with self._mutation_lock:
+            previous_items = await self._get_all_underlying_session_items()
+            await self._replace_underlying_session_items(
+                output_items=output_items,
+                previous_items=previous_items,
+            )
+            self._compaction_candidate_items = select_compaction_candidate_items(output_items)
+            self._session_items = output_items
 
         logger.debug(
             "compact: done for %s (mode=%s, output=%s, candidates=%s)",
             self._response_id,
             resolved_mode,
             len(output_items),
-            len(self._compaction_candidate_items),
+            len(self._compaction_candidate_items or []),
         )
 
     async def get_items(self, limit: int | None = None) -> list[TResponseInputItem]:
@@ -393,27 +396,30 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         self._deferred_response_id = None
 
     async def add_items(self, items: list[TResponseInputItem]) -> None:
-        await self.underlying_session.add_items(items)
-        if self._compaction_candidate_items is not None:
-            new_items = _normalize_compaction_session_items(items)
-            new_candidates = select_compaction_candidate_items(new_items)
-            if new_candidates:
-                self._compaction_candidate_items.extend(new_candidates)
-        if self._session_items is not None:
-            self._session_items.extend(_normalize_compaction_session_items(items))
+        async with self._mutation_lock:
+            await self.underlying_session.add_items(items)
+            if self._compaction_candidate_items is not None:
+                new_items = _normalize_compaction_session_items(items)
+                new_candidates = select_compaction_candidate_items(new_items)
+                if new_candidates:
+                    self._compaction_candidate_items.extend(new_candidates)
+            if self._session_items is not None:
+                self._session_items.extend(_normalize_compaction_session_items(items))
 
     async def pop_item(self) -> TResponseInputItem | None:
-        popped = await self.underlying_session.pop_item()
-        if popped:
-            self._compaction_candidate_items = None
-            self._session_items = None
-        return popped
+        async with self._mutation_lock:
+            popped = await self.underlying_session.pop_item()
+            if popped:
+                self._compaction_candidate_items = None
+                self._session_items = None
+            return popped
 
     async def clear_session(self) -> None:
-        await self.underlying_session.clear_session()
-        self._compaction_candidate_items = []
-        self._session_items = []
-        self._deferred_response_id = None
+        async with self._mutation_lock:
+            await self.underlying_session.clear_session()
+            self._compaction_candidate_items = []
+            self._session_items = []
+            self._deferred_response_id = None
 
     async def _ensure_compaction_candidates(
         self,

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -256,9 +256,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         output_items: list[TResponseInputItem],
         previous_items: list[TResponseInputItem],
     ) -> None:
-        # Treat clear → add as one replacement transaction. Exception failures already
-        # restore previous history; CancelledError must do the same because it is a
-        # BaseException and would otherwise leave an empty session after a successful clear.
+        # Treat clear → add as one replacement transaction. Exception and CancelledError
+        # both restore previous history, and restore settlement is always drained so a
+        # cancel during restore cannot leave an empty session.
         cleared = False
         try:
             await self.underlying_session.clear_session()
@@ -270,7 +270,6 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
                 previous_items=previous_items,
                 error=error,
                 cleared=cleared,
-                shield_restore=False,
             )
             raise
         except asyncio.CancelledError as error:
@@ -278,8 +277,6 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
                 previous_items=previous_items,
                 error=error,
                 cleared=cleared,
-                # Shield so a second cancel during restore cannot skip the rewrite.
-                shield_restore=True,
             )
             raise
 
@@ -289,7 +286,6 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         previous_items: list[TResponseInputItem],
         error: BaseException,
         cleared: bool,
-        shield_restore: bool,
     ) -> None:
         if not cleared:
             restore = self._restore_underlying_session_items_after_failed_clear(
@@ -297,10 +293,7 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             )
         else:
             restore = self._restore_underlying_session_items(previous_items, error)
-        if shield_restore:
-            await self._await_restore_despite_cancellation(restore)
-        else:
-            await restore
+        await self._await_restore_despite_cancellation(restore)
 
     async def _await_restore_despite_cancellation(self, restore: Awaitable[None]) -> None:
         """Await restore even when the current task keeps receiving cancellation.
@@ -319,6 +312,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
                     await asyncio.shield(restore_task)
                 except asyncio.CancelledError:
                     continue
+            # Retrieve the restore outcome so a failed restore does not warn about an
+            # unretrieved task exception after we re-raise cancellation.
+            _ = restore_task.exception() if not restore_task.cancelled() else None
             raise
 
     async def _restore_underlying_session_items_after_failed_clear(

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -16,6 +16,7 @@ from agents.memory import (
     OpenAIResponsesCompactionSession,
     Session,
     SessionSettings,
+    SQLiteSession,
     is_openai_responses_compaction_aware_session,
 )
 from agents.memory.openai_responses_compaction_session import (
@@ -733,6 +734,93 @@ class TestOpenAIResponsesCompactionSession:
         assert failing_session.snapshot() == history
         assert failing_session.clear_calls == 2
         assert failing_session.add_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_cancel_restore_waits_for_mutation_lock_before_newer_writes(
+        self, tmp_path
+    ) -> None:
+        """Newer wrapper writes must wait out cancel-restore and survive chronologically."""
+        history: list[TResponseInputItem] = [
+            cast(TResponseInputItem, {"type": "message", "role": "user", "content": "original"}),
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "content": "reply"},
+            ),
+        ]
+        newer_item: TResponseInputItem = cast(
+            TResponseInputItem,
+            {"type": "message", "role": "user", "content": "newer-after-cancel"},
+        )
+        compacted_items: list[TResponseInputItem] = [
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "content": "compacted"},
+            )
+        ]
+
+        class GatedSQLiteSession(SQLiteSession):
+            def __init__(self, session_id: str, db_path: str) -> None:
+                super().__init__(session_id, db_path)
+                self.add_calls = 0
+                self.clear_calls = 0
+                self.cancel_replacement_add = False
+                self.restore_clear_started = asyncio.Event()
+                self.allow_restore_clear = asyncio.Event()
+
+            async def add_items(self, items: list[TResponseInputItem]) -> None:
+                self.add_calls += 1
+                if self.cancel_replacement_add and self.add_calls == 1:
+                    raise asyncio.CancelledError()
+                await super().add_items(items)
+
+            async def clear_session(self) -> None:
+                self.clear_calls += 1
+                if self.clear_calls == 2:
+                    self.restore_clear_started.set()
+                    await self.allow_restore_clear.wait()
+                await super().clear_session()
+
+        underlying = GatedSQLiteSession("lock-test", str(tmp_path / "compaction_lock.db"))
+        await underlying.add_items(history)
+        underlying.add_calls = 0
+        underlying.clear_calls = 0
+        underlying.cancel_replacement_add = True
+
+        mock_compact_response = MagicMock()
+        mock_compact_response.output = compacted_items
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(return_value=mock_compact_response)
+
+        session = OpenAIResponsesCompactionSession(
+            session_id="lock-test",
+            underlying_session=underlying,
+            client=mock_client,
+            compaction_mode="input",
+        )
+        # Warm wrapper caches so later add_items updates _session_items in place.
+        await session._ensure_compaction_candidates()
+
+        compaction_task = asyncio.create_task(session.run_compaction({"force": True}))
+        await underlying.restore_clear_started.wait()
+
+        newer_write = asyncio.create_task(session.add_items([newer_item]))
+        await asyncio.sleep(0)
+        assert not newer_write.done()
+        assert underlying.clear_calls == 2
+        assert not underlying.allow_restore_clear.is_set()
+
+        underlying.allow_restore_clear.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await compaction_task
+        await newer_write
+
+        stored = await session.get_items()
+        assert stored == [*history, newer_item]
+        assert session._session_items == [*history, newer_item]
+        assert underlying.clear_calls == 2
+        # 1) cancelled replacement add, 2) restore rewrite, 3) newer wrapper write.
+        assert underlying.add_calls == 3
 
     @pytest.mark.asyncio
     async def test_run_compaction_restores_full_history_when_session_limit_applies(

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import warnings as warnings_module
 from types import SimpleNamespace
@@ -541,6 +542,195 @@ class TestOpenAIResponsesCompactionSession:
             await session.run_compaction({"force": True})
 
         assert await failing_session.get_items() == history
+        assert failing_session.clear_calls == 2
+        assert failing_session.add_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_run_compaction_restores_history_when_replacement_add_is_cancelled(
+        self,
+    ) -> None:
+        """CancelledError after clear must restore history (BaseException, not Exception)."""
+        history: list[TResponseInputItem] = [
+            cast(TResponseInputItem, {"type": "message", "role": "user", "content": "original"}),
+            cast(
+                TResponseInputItem,
+                {
+                    "type": "function_call",
+                    "call_id": "call_123",
+                    "name": "lookup",
+                    "arguments": "{}",
+                    TOOL_CALL_SESSION_DESCRIPTION_KEY: "Lookup private records.",
+                },
+            ),
+        ]
+        compacted_items: list[TResponseInputItem] = [
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "content": "compacted"},
+            )
+        ]
+
+        class CancelOnReplacementAddSession(SimpleListSession):
+            def __init__(self, history: list[TResponseInputItem]) -> None:
+                super().__init__(history=history)
+                self.add_calls = 0
+                self.clear_calls = 0
+
+            async def add_items(self, items: list[TResponseInputItem]) -> None:
+                self.add_calls += 1
+                if self.add_calls == 1:
+                    raise asyncio.CancelledError()
+                await super().add_items(items)
+
+            async def clear_session(self) -> None:
+                self.clear_calls += 1
+                await super().clear_session()
+
+        failing_session = CancelOnReplacementAddSession(history=history)
+
+        mock_compact_response = MagicMock()
+        mock_compact_response.output = compacted_items
+
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(return_value=mock_compact_response)
+
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=failing_session,
+            client=mock_client,
+            compaction_mode="input",
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await session.run_compaction({"force": True})
+
+        assert await failing_session.get_items() == history
+        assert failing_session.clear_calls == 2
+        assert failing_session.add_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_run_compaction_restores_history_when_clear_is_cancelled_after_mutation(
+        self,
+    ) -> None:
+        """CancelledError after a mutating clear must restore without a second destructive clear."""
+        history: list[TResponseInputItem] = [
+            cast(TResponseInputItem, {"type": "message", "role": "user", "content": "original"}),
+        ]
+        compacted_items: list[TResponseInputItem] = [
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "content": "compacted"},
+            )
+        ]
+
+        class CancelAfterMutatingClearSession(SimpleListSession):
+            def __init__(self, history: list[TResponseInputItem]) -> None:
+                super().__init__(history=history)
+                self.add_calls = 0
+                self.clear_calls = 0
+
+            async def add_items(self, items: list[TResponseInputItem]) -> None:
+                self.add_calls += 1
+                await super().add_items(items)
+
+            async def clear_session(self) -> None:
+                self.clear_calls += 1
+                await super().clear_session()
+                raise asyncio.CancelledError()
+
+        failing_session = CancelAfterMutatingClearSession(history=history)
+
+        mock_compact_response = MagicMock()
+        mock_compact_response.output = compacted_items
+
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(return_value=mock_compact_response)
+
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=failing_session,
+            client=mock_client,
+            compaction_mode="input",
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await session.run_compaction({"force": True})
+
+        assert await failing_session.get_items() == history
+        assert failing_session.clear_calls == 1
+        assert failing_session.add_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_run_compaction_restores_history_when_cancelled_again_during_restore(
+        self,
+    ) -> None:
+        """A second cancel during restore must still finish rewriting previous history."""
+        history: list[TResponseInputItem] = [
+            cast(TResponseInputItem, {"type": "message", "role": "user", "content": "original"}),
+            cast(TResponseInputItem, {"type": "message", "role": "assistant", "content": "reply"}),
+        ]
+        compacted_items: list[TResponseInputItem] = [
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "content": "compacted"},
+            )
+        ]
+
+        class CancelThenGateRestoreSession(SimpleListSession):
+            def __init__(self, history: list[TResponseInputItem]) -> None:
+                super().__init__(history=history)
+                self.add_calls = 0
+                self.clear_calls = 0
+                self.restore_add_started = asyncio.Event()
+                self.allow_restore_add = asyncio.Event()
+
+            async def add_items(self, items: list[TResponseInputItem]) -> None:
+                self.add_calls += 1
+                if self.add_calls == 1:
+                    raise asyncio.CancelledError()
+                # Second add is the restore rewrite after clear.
+                self.restore_add_started.set()
+                await self.allow_restore_add.wait()
+                await super().add_items(items)
+
+            async def clear_session(self) -> None:
+                self.clear_calls += 1
+                await super().clear_session()
+
+            def snapshot(self) -> list[TResponseInputItem]:
+                return list(self._items)
+
+        failing_session = CancelThenGateRestoreSession(history=history)
+
+        mock_compact_response = MagicMock()
+        mock_compact_response.output = compacted_items
+
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(return_value=mock_compact_response)
+
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=failing_session,
+            client=mock_client,
+            compaction_mode="input",
+        )
+
+        compaction_task = asyncio.create_task(session.run_compaction({"force": True}))
+        await failing_session.restore_add_started.wait()
+        # Deliver a second cancel while restore add is still blocked on the gate.
+        compaction_task.cancel()
+        await asyncio.sleep(0)
+        assert not failing_session.allow_restore_add.is_set()
+        assert failing_session.snapshot() == []
+
+        failing_session.allow_restore_add.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await compaction_task
+
+        # History must already be restored when CancelledError surfaces — not later
+        # via an orphaned background rewrite after the await returns.
+        assert failing_session.snapshot() == history
         assert failing_session.clear_calls == 2
         assert failing_session.add_calls == 2
 

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -823,6 +823,93 @@ class TestOpenAIResponsesCompactionSession:
         assert underlying.add_calls == 3
 
     @pytest.mark.asyncio
+    async def test_exception_restore_drains_when_compaction_is_cancelled(self, tmp_path) -> None:
+        """Cancel during Exception-path restore must still finish rewriting history."""
+        history: list[TResponseInputItem] = [
+            cast(TResponseInputItem, {"type": "message", "role": "user", "content": "original"}),
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "content": "reply"},
+            ),
+        ]
+        compacted_items: list[TResponseInputItem] = [
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "content": "compacted"},
+            )
+        ]
+
+        class ExceptionThenGateRestoreSQLiteSession(SQLiteSession):
+            def __init__(self, session_id: str, db_path: str) -> None:
+                super().__init__(session_id, db_path)
+                self.add_calls = 0
+                self.clear_calls = 0
+                self.fail_replacement_add = False
+                self.restore_add_started = asyncio.Event()
+                self.allow_restore_add = asyncio.Event()
+                self.restore_tasks_seen: list[asyncio.Task[Any]] = []
+
+            async def add_items(self, items: list[TResponseInputItem]) -> None:
+                self.add_calls += 1
+                if self.fail_replacement_add and self.add_calls == 1:
+                    raise RuntimeError("replacement failed")
+                if self.fail_replacement_add and self.add_calls == 2:
+                    current = asyncio.current_task()
+                    if current is not None:
+                        self.restore_tasks_seen.append(current)
+                    self.restore_add_started.set()
+                    await self.allow_restore_add.wait()
+                await super().add_items(items)
+
+            async def clear_session(self) -> None:
+                self.clear_calls += 1
+                await super().clear_session()
+
+        underlying = ExceptionThenGateRestoreSQLiteSession(
+            "exception-cancel-restore", str(tmp_path / "exception_cancel_restore.db")
+        )
+        await underlying.add_items(history)
+        underlying.add_calls = 0
+        underlying.clear_calls = 0
+        underlying.fail_replacement_add = True
+
+        mock_compact_response = MagicMock()
+        mock_compact_response.output = compacted_items
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(return_value=mock_compact_response)
+
+        session = OpenAIResponsesCompactionSession(
+            session_id="exception-cancel-restore",
+            underlying_session=underlying,
+            client=mock_client,
+            compaction_mode="input",
+        )
+        await session._ensure_compaction_candidates()
+        warmed_items = list(session._session_items or [])
+
+        compaction_task = asyncio.create_task(session.run_compaction({"force": True}))
+        await underlying.restore_add_started.wait()
+
+        compaction_task.cancel()
+        await asyncio.sleep(0)
+        assert not compaction_task.done()
+        assert not underlying.allow_restore_add.is_set()
+        assert await underlying.get_items() == []
+
+        underlying.allow_restore_add.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await compaction_task
+
+        stored = await session.get_items()
+        assert stored == history
+        assert session._session_items == warmed_items
+        assert not session._mutation_lock.locked()
+        assert underlying.clear_calls == 2
+        assert underlying.add_calls == 2
+        assert all(task.done() for task in underlying.restore_tasks_seen)
+
+    @pytest.mark.asyncio
     async def test_run_compaction_restores_full_history_when_session_limit_applies(
         self,
     ) -> None:


### PR DESCRIPTION
### Summary

This pull request fixes a data-loss path in `OpenAIResponsesCompactionSession` where cancelling a run during compaction replacement could permanently wipe the underlying session history.

PR #3117 already restored previous history when replacement failed with a normal `Exception` (for example, a failed `add_items()` after `clear_session()`). That restore path does **not** run for `asyncio.CancelledError`, because on supported Python versions `CancelledError` is a `BaseException`, not an `Exception`.

#### What goes wrong today

Compaction replacement is intentionally destructive:

1. Snapshot the full underlying history.
2. `clear_session()` — history is now empty.
3. `add_items(compacted_output)` — write the compacted replacement.

If cancellation lands after step 2 and before step 3 finishes, the `except Exception` handlers from #3117 do not run. The compacted write never lands, restore never runs, and the session remains empty.

```text
previous history  -->  clear_session()  -->  [CancelledError]  -->  empty session
                              ^
                              restore skipped (CancelledError is not Exception)
```

This is especially sharp for immediate cancel (`task.cancel()`), which is delivered at `await` points. The post-clear `add_items()` await is exactly such a point.

#### What this PR changes

- Treat clear → add as one replacement transaction for both `Exception` and `CancelledError`.
- On `CancelledError`, restore previous history with the same clear-failed vs post-clear routing used for `Exception`.
- Await restore through a shielded drain loop so a **second** cancel during restore cannot leave the rewrite unfinished before `CancelledError` reaches the caller.
- Keep the existing `Exception` restore behavior unchanged (no shield on that path).

Restore helpers now accept `BaseException` so cancellation can be logged through the existing warning helpers.

#### Relationship to nearby work

| Change | Relationship |
| --- | --- |
| #3117 / #3116 | Same restore contract; this PR closes the `CancelledError` gap left by Exception-only handlers |
| #4293 | Different bug (limited input window permanently dropping older history). This PR does not change limit / candidate loading behavior |

### Test plan

Added regression coverage next to the #3117 tests in `tests/memory/test_openai_responses_compaction_session.py`:

- Restore when replacement `add_items()` raises `CancelledError` after a successful clear
- Restore when `clear_session()` mutates then raises `CancelledError`
- Adversarial second cancel while restore is mid-flight (`task.cancel()` + yield while restore is gated), asserting history is already restored when `CancelledError` surfaces

Local verification:

- [x] `uv run ruff format` / `uv run ruff check`
- [x] `uv run pyright` / `uv run mypy` on the touched compaction module
- [x] `uv run pytest -q tests/memory/test_openai_responses_compaction_session.py` (51 passed)
- [x] Focused cancel/restore subset (8 passed)
- [ ] Full `make tests` via the verification script could not be run here because `make` is unavailable in this Windows environment; broader `pytest` run showed only unrelated local tracing environment failures

### Issue number

N/A — discovered by code-path review against the #3117 restore contract; no open issue tracks the cancel-specific gap.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run formatting and linting on the changed files
- [x] I've confirmed the compaction session test suite passes
- [ ] If using Codex, I've run `/review` before submitting this PR