### PR TITLE
fix(mcp): serialize manager lifecycle operations

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -39,21 +39,52 @@ class _ServerWorker:
         self._server = server
         self._queue: asyncio.Queue[_ServerCommand] = asyncio.Queue()
         self._task = asyncio.create_task(self._run())
+        self._cleanup_future: asyncio.Future[None] | None = None
 
     @property
     def is_done(self) -> bool:
         return self._task.done()
 
+    @property
+    def is_stopping(self) -> bool:
+        return self._cleanup_future is not None
+
+    @property
+    def cleanup_error(self) -> BaseException | None:
+        if (
+            self._cleanup_future is None
+            or not self._cleanup_future.done()
+            or self._cleanup_future.cancelled()
+        ):
+            return None
+        return self._cleanup_future.exception()
+
+    def add_done_callback(self, callback: Callable[[asyncio.Task[None]], None]) -> None:
+        self._task.add_done_callback(callback)
+
     async def connect(self, timeout_seconds: float | None) -> None:
         await self._submit("connect", timeout_seconds)
 
     async def cleanup(self, timeout_seconds: float | None) -> None:
-        await self._submit("cleanup", timeout_seconds)
+        if self._cleanup_future is None:
+            loop = asyncio.get_running_loop()
+            self._cleanup_future = loop.create_future()
+            self._queue.put_nowait(
+                _ServerCommand(
+                    action="cleanup",
+                    timeout_seconds=timeout_seconds,
+                    future=self._cleanup_future,
+                )
+            )
+        await asyncio.shield(self._cleanup_future)
+
+    async def wait_until_stopped(self) -> None:
+        await asyncio.shield(self._task)
 
     async def _submit(self, action: str, timeout_seconds: float | None) -> None:
         loop = asyncio.get_running_loop()
         future: asyncio.Future[None] = loop.create_future()
