### PR TITLE
feat: add explicit mount credential exposure acknowledgements

### DIFF
--- a/src/agents/extensions/sandbox/blaxel/mounts.py
+++ b/src/agents/extensions/sandbox/blaxel/mounts.py
@@ -16,12 +16,13 @@ Two strategies are provided:
 
 from __future__ import annotations
 
+import io
 import logging
 import shlex
 import uuid
 import warnings
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 from .... import _debug
@@ -36,7 +37,7 @@ from ....sandbox.errors import MountConfigError
 from ....sandbox.materialization import MaterializedFile
 from ....sandbox.session.base_sandbox_session import BaseSandboxSession
 from ....sandbox.types import FileMode, Permissions
-from ....sandbox.workspace_paths import sandbox_path_str
+from ....sandbox.workspace_paths import posix_path_as_path, sandbox_path_str
 
 logger = logging.getLogger(__name__)
 
@@ -300,52 +301,58 @@ async def _ensure_tool(session: BaseSandboxSession, tool: str) -> None:
     await _install_tool(session, tool)
 
 
+def _mount_credential_path(session: BaseSandboxSession, stem: str) -> Path:
+    root = PurePosixPath(session.state.manifest.root)
+    return posix_path_as_path(root / f".openai-agents-{stem}-{uuid.uuid4().hex[:8]}")
+
+
+async def _write_mount_credential_file(
+    session: BaseSandboxSession,
+    path: Path,
+    content: str,
+) -> None:
+    await session.write(path, io.BytesIO(content.encode()))
+    await _exec(session, f"chmod 600 {shlex.quote(sandbox_path_str(path))}")
+
+
 async def _mount_s3(session: BaseSandboxSession, config: BlaxelCloudBucketMountConfig) -> None:
     """Mount an S3 or R2 bucket using s3fs-fuse."""
     await _ensure_tool(session, "s3fs")
 
-    # Write credentials to a temp file.
-    cred_path = f"/tmp/s3fs-passwd-{uuid.uuid4().hex[:8]}"
-    if config.access_key_id and config.secret_access_key:
-        cred_content = f"{config.access_key_id}:{config.secret_access_key}"
-        if config.session_token:
-            cred_content += f":{config.session_token}"
-        await session.exec(
-            "sh",
-            "-c",
-            f"printf %s {shlex.quote(cred_content)} > {cred_path} && chmod 600 {cred_path}",
-        )
-    else:
-        cred_path = ""
-
-    # Build the s3fs command.
-    bucket = config.bucket
-    if config.prefix:
-        bucket = f"{config.bucket}:/{config.prefix.strip('/')}"
-    mount_path = shlex.quote(config.mount_path)
-
-    opts = ["allow_other", "nonempty"]
-    if cred_path:
-        opts.append(f"passwd_file={cred_path}")
-    else:
-        opts.append("public_bucket=1")
-
-    if config.endpoint_url:
-        opts.append(f"url={config.endpoint_url}")
-    elif config.region:
-        opts.append(f"url=https://s3.{config.region}.amazonaws.com")
-        opts.append(f"endpoint={config.region}")
-
-    if config.provider == "r2":
-        opts.append("sigv4")
-
-    if config.read_only:
-        opts.append("ro")
-
-    opts_str = ",".join(opts)
-    cmd = f"s3fs {shlex.quote(bucket)} {mount_path} -o {shlex.quote(opts_str)}"
-
+    cred_path: Path | None = None
     try:
+        if config.access_key_id and config.secret_access_key:
+            cred_path = _mount_credential_path(session, "s3fs-passwd")
+            cred_content = f"{config.access_key_id}:{config.secret_access_key}"
+            if config.session_token:
+                cred_content += f":{config.session_token}"
+            await _write_mount_credential_file(session, cred_path, cred_content)
+
+        bucket = config.bucket
+        if config.prefix:
+            bucket = f"{config.bucket}:/{config.prefix.strip('/')}"
+        mount_path = shlex.quote(config.mount_path)
+
+        opts = ["allow_other", "nonempty"]
+        if cred_path is not None:
+            opts.append(f"passwd_file={sandbox_path_str(cred_path)}")
+        else:
+            opts.append("public_bucket=1")
+
+        if config.endpoint_url:
+            opts.append(f"url={config.endpoint_url}")
+        elif config.region:
+            opts.append(f"url=https://s3.{config.region}.amazonaws.com")
+            opts.append(f"endpoint={config.region}")
+
+        if config.provider == "r2":
+            opts.append("sigv4")
+
+        if config.read_only:
+            opts.append("ro")
+
+        opts_str = ",".join(opts)
+        cmd = f"s3fs {shlex.quote(bucket)} {mount_path} -o {shlex.quote(opts_str)}"
         await _exec(session, f"mkdir -p {mount_path}")
         result = await _exec(session, cmd, timeout=60)
         if result.exit_code != 0:
@@ -355,45 +362,37 @@ async def _mount_s3(session: BaseSandboxSession, config: BlaxelCloudBucketMountC
                 context={"cmd": cmd, "exit_code": result.exit_code, "stderr": stderr},
             )
     finally:
-        # Clean up credentials file.
-        if cred_path:
-            await _exec(session, f"rm -f {cred_path}")
+        if cred_path is not None:
+            await _exec(session, f"rm -f {shlex.quote(sandbox_path_str(cred_path))}")
 
 
 async def _mount_gcs(session: BaseSandboxSession, config: BlaxelCloudBucketMountConfig) -> None:
     """Mount a GCS bucket using gcsfuse."""
     await _ensure_tool(session, "gcsfuse")
 
-    mount_path = shlex.quote(config.mount_path)
-    bucket = shlex.quote(config.bucket)
-
-    # Write service account key if provided.
-    key_path = ""
-    if config.service_account_key:
-        key_path = f"/tmp/gcs-creds-{uuid.uuid4().hex[:8]}.json"
-        await session.exec(
-            "sh",
-            "-c",
-            f"printf %s {shlex.quote(config.service_account_key)} "
-            f"> {key_path} && chmod 600 {key_path}",
-        )
-
-    opts: list[str] = []
-    if key_path:
-        opts.append(f"--key-file={key_path}")
-    else:
-        opts.append("--anonymous-access")
-
-    if config.read_only:
-        opts.append("-o ro")
-
-    if config.prefix:
-        opts.append(f"--only-dir={shlex.quote(config.prefix.strip('/'))}")
-
-    opts_str = " ".join(opts)
-    cmd = f"gcsfuse {opts_str} {bucket} {mount_path}"
-
+    key_path: Path | None = None
     try:
+        if config.service_account_key:
+            key_path = _mount_credential_path(session, "gcs-creds")
+            await _write_mount_credential_file(session, key_path, config.service_account_key)
+
+        mount_path = shlex.quote(config.mount_path)
+        bucket = shlex.quote(config.bucket)
+
+        opts: list[str] = []
+        if key_path is not None:
+            opts.append(f"--key-file={sandbox_path_str(key_path)}")
+        else:
+            opts.append("--anonymous-access")
+
+        if config.read_only:
+            opts.append("-o ro")
+
+        if config.prefix:
+            opts.append(f"--only-dir={shlex.quote(config.prefix.strip('/'))}")
+
+        opts_str = " ".join(opts)
+        cmd = f"gcsfuse {opts_str} {bucket} {mount_path}"
         await _exec(session, f"mkdir -p {mount_path}")
         result = await _exec(session, cmd, timeout=60)
         if result.exit_code != 0:
@@ -403,8 +402,8 @@ async def _mount_gcs(session: BaseSandboxSession, config: BlaxelCloudBucketMount
                 context={"cmd": cmd, "exit_code": result.exit_code, "stderr": stderr},
             )
     finally:
-        if key_path:
-            await _exec(session, f"rm -f {key_path}")
+        if key_path is not None:
+            await _exec(session, f"rm -f {shlex.quote(sandbox_path_str(key_path))}")
 
 
 async def _mount_bucket(session: BaseSandboxSession, config: BlaxelCloudBucketMountConfig) -> None:

--- a/src/agents/extensions/sandbox/blaxel/mounts.py
+++ b/src/agents/extensions/sandbox/blaxel/mounts.py
@@ -312,7 +312,12 @@ async def _write_mount_credential_file(
     content: str,
 ) -> None:
     await session.write(path, io.BytesIO(content.encode()))
-    await _exec(session, f"chmod 600 {shlex.quote(sandbox_path_str(path))}")
+    result = await _exec(session, f"chmod 600 {shlex.quote(sandbox_path_str(path))}")
+    if result.exit_code != 0:
+        raise MountConfigError(
+            message="failed to restrict mount credential file permissions",
+            context={"exit_code": result.exit_code},
+        )
 
 
 async def _mount_s3(session: BaseSandboxSession, config: BlaxelCloudBucketMountConfig) -> None:
@@ -381,7 +386,7 @@ async def _mount_gcs(session: BaseSandboxSession, config: BlaxelCloudBucketMount
 
         opts: list[str] = []
         if key_path is not None:
-            opts.append(f"--key-file={sandbox_path_str(key_path)}")
+            opts.append(shlex.quote(f"--key-file={sandbox_path_str(key_path)}"))
         else:
             opts.append("--anonymous-access")
 

--- a/src/agents/extensions/sandbox/blaxel/mounts.py
+++ b/src/agents/extensions/sandbox/blaxel/mounts.py
@@ -28,6 +28,7 @@ from typing import Any, Literal
 from .... import _debug
 from ....logger import log_tool_action_warning
 from ....sandbox._mount_security import (
+    _mark_mount_error_data_safe,
     redact_mount_error_data,
     validate_mount_activation_credential_boundary,
 )
@@ -303,7 +304,9 @@ async def _ensure_tool(session: BaseSandboxSession, tool: str) -> None:
 
 def _mount_credential_path(session: BaseSandboxSession, stem: str) -> Path:
     root = PurePosixPath(session.state.manifest.root)
-    return posix_path_as_path(root / f".openai-agents-{stem}-{uuid.uuid4().hex[:8]}")
+    relative_path = Path(f".openai-agents-{stem}-{uuid.uuid4().hex[:8]}")
+    session.register_persist_workspace_skip_path(relative_path)
+    return posix_path_as_path(root / relative_path.as_posix())
 
 
 async def _write_mount_credential_file(
@@ -318,6 +321,20 @@ async def _write_mount_credential_file(
             message="failed to restrict mount credential file permissions",
             context={"exit_code": result.exit_code},
         )
+
+
+async def _remove_mount_credential_file(
+    session: BaseSandboxSession,
+    path: Path,
+) -> None:
+    result = await _exec(session, f"rm -f {shlex.quote(sandbox_path_str(path))}")
+    if result.exit_code != 0:
+        error = MountConfigError(
+            message="failed to remove mount credential file",
+            context={"exit_code": result.exit_code},
+        )
+        _mark_mount_error_data_safe(error)
+        raise error
 
 
 async def _mount_s3(session: BaseSandboxSession, config: BlaxelCloudBucketMountConfig) -> None:
@@ -368,7 +385,7 @@ async def _mount_s3(session: BaseSandboxSession, config: BlaxelCloudBucketMountC
             )
     finally:
         if cred_path is not None:
-            await _exec(session, f"rm -f {shlex.quote(sandbox_path_str(cred_path))}")
+            await _remove_mount_credential_file(session, cred_path)
 
 
 async def _mount_gcs(session: BaseSandboxSession, config: BlaxelCloudBucketMountConfig) -> None:
@@ -408,7 +425,7 @@ async def _mount_gcs(session: BaseSandboxSession, config: BlaxelCloudBucketMount
             )
     finally:
         if key_path is not None:
-            await _exec(session, f"rm -f {shlex.quote(sandbox_path_str(key_path))}")
+            await _remove_mount_credential_file(session, key_path)
 
 
 async def _mount_bucket(session: BaseSandboxSession, config: BlaxelCloudBucketMountConfig) -> None:

--- a/src/agents/extensions/sandbox/blaxel/mounts.py
+++ b/src/agents/extensions/sandbox/blaxel/mounts.py
@@ -3,9 +3,9 @@ Mount strategies for Blaxel sandboxes.
 
 Two strategies are provided:
 
-* **BlaxelCloudBucketMountStrategy** -- mounts credentialless S3, R2, and GCS
-  buckets via FUSE tools (``s3fs``, ``gcsfuse``) executed inside the sandbox.
-  Authenticated mounts require an external or provider-native mount strategy.
+* **BlaxelCloudBucketMountStrategy** -- mounts S3, R2, and GCS buckets via FUSE tools
+  (``s3fs``, ``gcsfuse``) executed inside the sandbox. Credential-bearing mounts require
+  an exact-path runtime acknowledgement on the trusted manifest.
 
 * **BlaxelDriveMountStrategy** -- mounts Blaxel Drives (persistent network
   volumes) into the sandbox using the sandbox ``drives`` API
@@ -88,6 +88,8 @@ class BlaxelCloudBucketMountStrategy(MountStrategyBase):
         validate_mount_activation_credential_boundary(
             mount,
             self,
+            manifest=getattr(getattr(session, "state", None), "manifest", None),
+            mount_path=lambda: mount._resolve_mount_path(session, dest),
             provider_backend_id="blaxel",
         )
         _assert_blaxel_session(session)
@@ -129,6 +131,8 @@ class BlaxelCloudBucketMountStrategy(MountStrategyBase):
         validate_mount_activation_credential_boundary(
             mount,
             self,
+            manifest=getattr(getattr(session, "state", None), "manifest", None),
+            mount_path=path,
             provider_backend_id="blaxel",
         )
         _assert_blaxel_session(session)

--- a/src/agents/extensions/sandbox/daytona/mounts.py
+++ b/src/agents/extensions/sandbox/daytona/mounts.py
@@ -5,7 +5,7 @@ Provides ``DaytonaCloudBucketMountStrategy``, a wrapper around the generic
 the sandbox before delegating to :class:`RcloneMountPattern`.
 
 Supports credentialless S3, R2, GCS, and Azure Blob mounts through a single code path.
-Authenticated mounts require an external or provider-native mount strategy.
+Authenticated mounts require an exact-path runtime acknowledgement on the trusted manifest.
 """
 
 from __future__ import annotations
@@ -169,10 +169,11 @@ class DaytonaCloudBucketMountStrategy(MountStrategyBase):
     """Mount rclone-backed cloud storage in Daytona sandboxes.
 
     Wraps :class:`InContainerMountStrategy` with automatic ``rclone``
-    provisioning.  Use with rclone-backed provider mounts that support anonymous access
-    (``S3Mount``, ``R2Mount``, ``GCSMount``, ``AzureBlobMount``) and let the
-    generic framework handle anonymous config generation and mount execution. Explicit cloud
-    credentials are not supported because the delegated helper executes inside the sandbox.
+    provisioning. Use with rclone-backed provider mounts (``S3Mount``, ``R2Mount``,
+    ``GCSMount``, ``AzureBlobMount``) and let the generic framework handle config generation
+    and mount execution. Credential-bearing mounts require the applicable exact-path runtime
+    acknowledgement on the trusted manifest because the delegated helper executes inside the
+    sandbox.
 
     Usage::
 
@@ -206,6 +207,8 @@ class DaytonaCloudBucketMountStrategy(MountStrategyBase):
         validate_mount_activation_credential_boundary(
             mount,
             self,
+            manifest=getattr(getattr(session, "state", None), "manifest", None),
+            mount_path=lambda: mount._resolve_mount_path(session, dest),
             provider_backend_id="daytona",
         )
         _assert_daytona_session(session)
@@ -243,6 +246,8 @@ class DaytonaCloudBucketMountStrategy(MountStrategyBase):
         validate_mount_activation_credential_boundary(
             mount,
             self,
+            manifest=getattr(getattr(session, "state", None), "manifest", None),
+            mount_path=path,
             provider_backend_id="daytona",
         )
         _assert_daytona_session(session)

--- a/src/agents/extensions/sandbox/e2b/mounts.py
+++ b/src/agents/extensions/sandbox/e2b/mounts.py
@@ -92,6 +92,8 @@ class E2BCloudBucketMountStrategy(MountStrategyBase):
         validate_mount_activation_credential_boundary(
             mount,
             self,
+            manifest=getattr(getattr(session, "state", None), "manifest", None),
+            mount_path=lambda: mount._resolve_mount_path(session, dest),
             provider_backend_id="e2b",
         )
         _assert_e2b_session(session)
@@ -130,6 +132,8 @@ class E2BCloudBucketMountStrategy(MountStrategyBase):
         validate_mount_activation_credential_boundary(
             mount,
             self,
+            manifest=getattr(getattr(session, "state", None), "manifest", None),
+            mount_path=path,
             provider_backend_id="e2b",
         )
         _assert_e2b_session(session)

--- a/src/agents/extensions/sandbox/runloop/mounts.py
+++ b/src/agents/extensions/sandbox/runloop/mounts.py
@@ -138,6 +138,8 @@ class RunloopCloudBucketMountStrategy(MountStrategyBase):
         validate_mount_activation_credential_boundary(
             mount,
             self,
+            manifest=getattr(getattr(session, "state", None), "manifest", None),
+            mount_path=lambda: mount._resolve_mount_path(session, dest),
             provider_backend_id="runloop",
         )
         _assert_runloop_session(session)
@@ -176,6 +178,8 @@ class RunloopCloudBucketMountStrategy(MountStrategyBase):
         validate_mount_activation_credential_boundary(
             mount,
             self,
+            manifest=getattr(getattr(session, "state", None), "manifest", None),
+            mount_path=path,
             provider_backend_id="runloop",
         )
         _assert_runloop_session(session)

--- a/src/agents/extensions/sandbox/vercel/sandbox.py
+++ b/src/agents/extensions/sandbox/vercel/sandbox.py
@@ -35,6 +35,7 @@ from ....sandbox._mount_security import (
     _validate_mount_provenance,
     redact_mount_error_data,
     redact_mount_error_data_sync,
+    validate_manifest_mount_credential_boundaries,
 )
 from ....sandbox.entries import BaseEntry, Dir, S3Mount, resolve_workspace_path
 from ....sandbox.errors import (
@@ -187,6 +188,41 @@ def _resolve_manifest_root(manifest: Manifest | None) -> Manifest:
     return manifest
 
 
+def _with_released_vercel_s3_credential_exposure_compatibility(
+    manifest: Manifest,
+    allow_s3_credential_exposure: bool,
+) -> Manifest:
+    """Translate the released boolean option into exact mount-scoped acknowledgement."""
+
+    if not allow_s3_credential_exposure:
+        return manifest
+    _validate_manifest_mount_provenance(manifest)
+    paths: set[str] = set()
+    for mount, mount_path in manifest.mount_targets():
+        if not isinstance(mount, S3Mount) or mount.mount_strategy.type != "vercel_cloud_bucket":
+            continue
+        if any(
+            credential is not None
+            for credential in (
+                mount.access_key_id,
+                mount.secret_access_key,
+                mount.session_token,
+            )
+        ):
+            paths.add(mount_path.as_posix())
+    if not paths:
+        return manifest
+    trusted = manifest
+    for path in sorted(paths):
+        try:
+            trusted = trusted.with_in_container_mount_credential_exposure_acknowledged(path)
+        except ValueError:
+            # Preserve the released option's error boundary: an invalid/root target is rejected
+            # by normal mount validation rather than turning acknowledgement into authorization.
+            continue
+    return trusted
+
+
 def _validate_network_policy(value: object) -> NetworkPolicy | None:
     if value is None:
         return None
@@ -310,6 +346,24 @@ def _vercel_s3_mount_map(manifest: Manifest) -> dict[str, S3Mount]:
                 )
         mounts[path_text] = mount
     return mounts
+
+
+def _with_vercel_s3_mount_credentials(
+    manifest: Manifest,
+    trusted_s3_mounts: dict[str, S3Mount],
+) -> Manifest:
+    """Overlay released session-constructor credentials onto matching trusted topology."""
+
+    trusted = manifest.model_copy(deep=True)
+    mounts_by_path = _vercel_s3_mount_map(trusted)
+    for path, supplied_mount in trusted_s3_mounts.items():
+        mount = mounts_by_path.get(path)
+        if mount is None:
+            continue
+        mount.access_key_id = supplied_mount.access_key_id
+        mount.secret_access_key = supplied_mount.secret_access_key
+        mount.session_token = supplied_mount.session_token
+    return trusted
 
 
 def _vercel_s3_mount_topology(manifest: Manifest) -> dict[str, tuple[str, S3Mount]]:
@@ -497,10 +551,52 @@ class VercelSandboxSession(BaseSandboxSession):
         trusted_manifest: Manifest | None = None,
     ) -> None:
         _validate_manifest_mount_provenance(state.manifest)
-        if trusted_manifest is not None:
-            _validate_manifest_mount_provenance(trusted_manifest)
         for mount in (trusted_s3_mounts or {}).values():
             _validate_mount_provenance(mount)
+        if trusted_manifest is not None:
+            _validate_manifest_mount_provenance(trusted_manifest)
+        if trusted_s3_mounts:
+            trusted_manifest = _with_vercel_s3_mount_credentials(
+                trusted_manifest or state.manifest,
+                trusted_s3_mounts,
+            )
+        if trusted_manifest is not None:
+            credentialed_paths = tuple(
+                path
+                for path, mount in _vercel_s3_mount_map(trusted_manifest).items()
+                if any(
+                    credential is not None
+                    for credential in (
+                        mount.access_key_id,
+                        mount.secret_access_key,
+                        mount.session_token,
+                    )
+                )
+            )
+            if not allow_s3_credential_exposure and any(
+                not trusted_manifest._acknowledges_in_container_mount_credential_exposure(
+                    path,
+                    "mount_scoped",
+                )
+                for path in credentialed_paths
+            ):
+                raise MountConfigError(
+                    message=(
+                        "Vercel S3 mounts expose inline credentials to code running in the "
+                        "sandbox; set allow_s3_credential_exposure=True only for credentials "
+                        "scoped to that sandbox, or acknowledge each exact mount path on the "
+                        "trusted manifest"
+                    ),
+                    context={"backend": "vercel"},
+                )
+            trusted_manifest = _with_released_vercel_s3_credential_exposure_compatibility(
+                trusted_manifest,
+                allow_s3_credential_exposure,
+            )
+            validate_manifest_mount_credential_boundaries(
+                trusted_manifest,
+                provider_backend_id="vercel",
+            )
         resolved_trusted_s3_mounts: dict[str, S3Mount] = {}
         trusted_s3_mount_credentials: dict[
             str,
@@ -518,38 +614,30 @@ class VercelSandboxSession(BaseSandboxSession):
             trusted_mount.session_token = None
             resolved_trusted_s3_mounts[path] = trusted_mount
             trusted_s3_mount_credentials[path] = credentials
-        has_trusted_credentials = any(
-            credential is not None
-            for credentials in trusted_s3_mount_credentials.values()
-            for credential in credentials
-        )
-        if has_trusted_credentials and not allow_s3_credential_exposure:
-            raise MountConfigError(
-                message=(
-                    "Vercel S3 mounts expose inline credentials to code running in the sandbox; "
-                    "set allow_s3_credential_exposure=True only for credentials scoped to that "
-                    "sandbox"
-                ),
-                context={"backend": "vercel"},
-            )
-        if resolved_trusted_s3_mounts and trusted_manifest is None:
-            raise MountConfigError(
-                message=(
-                    "Vercel S3 mounts require a trusted create-time manifest so persisted "
-                    "session state cannot reconstruct their topology"
-                ),
-                context={"backend": "vercel"},
-            )
         resolved_trusted_manifest = (
             _manifest_without_vercel_s3_credentials(trusted_manifest)
             if trusted_manifest is not None
             else state.manifest.model_copy(deep=True)
         )
-        declared_topology = _vercel_s3_mount_topology(state.manifest)
+        state_has_inline_vercel_s3_credentials = any(
+            credential is not None
+            for mount in _vercel_s3_mounts(state.manifest)
+            for credential in (
+                mount.access_key_id,
+                mount.secret_access_key,
+                mount.session_token,
+            )
+        )
+        resolved_state_manifest = (
+            _manifest_without_vercel_s3_credentials(state.manifest)
+            if state_has_inline_vercel_s3_credentials
+            else state.manifest
+        )
+        declared_topology = _vercel_s3_mount_topology(resolved_state_manifest)
         trusted_topology = _vercel_s3_mount_topology(resolved_trusted_manifest)
         trusted_manifest_mounts = _vercel_s3_mount_map(resolved_trusted_manifest)
         trusted_topology_matches = (
-            state.manifest.root == resolved_trusted_manifest.root
+            resolved_state_manifest.root == resolved_trusted_manifest.root
             and declared_topology == trusted_topology
             and trusted_manifest_mounts == resolved_trusted_s3_mounts
         )
@@ -565,6 +653,7 @@ class VercelSandboxSession(BaseSandboxSession):
                     "trusted_mount_paths": sorted(resolved_trusted_s3_mounts),
                 },
             )
