### PR TITLE
feat(retry): allow applications to approve unsafe replays

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -1034,11 +1034,13 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
         stateful_request = bool(request.previous_response_id or request.conversation_id)
         wrapped_replay_safety = _get_wrapped_websocket_replay_safety(request.error)
         if wrapped_replay_safety == "unsafe":
-            if stateful_request or _did_start_websocket_response(request.error):
+            response_started = _did_start_websocket_response(request.error)
+            if stateful_request or response_started:
                 return ModelRetryAdvice(
                     suggested=False,
                     replay_safety="unsafe",
                     reason=str(request.error),
+                    response_started=response_started,
                 )
             return ModelRetryAdvice(
                 suggested=True,

--- a/src/agents/retry.py
+++ b/src/agents/retry.py
@@ -98,6 +98,8 @@ class ModelRetryAdvice:
     replay_safety: str | None = None
     reason: str | None = None
     normalized: ModelRetryNormalizedError | None = None
+    response_started: bool = False
+    """Whether the provider had begun emitting the response when the failure occurred."""
 
 
 @dataclass
@@ -118,8 +120,23 @@ class RetryDecision:
     retry: bool
     delay: float | None = None
     reason: str | None = None
+    approve_unsafe_replay: bool = False
+    """Explicit application approval to replay a request the provider marked replay-unsafe.
+
+    This is deliberately separate from ``retry``: an ordinary ``RetryDecision(retry=True)``
+    never bypasses replay protection. Set this only for workloads where repeating
+    provider-side work that may already have happened is acceptable.
+    """
     _hard_veto: bool = field(default=False, init=False, repr=False, compare=False)
+    _delegable_replay_veto: bool = field(default=False, init=False, repr=False, compare=False)
     _approves_replay: bool = field(default=False, init=False, repr=False, compare=False)
+
+
+@dataclass(frozen=True)
+class _ProviderRetryAuthority:
+    suggested: bool | None
+    replay_safety: str
+    response_started: bool
 
 
 @dataclass
@@ -132,6 +149,37 @@ class RetryPolicyContext:
     stream: bool
     normalized: ModelRetryNormalizedError
     provider_advice: ModelRetryAdvice | None = None
+    previous_response_id: str | None = None
+    conversation_id: str | None = None
+    _provider_authority: _ProviderRetryAuthority = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        advice = self.provider_advice
+        replay_safety = advice.replay_safety if advice is not None else None
+        self._provider_authority = _ProviderRetryAuthority(
+            suggested=advice.suggested if advice is not None else None,
+            replay_safety=(replay_safety if replay_safety in {"safe", "unsafe"} else "unknown"),
+            response_started=advice.response_started if advice is not None else False,
+        )
+
+    @property
+    def response_started(self) -> bool:
+        """Whether the provider had begun emitting the response when the failure occurred."""
+        return self._provider_authority.response_started
+
+    @property
+    def replay_safety(self) -> str:
+        """Provider replay classification: ``"safe"``, ``"unsafe"`` or ``"unknown"``."""
+        return self._provider_authority.replay_safety
+
+    @property
+    def stateful_request(self) -> bool:
+        """Whether the request carried ``previous_response_id`` or ``conversation_id``."""
+        return bool(self.previous_response_id or self.conversation_id)
 
 
 RetryPolicy: TypeAlias = Callable[[RetryPolicyContext], MaybeAwaitable[bool | RetryDecision]]
@@ -203,6 +251,12 @@ def _with_hard_veto(decision: RetryDecision) -> RetryDecision:
     return decision
 
 
+def _with_delegable_replay_veto(decision: RetryDecision) -> RetryDecision:
+    decision._hard_veto = True
+    decision._delegable_replay_veto = True
+    return decision
+
+
 def _with_replay_safe_approval(decision: RetryDecision) -> RetryDecision:
     decision._approves_replay = True
     return decision
@@ -216,6 +270,7 @@ def _merge_positive_retry_decisions(
         retry=True,
         delay=existing.delay,
         reason=existing.reason,
+        approve_unsafe_replay=existing.approve_unsafe_replay or incoming.approve_unsafe_replay,
     )
     if existing._approves_replay:
         merged = _with_replay_safe_approval(merged)
@@ -226,6 +281,24 @@ def _merge_positive_retry_decisions(
     if incoming._approves_replay:
         merged = _with_replay_safe_approval(merged)
     return merged
+
+
+def _resolve_delegable_replay_veto(
+    veto: RetryDecision,
+    approving: RetryDecision,
+) -> RetryDecision:
+    if not approving.retry or not approving.approve_unsafe_replay:
+        return veto
+
+    resolved = RetryDecision(
+        retry=True,
+        delay=approving.delay,
+        reason=approving.reason or veto.reason,
+        approve_unsafe_replay=True,
+    )
+    if approving._approves_replay:
+        resolved = _with_replay_safe_approval(resolved)
+    return resolved
 
 
 class _RetryPolicies:
@@ -241,13 +314,18 @@ class _RetryPolicies:
 
     def provider_suggested(self) -> RetryPolicy:
         def policy(context: RetryPolicyContext) -> bool | RetryDecision:
+            authority = context._provider_authority
             advice = context.provider_advice
-            if advice is None or advice.suggested is None:
+            reason = advice.reason if advice is not None else None
+            retry_after = advice.retry_after if advice is not None else None
+            if authority.suggested is None:
                 return False
-            if advice.suggested is False:
-                return _with_hard_veto(RetryDecision(retry=False, reason=advice.reason))
-            decision = RetryDecision(retry=True, delay=advice.retry_after, reason=advice.reason)
-            if advice.replay_safety == "safe":
+            if authority.suggested is False:
+                if authority.replay_safety == "unsafe":
+                    return _with_delegable_replay_veto(RetryDecision(retry=False, reason=reason))
+                return _with_hard_veto(RetryDecision(retry=False, reason=reason))
+            decision = RetryDecision(retry=True, delay=retry_after, reason=reason)
+            if authority.replay_safety == "safe":
                 return _with_replay_safe_approval(decision)
             return decision
 
@@ -301,9 +379,14 @@ class _RetryPolicies:
 
         async def policy(context: RetryPolicyContext) -> bool | RetryDecision:
             merged = RetryDecision(retry=True)
+            delegable_replay_veto: RetryDecision | None = None
             for predicate in policies:
                 decision = await _evaluate_policy(predicate, context)
                 if decision._hard_veto:
+                    if decision._delegable_replay_veto:
+                        if delegable_replay_veto is None:
+                            delegable_replay_veto = decision
+                        continue
                     return decision
                 if not decision.retry:
                     return decision
@@ -311,9 +394,13 @@ class _RetryPolicies:
                     merged.delay = decision.delay
                 if decision.reason is not None:
                     merged.reason = decision.reason
+                if decision.approve_unsafe_replay:
+                    merged.approve_unsafe_replay = True
                 if decision._approves_replay:
                     merged = _with_replay_safe_approval(merged)
 
+            if delegable_replay_veto is not None:
+                return _resolve_delegable_replay_veto(delegable_replay_veto, merged)
             return merged
 
         return _mark_retry_capabilities(
@@ -333,9 +420,14 @@ class _RetryPolicies:
         async def policy(context: RetryPolicyContext) -> bool | RetryDecision:
             first_positive: RetryDecision | None = None
             last_negative: RetryDecision | None = None
+            delegable_replay_veto: RetryDecision | None = None
             for predicate in policies:
                 decision = await _evaluate_policy(predicate, context)
                 if decision._hard_veto:
+                    if decision._delegable_replay_veto:
+                        if delegable_replay_veto is None:
+                            delegable_replay_veto = decision
+                        continue
                     return decision
                 if decision.retry:
                     if first_positive is None:
@@ -345,6 +437,13 @@ class _RetryPolicies:
                     continue
                 last_negative = decision
 
+            if delegable_replay_veto is not None:
+                if first_positive is None:
+                    return delegable_replay_veto
+                return _resolve_delegable_replay_veto(
+                    delegable_replay_veto,
+                    first_positive,
+                )
             if first_positive is not None:
                 return first_positive
             if last_negative is not None:

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -126,13 +126,16 @@ def _normalize_retry_error(
                 "message",
                 "request_id",
                 "retry_after",
-                "is_abort",
                 "is_network_error",
                 "is_timeout",
             ):
                 if field_name in getattr(override, "_explicit_fields", ()):
                     override_value = getattr(override, field_name)
                     setattr(normalized, field_name, override_value)
+            if "is_abort" in getattr(override, "_explicit_fields", ()):
+                # Provider normalization may add abort evidence but cannot clear an abort
+                # inferred from the raw exception.
+                normalized.is_abort = normalized.is_abort or override.is_abort
 
     return normalized
 
@@ -273,16 +276,36 @@ async def _evaluate_retry(
     replay_unsafe_request: bool,
     emitted_retry_unsafe_event: bool,
     provider_advice: ModelRetryAdvice | None,
+    previous_response_id: str | None = None,
+    conversation_id: str | None = None,
 ) -> RetryDecision:
     if attempt > max_retries:
         return RetryDecision(retry=False)
 
     normalized = _normalize_retry_error(error, provider_advice)
-    if (
-        normalized.is_abort
-        or emitted_retry_unsafe_event
-        or (provider_advice is not None and provider_advice.replay_safety == "unsafe")
-    ):
+    context = RetryPolicyContext(
+        error=error,
+        attempt=attempt,
+        max_retries=max_retries,
+        stream=stream,
+        normalized=normalized,
+        provider_advice=provider_advice,
+        previous_response_id=previous_response_id,
+        conversation_id=conversation_id,
+    )
+    provider_marks_replay_unsafe = context.replay_safety == "unsafe"
+    provider_marks_replay_safe = context.replay_safety == "safe"
+    # Aborts, and failures that already emitted user-visible streamed output, are absolute
+    # vetoes. No application decision can make replaying those safe.
+    if normalized.is_abort or emitted_retry_unsafe_event:
+        return RetryDecision(
+            retry=False,
+            reason=provider_advice.reason if provider_advice is not None else None,
+        )
+    # A provider-unsafe streamed failure and a request with a separate local-side-effect veto
+    # stay blocked before the policy runs. Only a non-streamed request without that separate
+    # veto can ask the application to approve provider-side replay risk.
+    if provider_marks_replay_unsafe and (stream or replay_unsafe_request):
         return RetryDecision(
             retry=False,
             reason=provider_advice.reason if provider_advice is not None else None,
@@ -291,24 +314,43 @@ async def _evaluate_retry(
     if retry_policy is None:
         return RetryDecision(retry=False)
 
-    decision = await _call_retry_policy(
-        retry_policy,
-        RetryPolicyContext(
-            error=error,
-            attempt=attempt,
-            max_retries=max_retries,
-            stream=stream,
-            normalized=normalized,
-            provider_advice=provider_advice,
-        ),
-    )
+    decision = await _call_retry_policy(retry_policy, context)
     if not decision.retry:
         return decision
 
-    provider_marks_replay_safe = (
-        provider_advice is not None and provider_advice.replay_safety == "safe"
-    )
+    stateful_request = bool(previous_response_id or conversation_id)
+    # Three separate vetoes, deliberately not folded together.
+    #
+    # 1. A request-level replay veto (Programmatic Tool Calling, for example) covers
+    #    application-local side effects that may already have run. That is outside what
+    #    `approve_unsafe_replay` authorizes, so only the provider-owned approval lifts it.
     if replay_unsafe_request and not decision._approves_replay and not provider_marks_replay_safe:
+        return RetryDecision(
+            retry=False,
+            reason=decision.reason
+            or (provider_advice.reason if provider_advice is not None else None),
+        )
+    # 2. A stateful request (`previous_response_id` / `conversation_id`, including the
+    #    `auto_previous_response_id` case) fails closed by default because the follow-up
+    #    depends on server-side state. It carries no application-local side effects, so an
+    #    application approval can accept it — but only for the provider-marked unsafe failure
+    #    this option is scoped to. When replay safety is unknown the request stays blocked:
+    #    there is no provider-unsafe failure for the approval to be about.
+    if stateful_request and not (
+        decision._approves_replay
+        or provider_marks_replay_safe
+        or (decision.approve_unsafe_replay and provider_marks_replay_unsafe)
+    ):
+        return RetryDecision(
+            retry=False,
+            reason=decision.reason
+            or (provider_advice.reason if provider_advice is not None else None),
+        )
+    # 3. Provider-marked replay unsafety is the case `approve_unsafe_replay` exists for.
+    #    Both approvals are explicit; an ordinary `retry=True` is neither.
+    if provider_marks_replay_unsafe and not (
+        decision._approves_replay or decision.approve_unsafe_replay
+    ):
         return RetryDecision(
             retry=False,
             reason=decision.reason
@@ -493,9 +535,11 @@ async def get_response_with_retry(
                 retry_policy=retry_settings.policy if retry_settings is not None else None,
                 retry_backoff=retry_settings.backoff if retry_settings is not None else None,
                 stream=False,
-                replay_unsafe_request=stateful_request or replay_unsafe_request,
+                replay_unsafe_request=replay_unsafe_request,
                 emitted_retry_unsafe_event=False,
                 provider_advice=provider_advice,
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
             )
             if not decision.retry:
                 raise
@@ -618,9 +662,11 @@ async def stream_response_with_retry(
                 retry_policy=retry_settings.policy if retry_settings is not None else None,
                 retry_backoff=retry_settings.backoff if retry_settings is not None else None,
                 stream=True,
-                replay_unsafe_request=stateful_request or replay_unsafe_request,
+                replay_unsafe_request=replay_unsafe_request,
                 emitted_retry_unsafe_event=emitted_retry_unsafe_event,
                 provider_advice=provider_advice,
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
             )
             if not decision.retry:
                 raise

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -2466,3 +2466,541 @@ async def test_stream_response_with_retry_closes_current_stream_when_consumer_st
     await outer_stream.aclose()
 
     assert stream.close_calls == 1
+
+
+def _ws_response_started_advice(request: ModelRetryAdviceRequest) -> ModelRetryAdvice:
+    """Advice matching the Responses WebSocket adapter after a response-started disconnect."""
+    return ModelRetryAdvice(
+        suggested=False,
+        replay_safety="unsafe",
+        reason=str(request.error),
+        response_started=True,
+    )
+
+
+def test_retry_policy_context_normalizes_unknown_provider_replay_safety() -> None:
+    context = RetryPolicyContext(
+        error=_connection_error(),
+        attempt=1,
+        max_retries=1,
+        stream=False,
+        normalized=ModelRetryNormalizedError(),
+        provider_advice=ModelRetryAdvice(replay_safety="conditional"),
+    )
+
+    assert context.replay_safety == "unknown"
+
+
+def test_provider_suggested_preserves_public_veto_for_unsafe_advice() -> None:
+    decision = retry_policies.provider_suggested()(
+        RetryPolicyContext(
+            error=_connection_error(),
+            attempt=1,
+            max_retries=1,
+            stream=False,
+            normalized=ModelRetryNormalizedError(is_network_error=True),
+            provider_advice=ModelRetryAdvice(
+                suggested=False,
+                replay_safety="unsafe",
+                reason="provider veto",
+            ),
+        )
+    )
+
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is False
+    assert decision.reason == "provider veto"
+
+
+@pytest.mark.asyncio
+async def test_provider_unsafe_replay_retries_when_policy_approves_explicitly() -> None:
+    calls = 0
+    seen: list[RetryPolicyContext] = []
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _connection_error("no close frame received or sent")
+        return ModelResponse(output=[get_text_message("ok")], usage=Usage(), response_id="resp")
+
+    def policy(context: RetryPolicyContext) -> RetryDecision:
+        seen.append(context)
+        return RetryDecision(
+            retry=True,
+            approve_unsafe_replay=True,
+            reason="Approved one replay of a read-only model turn",
+        )
+
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=lambda: asyncio.sleep(0),
+        retry_settings=ModelRetrySettings(
+            max_retries=1, backoff={"initial_delay": 0}, policy=policy
+        ),
+        get_retry_advice=_ws_response_started_advice,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    assert result.response_id == "resp"
+    assert calls == 2
+    # The policy must be able to scope its approval, so it needs the structured context.
+    assert len(seen) == 1
+    assert seen[0].stream is False
+    assert seen[0].response_started is True
+    assert seen[0].replay_safety == "unsafe"
+    assert seen[0].stateful_request is False
+
+
+@pytest.mark.asyncio
+async def test_provider_unsafe_replay_still_blocks_an_ordinary_retry_decision() -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error("no close frame received or sent")
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        # No `approve_unsafe_replay`, so this must not bypass replay protection.
+        return RetryDecision(retry=True)
+
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=_ws_response_started_advice,
+            previous_response_id=None,
+            conversation_id=None,
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_unsafe_replay_approval_is_ignored_for_streamed_requests() -> None:
+    calls = 0
+
+    async def get_stream() -> AsyncIterator[TResponseStreamEvent]:
+        nonlocal calls
+        calls += 1
+        raise _connection_error("no close frame received or sent")
+        yield  # pragma: no cover - generator marker
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    with pytest.raises(APIConnectionError):
+        async for _event in stream_response_with_retry(
+            get_stream=get_stream,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=_ws_response_started_advice,
+            previous_response_id=None,
+            conversation_id=None,
+        ):
+            pass
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unsafe_replay_approval_does_not_replay_programmatic_tool_calling() -> None:
+    calls = 0
+    policy_calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error()
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        nonlocal policy_calls
+        policy_calls += 1
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    # `replay_unsafe_request` is the request-level veto the runner sets for
+    # Programmatic Tool Calling. Application approval must not lift it.
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=_ws_response_started_advice,
+            previous_response_id=None,
+            conversation_id=None,
+            replay_unsafe_request=True,
+        )
+
+    assert calls == 1
+    assert policy_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("combinator", ["all", "any"])
+@pytest.mark.parametrize("provider_first", [False, True])
+async def test_unsafe_replay_approval_resolves_provider_veto_in_policy_combinators(
+    combinator: str,
+    provider_first: bool,
+) -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _connection_error("no close frame received or sent")
+        return ModelResponse(output=[get_text_message("ok")], usage=Usage(), response_id="resp")
+
+    def approving(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    provider_policy = retry_policies.provider_suggested()
+    policies = (provider_policy, approving) if provider_first else (approving, provider_policy)
+    combined = getattr(retry_policies, combinator)(*policies)
+
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=lambda: asyncio.sleep(0),
+        retry_settings=ModelRetrySettings(
+            max_retries=1, backoff={"initial_delay": 0}, policy=combined
+        ),
+        get_retry_advice=_ws_response_started_advice,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    assert result.response_id == "resp"
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_provider_normalization_cannot_clear_raw_abort_veto() -> None:
+    class AbortError(Exception):
+        pass
+
+    calls = 0
+    policy_calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise AbortError("cancelled")
+
+    async def rewind() -> None:
+        raise AssertionError("An abort must not rewind state")
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        nonlocal policy_calls
+        policy_calls += 1
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    def get_retry_advice(_request: ModelRetryAdviceRequest) -> ModelRetryAdvice:
+        return ModelRetryAdvice(
+            suggested=False,
+            replay_safety="unsafe",
+            normalized=ModelRetryNormalizedError(is_abort=False),
+        )
+
+    with pytest.raises(AbortError, match="cancelled"):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=rewind,
+            retry_settings=ModelRetrySettings(
+                max_retries=1,
+                backoff={"initial_delay": 0},
+                policy=policy,
+            ),
+            get_retry_advice=get_retry_advice,
+            previous_response_id=None,
+            conversation_id=None,
+        )
+
+    assert calls == 1
+    assert policy_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_policy_cannot_promote_unknown_provider_replay_safety() -> None:
+    calls = 0
+    policy_calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error()
+
+    async def rewind() -> None:
+        raise AssertionError("Unknown replay safety must not rewind state")
+
+    def policy(context: RetryPolicyContext) -> RetryDecision:
+        nonlocal policy_calls
+        policy_calls += 1
+        assert context.provider_advice is not None
+        assert context.replay_safety == "unknown"
+        context.provider_advice.replay_safety = "safe"
+        return RetryDecision(retry=True)
+
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=rewind,
+            retry_settings=ModelRetrySettings(
+                max_retries=1,
+                backoff={"initial_delay": 0},
+                policy=policy,
+            ),
+            get_retry_advice=lambda _request: ModelRetryAdvice(
+                suggested=True,
+                replay_safety="conditional",
+            ),
+            previous_response_id="resp_1",
+            conversation_id=None,
+        )
+
+    assert calls == 1
+    assert policy_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_policy_cannot_revoke_provider_safe_replay_evidence() -> None:
+    calls = 0
+    rewinds = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _connection_error()
+        return ModelResponse(output=[get_text_message("ok")], usage=Usage(), response_id="resp")
+
+    async def rewind() -> None:
+        nonlocal rewinds
+        rewinds += 1
+
+    def policy(context: RetryPolicyContext) -> RetryDecision:
+        assert context.provider_advice is not None
+        assert context.replay_safety == "safe"
+        context.provider_advice.replay_safety = "conditional"
+        return RetryDecision(retry=True)
+
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=rewind,
+        retry_settings=ModelRetrySettings(
+            max_retries=1,
+            backoff={"initial_delay": 0},
+            policy=policy,
+        ),
+        get_retry_advice=lambda _request: ModelRetryAdvice(
+            suggested=True,
+            replay_safety="safe",
+        ),
+        previous_response_id="resp_1",
+        conversation_id=None,
+    )
+
+    assert result.response_id == "resp"
+    assert calls == 2
+    assert rewinds == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("combinator", ["all", "any"])
+@pytest.mark.parametrize(
+    ("suggested", "initial_safety", "expected_context_safety"),
+    [
+        (False, "unsafe", "unsafe"),
+        (None, "conditional", "unknown"),
+    ],
+)
+async def test_composed_policy_cannot_mutate_provider_authority(
+    combinator: str,
+    suggested: bool | None,
+    initial_safety: str,
+    expected_context_safety: str,
+) -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error()
+
+    async def rewind() -> None:
+        raise AssertionError("Mutated provider authority must not rewind state")
+
+    def mutate_advice(context: RetryPolicyContext) -> RetryDecision:
+        assert context.provider_advice is not None
+        assert context.replay_safety == expected_context_safety
+        assert context.response_started is False
+        context.provider_advice.suggested = True
+        context.provider_advice.replay_safety = "safe"
+        context.provider_advice.response_started = True
+        assert context.replay_safety == expected_context_safety
+        assert context.response_started is False
+        return RetryDecision(retry=True)
+
+    policy = getattr(retry_policies, combinator)(
+        mutate_advice,
+        retry_policies.provider_suggested(),
+    )
+
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=rewind,
+            retry_settings=ModelRetrySettings(
+                max_retries=1,
+                backoff={"initial_delay": 0},
+                policy=policy,
+            ),
+            get_retry_advice=lambda _request: ModelRetryAdvice(
+                suggested=suggested,
+                replay_safety=initial_safety,
+                response_started=False,
+            ),
+            previous_response_id="resp_1",
+            conversation_id=None,
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_composed_policy_cannot_mutate_provider_authority_for_ptc() -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error()
+
+    async def rewind() -> None:
+        raise AssertionError("Mutated provider authority must not rewind PTC state")
+
+    def mutate_advice(context: RetryPolicyContext) -> RetryDecision:
+        assert context.provider_advice is not None
+        context.provider_advice.suggested = True
+        context.provider_advice.replay_safety = "safe"
+        return RetryDecision(retry=True)
+
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=rewind,
+            retry_settings=ModelRetrySettings(
+                max_retries=1,
+                backoff={"initial_delay": 0},
+                policy=retry_policies.all(
+                    mutate_advice,
+                    retry_policies.provider_suggested(),
+                ),
+            ),
+            get_retry_advice=lambda _request: ModelRetryAdvice(
+                suggested=None,
+                replay_safety="conditional",
+            ),
+            previous_response_id=None,
+            conversation_id=None,
+            replay_unsafe_request=True,
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unsafe_replay_approval_applies_to_a_stateful_request() -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _connection_error("no close frame received or sent")
+        return ModelResponse(output=[get_text_message("ok")], usage=Usage(), response_id="resp")
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    # `auto_previous_response_id=True` produces exactly this shape: a stateful request
+    # that fails closed by default but carries no application-local side effects.
+    result = await get_response_with_retry(
+        get_response=get_response,
+        rewind=lambda: asyncio.sleep(0),
+        retry_settings=ModelRetrySettings(
+            max_retries=1, backoff={"initial_delay": 0}, policy=policy
+        ),
+        get_retry_advice=_ws_response_started_advice,
+        previous_response_id="resp_1",
+        conversation_id=None,
+    )
+
+    assert result.response_id == "resp"
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_stateful_request_still_fails_closed_without_explicit_approval() -> None:
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error("no close frame received or sent")
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True)
+
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=_ws_response_started_advice,
+            previous_response_id=None,
+            conversation_id="conv_1",
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unsafe_replay_approval_does_not_lift_a_stateful_request_with_unknown_safety() -> (
+    None
+):
+    calls = 0
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise _connection_error()
+
+    def policy(_context: RetryPolicyContext) -> RetryDecision:
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    # No provider advice, so replay safety is unknown rather than unsafe. The approval is
+    # scoped to provider-marked unsafe failures, so the stateful gate must stay closed.
+    with pytest.raises(APIConnectionError):
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=lambda: asyncio.sleep(0),
+            retry_settings=ModelRetrySettings(
+                max_retries=1, backoff={"initial_delay": 0}, policy=policy
+            ),
+            get_retry_advice=lambda _request: None,
+            previous_response_id="resp_1",
+            conversation_id=None,
+        )
+
+    assert calls == 1

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4289,3 +4289,45 @@ async def test_stream_response_lets_in_flight_close_finish_after_cancellation() 
     finally:
         release.set()
         task.cancel()
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_get_retry_advice_reports_response_started() -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = _connection_closed_error("no close frame received or sent")
+    setattr(error, "_openai_agents_ws_replay_safety", "unsafe")  # noqa: B010
+    setattr(error, "_openai_agents_ws_response_started", True)  # noqa: B010
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=False,
+        )
+    )
+
+    assert advice is not None
+    assert advice.replay_safety == "unsafe"
+    # A retry policy needs this to tell a response-started disconnect apart from
+    # other replay-unsafe failures before approving a replay.
+    assert advice.response_started is True
+
+
+@pytest.mark.allow_call_model_methods
+def test_websocket_get_retry_advice_reports_no_response_started_for_stateful_request() -> None:
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+    error = _connection_closed_error("no close frame received or sent")
+    setattr(error, "_openai_agents_ws_replay_safety", "unsafe")  # noqa: B010
+
+    advice = model.get_retry_advice(
+        ModelRetryAdviceRequest(
+            error=error,
+            attempt=1,
+            stream=False,
+            previous_response_id="resp_1",
+        )
+    )
+
+    assert advice is not None
+    assert advice.replay_safety == "unsafe"
+    assert advice.response_started is False

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -36,6 +36,8 @@ from agents import (
     OpenAIConversationsSession,
     OutputGuardrail,
     OutputGuardrailTripwireTriggered,
+    RetryDecision,
+    RetryPolicyContext,
     RunConfig,
     RunContextWrapper,
     Runner,
@@ -5037,6 +5039,55 @@ async def test_previous_response_id_retry_does_not_resend_initial_input_multi_tu
     assert isinstance(last_input, list)
     assert len(last_input) == 1
     assert last_input[0].get("type") == "function_call_output"
+
+
+@pytest.mark.asyncio
+async def test_auto_previous_response_id_retries_when_policy_approves_unsafe_replay():
+    seen: list[RetryPolicyContext] = []
+
+    class StatefulRetryUnsafeFakeModel(FakeModel):
+        def get_retry_advice(self, request):
+            if request.previous_response_id or request.conversation_id:
+                return ModelRetryAdvice(
+                    suggested=False,
+                    replay_safety="unsafe",
+                    response_started=True,
+                )
+            return None
+
+    def policy(context: RetryPolicyContext) -> RetryDecision:
+        seen.append(context)
+        return RetryDecision(retry=True, approve_unsafe_replay=True)
+
+    model = StatefulRetryUnsafeFakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("test_func", '{"arg": "foo"}')],
+            APIConnectionError(
+                message="connection closed after response processing started",
+                request=httpx.Request("POST", "https://example.com"),
+            ),
+            [get_text_message("done")],
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("test_func", "tool_result")],
+        model_settings=ModelSettings(
+            retry=ModelRetrySettings(max_retries=1, policy=policy),
+        ),
+    )
+
+    result = await Runner.run(agent, input="user_message", auto_previous_response_id=True)
+
+    assert result.final_output == "done"
+    assert len(seen) == 1
+    assert seen[0].previous_response_id == "resp-789"
+    assert seen[0].conversation_id is None
+    assert seen[0].stateful_request is True
+    assert seen[0].response_started is True
+    assert seen[0].replay_safety == "unsafe"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request supersedes #4313 and resolves #4283 by allowing an application retry policy to explicitly approve a provider-marked replay-unsafe non-streamed model request.

It adds `RetryDecision.approve_unsafe_replay` without changing existing positional parameters and exposes response-started and conversation-state facts through `RetryPolicyContext`. The default remains fail-closed: ordinary retries cannot bypass replay safety, stateful requests with unknown safety stay blocked, and aborts, streamed output, and Programmatic Tool Calling side-effect boundaries remain vetoes. Policy combinators preserve explicit approval, and unrecognized provider replay classifications normalize to `unknown`.

Documentation is intentionally deferred to a release-timed docs update because this behavior is not available in the latest published release.