### PR TITLE
fix(run): preserve streamed guardrail session state

### DIFF
--- a/src/agents/exceptions.py
+++ b/src/agents/exceptions.py
@@ -24,33 +24,35 @@ _DATA_REDACTED_ATTR = "_agents_data_redacted"
 _DATA_REDACTED_ERROR_MESSAGE = "Error details are redacted."
 
 
-def _mark_error_to_drain_stream_events(error: Exception) -> None:
+def _mark_error_to_drain_stream_events(error: BaseException) -> None:
     setattr(error, _DRAIN_STREAM_EVENTS_ATTR, True)
 
 
-def _should_drain_stream_events_before_raising(error: Exception) -> bool:
+def _should_drain_stream_events_before_raising(error: BaseException) -> bool:
     return bool(getattr(error, _DRAIN_STREAM_EVENTS_ATTR, False))
 
 
-def _mark_error_data_redacted(error: Exception) -> None:
+def _mark_error_data_redacted(error: BaseException) -> None:
     setattr(error, _DATA_REDACTED_ATTR, True)
 
 
-def _is_error_data_redacted(error: Exception) -> bool:
+def _is_error_data_redacted(error: BaseException) -> bool:
     return bool(getattr(error, _DATA_REDACTED_ATTR, False))
 
 
-def _clear_data_redacted_error_traceback(error: Exception) -> None:
+def _clear_data_redacted_error_traceback(error: BaseException) -> None:
     if _is_error_data_redacted(error) and error.__traceback__ is not None:
         traceback.clear_frames(error.__traceback__)
 
 
-def _detach_data_redacted_error_traceback(error: Exception) -> None:
+def _detach_data_redacted_error_traceback(error: BaseException) -> None:
     if _is_error_data_redacted(error):
         error.__traceback__ = None
+        error.__cause__ = None
+        error.__context__ = None
 
 
-def _raise_data_redacted_error(error: Exception) -> NoReturn:
+def _raise_data_redacted_error(error: BaseException) -> NoReturn:
     """Raise a detached redacted error from a frame that owns no payload data."""
     raise error from None
 

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -575,7 +575,7 @@ class RunResultStreaming(RunResultBase):
     _input_guardrails_task: asyncio.Task[Any] | None = field(default=None, repr=False)
     _triggered_input_guardrail_result: InputGuardrailResult | None = field(default=None, repr=False)
     _output_guardrails_task: asyncio.Task[Any] | None = field(default=None, repr=False)
-    _stored_exception: Exception | None = field(default=None, repr=False)
+    _stored_exception: BaseException | None = field(default=None, repr=False)
     _cancel_mode: Literal["none", "immediate", "after_turn"] = field(default="none", repr=False)
     _last_processed_response: ProcessedResponse | None = field(default=None, repr=False)
     """The last processed model response. This is needed for resuming from interruptions."""
@@ -988,7 +988,7 @@ class RunResultStreaming(RunResultBase):
         if self.run_loop_task and self.run_loop_task.done():
             if not self.run_loop_task.cancelled():
                 run_impl_exc = self.run_loop_task.exception()
-                if isinstance(run_impl_exc, Exception):
+                if run_impl_exc is not None:
                     if (
                         isinstance(run_impl_exc, AgentsException)
                         and run_impl_exc.run_data is None
@@ -1008,18 +1008,6 @@ class RunResultStreaming(RunResultBase):
                     ):
                         in_guard_exc.run_data = self._create_error_details()
                     self._stored_exception = in_guard_exc
