### PR TITLE
fix(chat-completions): emit response.created before completing an empty stream

### DIFF
--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -1094,6 +1094,16 @@ class ChatCmplStreamHandler:
                             sequence_number=sequence_number.get_and_increment(),
                         )
 
+        # A degenerate stream can end without any chunk reaching the handler (an empty
+        # provider stream, or buffering dropping every chunk), so the terminal events
+        # below must still be preceded by response.created.
+        if not state.started:
+            yield ResponseCreatedEvent(
+                response=response,
+                type="response.created",
+                sequence_number=sequence_number.get_and_increment(),
+            )
+
         # Content-filter refusal with no emitted output: synthesize a refusal so
         # the completed response carries a ResponseOutputRefusal rather than an
         # empty turn. Only when nothing else was produced (text / refusal / tool

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -803,6 +803,42 @@ async def test_buffered_audio_only_delta_raises_instead_of_completing_empty() ->
 
 
 @pytest.mark.asyncio
+async def test_buffered_degenerate_stream_still_announces_response_created() -> None:
+    """response.created must precede response.completed even when buffering drops every chunk."""
+    role_only = _chunk_with([Choice(index=0, delta=ChoiceDelta(role="assistant"))])
+    empty_finish = _chunk_with([Choice(index=0, delta=ChoiceDelta(), finish_reason="stop")])
+
+    unbuffered_events = await _collect_handler_events(role_only, empty_finish)
+
+    buffered = ChatCmplStreamHandler.buffer_tool_call_stream(
+        _completion_stream(role_only, empty_finish)
+    )
+    buffered_events = [
+        event
+        async for event in ChatCmplStreamHandler.handle_stream(
+            _empty_response(), cast(Any, buffered)
+        )
+    ]
+
+    lifecycle = ["response.created", "response.completed"]
+    assert [event.type for event in unbuffered_events] == lifecycle
+    assert [event.type for event in buffered_events] == lifecycle
+    assert [event.sequence_number for event in buffered_events] == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_still_announces_response_created() -> None:
+    """A stream that ends without any chunk still describes a full response lifecycle."""
+    events = await _collect_handler_events()
+
+    assert [event.type for event in events] == ["response.created", "response.completed"]
+    assert [event.sequence_number for event in events] == [0, 1]
+    completed = events[-1]
+    assert isinstance(completed, ResponseCompletedEvent)
+    assert completed.response.output == []
+
+
+@pytest.mark.asyncio
 async def test_buffer_tool_call_stream_preserves_empty_choice_chunks() -> None:
     chunk = ChatCompletionChunk(
         id="chunk-id",


### PR DESCRIPTION
### Summary

A streamed Chat Completions response could emit `response.completed` without ever emitting `response.created`. `handle_stream` announces `response.created` lazily on the first chunk but emits the terminal `response.completed` unconditionally, so a stream where no chunk reaches the handler produces a completed event for a response that never started. Two paths get there: a provider stream that ends without yielding any chunk, and `buffer_streamed_tool_calls=True` dropping every chunk of a degenerate stream (a role-only delta followed by an empty finish chunk with no usage, a shape OpenAI-compatible proxies emit). `docs/streaming.md` documents `response.created` as one of the raw events reaching consumers through `RawResponsesStreamEvent.data`, so a consumer that keys on it to initialize per-response state receives an end without a beginning, while the same stream without buffering yields both events.

`handle_stream` now emits `response.created` immediately after the chunk loop when no chunk ever announced it, before any terminal event. Normal streams are unchanged: the guard only fires when the lazy emission never ran.

The patch does not change whether an empty stream is an error. `response.completed` fires exactly as today, and only the missing `response.created` is added. Completing with empty output is the released behavior, already covered by `test_stream_handler_keeps_empty_choice_usage_chunks` for a stream whose chunks carry no choices.

Two adjacent observations, left out of this patch:

* A zero-chunk stream has no terminal payload, which `.agents/references/model-provider-boundaries.md` says should fail, and `Runner.run` does raise `ModelBehaviorError` for the non-streamed equivalent. Whether the streamed path should raise too is a separate released-behavior call; happy to take it separately.
* `buffer_tool_call_stream` forwards a terminal choice only for `content_filter`. Widening that would change what the handler observes on every buffered stream.

### Test plan

Two new regressions fail on `main` by receiving `["response.completed"]` alone: a degenerate stream through the composed buffering pipeline, and a zero-chunk stream on the direct handler path, which also asserts the `[0, 1]` sequence numbers. The existing suite pins that normal and usage-only streams keep emitting exactly one `response.created` on the first chunk.

`.agents/skills/code-change-verification/scripts/run.sh` passes.

### Issue number

N/A. Self-discovered while auditing streaming lifecycle parity of the Chat Completions adapter.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR