### PR TITLE
fix(modal): settle snapshot directory mount transitions

### DIFF
--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -58,6 +58,12 @@ from ....sandbox.session import SandboxSession, SandboxSessionState
 from ....sandbox.session.base_sandbox_session import BaseSandboxSession
 from ....sandbox.session.dependencies import Dependencies
 from ....sandbox.session.manager import Instrumentation
+from ....sandbox.session.mount_lifecycle import (
+    _mount_transition_error,
+    _restore_detached_mounts_settled,
+    _settle_mount_transition,
+    _terminate_ambiguous_mount_session,
+)
 from ....sandbox.session.pty_types import (
     PTY_PROCESSES_MAX,
     PTY_PROCESSES_WARNING,
@@ -1412,6 +1418,8 @@ class ModalSandboxSession(BaseSandboxSession):
         self._modal_snapshot_ephemeral_backup = None
         self._modal_snapshot_ephemeral_backup_path = None
         detached_mounts: list[tuple[Mount, Path]] = []
+        caller_cancelled = False
+        teardown_transition_ambiguous = False
 
         async def restore_ephemeral_paths() -> WorkspaceArchiveReadError | None:
             backup_path = self._modal_snapshot_ephemeral_backup_path
@@ -1439,34 +1447,13 @@ class ModalSandboxSession(BaseSandboxSession):
                 )
             return None
 
-        async def restore_detached_mounts() -> WorkspaceArchiveReadError | None:
-            remount_error: WorkspaceArchiveReadError | None = None
-            for mount_entry, mount_path in reversed(detached_mounts):
-                try:
-                    await mount_entry.mount_strategy.restore_after_snapshot(
-                        mount_entry,
-                        self,
-                        mount_path,
-                    )
-                except Exception as e:
-                    current_error = WorkspaceArchiveReadError(path=error_root, cause=e)
-                    if remount_error is None:
-                        remount_error = current_error
-                    else:
-                        additional_remount_errors = remount_error.context.setdefault(
-                            "additional_remount_errors", []
-                        )
-                        assert isinstance(additional_remount_errors, list)
-                        additional_remount_errors.append(
-                            {
-                                "message": current_error.message,
-                                "cause_type": type(e).__name__,
-                                "cause": str(e),
-                            }
-                        )
-            return remount_error
+        async def restore_ephemeral_paths_or_raise() -> None:
+            restore_error = await restore_ephemeral_paths()
+            if restore_error is not None:
+                raise restore_error
 
         snapshot_error: WorkspaceArchiveReadError | None = None
+        cleanup_error: WorkspaceArchiveReadError | None = None
         snapshot_id: str | None = None
         try:
             if skip_abs:
@@ -1513,24 +1500,40 @@ class ModalSandboxSession(BaseSandboxSession):
                     )
 
             for mount_entry, mount_path in self._snapshot_directory_mount_targets_to_restore(root):
