### PR TITLE
fix(memory): skip legacy non-string rows in AsyncSQLiteSession.get_items

### DIFF
--- a/src/agents/extensions/memory/async_sqlite_session.py
+++ b/src/agents/extensions/memory/async_sqlite_session.py
@@ -244,7 +244,9 @@ class AsyncSQLiteSession(SessionABC):
                 try:
                     item = json.loads(message_data)
                     items.append(item)
-                except json.JSONDecodeError:
+                except (json.JSONDecodeError, TypeError):
+                    # Skip corrupted or malformed entries, including legacy non-string values,
+                    # matching pop_item and the other session backends.
                     continue
             return items
 

--- a/tests/extensions/memory/test_async_sqlite_session.py
+++ b/tests/extensions/memory/test_async_sqlite_session.py
@@ -177,6 +177,54 @@ async def test_async_sqlite_session_get_items_limit_skips_corrupt_newest_rows():
         await session.close()
 
 
+async def test_async_sqlite_session_get_items_skips_non_string_rows():
+    """get_items skips legacy non-string rows instead of raising TypeError.
+
+    ``pop_item`` and the other backends skip rows whose ``json.loads`` raises ``TypeError``
+    (for example a ``NULL`` ``message_data`` left by an older schema or external tooling that
+    the session is pointed at). ``get_items`` only caught ``json.JSONDecodeError``, so a single
+    such row raised ``TypeError`` and failed the whole read. This exercises both the unlimited
+    and the limited (window-expanding) decode paths.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "async_get_items_non_string.db"
+
+        # Simulate a legacy / externally-created messages table whose ``message_data`` column is
+        # nullable, holding a NULL row among valid rows. ``CREATE TABLE IF NOT EXISTS`` in the
+        # session leaves this schema in place.
+        with sqlite3.connect(db_path) as raw:
+            raw.execute(
+                "CREATE TABLE agent_messages ("
+                " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                " session_id TEXT NOT NULL,"
+                " message_data TEXT,"
+                " created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+            )
+            raw.execute(
+                "INSERT INTO agent_messages (session_id, message_data) VALUES (?, ?)",
+                ("legacy", json.dumps({"role": "user", "content": "valid 0"})),
+            )
+            raw.execute(
+                "INSERT INTO agent_messages (session_id, message_data) VALUES (?, ?)",
+                ("legacy", None),
+            )
+            raw.execute(
+                "INSERT INTO agent_messages (session_id, message_data) VALUES (?, ?)",
+                ("legacy", json.dumps({"role": "assistant", "content": "valid 1"})),
+            )
+            raw.commit()
+
+        session = AsyncSQLiteSession("legacy", db_path)
+        try:
+            all_items = await session.get_items()
+            assert [item.get("content") for item in all_items] == ["valid 0", "valid 1"]
+
+            limited = await session.get_items(limit=1)
+            assert [item.get("content") for item in limited] == ["valid 1"]
+        finally:
+            await session.close()
+
+
 async def test_async_sqlite_session_session_settings_default():
     """Test that session_settings defaults to empty SessionSettings."""
     session = AsyncSQLiteSession("async_default_settings")


### PR DESCRIPTION
### Summary

`AsyncSQLiteSession.get_items` decodes each stored row with `json.loads` inside a `try/except json.JSONDecodeError`, so it only skips rows that fail to parse as JSON. Every other decode site in the session layer also skips rows whose `json.loads` raises `TypeError` — i.e. rows whose `message_data` is a non-string (most commonly `NULL`):

- `AsyncSQLiteSession.pop_item` — `except (json.JSONDecodeError, TypeError)`
- sync `SQLiteSession.get_items` and `.pop_item` — `except (json.JSONDecodeError, TypeError)`
- `MongoDBSession.get_items` — `except (json.JSONDecodeError, TypeError)` ("Skip corrupted or malformed entries, including legacy non-string values.")

Because async `get_items` was the lone exception, a single non-string row made the entire read raise
`TypeError: the JSON object must be str, bytes or bytearray, not NoneType` instead of skipping that row.
`db_path`, `sessions_table`, and `messages_table` are public constructor arguments, so a session can be pointed at a database/table created by an older schema or external tooling whose `message_data` column is nullable — exactly the "legacy non-string values" case the sibling backends already guard. This also makes `get_items` and `pop_item` disagree on the same data: `pop_item` quietly drops the row while `get_items` crashes.

The fix widens the `get_items` decode guard to `(json.JSONDecodeError, TypeError)`, matching `pop_item` and the other backends. Both the unlimited read and the limited (window-expanding) read share the same `_decode_rows` helper, so both paths are covered.

### Test plan

New regression test `test_async_sqlite_session_get_items_skips_non_string_rows` seeds a legacy-shaped (nullable `message_data`) table with a `NULL` row among valid rows and asserts both `get_items()` and `get_items(limit=1)` skip it and return the valid items.

- Fails on `main` (raises `TypeError`), passes with this change. Verified by reverting only the `src` change and re-running: the read raises `TypeError`.
- `uv run pytest tests/extensions/memory/test_async_sqlite_session.py` → 40 passed
- `uv run pytest tests/memory tests/extensions/memory/test_async_sqlite_session.py tests/extensions/memory/test_advanced_sqlite_session.py` → 232 passed, 1 skipped
- `uv run ruff check` (changed files) → All checks passed
- `uv run ruff format --check` (changed files) → already formatted
- `uv run pyright` (changed files) → 0 errors, 0 warnings
- `git diff --check` → clean

Not run: the full `tests/extensions/memory` suite requires optional extras (`sqlalchemy`, etc.) that are not installed in this minimal environment; those modules are unrelated to this change (SQLite-only fix).

### Issue number

N/A — no issue filed; small correctness fix consistent with the sibling backends.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
