### PR TITLE
fix: prune orphaned tool outputs from limited sessions

### DIFF
--- a/src/agents/run_internal/items.py
+++ b/src/agents/run_internal/items.py
@@ -172,15 +172,17 @@ def drop_orphan_function_calls(
     items: list[TResponseInputItem],
     *,
     pruning_indexes: set[int] | None = None,
+    output_pruning_indexes: set[int] | None = None,
 ) -> list[TResponseInputItem]:
     """
     Remove tool and program call items that do not have corresponding outputs so resumptions or
-    retries do not replay stale calls. Program-owned items are removed with an orphan program,
-    while programs with retained hosted calls or tool outputs remain available for continuation.
-    Reasoning items that immediately precede a call dropped by this pass are also removed, since
-    the Responses API rejects reasoning items that are not followed by their associated
-    model-emitted item (``Item 'rs_...' of type 'reasoning' was provided without its required
-    following item``).
+    retries do not replay stale calls. When ``output_pruning_indexes`` identifies unambiguous
+    stored history, also remove tool outputs whose corresponding calls are no longer present after
+    history pruning. Program-owned items are removed with an orphan program, while programs with
+    retained hosted calls or tool outputs remain available for continuation. Reasoning items that
+    immediately precede a call dropped by this pass are also removed, since the Responses API
+    rejects reasoning items that are not followed by their associated model-emitted item (``Item
+    'rs_...' of type 'reasoning' was provided without its required following item``).
     """
 
     completed_call_ids = _completed_call_ids_by_type(items)
