### PR TITLE
fix(models): raise on audio output in the streamed chat completions path

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -48,7 +48,7 @@ from openai.types.responses.response_reasoning_text_done_event import (
 )
 from openai.types.responses.response_usage import OutputTokensDetails
 
-from ..exceptions import ModelBehaviorError, UserError
+from ..exceptions import AgentsException, ModelBehaviorError, UserError
 from ..items import TResponseStreamEvent
 from ..logger import logger
 from ..usage import (
@@ -297,6 +297,9 @@ class ChatCmplStreamHandler:
             return True
 
         if getattr(delta, "annotations", None):
+            return True
+
+        if getattr(delta, "audio", None):
             return True
 
         return False
@@ -672,6 +675,11 @@ class ChatCmplStreamHandler:
 
             delta = choice.delta
             choice_logprobs = choice.logprobs
+
+            if getattr(delta, "audio", None):
+                # The sync converter rejects audio output; a silent empty stream would
+                # diverge from that released behavior.
+                raise AgentsException("Audio is not currently supported")
 
             # Handle thinking blocks from Anthropic (for preserving signatures)
             if hasattr(delta, "thinking_blocks") and delta.thinking_blocks:

--- a/tests/models/test_openai_chatcompletions_converter.py
+++ b/tests/models/test_openai_chatcompletions_converter.py
@@ -47,7 +47,7 @@ from openai.types.responses import (
 from openai.types.responses.response_input_item_param import FunctionCallOutput
 
 from agents.agent_output import AgentOutputSchema
-from agents.exceptions import UserError
+from agents.exceptions import AgentsException, UserError
 from agents.items import TResponseInputItem
 from agents.models.chatcmpl_converter import Converter
 from agents.models.fake_id import FAKE_RESPONSES_ID
@@ -72,6 +72,27 @@ def test_message_to_output_items_with_text_only():
     text_part = cast(ResponseOutputText, message_item.content[0])
     assert text_part.type == "output_text"
     assert text_part.text == "Hello"
+
+
+def test_message_to_output_items_rejects_audio():
+    """
+    Audio output is unsupported by the Chat Completions converter, and the failure
+    must be loud so callers do not receive a silently truncated message.
+    """
+    msg = ChatCompletionMessage.model_validate(
+        {
+            "role": "assistant",
+            "content": None,
+            "audio": {
+                "id": "audio-1",
+                "data": "AAA=",
+                "expires_at": 1,
+                "transcript": "hi",
+            },
+        }
+    )
+    with pytest.raises(AgentsException, match="Audio is not currently supported"):
+        Converter.message_to_output_items(msg)
 
 
 def test_message_to_output_items_keeps_url_citation_annotations():

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -35,7 +35,7 @@ from openai.types.responses import (
 )
 
 from agents import Agent, Runner, function_tool, trace
-from agents.exceptions import ModelBehaviorError, UserError
+from agents.exceptions import AgentsException, ModelBehaviorError, UserError
 from agents.model_settings import ModelSettings
 from agents.models.chatcmpl_converter import Converter
 from agents.models.chatcmpl_stream_handler import (
@@ -783,6 +783,26 @@ def test_finish_reasoning_summary_part_clears_invalid_active_index() -> None:
 
 
 @pytest.mark.asyncio
+async def test_audio_delta_raises_like_the_sync_path() -> None:
+    """Audio output must fail loudly on the streamed path, matching the sync converter."""
+    chunk = _annotated_chunk({"content": "partial", "audio": {"id": "audio-1", "transcript": "hi"}})
+
+    with pytest.raises(AgentsException, match="Audio is not currently supported"):
+        await _collect_handler_events(chunk)
+
+
+@pytest.mark.asyncio
+async def test_buffered_audio_only_delta_raises_instead_of_completing_empty() -> None:
+    """Tool-call buffering must not swallow an audio-only delta into a silent empty run."""
+    audio_chunk = _annotated_chunk({"audio": {"id": "audio-1", "transcript": "hi"}})
+
+    buffered = ChatCmplStreamHandler.buffer_tool_call_stream(_completion_stream(audio_chunk))
+    with pytest.raises(AgentsException, match="Audio is not currently supported"):
+        async for _ in ChatCmplStreamHandler.handle_stream(_empty_response(), cast(Any, buffered)):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_buffer_tool_call_stream_preserves_empty_choice_chunks() -> None:
     chunk = ChatCompletionChunk(
         id="chunk-id",
@@ -842,6 +862,7 @@ async def test_buffer_tool_call_stream_keeps_passthrough_index_passthrough() -> 
         (ChoiceDelta.model_construct(reasoning_content="summary"), True),
         (ChoiceDelta.model_construct(reasoning="scratchpad"), True),
         (ChoiceDelta.model_construct(thinking_blocks=[{"thinking": "hidden"}]), True),
+        (ChoiceDelta.model_construct(audio={"id": "audio-1"}), True),
     ],
 )
 def test_stream_handler_detects_passthrough_delta_shapes(


### PR DESCRIPTION
### Summary

`Runner.run` raises `AgentsException("Audio is not currently supported")` when the message carries audio, while `Runner.run_streamed` could complete silently with empty output. The stream handler had no audio handling, and with `buffer_streamed_tool_calls=True` the buffering pre-pass dropped audio-only chunks because `_delta_has_passthrough_output` did not recognize them. This left the sync and streamed runners behaviorally inconsistent.

`_delta_has_passthrough_output` now recognizes `delta.audio` so buffering forwards the chunk, and `handle_stream` raises the same `AgentsException` with the released sync message when a delta carries audio (e.g. `gpt-4o-audio-preview` streamed through the Chat Completions path). The raise is unconditional to match the released sync behavior: the sync converter does not gate audio rejection behind `strict_feature_validation`, so gating only the streamed path would preserve the divergence by default. LiteLLM and any-llm streams funnel through the same handler and inherit the fix; their sync conversions already carry `message.audio` into the raising converter.

One corner-case error changes: a malformed stream ending with `finish_reason="tool_calls"`, an audio-only delta, and no buffered calls previously raised `ModelBehaviorError` about missing tool call deltas; it now raises the audio `AgentsException`, which is the more accurate error for that stream.

### Test plan

Two new streamed regressions fail on `main` with `DID NOT RAISE`: a mixed audio+content delta on the direct handler path, and an audio-only delta through the composed buffering pipeline, which currently completes with zero output items. Additional coverage: the passthrough classifier parametrization gains the audio shape, and a converter test pins the previously untested released sync raise.

`.agents/skills/code-change-verification/scripts/run.sh` passes.

### Issue number

N/A — self-discovered while auditing streaming/non-streaming parity of the Chat Completions adapter.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
