### PR TITLE
fix(sandbox): reject non-object rollout JSONL records

### DIFF
--- a/src/agents/sandbox/memory/phase_one.py
+++ b/src/agents/sandbox/memory/phase_one.py
@@ -46,6 +46,9 @@ def render_phase_one_prompt(*, rollout_contents: str) -> str:
     payloads = [json.loads(line) for line in rollout_contents.splitlines() if line.strip()]
     if not payloads:
         raise ValueError("rollout_contents must contain at least one JSONL record")
+    for record_number, payload in enumerate(payloads, start=1):
+        if not isinstance(payload, dict):
+            raise ValueError(f"rollout record {record_number} must be a JSON object")
     payload = payloads[-1]
     if len(payloads) == 1:
         terminal_metadata: object = payload.get("terminal_metadata", {})

--- a/tests/sandbox/test_memory.py
+++ b/tests/sandbox/test_memory.py
@@ -443,6 +443,23 @@ def test_render_phase_one_prompt_truncates_large_rollout_contents() -> None:
     assert "Do not assume the rendered rollout below is complete" in prompt
 
 
+@pytest.mark.parametrize(
+    "record",
+    ['"string"', '["list"]', "42", "true", "null"],
+    ids=["string", "list", "number", "boolean", "null"],
+)
+def test_render_phase_one_prompt_rejects_non_object_rollout_records(record: str) -> None:
+    with pytest.raises(ValueError, match=r"^rollout record 1 must be a JSON object$"):
+        render_phase_one_prompt(rollout_contents=record)
+
+
+def test_render_phase_one_prompt_rejects_non_object_final_rollout_record() -> None:
+    valid_record = json.dumps({"terminal_metadata": {"terminal_state": "completed"}})
+
+    with pytest.raises(ValueError, match=r"^rollout record 2 must be a JSON object$"):
+        render_phase_one_prompt(rollout_contents=f'{valid_record}\n["valid", "json"]')
+
+
 def test_sandbox_memory_input_preserves_empty_session_delta() -> None:
     assert (
         _sandbox_memory_input(


### PR DESCRIPTION
## Summary

`render_phase_one_prompt()` now validates every decoded JSONL record is an object before reading terminal metadata. Non-object values raise a record-numbered `ValueError` instead of an accidental `AttributeError`.

## Tests

- `uv run pytest tests/sandbox/test_memory.py`
- `uv run ruff format --check src/agents/sandbox/memory/phase_one.py tests/sandbox/test_memory.py`
- `uv run ruff check src/agents/sandbox/memory/phase_one.py tests/sandbox/test_memory.py`
- `uv run mypy src/agents/sandbox/memory/phase_one.py`
- `uv run pyright src/agents/sandbox/memory/phase_one.py`