### PR TITLE
fix(mcp): serialize manager lifecycle operations

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -177,6 +177,7 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
         self.suppress_cancelled_error = suppress_cancelled_error
         self.connect_in_parallel = connect_in_parallel
         self._workers: dict[MCPServer, _ServerWorker] = {}
+        self._lifecycle_lock = asyncio.Lock()
 
         self.failed_servers: list[MCPServer] = []
         self._failed_server_set: set[MCPServer] = set()
@@ -225,6 +226,10 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
 
     async def connect_all(self) -> list[MCPServer]:
         """Connect all servers in order and return the active list."""
+        async with self._lifecycle_lock:
+            return await self._connect_all()
+
+    async def _connect_all(self) -> list[MCPServer]:
         previous_connected_servers = set(self._connected_servers)
         previous_active_servers = list(self._active_servers)
         self.failed_servers = []
@@ -268,11 +273,15 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
             failed_only: If True, only retry servers that previously failed.
                 If False, cleanup and retry all servers.
         """
+        async with self._lifecycle_lock:
+            return await self._reconnect(failed_only=failed_only)
+
+    async def _reconnect(self, *, failed_only: bool) -> list[MCPServer]:
         if failed_only:
             failed_servers = self._unique_servers(self.failed_servers)
             servers_to_retry = await self._cleanup_servers(failed_servers)
         else:
-            await self.cleanup_all()
+            await self._cleanup_all()
             servers_to_retry = list(self._all_servers)
             self.failed_servers = []
             self._failed_server_set = set()
@@ -291,6 +300,10 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
 
     async def cleanup_all(self) -> None:
         """Cleanup all servers in reverse order."""
+        async with self._lifecycle_lock:
+            await self._cleanup_all()
+
+    async def _cleanup_all(self) -> None:
         for server in reversed(self._all_servers):
             try:
                 await self._cleanup_server(server)
@@ -368,6 +381,12 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
             await self._run_with_timeout(server.connect, self.connect_timeout_seconds)
 
     async def _cleanup_server(self, server: MCPServer) -> None:
+        if (
+            self.connect_in_parallel
+            and server not in self._workers
+            and server not in self._connected_servers
+        ):
+            return
         if self.connect_in_parallel and server in self._workers:
             worker = self._workers[server]
             if worker.is_done:

--- a/tests/mcp/test_mcp_server_manager.py
+++ b/tests/mcp/test_mcp_server_manager.py
@@ -74,6 +74,20 @@ class TaskBoundServer(MCPServer):
         return ReadResourceResult(contents=[])
 
 
+class BlockingCleanupServer(TaskBoundServer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cleanup_started = asyncio.Event()
+        self.allow_cleanup = asyncio.Event()
+        self.cleanup_calls = 0
+
+    async def cleanup(self) -> None:
+        self.cleanup_calls += 1
+        self.cleanup_started.set()
+        await self.allow_cleanup.wait()
+        await super().cleanup()
+
+
 class FlakyServer(MCPServer):
     def __init__(self, failures: int) -> None:
         super().__init__()
@@ -480,6 +494,24 @@ async def test_manager_connects_in_worker_tasks_when_parallel() -> None:
         assert server._connect_task is not asyncio.current_task()
 
     assert server.cleaned is True
+
+
+@pytest.mark.asyncio
+async def test_manager_serializes_overlapping_parallel_cleanup_calls() -> None:
+    server = BlockingCleanupServer()
+    manager = MCPServerManager([server], connect_in_parallel=True)
+    await manager.connect_all()
+
+    first_cleanup = asyncio.create_task(manager.cleanup_all())
+    await server.cleanup_started.wait()
+    second_cleanup = asyncio.create_task(manager.cleanup_all())
+
+    server.allow_cleanup.set()
+    await asyncio.wait_for(asyncio.gather(first_cleanup, second_cleanup), timeout=1)
+
+    assert server.cleanup_calls == 1
+    assert manager._workers == {}
+    assert manager._connected_servers == set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request resolves #4334 by serializing the public MCPServerManager lifecycle operations.

When connect_all(), reconnect(), or cleanup_all() overlapped in parallel mode, multiple cleanup commands could be submitted to a per-server worker. The worker exited after the first cleanup, leaving later command futures unresolved and callers hanging.

This change:
- Adds an internal lifecycle lock around the three public lifecycle entry points.
- Keeps nested internal cleanup unlocked so full reconnect does not deadlock.
- Preserves existing per-server worker task affinity and timeout behavior.
- Adds a deterministic regression test for overlapping parallel cleanup calls.

Verification:
- git diff --check: passed.
- Python AST parsing: passed.
- Repository verification could not run because this environment does not have make, uv, or pytest installed.