-                await mount_entry.mount_strategy.teardown_for_snapshot(
-                    mount_entry,
+                transition_error, transition_cancelled = await _settle_mount_transition(
                     self,
-                    mount_path,
+                    mount_entry.mount_strategy.teardown_for_snapshot(
+                        mount_entry,
+                        self,
+                        mount_path,
+                    ),
                 )
+                caller_cancelled = caller_cancelled or transition_cancelled
+                if transition_error is not None:
+                    snapshot_error = WorkspaceArchiveReadError(
+                        path=error_root,
+                        cause=transition_error,
+                    )
+                    teardown_transition_ambiguous = True
+                    break
                 detached_mounts.append((mount_entry, mount_path))
+                if caller_cancelled:
+                    break
 
-            snapshot_sandbox = await self._refresh_sandbox_handle_for_snapshot()
-            snap_coro = snapshot_sandbox.snapshot_directory.aio(root.as_posix())
-            if self.state.snapshot_filesystem_timeout_s is None:
-                snap = await snap_coro
-            else:
-                snap = await asyncio.wait_for(
-                    snap_coro, timeout=self.state.snapshot_filesystem_timeout_s
+            if snapshot_error is None and not caller_cancelled:
+                snapshot_sandbox = await self._refresh_sandbox_handle_for_snapshot()
+                snap_coro = snapshot_sandbox.snapshot_directory.aio(root.as_posix())
+                if self.state.snapshot_filesystem_timeout_s is None:
+                    snap = await snap_coro
+                else:
+                    snap = await asyncio.wait_for(
+                        snap_coro, timeout=self.state.snapshot_filesystem_timeout_s
+                    )
+                snapshot_id, snapshot_error = self._extract_modal_snapshot_id(
+                    snap=snap, root=root, snapshot_kind="snapshot_directory"
                 )
-            snapshot_id, snapshot_error = self._extract_modal_snapshot_id(
-                snap=snap, root=root, snapshot_kind="snapshot_directory"
-            )
+        except asyncio.CancelledError:
+            caller_cancelled = True
         except WorkspaceArchiveReadError as e:
             snapshot_error = e
         except Exception as e:
@@ -1538,8 +1541,34 @@ class ModalSandboxSession(BaseSandboxSession):
                 path=error_root, context={"reason": "snapshot_directory_failed"}, cause=e
             )
         finally:
-            remount_error = await restore_detached_mounts()
-            restore_error = await restore_ephemeral_paths()
+            remount_result, remount_cancelled = await _restore_detached_mounts_settled(
+                self,
+                detached_mounts,
+                error_path=error_root,
+                error_cls=WorkspaceArchiveReadError,
+            )
+            remount_error = cast(WorkspaceArchiveReadError | None, remount_result)
+            caller_cancelled = caller_cancelled or remount_cancelled
+
+            restore_error: WorkspaceArchiveReadError | None
+            if remount_error is None:
+                restore_transition_error, restore_cancelled = await _settle_mount_transition(
+                    self,
+                    restore_ephemeral_paths_or_raise(),
+                )
+                caller_cancelled = caller_cancelled or restore_cancelled
+                if isinstance(restore_transition_error, WorkspaceArchiveReadError):
+                    restore_error = restore_transition_error
+                elif restore_transition_error is not None:
+                    restore_error = WorkspaceArchiveReadError(
+                        path=error_root,
+                        cause=restore_transition_error,
+                    )
+                else:
+                    restore_error = None
+            else:
+                restore_error = None
+
             cleanup_error = remount_error
             if restore_error is not None:
                 if cleanup_error is None:
@@ -1566,7 +1595,23 @@ class ModalSandboxSession(BaseSandboxSession):
                     cleanup_error.context["snapshot_error_before_restore_corruption"] = {
                         "message": snapshot_error.message
                     }
-                raise cleanup_error
+
+            if teardown_transition_ambiguous and remount_error is None:
+                termination_error, termination_cancelled = await _terminate_ambiguous_mount_session(
+                    self
+                )
+                caller_cancelled = caller_cancelled or termination_cancelled
+                if termination_error is not None and not caller_cancelled:
+                    cleanup_error = cleanup_error or WorkspaceArchiveReadError(
+                        path=error_root,
+                        context={"reason": "snapshot_directory_terminal_cleanup_failed"},
+                        cause=termination_error,
+                    )
+
+        if caller_cancelled:
+            raise asyncio.CancelledError() from None
+        if cleanup_error is not None:
+            raise cleanup_error
 
         if snapshot_error is not None:
             raise snapshot_error
@@ -1823,21 +1868,49 @@ class ModalSandboxSession(BaseSandboxSession):
         sandbox = self._sandbox
 
         async def _run_restore() -> None:
+            caller_cancelled = False
+            transition_error: BaseException | None = None
             image = modal.Image.from_id(snapshot_id)
-            await self._call_modal(
-                sandbox.mount_image,
-                root.as_posix(),
-                image,
-                call_timeout=self.state.snapshot_filesystem_restore_timeout_s,
+            image_error, image_cancelled = await _settle_mount_transition(
+                self,
+                self._call_modal(
+                    sandbox.mount_image,
+                    root.as_posix(),
+                    image,
+                    call_timeout=self.state.snapshot_filesystem_restore_timeout_s,
+                ),
             )
-            for mount_entry, mount_path in reversed(
-                self._snapshot_directory_mount_targets_to_restore(root)
-            ):
-                await mount_entry.mount_strategy.restore_after_snapshot(
-                    mount_entry,
+            caller_cancelled = image_cancelled
+            if image_error is not None:
+                if isinstance(image_error, asyncio.CancelledError):
+                    transition_error = _mount_transition_error(
+                        WorkspaceArchiveWriteError,
+                        error_path=root,
+                        transition_error=image_error,
+                        reason="mount_image_cancelled",
+                    )
+                else:
+                    transition_error = image_error
+                (
+                    _termination_error,
+                    termination_cancelled,
+                ) = await _terminate_ambiguous_mount_session(self)
+                caller_cancelled = caller_cancelled or termination_cancelled
+            else:
+                remount_error, remount_cancelled = await _restore_detached_mounts_settled(
                     self,
-                    mount_path,
+                    self._snapshot_directory_mount_targets_to_restore(root),
+                    error_path=root,
+                    error_cls=WorkspaceArchiveWriteError,
                 )
+                caller_cancelled = caller_cancelled or remount_cancelled
+                if remount_error is not None:
+                    transition_error = remount_error
+
+            if caller_cancelled:
+                raise asyncio.CancelledError() from None
+            if transition_error is not None:
+                raise transition_error
 
         try:
             await asyncio.wait_for(

--- a/src/agents/sandbox/session/mount_lifecycle.py
+++ b/src/agents/sandbox/session/mount_lifecycle.py
@@ -92,7 +92,8 @@ async def with_ephemeral_mounts_removed(
         )
         caller_cancelled = caller_cancelled or restore_cancelled
     if detach_transition_ambiguous and restore_error is None:
-        terminal_error = await _terminate_ambiguous_mount_session(session)
+        terminal_error, terminal_cancelled = await _terminate_ambiguous_mount_session(session)
+        caller_cancelled = caller_cancelled or terminal_cancelled
         if terminal_error is not None and detach_error is not None:
             detach_error.context["terminal_cleanup_failed"] = True
 
@@ -167,7 +168,8 @@ async def _restore_detached_mounts_settled(
                 assert isinstance(additional_errors, list)
                 additional_errors.append(workspace_archive_error_summary(current_error))
     if restore_error is not None:
-        terminal_error = await _terminate_ambiguous_mount_session(session)
+        terminal_error, terminal_cancelled = await _terminate_ambiguous_mount_session(session)
+        caller_cancelled = caller_cancelled or terminal_cancelled
         if terminal_error is not None:
             restore_error.context["terminal_cleanup_failed"] = True
     return restore_error, caller_cancelled
@@ -188,16 +190,18 @@ async def _settle_mount_transition(
         finally:
             _MOUNT_TRANSITION_OWNER.reset(owner_token)
 
-    task = asyncio.create_task(run_registered_transition())
+    task = asyncio.create_task(
+        run_registered_transition(),
+        name="agents.mount_transition",
+    )
+    completion = asyncio.create_task(asyncio.wait((task,)))
     caller_cancelled = False
-    while not task.done():
+    while not completion.done():
         try:
-            await asyncio.shield(task)
+            await asyncio.shield(completion)
         except asyncio.CancelledError:
-            if not task.cancelled():
-                caller_cancelled = True
-        except Exception:
-            break
+            caller_cancelled = True
+    completion.result()
     try:
         task.result()
     except BaseException as exc:
@@ -213,12 +217,11 @@ def current_task_owns_mount_transition(session: BaseSandboxSession) -> bool:
 
 async def _terminate_ambiguous_mount_session(
     session: BaseSandboxSession,
-) -> BaseException | None:
-    terminal_error, _caller_cancelled = await _settle_mount_transition(
+) -> tuple[BaseException | None, bool]:
+    return await _settle_mount_transition(
         session,
         session._terminate_ambiguous_mount_transition(),
     )
-    return terminal_error
 
 
 def _mount_transition_error(

--- a/tests/extensions/sandbox/test_modal.py
+++ b/tests/extensions/sandbox/test_modal.py
@@ -75,6 +75,16 @@ def _trust_recording_mounts_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+class _AsyncGate:
+    def __init__(self, started: asyncio.Event, release: asyncio.Event) -> None:
+        self.started = started
+        self.release = release
+
+    def __deepcopy__(self, memo: dict[int, object]) -> _AsyncGate:
+        _ = memo
+        return self
+
+
 class _RecordingMount(Mount):
     type: str = "modal_recording_mount"
     mount_strategy: InContainerMountStrategy = Field(
@@ -82,6 +92,10 @@ class _RecordingMount(Mount):
     )
     _events: list[tuple[str, str]] = PrivateAttr(default_factory=list)
     _teardown_error: str | None = PrivateAttr(default=None)
+    _teardown_gate: _AsyncGate | None = PrivateAttr(default=None)
+    _restore_error: str | None = PrivateAttr(default=None)
+    _restore_cancelled: bool = PrivateAttr(default=False)
+    _restore_gate: _AsyncGate | None = PrivateAttr(default=None)
 
     def bind_events(self, events: list[tuple[str, str]]) -> _RecordingMount:
         self._events = events
@@ -89,6 +103,38 @@ class _RecordingMount(Mount):
 
     def bind_teardown_error(self, message: str) -> _RecordingMount:
         self._teardown_error = message
+        return self
+
+    def bind_restore_error(self, message: str) -> _RecordingMount:
+        self._restore_error = message
+        return self
+
+    def bind_restore_cancellation(
+        self,
+        started: asyncio.Event,
+        release: asyncio.Event,
+    ) -> _RecordingMount:
+        self._restore_gate = _AsyncGate(started, release)
+        self._restore_cancelled = True
+        return self
+
+    def bind_teardown_gate(
+        self,
+        started: asyncio.Event,
+        release: asyncio.Event,
+    ) -> _RecordingMount:
+        self._teardown_gate = _AsyncGate(started, release)
+        return self
+
+    def bind_restore_gate(
+        self,
+        started: asyncio.Event,
+        release: asyncio.Event,
+        *,
+        error: str | None = None,
+    ) -> _RecordingMount:
+        self._restore_gate = _AsyncGate(started, release)
+        self._restore_error = error
         return self
 
     def supported_in_container_patterns(
@@ -142,6 +188,9 @@ class _RecordingMount(Mount):
                 if mount._teardown_error is not None:
                     raise RuntimeError(mount._teardown_error)
                 mount._events.append(("unmount", path.as_posix()))
+                if mount._teardown_gate is not None:
+                    mount._teardown_gate.started.set()
+                    await mount._teardown_gate.release.wait()
 
             async def restore_after_snapshot(
                 self,
@@ -151,8 +200,23 @@ class _RecordingMount(Mount):
             ) -> None:
                 _ = (strategy, session)
                 mount._events.append(("mount", path.as_posix()))
+                if mount._restore_gate is not None:
+                    mount._restore_gate.started.set()
+                    await mount._restore_gate.release.wait()
+                if mount._restore_cancelled:
+                    raise asyncio.CancelledError()
+                if mount._restore_error is not None:
+                    raise RuntimeError(mount._restore_error)
 
         return _Adapter(self)
+
+
+def _unfinished_mount_transition_tasks() -> list[asyncio.Task[object]]:
+    return [
+        task
+        for task in asyncio.all_tasks()
+        if task.get_name() == "agents.mount_transition" and not task.done()
+    ]
 
 
 def _load_modal_module(
@@ -2434,6 +2498,13 @@ async def test_modal_snapshot_directory_teardown_failure_restores_partial_cleanu
         object_id = "sb-123"
         snapshot_directory: Any
 
+        def __init__(self) -> None:
+            self.terminate_calls = 0
+            self.terminate = _with_aio(self._terminate)
+
+        def _terminate(self) -> None:
+            self.terminate_calls += 1
+
     sandbox = _FakeSnapshotSandbox()
     state = modal_module.ModalSandboxSessionState(
         manifest=Manifest(
@@ -2494,6 +2565,9 @@ async def test_modal_snapshot_directory_teardown_failure_restores_partial_cleanu
     assert commands[2][0:2] == ["sh", "-lc"]
     assert "modal-snapshot-directory-ephemeral.tar" in commands[2][2]
     assert "tar xf" in commands[2][2]
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
 
 
 @pytest.mark.asyncio
@@ -3495,6 +3569,540 @@ async def test_modal_snapshot_directory_persist_only_detaches_durable_workspace_
     assert session._sandbox is not None  # noqa: SLF001
     assert archive.read() == modal_module._encode_snapshot_directory_ref(snapshot_id="im-123")
     assert events == [("unmount", "/workspace/actual"), ("mount", "/workspace/actual")]
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_persist_settles_cancelled_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    events: list[tuple[str, str]] = []
+    teardown_started = asyncio.Event()
+    teardown_release = asyncio.Event()
+    mount = (
+        _RecordingMount(mount_path=Path("actual"), ephemeral=False)
+        .bind_events(events)
+        .bind_teardown_gate(teardown_started, teardown_release)
+    )
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace", entries={"remote": mount}),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+
+    persist_task = asyncio.create_task(session.persist_workspace())
+    try:
+        await asyncio.wait_for(teardown_started.wait(), timeout=1)
+        persist_task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        teardown_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await persist_task
+
+    assert events == [("unmount", "/workspace/actual"), ("mount", "/workspace/actual")]
+    assert session._sandbox is not None  # noqa: SLF001
+    assert session.state.sandbox_id == "sb-123"
+    assert session._sandbox.terminate_calls == 0  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_persist_settles_cancelled_remount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    events: list[tuple[str, str]] = []
+    restore_started = asyncio.Event()
+    restore_release = asyncio.Event()
+    mount = (
+        _RecordingMount(mount_path=Path("actual"), ephemeral=False)
+        .bind_events(events)
+        .bind_restore_gate(restore_started, restore_release)
+    )
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace", entries={"remote": mount}),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+
+    persist_task = asyncio.create_task(session.persist_workspace())
+    try:
+        await asyncio.wait_for(restore_started.wait(), timeout=1)
+        persist_task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        restore_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await persist_task
+
+    assert events == [("unmount", "/workspace/actual"), ("mount", "/workspace/actual")]
+    assert session._sandbox is not None  # noqa: SLF001
+    assert session.state.sandbox_id == "sb-123"
+    assert session._sandbox.terminate_calls == 0  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_persist_terminates_cancelled_failed_remount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    events: list[tuple[str, str]] = []
+    restore_started = asyncio.Event()
+    restore_release = asyncio.Event()
+    first = _RecordingMount(mount_path=Path("first"), ephemeral=False).bind_events(events)
+    second = (
+        _RecordingMount(mount_path=Path("second"), ephemeral=False)
+        .bind_events(events)
+        .bind_restore_gate(restore_started, restore_release, error="remount failed")
+    )
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(
+            root="/workspace",
+            entries={"first": first, "second": second},
+        ),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+
+    persist_task = asyncio.create_task(session.persist_workspace())
+    try:
+        await asyncio.wait_for(restore_started.wait(), timeout=1)
+        assert session._sandbox is not None  # noqa: SLF001
+        sandbox = session._sandbox  # noqa: SLF001
+        persist_task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        restore_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await persist_task
+
+    assert events == [
+        ("unmount", "/workspace/first"),
+        ("unmount", "/workspace/second"),
+        ("mount", "/workspace/second"),
+        ("mount", "/workspace/first"),
+    ]
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert session._running is False  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_persist_distinguishes_simultaneous_cancellations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    events: list[tuple[str, str]] = []
+    restore_started = asyncio.Event()
+    restore_release = asyncio.Event()
+    mount = (
+        _RecordingMount(mount_path=Path("actual"), ephemeral=False)
+        .bind_events(events)
+        .bind_restore_cancellation(restore_started, restore_release)
+    )
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace", entries={"remote": mount}),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+
+    persist_task = asyncio.create_task(session.persist_workspace())
+    await asyncio.wait_for(restore_started.wait(), timeout=1)
+    assert session._sandbox is not None  # noqa: SLF001
+    sandbox = session._sandbox  # noqa: SLF001
+    restore_release.set()
+    persist_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await persist_task
+
+    assert events == [("unmount", "/workspace/actual"), ("mount", "/workspace/actual")]
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert session._running is False  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_failed_remount_does_not_create_replacement_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    events: list[tuple[str, str]] = []
+    mount = (
+        _RecordingMount(mount_path=Path("actual"), ephemeral=False)
+        .bind_events(events)
+        .bind_restore_error("remount failed")
+    )
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(
+            root="/workspace",
+            entries={
+                "tmp.txt": File(content=b"skip", ephemeral=True),
+                "remote": mount,
+            },
+        ),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+    await session._ensure_sandbox()  # noqa: SLF001
+    assert session._sandbox is not None  # noqa: SLF001
+    sandbox = session._sandbox  # noqa: SLF001
+
+    with pytest.raises(WorkspaceArchiveReadError) as exc_info:
+        await session.persist_workspace()
+
+    assert isinstance(exc_info.value.cause, RuntimeError)
+    assert str(exc_info.value.cause) == "remount failed"
+    assert events == [("unmount", "/workspace/actual"), ("mount", "/workspace/actual")]
+    assert len(create_calls) == 1
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert session._running is False  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_persist_propagates_cancelled_terminal_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    mount = _RecordingMount(
+        mount_path=Path("actual"),
+        ephemeral=False,
+    ).bind_teardown_error("unmount failed")
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace", entries={"remote": mount}),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+    await session._ensure_sandbox()  # noqa: SLF001
+    assert session._sandbox is not None  # noqa: SLF001
+    sandbox = session._sandbox  # noqa: SLF001
+    termination_started = asyncio.Event()
+    termination_release = asyncio.Event()
+
+    async def _terminate(**kwargs: object) -> None:
+        sandbox.terminate_calls += 1
+        sandbox.terminate_kwargs.append(kwargs)
+        termination_started.set()
+        await termination_release.wait()
+
+    sandbox.terminate.aio = _terminate
+    persist_task = asyncio.create_task(session.persist_workspace())
+    try:
+        await asyncio.wait_for(termination_started.wait(), timeout=1)
+        persist_task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        termination_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await persist_task
+
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert session._running is False  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_hydrate_settles_cancelled_image_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    events: list[tuple[str, str]] = []
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(
+            root="/workspace",
+            entries={
+                "remote": _RecordingMount(mount_path=Path("actual"), ephemeral=False).bind_events(
+                    events
+                )
+            },
+        ),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+    await session._ensure_sandbox()  # noqa: SLF001
+    assert session._sandbox is not None  # noqa: SLF001
+    sandbox = session._sandbox  # noqa: SLF001
+    mount_started = asyncio.Event()
+    mount_release = asyncio.Event()
+
+    async def _mount_image(path: str, image: object) -> None:
+        sandbox.mount_image_calls.append((path, getattr(image, "object_id", None)))
+        mount_started.set()
+        await mount_release.wait()
+
+    sandbox.mount_image.aio = _mount_image
+    hydrate_task = asyncio.create_task(
+        session.hydrate_workspace(
+            io.BytesIO(modal_module._encode_snapshot_directory_ref(snapshot_id="snap-dir-123"))
+        )
+    )
+    try:
+        await asyncio.wait_for(mount_started.wait(), timeout=1)
+        hydrate_task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        mount_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await hydrate_task
+
+    assert sandbox.mount_image_calls == [("/workspace", "snap-dir-123")]
+    assert events == [("mount", "/workspace/actual")]
+    assert session._sandbox is sandbox  # noqa: SLF001
+    assert session.state.sandbox_id == "sb-123"
+    assert sandbox.terminate_calls == 0
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_hydrate_terminates_cancelled_failed_image_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+    await session._ensure_sandbox()  # noqa: SLF001
+    assert session._sandbox is not None  # noqa: SLF001
+    sandbox = session._sandbox  # noqa: SLF001
+    mount_started = asyncio.Event()
+    mount_release = asyncio.Event()
+
+    async def _mount_image(path: str, image: object) -> None:
+        sandbox.mount_image_calls.append((path, getattr(image, "object_id", None)))
+        mount_started.set()
+        await mount_release.wait()
+        raise RuntimeError("mount image failed")
+
+    sandbox.mount_image.aio = _mount_image
+    hydrate_task = asyncio.create_task(
+        session.hydrate_workspace(
+            io.BytesIO(modal_module._encode_snapshot_directory_ref(snapshot_id="snap-dir-123"))
+        )
+    )
+    try:
+        await asyncio.wait_for(mount_started.wait(), timeout=1)
+        hydrate_task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        mount_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await hydrate_task
+
+    assert sandbox.mount_image_calls == [("/workspace", "snap-dir-123")]
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_hydrate_maps_inner_image_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+    await session._ensure_sandbox()  # noqa: SLF001
+    assert session._sandbox is not None  # noqa: SLF001
+    sandbox = session._sandbox  # noqa: SLF001
+
+    async def _mount_image(_path: str, _image: object) -> None:
+        raise asyncio.CancelledError()
+
+    sandbox.mount_image.aio = _mount_image
+
+    with pytest.raises(WorkspaceArchiveWriteError) as exc_info:
+        await session.hydrate_workspace(
+            io.BytesIO(modal_module._encode_snapshot_directory_ref(snapshot_id="snap-dir-123"))
+        )
+
+    assert isinstance(exc_info.value.cause, WorkspaceArchiveWriteError)
+    assert exc_info.value.cause.context["reason"] == "mount_image_cancelled"
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert session._running is False  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_hydrate_distinguishes_simultaneous_cancellations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+    await session._ensure_sandbox()  # noqa: SLF001
+    assert session._sandbox is not None  # noqa: SLF001
+    sandbox = session._sandbox  # noqa: SLF001
+    mount_started = asyncio.Event()
+    mount_release = asyncio.Event()
+
+    async def _mount_image(_path: str, _image: object) -> None:
+        mount_started.set()
+        await mount_release.wait()
+        raise asyncio.CancelledError()
+
+    sandbox.mount_image.aio = _mount_image
+    hydrate_task = asyncio.create_task(
+        session.hydrate_workspace(
+            io.BytesIO(modal_module._encode_snapshot_directory_ref(snapshot_id="snap-dir-123"))
+        )
+    )
+    await asyncio.wait_for(mount_started.wait(), timeout=1)
+    mount_release.set()
+    hydrate_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await hydrate_task
+
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert session._running is False  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_hydrate_propagates_cancelled_terminal_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+    await session._ensure_sandbox()  # noqa: SLF001
+    assert session._sandbox is not None  # noqa: SLF001
+    sandbox = session._sandbox  # noqa: SLF001
+    termination_started = asyncio.Event()
+    termination_release = asyncio.Event()
+
+    async def _mount_image(_path: str, _image: object) -> None:
+        raise RuntimeError("mount image failed")
+
+    async def _terminate(**kwargs: object) -> None:
+        sandbox.terminate_calls += 1
+        sandbox.terminate_kwargs.append(kwargs)
+        termination_started.set()
+        await termination_release.wait()
+
+    sandbox.mount_image.aio = _mount_image
+    sandbox.terminate.aio = _terminate
+    hydrate_task = asyncio.create_task(
+        session.hydrate_workspace(
+            io.BytesIO(modal_module._encode_snapshot_directory_ref(snapshot_id="snap-dir-123"))
+        )
+    )
+    try:
+        await asyncio.wait_for(termination_started.wait(), timeout=1)
+        hydrate_task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        termination_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await hydrate_task
+
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert session._running is False  # noqa: SLF001
+    assert _unfinished_mount_transition_tasks() == []
+
+
+@pytest.mark.asyncio
+async def test_modal_snapshot_directory_hydrate_terminates_cancelled_failed_remount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+    events: list[tuple[str, str]] = []
+    restore_started = asyncio.Event()
+    restore_release = asyncio.Event()
+    mount = (
+        _RecordingMount(mount_path=Path("actual"), ephemeral=False)
+        .bind_events(events)
+        .bind_restore_gate(restore_started, restore_release, error="remount failed")
+    )
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace", entries={"remote": mount}),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        workspace_persistence="snapshot_directory",
+    )
+    session = modal_module.ModalSandboxSession.from_state(state)
+
+    hydrate_task = asyncio.create_task(
+        session.hydrate_workspace(
+            io.BytesIO(modal_module._encode_snapshot_directory_ref(snapshot_id="snap-dir-123"))
+        )
+    )
+    try:
+        await asyncio.wait_for(restore_started.wait(), timeout=1)
+        assert session._sandbox is not None  # noqa: SLF001
+        sandbox = session._sandbox  # noqa: SLF001
+        hydrate_task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        restore_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await hydrate_task
+
+    assert sandbox.mount_image_calls == [("/workspace", "snap-dir-123")]
+    assert events == [("mount", "/workspace/actual")]
+    assert sandbox.terminate_calls == 1
+    assert session._sandbox is None  # noqa: SLF001
+    assert session.state.sandbox_id is None
+    assert _unfinished_mount_transition_tasks() == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes cancellation gaps in Modal `snapshot_directory` persistence and hydration.

It settles detach, image replacement, remount, and terminal-cleanup transitions before propagating cancellation; restores proven-detached mounts when safe; and terminates sessions with ambiguous topology. It reuses the shared mount lifecycle pipeline while preserving provider-native Modal bucket mounts, credentialless mounts, snapshot references, and tar fallback behavior.

Deterministic tests cover survivor and terminal outcomes, simultaneous cancellation, replacement-sandbox prevention, and orphan-task cleanup.
