### PR TITLE
fix: keep FunctionTool subclasses copyable

### DIFF
--- a/src/agents/sandbox/capabilities/capability.py
+++ b/src/agents/sandbox/capabilities/capability.py
@@ -6,7 +6,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from ...items import TResponseInputItem
-from ...tool import Tool
+from ...tool import FunctionTool, Tool
 from ..manifest import Manifest
 from ..session.base_sandbox_session import BaseSandboxSession
 from ..types import User
@@ -90,6 +90,8 @@ def _clone_capability_value(value: Any) -> Any:
     if hasattr(value, "__dict__"):
         cloned = copy.copy(value)
         for name, nested in value.__dict__.items():
+            if isinstance(value, FunctionTool) and name == "on_invoke_tool":
+                continue
             setattr(cloned, name, _clone_capability_value(nested))
         return cloned
     try:

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 import asyncio
 import copy
-import dataclasses
 import functools
 import inspect
 import json
@@ -600,15 +599,18 @@ class FunctionTool:
         _validate_function_tool_timeout_config(self)
 
     def __copy__(self) -> FunctionTool:
-        copied_tool = dataclasses.replace(self)
-        dataclass_field_names = {tool_field.name for tool_field in dataclasses.fields(FunctionTool)}
-        for tool_field in dataclasses.fields(FunctionTool):
-            if tool_field.init:
-                continue
-            setattr(copied_tool, tool_field.name, getattr(self, tool_field.name))
-        for attr_name, attr_value in self.__dict__.items():
-            if attr_name not in dataclass_field_names:
-                setattr(copied_tool, attr_name, attr_value)
+        # Rebuild the instance state directly instead of re-running the constructor, so
+        # FunctionTool subclasses that define their own __init__ signature stay copyable.
+        copied_tool = object.__new__(type(self))
+        copied_tool.__dict__.update(self.__dict__)
+        # A subclass may pass one of its own bound methods as the invoker, e.g.
+        # on_invoke_tool=self._invoke. Copying the __dict__ carries that binding over
+        # unchanged, so the copy would run against the original instance's state.
+        invoker = copied_tool.__dict__.get("on_invoke_tool")
+        if inspect.ismethod(invoker) and getattr(invoker, "__self__", None) is self:
+            copied_tool.on_invoke_tool = invoker.__func__.__get__(copied_tool, type(copied_tool))
+        # Reapply FunctionTool normalization without rerunning subclass lifecycle hooks.
+        FunctionTool.__post_init__(copied_tool)
         return copied_tool
 
 

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -87,7 +87,8 @@ from agents.sandbox.session.sandbox_session_state import SandboxSessionState
 from agents.sandbox.snapshot import LocalSnapshotSpec, NoopSnapshot, SnapshotBase
 from agents.sandbox.types import ExecResult
 from agents.stream_events import RunItemStreamEvent
-from agents.tool import Tool
+from agents.tool import FunctionTool, Tool
+from agents.tool_context import ToolContext
 from agents.tracing import trace
 from tests.fake_model import FakeModel
 from tests.test_responses import (
@@ -664,6 +665,25 @@ class _NestedObjectCapability(Capability):
             type="nested-object-state",
             **cast(Any, {"state": _NestedObjectState()}),
         )
+
+
+class _StatefulFunctionTool(FunctionTool):
+    def __init__(self, state: str) -> None:
+        self.state = state
+        super().__init__(
+            name="stateful_tool",
+            description="Return state from the tool instance.",
+            params_json_schema={},
+            on_invoke_tool=self._invoke,
+        )
+
+    async def _invoke(self, _ctx: ToolContext[Any], _raw_input: str) -> str:
+        return self.state
+
+
+class _ToolStateCapability(Capability):
+    type: Literal["tool-state"] = "tool-state"
+    tool: Any
 
 
 class _AwaitableSessionCapability(Capability):
@@ -4667,6 +4687,43 @@ def test_capability_clone_preserves_session_field_identity() -> None:
     assert cloned.session is session
     assert capability.model_dump() == {"type": "shell"}
     assert cloned.model_dump() == {"type": "shell"}