+        state.manifest = resolved_state_manifest
         self.state = state
         self._sandbox = sandbox
         self._token = token
@@ -1469,16 +1558,12 @@ class VercelSandboxClient(BaseSandboxClient[VercelSandboxClientOptions]):
         manifest: Manifest | None = None,
         options: VercelSandboxClientOptions,
     ) -> SandboxSession:
-        resolved_manifest = _resolve_manifest_root(manifest)
+        resolved_manifest = _with_released_vercel_s3_credential_exposure_compatibility(
+            _resolve_manifest_root(manifest),
+            options.allow_s3_credential_exposure,
+        )
         try:
-            self._validate_manifest_for_create(
-                resolved_manifest,
-                allowed_in_container_credential_strategy_types=(
-                    frozenset({"vercel_cloud_bucket"})
-                    if options.allow_s3_credential_exposure
-                    else frozenset()
-                ),
-            )
+            self._validate_manifest_for_create(resolved_manifest)
             trusted_s3_mounts = _vercel_s3_mount_map(resolved_manifest)
             for mount in trusted_s3_mounts.values():
                 mount.mount_strategy.validate_mount(mount)

--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -880,12 +880,12 @@ def _mount_has_usable_required_authority(
     return False
 
 
-def _invalid_required_authority_fields(
+def _invalid_in_container_authority_value_fields(
     mount: Mount,
-    required_fields: Collection[str],
+    mount_type: str,
 ) -> tuple[str, ...]:
     invalid: list[str] = []
-    for field_name in required_fields:
+    for field_name in _AUTHORITY_FIELDS_BY_MOUNT_TYPE.get(mount_type, ()):
         value = getattr(mount, field_name, None)
         if value is not None and (not isinstance(value, str) or not value.strip()):
             invalid.append(field_name)
@@ -1259,6 +1259,20 @@ def _mount_boundary_error(
             },
         )
 
+    invalid_authority_value_fields = (
+        _invalid_in_container_authority_value_fields(mount, mount_type)
+        if executes_in_container
+        else ()
+    )
+    if invalid_authority_value_fields:
+        return MountConfigError(
+            message="in-container mount authentication values must not be empty or whitespace-only",
+            context={
+                "mount_type": mount.type,
+                "credential_fields": invalid_authority_value_fields,
+            },
+        )
+
     authority_fields = frozenset(_configured_mount_authority_fields(mount))
     if strategy_boundary == "external":
         return None
@@ -1275,19 +1289,6 @@ def _mount_boundary_error(
     requires_implicit_broad = bool(
         capability is not None and capability.enables_broad_credential_discovery
     )
-    invalid_required_fields = (
-        _invalid_required_authority_fields(mount, capability.required_any_fields)
-        if capability is not None
-        else ()
-    )
-    if invalid_required_fields:
-        return MountConfigError(
-            message="in-container mount authentication values must not be empty or whitespace-only",
-            context={
-                "mount_type": mount.type,
-                "credential_fields": invalid_required_fields,
-            },
-        )
     if (
         capability is not None
         and capability.required_any_fields

--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -70,6 +70,25 @@ _AUTHORITY_FIELDS_BY_MOUNT_TYPE: dict[str, tuple[str, ...]] = {
     "r2_mount": ("access_key_id", "secret_access_key"),
     "s3_mount": ("access_key_id", "secret_access_key", "session_token"),
 }
+# Each entry identifies the fields that activate an inline credential set and the non-empty
+# fields required whenever that set is active. Keep this table aligned with provider selection
+# and credential emission in the built-in mount implementations.
+_IN_CONTAINER_CREDENTIAL_SET_REQUIREMENTS_BY_MOUNT_TYPE: dict[
+    str, tuple[tuple[str, ...], tuple[str, ...]]
+] = {
+    "gcs_mount": (
+        ("access_id", "secret_access_key"),
+        ("access_id", "secret_access_key"),
+    ),
+    "r2_mount": (
+        ("access_key_id", "secret_access_key"),
+        ("access_key_id", "secret_access_key"),
+    ),
+    "s3_mount": (
+        ("access_key_id", "secret_access_key", "session_token"),
+        ("access_key_id", "secret_access_key"),
+    ),
+}
 _AUTHORITY_FILE_FIELDS_BY_MOUNT_TYPE: dict[str, tuple[str, ...]] = {
     "box_mount": ("box_config_file",),
     "gcs_mount": ("service_account_file",),
@@ -873,11 +892,16 @@ def _invalid_required_authority_fields(
     return tuple(sorted(invalid))
 
 
-def _invalid_in_container_s3_credential_fields(mount: Mount) -> tuple[str, ...]:
-    values = {
-        field_name: getattr(mount, field_name, None)
-        for field_name in ("access_key_id", "secret_access_key", "session_token")
-    }
+def _invalid_in_container_credential_set_fields(
+    mount: Mount,
+    mount_type: str,
+) -> tuple[str, ...]:
+    requirement = _IN_CONTAINER_CREDENTIAL_SET_REQUIREMENTS_BY_MOUNT_TYPE.get(mount_type)
+    if requirement is None:
+        return ()
+
+    configured_fields, required_fields = requirement
+    values = {field_name: getattr(mount, field_name, None) for field_name in configured_fields}
     if all(value is None for value in values.values()):
         return ()
 
@@ -886,10 +910,10 @@ def _invalid_in_container_s3_credential_fields(mount: Mount) -> tuple[str, ...]:
         for field_name, value in values.items()
         if value is not None and (not isinstance(value, str) or not value.strip())
     }
-    if not isinstance(values["access_key_id"], str) or not values["access_key_id"].strip():
-        invalid.add("access_key_id")
-    if not isinstance(values["secret_access_key"], str) or not values["secret_access_key"].strip():
-        invalid.add("secret_access_key")
+    for field_name in required_fields:
+        value = values[field_name]
+        if not isinstance(value, str) or not value.strip():
+            invalid.add(field_name)
     return tuple(sorted(invalid))
 
 
@@ -1221,20 +1245,17 @@ def _mount_boundary_error(
             },
         )
 
-    invalid_s3_credential_fields = (
-        _invalid_in_container_s3_credential_fields(mount)
-        if executes_in_container and mount_type == "s3_mount"
+    invalid_credential_set_fields = (
+        _invalid_in_container_credential_set_fields(mount, mount_type)
+        if executes_in_container
         else ()
     )
-    if invalid_s3_credential_fields:
+    if invalid_credential_set_fields:
         return MountConfigError(
-            message=(
-                "in-container S3 credentials require non-empty access_key_id and "
-                "secret_access_key values, and session_token requires that pair"
-            ),
+            message="in-container access credentials require a complete non-empty credential set",
             context={
                 "mount_type": mount.type,
-                "credential_fields": invalid_s3_credential_fields,
+                "credential_fields": invalid_credential_set_fields,
             },
         )
 

--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -1040,9 +1040,14 @@ def _mark_mount_error_for_manifest(error: MountConfigError, manifest: Manifest) 
         _mark_error_data_redacted(error)
 
 
-def _mark_mount_validation_error(error: MountConfigError) -> None:
+def _mark_mount_error_data_safe(error: MountConfigError) -> None:
+    """Mark an SDK-created mount error whose message contains no credential-derived data."""
     _mark_error_data_redacted(error)
     setattr(error, _SAFE_MOUNT_VALIDATION_MESSAGE_ATTR, True)
+
+
+def _mark_mount_validation_error(error: MountConfigError) -> None:
+    _mark_mount_error_data_safe(error)
 
 
 def _absolute_manifest_path(root: str, value: str) -> str:

--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -8,8 +8,8 @@ import re
 import traceback
 from collections.abc import Callable, Collection, Coroutine, Iterable, Mapping
 from functools import wraps
-from pathlib import PurePosixPath
-from typing import Any, NoReturn, ParamSpec, TypeVar, cast
+from pathlib import PurePath, PurePosixPath
+from typing import TYPE_CHECKING, Any, NoReturn, ParamSpec, TypeVar, cast
 from urllib.parse import urlsplit
 
 from ..exceptions import (
@@ -41,7 +41,9 @@ from .entries.mounts.patterns import (
     S3FilesMountPattern,
 )
 from .errors import MountConfigError
-from .manifest import Manifest
+
+if TYPE_CHECKING:
+    from .manifest import Manifest
 
 REDACTED_MOUNT_AUTHORITY_KEY = "__openai_agents_redacted_mount_authority"
 CREDENTIALLESS_MOUNT_AUTHORITY_KEY = "__openai_agents_credentialless_mount_authority"
@@ -52,7 +54,6 @@ CREDENTIALLESS_MOUNT_AUTHORITY_KEY = "__openai_agents_credentialless_mount_autho
 _AUTHORITY_FIELDS_BY_MOUNT_TYPE: dict[str, tuple[str, ...]] = {
     "azure_blob_mount": ("identity_client_id", "account_key"),
     "box_mount": (
-        "client_id",
         "client_secret",
         "access_token",
         "token",
@@ -251,9 +252,136 @@ _SERIALIZED_OPTIONS_CLASS_BY_PATTERN_TYPE = {
     "mountpoint": MountpointMountPattern.MountpointOptions,
     "s3files": S3FilesMountPattern.S3FilesOptions,
 }
-_TRUSTED_IN_CONTAINER_OPT_IN_FIELDS: dict[str, frozenset[str]] = {
-    "vercel_cloud_bucket": frozenset({"access_key_id", "secret_access_key", "session_token"}),
-}
+
+
+@dataclasses.dataclass(frozen=True)
+class _InContainerMountCredentialCapability:
+    strategy_types: frozenset[str]
+    mount_type: str
+    pattern_type: str | None
+    mount_scoped_fields: frozenset[str]
+    broad_fields: frozenset[str]
+    enables_broad_credential_discovery: bool = False
+    required_any_fields: frozenset[str] = frozenset()
+
+
+_RCLONE_STRATEGY_TYPES = frozenset(
+    {
+        "in_container",
+        "daytona_cloud_bucket",
+        "e2b_cloud_bucket",
+        "runloop_cloud_bucket",
+    }
+)
+_IN_CONTAINER_MOUNT_CREDENTIAL_CAPABILITIES: tuple[_InContainerMountCredentialCapability, ...] = (
+    _InContainerMountCredentialCapability(
+        strategy_types=_RCLONE_STRATEGY_TYPES,
+        mount_type="s3_mount",
+        pattern_type="rclone",
+        mount_scoped_fields=frozenset({"access_key_id", "secret_access_key", "session_token"}),
+        broad_fields=frozenset({"mount_strategy.pattern.config_file_path"}),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=_RCLONE_STRATEGY_TYPES,
+        mount_type="r2_mount",
+        pattern_type="rclone",
+        mount_scoped_fields=frozenset({"access_key_id", "secret_access_key"}),
+        broad_fields=frozenset({"mount_strategy.pattern.config_file_path"}),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=_RCLONE_STRATEGY_TYPES,
+        mount_type="gcs_mount",
+        pattern_type="rclone",
+        mount_scoped_fields=frozenset(
+            {
+                "access_id",
+                "secret_access_key",
+                "service_account_credentials",
+                "access_token",
+            }
+        ),
+        broad_fields=frozenset({"service_account_file", "mount_strategy.pattern.config_file_path"}),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=_RCLONE_STRATEGY_TYPES,
+        mount_type="azure_blob_mount",
+        pattern_type="rclone",
+        mount_scoped_fields=frozenset({"account_key"}),
+        broad_fields=frozenset({"identity_client_id", "mount_strategy.pattern.config_file_path"}),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=_RCLONE_STRATEGY_TYPES,
+        mount_type="box_mount",
+        pattern_type="rclone",
+        mount_scoped_fields=frozenset(
+            {"client_secret", "access_token", "token", "config_credentials"}
+        ),
+        broad_fields=frozenset({"box_config_file", "mount_strategy.pattern.config_file_path"}),
+        required_any_fields=frozenset(
+            {"access_token", "token", "config_credentials", "box_config_file"}
+        ),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=frozenset({"in_container"}),
+        mount_type="s3_mount",
+        pattern_type="mountpoint",
+        mount_scoped_fields=frozenset({"access_key_id", "secret_access_key", "session_token"}),
+        broad_fields=frozenset(),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=frozenset({"in_container"}),
+        mount_type="gcs_mount",
+        pattern_type="mountpoint",
+        mount_scoped_fields=frozenset({"access_id", "secret_access_key"}),
+        broad_fields=frozenset(),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=frozenset({"in_container"}),
+        mount_type="azure_blob_mount",
+        pattern_type="fuse",
+        mount_scoped_fields=frozenset({"account_key"}),
+        broad_fields=frozenset({"identity_client_id"}),
+        enables_broad_credential_discovery=True,
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=frozenset({"in_container"}),
+        mount_type="s3_files_mount",
+        pattern_type="s3files",
+        mount_scoped_fields=frozenset(),
+        broad_fields=frozenset({"extra_options", "mount_strategy.pattern.options.extra_options"}),
+        enables_broad_credential_discovery=True,
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=frozenset({"vercel_cloud_bucket"}),
+        mount_type="s3_mount",
+        pattern_type=None,
+        mount_scoped_fields=frozenset({"access_key_id", "secret_access_key", "session_token"}),
+        broad_fields=frozenset(),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=frozenset({"blaxel_cloud_bucket"}),
+        mount_type="s3_mount",
+        pattern_type=None,
+        mount_scoped_fields=frozenset({"access_key_id", "secret_access_key", "session_token"}),
+        broad_fields=frozenset(),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=frozenset({"blaxel_cloud_bucket"}),
+        mount_type="r2_mount",
+        pattern_type=None,
+        mount_scoped_fields=frozenset({"access_key_id", "secret_access_key"}),
+        broad_fields=frozenset(),
+    ),
+    _InContainerMountCredentialCapability(
+        strategy_types=frozenset({"blaxel_cloud_bucket"}),
+        mount_type="gcs_mount",
+        pattern_type=None,
+        mount_scoped_fields=frozenset(
+            {"access_id", "secret_access_key", "service_account_credentials"}
+        ),
+        broad_fields=frozenset(),
+    ),
+)
 _RCLONE_SAFE_FLAG_ARGS = frozenset({"allow-other"})
 _RCLONE_SAFE_VALUE_ARGS = frozenset({"buffer-size", "gid", "uid"})
 _SAFE_MOUNT_VALIDATION_MESSAGE_ATTR = "_agents_safe_mount_validation_message"
@@ -306,8 +434,12 @@ def redact_mount_error_data(
     return wrapper
 
 
-def redact_mount_error_data_sync(function: Callable[_P, _T]) -> Callable[_P, _T]:
-    """Replace marked validation failures after clearing payload-bearing sync frames."""
+def _redact_mount_error_data_sync(
+    function: Callable[_P, _T],
+    *,
+    preserve_value_error_type: bool,
+) -> Callable[_P, _T]:
+    """Replace validation failures after clearing payload-bearing sync frames."""
 
     @wraps(function)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
@@ -324,6 +456,10 @@ def redact_mount_error_data_sync(function: Callable[_P, _T]) -> Callable[_P, _T]
                 error.__cause__ = None
                 error.__context__ = None
                 safe_error = error
+            elif preserve_value_error_type and call_has_authority and isinstance(error, ValueError):
+                discard_mount_source_exception(error)
+                safe_error = ValueError("sandbox mount validation failed")
+                _mark_error_data_redacted(safe_error)
             elif call_has_authority:
                 safe_error = _replace_mount_operation_error(error)
             else:
@@ -334,6 +470,20 @@ def redact_mount_error_data_sync(function: Callable[_P, _T]) -> Callable[_P, _T]
         _raise_data_redacted_error(safe_error)
 
     return wrapper
+
+
+def redact_mount_error_data_sync(function: Callable[_P, _T]) -> Callable[_P, _T]:
+    """Replace marked validation failures after clearing payload-bearing sync frames."""
+
+    return _redact_mount_error_data_sync(function, preserve_value_error_type=False)
+
+
+def redact_mount_validation_error_data_sync(
+    function: Callable[_P, _T],
+) -> Callable[_P, _T]:
+    """Redact sync mount validation failures while preserving `ValueError` compatibility."""
+
+    return _redact_mount_error_data_sync(function, preserve_value_error_type=True)
 
 
 def _replace_mount_error(error: MountConfigError) -> MountConfigError:
@@ -700,6 +850,29 @@ def _configured_mount_authority_fields(mount: Mount) -> tuple[str, ...]:
     return tuple(dict.fromkeys(fields))
 
 
+def _mount_has_usable_required_authority(
+    mount: Mount,
+    required_fields: Collection[str],
+) -> bool:
+    for field_name in required_fields:
+        value = getattr(mount, field_name, None)
+        if isinstance(value, str) and value.strip():
+            return True
+    return False
+
+
+def _invalid_required_authority_fields(
+    mount: Mount,
+    required_fields: Collection[str],
+) -> tuple[str, ...]:
+    invalid: list[str] = []
+    for field_name in required_fields:
+        value = getattr(mount, field_name, None)
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            invalid.append(field_name)
+    return tuple(sorted(invalid))
+
+
 def _manifest_has_configured_mount_authority(manifest: Manifest) -> bool:
     pending = list(manifest.entries.values())
     while pending:
@@ -722,6 +895,10 @@ def _mount_has_or_may_hide_configured_authority(mount: Mount) -> bool:
     pattern = getattr(strategy, "pattern", None)
     if pattern is not None and not _pattern_class_is_trusted(pattern):
         return True
+    mount_type = _canonical_mount_type(type(mount)) or mount.type
+    capability = _in_container_mount_credential_capability(mount_type, strategy)
+    if capability is not None and capability.enables_broad_credential_discovery:
+        return True
     return bool(_configured_mount_authority_fields(mount))
 
 
@@ -729,6 +906,8 @@ def _call_has_configured_mount_authority(
     args: tuple[object, ...], kwargs: Mapping[str, object]
 ) -> bool:
     """Inspect only SDK call-boundary manifest owners."""
+
+    from .manifest import Manifest
 
     try:
         for value in (*args, *kwargs.values()):
@@ -913,137 +1092,282 @@ def _validate_manifest_mount_provenance(manifest: Manifest) -> None:
     _raise_data_redacted_error(error)
 
 
+def _resolved_in_container_pattern_type(strategy: MountStrategyBase) -> str | None:
+    pattern = getattr(strategy, "pattern", None)
+    pattern_type = getattr(pattern, "type", None)
+    return pattern_type if isinstance(pattern_type, str) else None
+
+
+def _in_container_mount_credential_capability(
+    mount_type: str,
+    strategy: MountStrategyBase,
+) -> _InContainerMountCredentialCapability | None:
+    return _in_container_mount_credential_capability_for_types(
+        mount_type,
+        strategy.type,
+        _resolved_in_container_pattern_type(strategy),
+    )
+
+
+def _in_container_mount_credential_capability_for_types(
+    mount_type: str,
+    strategy_type: str,
+    pattern_type: str | None,
+) -> _InContainerMountCredentialCapability | None:
+    return next(
+        (
+            capability
+            for capability in _IN_CONTAINER_MOUNT_CREDENTIAL_CAPABILITIES
+            if strategy_type in capability.strategy_types
+            and mount_type == capability.mount_type
+            and pattern_type == capability.pattern_type
+        ),
+        None,
+    )
+
+
+def _mount_boundary_error(
+    manifest: Manifest,
+    mount: Mount,
+    mount_path: str | PurePath,
+    *,
+    provider_backend_id: str | None,
+) -> MountConfigError | None:
+    mount_type = _canonical_mount_type(type(mount)) or mount.type
+    strategy = mount.mount_strategy
+    strategy_boundary, strategy_backend_id = _strategy_classification(strategy)
+    pattern = getattr(strategy, "pattern", None)
+    executes_in_container = strategy_boundary == "in_container"
+    if (
+        provider_backend_id is not None
+        and strategy_backend_id is not None
+        and strategy_backend_id != provider_backend_id
+    ):
+        return MountConfigError(
+            message=(
+                "docker-volume mounts are not supported by this sandbox backend"
+                if strategy.type == "docker_volume"
+                else "mount strategy is not supported by this sandbox backend"
+            ),
+            context={
+                "mount_type": mount.type,
+                "strategy_type": strategy.type,
+                "sandbox_backend": provider_backend_id,
+            },
+        )
+
+    for field_name in _AUTHORITY_FILE_FIELDS_BY_MOUNT_TYPE.get(mount_type, ()):
+        value = getattr(mount, field_name, None)
+        if isinstance(value, str) and value and _manifest_materializes_path(manifest, value):
+            return MountConfigError(
+                message=(
+                    "credential files stored in the manifest are not supported for cloud "
+                    "mounts; configure credentials outside the sandbox manifest"
+                ),
+                context={"mount_type": mount.type, "credential_field": field_name},
+            )
+    if (
+        isinstance(pattern, RcloneMountPattern)
+        and pattern.config_file_path is not None
+        and _manifest_materializes_path(manifest, pattern.config_file_path.as_posix())
+    ):
+        return MountConfigError(
+            message=(
+                "credential files stored in the manifest are not supported for cloud mounts; "
+                "configure credentials outside the sandbox manifest"
+            ),
+            context={
+                "mount_type": mount.type,
+                "credential_field": "mount_strategy.pattern.config_file_path",
+            },
+        )
+
+    invalid_rclone_fields = _configured_rclone_line_fields(mount, mount_type)
+    if executes_in_container and isinstance(pattern, RcloneMountPattern) and invalid_rclone_fields:
+        return MountConfigError(
+            message="cloud mount configuration values must not contain line breaks",
+            context={
+                "mount_type": mount.type,
+                "configuration_fields": invalid_rclone_fields,
+            },
+        )
+    invalid_s3fs_fields = _configured_blaxel_s3fs_option_fields(mount, mount_type)
+    if invalid_s3fs_fields:
+        return MountConfigError(
+            message="cloud mount configuration values must not contain s3fs option delimiters",
+            context={
+                "mount_type": mount.type,
+                "configuration_fields": invalid_s3fs_fields,
+            },
+        )
+
+    authority_fields = frozenset(_configured_mount_authority_fields(mount))
+    if strategy_boundary == "external":
+        return None
+
+    mount_scoped_acknowledged = manifest._acknowledges_in_container_mount_credential_exposure(
+        mount_path,
+        "mount_scoped",
+    )
+    broad_acknowledged = manifest._acknowledges_in_container_mount_credential_exposure(
+        mount_path,
+        "broad",
+    )
+    capability = _in_container_mount_credential_capability(mount_type, strategy)
+    requires_implicit_broad = bool(
+        capability is not None and capability.enables_broad_credential_discovery
+    )
+    invalid_required_fields = (
+        _invalid_required_authority_fields(mount, capability.required_any_fields)
+        if capability is not None
+        else ()
+    )
+    if invalid_required_fields:
+        return MountConfigError(
+            message="in-container mount authentication values must not be empty or whitespace-only",
+            context={
+                "mount_type": mount.type,
+                "credential_fields": invalid_required_fields,
+            },
+        )
+    if (
+        capability is not None
+        and capability.required_any_fields
+        and not _mount_has_usable_required_authority(mount, capability.required_any_fields)
+    ):
+        return MountConfigError(
+            message=(
+                "in-container Box mounts require a non-interactive authentication source; "
+                "configure a token, access token, or JWT credentials before activation"
+            ),
+            context={"mount_type": mount.type},
+        )
+    if (
+        not authority_fields
+        and not mount_scoped_acknowledged
+        and not broad_acknowledged
+        and not requires_implicit_broad
+    ):
+        return None
+    if capability is None:
+        return MountConfigError(
+            message=(
+                "credential-bearing in-container mounts require an SDK-supported strategy, "
+                "mount type, and pattern combination before exposure can be acknowledged; "
+                "use a credentialless helper or an external/provider-native mount strategy"
+            ),
+            context={
+                "mount_type": mount.type,
+                "strategy_type": strategy.type,
+                "pattern_type": _resolved_in_container_pattern_type(strategy),
+                "credential_fields": tuple(sorted(authority_fields)),
+            },
+        )
+
+    supported_fields = capability.mount_scoped_fields | capability.broad_fields
+    unsupported_fields = authority_fields - supported_fields
+    if unsupported_fields:
+        return MountConfigError(
+            message=(
+                "the selected in-container mount capability does not support exposing the "
+                "configured credential fields; use supported credentials, a credentialless "
+                "helper, or an external/provider-native mount strategy"
+            ),
+            context={
+                "mount_type": mount.type,
+                "strategy_type": strategy.type,
+                "credential_fields": tuple(sorted(unsupported_fields)),
+            },
+        )
+
+    supports_mount_scoped = bool(capability.mount_scoped_fields)
+    supports_broad = bool(capability.broad_fields or capability.enables_broad_credential_discovery)
+    if mount_scoped_acknowledged and not supports_mount_scoped:
+        return MountConfigError(
+            message=(
+                "the selected in-container mount capability does not support mount-scoped "
+                "credentials"
+            ),
+            context={"mount_type": mount.type, "strategy_type": strategy.type},
+        )
+    if broad_acknowledged and not supports_broad:
+        return MountConfigError(
+            message=(
+                "the selected in-container mount capability does not support broad credential "
+                "authority"
+            ),
+            context={"mount_type": mount.type, "strategy_type": strategy.type},
+        )
+
+    requires_mount_scoped = bool(authority_fields & capability.mount_scoped_fields)
+    requires_broad = bool(authority_fields & capability.broad_fields) or requires_implicit_broad
+    if requires_mount_scoped and not mount_scoped_acknowledged:
+        return MountConfigError(
+            message=(
+                "mount-scoped credentials cannot be exposed to a helper inside a "
+                "model-controlled sandbox by default; use a credentialless or "
+                "external/provider-native strategy, or explicitly acknowledge exposure for "
+                "this exact path with "
+                "Manifest.with_in_container_mount_credential_exposure_acknowledged()"
+            ),
+            context={
+                "mount_type": mount.type,
+                "credential_fields": tuple(
+                    sorted(authority_fields & capability.mount_scoped_fields)
+                ),
+            },
+        )
+    if requires_broad and not broad_acknowledged:
+        return MountConfigError(
+            message=(
+                "broad credential authority cannot be exposed to a helper inside a "
+                "model-controlled sandbox by default; use a credentialless or "
+                "external/provider-native strategy, or explicitly acknowledge broad exposure "
+                "for this exact path with "
+                "Manifest.with_in_container_mount_broad_credential_exposure_acknowledged()"
+            ),
+            context={
+                "mount_type": mount.type,
+                "credential_fields": tuple(sorted(authority_fields & capability.broad_fields)),
+            },
+        )
+    return None
+
+
 def _manifest_boundary_error(
     manifest: Manifest,
     *,
-    allowed_in_container_credential_strategy_types: frozenset[str],
     provider_backend_id: str | None,
 ) -> MountConfigError | None:
     provenance_error = _manifest_mount_provenance_error(manifest)
     if provenance_error is not None:
         return provenance_error
-    for mount, _mount_path in manifest.mount_targets():
-        mount_type = _canonical_mount_type(type(mount)) or mount.type
-        strategy = mount.mount_strategy
-        strategy_boundary, strategy_backend_id = _strategy_classification(strategy)
-        pattern = getattr(strategy, "pattern", None)
-        executes_in_container = strategy_boundary == "in_container"
-        if (
-            provider_backend_id is not None
-            and strategy_backend_id is not None
-            and strategy_backend_id != provider_backend_id
+    for mount, mount_path in manifest.mount_targets():
+        if error := _mount_boundary_error(
+            manifest,
+            mount,
+            PurePosixPath(mount_path.as_posix()),
+            provider_backend_id=provider_backend_id,
         ):
-            return MountConfigError(
-                message=(
-                    "docker-volume mounts are not supported by this sandbox backend"
-                    if strategy.type == "docker_volume"
-                    else "mount strategy is not supported by this sandbox backend"
-                ),
-                context={
-                    "mount_type": mount.type,
-                    "strategy_type": strategy.type,
-                    "sandbox_backend": provider_backend_id,
-                },
-            )
-
-        for field_name in _AUTHORITY_FILE_FIELDS_BY_MOUNT_TYPE.get(mount_type, ()):
-            value = getattr(mount, field_name, None)
-            if isinstance(value, str) and value and _manifest_materializes_path(manifest, value):
-                return MountConfigError(
-                    message=(
-                        "credential files stored in the manifest are not supported for cloud "
-                        "mounts; configure credentials outside the sandbox manifest"
-                    ),
-                    context={"mount_type": mount.type, "credential_field": field_name},
-                )
-
-        invalid_rclone_fields = _configured_rclone_line_fields(mount, mount_type)
-        if (
-            executes_in_container
-            and isinstance(pattern, RcloneMountPattern)
-            and invalid_rclone_fields
-        ):
-            return MountConfigError(
-                message="cloud mount configuration values must not contain line breaks",
-                context={
-                    "mount_type": mount.type,
-                    "configuration_fields": invalid_rclone_fields,
-                },
-            )
-        if executes_in_container and mount_type == "box_mount":
-            return MountConfigError(
-                message=(
-                    "Box mounts require credentials and are not supported by helpers that run "
-                    "inside the sandbox; use an external/provider-native mount strategy"
-                ),
-                context={"mount_type": mount.type, "strategy_type": strategy.type},
-            )
-        if executes_in_container and isinstance(pattern, FuseMountPattern):
-            return MountConfigError(
-                message=(
-                    "credentialless blobfuse mounts are not supported inside the sandbox; "
-                    "use RcloneMountPattern or an external/provider-native mount strategy"
-                ),
-                context={"mount_type": mount.type, "strategy_type": strategy.type},
-            )
-        if executes_in_container and isinstance(pattern, S3FilesMountPattern):
-            return MountConfigError(
-                message=(
-                    "S3 Files mounts are not supported inside the sandbox because the helper "
-                    "requires ambient IAM credentials; use an external/provider-native strategy"
-                ),
-                context={"mount_type": mount.type, "strategy_type": strategy.type},
-            )
-        invalid_s3fs_fields = _configured_blaxel_s3fs_option_fields(mount, mount_type)
-        if invalid_s3fs_fields:
-            return MountConfigError(
-                message="cloud mount configuration values must not contain s3fs option delimiters",
-                context={
-                    "mount_type": mount.type,
-                    "configuration_fields": invalid_s3fs_fields,
-                },
-            )
-
-        authority_fields = _configured_mount_authority_fields(mount)
-        trusted_opt_in_fields = _TRUSTED_IN_CONTAINER_OPT_IN_FIELDS.get(strategy.type, frozenset())
-        exact_trusted_opt_in = (
-            strategy_boundary == "in_container"
-            and strategy_backend_id is not None
-            and strategy_backend_id == provider_backend_id
-            and strategy.type in allowed_in_container_credential_strategy_types
-            and frozenset(authority_fields).issubset(trusted_opt_in_fields)
-        )
-        if authority_fields and strategy_boundary != "external" and not exact_trusted_opt_in:
-            return MountConfigError(
-                message=(
-                    "cloud credentials are not supported by a mount helper that runs inside "
-                    "the sandbox; use an external/provider-native mount strategy"
-                ),
-                context={"mount_type": mount.type, "credential_fields": authority_fields},
-            )
-
+            return error
     return None
 
 
 def validate_manifest_mount_credential_boundaries(
     manifest: Manifest,
     *,
-    allowed_in_container_credential_strategy_types: frozenset[str] = frozenset(),
     provider_backend_id: str | None = None,
 ) -> None:
     """Validate all mount authority before a sandbox or helper has side effects."""
 
     error = _manifest_boundary_error(
         manifest,
-        allowed_in_container_credential_strategy_types=(
-            allowed_in_container_credential_strategy_types
-        ),
         provider_backend_id=provider_backend_id,
     )
     if error is None:
         return
     _mark_mount_validation_error(error)
-    del manifest, allowed_in_container_credential_strategy_types
+    del manifest
     provider_backend_id = None
     _raise_data_redacted_error(error)
 
@@ -1052,20 +1376,39 @@ def validate_mount_activation_credential_boundary(
     mount: Mount,
     strategy: MountStrategyBase,
     *,
+    manifest: Manifest | None = None,
+    mount_path: str | PurePath | Callable[[], str | PurePath] | None = None,
     provider_backend_id: str | None = None,
 ) -> None:
     """Revalidate the strategy that is about to execute inside a sandbox."""
 
+    from .manifest import Manifest
+
     _validate_mount_provenance(mount, strategy)
     activation_mount = mount.model_copy(deep=True, update={"mount_strategy": strategy})
-    validate_manifest_mount_credential_boundaries(
-        Manifest(entries={"mount": activation_mount}),
+    activation_manifest = manifest or Manifest(entries={"mount": activation_mount})
+    resolved_mount_path = mount_path() if callable(mount_path) else mount_path
+    activation_path = resolved_mount_path or PurePosixPath(activation_manifest.root) / "mount"
+    error = _mount_boundary_error(
+        activation_manifest,
+        activation_mount,
+        activation_path,
         provider_backend_id=provider_backend_id,
     )
+    if error is None:
+        return
+    _mark_mount_validation_error(error)
+    del mount, strategy, activation_mount, activation_manifest
+    mount_path = None
+    resolved_mount_path = None
+    provider_backend_id = None
+    _raise_data_redacted_error(error)
 
 
 def sanitize_manifest_mount_authority(manifest: Manifest) -> tuple[Manifest, bool]:
     """Return a typed manifest whose durable form contains no mount authority."""
+
+    from .manifest import Manifest
 
     provenance_error = _manifest_mount_provenance_error(manifest)
     if provenance_error is not None:
@@ -1096,11 +1439,10 @@ def rebind_manifest_mount_authority(
     *,
     provider_backend_id: str,
 ) -> Manifest:
-    """Restore external live authority after exact credential-free topology matching."""
+    """Restore live authority after exact credential-free topology matching."""
 
     error = _manifest_boundary_error(
         trusted_manifest,
-        allowed_in_container_credential_strategy_types=frozenset(),
         provider_backend_id=provider_backend_id,
     )
     sanitized_persisted, _ = sanitize_manifest_mount_authority(persisted_manifest)
@@ -1128,7 +1470,7 @@ def rebind_manifest_mount_authority(
         error = MountConfigError(
             message=(
                 "sandbox mount configuration can be rebound only from a current trusted "
-                "external mount configuration with exactly matching credential-free topology"
+                "mount configuration with exactly matching credential-free topology"
             ),
             context={"sandbox_backend": provider_backend_id},
         )
@@ -1152,6 +1494,7 @@ def rebind_manifest_mount_authority(
     for path, entry in rebound.iter_entries():
         if isinstance(entry, Mount):
             entry.__dict__.update(trusted_entries[path.as_posix()].model_copy(deep=True).__dict__)
+    rebound._copy_mount_credential_exposure_policy_from(trusted_manifest)
     return rebound
 
 
@@ -1373,6 +1716,15 @@ def _sanitize_raw_mount(
     pattern_type = pattern.get("type")
     if not isinstance(pattern_type, str):
         pattern["type"] = None
+        redacted = True
+    capability = _in_container_mount_credential_capability_for_types(
+        mount_type,
+        strategy_type,
+        pattern_type if isinstance(pattern_type, str) else None,
+    )
+    if capability is not None and capability.enables_broad_credential_discovery:
+        # Runtime-only broad acknowledgement must be rebound after serialization even when the
+        # helper discovers ambient authority without an explicit credential field to redact.
         redacted = True
     serialized_pattern_class = (
         _SERIALIZED_PATTERN_CLASS_BY_TYPE.get(pattern_type)

--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -873,6 +873,26 @@ def _invalid_required_authority_fields(
     return tuple(sorted(invalid))
 
 
+def _invalid_in_container_s3_credential_fields(mount: Mount) -> tuple[str, ...]:
+    values = {
+        field_name: getattr(mount, field_name, None)
+        for field_name in ("access_key_id", "secret_access_key", "session_token")
+    }
+    if all(value is None for value in values.values()):
+        return ()
+
+    invalid = {
+        field_name
+        for field_name, value in values.items()
+        if value is not None and (not isinstance(value, str) or not value.strip())
+    }
+    if not isinstance(values["access_key_id"], str) or not values["access_key_id"].strip():
+        invalid.add("access_key_id")
+    if not isinstance(values["secret_access_key"], str) or not values["secret_access_key"].strip():
+        invalid.add("secret_access_key")
+    return tuple(sorted(invalid))
+
+
 def _manifest_has_configured_mount_authority(manifest: Manifest) -> bool:
     pending = list(manifest.entries.values())
     while pending:
@@ -1198,6 +1218,23 @@ def _mount_boundary_error(
             context={
                 "mount_type": mount.type,
                 "configuration_fields": invalid_s3fs_fields,
+            },
+        )
+
+    invalid_s3_credential_fields = (
+        _invalid_in_container_s3_credential_fields(mount)
+        if executes_in_container and mount_type == "s3_mount"
+        else ()
+    )
+    if invalid_s3_credential_fields:
+        return MountConfigError(
+            message=(
+                "in-container S3 credentials require non-empty access_key_id and "
+                "secret_access_key values, and session_token requires that pair"
+            ),
+            context={
+                "mount_type": mount.type,
+                "credential_fields": invalid_s3_credential_fields,
             },
         )
 

--- a/src/agents/sandbox/entries/mounts/base.py
+++ b/src/agents/sandbox/entries/mounts/base.py
@@ -264,7 +264,17 @@ class InContainerMountStrategy(MountStrategyBase):
     ) -> list[MaterializedFile]:
         from ..._mount_security import validate_mount_activation_credential_boundary
 
-        validate_mount_activation_credential_boundary(mount, self)
+        validate_mount_activation_credential_boundary(
+            mount,
+            self,
+            manifest=getattr(session.state, "manifest", None),
+            mount_path=(
+                (lambda: mount._resolve_mount_path(session, dest))
+                if getattr(session.state, "manifest", None) is not None
+                else None
+            ),
+            provider_backend_id=session.state.type,
+        )
         return await mount.in_container_adapter().activate(self, session, dest, base_dir)
 
     async def deactivate(
@@ -293,7 +303,13 @@ class InContainerMountStrategy(MountStrategyBase):
     ) -> None:
         from ..._mount_security import validate_mount_activation_credential_boundary
 
-        validate_mount_activation_credential_boundary(mount, self)
+        validate_mount_activation_credential_boundary(
+            mount,
+            self,
+            manifest=getattr(session.state, "manifest", None),
+            mount_path=path,
+            provider_backend_id=session.state.type,
+        )
         await mount.in_container_adapter().restore_after_snapshot(self, session, path)
 
     def build_docker_volume_driver_config(
@@ -462,6 +478,12 @@ class Mount(BaseEntry):
         validate_mount_activation_credential_boundary(
             self,
             self.mount_strategy,
+            manifest=getattr(session.state, "manifest", None),
+            mount_path=(
+                (lambda: self._resolve_mount_path(session, dest))
+                if getattr(session.state, "manifest", None) is not None
+                else None
+            ),
             provider_backend_id=session.state.type,
         )
         return await self.mount_strategy.activate(self, session, dest, base_dir)

--- a/src/agents/sandbox/entries/mounts/providers/azure_blob.py
+++ b/src/agents/sandbox/entries/mounts/providers/azure_blob.py
@@ -96,8 +96,9 @@ class AzureBlobMount(_ConfiguredMount):
             lines.append(f"endpoint = {self.endpoint}")
         if self.account_key:
             lines.append(f"key = {self.account_key}")
+        elif self.identity_client_id:
+            lines.append("use_msi = true")
+            lines.append(f"msi_client_id = {self.identity_client_id}")
         else:
             lines.append("use_msi = false")
-            if self.identity_client_id:
-                lines.append(f"msi_client_id = {self.identity_client_id}")
         return lines

--- a/src/agents/sandbox/manifest.py
+++ b/src/agents/sandbox/manifest.py
@@ -371,6 +371,18 @@ class Manifest(BaseModel):
             broad=frozenset(broad),
         )
 
+    def _merge_mount_credential_exposure_policy(
+        self,
+        policy: _MountCredentialExposurePolicy,
+    ) -> _MountCredentialExposurePolicy:
+        current = self._mount_credential_exposure_policy
+        merged = _MountCredentialExposurePolicy(
+            mount_scoped=current.mount_scoped | policy.mount_scoped,
+            broad=current.broad | policy.broad,
+        )
+        self._mount_credential_exposure_policy = merged
+        return merged
+
     def _mount_credential_exposure_policy_key(
         self,
         value: str | PurePath,

--- a/src/agents/sandbox/manifest.py
+++ b/src/agents/sandbox/manifest.py
@@ -358,7 +358,26 @@ class Manifest(BaseModel):
         key = self._mount_credential_exposure_policy_key(mount_path, reject_root=False)
         if key is None:
             return False
-        return key in getattr(self._mount_credential_exposure_policy, authority)
+        lookup_keys = {key}
+        kind, _, path_text = key.partition(":")
+        root = coerce_posix_path(self.root)
+        root_normalized = PurePosixPath(
+            "/",
+            *[part for part in root.parts if part not in {"/", ""}],
+        )
+        if kind == "absolute":
+            try:
+                relative = PurePosixPath(path_text).relative_to(root_normalized)
+            except ValueError:
+                pass
+            else:
+                if relative.parts:
+                    lookup_keys.add(f"relative:{relative.as_posix()}")
+        else:
+            absolute = root_normalized / PurePosixPath(path_text)
+            lookup_keys.add(f"absolute:{absolute.as_posix()}")
+        acknowledged = getattr(self._mount_credential_exposure_policy, authority)
+        return not lookup_keys.isdisjoint(acknowledged)
 
     def _copy_mount_credential_exposure_policy_from(self, *sources: "Manifest") -> None:
         mount_scoped: set[str] = set()
@@ -434,11 +453,7 @@ class Manifest(BaseModel):
             if reject_root:
                 raise ValueError("Mount credential exposure path must identify a non-root path.")
             return None
-        try:
-            absolute_relative = normalized.relative_to(root_normalized)
-        except ValueError:
-            return f"absolute:{normalized.as_posix()}"
-        return f"relative:{absolute_relative.as_posix()}"
+        return f"absolute:{normalized.as_posix()}"
 
     def ephemeral_entry_paths(self, depth: int | None = 1) -> set[Path]:
         _ = depth

--- a/src/agents/sandbox/manifest.py
+++ b/src/agents/sandbox/manifest.py
@@ -1,21 +1,25 @@
 import abc
 import inspect
 from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
 from pathlib import Path, PurePath, PurePosixPath
 from typing import Any, ClassVar, Literal
 
 from pydantic import (
     BaseModel,
     Field,
+    PrivateAttr,
     SerializeAsAny,
     field_serializer,
     field_validator,
+    model_validator,
 )
 from pydantic_core import PydanticSerializationError
 from typing_extensions import assert_never
 
 from .._config_coercion import coerce_pydantic_config
 from ..util._asyncio_tasks import gather_with_cancel
+from ._mount_security import redact_mount_validation_error_data_sync
 from .entries import BaseEntry, Dir, Mount, resolve_workspace_path
 from .errors import InvalidManifestPathError
 from .manifest_render import render_manifest_description
@@ -47,6 +51,31 @@ DEFAULT_REMOTE_MOUNT_COMMAND_ALLOWLIST = [
     "mkdir",
     "rm",
 ]
+
+_MOUNT_CREDENTIAL_EXPOSURE_POLICY_KEYS = frozenset(
+    {
+        "in_container_mount_credential_exposure_allowed_paths",
+        "_in_container_mount_credential_exposure_allowed_paths",
+        "inContainerMountCredentialExposureAllowedPaths",
+        "_inContainerMountCredentialExposureAllowedPaths",
+        "in_container_mount_credential_exposure_acknowledged_paths",
+        "_in_container_mount_credential_exposure_acknowledged_paths",
+        "inContainerMountCredentialExposureAcknowledgedPaths",
+        "_inContainerMountCredentialExposureAcknowledgedPaths",
+        "in_container_mount_broad_credential_exposure_acknowledged_paths",
+        "_in_container_mount_broad_credential_exposure_acknowledged_paths",
+        "inContainerMountBroadCredentialExposureAcknowledgedPaths",
+        "_inContainerMountBroadCredentialExposureAcknowledgedPaths",
+        "mount_credential_exposure_policy",
+        "_mount_credential_exposure_policy",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _MountCredentialExposurePolicy:
+    mount_scoped: frozenset[str] = frozenset()
+    broad: frozenset[str] = frozenset()
 
 
 EnvValueClass = type["EnvValue"]
@@ -225,6 +254,21 @@ class Manifest(BaseModel):
     remote_mount_command_allowlist: list[str] = Field(
         default_factory=lambda: list(DEFAULT_REMOTE_MOUNT_COMMAND_ALLOWLIST)
     )
+    _mount_credential_exposure_policy: _MountCredentialExposurePolicy = PrivateAttr(
+        default_factory=_MountCredentialExposurePolicy
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_mount_credential_exposure_policy_input(cls, value: object) -> object:
+        if isinstance(value, Mapping) and _MOUNT_CREDENTIAL_EXPOSURE_POLICY_KEYS.intersection(
+            value
+        ):
+            raise TypeError(
+                "In-container mount credential exposure must be configured on a trusted "
+                "Manifest instance, not in manifest input."
+            )
+        return value
 
     @field_validator("entries", mode="before")
     @classmethod
@@ -248,6 +292,141 @@ class Manifest(BaseModel):
         for _path, _artifact in self.iter_entries():
             pass
         return validated
+
+    @redact_mount_validation_error_data_sync
+    def with_in_container_mount_credential_exposure_acknowledged(
+        self, *mount_paths: str | PurePath
+    ) -> "Manifest":
+        """Acknowledge mount-scoped credential exposure for exact in-container mount paths.
+
+        This trusted application-side policy is runtime-only and is not serialized.
+        """
+
+        return self._with_mount_credential_exposure_acknowledged(
+            "mount_scoped",
+            mount_paths,
+        )
+
+    @redact_mount_validation_error_data_sync
+    def with_in_container_mount_broad_credential_exposure_acknowledged(
+        self, *mount_paths: str | PurePath
+    ) -> "Manifest":
+        """Acknowledge broad credential exposure for exact in-container mount paths.
+
+        Broad authority includes managed or workload identity and external credential files.
+        This trusted application-side policy is runtime-only and is not serialized.
+        """
+
+        return self._with_mount_credential_exposure_acknowledged(
+            "broad",
+            mount_paths,
+        )
+
+    def _with_mount_credential_exposure_acknowledged(
+        self,
+        authority: Literal["mount_scoped", "broad"],
+        mount_paths: tuple[str | PurePath, ...],
+    ) -> "Manifest":
+        if not mount_paths:
+            raise TypeError("At least one in-container mount path is required.")
+
+        acknowledged: set[str] = set()
+        for path in mount_paths:
+            key = self._mount_credential_exposure_policy_key(path, reject_root=True)
+            assert key is not None
+            acknowledged.add(key)
+        from ._mount_security import _validate_manifest_mount_provenance
+
+        _validate_manifest_mount_provenance(self)
+        trusted = self.model_copy(deep=True)
+        current = self._mount_credential_exposure_policy
+        trusted._mount_credential_exposure_policy = _MountCredentialExposurePolicy(
+            mount_scoped=(
+                current.mount_scoped | acknowledged
+                if authority == "mount_scoped"
+                else current.mount_scoped
+            ),
+            broad=(current.broad | acknowledged if authority == "broad" else current.broad),
+        )
+        return trusted
+
+    def _acknowledges_in_container_mount_credential_exposure(
+        self,
+        mount_path: str | PurePath,
+        authority: Literal["mount_scoped", "broad"],
+    ) -> bool:
+        key = self._mount_credential_exposure_policy_key(mount_path, reject_root=False)
+        if key is None:
+            return False
+        return key in getattr(self._mount_credential_exposure_policy, authority)
+
+    def _copy_mount_credential_exposure_policy_from(self, *sources: "Manifest") -> None:
+        mount_scoped: set[str] = set()
+        broad: set[str] = set()
+        for source in sources:
+            mount_scoped.update(source._mount_credential_exposure_policy.mount_scoped)
+            broad.update(source._mount_credential_exposure_policy.broad)
+        self._mount_credential_exposure_policy = _MountCredentialExposurePolicy(
+            mount_scoped=frozenset(mount_scoped),
+            broad=frozenset(broad),
+        )
+
+    def _mount_credential_exposure_policy_key(
+        self,
+        value: str | PurePath,
+        *,
+        reject_root: bool,
+    ) -> str | None:
+        text = value.as_posix() if isinstance(value, PurePath) else value
+        if not text:
+            if reject_root:
+                raise ValueError("Mount credential exposure path must identify a non-root path.")
+            return None
+        if "\\" in text:
+            raise ValueError("Mount credential exposure paths must use '/' separators.")
+        if reject_root and any(character in text for character in "*?[]"):
+            raise ValueError("Mount credential exposure paths must not contain wildcard syntax.")
+
+        raw = PurePosixPath(text)
+        if reject_root and ".." in raw.parts:
+            raise ValueError("Mount credential exposure paths must not contain parent segments.")
+        if not raw.is_absolute():
+            rel = self._normalize_rel_path_within_root(
+                posix_path_as_path(raw),
+                original=posix_path_as_path(raw),
+            )
+            if not rel.parts:
+                if reject_root:
+                    raise ValueError(
+                        "Mount credential exposure path must identify a non-root path."
+                    )
+                return None
+            return f"relative:{coerce_posix_path(rel).as_posix()}"
+
+        normalized_parts: list[str] = []
+        for part in raw.parts:
+            if part in {"", ".", "/"}:
+                continue
+            if part == "..":
+                if normalized_parts:
+                    normalized_parts.pop()
+                continue
+            normalized_parts.append(part)
+        normalized = PurePosixPath("/", *normalized_parts)
+        root = coerce_posix_path(self.root)
+        root_normalized = PurePosixPath(
+            "/",
+            *[part for part in root.parts if part not in {"/", ""}],
+        )
+        if normalized == PurePosixPath("/") or normalized == root_normalized:
+            if reject_root:
+                raise ValueError("Mount credential exposure path must identify a non-root path.")
+            return None
+        try:
+            absolute_relative = normalized.relative_to(root_normalized)
+        except ValueError:
+            return f"absolute:{normalized.as_posix()}"
+        return f"relative:{absolute_relative.as_posix()}"
 
     def ephemeral_entry_paths(self, depth: int | None = 1) -> set[Path]:
         _ = depth

--- a/src/agents/sandbox/runtime_session_manager.py
+++ b/src/agents/sandbox/runtime_session_manager.py
@@ -557,10 +557,16 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
             manifest.model_copy(deep=True),
             run_as_user,
         )
+        mount_credential_exposure_policy = processed_manifest._mount_credential_exposure_policy
         for capability in capabilities:
             safe_error: RuntimeError | None = None
             try:
                 processed_manifest = capability.process_manifest(processed_manifest)
+                mount_credential_exposure_policy = (
+                    processed_manifest._merge_mount_credential_exposure_policy(
+                        mount_credential_exposure_policy
+                    )
+                )
             except Exception as error:
                 if not _manifest_has_configured_mount_authority(processed_manifest):
                     raise
@@ -571,6 +577,7 @@ class SandboxRuntimeSessionManager(Generic[TContext]):
                 capability = cast(Any, None)
                 manifest = None
                 processed_manifest = cast(Any, None)
+                mount_credential_exposure_policy = cast(Any, None)
                 run_as_user = None
                 _raise_data_redacted_error(safe_error)
         return processed_manifest

--- a/src/agents/sandbox/session/sandbox_client.py
+++ b/src/agents/sandbox/session/sandbox_client.py
@@ -132,16 +132,11 @@ class BaseSandboxClient(abc.ABC, Generic[ClientOptionsT]):
     def _validate_manifest_for_create(
         self,
         manifest: Manifest,
-        *,
-        allowed_in_container_credential_strategy_types: frozenset[str] = frozenset(),
     ) -> Manifest:
         from .._mount_security import validate_manifest_mount_credential_boundaries
 
         validate_manifest_mount_credential_boundaries(
             manifest,
-            allowed_in_container_credential_strategy_types=(
-                allowed_in_container_credential_strategy_types
-            ),
             provider_backend_id=self.backend_id,
         )
         return manifest

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -2314,15 +2314,19 @@ class TestValidateTarBytesExtra:
 class TestTarExcludeArgsWithSkipPaths:
     @pytest.mark.asyncio
     async def test_exclude_args_with_skip_paths(self, fake_sandbox: _FakeSandboxInstance) -> None:
+        from agents.extensions.sandbox.blaxel.mounts import _mount_credential_path
+
         session = _make_session(fake_sandbox)
-        session._runtime_persist_workspace_skip_relpaths = {
-            Path("node_modules"),
-            Path(".git"),
-        }
+        session.register_persist_workspace_skip_path(Path("node_modules"))
+        session.register_persist_workspace_skip_path(Path(".git"))
+        credential_path = _mount_credential_path(session, "s3fs-passwd")
+        credential_relative_path = credential_path.relative_to(Path(session.state.manifest.root))
         args = session._tar_exclude_args()
         assert len(args) > 0
         assert any("node_modules" in a for a in args)
         assert any(".git" in a for a in args)
+        assert any(credential_relative_path.as_posix() in arg for arg in args)
+        assert credential_relative_path in session._workspace_fingerprint_skip_relpaths()
 
     @pytest.mark.asyncio
     async def test_exclude_args_skips_empty_and_dot(
@@ -2863,6 +2867,9 @@ class _FakeMountSession:
     def __init__(self) -> None:
         self.exec_calls: list[tuple[tuple[str, ...], dict[str, float]]] = []
         self.write_calls: list[tuple[Path, bytes]] = []
+        self.persist_workspace_skip_paths: list[Path] = []
+        self.credential_lifecycle_events: list[tuple[str, Path]] = []
+        self.persist_workspace_skip_error: Exception | None = None
         self._next_results: list[_FakeExecResultForMount] = []
         self._default_result = _FakeExecResultForMount()
         self.state = MagicMock()
@@ -2878,7 +2885,16 @@ class _FakeMountSession:
         _ = user
         payload = data.read()
         assert isinstance(payload, bytes)
+        self.credential_lifecycle_events.append(("write", path))
         self.write_calls.append((path, payload))
+
+    def register_persist_workspace_skip_path(self, path: Path | str) -> Path:
+        relative_path = Path(path)
+        self.credential_lifecycle_events.append(("register", relative_path))
+        if self.persist_workspace_skip_error is not None:
+            raise self.persist_workspace_skip_error
+        self.persist_workspace_skip_paths.append(relative_path)
+        return relative_path
 
     class __class__:
         __name__ = "BlaxelSandboxSession"
@@ -3050,6 +3066,80 @@ class TestMountsModule:
         assert secret_access_key not in repr(session.exec_calls)
 
     @pytest.mark.asyncio
+    async def test_mount_s3_fails_when_credential_cleanup_fails(self) -> None:
+        from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountConfig, _mount_s3
+
+        session = _FakeMountSession()
+        secret_access_key = "s3-cleanup-secret"
+        session._next_results = [
+            _FakeExecResultForMount(exit_code=0),  # which s3fs
+            _FakeExecResultForMount(exit_code=0),  # chmod credential file
+            _FakeExecResultForMount(exit_code=0),  # mkdir
+            _FakeExecResultForMount(exit_code=0),  # s3fs mount
+            _FakeExecResultForMount(exit_code=1),  # rm credential file
+        ]
+
+        config = BlaxelCloudBucketMountConfig(
+            provider="s3",
+            bucket="my-bucket",
+            mount_path="/mnt/s3",
+            access_key_id="AKID",
+            secret_access_key=secret_access_key,
+        )
+        with pytest.raises(MountConfigError, match="failed to remove mount credential file"):
+            await _mount_s3(session, config)  # type: ignore[arg-type]
+
+        assert session.exec_calls[-1][0][2].startswith("rm -f ")
+        assert secret_access_key not in repr(session.exec_calls)
+        credential_path, _credential_payload = session.write_calls[0]
+        assert session.persist_workspace_skip_paths == [
+            credential_path.relative_to(Path("/workspace"))
+        ]
+        assert [event for event, _path in session.credential_lifecycle_events] == [
+            "register",
+            "write",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("provider", ["s3", "gcs"])
+    async def test_mount_credentials_reject_registration_before_write(self, provider: str) -> None:
+        from agents.extensions.sandbox.blaxel.mounts import (
+            BlaxelCloudBucketMountConfig,
+            _mount_gcs,
+            _mount_s3,
+        )
+
+        session = _FakeMountSession()
+        session.persist_workspace_skip_error = RuntimeError("registration rejected")
+        session._next_results = [_FakeExecResultForMount(exit_code=0)]  # which
+        if provider == "s3":
+            mount = _mount_s3
+            config = BlaxelCloudBucketMountConfig(
+                provider="s3",
+                bucket="bucket",
+                mount_path="/mnt/data",
+                access_key_id="AKID",
+                secret_access_key="SECRET",
+            )
+        else:
+            mount = _mount_gcs
+            config = BlaxelCloudBucketMountConfig(
+                provider="gcs",
+                bucket="bucket",
+                mount_path="/mnt/data",
+                service_account_key='{"private_key":"SECRET"}',
+            )
+
+        with pytest.raises(RuntimeError, match="registration rejected"):
+            await mount(session, config)  # type: ignore[arg-type]
+
+        assert [event for event, _path in session.credential_lifecycle_events] == ["register"]
+        assert session.persist_workspace_skip_paths == []
+        assert session.write_calls == []
+        assert len(session.exec_calls) == 1
+        assert session.exec_calls[0][0][2].startswith("which ")
+
+    @pytest.mark.asyncio
     async def test_mount_s3_public_bucket(self) -> None:
         from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountConfig, _mount_s3
 
@@ -3067,6 +3157,9 @@ class TestMountsModule:
             read_only=True,
         )
         await _mount_s3(session, config)  # type: ignore[arg-type]
+        assert len(session.exec_calls) == 3
+        assert not any(call[0][2].startswith("rm -f ") for call in session.exec_calls)
+        assert session.persist_workspace_skip_paths == []
 
     @pytest.mark.asyncio
     async def test_mount_s3_with_endpoint(self) -> None:
@@ -3153,12 +3246,47 @@ class TestMountsModule:
             prefix="data/",
         )
         await _mount_gcs(session, config)  # type: ignore[arg-type]
+        assert len(session.exec_calls) == 5
         assert len(session.write_calls) == 1
         credential_path, credential_payload = session.write_calls[0]
         assert credential_path.parent == Path("/workspace")
         assert credential_path.name.startswith(".openai-agents-gcs-creds-")
         assert credential_payload == service_account_key.encode()
         assert "gcs-secret-command-sentinel" not in repr(session.exec_calls)
+
+    @pytest.mark.asyncio
+    async def test_mount_gcs_fails_when_credential_cleanup_fails(self) -> None:
+        from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountConfig, _mount_gcs
+
+        session = _FakeMountSession()
+        service_account_key = '{"private_key":"gcs-cleanup-secret"}'
+        session._next_results = [
+            _FakeExecResultForMount(exit_code=0),  # which gcsfuse
+            _FakeExecResultForMount(exit_code=0),  # chmod credential file
+            _FakeExecResultForMount(exit_code=0),  # mkdir
+            _FakeExecResultForMount(exit_code=0),  # gcsfuse mount
+            _FakeExecResultForMount(exit_code=1),  # rm credential file
+        ]
+
+        config = BlaxelCloudBucketMountConfig(
+            provider="gcs",
+            bucket="gcs-bucket",
+            mount_path="/mnt/gcs",
+            service_account_key=service_account_key,
+        )
+        with pytest.raises(MountConfigError, match="failed to remove mount credential file"):
+            await _mount_gcs(session, config)  # type: ignore[arg-type]
+
+        assert session.exec_calls[-1][0][2].startswith("rm -f ")
+        assert "gcs-cleanup-secret" not in repr(session.exec_calls)
+        credential_path, _credential_payload = session.write_calls[0]
+        assert session.persist_workspace_skip_paths == [
+            credential_path.relative_to(Path("/workspace"))
+        ]
+        assert [event for event, _path in session.credential_lifecycle_events] == [
+            "register",
+            "write",
+        ]
 
     @pytest.mark.asyncio
     async def test_mount_gcs_quotes_generated_key_path(self) -> None:
@@ -3236,6 +3364,9 @@ class TestMountsModule:
             mount_path="/mnt/pub-gcs",
         )
         await _mount_gcs(session, config)  # type: ignore[arg-type]
+        assert len(session.exec_calls) == 3
+        assert not any(call[0][2].startswith("rm -f ") for call in session.exec_calls)
+        assert session.persist_workspace_skip_paths == []
 
     @pytest.mark.asyncio
     async def test_mount_gcs_fails(self) -> None:
@@ -3409,6 +3540,44 @@ class TestMountsModule:
         assert result == []
 
     @pytest.mark.asyncio
+    async def test_activate_preserves_safe_credential_cleanup_error(self) -> None:
+        from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountStrategy
+        from agents.sandbox.entries import S3Mount
+
+        strategy = BlaxelCloudBucketMountStrategy()
+        mount = S3Mount(
+            bucket="test",
+            access_key_id="AKID",
+            secret_access_key="s3-cleanup-secret",
+            mount_strategy=strategy,
+        )
+        session = _FakeMountSession()
+        session.state.manifest = Manifest(
+            entries={"data": mount}
+        ).with_in_container_mount_credential_exposure_acknowledged("data")
+        session._next_results = [
+            _FakeExecResultForMount(exit_code=0),  # which
+            _FakeExecResultForMount(exit_code=0),  # chmod credential file
+            _FakeExecResultForMount(exit_code=0),  # mkdir
+            _FakeExecResultForMount(exit_code=0),  # mount
+            _FakeExecResultForMount(exit_code=1),  # rm credential file
+        ]
+        mount._resolve_mount_path = lambda s, d: Path("/workspace/data")  # type: ignore[assignment]
+
+        with pytest.raises(
+            MountConfigError,
+            match="failed to remove mount credential file",
+        ):
+            await strategy.activate(
+                mount,
+                session,  # type: ignore[arg-type]
+                Path("/workspace/data"),
+                Path("/workspace"),
+            )
+
+        assert "s3-cleanup-secret" not in repr(session.exec_calls)
+
+    @pytest.mark.asyncio
     async def test_deactivate(self) -> None:
         from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountStrategy
         from agents.sandbox.entries import S3Mount
@@ -3458,6 +3627,41 @@ class TestMountsModule:
             session,  # type: ignore[arg-type]
             Path("/workspace/mnt/s3"),
         )
+
+    @pytest.mark.asyncio
+    async def test_restore_preserves_cleanup_error_over_mount_error(self) -> None:
+        from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountStrategy
+        from agents.sandbox.entries import GCSMount
+
+        strategy = BlaxelCloudBucketMountStrategy()
+        mount = GCSMount(
+            bucket="test",
+            service_account_credentials='{"private_key":"gcs-cleanup-secret"}',
+            mount_strategy=strategy,
+        )
+        session = _FakeMountSession()
+        session.state.manifest = Manifest(
+            entries={"data": mount}
+        ).with_in_container_mount_credential_exposure_acknowledged("data")
+        session._next_results = [
+            _FakeExecResultForMount(exit_code=0),  # which
+            _FakeExecResultForMount(exit_code=0),  # chmod credential file
+            _FakeExecResultForMount(exit_code=0),  # mkdir
+            _FakeExecResultForMount(exit_code=1, stderr=b"mount failed"),  # mount
+            _FakeExecResultForMount(exit_code=1),  # rm credential file
+        ]
+
+        with pytest.raises(
+            MountConfigError,
+            match="failed to remove mount credential file",
+        ):
+            await strategy.restore_after_snapshot(
+                mount,
+                session,  # type: ignore[arg-type]
+                Path("/workspace/data"),
+            )
+
+        assert "gcs-cleanup-secret" not in repr(session.exec_calls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import json
 import logging
+import shlex
 import tarfile
 import time
 import uuid
@@ -3158,6 +3159,65 @@ class TestMountsModule:
         assert credential_path.name.startswith(".openai-agents-gcs-creds-")
         assert credential_payload == service_account_key.encode()
         assert "gcs-secret-command-sentinel" not in repr(session.exec_calls)
+
+    @pytest.mark.asyncio
+    async def test_mount_gcs_quotes_generated_key_path(self) -> None:
+        from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountConfig, _mount_gcs
+
+        session = _FakeMountSession()
+        session.state.manifest = Manifest(root="/workspace data;echo not-executed")
+        session._next_results = [
+            _FakeExecResultForMount(exit_code=0),  # which gcsfuse
+            _FakeExecResultForMount(exit_code=0),  # chmod key
+            _FakeExecResultForMount(exit_code=0),  # mkdir
+            _FakeExecResultForMount(exit_code=0),  # gcsfuse mount
+            _FakeExecResultForMount(exit_code=0),  # rm key
+        ]
+
+        config = BlaxelCloudBucketMountConfig(
+            provider="gcs",
+            bucket="gcs-bucket",
+            mount_path="/mnt/gcs",
+            service_account_key='{"private_key":"gcs-secret"}',
+        )
+        await _mount_gcs(session, config)  # type: ignore[arg-type]
+
+        credential_path, _credential_payload = session.write_calls[0]
+        mount_command = session.exec_calls[3][0][2]
+        assert f"--key-file={credential_path.as_posix()}" in shlex.split(mount_command)
+        assert "echo" not in shlex.split(mount_command)
+
+    @pytest.mark.asyncio
+    async def test_mount_gcs_aborts_and_cleans_up_when_credential_chmod_fails(self) -> None:
+        from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountConfig, _mount_gcs
+
+        session = _FakeMountSession()
+        service_account_key = '{"private_key":"gcs-chmod-secret"}'
+        session._next_results = [
+            _FakeExecResultForMount(exit_code=0),  # which gcsfuse
+            _FakeExecResultForMount(exit_code=1),  # chmod key
+            _FakeExecResultForMount(exit_code=0),  # rm key
+        ]
+
+        config = BlaxelCloudBucketMountConfig(
+            provider="gcs",
+            bucket="gcs-bucket",
+            mount_path="/mnt/gcs",
+            service_account_key=service_account_key,
+        )
+        with pytest.raises(
+            MountConfigError,
+            match="failed to restrict mount credential file permissions",
+        ):
+            await _mount_gcs(session, config)  # type: ignore[arg-type]
+
+        commands = [call[0][2] for call in session.exec_calls]
+        assert len(session.write_calls) == 1
+        assert any(command.startswith("chmod 600 ") for command in commands)
+        assert any(command.startswith("rm -f ") for command in commands)
+        assert not any(command.startswith("mkdir -p ") for command in commands)
+        assert not any(command.startswith("gcsfuse ") for command in commands)
+        assert "gcs-chmod-secret" not in repr(session.exec_calls)
 
     @pytest.mark.asyncio
     async def test_mount_gcs_anonymous(self) -> None:

--- a/tests/extensions/sandbox/test_blaxel.py
+++ b/tests/extensions/sandbox/test_blaxel.py
@@ -2861,14 +2861,23 @@ class _FakeMountSession:
 
     def __init__(self) -> None:
         self.exec_calls: list[tuple[tuple[str, ...], dict[str, float]]] = []
+        self.write_calls: list[tuple[Path, bytes]] = []
         self._next_results: list[_FakeExecResultForMount] = []
         self._default_result = _FakeExecResultForMount()
+        self.state = MagicMock()
+        self.state.manifest = Manifest()
 
     async def exec(self, *cmd: str, timeout: float = 120) -> _FakeExecResultForMount:
         self.exec_calls.append((cmd, {"timeout": timeout}))
         if self._next_results:
             return self._next_results.pop(0)
         return self._default_result
+
+    async def write(self, path: Path, data: io.IOBase, *, user: object = None) -> None:
+        _ = user
+        payload = data.read()
+        assert isinstance(payload, bytes)
+        self.write_calls.append((path, payload))
 
     class __class__:
         __name__ = "BlaxelSandboxSession"
@@ -3010,10 +3019,11 @@ class TestMountsModule:
         from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountConfig, _mount_s3
 
         session = _FakeMountSession()
+        secret_access_key = "s3-secret-command-sentinel"
         # Simulate: which s3fs succeeds.
         session._next_results = [
             _FakeExecResultForMount(exit_code=0, stdout=b"/usr/bin/s3fs"),  # which s3fs
-            _FakeExecResultForMount(exit_code=0),  # write cred file
+            _FakeExecResultForMount(exit_code=0),  # chmod cred file
             _FakeExecResultForMount(exit_code=0),  # mkdir
             _FakeExecResultForMount(exit_code=0),  # s3fs mount
             _FakeExecResultForMount(exit_code=0),  # rm cred file
@@ -3024,13 +3034,19 @@ class TestMountsModule:
             bucket="my-bucket",
             mount_path="/mnt/s3",
             access_key_id="AKID",
-            secret_access_key="SECRET",
+            secret_access_key=secret_access_key,
             region="us-east-1",
             prefix="data/",
             read_only=True,
         )
         await _mount_s3(session, config)  # type: ignore[arg-type]
         assert len(session.exec_calls) == 5
+        assert len(session.write_calls) == 1
+        credential_path, credential_payload = session.write_calls[0]
+        assert credential_path.parent == Path("/workspace")
+        assert credential_path.name.startswith(".openai-agents-s3fs-passwd-")
+        assert credential_payload == f"AKID:{secret_access_key}".encode()
+        assert secret_access_key not in repr(session.exec_calls)
 
     @pytest.mark.asyncio
     async def test_mount_s3_public_bucket(self) -> None:
@@ -3118,9 +3134,10 @@ class TestMountsModule:
         from agents.extensions.sandbox.blaxel.mounts import BlaxelCloudBucketMountConfig, _mount_gcs
 
         session = _FakeMountSession()
+        service_account_key = '{"private_key":"gcs-secret-command-sentinel"}'
         session._next_results = [
             _FakeExecResultForMount(exit_code=0),  # which gcsfuse
-            _FakeExecResultForMount(exit_code=0),  # write key
+            _FakeExecResultForMount(exit_code=0),  # chmod key
             _FakeExecResultForMount(exit_code=0),  # mkdir
             _FakeExecResultForMount(exit_code=0),  # gcsfuse mount
             _FakeExecResultForMount(exit_code=0),  # rm key
@@ -3130,11 +3147,17 @@ class TestMountsModule:
             provider="gcs",
             bucket="gcs-bucket",
             mount_path="/mnt/gcs",
-            service_account_key='{"type":"service_account"}',
+            service_account_key=service_account_key,
             read_only=True,
             prefix="data/",
         )
         await _mount_gcs(session, config)  # type: ignore[arg-type]
+        assert len(session.write_calls) == 1
+        credential_path, credential_payload = session.write_calls[0]
+        assert credential_path.parent == Path("/workspace")
+        assert credential_path.name.startswith(".openai-agents-gcs-creds-")
+        assert credential_payload == service_account_key.encode()
+        assert "gcs-secret-command-sentinel" not in repr(session.exec_calls)
 
     @pytest.mark.asyncio
     async def test_mount_gcs_anonymous(self) -> None:

--- a/tests/extensions/sandbox/test_vercel.py
+++ b/tests/extensions/sandbox/test_vercel.py
@@ -640,7 +640,7 @@ def test_vercel_from_state_rejects_mismatched_trusted_mount_configuration(
         )
 
 
-def test_vercel_from_state_requires_trusted_manifest_for_mounts(
+def test_vercel_from_state_accepts_released_trusted_mount_shape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vercel_module = _load_vercel_module(monkeypatch)
@@ -652,11 +652,86 @@ def test_vercel_from_state_requires_trusted_manifest_for_mounts(
         sandbox_id="sandbox-existing",
     )
 
-    with pytest.raises(MountConfigError, match="trusted create-time manifest"):
-        vercel_module.VercelSandboxSession.from_state(
-            state,
-            trusted_s3_mounts=vercel_module._vercel_s3_mount_map(manifest),
-        )
+    session = vercel_module.VercelSandboxSession.from_state(
+        state,
+        trusted_s3_mounts=vercel_module._vercel_s3_mount_map(manifest),
+    )
+
+    assert session._trusted_manifest == manifest
+
+
+def test_vercel_from_state_accepts_released_credential_exposure_option(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vercel_module = _load_vercel_module(monkeypatch)
+    package_module = importlib.import_module("agents.extensions.sandbox.vercel")
+    trusted_manifest = _vercel_s3_manifest(package_module, credentials=True)
+    state_manifest = vercel_module._manifest_without_vercel_s3_credentials(trusted_manifest)
+    state = vercel_module.VercelSandboxSessionState(
+        manifest=state_manifest,
+        snapshot=NoopSnapshot(id="snapshot"),
+        sandbox_id="sandbox-existing",
+    )
+
+    session = vercel_module.VercelSandboxSession.from_state(
+        state,
+        allow_s3_credential_exposure=True,
+        trusted_s3_mounts=vercel_module._vercel_s3_mount_map(trusted_manifest),
+    )
+
+    assert session._trusted_manifest.model_dump(mode="json") == state_manifest.model_dump(
+        mode="json"
+    )
+    assert session._runtime_s3_mount_sensitive_values() == (
+        "test-access-key",
+        "test-secret-key",
+        "test-session-token",
+    )
+
+
+@pytest.mark.parametrize("entrypoint", ["constructor", "from_state"])
+@pytest.mark.parametrize("include_trusted_manifest", [False, True])
+def test_vercel_direct_session_normalizes_released_credentialed_state_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    entrypoint: str,
+    include_trusted_manifest: bool,
+) -> None:
+    vercel_module = _load_vercel_module(monkeypatch)
+    package_module = importlib.import_module("agents.extensions.sandbox.vercel")
+    manifest = _vercel_s3_manifest(package_module, credentials=True)
+    state = vercel_module.VercelSandboxSessionState(
+        manifest=manifest,
+        snapshot=NoopSnapshot(id="snapshot"),
+        sandbox_id="sandbox-existing",
+    )
+    kwargs: dict[str, Any] = {
+        "state": state,
+        "allow_s3_credential_exposure": True,
+        "trusted_s3_mounts": vercel_module._vercel_s3_mount_map(manifest),
+    }
+    if include_trusted_manifest:
+        kwargs["trusted_manifest"] = manifest
+
+    if entrypoint == "constructor":
+        session = vercel_module.VercelSandboxSession(**kwargs)
+    else:
+        session = vercel_module.VercelSandboxSession.from_state(**kwargs)
+
+    state_mount = state.manifest.entries["remote"]
+    assert isinstance(state_mount, S3Mount)
+    assert state_mount.access_key_id is None
+    assert state_mount.secret_access_key is None
+    assert state_mount.session_token is None
+    assert session.state is state
+    assert session._runtime_s3_mount_sensitive_values() == (
+        "test-access-key",
+        "test-secret-key",
+        "test-session-token",
+    )
+    payload = session.state.model_dump(mode="json")
+    assert "test-access-key" not in repr(payload)
+    assert "test-secret-key" not in repr(payload)
+    assert "test-session-token" not in repr(payload)
 
 
 def test_vercel_from_state_rejects_custom_mount_before_deepcopy(
@@ -899,7 +974,7 @@ async def test_vercel_create_requires_explicit_s3_credential_exposure(
     client = vercel_module.VercelSandboxClient()
     manifest = _vercel_s3_manifest(package_module, credentials=True)
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported") as exc:
+    with pytest.raises(MountConfigError, match="mount-scoped credentials") as exc:
         await client.create(
             manifest=manifest,
             options=vercel_module.VercelSandboxClientOptions(),
@@ -912,6 +987,27 @@ async def test_vercel_create_requires_explicit_s3_credential_exposure(
         if isinstance(module_name, str) and module_name.startswith("agents."):
             assert "test-secret-key" not in repr(traceback.tb_frame.f_locals)
         traceback = traceback.tb_next
+
+
+@pytest.mark.asyncio
+async def test_vercel_create_accepts_manifest_mount_scoped_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vercel_module = _load_vercel_module(monkeypatch)
+    package_module = importlib.import_module("agents.extensions.sandbox.vercel")
+    client = vercel_module.VercelSandboxClient()
+    manifest = _vercel_s3_manifest(
+        package_module,
+        credentials=True,
+    ).with_in_container_mount_credential_exposure_acknowledged("remote")
+
+    session = await client.create(
+        manifest=manifest,
+        options=vercel_module.VercelSandboxClientOptions(),
+    )
+
+    assert _FakeAsyncSandbox.create_calls
+    await client.delete(session)
 
 
 @pytest.mark.asyncio
@@ -1106,7 +1202,7 @@ async def test_vercel_credential_opt_in_does_not_allow_signed_endpoint_urls(
     mount = cast(S3Mount, manifest.entries["remote"])
     mount.endpoint_url = "https://example.test?signature=endpoint-secret"
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported"):
+    with pytest.raises(MountConfigError, match="does not support exposing"):
         await vercel_module.VercelSandboxClient().create(
             manifest=manifest,
             options=vercel_module.VercelSandboxClientOptions(
@@ -1179,7 +1275,7 @@ async def test_vercel_apply_manifest_uses_central_mount_validation(
     sandbox = _FakeAsyncSandbox(sandbox_id="sandbox-central-validation")
     session = vercel_module.VercelSandboxSession.from_state(state, sandbox=sandbox)
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported"):
+    with pytest.raises(MountConfigError, match="mount-scoped credentials"):
         await session.apply_manifest()
 
     assert sandbox.run_command_calls == []

--- a/tests/sandbox/test_mount_security.py
+++ b/tests/sandbox/test_mount_security.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import builtins
 import importlib
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, ClassVar, Literal, cast
 
 import pytest
@@ -29,6 +29,7 @@ from agents.sandbox.entries import (
     AzureBlobMount,
     BaseEntry,
     BoxMount,
+    Dir,
     DockerVolumeMountStrategy,
     File,
     FuseMountPattern,
@@ -223,7 +224,7 @@ def test_rejects_explicit_credentials_for_in_container_mounts() -> None:
         }
     )
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported") as exc:
+    with pytest.raises(MountConfigError, match="mount-scoped credentials") as exc:
         validate_manifest_mount_credential_boundaries(manifest)
 
     assert exc.value.context["credential_fields"] == (
@@ -232,6 +233,263 @@ def test_rejects_explicit_credentials_for_in_container_mounts() -> None:
     )
     assert "example-secret-key" not in str(exc.value)
     assert "example-secret-key" not in repr(exc.value.context)
+
+
+def test_exact_path_acknowledgement_allows_supported_mount_scoped_credentials() -> None:
+    manifest = Manifest(
+        entries={
+            "data": _s3_mount(
+                strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+                credentialed=True,
+            )
+        }
+    ).with_in_container_mount_credential_exposure_acknowledged("data")
+
+    validate_manifest_mount_credential_boundaries(manifest)
+
+    sibling = manifest.model_copy(deep=True)
+    sibling.entries["other"] = sibling.entries.pop("data")
+    with pytest.raises(MountConfigError, match="mount-scoped credentials"):
+        validate_manifest_mount_credential_boundaries(sibling)
+
+    mount = manifest.entries["data"]
+    assert isinstance(mount, S3Mount)
+    validate_mount_activation_credential_boundary(
+        mount,
+        mount.mount_strategy,
+        manifest=manifest,
+        mount_path="/workspace/data",
+        provider_backend_id="docker",
+    )
+    with pytest.raises(MountConfigError, match="mount-scoped credentials"):
+        validate_mount_activation_credential_boundary(
+            mount,
+            mount.mount_strategy,
+            manifest=manifest,
+            mount_path="/workspace/other",
+            provider_backend_id="docker",
+        )
+
+
+def test_mount_credential_acknowledgement_is_not_a_path_prefix() -> None:
+    mount = _s3_mount(
+        strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+        credentialed=True,
+    )
+    manifest = Manifest(
+        entries={"parent": Dir(children={"data": mount})}
+    ).with_in_container_mount_credential_exposure_acknowledged("parent")
+
+    with pytest.raises(MountConfigError, match="mount-scoped credentials"):
+        validate_manifest_mount_credential_boundaries(manifest)
+
+    validate_manifest_mount_credential_boundaries(
+        manifest.with_in_container_mount_credential_exposure_acknowledged("parent/data")
+    )
+
+
+def test_mount_credential_acknowledgement_preserves_path_whitespace() -> None:
+    manifest = Manifest(
+        entries={
+            "data ": _s3_mount(
+                strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+                credentialed=True,
+            )
+        }
+    ).with_in_container_mount_credential_exposure_acknowledged("data")
+
+    with pytest.raises(MountConfigError, match="mount-scoped credentials"):
+        validate_manifest_mount_credential_boundaries(manifest)
+
+    validate_manifest_mount_credential_boundaries(
+        manifest.with_in_container_mount_credential_exposure_acknowledged("data ")
+    )
+
+
+def test_mount_credential_acknowledgement_accepts_platform_path_objects() -> None:
+    manifest = Manifest(
+        entries={
+            "data": _s3_mount(
+                strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+                credentialed=True,
+            )
+        }
+    ).with_in_container_mount_credential_exposure_acknowledged(PureWindowsPath("data"))
+
+    mount = manifest.entries["data"]
+    assert isinstance(mount, S3Mount)
+    validate_mount_activation_credential_boundary(
+        mount,
+        mount.mount_strategy,
+        manifest=manifest,
+        mount_path=PureWindowsPath("/workspace/data"),
+        provider_backend_id="docker",
+    )
+    assert not Manifest()._acknowledges_in_container_mount_credential_exposure(
+        PureWindowsPath("/workspace/data"),
+        "mount_scoped",
+    )
+
+    with pytest.raises(ValueError, match="use '/' separators"):
+        Manifest().with_in_container_mount_credential_exposure_acknowledged("data\\child")
+
+
+@pytest.mark.parametrize(
+    "policy_key",
+    [
+        "in_container_mount_credential_exposure_acknowledged_paths",
+        "_in_container_mount_credential_exposure_acknowledged_paths",
+        "inContainerMountCredentialExposureAcknowledgedPaths",
+        "in_container_mount_broad_credential_exposure_acknowledged_paths",
+        "_mount_credential_exposure_policy",
+    ],
+)
+def test_manifest_input_cannot_inject_mount_credential_acknowledgement(policy_key: str) -> None:
+    with pytest.raises(TypeError, match="trusted Manifest instance"):
+        Manifest.model_validate({policy_key: ["data"]})
+
+
+def test_manifest_acknowledgement_is_runtime_only_and_rejects_root() -> None:
+    manifest = Manifest().with_in_container_mount_credential_exposure_acknowledged("data")
+    payload = manifest.model_dump(mode="json")
+
+    assert all("credential_exposure" not in key for key in payload)
+    restored = Manifest.model_validate(payload)
+    assert not restored._acknowledges_in_container_mount_credential_exposure(
+        "/workspace/data", "mount_scoped"
+    )
+    with pytest.raises(ValueError, match="non-root path"):
+        Manifest().with_in_container_mount_credential_exposure_acknowledged("/workspace")
+    with pytest.raises(TypeError, match="At least one"):
+        Manifest().with_in_container_mount_credential_exposure_acknowledged()
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "with_in_container_mount_credential_exposure_acknowledged",
+        "with_in_container_mount_broad_credential_exposure_acknowledged",
+    ],
+)
+@pytest.mark.parametrize(
+    "path",
+    [
+        "data/*",
+        "data?",
+        "data[0]",
+        "data/../other",
+        "/workspace/../outside",
+    ],
+)
+def test_manifest_acknowledgement_rejects_wildcard_and_parent_paths(
+    method_name: str,
+    path: str,
+) -> None:
+    method = getattr(Manifest(), method_name)
+
+    with pytest.raises(ValueError, match="wildcard syntax|parent segments"):
+        method(path)
+
+
+def test_manifest_acknowledgement_rejects_custom_mount_before_deepcopy() -> None:
+    sentinel = "custom-mount-deepcopy-secret"
+
+    class CustomS3Mount(S3Mount):
+        type: Literal["custom_deepcopy_s3_mount"] = "custom_deepcopy_s3_mount"  # type: ignore[assignment]
+        deepcopy_called: ClassVar[bool] = False
+
+        def __deepcopy__(self, memo: dict[int, Any] | None = None) -> CustomS3Mount:
+            _ = memo
+            type(self).deepcopy_called = True
+            raise RuntimeError(sentinel)
+
+    manifest = Manifest(
+        entries={
+            "data": CustomS3Mount(
+                bucket="bucket",
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            )
+        }
+    )
+
+    with pytest.raises(MountConfigError, match="custom mount implementations") as exc_info:
+        manifest.with_in_container_mount_credential_exposure_acknowledged("data")
+
+    assert CustomS3Mount.deepcopy_called is False
+    assert sentinel not in repr(exc_info.value)
+
+
+def test_manifest_acknowledgement_redacts_custom_provenance_traceback_locals() -> None:
+    sentinel = "custom-provenance-traceback-secret"
+
+    class CustomS3Mount(S3Mount):
+        type: Literal["custom_traceback_s3_mount"] = "custom_traceback_s3_mount"  # type: ignore[assignment]
+        api_token: str | None = None
+
+    class CustomInContainerStrategy(InContainerMountStrategy):
+        type: Literal["custom_traceback_strategy"] = "custom_traceback_strategy"  # type: ignore[assignment]
+        api_token: str | None = None
+
+    class CustomRclonePattern(RcloneMountPattern):
+        api_token: str | None = None
+
+    cases = [
+        (
+            Manifest(
+                entries={
+                    "data": CustomS3Mount(
+                        bucket="bucket",
+                        api_token=sentinel,
+                        mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+                    )
+                }
+            ),
+            "custom mount implementations",
+        ),
+        (
+            Manifest(
+                entries={
+                    "data": S3Mount(
+                        bucket="bucket",
+                        mount_strategy=CustomInContainerStrategy(
+                            api_token=sentinel,
+                            pattern=RcloneMountPattern(),
+                        ),
+                    )
+                }
+            ),
+            "custom mount strategies",
+        ),
+        (
+            Manifest(
+                entries={
+                    "data": S3Mount(
+                        bucket="bucket",
+                        mount_strategy=InContainerMountStrategy(
+                            pattern=CustomRclonePattern(api_token=sentinel)
+                        ),
+                    )
+                }
+            ),
+            "custom mount patterns",
+        ),
+    ]
+
+    for method_name in (
+        "with_in_container_mount_credential_exposure_acknowledged",
+        "with_in_container_mount_broad_credential_exposure_acknowledged",
+    ):
+        for manifest, message in cases:
+            method = getattr(manifest, method_name)
+            with pytest.raises(MountConfigError, match=message) as exc:
+                method("data")
+
+            traceback_cursor = exc.value.__traceback__
+            while traceback_cursor is not None:
+                module_name = str(traceback_cursor.tb_frame.f_globals.get("__name__", ""))
+                if module_name.startswith("agents."):
+                    assert sentinel not in repr(traceback_cursor.tb_frame.f_locals)
+                traceback_cursor = traceback_cursor.tb_next
 
 
 def test_builtin_mount_subclass_is_rejected_by_execution_provenance() -> None:
@@ -638,7 +896,7 @@ def test_preserves_credentialless_hosted_mount_strategies(
     assert isinstance(mount, S3Mount)
     mount.access_key_id = "example-access-key"
     mount.secret_access_key = "example-secret-key"
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported"):
+    with pytest.raises(MountConfigError, match="mount-scoped credentials"):
         validate_manifest_mount_credential_boundaries(
             credentialed,
             provider_backend_id=backend_id,
@@ -869,7 +1127,7 @@ def test_ignores_environment_values_already_exposed_to_the_sandbox() -> None:
     validate_manifest_mount_credential_boundaries(manifest)
 
 
-def test_rejects_credentialless_blobfuse_mounts() -> None:
+def test_blobfuse_mounts_require_broad_acknowledgement() -> None:
     manifest = Manifest(
         entries={
             "data": AzureBlobMount(
@@ -880,11 +1138,40 @@ def test_rejects_credentialless_blobfuse_mounts() -> None:
         }
     )
 
-    with pytest.raises(MountConfigError, match="credentialless blobfuse mounts"):
+    with pytest.raises(MountConfigError, match="broad credential authority"):
         validate_manifest_mount_credential_boundaries(manifest)
 
+    validate_manifest_mount_credential_boundaries(
+        manifest.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+    )
 
-def test_rejects_s3_files_before_ambient_iam_can_be_used() -> None:
+
+def test_blobfuse_account_key_requires_mount_scoped_and_broad_acknowledgement() -> None:
+    manifest = Manifest(
+        entries={
+            "data": AzureBlobMount(
+                account="example",
+                container="private",
+                account_key="account-key",
+                mount_strategy=InContainerMountStrategy(pattern=FuseMountPattern()),
+            )
+        }
+    )
+
+    mount_scoped = manifest.with_in_container_mount_credential_exposure_acknowledged("data")
+    with pytest.raises(MountConfigError, match="broad credential authority"):
+        validate_manifest_mount_credential_boundaries(mount_scoped)
+
+    broad = manifest.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+    with pytest.raises(MountConfigError, match="mount-scoped credentials"):
+        validate_manifest_mount_credential_boundaries(broad)
+
+    validate_manifest_mount_credential_boundaries(
+        mount_scoped.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+    )
+
+
+def test_s3_files_require_broad_acknowledgement_before_ambient_iam_can_be_used() -> None:
     safe = Manifest(
         entries={
             "data": S3FilesMount(
@@ -894,8 +1181,12 @@ def test_rejects_s3_files_before_ambient_iam_can_be_used() -> None:
             )
         }
     )
-    with pytest.raises(MountConfigError, match="requires ambient IAM credentials"):
+    with pytest.raises(MountConfigError, match="broad credential authority"):
         validate_manifest_mount_credential_boundaries(safe)
+
+    validate_manifest_mount_credential_boundaries(
+        safe.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+    )
 
 
 @pytest.mark.parametrize(
@@ -919,17 +1210,13 @@ def test_rejects_credential_required_patterns_in_inherited_in_container_strategi
         validate_manifest_mount_credential_boundaries(Manifest(entries={"data": mount}))
 
 
-def test_trusted_opt_in_requires_a_matching_provider_owned_strategy() -> None:
+def test_acknowledgement_requires_a_matching_provider_owned_strategy() -> None:
     strategy = InContainerMountStrategy(pattern=RcloneMountPattern())
     cast(Any, strategy).type = "vercel_cloud_bucket"
     manifest = Manifest(entries={"data": _s3_mount(strategy=strategy, credentialed=True)})
 
     with pytest.raises(MountConfigError, match="custom mount strategies"):
-        validate_manifest_mount_credential_boundaries(
-            manifest,
-            allowed_in_container_credential_strategy_types=frozenset({"vercel_cloud_bucket"}),
-            provider_backend_id="vercel",
-        )
+        manifest.with_in_container_mount_credential_exposure_acknowledged("data")
 
 
 @pytest.mark.parametrize(
@@ -953,7 +1240,7 @@ def test_rejects_rclone_credential_source_overrides(extra_args: list[str]) -> No
         }
     )
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported"):
+    with pytest.raises(MountConfigError, match="does not support exposing"):
         validate_manifest_mount_credential_boundaries(manifest)
 
 
@@ -964,17 +1251,176 @@ def test_rejects_rclone_credential_source_overrides(extra_args: list[str]) -> No
         (DaytonaCloudBucketMountStrategy(), "daytona"),
     ],
 )
-def test_rejects_box_mounts_that_execute_inside_the_sandbox(
+def test_box_mounts_with_direct_credentials_require_exact_acknowledgement(
     strategy: MountStrategyBase,
     backend_id: str | None,
 ) -> None:
-    manifest = Manifest(entries={"data": BoxMount(mount_strategy=strategy)})
+    manifest = Manifest(
+        entries={
+            "data": BoxMount(
+                access_token="box-access-token",
+                mount_strategy=strategy,
+            )
+        }
+    )
 
-    with pytest.raises(MountConfigError, match="Box mounts require credentials"):
+    with pytest.raises(MountConfigError, match="mount-scoped credentials"):
         validate_manifest_mount_credential_boundaries(
             manifest,
             provider_backend_id=backend_id,
         )
+
+    validate_manifest_mount_credential_boundaries(
+        manifest.with_in_container_mount_credential_exposure_acknowledged("data"),
+        provider_backend_id=backend_id,
+    )
+
+
+def test_box_config_file_requires_broad_acknowledgement() -> None:
+    manifest = Manifest(
+        entries={
+            "data": BoxMount(
+                box_config_file="/run/secrets/box.json",
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            )
+        }
+    )
+
+    with pytest.raises(MountConfigError, match="broad credential authority"):
+        validate_manifest_mount_credential_boundaries(manifest)
+    with pytest.raises(MountConfigError, match="broad credential authority"):
+        validate_manifest_mount_credential_boundaries(
+            manifest.with_in_container_mount_credential_exposure_acknowledged("data")
+        )
+    validate_manifest_mount_credential_boundaries(
+        manifest.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+    )
+
+
+@pytest.mark.parametrize(
+    "mount",
+    [
+        BoxMount(mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern())),
+        BoxMount(
+            client_id="client-id",
+            mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+        ),
+        BoxMount(
+            client_secret="client-secret",
+            mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+        ),
+    ],
+)
+def test_box_in_container_mount_requires_non_interactive_authentication(
+    mount: BoxMount,
+) -> None:
+    manifest = Manifest(entries={"data": mount})
+
+    with pytest.raises(MountConfigError, match="non-interactive authentication source"):
+        validate_manifest_mount_credential_boundaries(manifest)
+
+
+@pytest.mark.parametrize(
+    ("mount", "broad"),
+    [
+        (
+            BoxMount(
+                access_token=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            False,
+        )
+        for value in ("", "   ")
+    ]
+    + [
+        (
+            BoxMount(
+                token=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            False,
+        )
+        for value in ("", "   ")
+    ]
+    + [
+        (
+            BoxMount(
+                config_credentials=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            False,
+        )
+        for value in ("", "   ")
+    ]
+    + [
+        (
+            BoxMount(
+                box_config_file=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            True,
+        )
+        for value in ("", "   ")
+    ],
+)
+def test_box_in_container_mount_rejects_empty_authentication_sources(
+    mount: BoxMount,
+    broad: bool,
+) -> None:
+    manifest = Manifest(entries={"data": mount})
+    acknowledged = (
+        manifest.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+        if broad
+        else manifest.with_in_container_mount_credential_exposure_acknowledged("data")
+    )
+
+    with pytest.raises(MountConfigError, match="authentication values must not be empty"):
+        validate_manifest_mount_credential_boundaries(acknowledged)
+
+
+@pytest.mark.parametrize(
+    ("mount", "broad", "invalid_field"),
+    [
+        (
+            BoxMount(
+                access_token="box-access-token",
+                box_config_file=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            False,
+            "box_config_file",
+        )
+        for value in ("", "   ")
+    ]
+    + [
+        (
+            BoxMount(
+                access_token=value,
+                box_config_file="/run/secrets/box.json",
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            True,
+            "access_token",
+        )
+        for value in ("", "   ")
+    ],
+)
+def test_box_in_container_mount_rejects_mixed_usable_and_empty_authentication_sources(
+    mount: BoxMount,
+    broad: bool,
+    invalid_field: str,
+) -> None:
+    manifest = Manifest(entries={"data": mount})
+    acknowledged = (
+        manifest.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+        if broad
+        else manifest.with_in_container_mount_credential_exposure_acknowledged("data")
+    )
+
+    with pytest.raises(MountConfigError, match="authentication values must not be empty") as exc:
+        validate_manifest_mount_credential_boundaries(acknowledged)
+
+    assert exc.value.context["credential_fields"] == (invalid_field,)
 
 
 def test_preserves_box_mounts_with_an_external_strategy() -> None:
@@ -1172,7 +1618,7 @@ def test_rejects_rclone_on_the_fly_remote_name() -> None:
         }
     )
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported") as exc:
+    with pytest.raises(MountConfigError, match="does not support exposing") as exc:
         validate_manifest_mount_credential_boundaries(manifest)
 
     assert sentinel not in str(exc.value)
@@ -1273,7 +1719,7 @@ def test_rejects_malformed_inline_credential_url_without_mutating_trusted_manife
         }
     )
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported"):
+    with pytest.raises(MountConfigError, match="does not support exposing"):
         validate_manifest_mount_credential_boundaries(manifest)
 
     mount = manifest.entries["data"]
@@ -1303,7 +1749,7 @@ def test_rejects_mountpoint_endpoint_authority(endpoint_url: str) -> None:
         }
     )
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported") as exc:
+    with pytest.raises(MountConfigError, match="does not support exposing") as exc:
         validate_manifest_mount_credential_boundaries(manifest)
 
     assert exc.value.context["credential_fields"] == (
@@ -1349,6 +1795,23 @@ def test_rejects_manifest_backed_credential_files(
             manifest,
             provider_backend_id="docker",
         )
+
+
+def test_broad_acknowledgement_does_not_allow_manifest_backed_rclone_config() -> None:
+    manifest = Manifest(
+        entries={
+            "credentials.conf": File(content=b"credential-file-secret"),
+            "data": S3Mount(
+                bucket="bucket",
+                mount_strategy=InContainerMountStrategy(
+                    pattern=RcloneMountPattern(config_file_path=Path("credentials.conf"))
+                ),
+            ),
+        }
+    ).with_in_container_mount_broad_credential_exposure_acknowledged("data")
+
+    with pytest.raises(MountConfigError, match="credential files stored in the manifest"):
+        validate_manifest_mount_credential_boundaries(manifest)
 
 
 @pytest.mark.parametrize(
@@ -1729,6 +2192,82 @@ def test_opaque_external_authority_remains_resumable_through_trusted_rebind(
     assert rebound.mount_authority_redacted is False
 
 
+def test_in_container_acknowledgement_is_rebound_only_from_trusted_manifest() -> None:
+    manifest = Manifest(
+        entries={
+            "data": _s3_mount(
+                strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+                credentialed=True,
+            )
+        }
+    ).with_in_container_mount_credential_exposure_acknowledged("data")
+    client = _SecurityTestClient()
+    state = TestSessionState(manifest=manifest, snapshot=NoopSnapshot(id="snapshot"))
+
+    payload = client.serialize_session_state(state)
+    restored = client.deserialize_session_state(payload)
+
+    assert "credential_exposure" not in repr(payload)
+    with pytest.raises(ValueError, match="cannot be resumed"):
+        restored.assert_path_grants_rebound()
+
+    rebound = restored.rebind_persisted_mount_authority(
+        manifest,
+        provider_backend_id="docker",
+    )
+    validate_manifest_mount_credential_boundaries(
+        rebound.manifest,
+        provider_backend_id="docker",
+    )
+    assert rebound.manifest._acknowledges_in_container_mount_credential_exposure(
+        "/workspace/data",
+        "mount_scoped",
+    )
+
+
+@pytest.mark.parametrize(
+    "mount",
+    [
+        AzureBlobMount(
+            account="example",
+            container="private",
+            mount_strategy=InContainerMountStrategy(pattern=FuseMountPattern()),
+        ),
+        S3FilesMount(
+            file_system_id="fs-123",
+            mount_strategy=InContainerMountStrategy(pattern=S3FilesMountPattern()),
+        ),
+    ],
+)
+def test_implicit_broad_authority_is_rebound_only_from_trusted_manifest(
+    mount: Mount,
+) -> None:
+    manifest = Manifest(
+        entries={"data": mount}
+    ).with_in_container_mount_broad_credential_exposure_acknowledged("data")
+    client = _SecurityTestClient()
+    state = TestSessionState(manifest=manifest, snapshot=NoopSnapshot(id="snapshot"))
+
+    payload = client.serialize_session_state(state)
+    restored = client.deserialize_session_state(payload)
+
+    assert payload[REDACTED_MOUNT_AUTHORITY_KEY] is True
+    assert "credential_exposure" not in repr(payload)
+    assert restored.mount_authority_redacted is True
+    rebound = restored.rebind_persisted_mount_authority(
+        manifest,
+        provider_backend_id="docker",
+    )
+    validate_manifest_mount_credential_boundaries(
+        rebound.manifest,
+        provider_backend_id="docker",
+    )
+    assert rebound.manifest._acknowledges_in_container_mount_credential_exposure(
+        "/workspace/data",
+        "broad",
+    )
+
+
 def test_mount_authority_rebind_requires_exact_credential_free_topology() -> None:
     original = Manifest(
         entries={
@@ -2102,6 +2641,51 @@ async def test_operation_error_with_mount_authority_is_replaced() -> None:
         traceback = traceback.tb_next
 
 
+@pytest.mark.parametrize(
+    "mount",
+    [
+        AzureBlobMount(
+            account="example",
+            container="private",
+            mount_strategy=InContainerMountStrategy(pattern=FuseMountPattern()),
+        ),
+        S3FilesMount(
+            file_system_id="fs-123",
+            mount_strategy=InContainerMountStrategy(pattern=S3FilesMountPattern()),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_operation_error_with_implicit_broad_authority_is_replaced(
+    mount: Mount,
+) -> None:
+    sentinel = "implicit-broad-provider-secret"
+    manifest = Manifest(
+        entries={"data": mount}
+    ).with_in_container_mount_broad_credential_exposure_acknowledged("data")
+    provider_error = RuntimeError(sentinel)
+
+    @redact_mount_error_data
+    async def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise provider_error
+
+    with pytest.raises(RuntimeError, match="protected mount configuration") as exc:
+        await fail(manifest=manifest)
+
+    assert sentinel not in str(exc.value)
+    assert exc.value.__cause__ is None
+    assert exc.value.__context__ is None
+    assert provider_error.args == ()
+    assert provider_error.__traceback__ is None
+    traceback = exc.value.__traceback__
+    while traceback is not None:
+        frame_path = Path(traceback.tb_frame.f_code.co_filename).as_posix()
+        if "/src/agents/" in frame_path:
+            assert sentinel not in repr(traceback.tb_frame.f_locals)
+        traceback = traceback.tb_next
+
+
 def test_sync_operation_error_with_mount_authority_clears_source_arguments() -> None:
     sentinel = "sync-provider-operation-secret"
     manifest = Manifest(
@@ -2137,6 +2721,44 @@ def test_sync_operation_error_with_mount_authority_clears_source_arguments() -> 
     assert (
         cast(Any, BaseException.__traceback__).__get__(provider_error, type(provider_error)) is None
     )
+
+
+@pytest.mark.parametrize(
+    "mount",
+    [
+        AzureBlobMount(
+            account="example",
+            container="private",
+            mount_strategy=InContainerMountStrategy(pattern=FuseMountPattern()),
+        ),
+        S3FilesMount(
+            file_system_id="fs-123",
+            mount_strategy=InContainerMountStrategy(pattern=S3FilesMountPattern()),
+        ),
+    ],
+)
+def test_sync_operation_error_with_implicit_broad_authority_is_replaced(
+    mount: Mount,
+) -> None:
+    sentinel = "sync-implicit-broad-provider-secret"
+    manifest = Manifest(
+        entries={"data": mount}
+    ).with_in_container_mount_broad_credential_exposure_acknowledged("data")
+    provider_error = RuntimeError(sentinel)
+
+    @redact_mount_error_data_sync
+    def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise provider_error
+
+    with pytest.raises(RuntimeError, match="protected mount configuration") as exc:
+        fail(manifest=manifest)
+
+    assert sentinel not in str(exc.value)
+    assert exc.value.__cause__ is None
+    assert exc.value.__context__ is None
+    assert provider_error.args == ()
+    assert provider_error.__traceback__ is None
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_mount_security.py
+++ b/tests/sandbox/test_mount_security.py
@@ -271,6 +271,67 @@ def test_exact_path_acknowledgement_allows_supported_mount_scoped_credentials() 
         )
 
 
+@pytest.mark.parametrize(
+    ("credentials", "invalid_fields"),
+    [
+        ({"access_key_id": "access-key"}, ("secret_access_key",)),
+        ({"secret_access_key": "secret-key"}, ("access_key_id",)),
+        (
+            {"session_token": "session-token"},
+            ("access_key_id", "secret_access_key"),
+        ),
+        (
+            {"access_key_id": "access-key", "secret_access_key": ""},
+            ("secret_access_key",),
+        ),
+        (
+            {"access_key_id": " ", "secret_access_key": "secret-key"},
+            ("access_key_id",),
+        ),
+        (
+            {
+                "access_key_id": "access-key",
+                "secret_access_key": "secret-key",
+                "session_token": " ",
+            },
+            ("session_token",),
+        ),
+    ],
+)
+def test_acknowledgement_rejects_incomplete_in_container_s3_credentials(
+    credentials: dict[str, str],
+    invalid_fields: tuple[str, ...],
+) -> None:
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="example-bucket",
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+                **cast(Any, credentials),
+            )
+        }
+    ).with_in_container_mount_credential_exposure_acknowledged("data")
+
+    with pytest.raises(MountConfigError, match="require non-empty") as exc_info:
+        validate_manifest_mount_credential_boundaries(manifest)
+
+    assert exc_info.value.context["credential_fields"] == invalid_fields
+
+
+def test_incomplete_s3_credentials_remain_external_provider_configuration() -> None:
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="example-bucket",
+                access_key_id="access-key",
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    validate_manifest_mount_credential_boundaries(manifest, provider_backend_id="docker")
+
+
 def test_mount_credential_acknowledgement_is_not_a_path_prefix() -> None:
     mount = _s3_mount(
         strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),

--- a/tests/sandbox/test_mount_security.py
+++ b/tests/sandbox/test_mount_security.py
@@ -312,22 +312,124 @@ def test_acknowledgement_rejects_incomplete_in_container_s3_credentials(
         }
     ).with_in_container_mount_credential_exposure_acknowledged("data")
 
-    with pytest.raises(MountConfigError, match="require non-empty") as exc_info:
+    with pytest.raises(MountConfigError, match="complete non-empty credential set") as exc_info:
         validate_manifest_mount_credential_boundaries(manifest)
 
     assert exc_info.value.context["credential_fields"] == invalid_fields
 
 
-def test_incomplete_s3_credentials_remain_external_provider_configuration() -> None:
+@pytest.mark.parametrize(
+    ("credentials", "invalid_fields"),
+    [
+        ({"access_id": "access-id"}, ("secret_access_key",)),
+        ({"secret_access_key": "secret-key"}, ("access_id",)),
+        (
+            {"access_id": "access-id", "secret_access_key": ""},
+            ("secret_access_key",),
+        ),
+        (
+            {"access_id": " ", "secret_access_key": "secret-key"},
+            ("access_id",),
+        ),
+        (
+            {
+                "access_id": "access-id",
+                "service_account_credentials": '{"type":"service_account"}',
+            },
+            ("secret_access_key",),
+        ),
+    ],
+)
+def test_acknowledgement_rejects_incomplete_in_container_gcs_hmac_credentials(
+    credentials: dict[str, str],
+    invalid_fields: tuple[str, ...],
+) -> None:
     manifest = Manifest(
         entries={
-            "data": S3Mount(
+            "data": GCSMount(
                 bucket="example-bucket",
-                access_key_id="access-key",
-                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+                **cast(Any, credentials),
             )
         }
-    )
+    ).with_in_container_mount_credential_exposure_acknowledged("data")
+
+    with pytest.raises(MountConfigError, match="complete non-empty credential set") as exc_info:
+        validate_manifest_mount_credential_boundaries(manifest)
+
+    assert exc_info.value.context["credential_fields"] == invalid_fields
+
+
+def test_acknowledgement_accepts_complete_in_container_gcs_hmac_credentials() -> None:
+    manifest = Manifest(
+        entries={
+            "data": GCSMount(
+                bucket="example-bucket",
+                access_id="access-id",
+                secret_access_key="secret-key",
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            )
+        }
+    ).with_in_container_mount_credential_exposure_acknowledged("data")
+
+    validate_manifest_mount_credential_boundaries(manifest)
+
+
+@pytest.mark.parametrize(
+    ("credentials", "invalid_fields"),
+    [
+        ({"access_key_id": "access-key"}, ("secret_access_key",)),
+        ({"secret_access_key": "secret-key"}, ("access_key_id",)),
+        (
+            {"access_key_id": "access-key", "secret_access_key": ""},
+            ("secret_access_key",),
+        ),
+    ],
+)
+def test_acknowledgement_rejects_incomplete_in_container_r2_credentials(
+    credentials: dict[str, str],
+    invalid_fields: tuple[str, ...],
+) -> None:
+    manifest = Manifest(
+        entries={
+            "data": R2Mount(
+                bucket="example-bucket",
+                account_id="example-account",
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+                **cast(Any, credentials),
+            )
+        }
+    ).with_in_container_mount_credential_exposure_acknowledged("data")
+
+    with pytest.raises(MountConfigError, match="complete non-empty credential set") as exc_info:
+        validate_manifest_mount_credential_boundaries(manifest)
+
+    assert exc_info.value.context["credential_fields"] == invalid_fields
+
+
+@pytest.mark.parametrize(
+    "mount",
+    [
+        S3Mount(
+            bucket="example-bucket",
+            access_key_id="access-key",
+            mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+        ),
+        GCSMount(
+            bucket="example-bucket",
+            access_id="access-id",
+            mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+        ),
+        R2Mount(
+            bucket="example-bucket",
+            account_id="example-account",
+            access_key_id="access-key",
+            mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+        ),
+    ],
+)
+def test_incomplete_credentials_remain_external_provider_configuration(mount: Mount) -> None:
+    manifest = Manifest(entries={"data": mount})
 
     validate_manifest_mount_credential_boundaries(manifest, provider_backend_id="docker")
 

--- a/tests/sandbox/test_mount_security.py
+++ b/tests/sandbox/test_mount_security.py
@@ -375,6 +375,78 @@ def test_acknowledgement_accepts_complete_in_container_gcs_hmac_credentials() ->
     validate_manifest_mount_credential_boundaries(manifest)
 
 
+@pytest.mark.parametrize("blank_value", ["", "   "])
+@pytest.mark.parametrize(
+    ("mount_factory", "broad", "invalid_field"),
+    [
+        (
+            lambda value: GCSMount(
+                bucket="example-bucket",
+                access_token=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            False,
+            "access_token",
+        ),
+        (
+            lambda value: GCSMount(
+                bucket="example-bucket",
+                service_account_credentials=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            False,
+            "service_account_credentials",
+        ),
+        (
+            lambda value: GCSMount(
+                bucket="example-bucket",
+                service_account_file=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            True,
+            "service_account_file",
+        ),
+        (
+            lambda value: AzureBlobMount(
+                account="example-account",
+                container="example-container",
+                account_key=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            False,
+            "account_key",
+        ),
+        (
+            lambda value: AzureBlobMount(
+                account="example-account",
+                container="example-container",
+                identity_client_id=value,
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            ),
+            True,
+            "identity_client_id",
+        ),
+    ],
+)
+def test_acknowledgement_rejects_empty_in_container_scalar_authority(
+    mount_factory: Any,
+    broad: bool,
+    invalid_field: str,
+    blank_value: str,
+) -> None:
+    manifest = Manifest(entries={"data": mount_factory(blank_value)})
+    acknowledged = (
+        manifest.with_in_container_mount_broad_credential_exposure_acknowledged("data")
+        if broad
+        else manifest.with_in_container_mount_credential_exposure_acknowledged("data")
+    )
+
+    with pytest.raises(MountConfigError, match="must not be empty or whitespace-only") as exc_info:
+        validate_manifest_mount_credential_boundaries(acknowledged)
+
+    assert exc_info.value.context["credential_fields"] == (invalid_field,)
+
+
 @pytest.mark.parametrize(
     ("credentials", "invalid_fields"),
     [
@@ -424,6 +496,17 @@ def test_acknowledgement_rejects_incomplete_in_container_r2_credentials(
             bucket="example-bucket",
             account_id="example-account",
             access_key_id="access-key",
+            mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+        ),
+        GCSMount(
+            bucket="example-bucket",
+            access_token="",
+            mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+        ),
+        AzureBlobMount(
+            account="example-account",
+            container="example-container",
+            identity_client_id=" ",
             mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
         ),
     ],

--- a/tests/sandbox/test_mounts.py
+++ b/tests/sandbox/test_mounts.py
@@ -310,6 +310,30 @@ async def test_azure_blob_mount_builds_rclone_runtime_config_without_hidden_patt
 
 
 @pytest.mark.asyncio
+async def test_azure_blob_mount_enables_rclone_msi_for_managed_identity() -> None:
+    session = _MountConfigSession()
+    pattern = RcloneMountPattern()
+    mount = AzureBlobMount(
+        account="acct",
+        container="container",
+        identity_client_id="managed-identity-client-id",
+        mount_strategy=InContainerMountStrategy(pattern=pattern),
+    )
+
+    config = await mount.build_in_container_mount_config(
+        session,
+        pattern,
+        include_config_text=True,
+    )
+
+    assert isinstance(config, RcloneMountConfig)
+    assert config.config_text is not None
+    assert "use_msi = true" in config.config_text
+    assert "msi_client_id = managed-identity-client-id" in config.config_text
+    assert "use_msi = false" not in config.config_text
+
+
+@pytest.mark.asyncio
 async def test_box_mount_builds_rclone_runtime_config_with_box_auth_options() -> None:
     session_id = uuid.uuid4()
     pattern = RcloneMountPattern(config_file_path=Path("rclone.conf"))

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -736,7 +736,7 @@ async def test_sandbox_session_rejects_unsafe_manifest_before_workspace_persiste
     )
     session = SandboxSession(inner)
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported") as exc:
+    with pytest.raises(MountConfigError, match="mount-scoped credentials cannot be exposed") as exc:
         if operation == "persist":
             await session.persist_workspace()
         else:
@@ -4108,7 +4108,7 @@ async def test_session_manager_rejects_unsafe_stopped_injected_session_manifest(
     )
 
     manager.acquire_agent(agent)
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported"):
+    with pytest.raises(MountConfigError, match="mount-scoped credentials cannot be exposed"):
         await manager.ensure_session(
             agent=agent,
             capabilities=capabilities,
@@ -5369,7 +5369,7 @@ async def test_apply_manifest_rejects_mount_authority_before_materialization() -
         )
     )
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported") as exc:
+    with pytest.raises(MountConfigError, match="mount-scoped credentials cannot be exposed") as exc:
         await session.apply_manifest()
 
     assert session.materialize_calls == 0
@@ -5396,7 +5396,7 @@ async def test_start_workspace_rejects_mount_authority_before_materialization() 
         )
     )
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported"):
+    with pytest.raises(MountConfigError, match="mount-scoped credentials cannot be exposed"):
         await BaseSandboxSession.start(session)
 
     assert session.materialize_calls == 0
@@ -5476,7 +5476,7 @@ async def test_session_stop_rejects_mutated_unsafe_mount_before_snapshot_work() 
         )
     )
 
-    with pytest.raises(MountConfigError, match="cloud credentials are not supported"):
+    with pytest.raises(MountConfigError, match="mount-scoped credentials cannot be exposed"):
         await BaseSandboxSession.stop(session)
 
     assert session.persist_calls == 0

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -1155,6 +1155,18 @@ class _ManifestReplacementCapability(Capability):
         )
 
 
+class _ManifestRootReplacementCapability(_ManifestReplacementCapability):
+    type: str = "manifest-root-replacement"
+
+    def __init__(self) -> None:
+        Capability.__init__(self, type="manifest-root-replacement")
+
+    def process_manifest(self, manifest: Manifest) -> Manifest:
+        replaced = super().process_manifest(manifest)
+        replaced.root = "/other"
+        return replaced
+
+
 def test_process_manifest_preserves_mount_acknowledgement_across_replacement() -> None:
     manifest = Manifest(
         entries={
@@ -1179,6 +1191,51 @@ def test_process_manifest_preserves_mount_acknowledgement_across_replacement() -
         "/workspace/data",
         "mount_scoped",
     )
+
+
+@pytest.mark.parametrize(
+    ("acknowledged_path", "expected_at_replacement_root"),
+    [("/workspace/data", False), ("data", True)],
+)
+def test_process_manifest_preserves_absolute_or_relative_acknowledgement_identity(
+    acknowledged_path: str,
+    expected_at_replacement_root: bool,
+) -> None:
+    manifest = Manifest(
+        root="/workspace",
+        entries={
+            "data": S3Mount(
+                bucket="example-bucket",
+                access_key_id="example-access-key",
+                secret_access_key="example-secret-key",
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            )
+        },
+    ).with_in_container_mount_credential_exposure_acknowledged(acknowledged_path)
+
+    processed = SandboxRuntimeSessionManager._process_manifest(
+        [_ManifestRootReplacementCapability()],
+        manifest,
+    )
+
+    assert processed is not None
+    assert processed.root == "/other"
+    assert (
+        processed._acknowledges_in_container_mount_credential_exposure(
+            "/other/data",
+            "mount_scoped",
+        )
+        is expected_at_replacement_root
+    )
+    if expected_at_replacement_root:
+        validate_manifest_mount_credential_boundaries(processed)
+    else:
+        assert processed._acknowledges_in_container_mount_credential_exposure(
+            "/workspace/data",
+            "mount_scoped",
+        )
+        with pytest.raises(MountConfigError, match="mount-scoped credentials"):
+            validate_manifest_mount_credential_boundaries(processed)
 
 
 class _CredentialedMountCapability(Capability):

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -43,7 +43,10 @@ from agents.sandbox import (
     SandboxRunConfig,
     User,
 )
-from agents.sandbox._mount_security import REDACTED_MOUNT_AUTHORITY_KEY
+from agents.sandbox._mount_security import (
+    REDACTED_MOUNT_AUTHORITY_KEY,
+    validate_manifest_mount_credential_boundaries,
+)
 from agents.sandbox.capabilities import (
     Capability,
     Compaction,
@@ -1129,6 +1132,53 @@ class _ManifestMutationCapability(Capability):
         self.process_calls += 1
         manifest.entries[self.rel_path] = File(content=self.content)
         return manifest
+
+
+class _ManifestReplacementCapability(Capability):
+    type: str = "manifest-replacement"
+
+    def __init__(self) -> None:
+        super().__init__(type="manifest-replacement")
+
+    def process_manifest(self, manifest: Manifest) -> Manifest:
+        return Manifest(
+            version=manifest.version,
+            root=manifest.root,
+            entries={**manifest.entries, "cap.txt": File(content=b"capability")},
+            environment=manifest.environment.model_copy(deep=True),
+            users=[user.model_copy(deep=True) for user in manifest.users],
+            groups=[group.model_copy(deep=True) for group in manifest.groups],
+            extra_path_grants=tuple(
+                grant.model_copy(deep=True) for grant in manifest.extra_path_grants
+            ),
+            remote_mount_command_allowlist=list(manifest.remote_mount_command_allowlist),
+        )
+
+
+def test_process_manifest_preserves_mount_acknowledgement_across_replacement() -> None:
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="example-bucket",
+                access_key_id="example-access-key",
+                secret_access_key="example-secret-key",
+                mount_strategy=InContainerMountStrategy(pattern=RcloneMountPattern()),
+            )
+        }
+    ).with_in_container_mount_credential_exposure_acknowledged("data")
+
+    processed = SandboxRuntimeSessionManager._process_manifest(
+        [_ManifestReplacementCapability()],
+        manifest,
+    )
+
+    assert processed is not None
+    assert processed.entries["cap.txt"] == File(content=b"capability")
+    validate_manifest_mount_credential_boundaries(processed)
+    assert processed._acknowledges_in_container_mount_credential_exposure(
+        "/workspace/data",
+        "mount_scoped",
+    )
 
 
 class _CredentialedMountCapability(Capability):


### PR DESCRIPTION
This pull request adds trusted, runtime-only, exact-path acknowledgements for credential-bearing in-container sandbox mounts, aligning the Python SDK with openai/openai-agents-js#1627.

- Separates mount-scoped credential exposure from broad ambient, workload, and credential-file authority.
- Uses a closed SDK-owned capability matrix and rejects unknown or custom combinations before side effects.
- Revalidates provider-resolved effective mount paths immediately before activation.
- Conditionally supports Box+rclone mounts with the appropriate acknowledgement.
- Preserves the released Vercel `allow_s3_credential_exposure` behavior as a Vercel-S3-only compatibility bridge.
- Keeps credentials and acknowledgement policy out of serialized sandbox state.

Documentation changes are intentionally deferred to a follow-up pull request.