### PR TITLE
docs: update the documented default model

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -23,7 +23,7 @@ Start with the simplest path that fits your setup:
 
 For most OpenAI-only apps, the recommended path is to use string model names with the default OpenAI provider and stay on the Responses model path.
 
-When you don't specify a model when initializing an `Agent`, the default model will be used. The default is currently [`gpt-5.4-mini`](https://developers.openai.com/api/docs/models/gpt-5.4-mini) with `reasoning.effort="none"` and `verbosity="low"` for low-latency agent workflows. If you have access, we recommend setting your agents to `gpt-5.6-sol` for higher quality while keeping explicit `model_settings`.
+When you don't specify a model when initializing an `Agent`, the default model will be used. The default is currently `gpt-5.6-luna` with `reasoning.effort="none"` and `verbosity="low"` for low-latency agent workflows. If you have access, we recommend setting your agents to `gpt-5.6-sol` for higher quality while keeping explicit `model_settings`.
 
 If you want to switch to other models like `gpt-5.6-sol`, there are two ways to configure your agents.
 


### PR DESCRIPTION
This pull request resolves #4335 by updating docs/models/index.md to match the current SDK default model.

The implementation now defaults to gpt-5.6-luna with reasoning.effort=none, while the documentation still described gpt-5.4-mini. Historical release notes remain unchanged, and translated pages are intentionally not edited because they are generated.

Validation:
- git diff --check: passed.
- Confirmed the only remaining English gpt-5.4-mini reference is the historical release note in docs/release.md.
- make build-docs could not run because make is unavailable in the local environment.