### PR TITLE
fix(mcp): serialize non-text content blocks as JSON instead of Python repr

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -788,9 +788,11 @@ class MCPUtil:
                         )
                     )
                 else:
-                    # Fall back to regular text content
+                    # Fall back to text content holding the block serialized as JSON.
+                    # ``str()`` on the dump would produce a Python repr (single quotes,
+                    # ``None``/``True``), which the model cannot parse back as JSON.
                     tool_output_list.append(
-                        ToolOutputTextDict(type="text", text=str(item.model_dump(mode="json")))
+                        ToolOutputTextDict(type="text", text=item.model_dump_json())
                     )
             if len(tool_output_list) == 1:
                 tool_output = tool_output_list[0]

--- a/tests/mcp/model_compat.py
+++ b/tests/mcp/model_compat.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 from mcp import Tool as _Tool
 from mcp.types import (
+    AudioContent as _AudioContent,
     CallToolResult as _CallToolResult,
     ImageContent as _ImageContent,
     InitializeResult as _InitializeResult,
@@ -22,6 +23,11 @@ from agents.mcp._compat import MCP_V2, MCPError
 # MCP v1 and v2 accept their wire-format aliases at runtime, but expose different constructor
 # signatures to static type checkers. Keep alias-based fixture construction in one test-only module.
 class Tool(_Tool):
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+
+
+class AudioContent(_AudioContent):
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)
 

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1765,6 +1765,37 @@ async def test_mcp_fastmcp_behavior_verification():
 
 
 @pytest.mark.asyncio
+async def test_non_text_content_serialized_as_json():
+    """Non-text, non-image content blocks should reach the model as valid JSON, not repr."""
+
+    from mcp.types import ContentBlock, EmbeddedResource, ResourceLink, TextResourceContents
+
+    from .model_compat import AudioContent
+
+    server = FakeMCPServer()
+    server.add_tool("test_tool", {})
+
+    ctx = RunContextWrapper(context=None)
+    tool = MCPTool(name="test_tool", inputSchema={})
+
+    resource_link = ResourceLink(type="resource_link", name="report", uri="resource://reports/1")
+    embedded = EmbeddedResource(
+        type="resource",
+        resource=TextResourceContents(uri="resource://reports/2", text="hello world"),
+    )
+    audio = AudioContent(type="audio", data="AAAA", mimeType="audio/wav")
+    content_items: list[ContentBlock] = [resource_link, embedded, audio]
+    server._custom_content = content_items
+    result = await MCPUtil.invoke_mcp_tool(server, tool, ctx, "")
+
+    assert isinstance(result, list) and len(result) == len(content_items)
+    for output_item, content_item in zip(result, content_items, strict=False):
+        assert output_item["type"] == "text"
+        # The text must parse as JSON and round-trip the content block's data.
+        assert json.loads(output_item["text"]) == content_item.model_dump(mode="json")
+
+
+@pytest.mark.asyncio
 async def test_agent_convert_schemas_unset():
     """Test that leaving convert_schemas_to_strict unset (defaulting to False) leaves tool schemas
     as non-strict.


### PR DESCRIPTION
### Summary

MCP tool results whose content blocks are neither text nor images (resource links, embedded resources, audio) are currently sent to the model as a Python repr string rather than JSON:

```python
# src/agents/mcp/util.py — fallback branch
ToolOutputTextDict(type="text", text=str(item.model_dump(mode="json")))
# produces: {'name': 'report', 'title': None, 'uri': 'resource://reports/1', ...}
```

Single quotes and `None`/`True` literals make the text unparseable as JSON, so models that try to read the structured payload back fail. This was a regression: before image support, fb68e77f (#1250) serialized these blocks with `model_dump_json()` / `json.dumps(...)`; the `str()` form arrived with the image-support change in #2369, whose fallback branch had no test coverage.

This PR restores JSON serialization via `item.model_dump_json()`.

Two deliberate non-changes, for review context:

- Field naming keeps Python names (`mime_type`, not the MCP wire alias `mimeType`) — identical to both the current `str()` output and the pre-#2369 behavior. Switching to `by_alias=True` would be a separate behavioral change and is out of scope here.
- Downstream consumers (tracing span output, custom data extractors) now observe valid JSON text for these blocks instead of a repr string.

### Test plan

- New regression test `test_non_text_content_serialized_as_json` covering all three fallback content types (`ResourceLink`, `EmbeddedResource`, `AudioContent`), asserting the model-visible text parses with `json.loads` and round-trips each block's data.
- Full verification stack passes: `make format`, `make lint`, `make typecheck`, `make tests` (via `.agents/skills/code-change-verification/scripts/run.sh`).

### Issue number

None — found while exercising MCP tool output conversion; reproduction in the summary.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
