### PR TITLE
fix(run_state): preserve default-valued fields in serialized tool output

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1209,7 +1209,10 @@ class RunState(Generic[TContext, TAgent]):
             serialized_output = item.output
             try:
                 if hasattr(serialized_output, "model_dump"):
-                    serialized_output = serialized_output.model_dump(exclude_unset=True)
+                    # ``output`` is the tool's actual return value, not a wire item, so keep
+                    # fields left at their defaults. ``exclude_unset`` would drop them and make
+                    # the restored ``.output`` disagree with the full model-facing ``raw_item``.
+                    serialized_output = serialized_output.model_dump(mode="json")
                 elif dataclasses.is_dataclass(serialized_output):
                     serialized_output = dataclasses.asdict(serialized_output)  # type: ignore[arg-type]
                 serialized_output = _ensure_json_compatible(serialized_output)

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1212,7 +1212,11 @@ class RunState(Generic[TContext, TAgent]):
                     # ``output`` is the tool's actual return value, not a wire item, so keep
                     # fields left at their defaults. ``exclude_unset`` would drop them and make
                     # the restored ``.output`` disagree with the full model-facing ``raw_item``.
-                    serialized_output = serialized_output.model_dump(mode="json")
+                    # Stay in Python mode and let ``_ensure_json_compatible`` handle JSON
+                    # conversion below: ``mode="json"`` raises on values like non-UTF-8 bytes,
+                    # which would trip the fallback and replace the whole structured output with
+                    # an opaque string instead of a dict.
+                    serialized_output = serialized_output.model_dump()
                 elif dataclasses.is_dataclass(serialized_output):
                     serialized_output = dataclasses.asdict(serialized_output)  # type: ignore[arg-type]
                 serialized_output = _ensure_json_compatible(serialized_output)

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -3049,6 +3049,49 @@ class TestSerializationRoundTrip:
         assert isinstance(restored_item, ToolCallOutputItem)
         assert restored_item.custom_data == {"ui": {"kind": "chart"}, "ids": ["a", "b"]}
 
+    async def test_pydantic_tool_output_preserves_default_fields(self):
+        """A structured tool output's default-valued fields must survive RunState roundtrips.
+
+        ``ToolCallOutputItem.output`` holds the tool's actual return value. Serializing it with
+        ``exclude_unset`` drops fields left at their defaults, so a resumed run would expose an
+        incomplete ``.output`` that disagrees with the full model-facing ``raw_item`` payload.
+        """
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="ItemAgent")
+        state = make_state(agent, context=context, original_input="test", max_turns=5)
+
+        class WeatherReport(BaseModel):
+            temperature: int
+            unit: str = "celsius"
+            humidity: int | None = None
+
+        # Only ``temperature`` is set explicitly; ``unit`` and ``humidity`` keep their defaults.
+        output = WeatherReport(temperature=20)
+        raw_tool_output = {
+            "type": "function_call_output",
+            "call_id": "call_weather",
+            "output": '{"temperature":20,"unit":"celsius","humidity":null}',
+        }
+        state._generated_items.append(
+            ToolCallOutputItem(agent=agent, raw_item=raw_tool_output, output=output)
+        )
+
+        json_data = state.to_json()
+        assert json_data["generated_items"][0]["output"] == {
+            "temperature": 20,
+            "unit": "celsius",
+            "humidity": None,
+        }
+
+        new_state = await RunState.from_json(agent, json_data)
+        restored_item = new_state._generated_items[0]
+        assert isinstance(restored_item, ToolCallOutputItem)
+        assert restored_item.output == {
+            "temperature": 20,
+            "unit": "celsius",
+            "humidity": None,
+        }
+
     async def test_serializes_original_input_with_function_call_output(self):
         """Test that original_input with function_call_output items is preserved."""
         context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -3092,6 +3092,51 @@ class TestSerializationRoundTrip:
             "humidity": None,
         }
 
+    async def test_non_utf8_bytes_tool_output_keeps_dict_shape(self):
+        """A structured output with non-UTF-8 bytes must stay a dict, not collapse to a string.
+
+        Serializing in Python mode keeps default-valued fields and lets ``_ensure_json_compatible``
+        stringify only the offending value. Dumping with ``mode="json"`` would instead raise on the
+        non-UTF-8 bytes, trip the broad fallback, and replace the whole structured output with an
+        opaque ``str(item.output)``.
+        """
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="ItemAgent")
+        state = make_state(agent, context=context, original_input="test", max_turns=5)
+
+        class BlobResult(BaseModel):
+            payload: bytes
+            label: str = "default-label"
+            note: str | None = None
+
+        # An untyped function tool can return an arbitrary Pydantic model; here one field holds
+        # non-UTF-8 bytes while ``label``/``note`` are left at their defaults.
+        output = BlobResult(payload=b"\xff\xfe")
+        raw_tool_output = {
+            "type": "function_call_output",
+            "call_id": "call_blob",
+            "output": "blob stored",
+        }
+        state._generated_items.append(
+            ToolCallOutputItem(agent=agent, raw_item=raw_tool_output, output=output)
+        )
+
+        expected = {
+            "payload": str(b"\xff\xfe"),
+            "label": "default-label",
+            "note": None,
+        }
+
+        json_data = state.to_json()
+        serialized_output = json_data["generated_items"][0]["output"]
+        assert isinstance(serialized_output, dict)
+        assert serialized_output == expected
+
+        new_state = await RunState.from_json(agent, json_data)
+        restored_item = new_state._generated_items[0]
+        assert isinstance(restored_item, ToolCallOutputItem)
+        assert restored_item.output == expected
+
     async def test_serializes_original_input_with_function_call_output(self):
         """Test that original_input with function_call_output items is preserved."""
         context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})