-
-        if self._output_guardrails_task and self._output_guardrails_task.done():
-            if not self._output_guardrails_task.cancelled():
-                out_guard_exc = self._output_guardrails_task.exception()
-                if isinstance(out_guard_exc, Exception):
-                    if (
-                        isinstance(out_guard_exc, AgentsException)
-                        and out_guard_exc.run_data is None
-                        and not _is_error_data_redacted(out_guard_exc)
-                    ):
-                        out_guard_exc.run_data = self._create_error_details()
-                    self._stored_exception = out_guard_exc
 
     def _cleanup_tasks(self):
         if self.run_loop_task and not self.run_loop_task.done():

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -27,6 +27,7 @@ from .._tool_identity import (
 from ..agent import Agent
 from ..agent_output import AgentOutputSchemaBase
 from ..exceptions import (
+    _DATA_REDACTED_ERROR_MESSAGE,
     AgentsException,
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
@@ -37,6 +38,7 @@ from ..exceptions import (
     _clear_data_redacted_error_traceback,
     _detach_data_redacted_error_traceback,
     _is_error_data_redacted,
+    _mark_error_data_redacted,
 )
 from ..handoffs import Handoff
 from ..items import (
@@ -517,6 +519,7 @@ async def _finalize_streamed_final_output(
     store_setting: bool | None,
     persist_before_output_guardrails: bool,
 ) -> None:
+    redacted_persistence_error: BaseException | None = None
     if persist_before_output_guardrails:
         # A resumed approval has already committed the tool side effect, so keep its call/output
         # pair even when an agent output guardrail blocks delivery of the final result.
@@ -530,7 +533,7 @@ async def _finalize_streamed_final_output(
             context_wrapper=context_wrapper,
             streamed_result=streamed_result,
         )
-    except Exception:
+    except OutputGuardrailTripwireTriggered:
         # The blocked output itself is not persisted, but a tool that already ran is: the next run
         # has to see that side effect rather than re-issue it. This turn reaches here with tool
         # items when `tool_use_behavior="stop_on_first_tool"` (or `stop_at_tool_names`, or a custom
@@ -540,6 +543,60 @@ async def _finalize_streamed_final_output(
             if retained_items:
                 await save_items(retained_items, response_id, store_setting)
         raise
+    except Exception as guardrail_error:
+        # Only a tripwire means the output was judged undeliverable. A guardrail error leaves the
+        # verdict unknown, so the completed final turn is persisted whole and remains replayable.
+        # `asyncio.CancelledError` is deliberately not caught here: `cancel()` in its default
+        # immediate mode has to stay prompt, and awaiting a session write would block
+        # `stream_events()` on an arbitrary backend. `after_turn` is the mode that finishes the
+        # turn and saves.
+        guardrail_error_is_redacted = _is_error_data_redacted(guardrail_error)
+        if guardrail_error_is_redacted:
+            _detach_data_redacted_error_traceback(guardrail_error)
+        if not persist_before_output_guardrails:
+            try:
+                await save_items(items, response_id, store_setting)
+            except (Exception, asyncio.CancelledError) as persistence_error:
+                if guardrail_error_is_redacted:
+                    if isinstance(persistence_error, asyncio.CancelledError):
+                        safe_persistence_error: BaseException = asyncio.CancelledError(
+                            _DATA_REDACTED_ERROR_MESSAGE
+                        )
+                    else:
+                        safe_persistence_error = UserError(_DATA_REDACTED_ERROR_MESSAGE)
+                    _mark_error_data_redacted(safe_persistence_error)
+                    if (
+                        isinstance(safe_persistence_error, asyncio.CancelledError)
+                        and streamed_result._cancel_mode != "immediate"
+                    ):
+                        # A cancelled session write is distinct from the caller requesting
+                        # immediate cancellation. Retain a safe cancellation for `stream_events()`
+                        # without completing the run-loop task with the payload-bearing backend
+                        # exception.
+                        streamed_result._stored_exception = safe_persistence_error
+                        streamed_result.is_complete = True
+                        streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+                        return
+                    if isinstance(safe_persistence_error, asyncio.CancelledError):
+                        # Public immediate cancellation already owns stream completion and must
+                        # not surface a recovery failure.
+                        return
+                    redacted_persistence_error = safe_persistence_error
+                if (
+                    isinstance(persistence_error, asyncio.CancelledError)
+                    and streamed_result._cancel_mode != "immediate"
+                ):
+                    # A cancelled session write is distinct from the caller requesting immediate
+                    # cancellation. The run-loop task itself becomes cancelled, so retain the
+                    # backend cancellation for `stream_events()` to surface.
+                    streamed_result._stored_exception = persistence_error
+                if redacted_persistence_error is None:
+                    raise
+        if redacted_persistence_error is None:
+            raise
+
+    if redacted_persistence_error is not None:
+        raise redacted_persistence_error from None
 
     streamed_result.output_guardrail_results = output_guardrail_results
     streamed_result.final_output = output

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -2420,6 +2421,231 @@ async def test_mixed_final_turn_session_order_and_committed_items(
 
 
 @pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
+@pytest.mark.asyncio
+async def test_failing_output_guardrail_keeps_the_whole_final_turn(
+    mode: str,
+) -> None:
+    """A guardrail *error* is not a tripwire: the completed final turn stays replayable.
+
+    Only a tripwire means the output was judged undeliverable. An ordinary guardrail exception
+    leaves the verdict unknown, so the turn must be persisted whole, exactly as the non-streamed
+    path does.
+    """
+
+    @function_tool(name_override="commit_tool")
+    def commit_tool() -> str:
+        return "committed-result"
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        raise RuntimeError("guardrail failed")
+
+    model = FakeModel()
+    model.set_next_output(
+        [
+            get_text_message("assistant-preamble"),
+            get_function_tool_call("commit_tool", "{}", call_id="call-mixed"),
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[commit_tool],
+        tool_use_behavior="stop_on_first_tool",
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = SimpleListSession()
+
+    async def run_once() -> None:
+        if mode == "non_streamed":
+            await Runner.run(agent, "Use commit_tool", session=session)
+        else:
+            result = Runner.run_streamed(agent, "Use commit_tool", session=session)
+            await consume_stream(result)
+
+    with pytest.raises(RuntimeError, match="guardrail failed"):
+        await run_once()
+
+    saved_items = await session.get_items()
+    saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
+    assert saved == ["user", "message", "function_call", "function_call_output"]
+
+
+@pytest.mark.asyncio
+async def test_streamed_session_save_error_takes_precedence_over_output_guardrail_error() -> None:
+    guardrail_failed = False
+    final_turn_save_attempted = False
+
+    class FailingFinalTurnSession(SimpleListSession):
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            nonlocal final_turn_save_attempted
+            if guardrail_failed:
+                final_turn_save_attempted = True
+                raise LookupError("session save failed")
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        raise RuntimeError("guardrail failed")
+
+    model = FakeModel()
+    model.set_next_output([get_text_message("assistant-preamble")])
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = FailingFinalTurnSession()
+    result = Runner.run_streamed(agent, "Hello", session=session)
+
+    with pytest.raises(LookupError, match="session save failed") as exc_info:
+        await consume_stream(result)
+
+    assert final_turn_save_attempted is True
+    assert isinstance(exc_info.value.__context__, RuntimeError)
+    assert str(exc_info.value.__context__) == "guardrail failed"
+    assert result.run_loop_exception is exc_info.value
+    assert await session.get_items() == [{"content": "Hello", "role": "user"}]
+
+
+@pytest.mark.asyncio
+async def test_streamed_session_save_cancellation_is_not_a_public_immediate_cancel() -> None:
+    guardrail_failed = False
+
+    class CancellingFinalTurnSession(SimpleListSession):
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            if guardrail_failed:
+                raise asyncio.CancelledError("session save cancelled")
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        raise RuntimeError("guardrail failed")
+
+    model = FakeModel(initial_output=[get_text_message("assistant-preamble")])
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = CancellingFinalTurnSession()
+    result = Runner.run_streamed(agent, "Hello", session=session)
+
+    with pytest.raises(asyncio.CancelledError, match="session save cancelled") as exc_info:
+        await consume_stream(result)
+
+    assert result._cancel_mode == "none"
+    assert result._stored_exception is exc_info.value
+    assert isinstance(exc_info.value.__context__, RuntimeError)
+    assert str(exc_info.value.__context__) == "guardrail failed"
+    assert await session.get_items() == [{"content": "Hello", "role": "user"}]
+
+
+@pytest.mark.asyncio
+async def test_streamed_session_save_direct_base_exception_is_terminal() -> None:
+    guardrail_failed = False
+
+    class DirectAbort(BaseException):
+        pass
+
+    class AbortingFinalTurnSession(SimpleListSession):
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            if guardrail_failed:
+                raise DirectAbort("session save aborted")
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        raise RuntimeError("guardrail failed")
+
+    agent = Agent(
+        name="test",
+        model=FakeModel(initial_output=[get_text_message("assistant-preamble")]),
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = AbortingFinalTurnSession()
+    result = Runner.run_streamed(agent, "Hello", session=session)
+
+    with pytest.raises(DirectAbort, match="session save aborted") as exc_info:
+        await consume_stream(result)
+
+    assert result._stored_exception is exc_info.value
+    assert result.run_loop_exception is exc_info.value
+    assert await session.get_items() == [{"content": "Hello", "role": "user"}]
+
+
+@pytest.mark.asyncio
+async def test_public_immediate_cancel_during_guardrail_recovery_save_stays_prompt() -> None:
+    guardrail_failed = False
+    save_started = asyncio.Event()
+    save_cancelled = asyncio.Event()
+    never_set = asyncio.Event()
+
+    class BlockingFinalTurnSession(SimpleListSession):
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            if guardrail_failed:
+                save_started.set()
+                try:
+                    await never_set.wait()
+                finally:
+                    save_cancelled.set()
+                return
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        raise RuntimeError("guardrail failed")
+
+    model = FakeModel(initial_output=[get_text_message("assistant-preamble")])
+    agent = Agent(
+        name="test",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = BlockingFinalTurnSession()
+    result = Runner.run_streamed(agent, "Hello", session=session)
+    drain_task = asyncio.create_task(consume_stream(result))
+
+    try:
+        await asyncio.wait_for(save_started.wait(), timeout=1)
+        result.cancel()
+        await asyncio.wait_for(drain_task, timeout=1)
+    finally:
+        if not drain_task.done():
+            result.cancel()
+            drain_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await drain_task
+
+    assert save_cancelled.is_set()
+    assert result._stored_exception is None
+    assert await session.get_items() == [{"content": "Hello", "role": "user"}]
+
+
+@pytest.mark.parametrize("mode", ["non_streamed", "streamed"])
 @pytest.mark.parametrize("tripwire", [False, True], ids=["passes", "trips"])
 @pytest.mark.asyncio
 async def test_blocked_tool_final_keeps_reasoning_context_with_the_committed_call(
@@ -3213,3 +3439,88 @@ async def test_streamed_resume_handoff_turn_reports_tool_guardrail_results():
     assert len(streamed.tool_output_guardrail_results) == len(
         non_streamed.tool_output_guardrail_results
     )
+
+
+@pytest.mark.asyncio
+async def test_streamed_cancel_during_output_guardrail_starts_no_final_turn_write() -> None:
+    """Immediate cancel() must not start a final-turn session write.
+
+    `cancel()` in its default immediate mode cancels outstanding work; `after_turn` is the mode
+    that finishes the turn and saves. A cancellation raised inside an in-flight output guardrail
+    must therefore not be treated like a guardrail error, or `stream_events()` would stay blocked
+    on whatever the session backend does.
+    """
+    entered_guardrail = asyncio.Event()
+    never_set = asyncio.Event()
+    cancelled = False
+    tool_call_count = 0
+
+    async def parked_output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        entered_guardrail.set()
+        await never_set.wait()
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    class BlockingAfterCancelSession(SimpleListSession):
+        """Writes before the cancel are the turn's own; any write after it would hang the stream."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.wrote_after_cancel = False
+
+        async def add_items(self, items: list[TResponseInputItem]) -> None:
+            if cancelled:
+                self.wrote_after_cancel = True
+                await never_set.wait()
+            await super().add_items(items)
+
+    @function_tool(name_override="commit_tool")
+    def commit_tool() -> str:
+        nonlocal tool_call_count
+        tool_call_count += 1
+        return "committed-result"
+
+    model = FakeModel()
+    model.set_next_output(
+        [
+            get_text_message("assistant-preamble"),
+            get_function_tool_call("commit_tool", "{}", call_id="call-cancel"),
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[commit_tool],
+        tool_use_behavior="stop_on_first_tool",
+        output_guardrails=[OutputGuardrail(guardrail_function=parked_output_guardrail)],
+    )
+    session = BlockingAfterCancelSession()
+
+    result = Runner.run_streamed(agent, "Use commit_tool", session=session)
+
+    async def drain() -> None:
+        with contextlib.suppress(asyncio.CancelledError):
+            async for _event in result.stream_events():
+                pass
+
+    drain_task = asyncio.create_task(drain())
+    try:
+        await asyncio.wait_for(entered_guardrail.wait(), timeout=1)
+        cancelled = True
+        result.cancel()
+        # A final-turn write here would block on never_set and hang the stream.
+        await asyncio.wait_for(drain_task, timeout=1)
+    finally:
+        if not drain_task.done():
+            drain_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await drain_task
+
+    assert session.wrote_after_cancel is False
+    assert tool_call_count == 1
+    saved_items = await session.get_items()
+    saved = [item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)]
+    assert saved == ["user"]

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -1398,6 +1398,161 @@ async def test_streamed_output_guardrail_omits_run_data_from_redacted_error(
     _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
 
 
+@pytest.mark.parametrize("redacted", [False, True])
+@pytest.mark.parametrize("persistence_failure", ["error", "cancelled"])
+@pytest.mark.asyncio
+async def test_streamed_session_error_after_output_guardrail_respects_redaction(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    redacted: bool,
+    persistence_failure: Literal["error", "cancelled"],
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", redacted)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    guardrail_failed = False
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+
+    class FailingFinalTurnSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if guardrail_failed:
+                cause = RuntimeError(f"session save cause: {_MODEL_OUTPUT_SECRET}")
+                if persistence_failure == "cancelled":
+                    raise asyncio.CancelledError(
+                        f"session save cancelled: {_MODEL_OUTPUT_SECRET}"
+                    ) from cause
+                raise LookupError(f"session save failed: {_MODEL_OUTPUT_SECRET}") from cause
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _agent_output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        AgentOutputSchema(_RequiredOutput).validate_json(payload)
+        raise AssertionError("validation should fail")  # pragma: no cover
+
+    caplog.set_level(logging.ERROR, logger="openai.agents")
+    model = FakeModel(initial_output=[get_text_message(_MODEL_OUTPUT_SECRET)])
+    agent = Agent(
+        name="A",
+        model=model,
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    result = Runner.run_streamed(agent, "go", session=FailingFinalTurnSession())
+    run_loop_callback_errors: list[BaseException] = []
+    run_loop_done = asyncio.Event()
+
+    if redacted and persistence_failure == "cancelled":
+        assert result.run_loop_task is not None
+
+        def inspect_run_loop_task(task: asyncio.Task[Any]) -> None:
+            try:
+                task.result()
+            except BaseException as error:
+                run_loop_callback_errors.append(error)
+            finally:
+                run_loop_done.set()
+
+        result.run_loop_task.add_done_callback(inspect_run_loop_task)
+    expected_error_type = (
+        asyncio.CancelledError
+        if persistence_failure == "cancelled"
+        else UserError
+        if redacted
+        else LookupError
+    )
+    expected_message = (
+        "Error details are redacted."
+        if redacted
+        else "session save cancelled"
+        if persistence_failure == "cancelled"
+        else "session save failed"
+    )
+
+    with pytest.raises(expected_error_type, match=expected_message) as exc_info:
+        async for _ in result.stream_events():
+            pass
+
+    error = exc_info.value
+    guardrail_error = error.__context__
+
+    if redacted:
+        assert guardrail_error is None
+        assert error.__cause__ is None
+        assert _MODEL_OUTPUT_SECRET not in str(error)
+        _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
+        for record in caplog.records:
+            assert _MODEL_OUTPUT_SECRET not in repr(record.__dict__)
+            assert _MODEL_OUTPUT_SECRET not in logging.Formatter().format(record)
+            assert record.exc_info is None
+    else:
+        assert isinstance(guardrail_error, ModelBehaviorError)
+        assert error.__cause__ is not None
+        assert _MODEL_OUTPUT_SECRET in str(error.__cause__)
+        assert _MODEL_OUTPUT_SECRET in str(guardrail_error)
+        assert any(
+            _MODEL_OUTPUT_SECRET in repr(frame) for frame in _agents_traceback_frame_locals(error)
+        )
+
+    if persistence_failure == "cancelled":
+        assert result._stored_exception is error
+        assert result.run_loop_exception is None
+        if redacted:
+            await asyncio.wait_for(run_loop_done.wait(), timeout=1)
+            assert run_loop_callback_errors == []
+    else:
+        assert result.run_loop_exception is error
+        if redacted:
+            assert error.__traceback__ is None
+
+
+@pytest.mark.asyncio
+async def test_streamed_session_hostile_error_after_redacted_output_guardrail_is_replaced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persistence_secret = "HOSTILE_SESSION_FAILURE_SECRET"
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    guardrail_failed = False
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+
+    class FailingFinalTurnSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if guardrail_failed:
+                raise _HostileAttributeWriteException(persistence_secret)
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _agent_output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        AgentOutputSchema(_RequiredOutput).validate_json(payload)
+        raise AssertionError("validation should fail")  # pragma: no cover
+
+    agent = Agent(
+        name="A",
+        model=FakeModel(initial_output=[get_text_message(_MODEL_OUTPUT_SECRET)]),
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    result = Runner.run_streamed(agent, "go", session=FailingFinalTurnSession())
+
+    with pytest.raises(UserError, match="Error details are redacted.") as exc_info:
+        async for _ in result.stream_events():
+            pass
+
+    error = exc_info.value
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert persistence_secret not in str(error)
+    _assert_secret_absent_from_agents_traceback(error, persistence_secret)
+    _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
+
+
 @pytest.mark.asyncio
 async def test_streamed_input_guardrail_omits_run_data_from_redacted_error(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
This pull request supersedes #4271 and fixes streamed output-guardrail failure handling for client-managed sessions. Ordinary guardrail errors now persist the complete final turn before surfacing, while tripwires continue to retain only committed side effects and immediate cancellation remains prompt.

It also makes the composed run loop authoritative for terminal failures, preserves persistence error and cancellation semantics, and replaces sensitive backend failures with detached SDK-owned redacted errors when model-data logging is disabled.