### PR TITLE
fix(sandbox): preserve falsey instrumentation instances

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -1052,7 +1052,9 @@ class BlaxelSandboxClient(BaseSandboxClient["BlaxelSandboxClientOptions"]):
     ) -> None:
         # Validate that the Blaxel SDK is importable.
         _import_blaxel_sdk()
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
         self._token = token or os.environ.get("BL_API_KEY")
 

--- a/src/agents/extensions/sandbox/cloudflare/sandbox.py
+++ b/src/agents/extensions/sandbox/cloudflare/sandbox.py
@@ -1435,7 +1435,9 @@ class CloudflareSandboxClient(BaseSandboxClient[CloudflareSandboxClientOptions])
         request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
     ) -> None:
         super().__init__()
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
         self._exec_timeout_s = exec_timeout_s
         self._request_timeout_s = request_timeout_s

--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -1195,7 +1195,9 @@ class DaytonaSandboxClient(BaseSandboxClient[DaytonaSandboxClientOptions]):
         AsyncDaytona, DaytonaConfig, _, _ = _import_daytona_sdk()
         config = DaytonaConfig(api_key=api_key, api_url=api_url) if (api_key or api_url) else None
         self._daytona = AsyncDaytona(config)
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     async def _build_create_params(

--- a/src/agents/extensions/sandbox/e2b/sandbox.py
+++ b/src/agents/extensions/sandbox/e2b/sandbox.py
@@ -1680,7 +1680,9 @@ class E2BSandboxClient(BaseSandboxClient[E2BSandboxClientOptions]):
         instrumentation: Instrumentation | None = None,
         dependencies: Dependencies | None = None,
     ) -> None:
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     async def create(

--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -1947,7 +1947,9 @@ class ModalSandboxClient(BaseSandboxClient[ModalSandboxClientOptions]):
     ) -> None:
         self._default_image = image
         self._default_sandbox = sandbox
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     def _validate_manifest_for_workspace_persistence(

--- a/src/agents/extensions/sandbox/runloop/sandbox.py
+++ b/src/agents/extensions/sandbox/runloop/sandbox.py
@@ -1545,7 +1545,9 @@ class RunloopSandboxClient(BaseSandboxClient[RunloopSandboxClientOptions | None]
     ) -> None:
         self._sdk = _import_runloop_sdk().async_sdk(bearer_token=bearer_token, base_url=base_url)
         self._platform = RunloopPlatformClient(self._sdk)
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     @property

--- a/src/agents/extensions/sandbox/vercel/sandbox.py
+++ b/src/agents/extensions/sandbox/vercel/sandbox.py
@@ -1326,7 +1326,9 @@ class VercelSandboxClient(BaseSandboxClient[VercelSandboxClientOptions]):
         self._token = token
         self._project_id = project_id
         self._team_id = team_id
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     def _wrap_session(

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -1457,7 +1457,9 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
     ) -> None:
         super().__init__()
         self.docker_client = docker_client
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     async def create(

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -1090,7 +1090,9 @@ class UnixLocalSandboxClient(BaseSandboxClient[UnixLocalSandboxClientOptions | N
         instrumentation: Instrumentation | None = None,
         dependencies: Dependencies | None = None,
     ) -> None:
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     async def create(

--- a/src/agents/sandbox/session/sandbox_session.py
+++ b/src/agents/sandbox/session/sandbox_session.py
@@ -229,7 +229,9 @@ class SandboxSession(BaseSandboxSession):
     ) -> None:
         self._inner = inner
         self._inner.set_dependencies(dependencies)
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._seq = 0
 
         self._bind_session_to_sinks()

--- a/tests/sandbox/test_session_sinks.py
+++ b/tests/sandbox/test_session_sinks.py
@@ -919,3 +919,16 @@ async def test_sandbox_session_aclose_flushes_best_effort_sink_tasks(tmp_path: P
 
     assert ("stop", "finish") in seen
     assert ("shutdown", "finish") in seen
+
+
+def test_sandbox_session_preserves_falsey_instrumentation(tmp_path: Path) -> None:
+    class FalseyInstrumentation(Instrumentation):
+        def __bool__(self) -> bool:
+            return False
+
+    instrumentation = FalseyInstrumentation()
+    inner = _build_unix_local_session(tmp_path)
+
+    session = SandboxSession(inner, instrumentation=instrumentation)
+
+    assert session._instrumentation is instrumentation


### PR DESCRIPTION
### Summary

The sandbox sessions defaulted their instrumentation with `instrumentation or Instrumentation()`, so a caller-supplied instance that is falsey was silently discarded and replaced with a fresh default. `Instrumentation` is a public constructor parameter on every sandbox session and is exported from `agents.sandbox.session`, so a subclass that defines `__bool__` is a supported input.

This applies the same treatment #4286 and #4299 used for the realtime model and the compaction decision hooks, extending it to the ten remaining sites.

### Test plan

New test in `tests/sandbox/test_session_sinks.py` constructing a `SandboxSession` with a falsey `Instrumentation` subclass and asserting the instance is preserved. It fails on `main` because a different object is substituted. `make lint` is clean. `make typecheck` was not run to completion locally, though the change preserves the declared type.
