### PR TITLE
fix(memory): preserve falsey compaction decision hooks

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -125,7 +125,9 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         self.model = model
         self.compaction_mode = compaction_mode
         self.should_trigger_compaction = (
-            should_trigger_compaction or default_should_trigger_compaction
+            should_trigger_compaction
+            if should_trigger_compaction is not None
+            else default_should_trigger_compaction
         )
 
         # cache for incremental candidate tracking

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -157,6 +157,43 @@ class TestOpenAIResponsesCompactionSession:
             await session.run_compaction()
 
     @pytest.mark.asyncio
+    async def test_run_compaction_honors_falsey_decision_hook(self) -> None:
+        class FalseyDecisionHook:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def __bool__(self) -> bool:
+                return False
+
+            def __call__(self, context: dict[str, Any]) -> bool:
+                self.calls += 1
+                return False
+
+        items = [
+            cast(
+                TResponseInputItem,
+                {"type": "message", "role": "assistant", "content": f"message {index}"},
+            )
+            for index in range(DEFAULT_COMPACTION_THRESHOLD)
+        ]
+        underlying = SimpleListSession(history=items)
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock()
+        decision_hook = FalseyDecisionHook()
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=underlying,
+            client=mock_client,
+            compaction_mode="input",
+            should_trigger_compaction=decision_hook,
+        )
+
+        await session.run_compaction()
+
+        assert decision_hook.calls == 1
+        mock_client.responses.compact.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_run_compaction_input_mode_without_response_id(self) -> None:
         mock_session = self.create_mock_session()
         items: list[TResponseInputItem] = [


### PR DESCRIPTION
### Summary

`OpenAIResponsesCompactionSession` used truthiness to select its compaction decision hook, so a valid callable object with falsey boolean behavior was silently replaced by the default hook.

Preserve every explicitly supplied hook by falling back only when `should_trigger_compaction` is `None`. Add an offline regression test that verifies a falsey hook is invoked and can prevent compaction at the default threshold.

This is distinct from #4293, which changes which session history is compacted rather than how the decision hook is selected.

### Test plan

- Red before the fix: `uv run pytest tests/memory/test_openai_responses_compaction_session.py -q -k falsey_decision_hook` (`1 failed, 48 deselected`)
- Green after the fix: `uv run pytest tests/memory/test_openai_responses_compaction_session.py -q -k falsey_decision_hook` (`1 passed, 48 deselected`)
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` (format, lint, typecheck, and tests all passed)

No API key or live model call is required.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
