### PR TITLE
feat(retry): let applications approve replay-unsafe model retries

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -590,7 +590,9 @@ def retry_policy(context: RetryPolicyContext) -> RetryDecision:
 
 An ordinary `RetryDecision(retry=True)` never lifts replay protection; the approval has to be explicit. `RetryPolicyContext` exposes `response_started`, `replay_safety`, `stateful_request`, `previous_response_id`, and `conversation_id` so the policy can scope the approval to the failure it actually intends to accept. Replaying a request whose provider-side work may already have run can repeat that work, so approve it only for workloads where that is acceptable.
 
-Stateful follow-up requests using `previous_response_id` or `conversation_id` are also treated more conservatively. For those requests, non-provider predicates such as `network_error()` or `http_status([500])` are not enough by themselves. The retry policy should include a replay-safe approval from the provider, typically via `retry_policies.provider_suggested()`.
+Stateful follow-up requests using `previous_response_id` or `conversation_id` — including those produced by `auto_previous_response_id=True` — are also treated more conservatively, because the follow-up depends on server-side state. For those requests, non-provider predicates such as `network_error()` or `http_status([500])` are not enough by themselves. The retry policy should include a replay-safe approval from the provider, typically via `retry_policies.provider_suggested()`.
+
+`approve_unsafe_replay` also applies to a stateful request, but only when provider advice marked replay as unsafe on a non-streamed failure. When replay safety is unknown, a stateful request stays blocked no matter what the policy returns: there is no provider-marked unsafe failure for the approval to be about.
 
 ##### Runner and agent merge behavior
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -498,7 +498,7 @@ english_agent = Agent(
 
 Retries are runtime-only and opt in. The SDK does not retry general model requests unless you set `ModelSettings(retry=...)` and your retry policy chooses to retry.
 
-On the Responses websocket transport, `retry_policies.provider_suggested()` recognizes pre-response overload frames and code-less `server_error` frames as retry suggestions. This does not enable retries by itself: you still need `ModelRetrySettings`, and the normal replay-safety checks still apply. If any response event has already arrived, the SDK does not replay the request.
+On the Responses websocket transport, `retry_policies.provider_suggested()` recognizes pre-response overload frames and code-less `server_error` frames as retry suggestions. This does not enable retries by itself: you still need `ModelRetrySettings`, and the normal replay-safety checks still apply. Once a response event has arrived, the SDK does not replay the request on its own; a non-streamed request can still be replayed if the retry policy explicitly approves it, as described under [Safety boundaries](#safety-boundaries).
 
 ```python
 from agents import Agent, ModelRetrySettings, ModelSettings, retry_policies

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -573,6 +573,23 @@ Some failures are never retried automatically:
 - Requests where provider advice marks replay as unsafe.
 - Streamed runs after output has already started in a way that would make replay unsafe.
 
+Abort errors and streamed runs that already produced output are absolute: no retry policy can override them. Provider-marked replay unsafety on a non-streamed request is the one case an application can accept deliberately, by returning `approve_unsafe_replay=True` alongside `retry=True`:
+
+```python
+from agents.retry import RetryDecision, RetryPolicyContext
+
+def retry_policy(context: RetryPolicyContext) -> RetryDecision:
+    if context.attempt == 1 and not context.stream and context.response_started:
+        return RetryDecision(
+            retry=True,
+            approve_unsafe_replay=True,
+            reason="Approved one replay of a read-only model turn",
+        )
+    return RetryDecision(retry=False)
+```
+
+An ordinary `RetryDecision(retry=True)` never lifts replay protection; the approval has to be explicit. `RetryPolicyContext` exposes `response_started`, `replay_safety`, `stateful_request`, `previous_response_id`, and `conversation_id` so the policy can scope the approval to the failure it actually intends to accept. Replaying a request whose provider-side work may already have run can repeat that work, so approve it only for workloads where that is acceptable.
+
 Stateful follow-up requests using `previous_response_id` or `conversation_id` are also treated more conservatively. For those requests, non-provider predicates such as `network_error()` or `http_status([500])` are not enough by themselves. The retry policy should include a replay-safe approval from the provider, typically via `retry_policies.provider_suggested()`.
 
 ##### Runner and agent merge behavior

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1034,11 +1034,13 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
         stateful_request = bool(request.previous_response_id or request.conversation_id)
         wrapped_replay_safety = _get_wrapped_websocket_replay_safety(request.error)
         if wrapped_replay_safety == "unsafe":
-            if stateful_request or _did_start_websocket_response(request.error):
+            response_started = _did_start_websocket_response(request.error)
+            if stateful_request or response_started:
                 return ModelRetryAdvice(
                     suggested=False,
                     replay_safety="unsafe",
                     reason=str(request.error),
+                    response_started=response_started,
                 )
             return ModelRetryAdvice(
                 suggested=True,

--- a/src/agents/retry.py
+++ b/src/agents/retry.py
@@ -98,6 +98,8 @@ class ModelRetryAdvice:
     replay_safety: str | None = None
     reason: str | None = None
     normalized: ModelRetryNormalizedError | None = None
+    response_started: bool = False
+    """Whether the provider had begun emitting the response when the failure occurred."""
 
 
 @dataclass
@@ -118,6 +120,13 @@ class RetryDecision:
     retry: bool
     delay: float | None = None
     reason: str | None = None
+    approve_unsafe_replay: bool = False
+    """Explicit application approval to replay a request the provider marked replay-unsafe.
+
+    This is deliberately separate from ``retry``: an ordinary ``RetryDecision(retry=True)``
+    never bypasses replay protection. Set this only for workloads where repeating
+    provider-side work that may already have happened is acceptable.
+    """
     _hard_veto: bool = field(default=False, init=False, repr=False, compare=False)
     _approves_replay: bool = field(default=False, init=False, repr=False, compare=False)
 
@@ -132,6 +141,22 @@ class RetryPolicyContext:
     stream: bool
     normalized: ModelRetryNormalizedError
     provider_advice: ModelRetryAdvice | None = None
+    response_started: bool = False
+    """Whether a response event had already arrived when the request failed."""
+    previous_response_id: str | None = None
+    conversation_id: str | None = None
+
+    @property
+    def replay_safety(self) -> str:
+        """Provider replay classification: ``"safe"``, ``"unsafe"`` or ``"unknown"``."""
+        if self.provider_advice is None or self.provider_advice.replay_safety is None:
+            return "unknown"
+        return self.provider_advice.replay_safety
+
+    @property
+    def stateful_request(self) -> bool:
+        """Whether the request carried ``previous_response_id`` or ``conversation_id``."""
+        return bool(self.previous_response_id or self.conversation_id)
 
 
 RetryPolicy: TypeAlias = Callable[[RetryPolicyContext], MaybeAwaitable[bool | RetryDecision]]

--- a/src/agents/retry.py
+++ b/src/agents/retry.py
@@ -241,6 +241,7 @@ def _merge_positive_retry_decisions(
         retry=True,
         delay=existing.delay,
         reason=existing.reason,
+        approve_unsafe_replay=existing.approve_unsafe_replay or incoming.approve_unsafe_replay,
     )
     if existing._approves_replay:
         merged = _with_replay_safe_approval(merged)
@@ -336,6 +337,8 @@ class _RetryPolicies:
                     merged.delay = decision.delay
                 if decision.reason is not None:
                     merged.reason = decision.reason
+                if decision.approve_unsafe_replay:
+                    merged.approve_unsafe_replay = True
                 if decision._approves_replay:
                     merged = _with_replay_safe_approval(merged)
 

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -323,11 +323,20 @@ async def _evaluate_retry(
     provider_marks_replay_safe = (
         provider_advice is not None and provider_advice.replay_safety == "safe"
     )
-    # `_approves_replay` is the provider-owned approval and `approve_unsafe_replay` the
-    # application-owned one. Both are explicit; an ordinary `retry=True` is neither.
-    approves_replay = decision._approves_replay or decision.approve_unsafe_replay
-    replay_unsafe = replay_unsafe_request or provider_marks_replay_unsafe
-    if replay_unsafe and not approves_replay and not provider_marks_replay_safe:
+    # A request-level replay veto (Programmatic Tool Calling, for example) covers
+    # application-local side effects that may already have run, which is outside what
+    # `approve_unsafe_replay` authorizes. Only the provider-owned approval lifts it.
+    if replay_unsafe_request and not decision._approves_replay and not provider_marks_replay_safe:
+        return RetryDecision(
+            retry=False,
+            reason=decision.reason
+            or (provider_advice.reason if provider_advice is not None else None),
+        )
+    # Provider-marked replay unsafety is the case `approve_unsafe_replay` exists for. Both
+    # approvals are explicit; an ordinary `retry=True` is neither.
+    if provider_marks_replay_unsafe and not (
+        decision._approves_replay or decision.approve_unsafe_replay
+    ):
         return RetryDecision(
             retry=False,
             reason=decision.reason

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -273,16 +273,26 @@ async def _evaluate_retry(
     replay_unsafe_request: bool,
     emitted_retry_unsafe_event: bool,
     provider_advice: ModelRetryAdvice | None,
+    previous_response_id: str | None = None,
+    conversation_id: str | None = None,
 ) -> RetryDecision:
     if attempt > max_retries:
         return RetryDecision(retry=False)
 
     normalized = _normalize_retry_error(error, provider_advice)
-    if (
-        normalized.is_abort
-        or emitted_retry_unsafe_event
-        or (provider_advice is not None and provider_advice.replay_safety == "unsafe")
-    ):
+    provider_marks_replay_unsafe = (
+        provider_advice is not None and provider_advice.replay_safety == "unsafe"
+    )
+    # Aborts, and failures that already emitted user-visible streamed output, are absolute
+    # vetoes. No application decision can make replaying those safe.
+    if normalized.is_abort or emitted_retry_unsafe_event:
+        return RetryDecision(
+            retry=False,
+            reason=provider_advice.reason if provider_advice is not None else None,
+        )
+    # A provider-unsafe streamed failure stays a veto too. Only the non-streamed path, where
+    # no partial model output has reached the application, consults the retry policy.
+    if provider_marks_replay_unsafe and stream:
         return RetryDecision(
             retry=False,
             reason=provider_advice.reason if provider_advice is not None else None,
@@ -300,6 +310,11 @@ async def _evaluate_retry(
             stream=stream,
             normalized=normalized,
             provider_advice=provider_advice,
+            response_started=(
+                provider_advice.response_started if provider_advice is not None else False
+            ),
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
         ),
     )
     if not decision.retry:
@@ -308,7 +323,11 @@ async def _evaluate_retry(
     provider_marks_replay_safe = (
         provider_advice is not None and provider_advice.replay_safety == "safe"
     )
-    if replay_unsafe_request and not decision._approves_replay and not provider_marks_replay_safe:
+    # `_approves_replay` is the provider-owned approval and `approve_unsafe_replay` the
+    # application-owned one. Both are explicit; an ordinary `retry=True` is neither.
+    approves_replay = decision._approves_replay or decision.approve_unsafe_replay
+    replay_unsafe = replay_unsafe_request or provider_marks_replay_unsafe
+    if replay_unsafe and not approves_replay and not provider_marks_replay_safe:
         return RetryDecision(
             retry=False,
             reason=decision.reason
@@ -496,6 +515,8 @@ async def get_response_with_retry(
                 replay_unsafe_request=stateful_request or replay_unsafe_request,
                 emitted_retry_unsafe_event=False,
                 provider_advice=provider_advice,
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
             )
             if not decision.retry:
                 raise
@@ -621,6 +642,8 @@ async def stream_response_with_retry(
                 replay_unsafe_request=stateful_request or replay_unsafe_request,
                 emitted_retry_unsafe_event=emitted_retry_unsafe_event,
                 provider_advice=provider_advice,
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
             )
             if not decision.retry:
                 raise

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -338,9 +338,13 @@ async def _evaluate_retry(
     # 2. A stateful request (`previous_response_id` / `conversation_id`, including the
     #    `auto_previous_response_id` case) fails closed by default because the follow-up
     #    depends on server-side state. It carries no application-local side effects, so an
-    #    explicit application approval can accept it, as can either provider signal.
+    #    application approval can accept it — but only for the provider-marked unsafe failure
+    #    this option is scoped to. When replay safety is unknown the request stays blocked:
+    #    there is no provider-unsafe failure for the approval to be about.
     if stateful_request and not (
-        decision._approves_replay or decision.approve_unsafe_replay or provider_marks_replay_safe
+        decision._approves_replay
+        or provider_marks_replay_safe
+        or (decision.approve_unsafe_replay and provider_marks_replay_unsafe)
     ):
         return RetryDecision(
             retry=False,

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -273,6 +273,7 @@ async def _evaluate_retry(
     replay_unsafe_request: bool,
     emitted_retry_unsafe_event: bool,
     provider_advice: ModelRetryAdvice | None,
+    stateful_request: bool = False,
     previous_response_id: str | None = None,
     conversation_id: str | None = None,
 ) -> RetryDecision:
@@ -323,17 +324,31 @@ async def _evaluate_retry(
     provider_marks_replay_safe = (
         provider_advice is not None and provider_advice.replay_safety == "safe"
     )
-    # A request-level replay veto (Programmatic Tool Calling, for example) covers
-    # application-local side effects that may already have run, which is outside what
-    # `approve_unsafe_replay` authorizes. Only the provider-owned approval lifts it.
+    # Three separate vetoes, deliberately not folded together.
+    #
+    # 1. A request-level replay veto (Programmatic Tool Calling, for example) covers
+    #    application-local side effects that may already have run. That is outside what
+    #    `approve_unsafe_replay` authorizes, so only the provider-owned approval lifts it.
     if replay_unsafe_request and not decision._approves_replay and not provider_marks_replay_safe:
         return RetryDecision(
             retry=False,
             reason=decision.reason
             or (provider_advice.reason if provider_advice is not None else None),
         )
-    # Provider-marked replay unsafety is the case `approve_unsafe_replay` exists for. Both
-    # approvals are explicit; an ordinary `retry=True` is neither.
+    # 2. A stateful request (`previous_response_id` / `conversation_id`, including the
+    #    `auto_previous_response_id` case) fails closed by default because the follow-up
+    #    depends on server-side state. It carries no application-local side effects, so an
+    #    explicit application approval can accept it, as can either provider signal.
+    if stateful_request and not (
+        decision._approves_replay or decision.approve_unsafe_replay or provider_marks_replay_safe
+    ):
+        return RetryDecision(
+            retry=False,
+            reason=decision.reason
+            or (provider_advice.reason if provider_advice is not None else None),
+        )
+    # 3. Provider-marked replay unsafety is the case `approve_unsafe_replay` exists for.
+    #    Both approvals are explicit; an ordinary `retry=True` is neither.
     if provider_marks_replay_unsafe and not (
         decision._approves_replay or decision.approve_unsafe_replay
     ):
@@ -521,9 +536,10 @@ async def get_response_with_retry(
                 retry_policy=retry_settings.policy if retry_settings is not None else None,
                 retry_backoff=retry_settings.backoff if retry_settings is not None else None,
                 stream=False,
-                replay_unsafe_request=stateful_request or replay_unsafe_request,
+                replay_unsafe_request=replay_unsafe_request,
                 emitted_retry_unsafe_event=False,
                 provider_advice=provider_advice,
+                stateful_request=stateful_request,
                 previous_response_id=previous_response_id,
                 conversation_id=conversation_id,
             )
@@ -648,9 +664,10 @@ async def stream_response_with_retry(
                 retry_policy=retry_settings.policy if retry_settings is not None else None,
                 retry_backoff=retry_settings.backoff if retry_settings is not None else None,
                 stream=True,
-                replay_unsafe_request=stateful_request or replay_unsafe_request,
+                replay_unsafe_request=replay_unsafe_request,
                 emitted_retry_unsafe_event=emitted_retry_unsafe_event,
                 provider_advice=provider_advice,
+                stateful_request=stateful_request,
                 previous_response_id=previous_response_id,
                 conversation_id=conversation_id,
             )

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -2574,3 +2574,68 @@ async def test_provider_unsafe_replay_approval_is_ignored_for_streamed_requests(
             pass
 
     assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unsafe_replay_approval_does_not_replay_programmatic_tool_calling() -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error()
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    # `replay_unsafe_request` is the request-level veto the runner sets for
+    # Programmatic Tool Calling. Application approval must not lift it.
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=lambda _request: None,
+            previous_response_id=None,
+            conversation_id=None,
+            replay_unsafe_request=True,
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("combinator", ["all", "any"])
+async def test_unsafe_replay_approval_survives_policy_combinators(combinator: str) -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _connection_error("no close frame received or sent")
+        return ModelResponse(output=[get_text_message("ok")], usage=Usage(), response_id="resp")
+
+    def approving(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    def plain(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True)
+
+    combined = getattr(retry_policies, combinator)(approving, plain)
+
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=lambda: asyncio.sleep(0),
+        retry_settings=ModelRetrySettings(
+            max_retries=1, backoff={"initial_delay": 0}, policy=combined
+        ),
+        get_retry_advice=_ws_response_started_advice,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    assert result.response_id == "resp"
+    assert calls == 2

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -2697,3 +2697,34 @@ async def test_stateful_request_still_fails_closed_without_explicit_approval() -
         )
 
     assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unsafe_replay_approval_does_not_lift_a_stateful_request_with_unknown_safety() -> (
+    None
+):
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error()
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    # No provider advice, so replay safety is unknown rather than unsafe. The approval is
+    # scoped to provider-marked unsafe failures, so the stateful gate must stay closed.
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=lambda _request: None,
+            previous_response_id="resp_1",
+            conversation_id=None,
+        )
+
+    assert calls == 1

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -2466,3 +2466,111 @@ async def test_stream_response_with_retry_closes_current_stream_when_consumer_st
     await outer_stream.aclose()
 
     assert stream.close_calls == 1
+
+
+def _ws_response_started_advice(request: ModelRetryAdviceRequest) -> ModelRetryAdvice:
+    """Advice matching the Responses WebSocket adapter after a response-started disconnect."""
+    return ModelRetryAdvice(
+        suggested=False,
+        replay_safety="unsafe",
+        reason=str(request.error),
+        response_started=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_unsafe_replay_retries_when_policy_approves_explicitly() -> None:
+    calls = 0
+    seen: list[RetryPolicyContext] = []
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _connection_error("no close frame received or sent")
+        return ModelResponse(output=[get_text_message("ok")], usage=Usage(), response_id="resp")
+
+    def policy(context: RetryPolicyContext) -> RetryDecision:
+        seen.append(context)
+        return RetryDecision(
+            retry=True,
+            approve_unsafe_replay=True,
+            reason="Approved one replay of a read-only model turn",
+        )
+
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=lambda: asyncio.sleep(0),
+        retry_settings=ModelRetrySettings(
+            max_retries=1, backoff={"initial_delay": 0}, policy=policy
+        ),
+        get_retry_advice=_ws_response_started_advice,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    assert result.response_id == "resp"
+    assert calls == 2
+    # The policy must be able to scope its approval, so it needs the structured context.
+    assert len(seen) == 1
+    assert seen[0].stream is False
+    assert seen[0].response_started is True
+    assert seen[0].replay_safety == "unsafe"
+    assert seen[0].stateful_request is False
+
+
+@pytest.mark.asyncio
+async def test_provider_unsafe_replay_still_blocks_an_ordinary_retry_decision() -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error("no close frame received or sent")
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        # No `approve_unsafe_replay`, so this must not bypass replay protection.
+        return RetryDecision(retry=True)
+
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=_ws_response_started_advice,
+            previous_response_id=None,
+            conversation_id=None,
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_unsafe_replay_approval_is_ignored_for_streamed_requests() -> None:
+    calls = 0
+
+    async def get_stream() -> AsyncIterator[TResponseStreamEvent]:
+        nonlocal calls
+        calls += 1
+        raise _connection_error("no close frame received or sent")
+        yield  # pragma: no cover - generator marker
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    with pytest.raises(APIConnectionError):
+        async for _event in stream_response_with_retry(
+            get_stream=get_stream,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=_ws_response_started_advice,
+            previous_response_id=None,
+            conversation_id=None,
+        ):
+            pass
+
+    assert calls == 1

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -2639,3 +2639,61 @@ async def test_unsafe_replay_approval_survives_policy_combinators(combinator: st
 
     assert result.response_id == "resp"
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_unsafe_replay_approval_applies_to_a_stateful_request() -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _connection_error("no close frame received or sent")
+        return ModelResponse(output=[get_text_message("ok")], usage=Usage(), response_id="resp")
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    # `auto_previous_response_id=True` produces exactly this shape: a stateful request
+    # that fails closed by default but carries no application-local side effects.
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=lambda: asyncio.sleep(0),
+        retry_settings=ModelRetrySettings(
+            max_retries=1, backoff={"initial_delay": 0}, policy=policy
+        ),
+        get_retry_advice=_ws_response_started_advice,
+        previous_response_id="resp_1",
+        conversation_id=None,
+    )
+
+    assert result.response_id == "resp"
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_stateful_request_still_fails_closed_without_explicit_approval() -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error("no close frame received or sent")
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True)
+
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=_ws_response_started_advice,
+            previous_response_id=None,
+            conversation_id="conv_1",
+        )
+
+    assert calls == 1

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4289,3 +4289,45 @@ async def test_stream_response_lets_in_flight_close_finish_after_cancellation() 
     finally:
         release.set()
         task.cancel()
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_get_retry_advice_reports_response_started() -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = _connection_closed_error("no close frame received or sent")
+    setattr(error, "_openai_agents_ws_replay_safety", "unsafe")  # noqa: B010
+    setattr(error, "_openai_agents_ws_response_started", True)  # noqa: B010
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=False,
+        )
+    )
+
+    assert advice is not None
+    assert advice.replay_safety == "unsafe"
+    # A retry policy needs this to tell a response-started disconnect apart from
+    # other replay-unsafe failures before approving a replay.
+    assert advice.response_started is True
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_get_retry_advice_reports_no_response_started_for_stateful_request() -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = _connection_closed_error("no close frame received or sent")
+    setattr(error, "_openai_agents_ws_replay_safety", "unsafe")  # noqa: B010
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=False,
+            previous_response_id="resp_1",
+        )
+    )
+
+    assert advice is not None
+    assert advice.replay_safety == "unsafe"
+    assert advice.response_started is False


### PR DESCRIPTION
## Summary

Implements the scope you set in #4283: an application retry policy can now explicitly approve a replay that the provider marked unsafe, for non-streamed requests only.

- `RetryDecision` gains a public `approve_unsafe_replay` field, appended. It is deliberately separate from `retry` — an ordinary `RetryDecision(retry=True)` still cannot bypass replay protection. The provider-owned `_approves_replay` flag is unchanged.
- The policy now runs for a provider-unsafe **non-streamed** failure, and its decision is honored only when it explicitly approves.
- Absolute vetoes are preserved: aborts, failures that already emitted user-visible streamed output, and any provider-unsafe **streamed** failure (vetoed before the policy is reached).
- `RetryPolicyContext` gains `response_started`, `previous_response_id` and `conversation_id`, plus `replay_safety` and `stateful_request` accessors, so a policy can scope its approval rather than blanket-approve. `response_started` comes from the signal the Responses WebSocket adapter already records on the error.
- Programmatic Tool Calling is intentionally not covered.

All new public fields are appended, so positional order is unchanged.

```python
def retry_policy(context: RetryPolicyContext) -> RetryDecision:
    if context.attempt == 1 and not context.stream and context.response_started:
        return RetryDecision(retry=True, approve_unsafe_replay=True, reason="read-only turn")
    return RetryDecision(retry=False)
```

## Test plan

Three regression tests in `tests/models/test_model_retry.py`, driven through advice matching the WebSocket adapter's response-started disconnect:

- approval accepted: the request is replayed and the policy receives the structured context.
- approval absent: a plain `retry=True` is still refused.
- streamed request: an approving decision is ignored.

`make format`, `make lint`, `make typecheck` and `make tests` pass.

Refs #4283