-        await self._queue.put(
+        self._queue.put_nowait(
             _ServerCommand(action=action, timeout_seconds=timeout_seconds, future=future)
         )
         await future
@@ -177,6 +208,7 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
         self.suppress_cancelled_error = suppress_cancelled_error
         self.connect_in_parallel = connect_in_parallel
         self._workers: dict[MCPServer, _ServerWorker] = {}
+        self._lifecycle_lock = asyncio.Lock()
 
         self.failed_servers: list[MCPServer] = []
         self._failed_server_set: set[MCPServer] = set()
@@ -225,6 +257,14 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
 
     async def connect_all(self) -> list[MCPServer]:
         """Connect all servers in order and return the active list."""
+        if not await self._acquire_lifecycle_lock():
+            return self.active_servers
+        try:
+            return await self._connect_all()
+        finally:
+            self._lifecycle_lock.release()
+
+    async def _connect_all(self) -> list[MCPServer]:
         previous_connected_servers = set(self._connected_servers)
         previous_active_servers = list(self._active_servers)
         self.failed_servers = []
@@ -268,11 +308,19 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
             failed_only: If True, only retry servers that previously failed.
                 If False, cleanup and retry all servers.
         """
+        if not await self._acquire_lifecycle_lock():
+            return self.active_servers
+        try:
+            return await self._reconnect(failed_only=failed_only)
+        finally:
+            self._lifecycle_lock.release()
+
+    async def _reconnect(self, *, failed_only: bool) -> list[MCPServer]:
         if failed_only:
             failed_servers = self._unique_servers(self.failed_servers)
             servers_to_retry = await self._cleanup_servers(failed_servers)
         else:
-            await self.cleanup_all()
+            await self._cleanup_all()
             servers_to_retry = list(self._all_servers)
             self.failed_servers = []
             self._failed_server_set = set()
@@ -291,6 +339,23 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
 
     async def cleanup_all(self) -> None:
         """Cleanup all servers in reverse order."""
+        if not await self._acquire_lifecycle_lock():
+            return
+        try:
+            await self._cleanup_all()
+        finally:
+            self._lifecycle_lock.release()
+
+    async def _acquire_lifecycle_lock(self) -> bool:
+        try:
+            await self._lifecycle_lock.acquire()
+        except asyncio.CancelledError:
+            if not self.suppress_cancelled_error:
+                raise
+            return False
+        return True
+
+    async def _cleanup_all(self) -> None:
         for server in reversed(self._all_servers):
             try:
                 await self._cleanup_server(server)
@@ -362,23 +427,27 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
 
     async def _run_connect(self, server: MCPServer) -> None:
         if self.connect_in_parallel:
-            worker = self._get_worker(server)
+            worker = await self._get_worker(server)
             await worker.connect(self.connect_timeout_seconds)
         else:
             await self._run_with_timeout(server.connect, self.connect_timeout_seconds)
 
     async def _cleanup_server(self, server: MCPServer) -> None:
+        if (
+            self.connect_in_parallel
+            and server not in self._workers
+            and server not in self._connected_servers
+        ):
+            return
         if self.connect_in_parallel and server in self._workers:
             worker = self._workers[server]
-            if worker.is_done:
-                self._workers.pop(server, None)
-                self._connected_servers.discard(server)
-                return
             try:
                 await worker.cleanup(self.cleanup_timeout_seconds)
             finally:
-                self._workers.pop(server, None)
-                self._connected_servers.discard(server)
+                if worker.is_done:
+                    self._handle_worker_done(server, worker)
+                elif self._workers.get(server) is worker:
+                    self._connected_servers.discard(server)
             return
         try:
             await self._run_with_timeout(server.cleanup, self.cleanup_timeout_seconds)
@@ -441,12 +510,32 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
                     raise error
                 raise RuntimeError(f"Failed to connect MCP server '{first_failure.name}'")
 
-    def _get_worker(self, server: MCPServer) -> _ServerWorker:
+    async def _get_worker(self, server: MCPServer) -> _ServerWorker:
         worker = self._workers.get(server)
-        if worker is None or worker.is_done:
+        if worker is not None and worker.is_stopping:
+            await worker.wait_until_stopped()
+            await worker.cleanup(self.cleanup_timeout_seconds)
+            self._discard_worker(server, worker)
+            worker = self._workers.get(server)
+        if worker is not None and worker.is_done:
+            self._discard_worker(server, worker)
+            worker = self._workers.get(server)
+        if worker is None:
             worker = _ServerWorker(server=server)
             self._workers[server] = worker
+            worker.add_done_callback(lambda _task: self._handle_worker_done(server, worker))
         return worker
+
+    def _handle_worker_done(self, server: MCPServer, worker: _ServerWorker) -> None:
+        if worker.cleanup_error is None:
+            self._discard_worker(server, worker)
+        elif self._workers.get(server) is worker:
+            self._connected_servers.discard(server)
+
+    def _discard_worker(self, server: MCPServer, worker: _ServerWorker) -> None:
+        if self._workers.get(server) is worker:
+            self._workers.pop(server, None)
+            self._connected_servers.discard(server)
 
     def _remove_failed_server(self, server: MCPServer) -> None:
         if server in self._failed_server_set:

--- a/tests/mcp/test_mcp_server_manager.py
+++ b/tests/mcp/test_mcp_server_manager.py
@@ -74,6 +74,54 @@ class TaskBoundServer(MCPServer):
         return ReadResourceResult(contents=[])
 
 
+class BlockingCleanupServer(TaskBoundServer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cleanup_started = asyncio.Event()
+        self.allow_cleanup = asyncio.Event()
+        self.cleanup_finished = asyncio.Event()
+        self.connect_calls = 0
+        self.cleanup_calls = 0
+        self.active_generation: int | None = None
+
+    async def connect(self) -> None:
+        await super().connect()
+        self.connect_calls += 1
+        self.active_generation = self.connect_calls
+        self.cleaned = False
+
+    async def cleanup(self) -> None:
+        self.cleanup_calls += 1
+        self.cleanup_started.set()
+        await self.allow_cleanup.wait()
+        self.active_generation = None
+        try:
+            await super().cleanup()
+        finally:
+            self.cleanup_finished.set()
+
+
+class BlockingCleanupFailureServer(TaskBoundServer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cleanup_started = asyncio.Event()
+        self.allow_cleanup = asyncio.Event()
+        self.connect_calls = 0
+        self.cleanup_calls = 0
+
+    async def connect(self) -> None:
+        await super().connect()
+        self.connect_calls += 1
+        if self.connect_calls == 1:
+            raise RuntimeError("connect failed")
+
+    async def cleanup(self) -> None:
+        self.cleanup_calls += 1
+        self.cleanup_started.set()
+        await self.allow_cleanup.wait()
+        raise RuntimeError("cleanup failed")
+
+
 class FlakyServer(MCPServer):
     def __init__(self, failures: int) -> None:
         super().__init__()
@@ -483,6 +531,231 @@ async def test_manager_connects_in_worker_tasks_when_parallel() -> None:
 
 
 @pytest.mark.asyncio
+async def test_manager_serializes_overlapping_parallel_cleanup_calls() -> None:
+    server = BlockingCleanupServer()
+    manager = MCPServerManager([server], connect_in_parallel=True)
+    await manager.connect_all()
+
+    first_cleanup = asyncio.create_task(manager.cleanup_all())
+    await server.cleanup_started.wait()
+    second_cleanup = asyncio.create_task(manager.cleanup_all())
+
+    server.allow_cleanup.set()
+    await asyncio.wait_for(asyncio.gather(first_cleanup, second_cleanup), timeout=1)
+
+    assert server.cleanup_calls == 1
+    assert manager._workers == {}
+    assert manager._connected_servers == set()
+
+
+@pytest.mark.asyncio
+async def test_manager_serializes_parallel_cleanup_and_full_reconnect() -> None:
+    server = BlockingCleanupServer()
+    manager = MCPServerManager([server], connect_in_parallel=True)
+    await manager.connect_all()
+
+    cleanup_task = asyncio.create_task(manager.cleanup_all())
+    reconnect_task: asyncio.Task[list[MCPServer]] | None = None
+    try:
+        await asyncio.wait_for(server.cleanup_started.wait(), timeout=1)
+        reconnect_task = asyncio.create_task(manager.reconnect(failed_only=False))
+        await asyncio.sleep(0)
+
+        assert not reconnect_task.done()
+        assert server.connect_calls == 1
+
+        server.allow_cleanup.set()
+        await asyncio.wait_for(asyncio.gather(cleanup_task, reconnect_task), timeout=1)
+
+        assert server.connect_calls == 2
+        assert server.cleanup_calls == 1
+        assert server.active_generation == 2
+        assert manager.active_servers == [server]
+        assert manager._connected_servers == {server}
+    finally:
+        server.allow_cleanup.set()
+        tasks: list[asyncio.Task[Any]] = [cleanup_task]
+        if reconnect_task is not None:
+            tasks.append(reconnect_task)
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await manager.cleanup_all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["connect_all", "reconnect", "cleanup_all"])
+@pytest.mark.parametrize("suppress_cancelled_error", [True, False])
+async def test_manager_applies_cancellation_policy_while_waiting_for_lifecycle_lock(
+    operation: str,
+    suppress_cancelled_error: bool,
+) -> None:
+    server = BlockingCleanupServer()
+    manager = MCPServerManager(
+        [server],
+        connect_in_parallel=True,
+        suppress_cancelled_error=suppress_cancelled_error,
+    )
+    await manager.connect_all()
+
+    lock_owner = asyncio.create_task(manager.cleanup_all())
+    waiter: asyncio.Task[Any] | None = None
+    try:
+        await asyncio.wait_for(server.cleanup_started.wait(), timeout=1)
+        if operation == "connect_all":
+            waiter = asyncio.create_task(manager.connect_all())
+        elif operation == "reconnect":
+            waiter = asyncio.create_task(manager.reconnect(failed_only=False))
+        else:
+            waiter = asyncio.create_task(manager.cleanup_all())
+        await asyncio.sleep(0)
+
+        assert not waiter.done()
+        waiter.cancel()
+        result = await asyncio.wait_for(asyncio.gather(waiter, return_exceptions=True), timeout=1)
+
+        if suppress_cancelled_error:
+            if operation == "cleanup_all":
+                assert result[0] is None
+            else:
+                assert result[0] == [server]
+        else:
+            assert isinstance(result[0], asyncio.CancelledError)
+    finally:
+        server.allow_cleanup.set()
+        tasks: list[asyncio.Task[Any]] = [lock_owner]
+        if waiter is not None:
+            tasks.append(waiter)
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await manager.cleanup_all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suppress_cancelled_error", [True, False])
+async def test_manager_retains_parallel_cleanup_worker_after_caller_cancellation(
+    suppress_cancelled_error: bool,
+) -> None:
+    server = BlockingCleanupServer()
+    manager = MCPServerManager(
+        [server],
+        connect_in_parallel=True,
+        suppress_cancelled_error=suppress_cancelled_error,
+    )
+    await manager.connect_all()
+
+    original_worker = manager._workers[server]
+    cleanup_task = asyncio.create_task(manager.cleanup_all())
+    connect_task: asyncio.Task[list[MCPServer]] | None = None
+    try:
+        await asyncio.wait_for(server.cleanup_started.wait(), timeout=1)
+        cleanup_task.cancel()
+        cleanup_result = await asyncio.wait_for(
+            asyncio.gather(cleanup_task, return_exceptions=True), timeout=1
+        )
+
+        if suppress_cancelled_error:
+            assert cleanup_result[0] is None
+        else:
+            assert isinstance(cleanup_result[0], asyncio.CancelledError)
+        assert manager._workers[server] is original_worker
+        assert not original_worker.is_done
+
+        connect_task = asyncio.create_task(manager.connect_all())
+        await asyncio.sleep(0)
+
+        assert not connect_task.done()
+        assert manager._workers[server] is original_worker
+        assert server.connect_calls == 1
+
+        server.allow_cleanup.set()
+        await asyncio.wait_for(connect_task, timeout=1)
+
+        assert original_worker.is_done
+        assert manager._workers[server] is not original_worker
+        assert manager._connected_servers == {server}
+        assert manager.active_servers == [server]
+        assert manager.failed_servers == []
+        assert manager.errors == {}
+        assert server.connect_calls == 2
+        assert server.cleanup_calls == 1
+        assert server.active_generation == 2
+    finally:
+        server.allow_cleanup.set()
+        tasks: list[asyncio.Task[Any]] = [cleanup_task]
+        if connect_task is not None:
+            tasks.append(connect_task)
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await manager.cleanup_all()
+
+
+@pytest.mark.asyncio
+async def test_manager_discards_parallel_cleanup_worker_after_cancelled_caller() -> None:
+    server = BlockingCleanupServer()
+    manager = MCPServerManager([server], connect_in_parallel=True)
+    await manager.connect_all()
+
+    original_worker = manager._workers[server]
+    cleanup_task = asyncio.create_task(manager.cleanup_all())
+    try:
+        await asyncio.wait_for(server.cleanup_started.wait(), timeout=1)
+        cleanup_task.cancel()
+        cleanup_result = await asyncio.gather(cleanup_task, return_exceptions=True)
+        assert cleanup_result[0] is None
+
+        assert manager._workers[server] is original_worker
+        assert not original_worker.is_done
+
+        server.allow_cleanup.set()
+        await asyncio.wait_for(original_worker.wait_until_stopped(), timeout=1)
+        await asyncio.sleep(0)
+
+        assert manager._workers == {}
+        assert manager._connected_servers == set()
+    finally:
+        server.allow_cleanup.set()
+        await asyncio.gather(cleanup_task, return_exceptions=True)
+        await manager.cleanup_all()
+
+
+@pytest.mark.asyncio
+async def test_manager_preserves_cleanup_failure_after_cancelled_retry() -> None:
+    server = BlockingCleanupFailureServer()
+    manager = MCPServerManager([server], connect_in_parallel=True)
+    await manager.connect_all()
+
+    first_retry = asyncio.create_task(manager.reconnect())
+    second_retry: asyncio.Task[list[MCPServer]] | None = None
+    try:
+        await asyncio.wait_for(server.cleanup_started.wait(), timeout=1)
+        first_retry.cancel()
+        assert await first_retry == []
+
+        second_retry = asyncio.create_task(manager.reconnect())
+        await asyncio.sleep(0)
+        assert not second_retry.done()
+
+        server.allow_cleanup.set()
+        assert await asyncio.wait_for(second_retry, timeout=1) == []
+
+        assert server.connect_calls == 1
+        assert server.cleanup_calls == 1
+        assert manager.active_servers == []
+        assert manager.failed_servers == [server]
+        assert str(manager.errors[server]) == "cleanup failed"
+        worker = manager._workers[server]
+        assert worker.is_done
+        assert str(worker.cleanup_error) == "cleanup failed"
+
+        assert await manager.connect_all() == []
+        assert server.connect_calls == 1
+    finally:
+        server.allow_cleanup.set()
+        tasks: list[asyncio.Task[Any]] = [first_retry]
+        if second_retry is not None:
+            tasks.append(second_retry)
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await manager.cleanup_all()
+
+
+@pytest.mark.asyncio
 async def test_cross_task_cleanup_raises_without_manager() -> None:
     server = TaskBoundServer()
 
@@ -553,7 +826,12 @@ async def test_manager_reconnect_does_not_retry_after_cleanup_failure(
     assert server.cleanup_calls == 1
     assert server.resource_open is True
     assert str(manager.errors[server]) == "cleanup failed"
-    assert manager._workers == {}
+    if connect_in_parallel:
+        worker = manager._workers[server]
+        assert worker.is_done
+        assert str(worker.cleanup_error) == "cleanup failed"
+    else:
+        assert manager._workers == {}
 
 
 @pytest.mark.asyncio
@@ -700,29 +978,36 @@ async def test_manager_strict_connect_parallel_cleans_up_workers() -> None:
 
 
 @pytest.mark.asyncio
-async def test_manager_parallel_cleanup_clears_worker_on_failure() -> None:
+async def test_manager_parallel_cleanup_retains_worker_outcome_on_failure() -> None:
     server = CleanupFailingServer()
     manager = MCPServerManager([server], connect_in_parallel=True)
     await manager.connect_all()
     await manager.cleanup_all()
 
-    assert server not in manager._workers
+    worker = manager._workers[server]
+    assert worker.is_done
+    assert str(worker.cleanup_error) == "cleanup failed"
     assert server not in manager._connected_servers
 
 
 @pytest.mark.asyncio
-async def test_manager_parallel_cleanup_drops_worker_after_error() -> None:
+async def test_manager_parallel_cleanup_retains_worker_after_error() -> None:
     class HangingCleanupWorker:
         def __init__(self) -> None:
             self.cleanup_calls = 0
+            self.error = RuntimeError("cleanup failed")
 
         @property
         def is_done(self) -> bool:
-            return False
+            return self.cleanup_calls > 0
 
-        async def cleanup(self) -> None:
+        @property
+        def cleanup_error(self) -> BaseException | None:
+            return self.error if self.is_done else None
+
+        async def cleanup(self, timeout_seconds: float | None) -> None:
             self.cleanup_calls += 1
-            raise RuntimeError("cleanup failed")
+            raise self.error
 
     server = FlakyServer(failures=0)
     manager = MCPServerManager([server], connect_in_parallel=True)
@@ -730,7 +1015,7 @@ async def test_manager_parallel_cleanup_drops_worker_after_error() -> None:
 
     await manager.cleanup_all()
 
-    assert manager._workers == {}
+    assert manager._workers[server].cleanup_error is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request supersedes #4336 and fixes `MCPServerManager` lifecycle races by serializing public lifecycle operations.

- Keeps task-affine cleanup ownership alive across caller cancellation and applies `suppress_cancelled_error` while waiting for lifecycle ownership.
- Preserves terminal cleanup failures and timeouts so unsafe replacement connections cannot start after cleanup failure.
- Adds deterministic concurrency and cancellation regression coverage.

This pull request resolves #4334.
