### PR TITLE
fix(voice): report transcription session close failures to the consumer

### DIFF
--- a/src/agents/voice/pipeline.py
+++ b/src/agents/voice/pipeline.py
@@ -134,6 +134,7 @@ class VoicePipeline:
                 disabled=self.config.tracing_disabled,
             ):
                 transcription_session = None
+                reported_error = False
                 try:
                     try:
                         emitted_intro = False
@@ -170,10 +171,22 @@ class VoicePipeline:
                         # would see only the cleanup error.
                         log_model_and_tool_action_error(logger, "Error processing voice turns", e)
                         await output._add_error(e)
+                        reported_error = True
                         raise
                 finally:
                     if transcription_session is not None:
-                        await transcription_session.close()
+                        try:
+                            await transcription_session.close()
+                        except Exception as e:
+                            log_model_and_tool_action_error(
+                                logger, "Error closing voice transcription session", e
+                            )
+                            # Report only if nothing else has, which keeps the turn error's
+                            # precedence. Clean runs and cancelled producers both arrive here
+                            # with no terminal event queued and no other way to be released.
+                            if not reported_error:
+                                await output._add_error(e)
+                            raise
 
                 # Only a clean run reaches here. The error path above has already queued its
                 # terminal event, and a cancelled producer has no consumer left to serve, so

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1099,6 +1099,36 @@ async def test_voicepipeline_failing_close_does_not_replace_the_turn_error() -> 
 
 
 @pytest.mark.asyncio
+async def test_voicepipeline_failing_close_after_a_clean_run_reaches_the_consumer() -> None:
+    # A clean run has no error to report, so a failing close is the only thing left that can
+    # release the consumer. Unreported, the result stream waits on a terminal event forever.
+
+    close_error = RuntimeError("close blew up")
+
+    class FailingCloseSession(FakeSession):
+        async def close(self) -> None:
+            raise close_error
+
+    class FailingCloseSTT(FakeSTT):
+        async def create_session(self, *args: Any, **kwargs: Any) -> FailingCloseSession:
+            session = FailingCloseSession()
+            session.outputs = self.outputs
+            return session
+
+    pipeline = VoicePipeline(
+        workflow=FakeWorkflow([["hello"]]),
+        stt_model=FailingCloseSTT(["hello"]),
+        tts_model=FakeTTS(),
+    )
+    result = await pipeline.run(await FakeStreamedAudioInput.get(count=1))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await asyncio.wait_for(extract_events(result), timeout=5)
+
+    assert exc_info.value is close_error
+
+
+@pytest.mark.asyncio
 async def test_voicepipeline_cancelled_consumer_closes_the_session_without_further_tts() -> None:
     # Cancelling the consumer tears down the producer. The transcription session still has to be
     # closed, and the turn the producer had open must not be sent to TTS on the way out.


### PR DESCRIPTION
### Summary

#4259 pinned one half of this behavior: if a turn fails and `transcription_session.close()` also fails, the consumer must still see the original turn error rather than the cleanup error.

This PR covers the other half. When the turn succeeds but `close()` fails, no terminal event has been queued. `process_turns` reports turn failures through `_add_error`, but `close()` runs later in `finally`, outside that error path. `StreamedAudioResult.stream()` then waits on `self._queue.get()` forever: produced output is delivered, but the consumer never receives an error or `session_ended`.

`close()` is an abstract method on `StreamedTranscriptionSession`, so any transcription session implementation can fail here. The built-in `OpenAISTTTranscriptionSession` follows a different path: `transcribe_turns()` already closes itself in its own `finally`, so its close failures surface through the generator into the turn handler, which is the behavior pinned by #4259.

A close failure is now logged and reported through the same `_add_error` path the turn handler uses, guarded so it cannot replace an error the run already reported. The existing regression continues to pin that precedence.

Deliberately out of scope:

- A `close()` raising a non-`Exception` `BaseException` is not caught by this handler. Handling that would require a separate decision around the public `VoiceStreamEventError.error: Exception` contract and cancellation semantics.
- A producer that exits with a `BaseException`, including `CancelledError`, is not caught here either. Addressing those paths requires a separate decision about where the terminal-event guarantee should live and how producer-side cancellation should surface.

### Test plan

A new regression next to the existing close-failure test fails on `main` by timing out: a clean run whose `close()` raises must surface that error through `stream()` instead of hanging. The existing test continues to verify that a turn error wins over a later cleanup failure.

`.agents/skills/code-change-verification/scripts/run.sh` passes.

### Issue number

N/A. Found while auditing the voice producer lifecycle against `.agents/references/voice-pipeline-lifecycle.md`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR