### PR TITLE
fix: falsy optional reference handling

### DIFF
--- a/.github/scripts/check_optional_truthiness.py
+++ b/.github/scripts/check_optional_truthiness.py
@@ -1,0 +1,544 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+_CALLABLE_MODULES = {"collections.abc", "typing"}
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+ReferenceKind = Literal["callable", "class"]
+
+
+@dataclass(frozen=True, order=True)
+class Violation:
+    path: Path
+    line: int
+    column: int
+    expression: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line}:{self.column}: optional object uses truthiness: "
+            f"{self.expression}"
+        )
+
+
+@dataclass
+class _ClassInfo:
+    fields: set[str] = field(default_factory=set)
+
+
+@dataclass
+class _FunctionInfo:
+    node: FunctionNode
+    owner: int | None
+    signature_bindings: dict[str, ReferenceKind]
+    body_bindings: dict[str, ReferenceKind]
+
+
+@dataclass
+class _ModuleInfo:
+    path: Path
+    classes: dict[int, _ClassInfo]
+    functions: dict[int, _FunctionInfo]
+
+
+def _walk_scope(body: list[ast.stmt]) -> Iterable[ast.AST]:
+    stack: list[ast.AST] = list(reversed(body))
+    while stack:
+        current = stack.pop()
+        yield current
+        if isinstance(
+            current,
+            ast.FunctionDef
+            | ast.AsyncFunctionDef
+            | ast.ClassDef
+            | ast.Lambda
+            | ast.ListComp
+            | ast.SetComp
+            | ast.DictComp
+            | ast.GeneratorExp,
+        ):
+            continue
+        stack.extend(reversed(list(ast.iter_child_nodes(current))))
+
+
+def _walk_comprehension_bindings(nodes: Iterable[ast.AST]) -> Iterable[ast.AST]:
+    stack = list(reversed(list(nodes)))
+    while stack:
+        current = stack.pop()
+        if isinstance(current, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Lambda):
+            continue
+        if isinstance(current, ast.NamedExpr):
+            yield current.target
+            stack.append(current.value)
+            continue
+        stack.extend(reversed(list(ast.iter_child_nodes(current))))
+
+
+def _walk_scope_bindings(body: list[ast.stmt]) -> Iterable[ast.AST]:
+    stack: list[ast.AST] = list(reversed(body))
+    while stack:
+        current = stack.pop()
+        yield current
+        if isinstance(current, ast.FunctionDef | ast.AsyncFunctionDef):
+            defining_expressions: list[ast.AST] = [
+                *current.decorator_list,
+                current.args,
+            ]
+            if current.returns is not None:
+                defining_expressions.append(current.returns)
+            stack.extend(reversed(defining_expressions))
+            continue
+        if isinstance(current, ast.ClassDef):
+            defining_expressions = [
+                *current.decorator_list,
+                *current.bases,
+                *(keyword.value for keyword in current.keywords),
+            ]
+            stack.extend(reversed(defining_expressions))
+            continue
+        if isinstance(current, ast.Lambda):
+            stack.append(current.args)
+            continue
+        if isinstance(current, ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp):
+            first_generator, *remaining_generators = current.generators
+            stack.append(first_generator.iter)
+            nested_expressions: list[ast.AST] = [
+                *(condition for generator in current.generators for condition in generator.ifs),
+                *(generator.iter for generator in remaining_generators),
+            ]
+            if isinstance(current, ast.DictComp):
+                nested_expressions.extend((current.key, current.value))
+            else:
+                nested_expressions.append(current.elt)
+            yield from _walk_comprehension_bindings(nested_expressions)
+            continue
+        stack.extend(reversed(list(ast.iter_child_nodes(current))))
+
+
+def _walk_function(node: FunctionNode) -> Iterable[ast.AST]:
+    yield from _walk_scope(node.body)
+
+
+def _is_static_method(function: FunctionNode) -> bool:
+    return any(
+        isinstance(decorator, ast.Name)
+        and decorator.id == "staticmethod"
+        or isinstance(decorator, ast.Attribute)
+        and isinstance(decorator.value, ast.Name)
+        and decorator.value.id == "builtins"
+        and decorator.attr == "staticmethod"
+        for decorator in function.decorator_list
+    )
+
+
+def _owns_instance_fields(function: FunctionNode) -> bool:
+    return not _is_static_method(function)
+
+
+def _is_none_annotation(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Constant)
+        and node.value is None
+        or isinstance(node, ast.Name)
+        and node.id == "None"
+    )
+
+
+def _optional_payload(annotation: ast.expr) -> ast.expr | None:
+    if not isinstance(annotation, ast.BinOp) or not isinstance(annotation.op, ast.BitOr):
+        return None
+    members: list[ast.expr] = []
+
+    def collect(node: ast.expr) -> None:
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            collect(node.left)
+            collect(node.right)
+        else:
+            members.append(node)
+
+    collect(annotation)
+    payloads = [member for member in members if not _is_none_annotation(member)]
+    if len(payloads) != 1 or len(payloads) == len(members):
+        return None
+    return payloads[0]
+
+
+def _is_direct_optional_reference(
+    annotation: ast.expr,
+    *,
+    bindings: dict[str, ReferenceKind],
+) -> bool:
+    payload = _optional_payload(annotation)
+    if payload is None:
+        return False
+    if (
+        isinstance(payload, ast.Subscript)
+        and isinstance(payload.value, ast.Name)
+        and bindings.get(payload.value.id) == "callable"
+    ):
+        return True
+    if not isinstance(payload, ast.Name):
+        return False
+    return bindings.get(payload.id) == "class"
+
+
+def _reference_bindings_for_scope(
+    body: list[ast.stmt],
+    inherited_bindings: dict[str, ReferenceKind],
+    *,
+    arguments: Iterable[ast.arg] = (),
+    forced_shadows: Iterable[str] = (),
+    supported_classes: Mapping[int, str] | None = None,
+) -> dict[str, ReferenceKind]:
+    supported_classes = supported_classes or {}
+    tracked_names = {*inherited_bindings, *supported_classes.values(), "Callable"}
+    supported_bindings: dict[str, ReferenceKind] = {}
+    shadowed_names = {
+        name
+        for name in [*(argument.arg for argument in arguments), *forced_shadows]
+        if name in tracked_names
+    }
+
+    def record_supported(name: str, kind: ReferenceKind) -> None:
+        existing = supported_bindings.get(name)
+        if existing is not None:
+            shadowed_names.add(name)
+        else:
+            supported_bindings[name] = kind
+
+    for node in _walk_scope_bindings(body):
+        if isinstance(node, ast.Import | ast.ImportFrom):
+            for imported in node.names:
+                if isinstance(node, ast.ImportFrom) and imported.name == "*":
+                    shadowed_names.update(tracked_names)
+                    continue
+                local_name = imported.asname or imported.name.split(".")[0]
+                is_standard_callable = (
+                    isinstance(node, ast.ImportFrom)
+                    and node.level == 0
+                    and node.module in _CALLABLE_MODULES
+                    and imported.name == "Callable"
+                    and imported.asname is None
+                )
+                if is_standard_callable:
+                    record_supported("Callable", "callable")
+                elif local_name in tracked_names:
+                    shadowed_names.add(local_name)
+        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            if isinstance(node, ast.ClassDef) and id(node) in supported_classes:
+                record_supported(node.name, "class")
+            elif node.name in tracked_names:
+                shadowed_names.add(node.name)
+        elif (
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Store | ast.Del)
+            and node.id in tracked_names
+        ):
+            shadowed_names.add(node.id)
+        elif (
+            isinstance(node, ast.ExceptHandler)
+            and isinstance(node.name, str)
+            and node.name in tracked_names
+        ):
+            shadowed_names.add(node.name)
+        elif isinstance(node, ast.MatchAs | ast.MatchStar) and node.name in tracked_names:
+            shadowed_names.add(node.name)
+        elif isinstance(node, ast.MatchMapping) and node.rest in tracked_names:
+            shadowed_names.add(node.rest)
+
+    bindings = {
+        name: kind for name, kind in inherited_bindings.items() if name not in shadowed_names
+    }
+    bindings.update(
+        (name, kind) for name, kind in supported_bindings.items() if name not in shadowed_names
+    )
+    return bindings
+
+
+def _cross_scope_declared_names(tree: ast.Module) -> set[str]:
+    return {
+        name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Global | ast.Nonlocal)
+        for name in node.names
+    }
+
+
+def _type_parameter_names(node: FunctionNode | ast.ClassDef) -> set[str]:
+    return {
+        name
+        for type_parameter in getattr(node, "type_params", ())
+        if isinstance(name := getattr(type_parameter, "name", None), str)
+    }
+
+
+def _collect_module_info(path: Path, tree: ast.Module) -> _ModuleInfo:
+    classes: dict[int, _ClassInfo] = {}
+    functions: dict[int, _FunctionInfo] = {}
+    cross_scope_shadows = _cross_scope_declared_names(tree)
+
+    def is_simple_reference_class(node: ast.ClassDef) -> bool:
+        return not node.bases or all(
+            isinstance(base, ast.Name) and base.id == "object" for base in node.bases
+        )
+
+    supported_classes = {
+        id(node): node.name
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and is_simple_reference_class(node)
+    }
+    module_bindings = _reference_bindings_for_scope(
+        tree.body,
+        {},
+        forced_shadows=cross_scope_shadows,
+        supported_classes=supported_classes,
+    )
+
+    def register_function(
+        function: FunctionNode,
+        *,
+        signature_bindings: dict[str, ReferenceKind],
+        inherited_body_bindings: dict[str, ReferenceKind],
+        owner: int | None,
+    ) -> None:
+        forced_shadows = cross_scope_shadows | _type_parameter_names(function)
+        signature_bindings = {
+            name: kind for name, kind in signature_bindings.items() if name not in forced_shadows
+        }
+        body_bindings = _reference_bindings_for_scope(
+            function.body,
+            inherited_body_bindings,
+            arguments=_arguments(function),
+            forced_shadows=forced_shadows,
+        )
+        functions[id(function)] = _FunctionInfo(
+            node=function,
+            owner=owner,
+            signature_bindings=signature_bindings,
+            body_bindings=body_bindings,
+        )
+        if owner is not None and _owns_instance_fields(function):
+            class_info = classes[owner]
+            for item in _walk_function(function):
+                if (
+                    isinstance(item, ast.AnnAssign)
+                    and isinstance(item.target, ast.Attribute)
+                    and isinstance(item.target.value, ast.Name)
+                    and item.target.value.id == "self"
+                    and _is_direct_optional_reference(
+                        item.annotation,
+                        bindings=body_bindings,
+                    )
+                ):
+                    class_info.fields.add(item.target.attr)
+        for item in _walk_function(function):
+            if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+                register_function(
+                    item,
+                    signature_bindings=body_bindings,
+                    inherited_body_bindings=body_bindings,
+                    owner=None,
+                )
+            elif isinstance(item, ast.ClassDef):
+                register_class(
+                    item,
+                    inherited_body_bindings=body_bindings,
+                )
+
+    def register_class(
+        node: ast.ClassDef,
+        *,
+        inherited_body_bindings: dict[str, ReferenceKind],
+    ) -> None:
+        class_info = _ClassInfo()
+        classes[id(node)] = class_info
+        forced_shadows = cross_scope_shadows | _type_parameter_names(node)
+        nested_body_bindings = {
+            name: kind
+            for name, kind in inherited_body_bindings.items()
+            if name not in forced_shadows
+        }
+        class_bindings = _reference_bindings_for_scope(
+            node.body,
+            nested_body_bindings,
+            forced_shadows=forced_shadows,
+        )
+        for item in _walk_scope(node.body):
+            if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                if _is_direct_optional_reference(
+                    item.annotation,
+                    bindings=class_bindings,
+                ):
+                    class_info.fields.add(item.target.id)
+            elif isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+                register_function(
+                    item,
+                    signature_bindings=class_bindings,
+                    inherited_body_bindings=nested_body_bindings,
+                    owner=id(node),
+                )
+            elif isinstance(item, ast.ClassDef):
+                register_class(
+                    item,
+                    inherited_body_bindings=nested_body_bindings,
+                )
+
+    for node in _walk_scope(tree.body):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            register_function(
+                node,
+                signature_bindings=module_bindings,
+                inherited_body_bindings=module_bindings,
+                owner=None,
+            )
+        elif isinstance(node, ast.ClassDef):
+            register_class(
+                node,
+                inherited_body_bindings=module_bindings,
+            )
+
+    return _ModuleInfo(path, classes, functions)
+
+
+def _arguments(function: FunctionNode) -> list[ast.arg]:
+    arguments = [
+        *function.args.posonlyargs,
+        *function.args.args,
+        *function.args.kwonlyargs,
+    ]
+    if function.args.vararg is not None:
+        arguments.append(function.args.vararg)
+    if function.args.kwarg is not None:
+        arguments.append(function.args.kwarg)
+    return arguments
+
+
+def _function_declarations(function: _FunctionInfo) -> set[str]:
+    declarations = {
+        argument.arg
+        for argument in _arguments(function.node)
+        if argument.annotation is not None
+        and _is_direct_optional_reference(
+            argument.annotation,
+            bindings=function.signature_bindings,
+        )
+    }
+    for node in _walk_function(function.node):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and _is_direct_optional_reference(
+                node.annotation,
+                bindings=function.body_bindings,
+            )
+        ):
+            declarations.add(node.target.id)
+    return declarations
+
+
+def _truthiness_atoms(node: ast.expr) -> Iterable[ast.expr]:
+    if isinstance(node, ast.Name | ast.Attribute):
+        yield node
+    elif isinstance(node, ast.NamedExpr):
+        yield from _truthiness_atoms(node.value)
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        yield from _truthiness_atoms(node.operand)
+    elif isinstance(node, ast.BoolOp):
+        for value in node.values:
+            yield from _truthiness_atoms(value)
+
+
+def _tested_expressions(function: FunctionNode) -> Iterable[ast.expr]:
+    for node in _walk_function(function):
+        if isinstance(node, ast.If | ast.While | ast.Assert | ast.IfExp):
+            yield from _truthiness_atoms(node.test)
+        elif isinstance(node, ast.match_case) and node.guard is not None:
+            yield from _truthiness_atoms(node.guard)
+        elif isinstance(node, ast.BoolOp):
+            for value in node.values[:-1]:
+                yield from _truthiness_atoms(value)
+        elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+            yield from _truthiness_atoms(node.operand)
+
+
+def _is_declared_reference(
+    expression: ast.expr,
+    declarations: set[str],
+    owner: _ClassInfo | None,
+) -> bool:
+    if isinstance(expression, ast.Name):
+        return expression.id in declarations
+    return (
+        isinstance(expression, ast.Attribute)
+        and isinstance(expression.value, ast.Name)
+        and expression.value.id == "self"
+        and owner is not None
+        and expression.attr in owner.fields
+    )
+
+
+def _find_tree_violations(module: _ModuleInfo) -> list[Violation]:
+    violations: dict[tuple[int, int], Violation] = {}
+    for function in module.functions.values():
+        declarations = _function_declarations(function)
+        owner = (
+            module.classes.get(function.owner)
+            if function.owner is not None and _owns_instance_fields(function.node)
+            else None
+        )
+        for expression in _tested_expressions(function.node):
+            if not _is_declared_reference(expression, declarations, owner):
+                continue
+            violation = Violation(
+                path=module.path,
+                line=expression.lineno,
+                column=expression.col_offset + 1,
+                expression=ast.unparse(expression),
+            )
+            violations[(violation.line, violation.column)] = violation
+    return sorted(violations.values())
+
+
+def find_violations(paths: Iterable[Path]) -> list[Violation]:
+    files = sorted(
+        {
+            file
+            for path in paths
+            for file in (path.rglob("*.py") if path.is_dir() else [path])
+            if file.suffix == ".py"
+        }
+    )
+    violations: list[Violation] = []
+    for path in files:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        violations.extend(_find_tree_violations(_collect_module_info(path, tree)))
+    return sorted(violations)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject truthiness checks on directly declared optional references."
+    )
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+    violations = find_violations(args.paths)
+    for violation in violations:
+        print(violation.format())
+    if violations:
+        print(
+            "Use an explicit `is None` or `is not None` check so falsy user objects are preserved.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ format-check:
 .PHONY: lint
 lint: 
 	uv run ruff check
+	uv run python .github/scripts/check_optional_truthiness.py src/agents
 
 .PHONY: mypy
 mypy: 

--- a/src/agents/_tool_invocation.py
+++ b/src/agents/_tool_invocation.py
@@ -252,7 +252,11 @@ def tool_invocation_approval_scope(
     if invocation_role is not None:
         payload["invocation_role"] = invocation_role
     if invocation_type == "function_call":
-        resolved_lookup_key = tool_lookup_key or get_function_tool_lookup_key_for_call(mapping)
+        resolved_lookup_key = (
+            tool_lookup_key
+            if tool_lookup_key is not None
+            else get_function_tool_lookup_key_for_call(mapping)
+        )
         if resolved_lookup_key is None:
             return None
         payload["tool_lookup_key"] = _normalize_value(resolved_lookup_key)

--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -870,7 +870,7 @@ class Agent(AgentBase, Generic[TContext]):
                     stream_handler = on_stream
                     run_result_streaming = Runner.run_streamed(
                         starting_agent=cast(Agent[Any], self),
-                        input=resume_state or resolved_input,
+                        input=resume_state if resume_state is not None else resolved_input,
                         # On resume, pass the parent application context so
                         # resolve_resumed_context can update the nested restored
                         # wrapper's .context without dropping nested approvals.
@@ -942,7 +942,7 @@ class Agent(AgentBase, Generic[TContext]):
                 else:
                     run_result = await Runner.run(
                         starting_agent=cast(Agent[Any], self),
-                        input=resume_state or resolved_input,
+                        input=resume_state if resume_state is not None else resolved_input,
                         # On resume, pass the parent application context so
                         # resolve_resumed_context can update the nested restored
                         # wrapper's .context without dropping nested approvals.

--- a/src/agents/agent_tool_input.py
+++ b/src/agents/agent_tool_input.py
@@ -84,15 +84,15 @@ async def resolve_agent_tool_input(
 ) -> str | list[TResponseInputItem]:
     """Resolve structured tool input into a string or list of input items."""
     should_build_structured_input = input_builder is not None or bool(
-        schema_info and (schema_info.summary or schema_info.json_schema)
+        schema_info is not None and (schema_info.summary or schema_info.json_schema)
     )
     if should_build_structured_input:
         builder = input_builder if input_builder is not None else default_tool_input_builder
         result = builder(
             {
                 "params": params,
-                "summary": schema_info.summary if schema_info else None,
-                "json_schema": schema_info.json_schema if schema_info else None,
+                "summary": schema_info.summary if schema_info is not None else None,
+                "json_schema": schema_info.json_schema if schema_info is not None else None,
             }
         )
         if inspect.isawaitable(result):

--- a/src/agents/extensions/experimental/codex/codex.py
+++ b/src/agents/extensions/experimental/codex/codex.py
@@ -58,7 +58,9 @@ class Codex:
             )
         if has_kwargs:
             options = {key: value for key, value in kw_values.items() if value is not _UNSET}
-        resolved_options = coerce_codex_options(options) or CodexOptions()
+        resolved_options = coerce_codex_options(options)
+        if resolved_options is None:
+            resolved_options = CodexOptions()
         self._exec = CodexExec(
             executable_path=resolved_options.codex_path_override,
             env=_normalize_env(resolved_options),
@@ -67,7 +69,9 @@ class Codex:
         self._options = resolved_options
 
     def start_thread(self, options: ThreadOptions | Mapping[str, Any] | None = None) -> Thread:
-        resolved_options = coerce_thread_options(options) or ThreadOptions()
+        resolved_options = coerce_thread_options(options)
+        if resolved_options is None:
+            resolved_options = ThreadOptions()
         return Thread(
             exec_client=self._exec,
             options=self._options,
@@ -77,7 +81,9 @@ class Codex:
     def resume_thread(
         self, thread_id: str, options: ThreadOptions | Mapping[str, Any] | None = None
     ) -> Thread:
-        resolved_options = coerce_thread_options(options) or ThreadOptions()
+        resolved_options = coerce_thread_options(options)
+        if resolved_options is None:
+            resolved_options = ThreadOptions()
         return Thread(
             exec_client=self._exec,
             options=self._options,

--- a/src/agents/extensions/experimental/codex/codex_tool.py
+++ b/src/agents/extensions/experimental/codex/codex_tool.py
@@ -585,7 +585,7 @@ def _resolve_codex_options(
     options: CodexOptions | Mapping[str, Any] | None,
 ) -> CodexOptions | None:
     options = coerce_codex_options(options)
-    if options and options.api_key:
+    if options is not None and options.api_key:
         return options
 
     api_key = _resolve_default_codex_api_key(options)
@@ -605,10 +605,10 @@ def _resolve_codex_options(
 
 
 def _resolve_default_codex_api_key(options: CodexOptions | None) -> str | None:
-    if options and options.api_key:
+    if options is not None and options.api_key:
         return options.api_key
 
-    env_override = options.env if options else None
+    env_override = options.env if options is not None else None
     if env_override:
         env_codex = env_override.get("CODEX_API_KEY")
         if env_codex:
@@ -656,12 +656,17 @@ def _resolve_thread_options(
     skip_git_repo_check: bool | None,
 ) -> ThreadOptions | None:
     defaults = coerce_thread_options(defaults)
-    if not defaults and not sandbox_mode and not working_directory and skip_git_repo_check is None:
+    if (
+        defaults is None
+        and not sandbox_mode
+        and not working_directory
+        and skip_git_repo_check is None
+    ):
         return None
 
     return ThreadOptions(
         **{
-            **(defaults.__dict__ if defaults else {}),
+            **(defaults.__dict__ if defaults is not None else {}),
             **({"sandbox_mode": sandbox_mode} if sandbox_mode else {}),
             **({"working_directory": working_directory} if working_directory else {}),
             **(

--- a/src/agents/extensions/experimental/codex/thread.py
+++ b/src/agents/extensions/experimental/codex/thread.py
@@ -90,7 +90,7 @@ class Thread:
     async def run_streamed(
         self, input: Input, turn_options: TurnOptions | None = None
     ) -> StreamedTurn:
-        options = turn_options or TurnOptions()
+        options = turn_options if turn_options is not None else TurnOptions()
         return StreamedTurn(events=self._run_streamed_internal(input, options))
 
     async def _run_streamed_internal(
@@ -161,7 +161,7 @@ class Thread:
 
     async def run(self, input: Input, turn_options: TurnOptions | None = None) -> Turn:
         # Aggregate events into a single Turn result (matching the TS SDK behavior).
-        options = turn_options or TurnOptions()
+        options = turn_options if turn_options is not None else TurnOptions()
         generator = self._run_streamed_internal(input, options)
         items: list[ThreadItem] = []
         final_response = ""
@@ -182,7 +182,7 @@ class Thread:
             elif isinstance(event, ThreadErrorEvent):
                 raise RuntimeError(f"Codex stream error: {event.message}")
 
-        if turn_failure:
+        if turn_failure is not None:
             raise RuntimeError(turn_failure.message)
 
         return Turn(items=items, final_response=final_response, usage=usage)

--- a/src/agents/extensions/experimental/hosted_multi_agent/model.py
+++ b/src/agents/extensions/experimental/hosted_multi_agent/model.py
@@ -556,7 +556,7 @@ class OpenAIHostedMultiAgentModel(OpenAIResponsesModel):
         self,
         active: _ActiveWebSocketResponse | None = None,
     ) -> None:
-        target = active or self._active_response
+        target = active if active is not None else self._active_response
         if target is None:
             return
         if self._active_response is target:

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -81,7 +81,7 @@ class AdvancedSQLiteSession(SQLiteSession):
         # branch pointer is established or a write begins. A mismatch means
         # another instance cleared the session, so the local pointer resets to main.
         self._generation = 0
-        self._logger = logger or logging.getLogger(__name__)
+        self._logger = logger if logger is not None else logging.getLogger(__name__)
 
     def _commit_branch_pointer(self, branch_id: str, generation: int) -> bool:
         """Set the current-branch pointer unless a clear has committed meanwhile.

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -419,7 +419,7 @@ class AnyLLMModel(Model):
                     input_tokens_details=response.usage.input_tokens_details,
                     output_tokens_details=response.usage.output_tokens_details,
                 )
-                if response.usage
+                if response.usage is not None
                 # The request completed, so it counts even when the provider omits usage.
                 else Usage(requests=1)
             )
@@ -517,12 +517,12 @@ class AnyLLMModel(Model):
                         if final_response is not None:
                             span_response.span_data.usage = model_usage_to_span_usage(
                                 _response_usage_to_usage(final_response.usage)
-                                if final_response.usage
+                                if final_response.usage is not None
                                 else Usage(
                                     requests=_requests_for_response_without_usage(final_response)
                                 )
                             )
-                        if tracing.include_data() and final_response:
+                        if tracing.include_data() and final_response is not None:
                             span_response.span_data.response = final_response
                             span_response.span_data.input = input
                         if terminal_failure_error is not None:
@@ -614,7 +614,7 @@ class AnyLLMModel(Model):
                         json.dumps(message.model_dump(), indent=2, ensure_ascii=False),
                     )
                 else:
-                    finish_reason = first_choice.finish_reason if first_choice else "-"
+                    finish_reason = first_choice.finish_reason if first_choice is not None else "-"
                     logger.debug("LLM resp had no message. finish_reason: %s", finish_reason)
 
             usage = (
@@ -626,7 +626,7 @@ class AnyLLMModel(Model):
                     input_tokens_details=response.usage.prompt_tokens_details,  # type: ignore[arg-type]
                     output_tokens_details=response.usage.completion_tokens_details,  # type: ignore[arg-type]
                 )
-                if response.usage
+                if response.usage is not None
                 # The request completed, so it counts even when the provider omits usage.
                 else Usage(requests=1)
             )
@@ -671,7 +671,11 @@ class AnyLLMModel(Model):
             )
 
             logprob_models = None
-            if first_choice and first_choice.logprobs and first_choice.logprobs.content:
+            if (
+                first_choice is not None
+                and first_choice.logprobs is not None
+                and first_choice.logprobs.content
+            ):
                 logprob_models = ChatCmplHelpers.convert_logprobs_for_output_text(
                     first_choice.logprobs.content
                 )
@@ -787,7 +791,7 @@ class AnyLLMModel(Model):
         if tracing.include_data():
             span_generation.span_data.output = [final_response.model_dump()]
 
-        if final_response.usage:
+        if final_response.usage is not None:
             span_generation.span_data.usage = {
                 "requests": 1,
                 "input_tokens": final_response.usage.input_tokens,
@@ -795,12 +799,12 @@ class AnyLLMModel(Model):
                 "total_tokens": final_response.usage.total_tokens,
                 "input_tokens_details": (
                     final_response.usage.input_tokens_details.model_dump()
-                    if final_response.usage.input_tokens_details
+                    if final_response.usage.input_tokens_details is not None
                     else {"cached_tokens": 0, "cache_write_tokens": 0}
                 ),
                 "output_tokens_details": (
                     final_response.usage.output_tokens_details.model_dump()
-                    if final_response.usage.output_tokens_details
+                    if final_response.usage.output_tokens_details is not None
                     else {"reasoning_tokens": 0}
                 ),
             }
@@ -905,7 +909,9 @@ class AnyLLMModel(Model):
                 response_format,
             )
 
-        reasoning_effort = model_settings.reasoning.effort if model_settings.reasoning else None
+        reasoning_effort = (
+            model_settings.reasoning.effort if model_settings.reasoning is not None else None
+        )
         if reasoning_effort is None and model_settings.extra_args:
             reasoning_effort = cast(Any, model_settings.extra_args.get("reasoning_effort"))
 

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -179,7 +179,7 @@ class LitellmModel(Model):
         """
         reasoning_effort: Any | None = None
 
-        if model_settings.reasoning:
+        if model_settings.reasoning is not None:
             reasoning_effort = model_settings.reasoning.effort
             if model_settings.reasoning.summary is not None:
                 logger.warning(
@@ -267,7 +267,7 @@ class LitellmModel(Model):
                         json.dumps(message.model_dump(), indent=2, ensure_ascii=False),
                     )
                 else:
-                    finish_reason = first_choice.finish_reason if first_choice else "-"
+                    finish_reason = first_choice.finish_reason if first_choice is not None else "-"
                     logger.debug("LLM resp had no message. finish_reason: %s", finish_reason)
 
             if hasattr(response, "usage"):
@@ -294,7 +294,7 @@ class LitellmModel(Model):
                             or 0
                         ),
                     )
-                    if response.usage
+                    if response_usage is not None
                     # The request completed, so it counts even when the provider omits usage.
                     else Usage(requests=1)
                 )
@@ -353,7 +353,9 @@ class LitellmModel(Model):
             # LiteLLM's Choices omits the logprobs attribute entirely when it was not requested,
             # so access it defensively (mirrors the finish_reason handling above).
             logprob_models = None
-            choice_logprobs = getattr(first_choice, "logprobs", None) if first_choice else None
+            choice_logprobs = (
+                getattr(first_choice, "logprobs", None) if first_choice is not None else None
+            )
             if choice_logprobs is not None and getattr(choice_logprobs, "content", None):
                 logprob_models = ChatCmplHelpers.convert_logprobs_for_output_text(
                     choice_logprobs.content
@@ -466,7 +468,7 @@ class LitellmModel(Model):
         if tracing.include_data():
             span_generation.span_data.output = [final_response.model_dump()]
 
-        if final_response.usage:
+        if final_response.usage is not None:
             span_generation.span_data.usage = {
                 "requests": 1,
                 "input_tokens": final_response.usage.input_tokens,
@@ -474,12 +476,12 @@ class LitellmModel(Model):
                 "total_tokens": final_response.usage.total_tokens,
                 "input_tokens_details": (
                     final_response.usage.input_tokens_details.model_dump()
-                    if final_response.usage.input_tokens_details
+                    if final_response.usage.input_tokens_details is not None
                     else {"cached_tokens": 0, "cache_write_tokens": 0}
                 ),
                 "output_tokens_details": (
                     final_response.usage.output_tokens_details.model_dump()
-                    if final_response.usage.output_tokens_details
+                    if final_response.usage.output_tokens_details is not None
                     else {"reasoning_tokens": 0}
                 ),
             }

--- a/src/agents/extensions/sandbox/blaxel/sandbox.py
+++ b/src/agents/extensions/sandbox/blaxel/sandbox.py
@@ -1052,7 +1052,9 @@ class BlaxelSandboxClient(BaseSandboxClient["BlaxelSandboxClientOptions"]):
     ) -> None:
         # Validate that the Blaxel SDK is importable.
         _import_blaxel_sdk()
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
         self._token = token or os.environ.get("BL_API_KEY")
 

--- a/src/agents/extensions/sandbox/cloudflare/sandbox.py
+++ b/src/agents/extensions/sandbox/cloudflare/sandbox.py
@@ -1435,7 +1435,9 @@ class CloudflareSandboxClient(BaseSandboxClient[CloudflareSandboxClientOptions])
         request_timeout_s: float = _DEFAULT_REQUEST_TIMEOUT_S,
     ) -> None:
         super().__init__()
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
         self._exec_timeout_s = exec_timeout_s
         self._request_timeout_s = request_timeout_s

--- a/src/agents/extensions/sandbox/daytona/sandbox.py
+++ b/src/agents/extensions/sandbox/daytona/sandbox.py
@@ -1195,7 +1195,9 @@ class DaytonaSandboxClient(BaseSandboxClient[DaytonaSandboxClientOptions]):
         AsyncDaytona, DaytonaConfig, _, _ = _import_daytona_sdk()
         config = DaytonaConfig(api_key=api_key, api_url=api_url) if (api_key or api_url) else None
         self._daytona = AsyncDaytona(config)
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     async def _build_create_params(

--- a/src/agents/extensions/sandbox/e2b/sandbox.py
+++ b/src/agents/extensions/sandbox/e2b/sandbox.py
@@ -1680,7 +1680,9 @@ class E2BSandboxClient(BaseSandboxClient[E2BSandboxClientOptions]):
         instrumentation: Instrumentation | None = None,
         dependencies: Dependencies | None = None,
     ) -> None:
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     async def create(
@@ -1692,7 +1694,7 @@ class E2BSandboxClient(BaseSandboxClient[E2BSandboxClientOptions]):
     ) -> SandboxSession:
         if options is None:
             raise ValueError("E2BSandboxClient.create requires options")
-        manifest = manifest or Manifest()
+        manifest = manifest if manifest is not None else Manifest()
 
         sandbox_type = _coerce_sandbox_type(options.sandbox_type)
 

--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -679,7 +679,7 @@ class ModalSandboxSession(BaseSandboxSession):
             create_if_missing=True,
             call_timeout=10.0,
         )
-        if not self._image:
+        if self._image is None:
             image_id = self.state.image_id
             if image_id:
                 self._image = modal.Image.from_id(image_id)
@@ -1947,7 +1947,9 @@ class ModalSandboxClient(BaseSandboxClient[ModalSandboxClientOptions]):
     ) -> None:
         self._default_image = image
         self._default_sandbox = sandbox
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     def _validate_manifest_for_workspace_persistence(
@@ -2002,7 +2004,7 @@ class ModalSandboxClient(BaseSandboxClient[ModalSandboxClientOptions]):
 
         if options is None:
             raise ValueError("ModalSandboxClient.create requires options with app_name")
-        manifest = manifest or Manifest()
+        manifest = manifest if manifest is not None else Manifest()
         app_name = options.app_name
         if not app_name:
             raise ValueError("ModalSandboxClient.create requires a valid app_name")

--- a/src/agents/extensions/sandbox/runloop/sandbox.py
+++ b/src/agents/extensions/sandbox/runloop/sandbox.py
@@ -1545,7 +1545,9 @@ class RunloopSandboxClient(BaseSandboxClient[RunloopSandboxClientOptions | None]
     ) -> None:
         self._sdk = _import_runloop_sdk().async_sdk(bearer_token=bearer_token, base_url=base_url)
         self._platform = RunloopPlatformClient(self._sdk)
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     @property
@@ -1567,7 +1569,7 @@ class RunloopSandboxClient(BaseSandboxClient[RunloopSandboxClientOptions | None]
         configured blueprint selection or user profile when provisioning the devbox. The returned
         session follows the shared sandbox lifecycle and must be started before direct operations.
         """
-        resolved_options = options or RunloopSandboxClientOptions()
+        resolved_options = options if options is not None else RunloopSandboxClientOptions()
         if (
             resolved_options.blueprint_id is not None
             and resolved_options.blueprint_name is not None
@@ -1577,7 +1579,11 @@ class RunloopSandboxClient(BaseSandboxClient[RunloopSandboxClientOptions | None]
             )
 
         user_parameters = _normalize_runloop_user_parameters(resolved_options.user_parameters)
-        manifest = manifest or Manifest(root=_default_runloop_manifest_root(user_parameters))
+        manifest = (
+            manifest
+            if manifest is not None
+            else Manifest(root=_default_runloop_manifest_root(user_parameters))
+        )
         _validate_runloop_manifest_root(manifest, user_parameters=user_parameters)
 
         timeouts_in = resolved_options.timeouts

--- a/src/agents/extensions/sandbox/vercel/sandbox.py
+++ b/src/agents/extensions/sandbox/vercel/sandbox.py
@@ -1326,7 +1326,9 @@ class VercelSandboxClient(BaseSandboxClient[VercelSandboxClientOptions]):
         self._token = token
         self._project_id = project_id
         self._team_id = team_id
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     def _wrap_session(

--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -67,7 +67,7 @@ def get_all_nodes(
     parts = []
 
     # Start and end the graph
-    if not parent:
+    if parent is None:
         parts.append(
             '"__start__" [label="__start__", shape=ellipse, style=filled, '
             "fillcolor=lightblue, width=0.5, height=0.3];"
@@ -142,7 +142,7 @@ def get_all_edges(
 
     agent_name = _escape_label(agent.name)
 
-    if not parent:
+    if parent is None:
         parts.append(f'"__start__" -> "{agent_name}";')
 
     for tool in agent.tools:

--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -928,7 +928,9 @@ class ItemHelpers:
             # An empty list/tuple has no structured items; ``all([])`` is ``True``,
             # so guard against it to avoid emitting an empty structured-output list
             # (which would drop the tool result) and stringify instead.
-            if maybe_converted_output_list and all(maybe_converted_output_list):
+            if maybe_converted_output_list and all(
+                item is not None for item in maybe_converted_output_list
+            ):
                 return [
                     cls._convert_single_tool_output_pydantic_model(item)
                     for item in maybe_converted_output_list
@@ -937,7 +939,7 @@ class ItemHelpers:
             return None
 
         maybe_converted_output = cls._maybe_get_output_as_structured_function_output(output)
-        if maybe_converted_output:
+        if maybe_converted_output is not None:
             return [cls._convert_single_tool_output_pydantic_model(maybe_converted_output)]
         return None
 

--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -806,7 +806,7 @@ class MCPUtil:
             context._custom_data = custom_data
 
         current_span = get_current_span()
-        if current_span:
+        if current_span is not None:
             if isinstance(current_span.span_data, FunctionSpanData):
                 if not isinstance(context, ToolContext) or (
                     context.run_config is None or context.run_config.trace_include_sensitive_data

--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -15,7 +15,8 @@ from .session_settings import SessionSettings, coerce_session_settings, resolve_
 async def start_openai_conversations_session(openai_client: AsyncOpenAI | None = None) -> str:
     _maybe_openai_client = openai_client
     if openai_client is None:
-        _maybe_openai_client = get_default_openai_client() or AsyncOpenAI()
+        default_client = get_default_openai_client()
+        _maybe_openai_client = default_client if default_client is not None else AsyncOpenAI()
     # this never be None here
     _openai_client: AsyncOpenAI = _maybe_openai_client  # type: ignore [assignment]
 
@@ -42,7 +43,8 @@ class OpenAIConversationsSession(SessionABC):
         )
         _openai_client = openai_client
         if _openai_client is None:
-            _openai_client = get_default_openai_client() or AsyncOpenAI()
+            default_client = get_default_openai_client()
+            _openai_client = default_client if default_client is not None else AsyncOpenAI()
         # this never be None here
         self._openai_client: AsyncOpenAI = _openai_client
 

--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -140,7 +140,8 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
     @property
     def client(self) -> AsyncOpenAI:
         if self._client is None:
-            self._client = get_default_openai_client() or AsyncOpenAI()
+            default_client = get_default_openai_client()
+            self._client = default_client if default_client is not None else AsyncOpenAI()
         return self._client
 
     def _resolve_compaction_mode_for_response(

--- a/src/agents/models/_response_terminal.py
+++ b/src/agents/models/_response_terminal.py
@@ -20,10 +20,10 @@ def format_response_terminal_failure(
     if status:
         details.append(f"status={status}")
     error = getattr(response, "error", None)
-    if error:
+    if error is not None:
         details.append(f"error={error}")
     incomplete_details = getattr(response, "incomplete_details", None)
-    if incomplete_details:
+    if incomplete_details is not None:
         details.append(f"incomplete_details={incomplete_details}")
 
     if details:

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -106,7 +106,7 @@ class Converter:
     def convert_response_format(
         cls, final_output_schema: AgentOutputSchemaBase | None
     ) -> ResponseFormat | Omit:
-        if not final_output_schema or final_output_schema.is_plain_text():
+        if final_output_schema is None or final_output_schema.is_plain_text():
             return omit
 
         return {

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -863,12 +863,12 @@ class ChatCmplStreamHandler:
                     )
                 delta_logprobs = (
                     ChatCmplHelpers.convert_logprobs_for_text_delta(
-                        choice_logprobs.content if choice_logprobs else None
+                        choice_logprobs.content if choice_logprobs is not None else None
                     )
                     or []
                 )
                 output_logprobs = ChatCmplHelpers.convert_logprobs_for_output_text(
-                    choice_logprobs.content if choice_logprobs else None
+                    choice_logprobs.content if choice_logprobs is not None else None
                 )
                 # Emit the delta for this segment of content
                 yield ResponseTextDeltaEvent(

--- a/src/agents/models/openai_agent_registration.py
+++ b/src/agents/models/openai_agent_registration.py
@@ -43,8 +43,8 @@ def resolve_openai_agent_registration_config(
         config = _coerce_openai_agent_registration_config(config)
     default = get_default_openai_agent_registration_config()
     harness_id = _resolve_str(
-        explicit=config.harness_id if config else None,
-        default=default.harness_id if default else None,
+        explicit=config.harness_id if config is not None else None,
+        default=default.harness_id if default is not None else None,
         env_name=_ENV_HARNESS_ID,
     )
     if harness_id is None:

--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -282,7 +282,7 @@ class OpenAIChatCompletionsModel(Model):
                         json.dumps(message.model_dump(), indent=2, ensure_ascii=False),
                     )
                 else:
-                    finish_reason = first_choice.finish_reason if first_choice else "-"
+                    finish_reason = first_choice.finish_reason if first_choice is not None else "-"
                     logger.debug("LLM resp had no message. finish_reason: %s", finish_reason)
 
             usage = (
@@ -295,7 +295,7 @@ class OpenAIChatCompletionsModel(Model):
                     input_tokens_details=response.usage.prompt_tokens_details,  # type: ignore[arg-type]
                     output_tokens_details=response.usage.completion_tokens_details,  # type: ignore[arg-type]
                 )
-                if response.usage
+                if response.usage is not None
                 # The request completed, so it counts even when the provider omits usage.
                 else Usage(requests=1)
             )
@@ -342,7 +342,11 @@ class OpenAIChatCompletionsModel(Model):
             )
 
             logprob_models = None
-            if first_choice and first_choice.logprobs and first_choice.logprobs.content:
+            if (
+                first_choice is not None
+                and first_choice.logprobs is not None
+                and first_choice.logprobs.content
+            ):
                 logprob_models = ChatCmplHelpers.convert_logprobs_for_output_text(
                     first_choice.logprobs.content
                 )
@@ -506,7 +510,7 @@ class OpenAIChatCompletionsModel(Model):
         if tracing.include_data():
             span_generation.span_data.output = [final_response.model_dump()]
 
-        if final_response.usage:
+        if final_response.usage is not None:
             span_generation.span_data.usage = {
                 "requests": 1,
                 "input_tokens": final_response.usage.input_tokens,
@@ -514,12 +518,12 @@ class OpenAIChatCompletionsModel(Model):
                 "total_tokens": final_response.usage.total_tokens,
                 "input_tokens_details": (
                     final_response.usage.input_tokens_details.model_dump()
-                    if final_response.usage.input_tokens_details
+                    if final_response.usage.input_tokens_details is not None
                     else {"cached_tokens": 0, "cache_write_tokens": 0}
                 ),
                 "output_tokens_details": (
                     final_response.usage.output_tokens_details.model_dump()
-                    if final_response.usage.output_tokens_details
+                    if final_response.usage.output_tokens_details is not None
                     else {"reasoning_tokens": 0}
                 ),
             }
@@ -666,7 +670,9 @@ class OpenAIChatCompletionsModel(Model):
                 response_format,
             )
 
-        reasoning_effort = model_settings.reasoning.effort if model_settings.reasoning else None
+        reasoning_effort = (
+            model_settings.reasoning.effort if model_settings.reasoning is not None else None
+        )
         store = ChatCmplHelpers.get_store_param(self._get_client(), model_settings)
 
         stream_options = ChatCmplHelpers.get_stream_options_param(

--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -134,15 +134,20 @@ class OpenAIProvider(ModelProvider):
     # AsyncOpenAI() raises an error if you don't have an API key set.
     def _get_client(self) -> AsyncOpenAI:
         if self._client is None:
-            self._client = _openai_shared.get_default_openai_client() or AsyncOpenAI(
-                api_key=self._stored_api_key or _openai_shared.get_default_openai_key(),
-                base_url=self._stored_base_url or os.getenv("OPENAI_BASE_URL"),
-                websocket_base_url=(
-                    self._stored_websocket_base_url or os.getenv("OPENAI_WEBSOCKET_BASE_URL")
-                ),
-                organization=self._stored_organization,
-                project=self._stored_project,
-                http_client=shared_http_client(),
+            default_client = _openai_shared.get_default_openai_client()
+            self._client = (
+                default_client
+                if default_client is not None
+                else AsyncOpenAI(
+                    api_key=self._stored_api_key or _openai_shared.get_default_openai_key(),
+                    base_url=self._stored_base_url or os.getenv("OPENAI_BASE_URL"),
+                    websocket_base_url=(
+                        self._stored_websocket_base_url or os.getenv("OPENAI_WEBSOCKET_BASE_URL")
+                    ),
+                    organization=self._stored_organization,
+                    project=self._stored_project,
+                    http_client=shared_http_client(),
+                )
             )
 
         return self._client

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -527,8 +527,12 @@ class OpenAIResponsesModel(Model):
                         ),
                     )
 
-                usage = _response_usage_to_usage(response.usage) if response.usage else Usage()
-                if response.usage:
+                usage = (
+                    _response_usage_to_usage(response.usage)
+                    if response.usage is not None
+                    else Usage()
+                )
+                if response.usage is not None:
                     span_response.span_data.usage = model_usage_to_span_usage(usage)
 
                 if tracing.include_data():
@@ -661,10 +665,10 @@ class OpenAIResponsesModel(Model):
                 if terminal_failure_error is not None:
                     raise terminal_failure_error
 
-                if final_response and tracing.include_data():
+                if final_response is not None and tracing.include_data():
                     span_response.span_data.response = final_response
                     span_response.span_data.input = input
-                if final_response and final_response.usage:
+                if final_response is not None and final_response.usage is not None:
                     span_response.span_data.usage = model_usage_to_span_usage(
                         _response_usage_to_usage(final_response.usage)
                     )

--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -251,7 +251,11 @@ class _ResponseCreateSequencer:
 
     @property
     def pending_response_create_event_id(self) -> str | None:
-        return self._pending_response_create.event_id if self._pending_response_create else None
+        return (
+            self._pending_response_create.event_id
+            if self._pending_response_create is not None
+            else None
+        )
 
     def _next_pending_request_version(self) -> int | None:
         return min(self._pending_request_versions) if self._pending_request_versions else None
@@ -981,7 +985,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
             self._start_response_create(request_version)
 
     def _get_playback_state(self) -> RealtimePlaybackState:
-        if self._playback_tracker:
+        if self._playback_tracker is not None:
             return self._playback_tracker.get_state()
 
         if last_audio_item_id := self._audio_state_tracker.get_last_audio_item():
@@ -1112,7 +1116,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 self._audio_state_tracker.on_response_interrupted(event.response_id)
             else:
                 self._audio_state_tracker.on_interrupted()
-            if self._playback_tracker:
+            if self._playback_tracker is not None:
                 latest_playback_state = self._playback_tracker.get_state()
                 latest_item_id = latest_playback_state.get("current_item_id")
                 latest_content_index = latest_playback_state.get("current_item_content_index") or 0
@@ -1141,7 +1145,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
         if not event.playback_only:
             session = self._created_session
             automatic_response_cancellation_enabled = (
-                session
+                session is not None
                 and session.audio is not None
                 and session.audio.input is not None
                 and session.audio.input.turn_detection is not None
@@ -1438,14 +1442,14 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                 # Reset trackers so subsequent playback state queries don't
                 # reference audio that has been interrupted client‑side.
                 self._audio_state_tracker.on_interrupted()
-                if self._playback_tracker:
+                if self._playback_tracker is not None:
                     self._playback_tracker.on_interrupted()
 
                 # If server isn't configured to auto‑interrupt/cancel, cancel the
                 # response to prevent further audio.
                 session = self._created_session
                 automatic_response_cancellation_enabled = (
-                    session
+                    session is not None
                     and session.audio is not None
                     and session.audio.input is not None
                     and session.audio.input.turn_detection is not None
@@ -1551,7 +1555,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
     ) -> None:
         # Only store/playback-format information for realtime sessions (not transcription-only)
         normalized_session = self._normalize_session_payload(session)
-        if not normalized_session:
+        if normalized_session is None:
             return
 
         self._created_session = normalized_session
@@ -1560,7 +1564,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
             return
 
         self._audio_state_tracker.set_audio_format(normalized_format)
-        if self._playback_tracker:
+        if self._playback_tracker is not None:
             self._playback_tracker.set_audio_format(normalized_format)
 
     @staticmethod
@@ -1604,7 +1608,7 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
     @staticmethod
     def _extract_audio_format(session: OpenAISessionCreateRequest) -> str | None:
         audio = session.audio
-        if not audio or not audio.output or not audio.output.format:
+        if audio is None or audio.output is None or audio.output.format is None:
             return None
 
         return OpenAIRealtimeWebSocketModel._normalize_audio_format(audio.output.format)
@@ -1866,8 +1870,12 @@ class OpenAIRealtimeSIPModel(OpenAIRealtimeWebSocketModel):
         This helper can be used to accept SIP-originated calls by forwarding the returned payload to
         the Realtime Calls API without duplicating session setup logic.
         """
-        run_config_settings = (run_config or {}).get("model_settings") or {}
-        initial_model_settings = (model_config or {}).get("initial_model_settings") or {}
+        run_config_settings: RealtimeSessionModelSettings = (
+            run_config.get("model_settings") if run_config is not None else None
+        ) or {}
+        initial_model_settings: RealtimeSessionModelSettings = (
+            model_config.get("initial_model_settings") if model_config is not None else None
+        ) or {}
         base_settings: RealtimeSessionModelSettings = {
             **run_config_settings,
             **initial_model_settings,

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -1062,7 +1062,7 @@ class RealtimeSession(RealtimeModelListener):
         """Handle a tool call event."""
         mark_completed = False
         agent = dispatch_snapshot.agent if dispatch_snapshot is not None else agent_snapshot
-        agent = agent or self._current_agent
+        agent = agent if agent is not None else self._current_agent
         recorded_route = self._tool_invocation_routes.get(event.call_id)
         recorded_role = recorded_route[1] if recorded_route is not None else None
         if (
@@ -1636,7 +1636,7 @@ class RealtimeSession(RealtimeModelListener):
         if self._closing or self._closed:
             return False
 
-        source_agent = agent_snapshot or self._current_agent
+        source_agent = agent_snapshot if agent_snapshot is not None else self._current_agent
         combined_guardrails = source_agent.output_guardrails + self._run_config.get(
             "output_guardrails", []
         )
@@ -1832,7 +1832,7 @@ class RealtimeSession(RealtimeModelListener):
         # Check for exceptions and propagate as events
         if not task.cancelled():
             exception = task.exception()
-            if exception:
+            if exception is not None:
                 # Create an exception event instead of raising
                 self._put_event_nowait(
                     RealtimeError(

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -157,7 +157,7 @@ def _populate_state_from_result(
     trace_state = getattr(result, "_trace_state", None)
     if trace_state is None:
         trace_state = TraceState.from_trace(getattr(result, "trace", None))
-    state._trace_state = copy.deepcopy(trace_state) if trace_state else None
+    state._trace_state = copy.deepcopy(trace_state) if trace_state is not None else None
     sandbox_resume_state = getattr(result, "_sandbox_resume_state", None)
     if isinstance(sandbox_resume_state, dict):
         state._sandbox = copy.deepcopy(sandbox_resume_state)
@@ -865,7 +865,7 @@ class RunResultStreaming(RunResultBase):
                     self._stored_exception is not None
                     and _should_drain_stream_events_before_raising(self._stored_exception)
                 )
-                if self._stored_exception and (
+                if self._stored_exception is not None and (
                     not should_drain_queued_events or self._event_queue.empty()
                 ):
                     logger.debug("Breaking due to stored exception")
@@ -935,7 +935,7 @@ class RunResultStreaming(RunResultBase):
                 self._drain_input_guardrail_queue()
 
         stored_exception = self._stored_exception
-        if stored_exception:
+        if stored_exception is not None:
             if _is_error_data_redacted(stored_exception):
                 _detach_data_redacted_error_traceback(stored_exception)
                 # The streaming result retains caller-visible run data. Drop the local reference
@@ -988,7 +988,7 @@ class RunResultStreaming(RunResultBase):
         if self.run_loop_task and self.run_loop_task.done():
             if not self.run_loop_task.cancelled():
                 run_impl_exc = self.run_loop_task.exception()
-                if run_impl_exc and isinstance(run_impl_exc, Exception):
+                if isinstance(run_impl_exc, Exception):
                     if (
                         isinstance(run_impl_exc, AgentsException)
                         and run_impl_exc.run_data is None
@@ -1000,7 +1000,7 @@ class RunResultStreaming(RunResultBase):
         if self._input_guardrails_task and self._input_guardrails_task.done():
             if not self._input_guardrails_task.cancelled():
                 in_guard_exc = self._input_guardrails_task.exception()
-                if in_guard_exc and isinstance(in_guard_exc, Exception):
+                if isinstance(in_guard_exc, Exception):
                     if (
                         isinstance(in_guard_exc, AgentsException)
                         and in_guard_exc.run_data is None
@@ -1012,7 +1012,7 @@ class RunResultStreaming(RunResultBase):
         if self._output_guardrails_task and self._output_guardrails_task.done():
             if not self._output_guardrails_task.cancelled():
                 out_guard_exc = self._output_guardrails_task.exception()
-                if out_guard_exc and isinstance(out_guard_exc, Exception):
+                if isinstance(out_guard_exc, Exception):
                     if (
                         isinstance(out_guard_exc, AgentsException)
                         and out_guard_exc.run_data is None

--- a/src/agents/retry.py
+++ b/src/agents/retry.py
@@ -151,11 +151,11 @@ def _mark_retry_capabilities(
 
 
 def retry_policy_retries_safe_transport_errors(policy: RetryPolicy | None) -> bool:
-    return bool(policy and getattr(policy, _RETRIES_SAFE_TRANSPORT_ERRORS_ATTR, False))
+    return bool(policy is not None and getattr(policy, _RETRIES_SAFE_TRANSPORT_ERRORS_ATTR, False))
 
 
 def retry_policy_retries_all_transient_errors(policy: RetryPolicy | None) -> bool:
-    return bool(policy and getattr(policy, _RETRIES_ALL_TRANSIENT_ERRORS_ATTR, False))
+    return bool(policy is not None and getattr(policy, _RETRIES_ALL_TRANSIENT_ERRORS_ATTR, False))
 
 
 @pydantic_dataclass
@@ -345,7 +345,11 @@ class _RetryPolicies:
                     continue
                 last_negative = decision
 
-            return first_positive or last_negative or RetryDecision(retry=False)
+            if first_positive is not None:
+                return first_positive
+            if last_negative is not None:
+                return last_negative
+            return RetryDecision(retry=False)
 
         return _mark_retry_capabilities(
             policy,

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -169,7 +169,7 @@ def set_default_agent_runner(runner: AgentRunner | None) -> None:
     It should not be used directly.
     """
     global DEFAULT_AGENT_RUNNER
-    DEFAULT_AGENT_RUNNER = runner or AgentRunner()
+    DEFAULT_AGENT_RUNNER = runner if runner is not None else AgentRunner()
 
 
 def get_default_agent_runner() -> AgentRunner:
@@ -721,7 +721,7 @@ class AgentRunner:
             current_task_span: Span[TaskSpanData] | None = (
                 task_span(name=trace_workflow_name) if use_task_and_turn_spans else None
             )
-            if current_task_span:
+            if current_task_span is not None:
                 current_task_span.start(mark_as_current=True)
             task_usage_start = snapshot_usage(context_wrapper.usage)
 
@@ -843,7 +843,7 @@ class AgentRunner:
                     )
                     session_input_items_for_persistence = []
             except BaseException:
-                if current_task_span:
+                if current_task_span is not None:
                     attach_usage_to_span(
                         current_task_span,
                         usage_delta(task_usage_start, context_wrapper.usage),
@@ -1155,7 +1155,7 @@ class AgentRunner:
                     )
 
                     if current_span is None:
-                        if output_schema := get_output_schema(execution_agent):
+                        if (output_schema := get_output_schema(execution_agent)) is not None:
                             output_type_name = output_schema.name()
                         else:
                             output_type_name = "str"
@@ -1294,7 +1294,7 @@ class AgentRunner:
                         if use_task_and_turn_spans
                         else None
                     )
-                    if current_turn_span:
+                    if current_turn_span is not None:
                         current_turn_span.start(mark_as_current=True)
                     try:
                         if current_turn <= 1:
@@ -1417,7 +1417,7 @@ class AgentRunner:
                                 agent_span=current_span,
                             )
                     finally:
-                        if current_turn_span:
+                        if current_turn_span is not None:
                             attach_usage_to_span(
                                 current_turn_span,
                                 usage_delta(turn_usage_start, context_wrapper.usage),
@@ -1481,7 +1481,7 @@ class AgentRunner:
                                     call_id in output_call_ids
                                     and item not in items_to_save_turn
                                     and not (
-                                        run_state
+                                        run_state is not None
                                         and run_state._current_turn_persisted_item_count > 0
                                     )
                                 ):
@@ -1759,9 +1759,9 @@ class AgentRunner:
                     await dispose_resolved_computers(run_context=context_wrapper)
                 except Exception as error:
                     log_tool_action_warning(logger, "Failed to dispose computers after run", error)
-                if current_span:
+                if current_span is not None:
                     current_span.finish(reset_current=True)
-                if current_task_span:
+                if current_task_span is not None:
                     attach_usage_to_span(
                         current_task_span,
                         usage_delta(task_usage_start, context_wrapper.usage),
@@ -1987,7 +1987,7 @@ class AgentRunner:
             reattach_resumed_trace=is_resumed_state,
         )
         if run_state is not None:
-            run_state.set_trace(new_trace or get_current_trace())
+            run_state.set_trace(new_trace if new_trace is not None else get_current_trace())
 
         sandbox_runtime = SandboxRuntime(
             starting_agent=starting_agent,
@@ -2001,7 +2001,9 @@ class AgentRunner:
         )
 
         schema_agent = (
-            run_state._current_agent if run_state and run_state._current_agent else starting_agent
+            run_state._current_agent
+            if run_state is not None and run_state._current_agent is not None
+            else starting_agent
         )
         sandbox_runtime.assert_agent_supported(schema_agent)
         output_schema = get_output_schema(schema_agent)
@@ -2017,22 +2019,28 @@ class AgentRunner:
             # primeFromState will mark items as sent so prepareInput skips them.
             # Copy it: the streamed loop appends to new_items, and the caller still
             # owns the state as a resumable snapshot.
-            new_items=list(run_state._session_items) if run_state else [],
+            new_items=list(run_state._session_items) if run_state is not None else [],
             current_agent=schema_agent,
-            raw_responses=run_state._model_responses if run_state else [],
+            raw_responses=run_state._model_responses if run_state is not None else [],
             final_output=None,
             is_complete=False,
-            current_turn=run_state._current_turn if run_state else 0,
+            current_turn=run_state._current_turn if run_state is not None else 0,
             max_turns=max_turns,
-            input_guardrail_results=(list(run_state._input_guardrail_results) if run_state else []),
+            input_guardrail_results=(
+                list(run_state._input_guardrail_results) if run_state is not None else []
+            ),
             output_guardrail_results=(
-                list(run_state._output_guardrail_results) if run_state else []
+                list(run_state._output_guardrail_results) if run_state is not None else []
             ),
             tool_input_guardrail_results=(
-                list(getattr(run_state, "_tool_input_guardrail_results", [])) if run_state else []
+                list(getattr(run_state, "_tool_input_guardrail_results", []))
+                if run_state is not None
+                else []
             ),
             tool_output_guardrail_results=(
-                list(getattr(run_state, "_tool_output_guardrail_results", [])) if run_state else []
+                list(getattr(run_state, "_tool_output_guardrail_results", []))
+                if run_state is not None
+                else []
             ),
             _current_agent_output_schema=output_schema,
             trace=new_trace,
@@ -2042,13 +2050,13 @@ class AgentRunner:
             # If a cross-SDK state omits the counter, fall back to len(generated_items)
             # to avoid duplication.
             _current_turn_persisted_item_count=(
-                run_state._current_turn_persisted_item_count if run_state else 0
+                run_state._current_turn_persisted_item_count if run_state is not None else 0
             ),
             # When resuming from RunState, preserve the original input from the state
             # This ensures originalInput in serialized state reflects the first turn's input
             _original_input=(
                 copy_input_items(run_state._original_input)
-                if run_state and run_state._original_input is not None
+                if run_state is not None and run_state._original_input is not None
                 else copy_input_items(streamed_input)
             ),
         )

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -805,15 +805,19 @@ class RunContextWrapper(Generic[TContext]):
         pending_namespace = (
             self._resolve_tool_namespace(existing_pending) if existing_pending is not None else None
         )
-        pending_key = self._resolve_approval_key(existing_pending) if existing_pending else None
-        pending_tool_name = self._resolve_tool_name(existing_pending) if existing_pending else None
+        pending_key = (
+            self._resolve_approval_key(existing_pending) if existing_pending is not None else None
+        )
+        pending_tool_name = (
+            self._resolve_tool_name(existing_pending) if existing_pending is not None else None
+        )
         pending_keys = (
             list(self._resolve_approval_keys(existing_pending))
             if existing_pending is not None
             else []
         )
 
-        if existing_pending and pending_key is not None:
+        if existing_pending is not None and pending_key is not None:
             candidates.append(pending_key)
         explicit_keys = (
             list(
@@ -840,7 +844,7 @@ class RunContextWrapper(Generic[TContext]):
             and tool_name not in candidates
         ):
             candidates.append(tool_name)
-        if existing_pending:
+        if existing_pending is not None:
             for pending_candidate in pending_keys:
                 if pending_candidate not in candidates:
                     candidates.append(pending_candidate)
@@ -1063,7 +1067,9 @@ class RunContextWrapper(Generic[TContext]):
                 hosted_status, _ = self._resolve_hosted_mcp_approval_decision(existing_pending)
                 if hosted_status is None:
                     return None
-                effective_invocation = current_invocation or existing_pending
+                effective_invocation = (
+                    current_invocation if current_invocation is not None else existing_pending
+                )
                 binding_status = self._approved_tool_invocation_status(
                     effective_invocation.raw_item,
                     tool_lookup_key=effective_invocation.tool_lookup_key,
@@ -1078,15 +1084,19 @@ class RunContextWrapper(Generic[TContext]):
         pending_namespace = (
             self._resolve_tool_namespace(existing_pending) if existing_pending is not None else None
         )
-        pending_key = self._resolve_approval_key(existing_pending) if existing_pending else None
-        pending_tool_name = self._resolve_tool_name(existing_pending) if existing_pending else None
+        pending_key = (
+            self._resolve_approval_key(existing_pending) if existing_pending is not None else None
+        )
+        pending_tool_name = (
+            self._resolve_tool_name(existing_pending) if existing_pending is not None else None
+        )
         pending_keys = (
             list(self._resolve_approval_keys(existing_pending))
             if existing_pending is not None
             else []
         )
 
-        if existing_pending and pending_key is not None:
+        if existing_pending is not None and pending_key is not None:
             candidates.append(pending_key)
         explicit_keys = (
             list(
@@ -1113,7 +1123,7 @@ class RunContextWrapper(Generic[TContext]):
             and tool_name not in candidates
         ):
             candidates.append(tool_name)
-        if existing_pending:
+        if existing_pending is not None:
             for pending_candidate in pending_keys:
                 if pending_candidate not in candidates:
                     candidates.append(pending_candidate)
@@ -1131,7 +1141,9 @@ class RunContextWrapper(Generic[TContext]):
             if status is not None:
                 matched_record = self._approvals.get(candidate)
                 break
-        selected_invocation = current_invocation or existing_pending
+        selected_invocation = (
+            current_invocation if current_invocation is not None else existing_pending
+        )
         if status is None or matched_record is None or selected_invocation is None:
             return status
         is_sticky = isinstance(matched_record.approved, bool) or isinstance(

--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -260,7 +260,7 @@ def resolve_trace_settings(
     metadata: dict[str, Any] | None = run_config.trace_metadata
     tracing: TracingConfig | None = run_config.tracing
 
-    if trace_state:
+    if trace_state is not None:
         if workflow_name == default_workflow_name and trace_state.workflow_name:
             workflow_name = trace_state.workflow_name
         if trace_id is None:
@@ -367,7 +367,9 @@ def build_resumed_stream_debug_extra(
     """Build the logger extra payload when resuming a streamed run."""
     return {
         "current_turn": run_state._current_turn,
-        "current_agent": run_state._current_agent.name if run_state._current_agent else None,
+        "current_agent": (
+            run_state._current_agent.name if run_state._current_agent is not None else None
+        ),
         "generated_items_count": len(run_state._generated_items),
         "generated_items_types": [item.type for item in run_state._generated_items],
         "generated_items_details": build_generated_items_details(

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -284,7 +284,8 @@ async def _evaluate_retry(
         or (provider_advice is not None and provider_advice.replay_safety == "unsafe")
     ):
         return RetryDecision(
-            retry=False, reason=provider_advice.reason if provider_advice else None
+            retry=False,
+            reason=provider_advice.reason if provider_advice is not None else None,
         )
 
     if retry_policy is None:
@@ -310,7 +311,8 @@ async def _evaluate_retry(
     if replay_unsafe_request and not decision._approves_replay and not provider_marks_replay_safe:
         return RetryDecision(
             retry=False,
-            reason=decision.reason or (provider_advice.reason if provider_advice else None),
+            reason=decision.reason
+            or (provider_advice.reason if provider_advice is not None else None),
         )
 
     return RetryDecision(
@@ -324,7 +326,7 @@ async def _evaluate_retry(
                 else _default_retry_delay(attempt, retry_backoff)
             )
         ),
-        reason=decision.reason or (provider_advice.reason if provider_advice else None),
+        reason=decision.reason or (provider_advice.reason if provider_advice is not None else None),
     )
 
 
@@ -485,9 +487,11 @@ async def get_response_with_retry(
             decision = await _evaluate_retry(
                 error=error,
                 attempt=policy_attempt,
-                max_retries=max(retry_settings.max_retries or 0, 0) if retry_settings else 0,
-                retry_policy=retry_settings.policy if retry_settings else None,
-                retry_backoff=retry_settings.backoff if retry_settings else None,
+                max_retries=(
+                    max(retry_settings.max_retries or 0, 0) if retry_settings is not None else 0
+                ),
+                retry_policy=retry_settings.policy if retry_settings is not None else None,
+                retry_backoff=retry_settings.backoff if retry_settings is not None else None,
                 stream=False,
                 replay_unsafe_request=stateful_request or replay_unsafe_request,
                 emitted_retry_unsafe_event=False,
@@ -501,7 +505,7 @@ async def get_response_with_retry(
                 decision.delay,
                 policy_attempt,
                 retry_settings.max_retries
-                if retry_settings and retry_settings.max_retries is not None
+                if retry_settings is not None and retry_settings.max_retries is not None
                 else 0,
             )
             await rewind()
@@ -608,9 +612,11 @@ async def stream_response_with_retry(
             decision = await _evaluate_retry(
                 error=error,
                 attempt=policy_attempt,
-                max_retries=max(retry_settings.max_retries or 0, 0) if retry_settings else 0,
-                retry_policy=retry_settings.policy if retry_settings else None,
-                retry_backoff=retry_settings.backoff if retry_settings else None,
+                max_retries=(
+                    max(retry_settings.max_retries or 0, 0) if retry_settings is not None else 0
+                ),
+                retry_policy=retry_settings.policy if retry_settings is not None else None,
+                retry_backoff=retry_settings.backoff if retry_settings is not None else None,
                 stream=True,
                 replay_unsafe_request=stateful_request or replay_unsafe_request,
                 emitted_retry_unsafe_event=emitted_retry_unsafe_event,
@@ -624,7 +630,7 @@ async def stream_response_with_retry(
                 decision.delay,
                 policy_attempt,
                 retry_settings.max_retries
-                if retry_settings and retry_settings.max_retries is not None
+                if retry_settings is not None and retry_settings.max_retries is not None
                 else 0,
             )
             await rewind()

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -612,10 +612,11 @@ async def start_streaming(
     sandbox_runtime: SandboxRuntime[TContext] | None = None,
 ):
     """Run the streaming loop for a run result."""
-    if streamed_result.trace:
+    if streamed_result.trace is not None:
         streamed_result.trace.start(mark_as_current=True)
     if run_state is not None:
-        run_state.set_trace(get_current_trace() or streamed_result.trace)
+        current_trace = get_current_trace()
+        run_state.set_trace(current_trace if current_trace is not None else streamed_result.trace)
         streamed_result._trace_state = run_state._trace_state
 
     if is_resumed_state and run_state is not None:
@@ -634,7 +635,7 @@ async def start_streaming(
     current_task_span: Span[TaskSpanData] | None = (
         task_span(name=trace_workflow_name) if use_task_and_turn_spans else None
     )
-    if current_task_span:
+    if current_task_span is not None:
         current_task_span.start(mark_as_current=True)
     task_usage_start = snapshot_usage(context_wrapper.usage)
 
@@ -830,13 +831,13 @@ async def start_streaming(
                 store=store_setting,
             )
     except BaseException:
-        if current_task_span:
+        if current_task_span is not None:
             attach_usage_to_span(
                 current_task_span,
                 usage_delta(task_usage_start, context_wrapper.usage),
             )
             current_task_span.finish(reset_current=True)
-        if streamed_result.trace:
+        if streamed_result.trace is not None:
             streamed_result.trace.finish(reset_current=True)
         if not streamed_result.is_complete:
             streamed_result.is_complete = True
@@ -915,7 +916,7 @@ async def start_streaming(
 
             if is_resumed_state and run_state is not None and run_state._current_step is not None:
                 if isinstance(run_state._current_step, NextStepInterruption):
-                    if not run_state._model_responses or not run_state._last_processed_response:
+                    if not run_state._model_responses or run_state._last_processed_response is None:
                         raise UserError("No model response found in previous state")
 
                     last_model_response = run_state._model_responses[-1]
@@ -1014,7 +1015,7 @@ async def start_streaming(
                         if run_state is not None:
                             run_state._current_agent = current_agent
                         _publish_streamed_result_agent(streamed_result, current_agent)
-                        if current_span:
+                        if current_span is not None:
                             current_span.finish(reset_current=True)
                         current_span = None
                         should_run_agent_start_hooks = True
@@ -1072,7 +1073,7 @@ async def start_streaming(
             )
 
             if current_span is None:
-                if output_schema := get_output_schema(execution_agent):
+                if (output_schema := get_output_schema(execution_agent)) is not None:
                     output_type_name = output_schema.name()
                 else:
                     output_type_name = "str"
@@ -1088,7 +1089,7 @@ async def start_streaming(
             current_turn += 1
             streamed_result.current_turn = current_turn
             streamed_result._current_turn_persisted_item_count = 0
-            if run_state:
+            if run_state is not None:
                 run_state._current_turn_persisted_item_count = 0
 
             if max_turns is not None and current_turn > max_turns:
@@ -1223,7 +1224,7 @@ async def start_streaming(
                     if use_task_and_turn_spans
                     else None
                 )
-                if current_turn_span:
+                if current_turn_span is not None:
                     current_turn_span.start(mark_as_current=True)
                 try:
                     if (
@@ -1254,7 +1255,7 @@ async def start_streaming(
                         agent_span=current_span,
                     )
                 finally:
-                    if current_turn_span:
+                    if current_turn_span is not None:
                         attach_usage_to_span(
                             current_turn_span,
                             usage_delta(turn_usage_start, context_wrapper.usage),
@@ -1312,7 +1313,7 @@ async def start_streaming(
 
                 if isinstance(turn_result.next_step, NextStepRunAgain):
                     streamed_result._current_turn_persisted_item_count = 0
-                    if run_state:
+                    if run_state is not None:
                         run_state._current_turn_persisted_item_count = 0
 
                 if server_conversation_tracker is not None:
@@ -1455,15 +1456,15 @@ async def start_streaming(
             await dispose_resolved_computers(run_context=context_wrapper)
         except Exception as error:
             log_tool_action_warning(logger, "Failed to dispose computers after streamed run", error)
-        if current_span:
+        if current_span is not None:
             current_span.finish(reset_current=True)
-        if current_task_span:
+        if current_task_span is not None:
             attach_usage_to_span(
                 current_task_span,
                 usage_delta(task_usage_start, context_wrapper.usage),
             )
             current_task_span.finish(reset_current=True)
-        if streamed_result.trace:
+        if streamed_result.trace is not None:
             streamed_result.trace.finish(reset_current=True)
 
         if not streamed_result.is_complete:
@@ -1526,7 +1527,7 @@ async def run_single_turn_streamed(
             hooks.on_agent_start(agent_hook_context, public_agent),
             (
                 public_agent.hooks.on_start(agent_hook_context, public_agent)
-                if public_agent.hooks
+                if public_agent.hooks is not None
                 else _coro.noop_coroutine()
             ),
         )
@@ -1611,7 +1612,7 @@ async def run_single_turn_streamed(
                 filtered.instructions,
                 filtered.input,
             )
-            if public_agent.hooks
+            if public_agent.hooks is not None
             else _coro.noop_coroutine()
         ),
     )
@@ -1641,12 +1642,14 @@ async def run_single_turn_streamed(
 
     previous_response_id = (
         server_conversation_tracker.previous_response_id
-        if server_conversation_tracker
+        if server_conversation_tracker is not None
         and server_conversation_tracker.previous_response_id is not None
         else None
     )
     conversation_id = (
-        server_conversation_tracker.conversation_id if server_conversation_tracker else None
+        server_conversation_tracker.conversation_id
+        if server_conversation_tracker is not None
+        else None
     )
     if conversation_id:
         logger.debug("Using conversation_id=%s", conversation_id)
@@ -1751,7 +1754,7 @@ async def run_single_turn_streamed(
         if isinstance(event, ResponseOutputItemDoneEvent):
             streamed_response_output.append(event.item)
 
-    if not final_response:
+    if final_response is None:
         raise ModelBehaviorError("Model did not produce a final response!")
 
     context_wrapper.usage.add(final_response.usage)
@@ -1773,7 +1776,7 @@ async def run_single_turn_streamed(
         await gather_with_cancel(
             (
                 public_agent.hooks.on_llm_end(context_wrapper, public_agent, final_response)
-                if public_agent.hooks
+                if public_agent.hooks is not None
                 else _coro.noop_coroutine()
             ),
             hooks.on_llm_end(context_wrapper, public_agent, final_response),
@@ -1852,7 +1855,7 @@ async def run_single_turn(
             hooks.on_agent_start(agent_hook_context, public_agent),
             (
                 public_agent.hooks.on_start(agent_hook_context, public_agent)
-                if public_agent.hooks
+                if public_agent.hooks is not None
                 else _coro.noop_coroutine()
             ),
         )
@@ -1907,7 +1910,7 @@ async def run_single_turn(
         await gather_with_cancel(
             (
                 public_agent.hooks.on_llm_end(context_wrapper, public_agent, new_response)
-                if public_agent.hooks
+                if public_agent.hooks is not None
                 else _coro.noop_coroutine()
             ),
             hooks.on_llm_end(context_wrapper, public_agent, new_response),
@@ -1979,19 +1982,21 @@ async def get_new_response(
                 filtered.instructions,
                 filtered.input,
             )
-            if public_agent.hooks
+            if public_agent.hooks is not None
             else _coro.noop_coroutine()
         ),
     )
 
     previous_response_id = (
         server_conversation_tracker.previous_response_id
-        if server_conversation_tracker
+        if server_conversation_tracker is not None
         and server_conversation_tracker.previous_response_id is not None
         else None
     )
     conversation_id = (
-        server_conversation_tracker.conversation_id if server_conversation_tracker else None
+        server_conversation_tracker.conversation_id
+        if server_conversation_tracker is not None
+        else None
     )
     if conversation_id:
         logger.debug("Using conversation_id=%s", conversation_id)
@@ -2059,7 +2064,7 @@ async def get_new_response(
         await gather_with_cancel(
             (
                 public_agent.hooks.on_llm_end(context_wrapper, public_agent, new_response)
-                if public_agent.hooks
+                if public_agent.hooks is not None
                 else _coro.noop_coroutine()
             ),
             hooks.on_llm_end(context_wrapper, public_agent, new_response),

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -442,7 +442,7 @@ async def save_result_to_session(
     Returns:
         The number of new run items persisted for this call.
     """
-    already_persisted = run_state._current_turn_persisted_item_count if run_state else 0
+    already_persisted = run_state._current_turn_persisted_item_count if run_state is not None else 0
 
     if session is None:
         return 0
@@ -454,7 +454,7 @@ async def save_result_to_session(
         new_run_items = []
     else:
         new_run_items = new_items[already_persisted:]
-    if run_state and new_items and new_run_items:
+    if run_state is not None and new_items and new_run_items:
         missing_outputs = [
             item
             for item in new_items
@@ -525,13 +525,13 @@ async def save_result_to_session(
         ]
 
     if len(items_to_save) == 0:
-        if run_state:
+        if run_state is not None:
             run_state._current_turn_persisted_item_count = already_persisted + saved_run_items_count
         return saved_run_items_count
 
     await _session_add_items(session, items_to_save, wrapper=wrapper)
 
-    if run_state:
+    if run_state is not None:
         run_state._current_turn_persisted_item_count = already_persisted + saved_run_items_count
 
     if response_id and is_openai_responses_compaction_aware_session(session):

--- a/src/agents/run_internal/tool_actions.py
+++ b/src/agents/run_internal/tool_actions.py
@@ -119,7 +119,7 @@ class ComputerAction:
         trace_tool_name = get_tool_trace_name_for_tool(action.computer_tool) or cls.TRACE_TOOL_NAME
 
         async def _run_action(span: Any | None) -> RunItem:
-            if span and config.trace_include_sensitive_data:
+            if span is not None and config.trace_include_sensitive_data:
                 span.span_data.input = _serialize_trace_payload(
                     cls._get_trace_input_payload(action.tool_call)
                 )
@@ -132,7 +132,7 @@ class ComputerAction:
                 hooks.on_tool_start(context_wrapper, agent, action.computer_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, action.computer_tool)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
@@ -145,7 +145,7 @@ class ComputerAction:
                     trace_include_sensitive_data=config.trace_include_sensitive_data,
                     error_message=error_text,
                 )
-                if span:
+                if span is not None:
                     span.set_error(
                         SpanError(
                             message="Error running tool",
@@ -191,12 +191,12 @@ class ComputerAction:
                 hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, action.computer_tool, output)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
 
-            if span and config.trace_include_sensitive_data:
+            if span is not None and config.trace_include_sensitive_data:
                 span.span_data.output = image_url
 
             return output_item
@@ -407,7 +407,7 @@ class LocalShellAction:
             hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool),
             (
                 agent_hooks.on_tool_start(context_wrapper, agent, call.local_shell_tool)
-                if agent_hooks
+                if agent_hooks is not None
                 else _coro.noop_coroutine()
             ),
         )
@@ -436,7 +436,7 @@ class LocalShellAction:
             hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result),
             (
                 agent_hooks.on_tool_end(context_wrapper, agent, call.local_shell_tool, result)
-                if agent_hooks
+                if agent_hooks is not None
                 else _coro.noop_coroutine()
             ),
         )
@@ -468,7 +468,7 @@ class ShellAction:
         )
 
         async def _run_call(span: Any | None) -> RunItem:
-            if span and config.trace_include_sensitive_data:
+            if span is not None and config.trace_include_sensitive_data:
                 span.span_data.input = _serialize_trace_payload(
                     dataclasses.asdict(shell_call.action)
                 )
@@ -530,7 +530,7 @@ class ShellAction:
                 hooks.on_tool_start(context_wrapper, agent, shell_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, shell_tool)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
@@ -585,7 +585,7 @@ class ShellAction:
                     trace_include_sensitive_data=config.trace_include_sensitive_data,
                     error_message=output_text,
                 )
-                if span:
+                if span is not None:
                     span.set_error(
                         SpanError(
                             message="Error running tool",
@@ -641,12 +641,12 @@ class ShellAction:
                 hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, call.shell_tool, output_text)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
 
-            if span and config.trace_include_sensitive_data:
+            if span is not None and config.trace_include_sensitive_data:
                 span.span_data.output = output_text
 
             return output_item
@@ -696,7 +696,7 @@ class CustomToolAction:
         )
 
         async def _run_call(span: Any | None) -> RunItem:
-            if span and config.trace_include_sensitive_data:
+            if span is not None and config.trace_include_sensitive_data:
                 span.span_data.input = tool_input
 
             approval_status = context_wrapper.get_approval_status(
@@ -757,7 +757,7 @@ class CustomToolAction:
                 hooks.on_tool_start(tool_context, agent, custom_tool),
                 (
                     agent_hooks.on_tool_start(tool_context, agent, custom_tool)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
@@ -772,7 +772,7 @@ class CustomToolAction:
                     trace_include_sensitive_data=config.trace_include_sensitive_data,
                     error_message=output_text,
                 )
-                if span:
+                if span is not None:
                     span.set_error(
                         SpanError(
                             message="Error running tool",
@@ -813,12 +813,12 @@ class CustomToolAction:
                 hooks.on_tool_end(tool_context, agent, custom_tool, output_text),
                 (
                     agent_hooks.on_tool_end(tool_context, agent, custom_tool, output_text)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
 
-            if span and config.trace_include_sensitive_data:
+            if span is not None and config.trace_include_sensitive_data:
                 span.span_data.output = output_text
             return output_item
 
@@ -895,7 +895,7 @@ class ApplyPatchAction:
         )
 
         async def _run_call(span: Any | None) -> RunItem:
-            if span and config.trace_include_sensitive_data:
+            if span is not None and config.trace_include_sensitive_data:
                 span.span_data.input = _serialize_trace_payload(
                     [
                         {
@@ -964,7 +964,7 @@ class ApplyPatchAction:
                 hooks.on_tool_start(context_wrapper, agent, apply_patch_tool),
                 (
                     agent_hooks.on_tool_start(context_wrapper, agent, apply_patch_tool)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
@@ -989,7 +989,7 @@ class ApplyPatchAction:
 
                     awaited = await result if inspect.isawaitable(result) else result
                     normalized = normalize_apply_patch_result(awaited)
-                    if normalized:
+                    if normalized is not None:
                         if normalized.status == "failed":
                             status = "failed"
                         elif normalized.status == "completed" and status != "failed":
@@ -1004,7 +1004,7 @@ class ApplyPatchAction:
                     trace_include_sensitive_data=config.trace_include_sensitive_data,
                     error_message=output_text,
                 )
-                if span:
+                if span is not None:
                     span.set_error(
                         SpanError(
                             message="Error running tool",
@@ -1050,12 +1050,12 @@ class ApplyPatchAction:
                 hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text),
                 (
                     agent_hooks.on_tool_end(context_wrapper, agent, apply_patch_tool, output_text)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
 
-            if span and config.trace_include_sensitive_data:
+            if span is not None and config.trace_include_sensitive_data:
                 span.span_data.output = output_text
 
             return output_item

--- a/src/agents/run_internal/tool_execution.py
+++ b/src/agents/run_internal/tool_execution.py
@@ -879,7 +879,7 @@ def is_apply_patch_name(name: str | None, tool: ApplyPatchTool | None) -> bool:
     candidate = name.strip().lower()
     if candidate.startswith("apply_patch"):
         return True
-    if tool and candidate == tool.name.strip().lower():
+    if tool is not None and candidate == tool.name.strip().lower():
         return True
     return False
 
@@ -1188,7 +1188,7 @@ async def resolve_approval_status(
         tool_lookup_key=tool_lookup_key,
         current_invocation=approval_item,
     )
-    if approval_status is None and on_approval:
+    if approval_status is None and on_approval is not None:
         decision_result = on_approval(context_wrapper, approval_item)
         if inspect.isawaitable(decision_result):
             decision_result = await decision_result
@@ -1588,7 +1588,9 @@ class _FunctionToolBatchExecutor:
         self.propagating_failure: BaseException | None = None
         self.available_function_tools: list[FunctionTool] = []
         self.max_function_tool_concurrency = (
-            config.tool_execution.max_function_tool_concurrency if config.tool_execution else None
+            config.tool_execution.max_function_tool_concurrency
+            if config.tool_execution is not None
+            else None
         )
 
     async def execute(
@@ -2021,7 +2023,7 @@ class _FunctionToolBatchExecutor:
                 self.hooks.on_tool_start(tool_context, self.public_agent, func_tool),
                 (
                     agent_hooks.on_tool_start(tool_context, self.public_agent, func_tool)
-                    if agent_hooks
+                    if agent_hooks is not None
                     else _coro.noop_coroutine()
                 ),
             )
@@ -2157,7 +2159,7 @@ class _FunctionToolBatchExecutor:
             self.hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result),
             (
                 agent_hooks.on_tool_end(tool_context, self.public_agent, func_tool, final_result)
-                if agent_hooks
+                if agent_hooks is not None
                 else _coro.noop_coroutine()
             ),
         )
@@ -2456,7 +2458,10 @@ async def execute_computer_actions(
             tool_name=action.computer_tool.name,
         )
         acknowledged: list[ComputerCallOutputAcknowledgedSafetyCheck] | None = None
-        if action.tool_call.pending_safety_checks and action.computer_tool.on_safety_check:
+        if (
+            action.tool_call.pending_safety_checks
+            and action.computer_tool.on_safety_check is not None
+        ):
             acknowledged = []
             for check in action.tool_call.pending_safety_checks:
                 data = ComputerToolSafetyCheckData(

--- a/src/agents/run_internal/tool_planning.py
+++ b/src/agents/run_internal/tool_planning.py
@@ -581,7 +581,7 @@ def _partition_mcp_approval_requests(
     manual: list[ToolRunMCPApprovalRequest] = []
     for request in requests:
         if (
-            request.mcp_tool.on_approval_request
+            request.mcp_tool.on_approval_request is not None
             and tool_invocation_identity(request.request_item) is not None
         ):
             with_callback.append(request)
@@ -774,7 +774,7 @@ async def _collect_runs_by_approval(
     rejection_items: list[RunItem] = []
     for run in runs:
         call_id = call_id_extractor(run)
-        if output_exists_checker and output_exists_checker(call_id):
+        if output_exists_checker is not None and output_exists_checker(call_id):
             continue
         tool_name = tool_name_resolver(run)
         existing_pending = approval_items_by_call_id.get(call_id)
@@ -803,7 +803,7 @@ async def _collect_runs_by_approval(
         )
 
         needs_approval = True
-        if approval_status is None and needs_approval_checker:
+        if approval_status is None and needs_approval_checker is not None:
             try:
                 needs_approval = await needs_approval_checker(run)
             except UserError:
@@ -834,7 +834,7 @@ async def _collect_runs_by_approval(
             approved_runs.append(run)
             continue
 
-        pending_item = existing_pending or current_item
+        pending_item = existing_pending if existing_pending is not None else current_item
         pending_interruption_adder(pending_item)
 
     return approved_runs, rejection_items
@@ -901,11 +901,12 @@ async def _select_function_tool_runs_for_resume(
             continue
 
         current_item = pending_item_builder(run)
+        existing_pending = approval_items_by_call_id.get(call_id)
         approval_status = context_wrapper.get_approval_status(
             run.function_tool.name,
             call_id,
             tool_namespace=get_tool_call_namespace(run.tool_call),
-            existing_pending=approval_items_by_call_id.get(call_id),
+            existing_pending=existing_pending,
             tool_lookup_key=current_item.tool_lookup_key,
             current_invocation=current_item,
         )
@@ -917,7 +918,7 @@ async def _select_function_tool_runs_for_resume(
                 run.function_tool.name,
                 call_id,
                 tool_namespace=get_tool_call_namespace(run.tool_call),
-                existing_pending=approval_items_by_call_id.get(call_id),
+                existing_pending=existing_pending,
                 tool_lookup_key=current_item.tool_lookup_key,
                 current_invocation=current_item,
             )
@@ -934,9 +935,8 @@ async def _select_function_tool_runs_for_resume(
             selected.append(run)
             continue
 
-        pending_interruption_adder(
-            approval_items_by_call_id.get(run.tool_call.call_id) or current_item
-        )
+        pending_item = existing_pending if existing_pending is not None else current_item
+        pending_interruption_adder(pending_item)
 
     return selected
 

--- a/src/agents/run_internal/tool_use_tracker.py
+++ b/src/agents/run_internal/tool_use_tracker.py
@@ -158,7 +158,9 @@ def hydrate_tool_use_tracker(
     agent_map = _build_agent_map(starting_agent)
     agent_identity_map = _build_agent_identity_map(starting_agent)
     for agent_name, tool_names in snapshot.items():
-        agent = agent_identity_map.get(agent_name) or agent_map.get(agent_name)
+        agent = agent_identity_map.get(agent_name)
+        if agent is None:
+            agent = agent_map.get(agent_name)
         if agent is None:
             continue
         tool_use_tracker.add_tool_use(agent, list(tool_names))

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -232,7 +232,7 @@ async def _maybe_finalize_from_tool_results(
     if not check_tool_use.is_final_output:
         return None
 
-    if not public_agent.output_type or public_agent.output_type is str:
+    if public_agent.output_type is None or public_agent.output_type is str:
         check_tool_use.final_output = str(check_tool_use.final_output)
 
     if check_tool_use.final_output is None:
@@ -348,7 +348,7 @@ async def run_final_output_hooks(
     await gather_with_cancel(
         hooks.on_agent_end(agent_hook_context, agent, final_output),
         agent.hooks.on_end(agent_hook_context, agent, final_output)
-        if agent.hooks
+        if agent.hooks is not None
         else _coro.noop_coroutine(),
     )
 
@@ -371,7 +371,11 @@ async def execute_final_output_step(
     | None = None,
 ) -> SingleStepResult:
     """Finalize a turn once final output is known and run end hooks."""
-    final_output_hooks = run_final_output_hooks_fn or run_final_output_hooks
+    final_output_hooks = (
+        run_final_output_hooks_fn
+        if run_final_output_hooks_fn is not None
+        else run_final_output_hooks
+    )
     await final_output_hooks(public_agent, hooks, context_wrapper, final_output)
 
     return SingleStepResult(
@@ -618,7 +622,7 @@ async def execute_handoffs(
                     agent=new_agent,
                     source=public_agent,
                 )
-                if public_agent.hooks
+                if public_agent.hooks is not None
                 else _coro.noop_coroutine()
             ),
         )
@@ -981,7 +985,7 @@ async def execute_tools_and_side_effects(
                     tool_input_guardrail_results=tool_input_guardrail_results,
                     tool_output_guardrail_results=tool_output_guardrail_results,
                 )
-            if output_schema and not output_schema.is_plain_text():
+            if output_schema is not None and not output_schema.is_plain_text():
                 if potential_final_output_text:
                     validation_error: ModelBehaviorError | None = None
                     try:
@@ -1058,7 +1062,7 @@ async def execute_tools_and_side_effects(
                     tool_input_guardrail_results=tool_input_guardrail_results,
                     tool_output_guardrail_results=tool_output_guardrail_results,
                 )
-            if not output_schema or output_schema.is_plain_text():
+            if output_schema is None or output_schema.is_plain_text():
                 return await execute_final_output_call(
                     public_agent=public_agent,
                     original_input=original_input,
@@ -2330,8 +2334,7 @@ async def resolve_interrupted_turn(
     ):
         append_if_new(item)
     for pending_item in pending_interruptions:
-        if pending_item:
-            append_if_new(pending_item)
+        append_if_new(pending_item)
     for shell_rejection in rejected_shell_results:
         append_if_new(shell_rejection)
     for custom_tool_rejection in rejected_custom_tool_results:
@@ -2368,9 +2371,7 @@ async def resolve_interrupted_turn(
                 model_response=new_response,
                 pre_step_items=original_pre_step_items,
                 new_step_items=new_items,
-                next_step=NextStepInterruption(
-                    interruptions=[item for item in pending_interruptions if item]
-                ),
+                next_step=NextStepInterruption(interruptions=list(pending_interruptions)),
                 tool_input_guardrail_results=tool_input_guardrail_results,
                 tool_output_guardrail_results=tool_output_guardrail_results,
                 processed_response=processed_response,
@@ -2691,7 +2692,7 @@ def process_model_response(
                     "created_by": get_mapping_or_attr(output, "created_by"),
                 }
             shell_call_raw.pop("created_by", None)
-            if not shell_tool:
+            if shell_tool is None:
                 tools_used.append("shell")
                 _error_tracing.attach_error_to_current_span(
                     SpanError(
@@ -2743,7 +2744,7 @@ def process_model_response(
                 tool_name=shell_tool.name if shell_tool is not None else "shell",
                 agent_name=agent.name,
             )
-            tools_used.append(shell_tool.name if shell_tool else "shell")
+            tools_used.append(shell_tool.name if shell_tool is not None else "shell")
             if isinstance(output, dict):
                 shell_output_raw = dict(output)
             else:
@@ -2777,7 +2778,7 @@ def process_model_response(
                     "created_by": get_mapping_or_attr(output, "created_by"),
                 }
             apply_patch_call_raw.pop("created_by", None)
-            if apply_patch_tool:
+            if apply_patch_tool is not None:
                 ensure_tool_caller_allowed(
                     tool_call=apply_patch_call_raw,
                     allowed_callers=apply_patch_tool.allowed_callers,
@@ -2880,7 +2881,7 @@ def process_model_response(
         elif isinstance(output, ResponseReasoningItem):
             items.append(ReasoningItem(raw_item=output, agent=agent))
         elif isinstance(output, ResponseComputerToolCall):
-            if not computer_tool:
+            if computer_tool is None:
                 tools_used.append("computer")
                 _error_tracing.attach_error_to_current_span(
                     SpanError(
@@ -2929,7 +2930,7 @@ def process_model_response(
                     mcp_tool=server,
                 )
             )
-            if not server.on_approval_request:
+            if server.on_approval_request is None:
                 logger.debug(
                     "Hosted MCP server %s has no on_approval_request hook; approvals will be "
                     "surfaced as interruptions for the caller to handle.",
@@ -3001,7 +3002,7 @@ def process_model_response(
             items.append(ToolCallItem(raw_item=output, agent=agent))
             tools_used.append("code_interpreter")
         elif isinstance(output, LocalShellCall):
-            if local_shell_tool:
+            if local_shell_tool is not None:
                 ensure_tool_caller_allowed(
                     tool_call=output,
                     allowed_callers=None,
@@ -3019,7 +3020,7 @@ def process_model_response(
                 local_shell_calls.append(
                     ToolRunLocalShellCall(tool_call=output, local_shell_tool=local_shell_tool)
                 )
-            elif shell_tool:
+            elif shell_tool is not None:
                 ensure_tool_caller_allowed(
                     tool_call=output,
                     allowed_callers=shell_tool.allowed_callers,
@@ -3061,7 +3062,7 @@ def process_model_response(
             elif is_apply_patch_name(output.name, apply_patch_tool):
                 pseudo_call = normalize_apply_patch_fallback_call(output)
                 assert pseudo_call is not None
-                if apply_patch_tool:
+                if apply_patch_tool is not None:
                     ensure_tool_caller_allowed(
                         tool_call=pseudo_call,
                         allowed_callers=apply_patch_tool.allowed_callers,
@@ -3110,7 +3111,7 @@ def process_model_response(
         ):
             pseudo_call = normalize_apply_patch_fallback_call(output)
             assert pseudo_call is not None
-            if apply_patch_tool:
+            if apply_patch_tool is not None:
                 ensure_tool_caller_allowed(
                     tool_call=pseudo_call,
                     allowed_callers=apply_patch_tool.allowed_callers,
@@ -3295,7 +3296,7 @@ def _preflight_response_invocations_after_processing_error(
         elif output_type == "shell_call":
             tool_name = shell_tool.name if shell_tool is not None else None
         elif isinstance(output, LocalShellCall):
-            selected_shell_tool = local_shell_tool or shell_tool
+            selected_shell_tool = local_shell_tool if local_shell_tool is not None else shell_tool
             tool_name = selected_shell_tool.name if selected_shell_tool is not None else None
         elif output_type == "apply_patch_call":
             tool_name = apply_patch_tool.name if apply_patch_tool is not None else None

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -873,7 +873,7 @@ class RunState(Generic[TContext, TAgent]):
 
     def _current_generated_items_merge_marker(self) -> str | None:
         """Return a marker for the processed response already reflected in _generated_items."""
-        if not (self._last_processed_response and self._last_processed_response.new_items):
+        if self._last_processed_response is None or not self._last_processed_response.new_items:
             return None
 
         latest_response_id = (
@@ -909,7 +909,7 @@ class RunState(Generic[TContext, TAgent]):
     def _merge_generated_items_with_processed(self) -> list[RunItem]:
         """Merge persisted and newly processed items without duplication."""
         generated_items = list(self._generated_items)
-        if not (self._last_processed_response and self._last_processed_response.new_items):
+        if self._last_processed_response is None or not self._last_processed_response.new_items:
             return generated_items
 
         current_merge_marker = self._current_generated_items_merge_marker()
@@ -1094,7 +1094,7 @@ class RunState(Generic[TContext, TAgent]):
                 strict_context=strict_context,
                 include_tracing_api_key=include_tracing_api_key,
             )
-            if self._last_processed_response
+            if self._last_processed_response is not None
             else None
         )
         result["current_turn_persisted_item_count"] = self._current_turn_persisted_item_count
@@ -1326,7 +1326,7 @@ class RunState(Generic[TContext, TAgent]):
         self._trace_state = TraceState.from_trace(trace)
 
     def _serialize_trace_data(self, *, include_tracing_api_key: bool) -> dict[str, Any] | None:
-        if not self._trace_state:
+        if self._trace_state is None:
             return None
         return self._trace_state.to_json(include_tracing_api_key=include_tracing_api_key)
 
@@ -2146,7 +2146,7 @@ async def _deserialize_processed_response(
         deserialized: list[TAction] = []
         for entry in entries or []:
             tool_container = entry.get(tool_key, {}) if isinstance(entry, Mapping) else {}
-            if name_resolver:
+            if name_resolver is not None:
                 tool_name = name_resolver(entry)
             else:
                 if isinstance(tool_container, Mapping):
@@ -2165,7 +2165,7 @@ async def _deserialize_processed_response(
                     bare_lookup_key = get_function_tool_lookup_key(bare_name)
                     if bare_lookup_key is not None:
                         tool = tool_map.get(bare_lookup_key)
-            if not tool:
+            if tool is None:
                 continue
 
             tool_call_data_raw = entry.get("tool_call", {}) if isinstance(entry, Mapping) else {}
@@ -2400,7 +2400,7 @@ async def _deserialize_processed_response(
 
         mcp_tool = mcp_tools_map.get(request_item.server_label)
 
-        if mcp_tool:
+        if mcp_tool is not None:
             _ensure_restored_tool_call_allowed(
                 tool_call=request_item,
                 allowed_callers=mcp_tool.tool_config.get("allowed_callers"),
@@ -2557,7 +2557,8 @@ def _resolve_agent_from_data(
             resolved = agent_identity_map.get(agent_name)
             if resolved is not None:
                 return resolved
-        return agent_map.get(agent_name) or fallback_agent
+        resolved = agent_map.get(agent_name)
+        return resolved if resolved is not None else fallback_agent
     return fallback_agent
 
 
@@ -2989,7 +2990,7 @@ async def _build_run_state_from_json(
         agent_map,
         agent_identity_map=agent_identity_map,
     )
-    if not current_agent:
+    if current_agent is None:
         raise UserError(f"Agent {current_agent_name} not found in agent map")
 
     context_data = state_json["context"]
@@ -3650,7 +3651,7 @@ def _iter_agent_graph(initial_agent: Agent[Any]) -> Iterator[Agent[Any]]:
                     continue
                 tool_agent = getattr(tool, "_agent_instance", None)
                 tool_agent_name = getattr(tool_agent, "name", None)
-                if tool_agent and tool_agent_name:
+                if tool_agent is not None and tool_agent_name:
                     queue.append(tool_agent)
 
 
@@ -4156,7 +4157,7 @@ def _deserialize_items(
                 agent_map,
                 agent_identity_map,
             )
-            if agent_candidate:
+            if agent_candidate is not None:
                 return agent_candidate, agent_candidate.name
 
         return None, candidate_name
@@ -4168,7 +4169,7 @@ def _deserialize_items(
             continue
 
         agent, agent_name = _resolve_agent_info(item_data, item_type)
-        if not agent:
+        if agent is None:
             if agent_name:
                 log_model_and_tool_data_warning(
                     logger,
@@ -4273,7 +4274,7 @@ def _deserialize_items(
                 )
 
                 # If we cannot resolve both agents, skip this item gracefully
-                if not source_agent or not target_agent:
+                if source_agent is None or target_agent is None:
                     source_name = item_data.get("source_agent")
                     target_name = item_data.get("target_agent")
                     log_model_and_tool_data_warning(

--- a/src/agents/sandbox/capabilities/skills.py
+++ b/src/agents/sandbox/capabilities/skills.py
@@ -592,7 +592,7 @@ class Skills(Capability):
         skills_root = posix_path_as_path(coerce_posix_path(self.skills_path))
         existing_paths = _manifest_entry_paths(manifest)
 
-        if self.lazy_from:
+        if self.lazy_from is not None:
             # Lazy sources do not claim `skills_root` in the manifest up front, so reserve the
             # whole namespace here and fail fast if any existing manifest entry is equal to,
             # above, or below that path.
@@ -612,7 +612,7 @@ class Skills(Capability):
                 )
             return manifest
 
-        if self.from_:
+        if self.from_ is not None:
             if skills_root in existing_paths:
                 existing_entry = _get_manifest_entry_by_path(manifest, skills_root)
                 if existing_entry is None:

--- a/src/agents/sandbox/runtime_session_manager.py
+++ b/src/agents/sandbox/runtime_session_manager.py
@@ -369,7 +369,7 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
         if effective_manifest is not None or run_as_user is not None:
             effective_manifest = self._process_manifest(
                 capabilities,
-                effective_manifest or Manifest(),
+                effective_manifest if effective_manifest is not None else Manifest(),
                 run_as_user=run_as_user,
             )
 
@@ -530,7 +530,11 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
         agent: SandboxAgent[TContext],
     ) -> Manifest | None:
         sandbox_config = self._require_sandbox_config()
-        return sandbox_config.manifest or agent.default_manifest
+        return (
+            sandbox_config.manifest
+            if sandbox_config.manifest is not None
+            else agent.default_manifest
+        )
 
     @staticmethod
     def _process_manifest(

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -1457,7 +1457,9 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
     ) -> None:
         super().__init__()
         self.docker_client = docker_client
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     async def create(
@@ -1469,7 +1471,7 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
     ) -> SandboxSession:
         image = options.image
         session_id = uuid.uuid4()
-        manifest = manifest or Manifest()
+        manifest = manifest if manifest is not None else Manifest()
         _validate_docker_path_grants(manifest)
 
         container = await self._create_container(
@@ -1583,7 +1585,7 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
 
         assert self.image_exists(image)
         environment: dict[str, str] | None = None
-        if manifest:
+        if manifest is not None:
             environment = await manifest.environment.resolve()
         create_kwargs: dict[str, object] = {
             "entrypoint": ["tail"],

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -1090,7 +1090,9 @@ class UnixLocalSandboxClient(BaseSandboxClient[UnixLocalSandboxClientOptions | N
         instrumentation: Instrumentation | None = None,
         dependencies: Dependencies | None = None,
     ) -> None:
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._dependencies = dependencies
 
     async def create(
@@ -1100,7 +1102,7 @@ class UnixLocalSandboxClient(BaseSandboxClient[UnixLocalSandboxClientOptions | N
         manifest: Manifest | None = None,
         options: UnixLocalSandboxClientOptions | None = None,
     ) -> SandboxSession:
-        resolved_options = options or UnixLocalSandboxClientOptions()
+        resolved_options = options if options is not None else UnixLocalSandboxClientOptions()
         if manifest is not None:
             _assert_unix_local_host_path_grants_unsupported(manifest)
         # For local execution, runner-created sessions should always get an isolated temp root

--- a/src/agents/sandbox/session/manager.py
+++ b/src/agents/sandbox/session/manager.py
@@ -24,7 +24,7 @@ class Instrumentation:
         payload_policy_by_op: dict[OpName, EventPayloadPolicy] | None = None,
     ) -> None:
         self._sinks: list[EventSink] = list(sinks or [])
-        self.payload_policy = payload_policy or EventPayloadPolicy()
+        self.payload_policy = payload_policy if payload_policy is not None else EventPayloadPolicy()
         self.payload_policy_by_op = payload_policy_by_op or {}
         self._tasks: set[asyncio.Task[None]] = set()
 

--- a/src/agents/sandbox/session/sandbox_session.py
+++ b/src/agents/sandbox/session/sandbox_session.py
@@ -229,7 +229,9 @@ class SandboxSession(BaseSandboxSession):
     ) -> None:
         self._inner = inner
         self._inner.set_dependencies(dependencies)
-        self._instrumentation = instrumentation or Instrumentation()
+        self._instrumentation = (
+            instrumentation if instrumentation is not None else Instrumentation()
+        )
         self._seq = 0
 
         self._bind_session_to_sinks()

--- a/src/agents/sandbox/snapshot.py
+++ b/src/agents/sandbox/snapshot.py
@@ -257,4 +257,5 @@ SnapshotSpecUnion = Annotated[
 def resolve_snapshot(spec: SnapshotBase | SnapshotSpec | None, snapshot_id: str) -> SnapshotBase:
     if isinstance(spec, SnapshotBase):
         return spec
-    return (spec or NoopSnapshotSpec()).build(snapshot_id)
+    resolved_spec = spec if spec is not None else NoopSnapshotSpec()
+    return resolved_spec.build(snapshot_id)

--- a/src/agents/sandbox/snapshot_defaults.py
+++ b/src/agents/sandbox/snapshot_defaults.py
@@ -29,7 +29,7 @@ def default_local_snapshot_base_dir(
     platform: str | None = None,
     os_name: str | None = None,
 ) -> Path:
-    resolved_home = home or Path.home()
+    resolved_home = home if home is not None else Path.home()
     resolved_env = os.environ if env is None else env
     resolved_platform = platform or sys.platform
     resolved_os_name = os_name or os.name

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -758,7 +758,11 @@ def get_function_tool_origin(function_tool: FunctionTool) -> ToolOrigin | None:
     """Return scalar origin metadata for a function tool."""
     if not function_tool._emit_tool_origin:
         return None
-    return function_tool._tool_origin or ToolOrigin(type=ToolOriginType.FUNCTION)
+    return (
+        function_tool._tool_origin
+        if function_tool._tool_origin is not None
+        else ToolOrigin(type=ToolOriginType.FUNCTION)
+    )
 
 
 @dataclass
@@ -903,7 +907,7 @@ async def resolve_computer(
         else None
     )
     initializer: ComputerCreate[Any] | None = None
-    disposer: ComputerDispose[Any] | None = lifecycle.dispose if lifecycle else None
+    disposer: ComputerDispose[Any] | None = lifecycle.dispose if lifecycle is not None else None
 
     if lifecycle is not None:
         initializer = lifecycle.create
@@ -914,7 +918,7 @@ async def resolve_computer(
         initializer = lifecycle_provider.create
         disposer = lifecycle_provider.dispose
 
-    if initializer:
+    if initializer is not None:
         computer_candidate = initializer(run_context=run_context)
         computer = (
             await computer_candidate

--- a/src/agents/tracing/context.py
+++ b/src/agents/tracing/context.py
@@ -57,7 +57,7 @@ def create_trace_for_run(
 ) -> Trace | None:
     """Return a trace object for this run when one is not already active."""
     current_trace = get_current_trace()
-    if current_trace:
+    if current_trace is not None:
         return None
 
     if (
@@ -123,11 +123,10 @@ class TraceCtxManager:
             trace_state=self.trace_state,
             reattach_resumed_trace=self.reattach_resumed_trace,
         )
-        if self.trace:
-            assert self.trace is not None
+        if self.trace is not None:
             self.trace.start(mark_as_current=True)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.trace:
+        if self.trace is not None:
             self.trace.finish(reset_current=True)

--- a/src/agents/tracing/create.py
+++ b/src/agents/tracing/create.py
@@ -61,7 +61,7 @@ def trace(
         The newly created trace object.
     """
     current_trace = get_trace_provider().get_current_trace()
-    if current_trace:
+    if current_trace is not None:
         logger.warning(
             "Trace already exists. Creating a new trace, but this is probably a mistake."
         )

--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -430,7 +430,7 @@ class DefaultTraceProvider(TraceProvider):
             logger.debug("Span id is no-op, returning NoOpSpan")
             return NoOpSpan(span_data)
 
-        if not parent:
+        if parent is None:
             current_span = Scope.get_current_span()
             current_trace = Scope.get_current_trace()
             if current_trace is None:
@@ -450,7 +450,7 @@ class DefaultTraceProvider(TraceProvider):
                     )
                 return NoOpSpan(span_data)
 
-            parent_id = current_span.span_id if current_span else None
+            parent_id = current_span.span_id if current_span is not None else None
             trace_id = current_trace.trace_id
             tracing_api_key = current_trace.tracing_api_key
             # Trace is an interface; custom implementations may omit metadata.

--- a/src/agents/tracing/scope.py
+++ b/src/agents/tracing/scope.py
@@ -40,7 +40,7 @@ class Scope:
 
     @classmethod
     def set_current_trace(cls, trace: "Trace | None") -> "contextvars.Token[Trace | None]":
-        logger.debug("Setting current trace: %s", trace.trace_id if trace else None)
+        logger.debug("Setting current trace: %s", trace.trace_id if trace is not None else None)
         return _current_trace.set(trace)
 
     @classmethod

--- a/src/agents/tracing/span_data.py
+++ b/src/agents/tracing/span_data.py
@@ -236,7 +236,7 @@ class ResponseSpanData(SpanData):
     def export(self) -> dict[str, Any]:
         return {
             "type": self.type,
-            "response_id": self.response.id if self.response else None,
+            "response_id": self.response.id if self.response is not None else None,
             "usage": self.usage,
         }
 

--- a/src/agents/util/_error_tracing.py
+++ b/src/agents/util/_error_tracing.py
@@ -25,7 +25,7 @@ def attach_error_to_span(span: Span[Any], error: SpanError) -> None:
 
 def attach_error_to_current_span(error: SpanError) -> None:
     span = get_current_span()
-    if span:
+    if span is not None:
         attach_error_to_span(span, error)
     elif _debug.DONT_LOG_MODEL_DATA or _debug.DONT_LOG_TOOL_DATA:
         logger.warning("No active span; trace error was not attached")

--- a/src/agents/voice/models/openai_model_provider.py
+++ b/src/agents/voice/models/openai_model_provider.py
@@ -78,12 +78,17 @@ class OpenAIVoiceModelProvider(VoiceModelProvider):
     # AsyncOpenAI() raises an error if you don't have an API key set.
     def _get_client(self) -> AsyncOpenAI:
         if self._client is None:
-            self._client = _openai_shared.get_default_openai_client() or AsyncOpenAI(
-                api_key=self._stored_api_key or _openai_shared.get_default_openai_key(),
-                base_url=self._stored_base_url,
-                organization=self._stored_organization,
-                project=self._stored_project,
-                http_client=shared_http_client(),
+            default_client = _openai_shared.get_default_openai_client()
+            self._client = (
+                default_client
+                if default_client is not None
+                else AsyncOpenAI(
+                    api_key=self._stored_api_key or _openai_shared.get_default_openai_key(),
+                    base_url=self._stored_base_url,
+                    organization=self._stored_organization,
+                    project=self._stored_project,
+                    http_client=shared_http_client(),
+                )
             )
 
         return self._client

--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -133,7 +133,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
         self._tracing_span.start()
 
     def _end_turn(self, _transcript: str) -> None:
-        if self._tracing_span:
+        if self._tracing_span is not None:
             # Only encode audio if tracing is enabled AND buffer is not empty
             if self._trace_include_sensitive_audio_data and self._turn_audio_buffer:
                 self._tracing_span.span_data.input = _audio_to_base64(self._turn_audio_buffer)
@@ -332,7 +332,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             and not self._connection_task.cancelled()
         ):
             exc = self._connection_task.exception()
-            if exc and isinstance(exc, Exception):
+            if isinstance(exc, Exception):
                 self._stored_exception = exc
 
         if (
@@ -341,7 +341,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             and not self._process_events_task.cancelled()
         ):
             exc = self._process_events_task.exception()
-            if exc and isinstance(exc, Exception):
+            if isinstance(exc, Exception):
                 self._stored_exception = exc
 
         if (
@@ -350,7 +350,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             and not self._stream_audio_task.cancelled()
         ):
             exc = self._stream_audio_task.exception()
-            if exc and isinstance(exc, Exception):
+            if isinstance(exc, Exception):
                 self._stored_exception = exc
 
         if (
@@ -359,7 +359,7 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             and not self._listener_task.cancelled()
         ):
             exc = self._listener_task.exception()
-            if exc and isinstance(exc, Exception):
+            if isinstance(exc, Exception):
                 self._stored_exception = exc
 
     async def _cleanup_tasks(self) -> None:

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -156,7 +156,7 @@ class StreamedAudioResult:
                                 audio_np = self._transform_audio_buffer(
                                     [combined], self.tts_settings.dtype
                                 )
-                                if self.tts_settings.transform_data:
+                                if self.tts_settings.transform_data is not None:
                                     audio_np = self.tts_settings.transform_data(audio_np)
                                 await local_queue.put(
                                     VoiceStreamEventAudio(data=audio_np)
@@ -172,7 +172,7 @@ class StreamedAudioResult:
                     if len(combined) % 2 != 0:
                         combined += b"\x00"
                     audio_np = self._transform_audio_buffer([combined], self.tts_settings.dtype)
-                    if self.tts_settings.transform_data:
+                    if self.tts_settings.transform_data is not None:
                         audio_np = self.tts_settings.transform_data(audio_np)
                     await local_queue.put(VoiceStreamEventAudio(data=audio_np))  # Use local queue
 
@@ -245,7 +245,7 @@ class StreamedAudioResult:
         await asyncio.gather(*self._tasks)
 
     def _finish_turn(self):
-        if self._tracing_span:
+        if self._tracing_span is not None:
             if self._voice_pipeline_config.trace_include_sensitive_data:
                 self._tracing_span.span_data.input = self._turn_text_buffer
             else:
@@ -321,8 +321,9 @@ class StreamedAudioResult:
     def _check_errors(self):
         for task in self._tasks:
             if task.done() and not task.cancelled():
-                if task.exception():
-                    self._stored_exception = task.exception()
+                error = task.exception()
+                if error is not None:
+                    self._stored_exception = error
                     break
 
     async def stream(self) -> AsyncIterator[VoiceStreamEvent]:
@@ -353,7 +354,7 @@ class StreamedAudioResult:
                     break
 
             self._check_errors()
-            if self._stored_exception:
+            if self._stored_exception is not None:
                 raise self._stored_exception
         except BaseException as exc:
             primary_exception = exc
@@ -423,5 +424,5 @@ class StreamedAudioResult:
                 raise exception_to_raise
 
         self._check_errors()
-        if self._stored_exception:
+        if self._stored_exception is not None:
             raise self._stored_exception

--- a/src/agents/voice/workflow.py
+++ b/src/agents/voice/workflow.py
@@ -78,7 +78,7 @@ class SingleAgentVoiceWorkflow(VoiceWorkflowBase):
         self._callbacks = callbacks
 
     async def run(self, transcription: str) -> AsyncIterator[str]:
-        if self._callbacks:
+        if self._callbacks is not None:
             self._callbacks.on_run(self, transcription)
 
         # Add the transcription to the input history

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -82,6 +82,21 @@ class TestStartOpenAIConversationsSession:
                 mock_default_client.conversations.create.assert_called_once_with(items=[])
 
     @pytest.mark.asyncio
+    async def test_start_preserves_falsy_default_client(self):
+        mock_default_client = AsyncMock()
+        mock_default_client.__bool__.return_value = False
+        mock_default_client.conversations.create.return_value = MagicMock(id="default_client_id")
+
+        with patch(
+            "agents.memory.openai_conversations_session.get_default_openai_client",
+            return_value=mock_default_client,
+        ):
+            conversation_id = await start_openai_conversations_session(None)
+
+        assert conversation_id == "default_client_id"
+        mock_default_client.conversations.create.assert_awaited_once_with(items=[])
+
+    @pytest.mark.asyncio
     async def test_start_with_none_client_fallback(self):
         """Test starting a conversation session when get_default_openai_client returns None."""
         with patch(

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -4,7 +4,7 @@ import logging
 import warnings as warnings_module
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -87,6 +87,20 @@ class TestSelectCompactionCandidateItems:
 
 
 class TestOpenAIResponsesCompactionSession:
+    def test_client_preserves_falsy_default_client(self) -> None:
+        mock_client = MagicMock()
+        mock_client.__bool__.return_value = False
+        session = OpenAIResponsesCompactionSession(
+            session_id="test",
+            underlying_session=self.create_mock_session(),
+        )
+
+        with patch(
+            "agents.memory.openai_responses_compaction_session.get_default_openai_client",
+            return_value=mock_client,
+        ):
+            assert session.client is mock_client
+
     def create_mock_session(self) -> MagicMock:
         mock = MagicMock(spec=Session)
         mock.session_id = "test-session"

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -283,6 +283,33 @@ async def test_user_agent_header_any_llm_chat(override_ua: str | None, monkeypat
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_any_llm_chat_preserves_falsy_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FalsyReasoning(Reasoning):
+        def __bool__(self) -> bool:
+            return False
+
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=_chat_completion("Hello"))
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini")
+
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(reasoning=FalsyReasoning(effort="low")),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert provider.chat_calls[0]["reasoning_effort"] == "low"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider_name", ["gemini", "vertexai"])
 @pytest.mark.parametrize("options_type", ["unset", "dictionary", "model"])
 async def test_any_llm_google_chat_headers_use_http_options(

--- a/tests/models/test_litellm_extra_body.py
+++ b/tests/models/test_litellm_extra_body.py
@@ -3,11 +3,23 @@ import logging
 import litellm
 import pytest
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
+from openai.types.shared import Reasoning
 
 from agents import function_tool
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
+
+
+def test_falsy_reasoning_effort_is_preserved() -> None:
+    class FalsyReasoning(Reasoning):
+        def __bool__(self) -> bool:
+            return False
+
+    model = LitellmModel(model="test-model")
+    settings = ModelSettings(reasoning=FalsyReasoning(effort="low"))
+
+    assert model._get_reasoning_effort(settings) == "low"
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -24,6 +24,8 @@ from agents.retry import (
     RetryDecision,
     RetryPolicyContext,
     retry_policies,
+    retry_policy_retries_all_transient_errors,
+    retry_policy_retries_safe_transport_errors,
 )
 from agents.run_internal.model_retry import get_response_with_retry, stream_response_with_retry
 from agents.usage import Usage
@@ -54,6 +56,25 @@ def test_model_retry_backoff_settings_allow_zero_values() -> None:
     assert backoff.initial_delay == 0
     assert backoff.max_delay == 0
     assert backoff.multiplier == 0
+
+
+def test_retry_capabilities_preserve_falsey_policy() -> None:
+    class FalseyPolicy:
+        _openai_agents_retries_safe_transport_errors: bool
+        _openai_agents_retries_all_transient_errors: bool
+
+        def __bool__(self) -> bool:
+            return False
+
+        def __call__(self, _context: RetryPolicyContext) -> bool:
+            return False
+
+    policy = FalseyPolicy()
+    policy._openai_agents_retries_safe_transport_errors = True
+    policy._openai_agents_retries_all_transient_errors = True
+
+    assert retry_policy_retries_safe_transport_errors(policy) is True
+    assert retry_policy_retries_all_transient_errors(policy) is True
 
 
 def _connection_error(message: str = "connection error") -> APIConnectionError:

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -114,6 +114,20 @@ async def _run_chat_completions_model_with_custom_base_url(
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_falsy_reasoning_is_forwarded() -> None:
+    class FalsyReasoning(Reasoning):
+        def __bool__(self) -> bool:
+            return False
+
+    kwargs = await _run_chat_completions_model_with_custom_base_url(
+        ModelSettings(reasoning=FalsyReasoning(effort="low"))
+    )
+
+    assert kwargs["reasoning_effort"] == "low"
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_get_response_with_text_message(monkeypatch) -> None:
     """
     When the model returns a ChatCompletionMessage with plain text content,
@@ -663,12 +677,20 @@ async def test_get_response_warns_and_sends_placeholder_for_non_text_tool_output
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 async def test_get_response_attaches_logprobs(monkeypatch) -> None:
+    class FalsyChoiceLogprobs(ChoiceLogprobs):
+        def __bool__(self) -> bool:
+            return False
+
+    class FalsyCompletionUsage(CompletionUsage):
+        def __bool__(self) -> bool:
+            return False
+
     msg = ChatCompletionMessage(role="assistant", content="Hi!")
     choice = Choice(
         index=0,
         finish_reason="stop",
         message=msg,
-        logprobs=ChoiceLogprobs(
+        logprobs=FalsyChoiceLogprobs(
             content=[
                 ChatCompletionTokenLogprob(
                     token="Hi",
@@ -691,7 +713,11 @@ async def test_get_response_attaches_logprobs(monkeypatch) -> None:
         model="fake",
         object="chat.completion",
         choices=[choice],
-        usage=None,
+        usage=FalsyCompletionUsage(
+            completion_tokens=2,
+            prompt_tokens=3,
+            total_tokens=5,
+        ),
     )
 
     async def patched_fetch_response(self, *args, **kwargs):
@@ -717,6 +743,9 @@ async def test_get_response_attaches_logprobs(monkeypatch) -> None:
     assert isinstance(text_part, ResponseOutputText)
     assert text_part.logprobs is not None
     assert [lp.token for lp in text_part.logprobs] == ["Hi", "!"]
+    assert resp.usage.input_tokens == 3
+    assert resp.usage.output_tokens == 2
+    assert resp.usage.total_tokens == 5
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -10,6 +10,7 @@ import pytest
 from openai import NOT_GIVEN, APIConnectionError, AsyncOpenAI, RateLimitError, omit
 from openai.types.responses import ResponseCompletedEvent, ResponseErrorEvent
 from openai.types.responses.response_create_params import ContextManagement, PromptCacheOptions
+from openai.types.responses.response_usage import ResponseUsage
 from openai.types.shared.reasoning import Reasoning
 
 from agents import (
@@ -268,13 +269,20 @@ async def test_get_response_exposes_request_id():
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
 async def test_get_response_span_exports_usage():
+    class FalsyResponseUsage(ResponseUsage):
+        def __bool__(self) -> bool:
+            return False
+
     class DummyResponses:
         async def create(self, **kwargs):
-            return get_response_obj(
+            response = get_response_obj(
                 [],
                 response_id="resp-usage",
                 usage=Usage(requests=1, input_tokens=10, output_tokens=4, total_tokens=14),
             )
+            assert response.usage is not None
+            response.usage = FalsyResponseUsage.model_validate(response.usage.model_dump())
+            return response
 
     class DummyResponsesClient:
         def __init__(self):

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import websockets
+from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
 from pydantic import TypeAdapter
 
 from agents import Agent, WebSearchTool, function_tool
@@ -1271,6 +1272,35 @@ class TestSendEventAndConfig(TestOpenAIRealtimeWebSocketModel):
         assert model._ongoing_response is False
         assert model._response_control == "free"
         assert model._audio_state_tracker.get_last_audio_item() is None
+
+    @pytest.mark.asyncio
+    async def test_interrupt_honors_falsy_present_session_auto_cancellation(
+        self, model, monkeypatch
+    ):
+        class FalsySession(RealtimeSessionCreateRequest):
+            def __bool__(self) -> bool:
+                return False
+
+        model._audio_state_tracker.set_audio_format("pcm16")
+        model._audio_state_tracker.on_audio_delta("item_1", 0, b"\x00" * 4800)
+        await model._mark_response_created()
+        model._created_session = FalsySession.model_construct(
+            type="realtime",
+            model="gpt-realtime-2.1",
+            audio=SimpleNamespace(
+                input=SimpleNamespace(turn_detection=SimpleNamespace(interrupt_response=True))
+            ),
+        )
+
+        send_raw = AsyncMock()
+        monkeypatch.setattr(model, "_send_raw_message", send_raw)
+
+        await model._send_interrupt(RealtimeModelSendInterrupt())
+
+        assert send_raw.await_count == 1
+        sent = send_raw.await_args
+        assert sent is not None
+        assert sent.args[0].type == "conversation.item.truncate"
 
     @pytest.mark.asyncio
     async def test_response_only_interrupt_targets_response_without_touching_audio(

--- a/tests/realtime/test_session_payload_and_formats.py
+++ b/tests/realtime/test_session_payload_and_formats.py
@@ -75,6 +75,36 @@ def test_extract_audio_format_from_session_objects() -> None:
     assert Model._extract_audio_format(s_none) is None
 
 
+def test_extract_audio_format_preserves_falsy_present_models() -> None:
+    class FalsyAudioConfig(RealtimeAudioConfig):
+        def __bool__(self) -> bool:
+            return False
+
+    class FalsyAudioPCM(AudioPCM):
+        def __bool__(self) -> bool:
+            return False
+
+    audio = FalsyAudioConfig(output=cast(Any, {"format": AudioPCM(type="audio/pcm")}))
+    falsy_audio_session = RealtimeSessionCreateRequest(
+        type="realtime",
+        model="gpt-realtime-2.1",
+        audio=audio,
+    )
+    fmt = FalsyAudioPCM(type="audio/pcm")
+    falsy_format_session = RealtimeSessionCreateRequest(
+        type="realtime",
+        model="gpt-realtime-2.1",
+        audio=RealtimeAudioConfig(output=cast(Any, {"format": fmt})),
+    )
+
+    assert falsy_audio_session.audio is audio
+    assert Model._extract_audio_format(falsy_audio_session) == "pcm16"
+    assert falsy_format_session.audio is not None
+    assert falsy_format_session.audio.output is not None
+    assert falsy_format_session.audio.output.format is fmt
+    assert Model._extract_audio_format(falsy_format_session) == "pcm16"
+
+
 def test_normalize_audio_format_fallbacks() -> None:
     # String passthrough
     assert Model._normalize_audio_format("pcm24") == "pcm24"

--- a/tests/test_agent_hooks.py
+++ b/tests/test_agent_hooks.py
@@ -74,6 +74,38 @@ class AgentHooksForTests(AgentHooks):
             self.tool_context_ids.append(context.tool_call_id)
 
 
+class FalsyAgentHooks(AgentHooksForTests):
+    def __bool__(self) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_falsy_agent_hooks_are_invoked() -> None:
+    hooks = FalsyAgentHooks()
+    model = FakeModel()
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+        hooks=hooks,
+    )
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("some_function", json.dumps({"a": "b"}))],
+            [get_text_message("done")],
+        ]
+    )
+
+    await Runner.run(agent, input="user_message")
+
+    assert hooks.events == {
+        "on_start": 1,
+        "on_tool_start": 1,
+        "on_tool_end": 1,
+        "on_end": 1,
+    }
+
+
 @pytest.mark.asyncio
 async def test_non_streamed_agent_hooks():
     hooks = AgentHooksForTests()

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -23,6 +23,7 @@ from typing_extensions import TypedDict
 import agents._debug as _debug
 from agents import (
     Agent,
+    AgentOutputSchema,
     GuardrailFunctionOutput,
     Handoff,
     HandoffInputData,
@@ -68,6 +69,7 @@ from agents.models.fake_id import FAKE_RESPONSES_ID
 from agents.run import AgentRunner, get_default_agent_runner, set_default_agent_runner
 from agents.run_config import _default_trace_include_sensitive_data
 from agents.run_internal.agent_bindings import bind_public_agent
+from agents.run_internal.agent_runner_helpers import build_resumed_stream_debug_extra
 from agents.run_internal.items import (
     TOOL_CALL_SESSION_DESCRIPTION_KEY,
     TOOL_CALL_SESSION_TITLE_KEY,
@@ -596,6 +598,38 @@ def test_set_default_agent_runner_roundtrip():
     # Reset to ensure other tests are unaffected.
     set_default_agent_runner(None)
     assert isinstance(get_default_agent_runner(), AgentRunner)
+
+
+def test_set_default_agent_runner_preserves_falsey_runner():
+    class FalseyRunner(AgentRunner):
+        def __bool__(self) -> bool:
+            return False
+
+    original_runner = get_default_agent_runner()
+    runner = FalseyRunner()
+    try:
+        set_default_agent_runner(runner)
+        assert get_default_agent_runner() is runner
+    finally:
+        set_default_agent_runner(original_runner)
+
+
+def test_resumed_stream_debug_extra_preserves_falsy_current_agent() -> None:
+    class FalsyAgent(Agent[Any]):
+        def __bool__(self) -> bool:
+            return False
+
+    agent: Agent[Any] = FalsyAgent(name="falsy")
+    state: RunState[None] = RunState(
+        context=RunContextWrapper(context=None),
+        original_input="input",
+        starting_agent=agent,
+        max_turns=1,
+    )
+
+    extra = build_resumed_stream_debug_extra(state, include_tool_output=False)
+
+    assert extra["current_agent"] == "falsy"
 
 
 def test_run_streamed_preserves_legacy_positional_previous_response_id():
@@ -4530,13 +4564,17 @@ def test_tool_two():
 
 @pytest.mark.asyncio
 async def test_tool_use_behavior_first_output():
+    class FalsyAgentOutputSchema(AgentOutputSchema):
+        def __bool__(self) -> bool:
+            return False
+
     model = FakeModel()
     agent = Agent(
         name="test",
         model=model,
         tools=[get_function_tool("foo", "tool_result"), test_tool_one, test_tool_two],
         tool_use_behavior="stop_on_first_tool",
-        output_type=Foo,
+        output_type=FalsyAgentOutputSchema(Foo),
     )
 
     model.add_multiple_turn_outputs(

--- a/tests/test_cancel_streaming.py
+++ b/tests/test_cancel_streaming.py
@@ -6,6 +6,7 @@ import pytest
 from openai.types.responses import ResponseCompletedEvent
 
 from agents import Agent, Runner
+from agents.guardrail import input_guardrail
 from agents.stream_events import RawResponsesStreamEvent
 
 from .fake_model import FakeModel
@@ -269,3 +270,43 @@ async def test_run_loop_exception_surfaced_after_stream():
     assert result.run_loop_exception is not None
     assert isinstance(result.run_loop_exception, RuntimeError)
     assert "run loop boom" in str(result.run_loop_exception)
+
+
+@pytest.mark.asyncio
+async def test_falsy_run_loop_exception_is_surfaced_after_stream() -> None:
+    class FalsyRuntimeError(RuntimeError):
+        def __bool__(self) -> bool:
+            return False
+
+    class BoomModel(FakeModel):
+        async def stream_response(self, *args, **kwargs):
+            raise FalsyRuntimeError("falsy run loop boom")
+            yield
+
+    result = Runner.run_streamed(Agent(name="A", model=BoomModel()), input="hi")
+
+    with pytest.raises(FalsyRuntimeError, match="falsy run loop boom"):
+        async for _ in result.stream_events():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_falsy_input_guardrail_exception_is_surfaced_after_stream() -> None:
+    class FalsyRuntimeError(RuntimeError):
+        def __bool__(self) -> bool:
+            return False
+
+    @input_guardrail
+    async def raising_guardrail(context, agent, input):
+        raise FalsyRuntimeError("falsy guardrail boom")
+
+    model = FakeModel()
+    model.set_next_output([get_text_message("done")])
+    result = Runner.run_streamed(
+        Agent(name="A", model=model, input_guardrails=[raising_guardrail]),
+        input="hi",
+    )
+
+    with pytest.raises(FalsyRuntimeError, match="falsy guardrail boom"):
+        async for _ in result.stream_events():
+            pass

--- a/tests/test_check_optional_truthiness.py
+++ b/tests/test_check_optional_truthiness.py
@@ -1,0 +1,831 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
+
+import pytest
+
+
+def _load_checker() -> ModuleType:
+    path = Path(__file__).parents[1] / ".github/scripts/check_optional_truthiness.py"
+    spec = importlib.util.spec_from_file_location("check_optional_truthiness", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+def _violations(tmp_path: Path, source: str) -> list[Any]:
+    path = tmp_path / "example.py"
+    path.write_text(source, encoding="utf-8")
+    return cast(list[Any], checker.find_violations([path]))
+
+
+@pytest.mark.parametrize(
+    ("statement", "expected_expression"),
+    [
+        ("if callback:\n        callback()", "callback"),
+        ("while callback:\n        break", "callback"),
+        ("assert callback", "callback"),
+        ("return callback if callback else fallback", "callback"),
+        ("return not callback", "callback"),
+        ("return callback and callback()", "callback"),
+        ("return callback or fallback", "callback"),
+    ],
+)
+def test_rejects_supported_boolean_forms(
+    tmp_path: Path,
+    statement: str,
+    expected_expression: str,
+) -> None:
+    violations = _violations(
+        tmp_path,
+        f"""
+from collections.abc import Callable
+
+def invoke(callback: Callable[[], str] | None, fallback: Callable[[], str]):
+    {statement}
+""",
+    )
+
+    assert [violation.expression for violation in violations] == [expected_expression]
+
+
+def test_rejects_direct_local_class_parameter_and_local(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+class Model: ...
+
+def select(model: Model | None):
+    current: Model | None = model
+    if model:
+        return model
+    return current or Model()
+""",
+    )
+
+    assert {violation.expression for violation in violations} == {"model", "current"}
+
+
+def test_rejects_callable_imported_in_function_scope(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+def select(fallback):
+    from typing import Callable
+
+    callback: Callable[[], str] | None = None
+    return callback or fallback
+""",
+    )
+
+    assert [violation.expression for violation in violations] == ["callback"]
+
+
+def test_rejects_callable_imported_in_class_scope_without_leaking(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+class Runner:
+    from typing import Callable
+
+    callback: Callable[[], str] | None = None
+
+    def select(self, override: Callable[[], str] | None):
+        return self.callback or override or fallback
+
+def unrelated(callback: Callable[[], str] | None):
+    return callback or fallback
+""",
+    )
+
+    assert {violation.expression for violation in violations} == {
+        "self.callback",
+        "override",
+    }
+
+
+def test_class_scope_callable_shadow_suppresses_only_that_class(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from typing import Callable
+
+class Runner:
+    from vendor import Callable
+
+    callback: Callable[[], str] | None = None
+
+    def select(self, override: Callable[[], str] | None):
+        return self.callback or override or fallback
+
+def unrelated(callback: Callable[[], str] | None):
+    return callback or fallback
+""",
+    )
+
+    assert [violation.expression for violation in violations] == ["callback"]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+from typing import Callable
+
+def select(callback: Callable[[], str] | None):
+    return callback or fallback
+
+Callable = replacement
+""",
+        """
+from typing import Callable
+
+class Runner:
+    def select(self, callback: Callable[[], str] | None):
+        return callback or fallback
+
+    Callable = replacement
+""",
+    ],
+    ids=["module", "class"],
+)
+def test_rebound_callable_scope_remains_unclassified(tmp_path: Path, source: str) -> None:
+    assert _violations(tmp_path, source) == []
+
+
+def test_rejects_callbacks_in_nested_class_scopes(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from typing import Callable
+
+def outer():
+    class Runner:
+        def select(self, callback: Callable[[], str] | None):
+            return callback or fallback
+
+class Container:
+    class Runner:
+        def select(self, callback: Callable[[], str] | None):
+            return callback or fallback
+""",
+    )
+
+    assert [violation.expression for violation in violations] == ["callback", "callback"]
+
+
+def test_redefined_same_file_class_remains_unclassified(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+class Base: ...
+class Model(Base): ...
+
+def select(model: Model | None):
+    return model or fallback
+
+class Model: ...
+""",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+class Model: ...
+from vendor import Model
+
+def select():
+    value: Model | None = None
+    return value or fallback
+""",
+        """
+class Model: ...
+
+class Runner:
+    from vendor import Model
+    value: Model | None = None
+
+    def select(self):
+        return self.value or fallback
+""",
+        """
+class Model: ...
+
+def select():
+    from vendor import Model
+    value: Model | None = None
+    return value or fallback
+""",
+        """
+class Model: ...
+
+def outer():
+    from vendor import Model
+
+    def inner():
+        value: Model | None = None
+        return value or fallback
+
+    return inner()
+""",
+    ],
+    ids=["module", "class", "function", "nested-function"],
+)
+def test_same_file_class_shadow_remains_unclassified(tmp_path: Path, source: str) -> None:
+    assert _violations(tmp_path, source) == []
+
+
+@pytest.mark.parametrize("module", [".typing", ".collections.abc"])
+def test_relative_callable_import_remains_unclassified(tmp_path: Path, module: str) -> None:
+    violations = _violations(
+        tmp_path,
+        f"""
+from {module} import Callable
+
+def select(callback: Callable[[], str] | None):
+    return callback or fallback
+""",
+    )
+
+    assert violations == []
+
+
+def test_comprehension_binding_does_not_shadow_enclosing_scope(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from typing import Callable
+
+def select(values):
+    ignored = [Callable for Callable in values]
+    callback: Callable[[], str] | None = None
+    return callback or fallback
+
+class Runner:
+    ignored = [Callable for Callable in values]
+    callback: Callable[[], str] | None = None
+
+    def select(self):
+        return self.callback or fallback
+""",
+    )
+
+    assert {violation.expression for violation in violations} == {
+        "callback",
+        "self.callback",
+    }
+
+
+def test_comprehension_walrus_shadows_enclosing_scope(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from typing import Callable
+
+def select(values):
+    ignored = [value for value in values if (Callable := value)]
+    callback: Callable[[], str] | None = None
+    return callback or fallback
+""",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [
+        "def nested(value=(Callable := factory)): ...",
+        "factory = lambda value=(Callable := factory): value",
+        "@((Callable := decorate))\ndef nested(): ...",
+        "class Nested((Callable := Base)): ...",
+    ],
+    ids=["function-default", "lambda-default", "decorator", "class-base"],
+)
+def test_definition_expression_walrus_shadows_enclosing_scope(
+    tmp_path: Path,
+    definition: str,
+) -> None:
+    indented_definition = definition.replace("\n", "\n    ")
+    violations = _violations(
+        tmp_path,
+        f"""
+def outer():
+    from typing import Callable
+
+    {indented_definition}
+    callback: Callable[[], str] | None = None
+    return callback or fallback
+""",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    ["Callable", "[*Callable]", "{**Callable}"],
+    ids=["match-as", "match-star", "match-mapping-rest"],
+)
+def test_match_capture_shadows_callable_binding(tmp_path: Path, pattern: str) -> None:
+    violations = _violations(
+        tmp_path,
+        f"""
+from typing import Callable
+
+def select(subject):
+    match subject:
+        case {pattern}:
+            pass
+    callback: Callable[[], str] | None = None
+    return callback or fallback
+""",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        "Callable = make_type()",
+        "def Callable(): ...",
+        "from vendor import *",
+    ],
+    ids=["assignment", "definition", "star-import"],
+)
+def test_callable_shadow_forms_remain_unclassified(
+    tmp_path: Path,
+    binding: str,
+) -> None:
+    violations = _violations(
+        tmp_path,
+        f"""
+from typing import Callable
+
+def select():
+    {binding}
+    callback: Callable[[], str] | None = None
+    return callback or fallback
+""",
+    )
+
+    assert violations == []
+
+
+def test_rejects_direct_self_fields_declared_in_class_or_method(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from collections.abc import Callable
+
+class Runner:
+    callback: Callable[[], str] | None = None
+
+    def configure(self):
+        self.fallback: Callable[[], str] | None = None
+
+    def run(self):
+        if self.callback:
+            self.callback()
+        return self.fallback or default_callback
+""",
+    )
+
+    assert {violation.expression for violation in violations} == {
+        "self.callback",
+        "self.fallback",
+    }
+
+
+def test_static_method_parameter_is_checked_without_instance_field_inference(
+    tmp_path: Path,
+) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from collections.abc import Callable
+
+class Runner:
+    callback: Callable[[], str] | None = None
+
+    @staticmethod
+    def run(callback: Callable[[], str] | None):
+        if callback:
+            callback()
+""",
+    )
+
+    assert [violation.expression for violation in violations] == ["callback"]
+
+
+def test_static_method_receiver_field_declaration_is_not_inferred(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from collections.abc import Callable
+
+class Runner:
+    @staticmethod
+    def configure(self):
+        self.callback: Callable[[], str] | None = None
+
+    def run(self):
+        return self.callback or default_callback
+""",
+    )
+
+    assert violations == []
+
+
+def test_qualified_static_method_receiver_field_declaration_is_not_inferred(
+    tmp_path: Path,
+) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+import builtins
+from collections.abc import Callable
+
+class Runner:
+    @builtins.staticmethod
+    def configure(self):
+        self.callback: Callable[[], str] | None = None
+
+    def run(self):
+        return self.callback or default_callback
+""",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+from typing import Callable
+
+def mutate():
+    global Callable
+    Callable = replacement
+
+def select(callback: Callable[[], str] | None):
+    return callback or fallback
+""",
+        """
+def outer():
+    from typing import Callable
+
+    def mutate():
+        nonlocal Callable
+        Callable = replacement
+
+    callback: Callable[[], str] | None = None
+    return callback or fallback
+""",
+    ],
+    ids=["global", "nonlocal"],
+)
+def test_outer_scope_rebinding_remains_unclassified(tmp_path: Path, source: str) -> None:
+    assert _violations(tmp_path, source) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+from typing import Callable
+
+def inspect():
+    global Callable
+    return Callable
+
+def select(callback: Callable[[], str] | None):
+    return callback or fallback
+""",
+        """
+Callable = replacement
+
+def configure():
+    global Callable
+    from typing import Callable
+
+def select(callback: Callable[[], str] | None):
+    return callback or fallback
+""",
+        """
+def outer():
+    from typing import Callable
+
+    callback: Callable[[], str] | None = None
+
+    def middle():
+        from typing import Callable
+
+        def inner():
+            nonlocal Callable
+            Callable = replacement
+
+    return callback or fallback
+""",
+        """
+def outer():
+    from typing import Callable
+
+    callback: Callable[[], str] | None = None
+
+    class Mutator:
+        nonlocal Callable
+        Callable = replacement
+
+    return callback or fallback
+""",
+        """
+def outer():
+    from typing import Callable
+
+    callback: Callable[[], str] | None = None
+
+    def middle():
+        def inner():
+            nonlocal Callable
+            Callable = replacement
+
+    return callback or fallback
+""",
+    ],
+    ids=[
+        "read-only-global",
+        "global-import",
+        "deep-nonlocal-with-binding",
+        "class-nonlocal",
+        "deep-nonlocal-without-binding",
+    ],
+)
+def test_cross_scope_declarations_remain_unclassified(tmp_path: Path, source: str) -> None:
+    assert _violations(tmp_path, source) == []
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12+")
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+from typing import Callable
+
+def select[Callable](callback: Callable[[], str] | None):
+    return callback or fallback
+""",
+        """
+from typing import Callable
+
+class Runner[Callable]:
+    callback: Callable[[], str] | None = None
+
+    def select(self):
+        return self.callback or fallback
+""",
+        """
+class Model: ...
+
+class Runner[Model]:
+    def select(self):
+        value: Model | None = None
+        return value or fallback
+""",
+        """
+from typing import Callable
+
+class Runner[Callable]:
+    def select(self):
+        callback: Callable[[], str] | None = None
+        return callback or fallback
+""",
+    ],
+    ids=["function", "class-field", "class-method-model", "class-method-callable"],
+)
+def test_type_parameter_bindings_remain_unclassified(tmp_path: Path, source: str) -> None:
+    assert _violations(tmp_path, source) == []
+
+
+def test_rejects_match_guard_truthiness(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from typing import Callable
+
+def select(value, callback: Callable[[], str] | None):
+    match value:
+        case _ if callback:
+            return callback()
+""",
+    )
+
+    assert [violation.expression for violation in violations] == ["callback"]
+
+
+def test_allows_explicit_none_checks_and_direct_value_truthiness(tmp_path: Path) -> None:
+    violations = _violations(
+        tmp_path,
+        """
+from collections.abc import Callable
+
+def select(
+    callback: Callable[[], str] | None,
+    name: str | None,
+    count: int | None,
+    values: list[str] | None,
+    options: dict[str, str] | None,
+):
+    if callback is not None:
+        callback()
+    return name or "default", count or 1, values or [], options or {}
+""",
+    )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """
+from collections.abc import Callable
+Callback = Callable[[], str]
+def select(callback: Callback | None):
+    return callback or fallback
+""",
+        """
+from vendor import ImportedModel
+def select(model: ImportedModel | None):
+    return model or fallback
+""",
+        """
+import typing
+def select(callback: typing.Callable[[], str] | None):
+    return callback or fallback
+""",
+        """
+from typing import Annotated, Callable
+def select(callback: Annotated[Callable[[], str] | None, "meta"]):
+    return callback or fallback
+""",
+        """
+from typing import Callable, Optional
+def select(callback: Optional[Callable[[], str]]):
+    return callback or fallback
+""",
+        """
+from collections.abc import Callable
+class Base:
+    callback: Callable[[], str] | None = None
+class Child(Base):
+    def select(self):
+        return self.callback or fallback
+""",
+        """
+from collections.abc import Callable
+def select(callback: Callable[[], str] | None):
+    current = callback
+    return current or fallback
+""",
+        """
+from collections.abc import Callable
+class Runner:
+    callback: Callable[[], str] | None = None
+    def select(self, other: Runner):
+        return other.callback or fallback
+""",
+        """
+from collections.abc import Callable
+def current() -> Callable[[], str] | None:
+    return None
+def select():
+    return current() or fallback
+""",
+        """
+from collections.abc import Callable
+class Runner:
+    @property
+    def callback(self) -> Callable[[], str] | None:
+        return None
+    def select(self):
+        return self.callback or fallback
+""",
+        """
+from collections.abc import Callable
+def select(callback: Callable | None):
+    return callback or fallback
+""",
+        """
+class Box: ...
+def select(value: Box[int] | None):
+    return value or fallback
+""",
+        """
+from typing import Callable as Callback
+def select(callback: Callback[[], str] | None):
+    return callback or fallback
+""",
+        """
+from collections.abc import Callable
+def select(callback: Callable[[], str] | None):
+    return bool(callback)
+""",
+        """
+from collections.abc import Callable
+def select(callback: Callable[[], str] | None):
+    first = True and callback
+    second = False or callback
+    return first, second
+""",
+        """
+from collections.abc import Callable
+def outer(callback: Callable[[], str] | None):
+    def inner(value=callback or fallback):
+        return value
+""",
+        """
+from collections.abc import Callable
+def outer(callback: Callable[[], str] | None):
+    @decorate(callback or fallback)
+    def inner():
+        pass
+""",
+        """
+from collections.abc import Callable
+def outer(callback: Callable[[], str] | None):
+    return lambda value=callback or fallback: value
+""",
+        """
+from collections.abc import Callable
+def outer(callback: Callable[[], str] | None):
+    class Inner(callback or fallback):
+        pass
+""",
+        """
+from collections.abc import Callable
+def outer(callback: Callable[[], str] | None):
+    return [value for value in (callback or fallback)]
+""",
+    ],
+    ids=[
+        "type-alias",
+        "imported-type",
+        "qualified-type",
+        "annotated",
+        "legacy-optional",
+        "inherited-field",
+        "assignment-flow",
+        "nested-receiver",
+        "call-return",
+        "descriptor-return",
+        "bare-callable",
+        "parameterized-local-class",
+        "aliased-callable-import",
+        "bool-call",
+        "final-boolean-operand",
+        "nested-function-default",
+        "nested-function-decorator",
+        "lambda-default",
+        "nested-class-base",
+        "comprehension-first-iterator",
+    ],
+)
+def test_leaves_each_unsupported_category_unclassified(tmp_path: Path, source: str) -> None:
+    assert _violations(tmp_path, source) == []
+
+
+def test_cli_reports_actionable_failure(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    path = tmp_path / "example.py"
+    path.write_text(
+        """
+from collections.abc import Callable
+
+def invoke(callback: Callable[[], str] | None):
+    return callback or fallback
+""",
+        encoding="utf-8",
+    )
+
+    result = checker.main([str(path)])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "optional object uses truthiness: callback" in captured.out
+    assert "explicit `is None` or `is not None`" in captured.err

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import asyncio
 import gc
 import os
 import weakref
+from typing import Any, cast
 
 import openai
 import pytest
@@ -37,6 +38,17 @@ def test_cc_set_default_openai_client():
     set_default_openai_client(client)
     chat_model = OpenAIProvider(use_responses=False).get_model("gpt-4")
     assert chat_model._client.api_key == "test_key"  # type: ignore
+
+
+def test_provider_preserves_falsy_default_client(monkeypatch):
+    class FalsyClient:
+        def __bool__(self) -> bool:
+            return False
+
+    client = cast(Any, FalsyClient())
+    monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: client)
+
+    assert OpenAIProvider()._get_client() is client
 
 
 def test_resp_no_default_key_errors(monkeypatch):

--- a/tests/test_hitl_error_scenarios.py
+++ b/tests/test_hitl_error_scenarios.py
@@ -1559,6 +1559,52 @@ async def test_resume_skips_needs_approval_checker_when_status_resolved() -> Non
 
 
 @pytest.mark.asyncio
+async def test_function_resume_reuses_falsy_pending_item() -> None:
+    class FalsyToolApprovalItem(ToolApprovalItem):
+        def __bool__(self) -> bool:
+            return False
+
+    @function_tool(needs_approval=True)
+    async def approve_me(value: str) -> str:
+        return value
+
+    tool_call = make_function_tool_call(
+        approve_me.name,
+        call_id="pending-function",
+        arguments='{"value":"a"}',
+    )
+    agent = Agent(name="agent", tools=[approve_me])
+    existing_pending = FalsyToolApprovalItem(agent=agent, raw_item=tool_call)
+    run = ToolRunFunction(tool_call=tool_call, function_tool=approve_me)
+    pending: list[ToolApprovalItem] = []
+
+    async def _needs_approval_checker(_run: ToolRunFunction) -> bool:
+        return True
+
+    async def _record_rejection(
+        _call_id: str | None,
+        _tool_call: ResponseFunctionToolCall,
+        _tool: FunctionTool,
+    ) -> None:
+        raise AssertionError("unresolved approval must not be recorded as a rejection")
+
+    selected = await _select_function_tool_runs_for_resume(
+        [run],
+        approval_items_by_call_id={tool_call.call_id: existing_pending},
+        context_wrapper=make_context_wrapper(),
+        needs_approval_checker=_needs_approval_checker,
+        output_exists_checker=lambda _run: False,
+        record_rejection=_record_rejection,
+        pending_interruption_adder=pending.append,
+        pending_item_builder=lambda _run: ToolApprovalItem(agent=agent, raw_item=tool_call),
+    )
+
+    assert selected == []
+    assert pending == [existing_pending]
+    assert pending[0] is existing_pending
+
+
+@pytest.mark.asyncio
 async def test_resume_rechecks_rejection_after_function_approval_checker() -> None:
     """A rejection recorded while the checker waits must prevent another interruption."""
 
@@ -2133,6 +2179,51 @@ async def test_collect_runs_by_approval_skips_checker_when_status_resolved() -> 
     assert checker_calls == []
     assert approved == [runs[0]]
     assert len(rejections) == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_runs_by_approval_reuses_falsy_pending_item() -> None:
+    class FalsyToolApprovalItem(ToolApprovalItem):
+        def __bool__(self) -> bool:
+            return False
+
+    shell_tool = ShellTool(executor=lambda _req: "ok", needs_approval=True)
+    shell_call = make_shell_call("pending-shell")
+    agent = Agent(name="agent")
+    existing_pending = FalsyToolApprovalItem(
+        agent=agent,
+        raw_item=cast(dict[str, Any], shell_call),
+        tool_name=shell_tool.name,
+    )
+    run = ToolRunShellCall(tool_call=shell_call, shell_tool=shell_tool)
+    pending: list[ToolApprovalItem] = []
+
+    async def _build_rejection(_run: ToolRunShellCall, call_id: str) -> RunItem:
+        return ToolCallOutputItem(
+            output="rejected",
+            raw_item={"type": "function_call_output", "call_id": call_id, "output": "rejected"},
+            agent=agent,
+        )
+
+    async def _needs_approval(_run: ToolRunShellCall) -> bool:
+        return True
+
+    approved, rejections = await _collect_runs_by_approval(
+        [run],
+        call_id_extractor=lambda item: item.tool_call["call_id"],
+        tool_name_resolver=lambda item: item.shell_tool.name,
+        rejection_builder=_build_rejection,
+        context_wrapper=make_context_wrapper(),
+        approval_items_by_call_id={"pending-shell": existing_pending},
+        agent=agent,
+        pending_interruption_adder=pending.append,
+        needs_approval_checker=_needs_approval,
+    )
+
+    assert approved == []
+    assert rejections == []
+    assert pending == [existing_pending]
+    assert pending[0] is existing_pending
 
 
 @pytest.mark.parametrize("approved", [True, False], ids=["approved", "rejected"])
@@ -3229,6 +3320,10 @@ async def test_resume_skips_computer_actions_with_existing_output() -> None:
 async def test_rebuild_function_runs_handles_pending_and_rejections() -> None:
     """Rebuilt function runs should surface pending approvals and emit rejections."""
 
+    class FalsyToolApprovalItem(ToolApprovalItem):
+        def __bool__(self) -> bool:
+            return False
+
     @function_tool(needs_approval=True)
     def reject_me(text: str = "nope") -> str:
         return text
@@ -3254,7 +3349,7 @@ async def test_rebuild_function_runs_handles_pending_and_rejections() -> None:
     }
 
     rejected_item = ToolApprovalItem(agent=agent, raw_item=rejected_raw)
-    pending_item = ToolApprovalItem(agent=agent, raw_item=pending_raw)
+    pending_item = FalsyToolApprovalItem(agent=agent, raw_item=pending_raw)
     context_wrapper.reject_tool(rejected_item)
 
     run_state = make_state_with_interruptions(agent, [rejected_item, pending_item])
@@ -3284,7 +3379,8 @@ async def test_rebuild_function_runs_handles_pending_and_rejections() -> None:
     )
 
     assert isinstance(result.next_step, NextStepInterruption)
-    assert pending_item in result.next_step.interruptions
+    assert any(item is pending_item for item in result.next_step.interruptions)
+    assert any(item is pending_item for item in result.new_step_items)
     rejection_outputs = [
         item
         for item in result.new_step_items

--- a/tests/test_process_model_response.py
+++ b/tests/test_process_model_response.py
@@ -89,6 +89,27 @@ def test_process_model_response_shell_call_without_tool_raises() -> None:
         )
 
 
+def test_process_model_response_dispatches_falsy_shell_tool() -> None:
+    class FalsyShellTool(ShellTool):
+        def __bool__(self) -> bool:
+            return False
+
+    shell_tool = FalsyShellTool(environment={"type": "container_auto"})
+    shell_call = make_shell_call("shell-falsy")
+
+    processed = run_loop.process_model_response(
+        agent=Agent(name="falsy-shell", tools=[shell_tool]),
+        all_tools=[shell_tool],
+        response=_response([shell_call]),
+        output_schema=None,
+        handoffs=[],
+    )
+
+    assert processed.tools_used == [shell_tool.name]
+    assert isinstance(processed.new_items[0], ToolCallItem)
+    assert processed.new_items[0]._resolved_tool_name == shell_tool.name
+
+
 def test_process_model_response_sets_title_for_local_mcp_function_tool() -> None:
     agent = Agent(name="local-mcp", model=FakeModel())
     mcp_tool = MCPTool(name="search_docs", inputSchema={}, description=None, title="Search Docs")
@@ -374,6 +395,26 @@ def test_process_model_response_queues_apply_patch_call() -> None:
     converted_call = processed.apply_patch_calls[0].tool_call
     assert isinstance(converted_call, dict)
     assert converted_call.get("type") == "apply_patch_call"
+
+
+def test_process_model_response_dispatches_falsy_apply_patch_tool() -> None:
+    class FalsyApplyPatchTool(ApplyPatchTool):
+        def __bool__(self) -> bool:
+            return False
+
+    apply_patch_tool = FalsyApplyPatchTool(editor=RecordingEditor())
+    apply_patch_call = make_apply_patch_dict("apply-falsy")
+
+    processed = run_loop.process_model_response(
+        agent=Agent(name="falsy-apply", tools=[apply_patch_tool]),
+        all_tools=[apply_patch_tool],
+        response=_response([apply_patch_call]),
+        output_schema=None,
+        handoffs=[],
+    )
+
+    assert processed.tools_used == [apply_patch_tool.name]
+    assert processed.apply_patch_calls[0].apply_patch_tool is apply_patch_tool
 
 
 def test_process_model_response_queues_hosted_apply_patch_from_custom_tool_call() -> None:

--- a/tests/test_run_context_wrapper.py
+++ b/tests/test_run_context_wrapper.py
@@ -10,6 +10,11 @@ class BrokenStr:
         raise RuntimeError("broken")
 
 
+class FalsyToolApprovalItem(ToolApprovalItem):
+    def __bool__(self) -> bool:
+        return False
+
+
 def test_run_context_to_str_or_none_handles_errors() -> None:
     assert RunContextWrapper._to_str_or_none("ok") == "ok"
     assert RunContextWrapper._to_str_or_none(123) == "123"
@@ -83,6 +88,40 @@ def test_run_context_honors_global_approval_and_rejection() -> None:
 
     wrapper.reject_tool(approval, always_reject=True)
     assert wrapper.is_tool_approved("tool_call", "call-3") is False
+
+
+def test_run_context_uses_falsy_pending_item_for_sticky_decisions() -> None:
+    approval = FalsyToolApprovalItem(
+        agent=make_agent(),
+        raw_item={
+            "type": "function_call",
+            "name": "tool_call",
+            "call_id": "call-1",
+            "arguments": "{}",
+        },
+    )
+
+    approved: RunContextWrapper[None] = RunContextWrapper(context=None)
+    approved.approve_tool(approval, always_approve=True)
+    assert (
+        approved.get_approval_status(
+            "tool_call",
+            "call-2",
+            existing_pending=approval,
+        )
+        is True
+    )
+
+    rejected: RunContextWrapper[None] = RunContextWrapper(context=None)
+    rejected.reject_tool(approval, always_reject=True, rejection_message="Denied")
+    assert (
+        rejected.get_rejection_message(
+            "tool_call",
+            "call-2",
+            existing_pending=approval,
+        )
+        == "Denied"
+    )
 
 
 def test_run_context_stores_per_call_rejection_messages() -> None:

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -130,6 +130,7 @@ from agents.tool_guardrails import (
     ToolOutputGuardrail,
     ToolOutputGuardrailResult,
 )
+from agents.tracing.traces import TraceState
 from agents.usage import Usage
 from tests.utils.factories import TestSessionState
 
@@ -303,6 +304,37 @@ def set_last_processed_response(
 class TestRunState:
     """Test RunState initialization, serialization, and core functionality."""
 
+    @pytest.mark.asyncio
+    async def test_results_to_state_preserve_falsy_trace_state(self) -> None:
+        class FalsyTraceState(TraceState):
+            def __bool__(self) -> bool:
+                return False
+
+        trace_state = FalsyTraceState(trace_id="trace_falsy")
+
+        model = FakeModel()
+        model.set_next_output([get_final_output_message("done")])
+        result = await Runner.run(Agent(name="test", model=model), "input")
+        result._trace_state = trace_state
+
+        restored = result.to_state()._trace_state
+        assert isinstance(restored, FalsyTraceState)
+        assert restored.trace_id == "trace_falsy"
+
+        streaming_model = FakeModel()
+        streaming_model.set_next_output([get_final_output_message("done")])
+        streaming_result = Runner.run_streamed(
+            Agent(name="streaming-test", model=streaming_model),
+            "input",
+        )
+        async for _ in streaming_result.stream_events():
+            pass
+        streaming_result._trace_state = trace_state
+
+        streaming_restored = streaming_result.to_state()._trace_state
+        assert isinstance(streaming_restored, FalsyTraceState)
+        assert streaming_restored.trace_id == "trace_falsy"
+
     def test_initializes_with_default_values(self):
         """Test that RunState initializes with correct default values."""
         context = RunContextWrapper(context={"foo": "bar"})
@@ -318,6 +350,18 @@ class TestRunState:
         assert state._current_step is None
         assert state._context is not None
         assert state._context.context == {"foo": "bar"}
+
+    def test_to_json_preserves_falsy_processed_response(self) -> None:
+        class FalsyProcessedResponse(ProcessedResponse):
+            def __bool__(self) -> bool:
+                return False
+
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        state = make_state(Agent(name="test"), context=context)
+        processed = make_processed_response()
+        state._last_processed_response = FalsyProcessedResponse(**vars(processed))
+
+        assert state.to_json()["last_processed_response"] is not None
 
     def test_set_tool_use_tracker_snapshot_filters_non_strings(self):
         """Test that set_tool_use_tracker_snapshot filters out non-string agent names and tools."""
@@ -497,6 +541,31 @@ class TestRunState:
 
         json_data = state.to_json()
         assert json_data["current_agent"] == {"name": "duplicate"}
+
+        restored = await RunState.from_json(root, json_data)
+        assert restored._current_agent is second
+
+    @pytest.mark.asyncio
+    async def test_from_json_restores_falsy_current_agent_via_identity_map(self):
+        class FalsyAgent(Agent[Any]):
+            def __bool__(self) -> bool:
+                return False
+
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        first = Agent(name="duplicate", instructions="zeta")
+        second = FalsyAgent(name="duplicate", instructions="alpha")
+        root = Agent(name="triage", handoffs=[first, second])
+        first.handoffs = [root]
+        second.handoffs = [root]
+
+        state = make_state(root, context=context, original_input="input1", max_turns=2)
+        state._current_agent = second
+
+        json_data = state.to_json()
+        assert json_data["current_agent"] == {
+            "name": "duplicate",
+            "identity": "duplicate#2",
+        }
 
         restored = await RunState.from_json(root, json_data)
         assert restored._current_agent is second
@@ -6130,10 +6199,14 @@ class TestRunStateSerializationEdgeCases:
         context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
         agent = Agent(name="TestAgent")
 
+        class FalsyShellTool(ShellTool):
+            def __bool__(self) -> bool:
+                return False
+
         async def shell_executor(request: Any) -> Any:
             return {"output": "test output"}
 
-        shell_tool = ShellTool(executor=shell_executor)
+        shell_tool = FalsyShellTool(executor=shell_executor)
         agent.tools = [shell_tool]
 
         # Create invalid tool_call_data that will cause ValidationError
@@ -6168,6 +6241,7 @@ class TestRunStateSerializationEdgeCases:
         assert len(result.shell_calls) == 1
         # shell_call should have raw tool_call_data (dict) instead of validated LocalShellCall
         assert isinstance(result.shell_calls[0].tool_call, dict)
+        assert result.shell_calls[0].shell_tool is shell_tool
 
     async def test_deserialize_processed_response_apply_patch_action_with_exception(self):
         """Test deserialization of ProcessedResponse with apply patch action Exception."""
@@ -8811,7 +8885,11 @@ async def test_resume_nested_agent_as_tool_with_context_override() -> None:
 
 @pytest.mark.asyncio
 async def test_hosted_mcp_approval_request_restores_matching_server_tool() -> None:
-    server_a = HostedMCPTool(
+    class FalsyHostedMCPTool(HostedMCPTool):
+        def __bool__(self) -> bool:
+            return False
+
+    server_a = FalsyHostedMCPTool(
         tool_config=Mcp(
             type="mcp",
             server_label="server-a",

--- a/tests/test_tool_output_conversion.py
+++ b/tests/test_tool_output_conversion.py
@@ -28,6 +28,17 @@ def test_tool_call_output_item_text_model() -> None:
     assert item["text"] == "hello"
 
 
+def test_tool_call_output_item_list_preserves_falsy_structured_model() -> None:
+    class FalsyToolOutputText(ToolOutputText):
+        def __bool__(self) -> bool:
+            return False
+
+    call = _make_tool_call()
+    payload = ItemHelpers.tool_call_output_item(call, [FalsyToolOutputText(text="hello")])
+
+    assert payload["output"] == [{"type": "input_text", "text": "hello"}]
+
+
 def test_tool_call_output_item_image_model() -> None:
     call = _make_tool_call()
     out = ToolOutputImage(image_url="data:image/png;base64,AAAA")

--- a/tests/test_tool_use_tracker.py
+++ b/tests/test_tool_use_tracker.py
@@ -17,6 +17,11 @@ from agents.run_internal.tool_use_tracker import (
 from .test_responses import get_function_tool_call
 
 
+class FalsyAgent(Agent[Any]):
+    def __bool__(self) -> bool:
+        return False
+
+
 def test_tool_use_tracker_as_serializable_uses_agent_map_or_runtime_snapshot() -> None:
     tracker = AgentToolUseTracker()
     tracker.agent_map = {"agent-a": {"tool-b", "tool-a"}}
@@ -40,7 +45,7 @@ def test_tool_use_tracker_from_and_serialize_snapshots() -> None:
 
 
 def test_serialize_and_hydrate_tool_use_tracker_preserves_duplicate_agent_identity() -> None:
-    second = Agent(name="duplicate")
+    second = FalsyAgent(name="duplicate")
     first = Agent(name="duplicate", handoffs=[second])
     second.handoffs = [first]
 

--- a/tests/tracing/test_trace_context.py
+++ b/tests/tracing/test_trace_context.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import logging
 from uuid import uuid4
 
+from openai.types.responses import Response
+
 import agents.tracing.traces as trace_module
 from agents.tracing import TracingConfig, set_tracing_disabled, trace
-from agents.tracing.context import create_trace_for_run
+from agents.tracing.context import TraceCtxManager, create_trace_for_run
 from agents.tracing.scope import Scope
+from agents.tracing.span_data import ResponseSpanData
 from agents.tracing.traces import (
     NoOpTrace,
     ReattachedTrace,
@@ -52,6 +55,16 @@ def _mark_trace_as_started(
     trace_state = TraceState.from_trace(original)
     assert trace_state is not None
     return trace_state
+
+
+def test_response_span_data_preserves_falsy_response_id() -> None:
+    class FalsyResponse(Response):
+        def __bool__(self) -> bool:
+            return False
+
+    response = FalsyResponse.model_construct(id="resp_falsy")
+
+    assert ResponseSpanData(response=response).export()["response_id"] == "resp_falsy"
 
 
 def test_create_trace_for_run_reattaches_matching_started_trace() -> None:
@@ -235,6 +248,44 @@ def test_create_trace_for_run_uses_existing_current_trace() -> None:
         assert created is None
 
 
+def test_trace_context_manager_starts_and_finishes_falsy_trace(monkeypatch) -> None:
+    class FalsyTrace:
+        def __init__(self) -> None:
+            self.started = False
+            self.finished = False
+
+        def __bool__(self) -> bool:
+            return False
+
+        def start(self, *, mark_as_current: bool) -> None:
+            assert mark_as_current is True
+            self.started = True
+
+        def finish(self, *, reset_current: bool) -> None:
+            assert reset_current is True
+            self.finished = True
+
+    falsy_trace = FalsyTrace()
+    monkeypatch.setattr(
+        "agents.tracing.context.create_trace_for_run",
+        lambda **kwargs: falsy_trace,
+    )
+
+    manager = TraceCtxManager(
+        workflow_name="workflow",
+        trace_id=None,
+        group_id=None,
+        metadata=None,
+        tracing=None,
+        disabled=False,
+    )
+    with manager:
+        pass
+
+    assert falsy_trace.started is True
+    assert falsy_trace.finished is True
+
+
 def test_trace_logs_warning_when_current_trace_exists(
     caplog,
 ) -> None:
@@ -247,6 +298,32 @@ def test_trace_logs_warning_when_current_trace_exists(
             inner_trace = trace(workflow_name="inner", trace_id=_new_trace_id())
 
     assert isinstance(inner_trace, TraceImpl)
+    assert "Trace already exists" in caplog.text
+
+
+def test_trace_logs_warning_when_current_trace_is_falsy(
+    monkeypatch,
+    caplog,
+) -> None:
+    class FalsyTrace:
+        def __bool__(self) -> bool:
+            return False
+
+    created_trace = object()
+
+    class Provider:
+        def get_current_trace(self):
+            return FalsyTrace()
+
+        def create_trace(self, **_kwargs):
+            return created_trace
+
+    monkeypatch.setattr("agents.tracing.create.get_trace_provider", lambda: Provider())
+
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        result = trace(workflow_name="inner")
+
+    assert result is created_trace
     assert "Trace already exists" in caplog.text
 
 

--- a/tests/tracing/test_tracing_env_disable.py
+++ b/tests/tracing/test_tracing_env_disable.py
@@ -132,3 +132,32 @@ def test_noop_current_span_id_does_not_become_parent_id():
         Scope.reset_current_trace(trace_token)
 
     assert isinstance(span, NoOpSpan)
+
+
+def test_falsy_current_span_becomes_parent() -> None:
+    class FalsySpan(SpanImpl[AgentSpanData]):
+        def __bool__(self) -> bool:
+            return False
+
+    Scope.set_current_trace(None)
+    Scope.set_current_span(None)
+    provider = DefaultTraceProvider()
+    trace = provider.create_trace("active", trace_id="trace_123")
+    parent = FalsySpan(
+        trace_id="trace_123",
+        span_id="span_parent",
+        parent_id=None,
+        processor=provider._multi_processor,
+        span_data=AgentSpanData(name="parent"),
+        tracing_api_key=None,
+    )
+    trace_token = Scope.set_current_trace(trace)
+    span_token = Scope.set_current_span(parent)
+    try:
+        child = provider.create_span(AgentSpanData(name="child"))
+    finally:
+        Scope.reset_current_span(span_token)
+        Scope.reset_current_trace(trace_token)
+
+    assert isinstance(child, SpanImpl)
+    assert child.parent_id == "span_parent"

--- a/tests/voice/test_openai_model_provider.py
+++ b/tests/voice/test_openai_model_provider.py
@@ -1,9 +1,12 @@
 # Tests for the OpenAI voice model provider (OpenAIVoiceModelProvider).
 
+from typing import Any, cast
+
 import openai
 import pytest
 
 from agents.exceptions import UserError
+from agents.models import _openai_shared
 from agents.voice.models.openai_model_provider import OpenAIVoiceModelProvider
 
 
@@ -27,3 +30,14 @@ def test_voice_provider_accepts_client_without_conflicting_args():
     client = openai.AsyncOpenAI(api_key="test_key")
     provider = OpenAIVoiceModelProvider(openai_client=client)
     assert provider._get_client() is client
+
+
+def test_voice_provider_preserves_falsy_default_client(monkeypatch):
+    class FalsyClient:
+        def __bool__(self) -> bool:
+            return False
+
+    client = cast(Any, FalsyClient())
+    monkeypatch.setattr(_openai_shared, "get_default_openai_client", lambda: client)
+
+    assert OpenAIVoiceModelProvider()._get_client() is client

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -69,6 +69,34 @@ def test_streamed_audio_result_odd_length_buffer_int16() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streamed_audio_result_raises_falsy_task_exception() -> None:
+    class FalsyError(RuntimeError):
+        def __bool__(self) -> bool:
+            return False
+
+    result = StreamedAudioResult(
+        FakeTTS(),
+        TTSModelSettings(),
+        VoicePipelineConfig(),
+    )
+    error = FalsyError("failed")
+
+    async def fail() -> None:
+        raise error
+
+    task = asyncio.create_task(fail())
+    result._tasks.append(task)
+    await asyncio.gather(task, return_exceptions=True)
+    await result._queue.put(cast(Any, None))
+
+    with pytest.raises(FalsyError) as exc_info:
+        async for _ in result.stream():
+            pass
+
+    assert exc_info.value is error
+
+
+@pytest.mark.asyncio
 async def test_streamed_audio_result_propagates_consumer_cancellation(monkeypatch) -> None:
     result = StreamedAudioResult(
         FakeTTS(),


### PR DESCRIPTION
This pull request fixes the remaining cases around #4299 where non-`None` Optional reference objects were incorrectly treated as absent because they were falsy.

It updates runtime, resume, tracing, provider, Realtime, sandbox, and voice paths to use explicit `None` checks while preserving intentional empty scalar and container semantics. It also adds a deliberately narrow AST checker to `make lint` that detects direct Optional-reference truthiness mistakes before merge and conservatively excludes complex lexical forms.