### PR DESCRIPTION
## Summary

`RunState` serialization dropped default-valued fields from a structured tool
output, so a serialize/resume round trip returned an **incomplete**
`ToolCallOutputItem.output`.

## Component

`src/agents/run_state.py` — `RunState._serialize_item` (the `output` field of
`ToolCallOutputItem`).

## Problem

`ToolCallOutputItem.output` holds the tool's **actual return value** (e.g. the
Pydantic model a function tool returned). `_serialize_item` serialized it with:

```python
serialized_output = serialized_output.model_dump(exclude_unset=True)
```

`exclude_unset=True` is the right choice for *wire items* (it mirrors what the
API sent), and it is used deliberately in `_serialize_raw_item_value`. But
`output` is application data, not a wire item. `exclude_unset` drops any field
left at its default, so those values are lost when the state is serialized and
resumed.

This is also internally inconsistent:

- The **model-facing** `raw_item.output` keeps every field — it is built with a
  full `dump_python(mode="json", by_alias=True)` in `ItemHelpers.tool_call_output_item`.
- The **dataclass** branch of the same `_serialize_item` block already keeps
  defaults via `dataclasses.asdict`.

Only the Pydantic branch of `.output` silently discarded them.

### Reproduction (no network / no API key)

```python
class WeatherReport(BaseModel):
    temperature: int
    unit: str = "celsius"
    humidity: int | None = None

# only `temperature` is set explicitly
state._generated_items.append(
    ToolCallOutputItem(agent=agent, raw_item=raw_output, output=WeatherReport(temperature=20))
)
json_data = state.to_json()
new_state = await RunState.from_json(agent, json_data)
```

- **Before:** `new_state._generated_items[0].output == {"temperature": 20}`
  (`unit` and `humidity` are gone).
- **After:** `{"temperature": 20, "unit": "celsius", "humidity": None}`.

## Root cause

`model_dump(exclude_unset=True)` on a value that is user data, not a wire item,
excludes every field the caller left at its default.

## Fix

Drop `exclude_unset` and dump the output with plain `model_dump()` (Python mode),
then let the existing `_ensure_json_compatible` pass do the JSON conversion — the
same approach the sibling app-data serializers (`_serialize_context_payload`,
`_serialize_tool_input`) already use.

Staying in Python mode matters: `model_dump(mode="json")` **raises** on values
such as non-UTF-8 bytes, which would trip the broad `except` fallback and replace
the whole structured output with an opaque `str(item.output)` instead of the dict
the base branch preserves. Python-mode `model_dump()` keeps the dict shape and
`_ensure_json_compatible` stringifies only the offending value.

The dataclass and non-model paths are unchanged; `raw_item` serialization is
untouched.

## Why minimal

One expression changed (remove `exclude_unset=True`). No public API, signature,
exception type, or wire-format change. `raw_item` (the model-facing payload) is
not touched.

## Tests

Two round-trip tests in `TestSerializationRoundTrip`:

- `test_pydantic_tool_output_preserves_default_fields` — a Pydantic output with a
  field left at its default; fails on `main` (restored `.output == {"temperature": 20}`),
  passes with this change.
- `test_non_utf8_bytes_tool_output_keeps_dict_shape` — a Pydantic output holding
  **non-UTF-8 bytes plus a default-valued field**; asserts the serialized value
  stays a `dict` (not an opaque string) and survives the full `to_json`/`from_json`
  round trip. This one fails if the dump is switched to `mode="json"`.

## Validation

- `uv run pytest tests/` → **7192 passed, 39 skipped** (after `uv sync --all-extras --all-groups`)
- `uv run pytest tests/test_run_state.py tests/test_hitl_error_scenarios.py tests/test_shell_call_serialization.py` → 415 passed
- `uv run ruff format --check` / `uv run ruff check` → clean
- `uv run mypy src/agents/run_state.py` → clean
- `uv run pyright src/agents/run_state.py tests/test_run_state.py` → 0 errors
- `git diff --check` → clean

Full-repo mypy/pyright were not re-run beyond the changed files; the change is a
single expression with no signature or type changes.

## Compatibility

No breaking change. Previously-serialized states still deserialize; only newly
serialized outputs now carry the fields that were being dropped.
