### PR TITLE
fix: honor zero limit in encrypted sessions

### DIFF
--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -189,6 +189,8 @@ class EncryptedSession(SessionABC):
     ) -> list[TResponseInputItem]:
         wrapper = _get_session_wrapper(self.underlying_session, wrapper)
         effective_limit = resolve_session_limit(limit, self.session_settings)
+        if effective_limit == 0:
+            return []
         if effective_limit is not None and effective_limit > 0:
             window = effective_limit
             while True:

--- a/tests/extensions/memory/test_encrypt_session.py
+++ b/tests/extensions/memory/test_encrypt_session.py
@@ -359,6 +359,24 @@ async def test_encrypted_session_get_items_limit(
     underlying_session.close()
 
 
+async def test_encrypted_session_get_items_session_settings_zero_limit(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """Test that a zero session settings limit returns no history."""
+    underlying_session.session_settings = SessionSettings(limit=0)
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+    await session.add_items([{"role": "user", "content": "hidden history"}])
+
+    assert await session.get_items() == []
+    assert len(await underlying_session.get_items()) == 1
+
+    underlying_session.close()
+
+
 async def test_encrypted_session_get_items_limit_skips_invalid_latest_envelope(
     encryption_key: str, underlying_session: SQLiteSession
 ):


### PR DESCRIPTION
### Summary

Honor an effective `SessionSettings(limit=0)` in `EncryptedSession.get_items()` by returning no historical items before delegating to the underlying session. Add regression coverage proving encrypted history remains stored while the wrapper excludes it.

### Test plan

- Added `test_encrypted_session_get_items_session_settings_zero_limit`.
- `git diff --check` passes.
- Two independent final reviews reported clean on the final diff.
- Focused pytest could not run because `uv` is not installed and system Python does not have `pytest`.
- The mandatory command `powershell -ExecutionPolicy Bypass -File .agents/skills/code-change-verification/scripts/run.ps1` could not start because `make` is not installed in the local environment.

### Issue number

Closes #4331

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
