### PR TITLE
docs(usage): document the raw provider usage snapshot opt-in

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,6 +38,33 @@ Usage reporting varies across third-party adapters and provider backends. If you
 
 Review the adapter-specific notes in the [Third-party adapters](models/index.md#third-party-adapters) section of the Models guide and validate usage reporting on the exact provider backend you plan to deploy.
 
+### Preserving the raw provider usage payload
+
+`Usage` normalizes missing fields to `0`, so a field the provider never reported and a field the provider explicitly reported as `0` look identical. If you build cost or coverage reporting on top of usage, opt in to [`ModelSettings.preserve_raw_usage`][agents.model_settings.ModelSettings.preserve_raw_usage] and read [`ModelResponse.raw_usage`][agents.items.ModelResponse.raw_usage] from `result.raw_responses`:
+
+```python
+from agents import Agent, ModelSettings, Runner
+
+agent = Agent(
+    name="Assistant",
+    model_settings=ModelSettings(preserve_raw_usage=True),
+)
+
+result = await Runner.run(agent, "What's the weather in Tokyo?")
+
+for response in result.raw_responses:
+    print(response.raw_usage)
+```
+
+`raw_usage` is a JSON-compatible snapshot of the usage object as the model adapter received it, taken before the SDK normalizes it. Keys the provider omitted stay absent, while explicit `null`, zero, and provider-specific keys stay present as received. A provider that omitted `cached_tokens` yields `{"prompt_tokens_details": {}}` and one that reported it as zero yields `{"prompt_tokens_details": {"cached_tokens": 0}}`, even though `usage.input_tokens_details.cached_tokens` is `0` in both cases.
+
+Keep these boundaries in mind:
+
+-   It is one snapshot per completed `ModelResponse`, on both streamed and non-streamed calls. It is never aggregated, and `result.context_wrapper.usage` is unaffected.
+-   It does not ask the provider for usage. Streaming backends that need `ModelSettings(include_usage=True)` still need it.
+-   It is `None` when the adapter received no usage payload, or when an upstream adapter already discarded field-presence information.
+-   It is diagnostic metadata that `RunState` serialization does not persist, so it is unavailable after resuming a run from a serialized state.
+
 ## Per-request usage tracking
 
 The SDK automatically tracks usage for each API request in `request_usage_entries`, useful for detailed cost calculation and monitoring context window consumption.
@@ -82,5 +109,7 @@ For detailed API documentation, see:
 
 -   [`Usage`][agents.usage.Usage] - Usage tracking data structure
 -   [`RequestUsage`][agents.usage.RequestUsage] - Per-request usage details
+-   [`ModelSettings.preserve_raw_usage`][agents.model_settings.ModelSettings.preserve_raw_usage] - Opt in to raw provider usage snapshots
+-   [`ModelResponse.raw_usage`][agents.items.ModelResponse.raw_usage] - The preserved provider usage payload
 -   [`RunContextWrapper`][agents.run.RunContextWrapper] - Access usage from run context
 -   [`RunHooks`][agents.run.RunHooks] - Hook into usage tracking lifecycle


### PR DESCRIPTION
`ModelSettings.preserve_raw_usage` and `ModelResponse.raw_usage` shipped in #4279 with no prose docs. The feature exists specifically to distinguish a usage field the provider omitted from one it reported as zero — a distinction `Usage` cannot express — so its target audience needs both an entry point and the boundaries of the snapshot.

Adds a subsection to `docs/usage.md` under third-party adapter usage, plus two API reference links. Covers: how to enable and read it, that omitted keys stay absent while explicit zeros stay present, and the four boundaries (one snapshot per `ModelResponse` on streamed and non-streamed calls, never aggregated; does not request usage from the provider; `None` when no usage reaches the adapter; not persisted by `RunState`).

Verified the snippet and every claim against the current implementation on both the streamed and non-streamed Chat Completions paths. `make build-docs` is clean; only the English source is touched.

Refs #4270
