### PR TITLE
fix: stop merging anyOf and oneOf into a single widened union

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -163,9 +163,20 @@ def _ensure_strict_json_schema(
     one_of = json_schema.get("oneOf")
     if is_list(one_of):
         existing_any_of = json_schema.get("anyOf", [])
-        if not is_list(existing_any_of):
-            existing_any_of = []
-        json_schema["anyOf"] = existing_any_of + [
+        if is_list(existing_any_of) and existing_any_of:
+            # `anyOf` and `oneOf` on the same node are two constraints that must BOTH hold.
+            # Folding them into a single `anyOf` turns the conjunction into a union, so values
+            # that either constraint rejects become accepted: with anyOf [string, integer] and
+            # oneOf [string, boolean], the merge accepts 5 and true, both of which the
+            # original schema rejects. That cannot be expressed in strict mode, so fail the
+            # way other inexpressible schemas do, letting callers that can degrade (such as
+            # MCP tool conversion) fall back to serving the schema as non-strict.
+            raise UserError(
+                "Strict JSON schemas cannot express a schema that constrains the same value "
+                "with both anyOf and oneOf. Combine the two constraints into a single union, "
+                "or update the function or output tool to not use a strict schema."
+            )
+        json_schema["anyOf"] = [
             _ensure_strict_json_schema(
                 variant, path=(*path, "oneOf", str(i)), root=root, budget=budget
             )

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -362,3 +362,47 @@ def test_ref_expansion_bomb_is_rejected():
     }
     with pytest.raises(UserError):
         ensure_strict_json_schema(schema)
+
+
+def test_anyof_and_oneof_on_the_same_node_are_rejected_not_merged():
+    # These are two constraints that must BOTH hold. Folding them into a single anyOf turns
+    # the conjunction into a union: with anyOf [string, integer] and oneOf [string, boolean],
+    # the merged schema accepts 5 and true, both of which the original rejects.
+    with pytest.raises(UserError, match="both anyOf and oneOf"):
+        ensure_strict_json_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "f": {
+                        "anyOf": [{"type": "string"}, {"type": "integer"}],
+                        "oneOf": [{"type": "string"}, {"type": "boolean"}],
+                    }
+                },
+            }
+        )
+
+
+def test_oneof_alone_still_converts_to_anyof():
+    # Without a competing anyOf, the documented discriminated-union conversion is unchanged.
+    result = ensure_strict_json_schema(
+        {
+            "type": "object",
+            "properties": {"f": {"oneOf": [{"type": "string"}, {"type": "boolean"}]}},
+        }
+    )
+
+    field = result["properties"]["f"]
+    assert "oneOf" not in field
+    assert field["anyOf"] == [{"type": "string"}, {"type": "boolean"}]
+
+
+def test_oneof_with_an_empty_anyof_list_still_converts():
+    # An empty anyOf constrains nothing, so replacing it keeps the original meaning.
+    result = ensure_strict_json_schema(
+        {
+            "type": "object",
+            "properties": {"f": {"anyOf": [], "oneOf": [{"type": "string"}]}},
+        }
+    )
+
+    assert result["properties"]["f"]["anyOf"] == [{"type": "string"}]

--- a/tests/test_strict_schema_oneof.py
+++ b/tests/test_strict_schema_oneof.py
@@ -1,8 +1,10 @@
 from typing import Annotated, Literal
 
+import pytest
 from pydantic import BaseModel, Field
 
 from agents.agent_output import AgentOutputSchema
+from agents.exceptions import UserError
 from agents.strict_schema import ensure_strict_json_schema
 
 
@@ -132,7 +134,11 @@ def test_discriminated_union_with_pydantic():
     assert "discriminator" in items_schema
 
 
