### PR TITLE
fix(litellm): omit parallel tool calls without tools

### DIFF
--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -576,7 +576,7 @@ class LitellmModel(Model):
             True
             if model_settings.parallel_tool_calls and tools and len(tools) > 0
             else False
-            if model_settings.parallel_tool_calls is False
+            if model_settings.parallel_tool_calls is False and (tools or handoffs)
             else None
         )
         tool_choice = Converter.convert_tool_choice(model_settings.tool_choice)

--- a/tests/models/test_kwargs_functionality.py
+++ b/tests/models/test_kwargs_functionality.py
@@ -11,7 +11,7 @@ from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.completion_usage import CompletionUsage
 
-from agents import Agent
+from agents import Agent, Handoff, Tool, function_tool, handoff
 from agents.extensions.models.litellm_model import LitellmModel
 from agents.model_settings import ModelSettings
 from agents.models._retry_runtime import provider_managed_retries_disabled
@@ -67,6 +67,51 @@ async def test_litellm_kwargs_forwarded(monkeypatch):
 
     # Verify regular parameters are still passed
     assert captured["temperature"] == 0.5
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("capability", "expected_parallel_tool_calls"),
+    [("none", None), ("tool", False), ("handoff", False)],
+)
+async def test_litellm_parallel_tool_calls_requires_capability(
+    monkeypatch, capability: str, expected_parallel_tool_calls: bool | None
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        captured.update(kwargs)
+        message = Message(role="assistant", content="test response")
+        choice = Choices(index=0, message=message)
+        return ModelResponse(choices=[choice], usage=Usage(0, 0, 0))
+
+    @function_tool
+    def lookup() -> str:
+        """Return a deterministic result."""
+        return "ok"
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    tools: list[Tool] = [lookup] if capability == "tool" else []
+    handoffs: list[Handoff] = [handoff(Agent(name="delegate"))] if capability == "handoff" else []
+
+    await LitellmModel(model="test-model").get_response(
+        system_instructions=None,
+        input="test input",
+        model_settings=ModelSettings(parallel_tool_calls=False),
+        tools=tools,
+        output_schema=None,
+        handoffs=handoffs,
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    if capability == "none":
+        assert captured["tools"] is None
+    else:
+        assert captured["tools"] is not None
+    assert captured["parallel_tool_calls"] is expected_parallel_tool_calls
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

This pull request fixes LiteLLM request construction when `parallel_tool_calls` is explicitly disabled but the request has no tools or handoffs. The adapter now omits the option for that invalid request shape while preserving `false` for function-tool and handoff requests.

It also adds regression coverage for no-capability, function-tool, and handoff-only requests.

### Test plan

- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`
- Focused LiteLLM kwargs tests and mypy check

### Issue number

Closes #4326

Related downstream fix: usestrix/strix#951

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
