### PR TITLE
fix(handoffs): preserve message name when nesting handoff history

### DIFF
--- a/src/agents/handoffs/history.py
+++ b/src/agents/handoffs/history.py
@@ -403,13 +403,33 @@ def _format_transcript_item(item: TResponseInputItem) -> str:
     role = item.get("role")
     if isinstance(role, str):
         content = item.get("content")
-        if content is None or (isinstance(content, str) and not _contains_newline(content)):
+        if (
+            content is None or (isinstance(content, str) and not _contains_newline(content))
+        ) and _legacy_summary_line_is_reversible(item):
             return _format_transcript_item_legacy(item)
     return _format_transcript_item_json(item)
 
 
 def _contains_newline(value: str) -> bool:
     return "\n" in value or "\r" in value
+
+
+# Characters the compact ``role (name): content`` summary line splits on. A role or name that
+# contains any of them cannot be recovered from that form: a ":" is consumed by the
+# ``role: content`` split, and "(" / ")" confuse the ``(name)`` extraction. The item is encoded
+# as JSON instead, which round-trips losslessly.
+_LEGACY_SUMMARY_DELIMITERS = (":", "(", ")", "\n", "\r")
+
+
+def _legacy_summary_line_is_reversible(item: TResponseInputItem) -> bool:
+    """Return whether the legacy compact summary form round-trips for this item."""
+    role = item.get("role")
+    if not isinstance(role, str) or any(char in role for char in _LEGACY_SUMMARY_DELIMITERS):
+        return False
+    name = item.get("name")
+    if isinstance(name, str) and any(char in name for char in _LEGACY_SUMMARY_DELIMITERS):
+        return False
+    return True
 
 
 def _format_transcript_item_json(item: TResponseInputItem) -> str:

--- a/tests/test_handoff_history_duplication.py
+++ b/tests/test_handoff_history_duplication.py
@@ -2343,6 +2343,40 @@ def test_nested_history_keeps_turns_with_no_content(empty_item: dict[str, Any]) 
     assert [item.get("role") for item in transcript] == ["user", empty_item["role"], "user"]
 
 
+@pytest.mark.parametrize(
+    "name",
+    ["bob", "O(1)", "a:b", "foo(bar)", "x)y"],
+    ids=["plain", "trailing_call", "colon", "parens", "close_paren"],
+)
+def test_nested_history_preserves_message_name(name: str) -> None:
+    """A message ``name`` must survive being summarized and flattened again.
+
+    The compact ``role (name): content`` summary line cannot be reversed when the name
+    contains the delimiters the parser splits on (":", "(", ")"), so such a name was
+    silently corrupted on the next handoff. The item must be rendered losslessly instead.
+    """
+    named = {"role": "assistant", "name": name, "content": "answer here"}
+    history = (
+        {"role": "user", "content": "first question"},
+        named,
+        {"role": "user", "content": "second question"},
+    )
+    data = HandoffInputData(
+        input_history=cast(Any, history),
+        pre_handoff_items=(),
+        new_items=(),
+        run_context=None,
+    )
+
+    # Flatten across several handoffs to confirm the encoding is also idempotent.
+    nested = nest_handoff_history(data)
+    for _ in range(3):
+        transcript = _extract_nested_history_transcript(cast(Any, nested.input_history)[0])
+        assert transcript is not None
+        assert transcript == list(history)
+        nested = nest_handoff_history(nested)
+
+
 def test_nested_history_survives_repeated_handoffs() -> None:
     """Flattening and re-nesting must not shed the empty turn on each hop."""
     history = (


### PR DESCRIPTION
### Summary

When `nest_handoff_history` (nested handoff history) summarizes the previous transcript, each turn is rendered as a compact `role (name): content` line. On a subsequent handoff the summary is flattened back into structured items by `_extract_nested_history_transcript`, which reverses that format.

That compact form is ambiguous when the `role` or the message `name` contains one of the characters the parser splits on:

- `:` is consumed by the `role: content` split.
- `(` / `)` confuse the `(name)` extraction (which uses `rfind("(")`).

So a message whose `name` contained those characters was silently corrupted on the next handoff. For example, with `{"role": "assistant", "name": "a:b", "content": "answer here"}`:

- before: `{"role": "assistant (a", "content": "b): answer here"}` — the role, name, and content are all wrong
- after: the item round-trips unchanged

The SDK already renders items losslessly via the JSON encoding used for content that contains newlines. This change routes items to that JSON encoding whenever the compact line would not be reversible (role/name containing `:`, `(`, `)`, `\n`, or `\r`), and keeps the readable compact form for everything else (e.g. a plain `name` like `"bob"`, which is unaffected).

The fix is confined to `_format_transcript_item`'s legacy-vs-JSON choice; parsing is unchanged. The JSON path is already exercised by existing tests, and the change is idempotent across repeated handoffs.

### Test plan

Added `test_nested_history_preserves_message_name`, parametrized over names `bob`, `O(1)`, `a:b`, `foo(bar)`, `x)y`. It nests a 3-turn history whose middle message carries the `name`, then re-flattens across several handoffs and asserts the transcript is unchanged each time.

- Fails on `main` for the `colon`, `parens`, and `trailing_call` cases (role/name/content corrupted); passes with this change.

Commands run (from a clean `upstream/main` worktree):

- `uv run pytest tests/test_handoff_history_duplication.py -q` → 97 passed
- `uv run pytest tests/test_handoff_history_duplication.py tests/test_run_internal_items.py tests/test_handoff_tool.py tests/test_run_step_processing.py -q` → 198 passed
- `uv run ruff check src/agents/handoffs/history.py tests/test_handoff_history_duplication.py` → All checks passed
- `uv run ruff format --check …` → already formatted
- `uv run pyright src/agents/handoffs/history.py` → 0 errors
- `TYPECHECK_SRC_ONLY=1 uv run mypy src --exclude site` → no new errors in `handoffs/history.py`; the 44 reported errors are pre-existing on `main` in unrelated optional-dependency modules (`extensions/sandbox/*`, `extensions/models/litellm_model.py`, `extensions/memory/sqlalchemy_session.py`, `voice/imports.py`, etc.).

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass (ran the ruff / pyright / mypy / pytest commands listed above individually rather than via `run.sh`)
- [ ] If using Codex, I've run `/review` before submitting this PR
