### PR TITLE
fix(voice): preserve explicit falsey STT/TTS models in VoicePipeline

### DIFF
--- a/src/agents/voice/pipeline.py
+++ b/src/agents/voice/pipeline.py
@@ -75,12 +75,12 @@ class VoicePipeline:
             raise UserError(f"Unsupported audio input type: {type(audio_input)}")
 
     def _get_tts_model(self) -> TTSModel:
-        if not self.tts_model:
+        if self.tts_model is None:
             self.tts_model = self.config.model_provider.get_tts_model(self._tts_model_name)
         return self.tts_model
 
     def _get_stt_model(self) -> STTModel:
-        if not self.stt_model:
+        if self.stt_model is None:
             self.stt_model = self.config.model_provider.get_stt_model(self._stt_model_name)
         return self.stt_model
 

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -20,6 +20,7 @@ try:
         StreamedAudioResult,
         STTModelSettings,
         TTSModelSettings,
+        VoiceModelProvider,
         VoicePipeline,
         VoicePipelineConfig,
         VoiceStreamEvent,
@@ -1479,3 +1480,93 @@ async def test_voice_workflow_errors_apply_model_and_tool_logging_policies(
             assert error in record.args
             assert record.exc_info is not None
             assert record.exc_info[1] is error
+
+
+class _FalseySTT(FakeSTT):
+    """A concrete STT model whose truth value is False."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
+class _FalseyTTS(FakeTTS):
+    """A concrete TTS model whose truth value is False."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
+class _RaisingModelProvider(VoiceModelProvider):
+    """A provider that records lookups and fails if the pipeline ever falls back to it."""
+
+    def __init__(self) -> None:
+        self.stt_calls = 0
+        self.tts_calls = 0
+
+    def get_stt_model(self, model_name: str | None) -> Any:
+        self.stt_calls += 1
+        raise AssertionError("provider STT lookup should not be reached for an explicit model")
+
+    def get_tts_model(self, model_name: str | None) -> Any:
+        self.tts_calls += 1
+        raise AssertionError("provider TTS lookup should not be reached for an explicit model")
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_preserves_falsey_explicit_models_single_turn() -> None:
+    # An explicit STT/TTS model whose __bool__ is False must still be used instead of the
+    # provider default on the single static-audio turn path.
+    fake_stt = _FalseySTT(["first"])
+    workflow = FakeWorkflow([["out_1"]])
+    fake_tts = _FalseyTTS()
+    provider = _RaisingModelProvider()
+    config = VoicePipelineConfig(
+        model_provider=provider, tts_settings=TTSModelSettings(buffer_size=1)
+    )
+    pipeline = VoicePipeline(
+        workflow=workflow, stt_model=fake_stt, tts_model=fake_tts, config=config
+    )
+    assert pipeline.stt_model is fake_stt
+    assert pipeline.tts_model is fake_tts
+
+    audio_input = AudioInput(buffer=np.zeros(2, dtype=np.int16))
+    result = await pipeline.run(audio_input)
+    events, audio_chunks = await extract_events(result)
+
+    assert events == ["turn_started", "audio", "turn_ended", "session_ended"]
+    await fake_tts.verify_audio("out_1", audio_chunks[0])
+    assert pipeline.stt_model is fake_stt
+    assert pipeline.tts_model is fake_tts
+    assert provider.stt_calls == 0
+    assert provider.tts_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_voicepipeline_preserves_falsey_explicit_models_streamed() -> None:
+    # The streamed multi-turn path reaches the STT getter via create_session; a falsey but
+    # explicit model must still be used instead of the provider default.
+    fake_stt = _FalseySTT(["first", "second"])
+    workflow = FakeWorkflow([["out_1"], ["out_2"]])
+    fake_tts = _FalseyTTS()
+    provider = _RaisingModelProvider()
+    config = VoicePipelineConfig(model_provider=provider)
+    pipeline = VoicePipeline(
+        workflow=workflow, stt_model=fake_stt, tts_model=fake_tts, config=config
+    )
+
+    streamed_audio_input = await FakeStreamedAudioInput.get(count=2)
+    result = await pipeline.run(streamed_audio_input)
+    events, audio_chunks = await extract_events(result)
+
+    assert events == [
+        "turn_started",
+        "audio",
+        "turn_ended",
+        "turn_started",
+        "audio",
+        "turn_ended",
+        "session_ended",
+    ]
+    assert len(audio_chunks) == 2
+    assert provider.stt_calls == 0
+    assert provider.tts_calls == 0


### PR DESCRIPTION
### Summary

`VoicePipeline` accepts concrete `STTModel`/`TTSModel` instances and stores them, but `_get_tts_model()` / `_get_stt_model()` decided whether a model was supplied with a truthiness check (`if not self.<model>`). A valid model subclass whose `__bool__()` returns `False` was therefore treated as *absent* and silently replaced by a provider-default lookup.

The constructor documents the default as used only "if not provided," and only `None` actually means "no concrete model was supplied." Replacing a present-but-falsey model changes observable model identity and can trigger an unexpected credential/network dependency (the provider lookup) that the caller never intended.

The fix checks `self.<model> is None` instead. String model-name resolution and the `None`-default path are unchanged; the constructor's accepted types are untouched. Both the single-turn (`AudioInput`) and streamed (`StreamedAudioInput`) paths share these getters and are covered.

This is the same optional-reference-vs-truthiness class that the repo has already treated as a bug elsewhere (e.g. #4286 for realtime models, and the #4305 sweep). The `check_optional_truthiness.py` lint added in #4305 does not flag these getters because `stt_model`/`tts_model` are typed `Model | str | None`; the extra `str` union member puts them outside the checker's single-payload optional-reference heuristic, so this instance was missed.

### Test plan

Added two regression tests in `tests/voice/test_pipeline.py` that inject concrete `STTModel`/`TTSModel` subclasses whose `__bool__` returns `False`, backed by a `VoiceModelProvider` whose lookups raise. They assert the explicit models are used and provider lookup is never reached, on both the single static-turn and streamed multi-turn paths. Both tests fail on `main` (provider lookup is invoked) and pass with this change.

Ran the repository verification script `.agents/skills/code-change-verification/scripts/run.sh`: `make format`, `make lint`, `make typecheck` (mypy + pyright), and `make tests` (full suite) all pass. `tests/voice` passes (121 tests), and `check_optional_truthiness.py src/agents` is clean.

### Issue number

N/A — found by inspection; no existing issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