@@ -208,54 +210,71 @@ def drop_orphan_function_calls(
             orphan_program_call_ids.add(call_id)
 
     dropped_indexes: set[int] = set()
-    filtered: list[TResponseInputItem] = []
+    reasoning_trigger_indexes: set[int] = set()
     for index, entry in enumerate(items):
         if not isinstance(entry, dict):
-            filtered.append(entry)
             continue
         entry_type = entry.get("type")
         if not isinstance(entry_type, str):
-            filtered.append(entry)
             continue
         if pruning_indexes is not None and index not in pruning_indexes:
-            filtered.append(entry)
             continue
         program_caller_id = _get_program_caller_id(entry)
         if program_caller_id is not None and program_caller_id in orphan_program_call_ids:
             dropped_indexes.add(index)
-            continue
-        output_type = _TOOL_CALL_TO_OUTPUT_TYPE.get(entry_type)
-        if output_type is None:
-            filtered.append(entry)
+            reasoning_trigger_indexes.add(index)
             continue
         call_id = entry.get("call_id")
+        output_type = _TOOL_CALL_TO_OUTPUT_TYPE.get(entry_type)
+        if output_type is None:
+            continue
         if program_caller_id is not None and _is_pending_hosted_shell_call(entry):
-            filtered.append(entry)
             continue
         if entry_type == "program" and call_id in active_program_call_ids:
-            filtered.append(entry)
             continue
         if isinstance(call_id, str) and call_id in completed_call_ids.get(output_type, set()):
-            filtered.append(entry)
             continue
         if (
             entry_type == "tool_search_call"
             and not isinstance(call_id, str)
             and index in matched_anonymous_tool_search_calls
         ):
-            filtered.append(entry)
             continue
         # Tool call entry will be dropped; record so we can also drop preceding reasoning items.
         dropped_indexes.add(index)
+        reasoning_trigger_indexes.add(index)
+
+    available_call_ids = _available_call_ids_by_output_type(
+        items,
+        excluded_indexes=dropped_indexes,
+    )
+    if output_pruning_indexes is not None:
+        for index in output_pruning_indexes:
+            if index in dropped_indexes or index < 0 or index >= len(items):
+                continue
+            entry = items[index]
+            if not isinstance(entry, dict):
+                continue
+            entry_type = entry.get("type")
+            if not isinstance(entry_type, str) or entry_type not in available_call_ids:
+                continue
+            call_id = entry.get("call_id")
+            if isinstance(call_id, str) and call_id not in available_call_ids[entry_type]:
+                dropped_indexes.add(index)
 
     if not dropped_indexes:
-        return filtered
-    return _drop_reasoning_items_preceding_dropped_calls(items, dropped_indexes)
+        return list(items)
+    return _drop_reasoning_items_preceding_dropped_calls(
+        items,
+        dropped_indexes,
+        reasoning_trigger_indexes,
+    )
 
 
 def _drop_reasoning_items_preceding_dropped_calls(
     items: list[TResponseInputItem],
     dropped_indexes: set[int],
+    reasoning_trigger_indexes: set[int],
 ) -> list[TResponseInputItem]:
     """Drop reasoning items whose tied tool call was just dropped as orphan.
 
@@ -278,7 +297,7 @@ def _drop_reasoning_items_preceding_dropped_calls(
             next_entry = items[next_index]
             if isinstance(next_entry, dict) and next_entry.get("type") == "reasoning":
                 continue
-            if next_index in dropped_indexes:
+            if next_index in reasoning_trigger_indexes:
                 drop_reasoning.add(index)
             break
     excluded = dropped_indexes | drop_reasoning
@@ -957,6 +976,32 @@ def _completed_call_ids_by_type(payload: list[TResponseInputItem]) -> dict[str, 
         if isinstance(call_id, str):
             completed[item_type].add(call_id)
     return completed
+
+
+def _available_call_ids_by_output_type(
+    payload: list[TResponseInputItem],
+    *,
+    excluded_indexes: set[int],
+) -> dict[str, set[str]]:
+    """Return retained call ids grouped by their required output type."""
+    available: dict[str, set[str]] = {
+        output_type: set() for output_type in _TOOL_CALL_TO_OUTPUT_TYPE.values()
+    }
+    for index, entry in enumerate(payload):
+        if index in excluded_indexes:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        item_type = entry.get("type")
+        if not isinstance(item_type, str):
+            continue
+        output_type = _TOOL_CALL_TO_OUTPUT_TYPE.get(item_type)
+        if output_type is None:
+            continue
+        call_id = entry.get("call_id")
+        if isinstance(call_id, str):
+            available[output_type].add(call_id)
+    return available
 
 
 def _get_program_caller_id(entry: TResponseInputItem) -> str | None:

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -372,6 +372,7 @@ async def prepare_input_with_session(
     ]
 
     prune_history_indexes: set[int] = set()
+    output_pruning_indexes: set[int] | None = None
 
     if session_input_callback is None or not include_history_in_prepared_input:
         prepared_items_raw: list[TResponseInputItem] = (
@@ -382,6 +383,8 @@ async def prepare_input_with_session(
         appended_items = list(new_input_list)
         if include_history_in_prepared_input:
             prune_history_indexes = set(range(len(converted_history)))
+            if session_input_callback is None and resolved_settings.limit is not None:
+                output_pruning_indexes = set(prune_history_indexes)
     else:
         if not callable(session_input_callback):
             raise UserError(
@@ -465,6 +468,7 @@ async def prepare_input_with_session(
     filtered = drop_orphan_function_calls(
         prepared_as_inputs,
         pruning_indexes=prune_history_indexes,
+        output_pruning_indexes=output_pruning_indexes,
     )
     normalized = normalize_input_items_for_api(filtered)
     deduplicated = deduplicate_input_items_preferring_latest(normalized)

--- a/tests/memory/test_session_limit.py
+++ b/tests/memory/test_session_limit.py
@@ -2,10 +2,12 @@
 
 import tempfile
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from agents import Agent, RunConfig, SQLiteSession
+from agents.items import TResponseInputItem
 from agents.memory import SessionSettings
 from tests.fake_model import FakeModel
 from tests.memory.test_session import run_agent_async
@@ -59,6 +61,63 @@ async def test_session_limit_parameter(runner_method):
         assert last_input[1].get("content")[0]["text"] == "Reply 3"
         assert last_input[2].get("content") == "Message 4"
 
+        session.close()
+
+
+@pytest.mark.parametrize("runner_method", ["run", "run_sync", "run_streamed"])
+@pytest.mark.asyncio
+async def test_session_limit_drops_unmatched_history_function_call_output(runner_method):
+    """A limit boundary must not pass an output whose matching call was excluded."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        session = SQLiteSession("limit_tool_pair", Path(temp_dir) / "test_limit_tool_pair.db")
+        history = cast(
+            list[TResponseInputItem],
+            [
+                {"role": "user", "content": "What is the weather?"},
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "get_weather",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "sunny",
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "It is sunny.",
+                            "annotations": [],
+                        }
+                    ],
+                },
+            ],
+        )
+        await session.add_items(history)
+
+        assert await session.get_items(limit=2) == history[-2:]
+
+        model = FakeModel()
+        model.set_next_output([get_text_message("Tomorrow is sunny too.")])
+        agent = Agent(name="test", model=model)
+
+        await run_agent_async(
+            runner_method,
+            agent,
+            "What about tomorrow?",
+            session=session,
+            run_config=RunConfig(session_settings=SessionSettings(limit=2)),
+        )
+
+        assert model.last_turn_args["input"] == [
+            history[-1],
+            {"role": "user", "content": "What about tomorrow?"},
+        ]
         session.close()
 
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -67,6 +67,7 @@ from agents.items import (
     TResponseInputItem,
 )
 from agents.lifecycle import RunHooks
