### PR TITLE
fix(tracing): release the span scope when finish fails on generator close

### DIFF
--- a/src/agents/tracing/spans.py
+++ b/src/agents/tracing/spans.py
@@ -43,17 +43,22 @@ def _finish_on_generator_exit(span: Span[Any]) -> None:
     An explicit ``finish`` from the wrong context is a context-ownership violation rather
     than an unavoidable one, so it still raises, and a processor that fails during
     ``finish`` still surfaces rather than being mistaken for a foreign token.
-    """
-    span.finish(reset_current=False)
 
-    token: contextvars.Token[Span[Any] | None] | None = span._prev_span_token  # type: ignore[attr-defined]
-    if token is None:
-        return
-    span._prev_span_token = None  # type: ignore[attr-defined]
+    The reset runs in a ``finally`` so that a failing ``finish`` still releases the scope
+    instead of leaving the finished span current, and the token is cleared only once the
+    reset has either succeeded or hit the foreign-context ``ValueError`` it expects. An
+    unexpected reset failure therefore leaves the handle in place rather than losing it.
+    """
     try:
-        Scope.reset_current_span(token)
-    except ValueError:
-        logger.debug("Skipping span context reset, token belongs to another context")
+        span.finish(reset_current=False)
+    finally:
+        token: contextvars.Token[Span[Any] | None] | None = span._prev_span_token  # type: ignore[attr-defined]
+        if token is not None:
+            try:
+                Scope.reset_current_span(token)
+            except ValueError:
+                logger.debug("Skipping span context reset, token belongs to another context")
+            span._prev_span_token = None  # type: ignore[attr-defined]
 
 
 class Span(abc.ABC, Generic[TSpanData]):

--- a/tests/tracing/test_spans_impl.py
+++ b/tests/tracing/test_spans_impl.py
@@ -160,3 +160,44 @@ async def test_generator_close_surfaces_processor_failure() -> None:
         await generator.aclose()
 
     Scope.set_current_span(None)
+
+
+async def test_generator_close_releases_the_span_scope_when_finish_fails() -> None:
+    """A failing ``finish`` must still release the scope it took.
+
+    ``SpanImpl.finish`` runs the processor before resetting the scope, so a processor that
+    raises leaves the reset unreached. The finished span then stays current for the rest of
+    the caller's scope and every later span nests under it, which is the same leak the
+    ``GeneratorExit`` handling exists to prevent. ``TraceImpl`` already resets in a
+    ``finally`` for this reason.
+    """
+    Scope.set_current_span(None)
+
+    class FailingProcessor(DummyProcessor):
+        def on_span_end(self, span: Span[Any]) -> None:
+            raise ValueError("processor exploded")
+
+    span = SpanImpl(
+        trace_id="trace-finish-failure",
+        span_id="span-finish-failure",
+        parent_id=None,
+        processor=cast(Any, FailingProcessor()),
+        span_data=AgentSpanData(name="finish-failure"),
+        tracing_api_key=None,
+    )
+
+    async def stream() -> AsyncGenerator[int, None]:
+        with span:
+            yield 1
+
+    generator = stream()
+    assert await generator.asend(None) == 1
+    assert Scope.get_current_span() is span
+
+    with pytest.raises(ValueError, match="processor exploded"):
+        await generator.aclose()
+
+    assert Scope.get_current_span() is None
+    assert span._prev_span_token is None
+
+    Scope.set_current_span(None)


### PR DESCRIPTION
`SpanImpl.finish` calls `on_span_end` before resetting the scope, so a processor that raises leaves the reset unreached. The finished span stays current for the rest of the caller's scope and later spans nest under it — the same leak the `GeneratorExit` handling exists to prevent.

#4232 fixed this for `TraceImpl` by running the reset in a `finally` and clearing the token only after the reset has been attempted. #4233 landed first, so `spans.py` never got that refinement. This applies it, leaving the two helpers identical.

New test in `tests/tracing/test_spans_impl.py` fails on `main` (`Scope.get_current_span()` is still the finished span) and passes here. Existing tests unchanged.

Refs #4232