-def test_oneof_merged_with_existing_anyof():
+def test_oneof_alongside_anyof_is_rejected_rather_than_merged():
+    # `anyOf` and `oneOf` on one node are two constraints that must BOTH hold. The previous
+    # expectation merged them into a single union, which widens the schema: this very value
+    # schema accepts nothing at all (a string fails the oneOf, an integer fails the anyOf),
+    # yet the merged form accepted strings, integers and booleans alike.
     schema = {
         "type": "object",
         "properties": {
@@ -143,23 +149,8 @@ def test_oneof_merged_with_existing_anyof():
         },
     }
 
-    result = ensure_strict_json_schema(schema)
-
-    expected = {
-        "type": "object",
-        "properties": {
-            "value": {
-                "anyOf": [
-                    {"type": "string"},
-                    {"type": "integer"},
-                    {"type": "boolean"},
-                ]
-            }
-        },
-        "additionalProperties": False,
-        "required": ["value"],
-    }
-    assert result == expected
+    with pytest.raises(UserError, match="both anyOf and oneOf"):
+        ensure_strict_json_schema(schema)
 
 
 def test_discriminator_preserved():


### PR DESCRIPTION
### Summary

When a schema node carries both `anyOf` and `oneOf`, strict conversion folds the `oneOf` variants into the existing `anyOf` list. Those are two constraints that must BOTH hold, so the fold turns a conjunction into a union, and the converted schema accepts values the original rejects.

Checked against a JSON Schema validator:

```python
{"anyOf": [{"type": "string"}, {"type": "integer"}],
 "oneOf": [{"type": "string"}, {"type": "boolean"}]}
```

| value | original | after conversion |
| --- | --- | --- |
| `"hello"` | accept | accept |
| `5` | reject (fails the `oneOf`) | **accept** |
| `true` | reject (fails the `anyOf`) | **accept** |
| `3.14` | reject | reject |

For a function tool or output type this widens the declared contract: the provider constrains generation to the converted schema, so the model can produce arguments or outputs the original schema forbids, and nothing downstream notices.

The prior expectation in `test_oneof_merged_with_existing_anyof` makes the problem concrete: its input schema accepts **no value at all** (a string fails its `oneOf`, an integer fails its `anyOf`), yet the merged form accepted strings, integers and booleans alike.

### Fix

The combination now fails conversion the way other inexpressible schemas do, with an actionable message. Callers that can degrade take their existing fallback: an MCP tool with such a schema is served non-strict with both constraints intact:

```
MCP: strict = False | field served as:
{"anyOf": [string, integer], "oneOf": [string, boolean]}
```

There is no meaning-preserving strict form to emit instead: computing the actual conjunction of two schema lists is not generally possible, and any flattening picks one constraint over the other.

Unchanged behaviour, pinned by tests that pass both before and after:

- `oneOf` alone still converts to `anyOf`, the documented discriminated-union path
- `oneOf` next to an **empty** `anyOf` list still converts, since an empty list constrains nothing
- discriminator preservation and nested/deep `oneOf` conversions are untouched

### Test plan

`test_anyof_and_oneof_on_the_same_node_are_rejected_not_merged` fails on `main` and passes here. `test_oneof_merged_with_existing_anyof` asserted the widened merge and is replaced by `test_oneof_alongside_anyof_is_rejected_rather_than_merged`, with the unsatisfiable-input observation recorded in the test.

| Command | Result |
| --- | --- |
| `make format` / `make lint` | clean |
| `make mypy` | 5 errors, all pre-existing on `main` |
| `make pyright` | 0 errors on the touched files |
| `uv run pytest tests/test_strict_schema.py tests/test_strict_schema_oneof.py` | 41 passed |
| `make tests` | 6407 passed, no new failures against `main` at the same commit |

This is independent of #4277: it changes only the `oneOf` block, which that PR does not modify, and the defect exists on `main` today. If both land, whichever goes second rebases trivially and I will handle that.

### Issue number

None reported; found while auditing the strict conversion for other silent semantic changes.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script shells out to `make`; I ran the underlying steps individually, with the results above.
