### PR TITLE
fix(items): strip output-only created_by when replaying model output as input

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -230,6 +230,20 @@ def _output_item_to_input_item(raw_item: Any) -> TResponseInputItem:
     # carry it (apply_patch/shell calls and tool-call outputs); the tool_search branch above
     # already drops it, so do the same for every other item type.
     payload.pop("created_by", None)
+    if item_type == "shell_call_output":
+        # ``shell_call_output.output`` is a list of content chunks that each carry their own
+        # output-only ``created_by``. ``payload`` was only shallow-copied above, so rebuild the
+        # list with fresh chunk copies to strip the nested field without mutating the caller's
+        # original mapping. Mirrors the two-level stripping the runner already does in
+        # ``turn_resolution``.
+        chunks = payload.get("output")
+        if isinstance(chunks, list):
+            payload["output"] = [
+                {key: value for key, value in chunk.items() if key != "created_by"}
+                if isinstance(chunk, dict)
+                else chunk
+                for chunk in chunks
+            ]
     return cast(TResponseInputItem, payload)
 
 

--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -211,7 +211,7 @@ def _tool_search_item_to_input_item(
 
 
 def _output_item_to_input_item(raw_item: Any) -> TResponseInputItem:
-    """Convert an output item into replayable input, normalizing tool_search items."""
+    """Convert an output item into replayable input, stripping output-only metadata."""
     item_type = (
         raw_item.get("type") if isinstance(raw_item, dict) else getattr(raw_item, "type", None)
     )
@@ -219,11 +219,18 @@ def _output_item_to_input_item(raw_item: Any) -> TResponseInputItem:
         return _tool_search_item_to_input_item(raw_item)
 
     if isinstance(raw_item, dict):
-        return cast(TResponseInputItem, dict(raw_item))
-    if isinstance(raw_item, BaseModel):
-        return cast(TResponseInputItem, raw_item.model_dump(exclude_unset=True))
+        payload = dict(raw_item)
+    elif isinstance(raw_item, BaseModel):
+        payload = raw_item.model_dump(exclude_unset=True)
+    else:
+        raise AgentsException(f"Unexpected raw item type: {type(raw_item)}")
 
-    raise AgentsException(f"Unexpected raw item type: {type(raw_item)}")
+    # ``created_by`` is server-assigned, output-only metadata that is absent from the Responses
+    # input-item schema, so it must not be replayed back to the API. Several output item types
+    # carry it (apply_patch/shell calls and tool-call outputs); the tool_search branch above
+    # already drops it, so do the same for every other item type.
+    payload.pop("created_by", None)
+    return cast(TResponseInputItem, payload)
 
 
 def _copy_tool_search_mapping(raw_item: Mapping[str, Any]) -> dict[str, Any]:
@@ -694,9 +701,10 @@ class ModelResponse:
 
     def to_input_items(self) -> list[TResponseInputItem]:
         """Convert the output into a list of input items suitable for passing to the model."""
-        # Most output items can be replayed via a direct model_dump. Tool-search items carry
-        # output-only metadata such as `created_by`, so they must go through the same replay
-        # sanitizer used elsewhere in the runtime.
+        # Most output items can be replayed via a direct model_dump, but several types (tool
+        # search, apply_patch/shell calls, and tool-call outputs) carry output-only metadata
+        # such as `created_by` that is not part of the input schema, so they go through the
+        # replay sanitizer that strips it before the items are sent back to the model.
         return [_output_item_to_input_item(it) for it in self.output]
 
 

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import pytest
 from openai.types.responses.computer_action import Click as BatchedClick, Type as BatchedType
+from openai.types.responses.response_apply_patch_tool_call import ResponseApplyPatchToolCall
 from openai.types.responses.response_computer_tool_call import (
     ActionScreenshot,
     ResponseComputerToolCall,
@@ -17,6 +18,9 @@ from openai.types.responses.response_file_search_tool_call_param import (
     ResponseFileSearchToolCallParam,
 )
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
+from openai.types.responses.response_function_tool_call_output_item import (
+    ResponseFunctionToolCallOutputItem,
+)
 from openai.types.responses.response_function_tool_call_param import ResponseFunctionToolCallParam
 from openai.types.responses.response_function_web_search import (
     ActionSearch,
@@ -559,6 +563,59 @@ def test_to_input_items_for_tool_search_strips_created_by() -> None:
             "type": "tool_search_output",
         },
     ]
+
+
+def test_to_input_items_strips_created_by_for_non_tool_search_items() -> None:
+    """Output-only ``created_by`` must be stripped for every replayed item, not just tool search.
+
+    ``created_by`` is server-assigned metadata that is absent from the Responses input-item
+    schema, so replaying it back to the API is invalid. The tool-search branch already strips
+    it; apply-patch calls and tool-call outputs (which also carry the field) must behave the
+    same way.
+    """
+    apply_patch_call = ResponseApplyPatchToolCall.model_validate(
+        {
+            "id": "apc_1",
+            "call_id": "call_1",
+            "type": "apply_patch_call",
+            "status": "completed",
+            "operation": {"type": "delete_file", "path": "foo.py"},
+            "created_by": "program_1",
+        }
+    )
+    function_call_output = ResponseFunctionToolCallOutputItem.model_validate(
+        {
+            "id": "fco_1",
+            "call_id": "call_1",
+            "type": "function_call_output",
+            "output": "done",
+            "status": "completed",
+            "created_by": "program_1",
+        }
+    )
+
+    resp = ModelResponse(
+        output=[apply_patch_call, function_call_output], usage=Usage(), response_id=None
+    )
+    input_items = resp.to_input_items()
+
+    assert input_items == [
+        {
+            "id": "apc_1",
+            "call_id": "call_1",
+            "operation": {"path": "foo.py", "type": "delete_file"},
+            "status": "completed",
+            "type": "apply_patch_call",
+        },
+        {
+            "id": "fco_1",
+            "call_id": "call_1",
+            "output": "done",
+            "status": "completed",
+            "type": "function_call_output",
+        },
+    ]
+    assert all("created_by" not in item for item in input_items)
 
 
 def test_input_to_new_input_list_copies_the_ones_produced_by_pydantic() -> None:

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -53,7 +53,7 @@ from agents import (
     TResponseInputItem,
     Usage,
 )
-from agents.items import ToolCallItem, ToolCallOutputItem
+from agents.items import ToolCallItem, ToolCallOutputItem, TResponseOutputItem
 
 
 def make_message(
@@ -650,7 +650,9 @@ def test_to_input_items_strips_nested_created_by_from_shell_call_output() -> Non
     raw_item = shell_output.model_dump(exclude_unset=True)
     original_chunk = raw_item["output"][0]
 
-    resp = ModelResponse(output=[raw_item], usage=Usage(), response_id=None)
+    resp = ModelResponse(
+        output=[cast(TResponseOutputItem, raw_item)], usage=Usage(), response_id=None
+    )
     input_items = resp.to_input_items()
 
     assert input_items == [

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -17,6 +17,9 @@ from openai.types.responses.response_file_search_tool_call import ResponseFileSe
 from openai.types.responses.response_file_search_tool_call_param import (
     ResponseFileSearchToolCallParam,
 )
+from openai.types.responses.response_function_shell_tool_call_output import (
+    ResponseFunctionShellToolCallOutput,
+)
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 from openai.types.responses.response_function_tool_call_output_item import (
     ResponseFunctionToolCallOutputItem,
@@ -616,6 +619,61 @@ def test_to_input_items_strips_created_by_for_non_tool_search_items() -> None:
         },
     ]
     assert all("created_by" not in item for item in input_items)
+
+
+def test_to_input_items_strips_nested_created_by_from_shell_call_output() -> None:
+    """``shell_call_output`` carries ``created_by`` at the item level and inside each output chunk.
+
+    Both levels are output-only and absent from the input schema, so both must be stripped on
+    replay (mirroring the two-level stripping the runner does in ``turn_resolution``). The
+    original mapping input must not be mutated in the process.
+    """
+    shell_output = ResponseFunctionShellToolCallOutput.model_validate(
+        {
+            "id": "sco_1",
+            "call_id": "call_1",
+            "type": "shell_call_output",
+            "status": "completed",
+            "created_by": "program_top",
+            "output": [
+                {
+                    "outcome": {"type": "exit", "exit_code": 0},
+                    "stdout": "hi",
+                    "stderr": "",
+                    "created_by": "program_chunk",
+                }
+            ],
+        }
+    )
+    # A dict-form item shares its nested chunk dicts with the caller, so replaying must not
+    # mutate them.
+    raw_item = shell_output.model_dump(exclude_unset=True)
+    original_chunk = raw_item["output"][0]
+
+    resp = ModelResponse(output=[raw_item], usage=Usage(), response_id=None)
+    input_items = resp.to_input_items()
+
+    assert input_items == [
+        {
+            "id": "sco_1",
+            "call_id": "call_1",
+            "type": "shell_call_output",
+            "status": "completed",
+            "output": [
+                {
+                    "outcome": {"type": "exit", "exit_code": 0},
+                    "stdout": "hi",
+                    "stderr": "",
+                }
+            ],
+        }
+    ]
+    replayed = cast(dict[str, Any], input_items[0])
+    assert "created_by" not in replayed
+    assert "created_by" not in replayed["output"][0]
+    # The caller's original mapping (and its nested chunk) is untouched.
+    assert original_chunk["created_by"] == "program_chunk"
+    assert raw_item["created_by"] == "program_top"
 
 
 def test_input_to_new_input_list_copies_the_ones_produced_by_pydantic() -> None:


### PR DESCRIPTION
### Summary

`ModelResponse.to_input_items()` replays each model output item back as a Responses API **input** item. Several output item types carry a server-assigned, output-only `created_by` field that is **not** part of the input-item schema:

- `apply_patch_call` and `shell_call` (supported `ApplyPatchTool` / `ShellTool` calls)
- `function_call_output`, `custom_tool_call_output`, `computer_call_output` (tool-call outputs)
- `tool_search_call` / `tool_search_output`

The replay sanitizer in `_output_item_to_input_item` only stripped `created_by` for the two `tool_search` types, so every other type leaked `created_by` straight back to the API on replay.

`created_by` is not accepted by any input-item param in the OpenAI SDK schema, and the SDK already strips it at resolution time for shell/apply_patch calls (`turn_resolution.py`) and for tool_search (`_tool_search_item_to_input_item`). The direct `ModelResponse.to_input_items()` replay path bypassed that resolution-time stripping, leaving the field in place.

**Fix:** strip `created_by` for every replayed item in `_output_item_to_input_item`, generalizing the existing tool_search behavior. `created_by` is never read by any SDK logic (it is only ever popped), so dropping it on replay is safe.

Before:

```python
resp = ModelResponse(output=[apply_patch_call_with_created_by], usage=Usage(), response_id=None)
resp.to_input_items()
# [{'id': 'apc_1', 'call_id': 'call_1', 'operation': {...}, 'status': 'completed',
#   'type': 'apply_patch_call', 'created_by': 'program_1'}]   # <-- leaked
```

After:

```python
# [{'id': 'apc_1', 'call_id': 'call_1', 'operation': {...}, 'status': 'completed',
#   'type': 'apply_patch_call'}]   # created_by stripped
```

The behavior is otherwise unchanged: items are still converted via the same `dict(...)` / `model_dump(exclude_unset=True)` logic, and the `AgentsException` fallback for unexpected types is preserved. The only caller affected is `ModelResponse.to_input_items()`; the two other callers (`_fingerprint_for_tracker`, `_anonymous_tool_search_fingerprint` in `oai_conversation.py`) only pass `tool_search` items, which already routed through the created_by-stripping branch.

### Test plan

- Added `test_to_input_items_strips_created_by_for_non_tool_search_items` in `tests/test_items_helpers.py`, which builds an `apply_patch_call` and a `function_call_output` output item with `created_by` set and asserts the field is dropped on replay. It fails on `main` (leaks `created_by`) and passes with this change.
- The existing `test_to_input_items_for_tool_search_strips_created_by` and all other `to_input_items` round-trip tests still pass.
- Commands run locally:
  - `uv run pytest tests/test_items_helpers.py` → 36 passed
  - `uv run pytest tests/test_items_helpers.py tests/memory tests/test_agent_runner.py tests/test_run_state.py tests/test_server_conversation_tracker.py tests/test_programmatic_tool_calling.py` → 903 passed
  - `uv run ruff format --check` and `uv run ruff check` → clean
  - `uv run python .github/scripts/check_optional_truthiness.py src/agents` → clean
  - `uv run mypy src/agents/items.py` → Success
  - `uv run pyright src/agents/items.py tests/test_items_helpers.py` → 0 errors

Not run: the full test matrix and integration/coverage profiles (they require provider credentials / live services, which are unrelated to this change).

### Issue number

N/A — no existing issue.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
