### PR TITLE
fix(run_state): serialize containers of models and dataclasses as structured data

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1307,20 +1307,8 @@ class RunState(Generic[TContext, TAgent]):
 
         # Add additional fields based on item type
         if hasattr(item, "output"):
-            serialized_output = item.output
             try:
-                if hasattr(serialized_output, "model_dump"):
-                    # ``output`` is the tool's actual return value, not a wire item, so keep
-                    # fields left at their defaults. ``exclude_unset`` would drop them and make
-                    # the restored ``.output`` disagree with the full model-facing ``raw_item``.
-                    # Stay in Python mode and let ``_ensure_json_compatible`` handle JSON
-                    # conversion below: ``mode="json"`` raises on values like non-UTF-8 bytes,
-                    # which would trip the fallback and replace the whole structured output with
-                    # an opaque string instead of a dict.
-                    serialized_output = serialized_output.model_dump()
-                elif dataclasses.is_dataclass(serialized_output):
-                    serialized_output = dataclasses.asdict(serialized_output)  # type: ignore[arg-type]
-                serialized_output = _ensure_json_compatible(serialized_output)
+                serialized_output = _ensure_json_compatible(_serialize_output_value(item.output))
             except Exception:
                 serialized_output = str(item.output)
             result["output"] = serialized_output
@@ -1734,6 +1722,33 @@ def _ensure_json_compatible(value: Any) -> Any:
         return json.loads(json.dumps(value, default=str))
     except Exception:
         return str(value)
+
+
+def _serialize_output_value(value: Any) -> Any:
+    """Convert a tool output value, including containers of models, to plain data.
+
+    ``_ensure_json_compatible`` stringifies anything ``json.dumps`` cannot handle, so
+    Pydantic models and dataclasses nested in containers would otherwise degrade to
+    their reprs instead of structured data. Sets and models nested inside dataclass
+    instances intentionally keep the previous behavior and degrade through
+    ``_ensure_json_compatible``'s string fallback.
+    """
+    if hasattr(value, "model_dump"):
+        # ``output`` is the tool's actual return value, not a wire item, so keep fields
+        # left at their defaults. ``exclude_unset`` would drop them and make the restored
+        # ``.output`` disagree with the full model-facing ``raw_item``. Stay in Python
+        # mode and let ``_ensure_json_compatible`` handle JSON conversion afterwards:
+        # ``mode="json"`` raises on values like non-UTF-8 bytes, which would trip the
+        # fallback and replace the whole structured output with an opaque string
+        # instead of a dict.
+        return value.model_dump()
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return dataclasses.asdict(value)
+    if isinstance(value, dict):
+        return {key: _serialize_output_value(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_serialize_output_value(item) for item in value]
+    return value
 
 
 def _serialize_tool_call_data(tool_call: Any) -> Any:

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -3128,6 +3128,46 @@ class TestSerializationRoundTrip:
         assert raw_item_again["acknowledged_safety_checks"] == expected_checks
         json.dumps(roundtripped.to_json())
 
+    async def test_serializes_output_containers_of_models(self):
+        """Containers of Pydantic models and dataclasses should serialize as structured data."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="ItemAgent")
+
+        class Weather(BaseModel):
+            city: str
+            temperature: int
+
+        @dataclass
+        class Reading:
+            value: int
+            label: str
+
+        cases: list[tuple[Any, Any]] = [
+            ([Weather(city="sf", temperature=18)], [{"city": "sf", "temperature": 18}]),
+            (
+                {"today": Weather(city="sf", temperature=18)},
+                {"today": {"city": "sf", "temperature": 18}},
+            ),
+            ((Reading(value=1, label="ok"),), [{"value": 1, "label": "ok"}]),
+        ]
+        for output, expected in cases:
+            state = make_state(agent, context=context, original_input="test", max_turns=5)
+            state._generated_items.append(
+                ToolCallOutputItem(
+                    agent=agent,
+                    raw_item={"type": "function_call_output", "call_id": "c1", "output": "x"},
+                    output=output,
+                )
+            )
+
+            json_data = state.to_json()
+            assert json_data["generated_items"][0]["output"] == expected
+
+            new_state = await RunState.from_json(agent, json_data)
+            restored_item = new_state._generated_items[0]
+            assert isinstance(restored_item, ToolCallOutputItem)
+            assert restored_item.output == expected
+
     async def test_deserializes_tool_call_output_custom_data(self):
         """SDK-only tool output custom data should survive RunState roundtrips."""
         context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})


### PR DESCRIPTION
### Summary

`RunState` serialization degrades containers of Pydantic models or dataclasses in `ToolCallOutputItem.output` into lists/dicts of repr strings. A tool returning `[Weather(city="sf", temperature=18)]` round-trips to `["city='sf' temperature=18"]` — silent loss of structured data on the durable pause/resume boundary.

Root cause: `_serialize_item` only converts a bare top-level `model_dump`-capable object or dataclass; anything nested inside a container falls through to `_ensure_json_compatible`, whose `json.dumps(value, default=str)` stringifies each element.

Fix: a module-level `_serialize_output_value` helper recursively converts models (`model_dump()`, Python mode) and dataclass instances (`dataclasses.asdict`) inside dict/list/tuple containers before the existing `_ensure_json_compatible` pass. The exclude_unset/Python-mode reasoning introduced in #4307 is preserved verbatim in the helper's comments.

Deliberate scope limits, for review context:

- Sets (and models nested inside dataclass instances, which `asdict` deep-copies) intentionally keep the existing string-fallback behavior — unchanged from before this fix and noted in the helper's docstring.
- A container holding a model whose `model_dump()` raises now degrades the whole output to a single `str(item.output)` (the existing exception fallback), where before the container survived with per-element reprs. Pathological input only; simpler failure mode.
- No `$schemaVersion` bump: `from_json` passes `output` through unchanged, so old snapshots (including ones holding repr strings) restore exactly as before; only newly serialized states gain structured data, and the field's meaning (best-effort JSON of the tool's return value) is unchanged.

### Test plan

- New regression test `test_serializes_output_containers_of_models` covering list-of-models, dict-of-models, and tuple-of-dataclasses: asserts the serialized JSON holds structured dicts and that a `from_json` round-trip restores them.
- Full verification stack passes: `make format`, `make lint`, `make typecheck`, `make tests` (via `.agents/skills/code-change-verification/scripts/run.sh`).

### Issue number

None — found while exercising RunState round-trips; example in the summary.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