+
+
+@pytest.mark.asyncio
+async def test_capability_clone_preserves_function_tool_invoker_owner() -> None:
+    original_tool = _StatefulFunctionTool("original")
+    capability = _ToolStateCapability(tool=original_tool)
+
+    cloned = cast(_ToolStateCapability, capability.clone())
+    cloned_tool = cast(_StatefulFunctionTool, cloned.tool)
+    cloned_tool.state = "cloned"
+
+    assert cloned_tool is not original_tool
+    assert getattr(cloned_tool.on_invoke_tool, "__self__", None) is cloned_tool
+    assert (
+        await cloned_tool.on_invoke_tool(
+            ToolContext(
+                None,
+                tool_name=cloned_tool.name,
+                tool_call_id="1",
+                tool_arguments="{}",
+            ),
+            "{}",
+        )
+        == "cloned"
+    )
+    assert (
+        await original_tool.on_invoke_tool(
+            ToolContext(
+                None,
+                tool_name=original_tool.name,
+                tool_call_id="2",
+                tool_arguments="{}",
+            ),
+            "{}",
+        )
+        == "original"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -820,6 +820,143 @@ async def test_shallow_copied_function_tool_normal_failure_uses_copied_policy() 
     assert cast(Any, copied_tool).custom_state is custom_state
 
 
+@dataclasses.dataclass(init=False)
+class _CustomConstructorFunctionTool(FunctionTool):
+    """FunctionTool subclass with its own constructor, like the sandbox shell tools."""
+
+    session: Any = dataclasses.field(init=False, repr=False, compare=False)
+
+    def __init__(self, *, session: Any) -> None:
+        self.session = session
+        super().__init__(
+            name="custom_constructor_tool",
+            description="Tool with a custom constructor.",
+            params_json_schema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": False,
+            },
+            on_invoke_tool=self._invoke,
+        )
+
+    async def _invoke(self, _ctx: ToolContext[Any], raw_input: str) -> str:
+        # Reads instance state so a copy that is still bound to the original is visible.
+        return f"{self.session}:{raw_input}"
+
+
+@dataclasses.dataclass
+class _PostInitStateFunctionTool(FunctionTool):
+    """FunctionTool subclass whose lifecycle hook owns additional shallow state."""
+
+    post_init_calls: int = dataclasses.field(default=0, init=False)
+    derived_state: list[str] = dataclasses.field(default_factory=list, init=False)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.post_init_calls += 1
+        self.derived_state.append(f"initialized-{self.post_init_calls}")
+
+
+def _tool_context(tool: FunctionTool) -> ToolContext[Any]:
+    return ToolContext(None, tool_name=tool.name, tool_call_id="1", tool_arguments="{}")
+
+
+@pytest.mark.asyncio
+async def test_shallow_copy_supports_function_tool_subclass_constructors() -> None:
+    session = object()
+    original_tool = _CustomConstructorFunctionTool(session=session)
+
+    copied_tool = copy.copy(original_tool)
+
+    assert isinstance(copied_tool, _CustomConstructorFunctionTool)
+    assert copied_tool is not original_tool
+    assert copied_tool.session is session
+    assert copied_tool.name == original_tool.name
+    assert await copied_tool.on_invoke_tool(_tool_context(copied_tool), "{}") == f"{session}:{{}}"
+
+
+@pytest.mark.asyncio
+async def test_shallow_copied_subclass_invoker_uses_the_copied_instance_state() -> None:
+    original_tool = _CustomConstructorFunctionTool(session="original-session")
+
+    copied_tool = copy.copy(original_tool)
+    copied_tool.session = "copied-session"
+
+    # The subclass passes its own bound method as the invoker, so the copy must be
+    # rebound; otherwise it keeps reading the original instance's session.
+    assert await copied_tool.on_invoke_tool(_tool_context(copied_tool), "{}") == (
+        "copied-session:{}"
+    )
+    assert await original_tool.on_invoke_tool(_tool_context(original_tool), "{}") == (
+        "original-session:{}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shallow_copy_preserves_callable_with_bound_method_metadata() -> None:
+    async def invoke(_ctx: ToolContext[Any], raw_input: str) -> str:
+        return raw_input
+
+    async def metadata_target(_tool: FunctionTool, _ctx: ToolContext[Any], _raw_input: str) -> str:
+        return "metadata-target"
+
+    class CallableProxy:
+        def __init__(self, owner: FunctionTool) -> None:
+            self.__self__ = owner
+            self.__func__ = metadata_target
+
+        async def __call__(self, _ctx: ToolContext[Any], _raw_input: str) -> str:
+            return "proxy-call"
+
+    original_tool = FunctionTool(
+        name="callable_proxy_tool",
+        description="Tool with bound-method-like callable metadata.",
+        params_json_schema={},
+        on_invoke_tool=invoke,
+    )
+    proxy = CallableProxy(original_tool)
+    original_tool.on_invoke_tool = proxy
+
+    copied_tool = copy.copy(original_tool)
+
+    assert copied_tool.on_invoke_tool is proxy
+    assert await copied_tool.on_invoke_tool(_tool_context(copied_tool), "{}") == "proxy-call"
+
+
+def test_shallow_copy_does_not_rerun_subclass_post_init() -> None:
+    async def invoke(_ctx: ToolContext[Any], raw_input: str) -> str:
+        return raw_input
+
+    original_tool = _PostInitStateFunctionTool(
+        name="post_init_tool",
+        description="Tool with subclass post-init state.",
+        params_json_schema={},
+        on_invoke_tool=invoke,
+    )
+    original_tool.derived_state.append("mutated")
+
+    copied_tool = copy.copy(original_tool)
+
+    assert copied_tool.post_init_calls == 1
+    assert copied_tool.derived_state is original_tool.derived_state
+    assert copied_tool.derived_state == ["initialized-1", "mutated"]
+
+
+def test_tool_namespace_supports_function_tool_subclass_constructors() -> None:
+    original_tool = _CustomConstructorFunctionTool(session=object())
+
+    namespaced_tool = tool_namespace(
+        name="workspace",
+        description="Workspace tools.",
+        tools=[original_tool],
+    )[0]
+
+    assert isinstance(namespaced_tool, _CustomConstructorFunctionTool)
+    assert namespaced_tool.qualified_name == "workspace.custom_constructor_tool"
+    assert original_tool.qualified_name == "custom_constructor_tool"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("copy_style", ["replace", "shallow_copy"])
 async def test_copied_function_tool_invalid_input_uses_current_name(copy_style: str) -> None:


### PR DESCRIPTION
This pull request supersedes #4273 and fixes shallow copying for `FunctionTool` subclasses that define custom constructors.

`FunctionTool.__copy__` now reconstructs dict-backed subclass instances without replaying their constructor, rebinds only genuine self-bound invokers to the copied instance, and reapplies base normalization without rerunning subclass lifecycle hooks. Sandbox capability cloning preserves the copied tool's invoker ownership while continuing to recursively clone other per-run state, preventing cloned tools from invoking against original state.

Regression coverage includes custom constructors, tool namespaces, callable proxies, subclass post-init state, wrapper normalization, and capability-clone isolation.