+from agents.memory import SessionSettings
 from agents.models.fake_id import FAKE_RESPONSES_ID
 from agents.run import AgentRunner, get_default_agent_runner, set_default_agent_runner
 from agents.run_config import _default_trace_include_sensitive_data
@@ -2516,7 +2517,7 @@ async def test_input_guardrail_tripwire_does_not_save_assistant_message_to_sessi
 
 
 @pytest.mark.asyncio
-async def test_prepare_input_with_session_keeps_function_call_outputs():
+async def test_prepare_input_with_session_keeps_orphan_output_without_limit():
     history_item = cast(
         TResponseInputItem,
         {
@@ -2529,14 +2530,160 @@ async def test_prepare_input_with_session_keeps_function_call_outputs():
 
     prepared_input, session_items = await prepare_input_with_session("hello", session, None)
 
-    assert isinstance(prepared_input, list)
-    assert len(session_items) == 1
-    assert cast(dict[str, Any], session_items[0]).get("role") == "user"
-    first_item = cast(dict[str, Any], prepared_input[0])
-    last_item = cast(dict[str, Any], prepared_input[-1])
-    assert first_item["type"] == "function_call_output"
-    assert last_item["role"] == "user"
-    assert last_item["content"] == "hello"
+    assert prepared_input == [history_item, {"role": "user", "content": "hello"}]
+    assert session_items == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_drops_limited_orphan_history_function_call_outputs():
+    history_item = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call_output",
+            "call_id": "call_prepare",
+            "output": "ok",
+        },
+    )
+    session = SimpleListSession(history=[history_item])
+
+    prepared_input, session_items = await prepare_input_with_session(
+        "hello",
+        session,
+        None,
+        SessionSettings(limit=1),
+    )
+
+    assert prepared_input == [{"role": "user", "content": "hello"}]
+    assert session_items == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_preserves_new_function_call_outputs():
+    new_output = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call_output",
+            "call_id": "call_prepare",
+            "output": "ok",
+        },
+    )
+    session = SimpleListSession()
+
+    prepared_input, session_items = await prepare_input_with_session(
+        [new_output],
+        session,
+        None,
+        SessionSettings(limit=1),
+    )
+
+    assert prepared_input == [new_output]
+    assert session_items == [new_output]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_leaves_custom_callback_output_unchanged():
+    history_output = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call_output",
+            "call_id": "call_callback",
+            "output": "ok",
+        },
+    )
+    session = SimpleListSession(history=[history_output])
+
+    def callback(
+        history: list[TResponseInputItem], new_input: list[TResponseInputItem]
+    ) -> list[TResponseInputItem]:
+        return history + new_input
+
+    prepared_input, session_items = await prepare_input_with_session(
+        "hello",
+        session,
+        callback,
+        SessionSettings(limit=1),
+    )
+
+    assert prepared_input == [history_output, {"role": "user", "content": "hello"}]
+    assert session_items == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_drops_output_for_program_owned_call_pruned_with_parent():
+    program = cast(
+        TResponseInputItem,
+        {
+            "type": "program",
+            "call_id": "program_orphan",
+            "code": "return await tools.lookup({});",
+            "fingerprint": "fingerprint:orphan",
+        },
+    )
+    function_call = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call",
+            "call_id": "call_orphan",
+            "name": "lookup",
+            "arguments": "{}",
+            "caller": {"type": "program", "caller_id": "program_orphan"},
+        },
+    )
+    function_output = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call_output",
+            "call_id": "call_orphan",
+            "output": "ok",
+        },
+    )
+    session = SimpleListSession(history=[program, function_call, function_output])
+
+    prepared_input, session_items = await prepare_input_with_session(
+        "hello",
+        session,
+        None,
+        SessionSettings(limit=3),
+    )
+
+    assert prepared_input == [{"role": "user", "content": "hello"}]
+    assert session_items == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_prepare_input_with_session_keeps_paired_history_function_call_outputs():
+    function_call = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call",
+            "call_id": "call_prepare",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    )
+    function_call_output = cast(
+        TResponseInputItem,
+        {
+            "type": "function_call_output",
+            "call_id": "call_prepare",
+            "output": "ok",
+        },
+    )
+    session = SimpleListSession(history=[function_call, function_call_output])
+
+    prepared_input, session_items = await prepare_input_with_session(
+        "hello",
+        session,
+        None,
+        SessionSettings(limit=2),
+    )
+
+    assert prepared_input == [
+        function_call,
+        function_call_output,
+        {"role": "user", "content": "hello"},
+    ]
+    assert session_items == [{"role": "user", "content": "hello"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes limited client-session replay when the retained history window starts with a tool output whose matching call was excluded. It removes only unmatched stored tool outputs from the model-facing input after existing call pruning, while preserving exact session retrieval, persisted history, current-turn input, unlimited history, and custom callback behavior.

This pull request resolves #4322.
