### PR TITLE
fix: preserve sandbox error contracts during mount redaction

### DIFF
--- a/src/agents/exceptions.py
+++ b/src/agents/exceptions.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+import asyncio
+import builtins
+import sys
 import traceback
+import types
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn, cast
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+else:
+    BaseExceptionGroup = builtins.BaseExceptionGroup
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -22,6 +31,8 @@ from .util._pretty_print import pretty_print_run_error_details
 _DRAIN_STREAM_EVENTS_ATTR = "_agents_drain_queued_stream_events"
 _DATA_REDACTED_ATTR = "_agents_data_redacted"
 _DATA_REDACTED_ERROR_MESSAGE = "Error details are redacted."
+_TYPE_NAMESPACE_DESCRIPTOR = cast(Any, type).__dict__["__dict__"]
+_TYPE_MRO_DESCRIPTOR = cast(Any, type).__dict__["__mro__"]
 
 
 def _mark_error_to_drain_stream_events(error: BaseException) -> None:
@@ -36,20 +47,277 @@ def _mark_error_data_redacted(error: BaseException) -> None:
     setattr(error, _DATA_REDACTED_ATTR, True)
 
 
+def _base_exception_instance_dict(error: BaseException) -> dict[object, object] | None:
+    """Return built-in exception state without invoking subclass attribute descriptors."""
+    try:
+        reduced = BaseException.__reduce__(error)
+    except BaseException:
+        return None
+    if type(reduced) is not tuple or len(reduced) < 3:
+        return None
+    state = reduced[2]
+    return state if type(state) is dict else None
+
+
+def _static_type_metadata(
+    value: type,
+) -> tuple[types.MappingProxyType[str, object], tuple[type, ...]] | None:
+    """Return built-in type metadata without invoking metaclass descriptors."""
+    try:
+        namespace = _TYPE_NAMESPACE_DESCRIPTOR.__get__(value, type(value))
+        mro = _TYPE_MRO_DESCRIPTOR.__get__(value, type(value))
+    except BaseException:
+        return None
+    if type(namespace) is not types.MappingProxyType or type(mro) is not tuple:
+        return None
+    return cast(types.MappingProxyType[str, object], namespace), cast(tuple[type, ...], mro)
+
+
+def _object_instance_dict(
+    value: object,
+    *,
+    trusted_base: type,
+) -> dict[object, object] | None:
+    """Return instance state through a descriptor owned by a trusted base type."""
+    value_metadata = _static_type_metadata(type(value))
+    trusted_metadata = _static_type_metadata(trusted_base)
+    if value_metadata is None or trusted_metadata is None:
+        return None
+    _, value_mro = value_metadata
+    if not any(base is trusted_base for base in value_mro):
+        return None
+
+    _, trusted_mro = trusted_metadata
+    for base in trusted_mro:
+        base_metadata = _static_type_metadata(base)
+        if base_metadata is None:
+            continue
+        namespace, _ = base_metadata
+        for name, descriptor in namespace.items():
+            if (
+                type(name) is str
+                and str.__eq__(name, "__dict__") is True
+                and type(descriptor) is types.GetSetDescriptorType
+            ):
+                try:
+                    state = descriptor.__get__(value, type(value))
+                except BaseException:
+                    return None
+                return state if type(state) is dict else None
+    return None
+
+
+def _exact_string_state_entry(
+    state: dict[object, object],
+    name: str,
+) -> tuple[bool, object | None]:
+    """Read an exact string key without hashing or comparing provider keys."""
+    for candidate, value in dict.items(state):
+        if type(candidate) is str and str.__eq__(candidate, name) is True:
+            return True, value
+    return False, None
+
+
+def _exact_string_state_value(
+    state: dict[object, object],
+    name: str,
+) -> object | None:
+    """Read an exact string key, returning `None` for a missing key."""
+    return _exact_string_state_entry(state, name)[1]
+
+
 def _is_error_data_redacted(error: BaseException) -> bool:
-    return bool(getattr(error, _DATA_REDACTED_ATTR, False))
+    state = _base_exception_instance_dict(error)
+    return state is not None and _exact_string_state_value(state, _DATA_REDACTED_ATTR) is True
 
 
 def _clear_data_redacted_error_traceback(error: BaseException) -> None:
-    if _is_error_data_redacted(error) and error.__traceback__ is not None:
-        traceback.clear_frames(error.__traceback__)
+    if not _is_error_data_redacted(error):
+        return
+    descriptor = cast(Any, BaseException.__traceback__)
+    source_traceback = descriptor.__get__(error, type(error))
+    if source_traceback is not None:
+        traceback.clear_frames(source_traceback)
 
 
 def _detach_data_redacted_error_traceback(error: BaseException) -> None:
     if _is_error_data_redacted(error):
-        error.__traceback__ = None
-        error.__cause__ = None
-        error.__context__ = None
+        for descriptor in (
+            cast(Any, BaseException.__traceback__),
+            cast(Any, BaseException.__cause__),
+            cast(Any, BaseException.__context__),
+        ):
+            descriptor.__set__(error, None)
+
+
+def _replace_data_redacted_process_control_error(
+    error: BaseException,
+) -> BaseException | None:
+    """Discard a process-control source and return a fresh value-free replacement."""
+    error_type = type(error)
+    if issubclass(error_type, asyncio.CancelledError):
+        safe_error: BaseException | None = asyncio.CancelledError()
+    elif issubclass(error_type, GeneratorExit):
+        safe_error = GeneratorExit()
+    elif issubclass(error_type, KeyboardInterrupt):
+        safe_error = KeyboardInterrupt()
+    elif not issubclass(error_type, SystemExit):
+        return None
+    else:
+        try:
+            code_descriptor = type.__getattribute__(SystemExit, "__dict__")["code"]
+            code = cast(Any, code_descriptor).__get__(error, error_type)
+        except BaseException:
+            safe_error = SystemExit(1)
+        else:
+            if code is None:
+                safe_error = SystemExit()
+            elif type(code) is int:
+                safe_error = SystemExit(code)
+            else:
+                safe_error = SystemExit(1)
+
+    assert safe_error is not None
+    _discard_exception_graph(error)
+    _mark_error_data_redacted(safe_error)
+    return safe_error
+
+
+def _collect_nested_exceptions(value: object, linked: list[BaseException]) -> None:
+    """Collect exceptions reachable through exact built-in containers without callbacks."""
+    pending = [value]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if issubclass(type(current), BaseException):
+            linked.append(cast(BaseException, current))
+        elif type(current) is dict:
+            for key, item in dict.items(current):
+                pending.extend((key, item))
+        elif (
+            type(current) is list
+            or type(current) is tuple
+            or type(current) is set
+            or type(current) is frozenset
+        ):
+            pending.extend(current)
+
+
+def _discard_exception_graph(error: BaseException) -> None:
+    """Best-effort clear discoverable state from an exception and its linked graph.
+
+    Exact built-in descriptors avoid provider-controlled attribute, descriptor, and
+    metaclass callbacks. Read-only storage such as an exception group's message
+    cannot be changed in place, so public boundaries must return a fresh error that
+    does not retain the source exception.
+    """
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+
+        linked: list[BaseException] = []
+        group_exceptions: tuple[BaseException, ...] | None = None
+        current_type = type(current)
+        if issubclass(current_type, BaseExceptionGroup):
+            try:
+                if sys.version_info < (3, 11):
+                    group_state = _base_exception_instance_dict(current)
+                    raw_group_exceptions = (
+                        _exact_string_state_value(group_state, "_exceptions")
+                        if group_state is not None
+                        else None
+                    )
+                else:
+                    group_descriptor = type.__getattribute__(BaseExceptionGroup, "__dict__")[
+                        "exceptions"
+                    ]
+                    raw_group_exceptions = group_descriptor.__get__(current, current_type)
+                if type(raw_group_exceptions) is tuple:
+                    group_exceptions = tuple(
+                        cast(BaseException, candidate)
+                        for candidate in raw_group_exceptions
+                        if issubclass(type(candidate), BaseException)
+                    )
+                else:
+                    group_exceptions = ()
+                linked.extend(group_exceptions)
+            except BaseException:
+                pass
+        for descriptor in (
+            cast(Any, BaseException.__cause__),
+            cast(Any, BaseException.__context__),
+        ):
+            try:
+                candidate = descriptor.__get__(current, current_type)
+            except BaseException:
+                continue
+            if issubclass(type(candidate), BaseException):
+                linked.append(cast(BaseException, candidate))
+
+        try:
+            args = cast(Any, BaseException.args).__get__(current, current_type)
+            _collect_nested_exceptions(args, linked)
+        except BaseException:
+            pass
+
+        try:
+            source_traceback = cast(Any, BaseException.__traceback__).__get__(current, current_type)
+        except BaseException:
+            source_traceback = None
+        if source_traceback is not None:
+            try:
+                traceback.clear_frames(source_traceback)
+            except BaseException:
+                pass
+
+        state = _base_exception_instance_dict(current)
+        if state is not None:
+            _collect_nested_exceptions(state, linked)
+            state.clear()
+
+        current_metadata = _static_type_metadata(current_type)
+        if current_metadata is not None:
+            _, current_mro = current_metadata
+            for base in current_mro:
+                base_metadata = _static_type_metadata(base)
+                if base_metadata is None:
+                    continue
+                namespace, _ = base_metadata
+                for descriptor in namespace.values():
+                    if type(descriptor) is not types.MemberDescriptorType:
+                        continue
+                    try:
+                        value = descriptor.__get__(current, current_type)
+                        _collect_nested_exceptions(value, linked)
+                    except BaseException:
+                        pass
+                    try:
+                        descriptor.__delete__(current)
+                    except BaseException:
+                        pass
+
+        if group_exceptions is None:
+            safe_args: tuple[object, ...] = ()
+        else:
+            safe_args = (_DATA_REDACTED_ERROR_MESSAGE, group_exceptions)
+        for descriptor, value in (
+            (cast(Any, BaseException.args), safe_args),
+            (cast(Any, BaseException.__traceback__), None),
+            (cast(Any, BaseException.__cause__), None),
+            (cast(Any, BaseException.__context__), None),
+        ):
+            try:
+                descriptor.__set__(current, value)
+            except BaseException:
+                pass
+        pending.extend(linked)
 
 
 def _raise_data_redacted_error(error: BaseException) -> NoReturn:

--- a/src/agents/sandbox/_mount_security.py
+++ b/src/agents/sandbox/_mount_security.py
@@ -1,24 +1,30 @@
 from __future__ import annotations
 
-import asyncio
 import copy
 import dataclasses
 import importlib
 import re
-import traceback
+import sys
+import types
 from collections.abc import Callable, Collection, Coroutine, Iterable, Mapping
 from functools import wraps
 from pathlib import PurePath, PurePosixPath
-from typing import TYPE_CHECKING, Any, NoReturn, ParamSpec, TypeVar, cast
+from typing import TYPE_CHECKING, Any, NoReturn, ParamSpec, TypeVar, cast, get_args
 from urllib.parse import urlsplit
 
 from ..exceptions import (
-    _clear_data_redacted_error_traceback,
-    _detach_data_redacted_error_traceback,
+    _base_exception_instance_dict,
+    _discard_exception_graph,
+    _exact_string_state_entry,
+    _exact_string_state_value,
     _is_error_data_redacted,
     _mark_error_data_redacted,
+    _object_instance_dict,
     _raise_data_redacted_error,
+    _replace_data_redacted_process_control_error,
+    _static_type_metadata,
 )
+from . import errors as _sandbox_errors
 from .entries import (
     AzureBlobMount,
     BaseEntry,
@@ -40,7 +46,7 @@ from .entries.mounts.patterns import (
     RcloneMountPattern,
     S3FilesMountPattern,
 )
-from .errors import MountConfigError
+from .errors import ErrorCode, MountConfigError, OpName, SandboxError
 
 if TYPE_CHECKING:
     from .manifest import Manifest
@@ -404,6 +410,71 @@ _IN_CONTAINER_MOUNT_CREDENTIAL_CAPABILITIES: tuple[_InContainerMountCredentialCa
 _RCLONE_SAFE_FLAG_ARGS = frozenset({"allow-other"})
 _RCLONE_SAFE_VALUE_ARGS = frozenset({"buffer-size", "gid", "uid"})
 _SAFE_MOUNT_VALIDATION_MESSAGE_ATTR = "_agents_safe_mount_validation_message"
+_SAFE_MOUNT_VALIDATION_MESSAGE_MARKER = object()
+_SANDBOX_ERROR_OPS = frozenset(get_args(OpName))
+_STRUCTURED_SANDBOX_ERROR_SAFE_SUBTYPE_STATE: tuple[
+    tuple[type[SandboxError], tuple[tuple[str, object], ...]], ...
+] = (
+    (_sandbox_errors.SandboxError, ()),
+    (_sandbox_errors.ConfigurationError, ()),
+    (_sandbox_errors.SandboxRuntimeError, ()),
+    (_sandbox_errors.ArtifactError, ()),
+    (_sandbox_errors.SnapshotError, ()),
+    (_sandbox_errors.ApplyPatchError, ()),
+    (_sandbox_errors.InvalidManifestPathError, ()),
+    (_sandbox_errors.InvalidCompressionSchemeError, ()),
+    (_sandbox_errors.ExposedPortUnavailableError, ()),
+    (_sandbox_errors.ExecFailureError, (("command", ()),)),
+    (
+        _sandbox_errors.ExecNonZeroError,
+        (("command", ()), ("exit_code", 1), ("stdout", b""), ("stderr", b"")),
+    ),
+    (_sandbox_errors.ExecTimeoutError, (("command", ()), ("timeout_s", None))),
+    (_sandbox_errors.ExecTransportError, (("command", ()),)),
+    (_sandbox_errors.PtySessionNotFoundError, (("session_id", -1),)),
+    (_sandbox_errors.WorkspaceIOError, ()),
+    (_sandbox_errors.ApplyPatchPathError, ()),
+    (_sandbox_errors.ApplyPatchDiffError, ()),
+    (_sandbox_errors.ApplyPatchFileNotFoundError, ()),
+    (_sandbox_errors.ApplyPatchDecodeError, ()),
+    (_sandbox_errors.WorkspaceReadNotFoundError, ()),
+    (_sandbox_errors.WorkspaceArchiveReadError, ()),
+    (_sandbox_errors.WorkspaceArchiveWriteError, ()),
+    (_sandbox_errors.WorkspaceWriteTypeError, ()),
+    (_sandbox_errors.WorkspaceStopError, ()),
+    (_sandbox_errors.WorkspaceStartError, ()),
+    (_sandbox_errors.WorkspaceRootNotFoundError, ()),
+    (_sandbox_errors.LocalArtifactError, ()),
+    (_sandbox_errors.LocalFileReadError, ()),
+    (_sandbox_errors.LocalDirReadError, ()),
+    (_sandbox_errors.LocalChecksumError, ()),
+    (_sandbox_errors.GitArtifactError, ()),
+    (_sandbox_errors.GitMissingInImageError, ()),
+    (_sandbox_errors.GitCloneError, ()),
+    (_sandbox_errors.GitSubpathError, ()),
+    (_sandbox_errors.GitCopyError, ()),
+    (_sandbox_errors.MountArtifactError, ()),
+    (_sandbox_errors.MountToolMissingError, ()),
+    (_sandbox_errors.MountCommandError, ()),
+    (_sandbox_errors.SkillsConfigError, ()),
+    (_sandbox_errors.SnapshotPersistError, ()),
+    (_sandbox_errors.SnapshotRestoreError, ()),
+    (_sandbox_errors.SnapshotNotRestorableError, ()),
+)
+_CALL_AUTHORITY_REQUIRED_STATE_KEYS = (
+    "state",
+    "manifest",
+    "default_manifest",
+    "_sandbox_config",
+    "session_state",
+    "_trusted_manifest",
+)
+_CALL_AUTHORITY_LINK_STATE_KEYS = (
+    "session",
+    "_session",
+    "_client",
+    "_inner",
+)
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
@@ -416,37 +487,26 @@ class _InvalidRawMountManifestError(ValueError):
 def redact_mount_error_data(
     function: Callable[_P, Coroutine[Any, Any, _T]],
 ) -> Callable[_P, Coroutine[Any, Any, _T]]:
-    """Replace marked validation failures after clearing payload-bearing async frames."""
+    """Replace failures after clearing async frames that handled mount authority."""
 
     @wraps(function)
     async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-        call_has_authority = _call_has_configured_mount_authority(args, kwargs)
-        safe_error: Exception | None = None
-        safe_cancel: asyncio.CancelledError | None = None
+        call_has_authority = _call_has_configured_mount_authority(
+            args,
+            kwargs,
+            function=function,
+        )
+        safe_error: BaseException | None = None
         try:
             return await function(*args, **kwargs)
-        except asyncio.CancelledError as error:
-            if not call_has_authority:
-                raise
-            discard_mount_source_exception(error)
-            safe_cancel = asyncio.CancelledError()
-        except Exception as error:
-            if isinstance(error, MountConfigError) and _is_error_data_redacted(error):
-                safe_error = _replace_mount_error(error)
-            elif _is_error_data_redacted(error):
-                _clear_data_redacted_error_traceback(error)
-                _detach_data_redacted_error_traceback(error)
-                error.__cause__ = None
-                error.__context__ = None
-                safe_error = error
-            elif call_has_authority:
-                safe_error = _replace_mount_operation_error(error)
+        except BaseException as error:
+            error_is_redacted = _is_error_data_redacted(error)
+            if call_has_authority or error_is_redacted:
+                safe_error = _replace_protected_mount_error(error)
             else:
                 raise
 
-        del args, kwargs, call_has_authority
-        if safe_cancel is not None:
-            raise safe_cancel from None
+        del args, kwargs, call_has_authority, error_is_redacted
         assert safe_error is not None
         _raise_data_redacted_error(safe_error)
 
@@ -458,33 +518,30 @@ def _redact_mount_error_data_sync(
     *,
     preserve_value_error_type: bool,
 ) -> Callable[_P, _T]:
-    """Replace validation failures after clearing payload-bearing sync frames."""
+    """Replace failures after clearing sync frames that handled mount authority."""
 
     @wraps(function)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-        call_has_authority = _call_has_configured_mount_authority(args, kwargs)
-        safe_error: Exception | None = None
+        call_has_authority = _call_has_configured_mount_authority(
+            args,
+            kwargs,
+            function=function,
+        )
+        safe_error: BaseException | None = None
         try:
             return function(*args, **kwargs)
-        except Exception as error:
-            if isinstance(error, MountConfigError) and _is_error_data_redacted(error):
-                safe_error = _replace_mount_error(error)
-            elif _is_error_data_redacted(error):
-                _clear_data_redacted_error_traceback(error)
-                _detach_data_redacted_error_traceback(error)
-                error.__cause__ = None
-                error.__context__ = None
-                safe_error = error
-            elif preserve_value_error_type and call_has_authority and isinstance(error, ValueError):
+        except BaseException as error:
+            error_is_redacted = _is_error_data_redacted(error)
+            if preserve_value_error_type and call_has_authority and isinstance(error, ValueError):
                 discard_mount_source_exception(error)
                 safe_error = ValueError("sandbox mount validation failed")
                 _mark_error_data_redacted(safe_error)
-            elif call_has_authority:
-                safe_error = _replace_mount_operation_error(error)
+            elif call_has_authority or error_is_redacted:
+                safe_error = _replace_protected_mount_error(error)
             else:
                 raise
 
-        del args, kwargs, call_has_authority
+        del args, kwargs, call_has_authority, error_is_redacted
         assert safe_error is not None
         _raise_data_redacted_error(safe_error)
 
@@ -492,7 +549,7 @@ def _redact_mount_error_data_sync(
 
 
 def redact_mount_error_data_sync(function: Callable[_P, _T]) -> Callable[_P, _T]:
-    """Replace marked validation failures after clearing payload-bearing sync frames."""
+    """Replace failures after clearing sync frames that handled mount authority."""
 
     return _redact_mount_error_data_sync(function, preserve_value_error_type=False)
 
@@ -505,24 +562,95 @@ def redact_mount_validation_error_data_sync(
     return _redact_mount_error_data_sync(function, preserve_value_error_type=True)
 
 
-def _replace_mount_error(error: MountConfigError) -> MountConfigError:
-    message = (
-        error.message
-        if getattr(error, _SAFE_MOUNT_VALIDATION_MESSAGE_ATTR, False)
-        else "sandbox mount configuration is invalid"
-    )
+def _replace_mount_error(
+    error: MountConfigError,
+    *,
+    state: dict[object, object],
+    error_code: ErrorCode,
+    op: OpName,
+    retryable: bool | None,
+) -> MountConfigError:
+    message = "sandbox mount configuration is invalid"
+    if (
+        state is not None
+        and _exact_string_state_value(state, _SAFE_MOUNT_VALIDATION_MESSAGE_ATTR)
+        is _SAFE_MOUNT_VALIDATION_MESSAGE_MARKER
+        and type(_exact_string_state_value(state, "message")) is str
+    ):
+        message = cast(str, _exact_string_state_value(state, "message"))
+    discard_mount_source_exception(error)
     safe_error = MountConfigError(message=message)
+    safe_error.error_code = error_code
+    safe_error.op = op
+    safe_error.retryable = retryable
     _mark_error_data_redacted(safe_error)
-    _clear_data_redacted_error_traceback(error)
-    _detach_data_redacted_error_traceback(error)
-    error.__cause__ = None
-    error.__context__ = None
-    error.args = ("Error details are redacted.",)
-    error.context = {}
     return safe_error
 
 
-def _replace_mount_operation_error(error: Exception) -> RuntimeError:
+def _replace_protected_mount_error(error: BaseException) -> BaseException:
+    process_control_error = _replace_data_redacted_process_control_error(error)
+    if process_control_error is not None:
+        return process_control_error
+    structured_error = _replace_structured_sandbox_error(error)
+    if structured_error is not None:
+        return structured_error
+    return _replace_mount_operation_error(error)
+
+
+def _replace_structured_sandbox_error(error: BaseException) -> SandboxError | None:
+    error_type = type(error)
+    state = _base_exception_instance_dict(error)
+    if state is None:
+        return None
+    error_code = _exact_string_state_value(state, "error_code")
+    op = _exact_string_state_value(state, "op")
+    retryable_found, retryable = _exact_string_state_entry(state, "retryable")
+    if (
+        type(error_code) is not ErrorCode
+        or type(op) is not str
+        or op not in _SANDBOX_ERROR_OPS
+        or not retryable_found
+        or (retryable is not None and type(retryable) is not bool)
+    ):
+        return None
+
+    if error_type is MountConfigError:
+        return _replace_mount_error(
+            cast(MountConfigError, error),
+            state=state,
+            error_code=error_code,
+            op=cast(OpName, op),
+            retryable=retryable,
+        )
+
+    safe_subtype_state = next(
+        (
+            fields
+            for candidate, fields in _STRUCTURED_SANDBOX_ERROR_SAFE_SUBTYPE_STATE
+            if error_type is candidate
+        ),
+        None,
+    )
+    if safe_subtype_state is None:
+        return None
+
+    discard_mount_source_exception(error)
+    safe_error = cast(SandboxError, BaseException.__new__(error_type))
+    message = "sandbox operation failed while using a protected mount configuration"
+    object.__setattr__(safe_error, "message", message)
+    object.__setattr__(safe_error, "error_code", error_code)
+    object.__setattr__(safe_error, "op", cast(OpName, op))
+    object.__setattr__(safe_error, "context", {})
+    object.__setattr__(safe_error, "cause", None)
+    object.__setattr__(safe_error, "retryable", retryable)
+    for field_name, field_value in safe_subtype_state:
+        object.__setattr__(safe_error, field_name, field_value)
+    BaseException.__init__(safe_error, message)
+    _mark_error_data_redacted(safe_error)
+    return safe_error
+
+
+def _replace_mount_operation_error(error: BaseException) -> RuntimeError:
     discard_mount_source_exception(error)
     safe_error = RuntimeError(
         "sandbox operation failed while using a protected mount configuration"
@@ -533,53 +661,7 @@ def _replace_mount_operation_error(error: Exception) -> RuntimeError:
 
 def discard_mount_source_exception(error: BaseException) -> None:
     """Clear source frames without consulting provider-defined exception attributes."""
-
-    pending = [error]
-    seen: set[int] = set()
-    while pending:
-        current = pending.pop()
-        if id(current) in seen:
-            continue
-        seen.add(id(current))
-
-        linked: list[BaseException] = []
-        for descriptor in (
-            cast(Any, BaseException.__cause__),
-            cast(Any, BaseException.__context__),
-        ):
-            try:
-                candidate = descriptor.__get__(current, type(current))
-            except BaseException:
-                continue
-            if isinstance(candidate, BaseException):
-                linked.append(candidate)
-
-        try:
-            source_traceback = cast(Any, BaseException.__traceback__).__get__(
-                current, type(current)
-            )
-        except BaseException:
-            source_traceback = None
-        if source_traceback is not None:
-            try:
-                traceback.clear_frames(source_traceback)
-            except BaseException:
-                pass
-        try:
-            BaseException.__init__(current)
-        except BaseException:
-            pass
-        for descriptor, value in (
-            (cast(Any, BaseException.args), ()),
-            (cast(Any, BaseException.__traceback__), None),
-            (cast(Any, BaseException.__cause__), None),
-            (cast(Any, BaseException.__context__), None),
-        ):
-            try:
-                descriptor.__set__(current, value)
-            except BaseException:
-                pass
-        pending.extend(linked)
+    _discard_exception_graph(error)
 
 
 def _url_contains_inline_authority(value: object) -> bool:
@@ -921,10 +1003,16 @@ def _manifest_has_configured_mount_authority(manifest: Manifest) -> bool:
     pending = list(manifest.entries.values())
     while pending:
         entry = pending.pop()
-        if isinstance(entry, Mount) and _mount_has_or_may_hide_configured_authority(entry):
+        entry_metadata = _static_type_metadata(type(entry))
+        entry_mro = () if entry_metadata is None else entry_metadata[1]
+        if any(base is Mount for base in entry_mro) and _mount_has_or_may_hide_configured_authority(
+            cast(Mount, entry)
+        ):
             return True
-        if isinstance(entry, Dir):
+        if type(entry) is Dir:
             pending.extend(entry.children.values())
+        elif any(base is Dir for base in entry_mro):
+            return True
     return False
 
 
@@ -946,65 +1034,224 @@ def _mount_has_or_may_hide_configured_authority(mount: Mount) -> bool:
     return bool(_configured_mount_authority_fields(mount))
 
 
+def _decorated_owner_type(function: Callable[..., object]) -> type | None:
+    """Resolve the SDK class that owns a decorated function without importing modules."""
+
+    if type(function) is not types.FunctionType:
+        return None
+    module_name = function.__module__
+    qualname = function.__qualname__
+    if (
+        type(module_name) is not str
+        or not module_name.startswith("agents.")
+        or type(qualname) is not str
+        or qualname.count(".") != 1
+    ):
+        return None
+    owner_name, _ = qualname.split(".", 1)
+    module = sys.modules.get(module_name)
+    if type(module) is not types.ModuleType:
+        return None
+    module_dict_descriptor = cast(Any, types.ModuleType).__dict__["__dict__"]
+    module_state = module_dict_descriptor.__get__(module, types.ModuleType)
+    if type(module_state) is not dict:
+        return None
+    candidate = _exact_string_state_value(module_state, owner_name)
+    if not isinstance(candidate, type) or _static_type_metadata(candidate) is None:
+        return None
+    return candidate
+
+
+def _trusted_authority_owner_base(
+    value: object,
+    *,
+    decorated_owner_type: type | None,
+) -> type | None:
+    """Return a canonical SDK base whose instance-state descriptor is trusted."""
+
+    from ..run_config import SandboxRunConfig
+    from .sandbox_agent import SandboxAgent
+    from .session.base_sandbox_session import BaseSandboxSession
+    from .session.sandbox_client import BaseSandboxClient
+    from .session.sandbox_session_state import SandboxSessionState
+
+    metadata = _static_type_metadata(type(value))
+    if metadata is None:
+        return None
+    _, value_mro = metadata
+    candidates = (
+        decorated_owner_type,
+        BaseSandboxSession,
+        BaseSandboxClient,
+        SandboxSessionState,
+        SandboxRunConfig,
+        SandboxAgent,
+        MountStrategyBase,
+    )
+    for candidate in candidates:
+        if candidate is not None and any(base is candidate for base in value_mro):
+            return candidate
+    return None
+
+
+def _exact_slot_state_entry(
+    value: object,
+    *,
+    trusted_base: type,
+    name: str,
+) -> tuple[bool, bool, object | None]:
+    """Read one exact Python slot without invoking provider attribute hooks.
+
+    The first boolean reports whether the named state is declared by the
+    inspected hierarchy. The second reports whether that declaration is an
+    exact Python slot. A non-slot declaration is returned as the third value
+    for identity comparison only. A declared but unreadable slot is unresolved
+    and returns ``(True, True, None)`` so callers can fail closed.
+    """
+
+    value_metadata = _static_type_metadata(type(value))
+    if value_metadata is None:
+        return False, False, None
+    _, value_mro = value_metadata
+    if not any(base is trusted_base for base in value_mro):
+        return False, False, None
+
+    for base in value_mro:
+        base_metadata = _static_type_metadata(base)
+        if base_metadata is None:
+            return False, False, None
+        namespace, _ = base_metadata
+        for candidate, descriptor in namespace.items():
+            if type(candidate) is not str or str.__eq__(candidate, name) is not True:
+                continue
+            if type(descriptor) is not types.MemberDescriptorType:
+                return True, False, descriptor
+            try:
+                slot_value = descriptor.__get__(value, type(value))
+            except BaseException:
+                return True, True, None
+            return True, True, slot_value
+        if base is trusted_base:
+            break
+    return False, False, None
+
+
 def _call_has_configured_mount_authority(
-    args: tuple[object, ...], kwargs: Mapping[str, object]
+    args: tuple[object, ...],
+    kwargs: Mapping[str, object],
+    *,
+    function: Callable[..., object],
 ) -> bool:
-    """Inspect only SDK call-boundary manifest owners."""
+    """Inspect SDK-owned call-boundary state for protected authority."""
 
     from .manifest import Manifest
+    from .session.base_sandbox_session import BaseSandboxSession
+    from .session.sandbox_session import SandboxSession
 
     try:
-        for value in (*args, *kwargs.values()):
-            candidates = [value]
-            state = getattr(value, "state", None)
-            if state is not None:
-                candidates.append(state)
-            default_manifest = getattr(value, "default_manifest", None)
-            if default_manifest is not None:
-                candidates.append(default_manifest)
-            sandbox_config = getattr(value, "_sandbox_config", None)
-            if sandbox_config is not None:
-                candidates.append(sandbox_config)
-                configured_state = getattr(sandbox_config, "session_state", None)
-                if configured_state is not None:
-                    candidates.append(configured_state)
-                configured_session = getattr(sandbox_config, "session", None)
-                if configured_session is not None:
-                    candidates.append(configured_session)
-                    configured_session_state = getattr(configured_session, "state", None)
-                    if configured_session_state is not None:
-                        candidates.append(configured_session_state)
-            for candidate in candidates:
-                has_runtime_authority = getattr(
-                    candidate,
-                    "_runtime_has_protected_mount_authority",
-                    None,
-                )
-                if (
-                    not isinstance(candidate, type)
-                    and callable(has_runtime_authority)
-                    and has_runtime_authority()
-                ):
+        sandbox_session_metadata = _static_type_metadata(SandboxSession)
+        if sandbox_session_metadata is None:
+            return True
+        sandbox_session_state_descriptor = sandbox_session_metadata[0]["state"]
+        values = (*args, *kwargs.values())
+        for value in values:
+            if type(value) is Manifest and _manifest_has_configured_mount_authority(value):
+                return True
+
+        decorated_owner_type = _decorated_owner_type(function)
+        pending = [(value, False) for value in values]
+        seen_optional: set[int] = set()
+        seen_required: set[int] = set()
+        while pending:
+            value, must_resolve_owner = pending.pop()
+            value_id = id(value)
+            if value_id in seen_required or (not must_resolve_owner and value_id in seen_optional):
+                continue
+            if must_resolve_owner:
+                seen_required.add(value_id)
+            else:
+                seen_optional.add(value_id)
+
+            value_metadata = _static_type_metadata(type(value))
+            value_mro = () if value_metadata is None else value_metadata[1]
+            if type(value) is Manifest:
+                if _manifest_has_configured_mount_authority(value):
                     return True
-                if isinstance(candidate, Mount):
-                    if _mount_has_or_may_hide_configured_authority(candidate):
+                continue
+            if any(base is Manifest for base in value_mro):
+                return True
+            if any(base is Mount for base in value_mro):
+                if _mount_has_or_may_hide_configured_authority(cast(Mount, value)):
+                    return True
+                continue
+            if type(value) is dict:
+                pending.extend((item, must_resolve_owner) for item in dict.values(value))
+                continue
+            if type(value) is list or type(value) is tuple:
+                pending.extend((item, must_resolve_owner) for item in value)
+                continue
+            if value is None or type(value) in (str, bytes, int, float, bool, complex):
+                continue
+            if any(base is PurePath for base in value_mro):
+                continue
+
+            trusted_base = _trusted_authority_owner_base(
+                value,
+                decorated_owner_type=decorated_owner_type,
+            )
+            if trusted_base is None:
+                if must_resolve_owner:
+                    return True
+                continue
+            state = _object_instance_dict(value, trusted_base=trusted_base)
+            if state is None:
+                return True
+            is_session_owner = any(base is BaseSandboxSession for base in value_mro)
+            for name in _CALL_AUTHORITY_REQUIRED_STATE_KEYS:
+                found, candidate = _exact_string_state_entry(state, name)
+                if name == "state" and is_session_owner:
+                    if not found:
+                        state_declared, is_exact_slot, candidate = _exact_slot_state_entry(
+                            value,
+                            trusted_base=trusted_base,
+                            name=name,
+                        )
+                        if state_declared and is_exact_slot:
+                            if candidate is None:
+                                return True
+                            found = True
+                        elif state_declared and candidate is sandbox_session_state_descriptor:
+                            inner_found, inner = _exact_string_state_entry(state, "_inner")
+                            if (
+                                not inner_found
+                                or inner is None
+                                or _trusted_authority_owner_base(
+                                    inner,
+                                    decorated_owner_type=decorated_owner_type,
+                                )
+                                is None
+                            ):
+                                return True
+                        elif state_declared:
+                            return True
+                if found and candidate is not None:
+                    pending.append((candidate, True))
+            for name in _CALL_AUTHORITY_LINK_STATE_KEYS:
+                found, candidate = _exact_string_state_entry(state, name)
+                if found and candidate is not None:
+                    pending.append((candidate, False))
+
+            credentials_found, credentials = _exact_string_state_entry(
+                state,
+                "_trusted_s3_mount_credentials",
+            )
+            if type(credentials) is dict:
+                for configured in dict.values(credentials):
+                    if type(configured) is tuple and any(item is not None for item in configured):
                         return True
-                    continue
-                if isinstance(candidate, Mapping) and any(
-                    isinstance(item, Mount) and _mount_has_or_may_hide_configured_authority(item)
-                    for item in candidate.values()
-                ):
-                    return True
-                manifest = (
-                    candidate
-                    if isinstance(candidate, Manifest)
-                    else getattr(candidate, "manifest", None)
-                )
-                if isinstance(manifest, Manifest) and _manifest_has_configured_mount_authority(
-                    manifest
-                ):
-                    return True
-    except Exception:
+            elif credentials_found and credentials is not None:
+                return True
+    except BaseException:
         return True
     return False
 
@@ -1043,7 +1290,11 @@ def _mark_mount_error_for_manifest(error: MountConfigError, manifest: Manifest) 
 def _mark_mount_error_data_safe(error: MountConfigError) -> None:
     """Mark an SDK-created mount error whose message contains no credential-derived data."""
     _mark_error_data_redacted(error)
-    setattr(error, _SAFE_MOUNT_VALIDATION_MESSAGE_ATTR, True)
+    setattr(
+        error,
+        _SAFE_MOUNT_VALIDATION_MESSAGE_ATTR,
+        _SAFE_MOUNT_VALIDATION_MESSAGE_MARKER,
+    )
 
 
 def _mark_mount_validation_error(error: MountConfigError) -> None:

--- a/tests/extensions/sandbox/test_cloudflare.py
+++ b/tests/extensions/sandbox/test_cloudflare.py
@@ -589,7 +589,7 @@ async def test_cloudflare_protected_mount_state_drops_identity_before_resume() -
         provider_backend_id="cloudflare",
     )
 
-    with pytest.raises(RuntimeError, match="protected mount configuration"):
+    with pytest.raises(MountConfigError, match="sandbox mount configuration is invalid"):
         await client.resume(rebound)
 
 
@@ -617,7 +617,7 @@ async def test_cloudflare_resume_rejects_direct_state_with_configured_authority(
 
     monkeypatch.setattr(CloudflareSandboxSession, "running", running)
 
-    with pytest.raises(RuntimeError, match="protected mount configuration"):
+    with pytest.raises(MountConfigError, match="sandbox mount configuration is invalid"):
         await CloudflareSandboxClient().resume(_make_state(manifest=manifest))
 
     assert provider_calls == 0
@@ -1567,9 +1567,16 @@ async def test_cloudflare_resume_reapply_surfaces_terminal_delete_failure() -> N
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("operation", ["persist", "hydrate"])
+@pytest.mark.parametrize(
+    ("operation", "expected_type"),
+    [
+        ("persist", WorkspaceArchiveReadError),
+        ("hydrate", WorkspaceArchiveWriteError),
+    ],
+)
 async def test_cloudflare_direct_persistence_redacts_protected_remount_failure(
     operation: str,
+    expected_type: type[WorkspaceArchiveReadError | WorkspaceArchiveWriteError],
 ) -> None:
     sentinel = "cloudflare-direct-persistence-secret"
     fake_http = _FakeHttp(
@@ -1595,7 +1602,7 @@ async def test_cloudflare_direct_persistence_redacts_protected_remount_failure(
     )
     sess = _make_session(state=_make_state(manifest=manifest), fake_http=fake_http)
 
-    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+    with pytest.raises(expected_type, match="protected mount configuration") as exc_info:
         if operation == "persist":
             await sess.persist_workspace()
         else:
@@ -1603,6 +1610,7 @@ async def test_cloudflare_direct_persistence_redacts_protected_remount_failure(
 
     assert sentinel not in str(exc_info.value)
     assert sentinel not in repr(exc_info.value)
+    assert exc_info.value.context == {}
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None
     traceback = exc_info.value.__traceback__

--- a/tests/extensions/sandbox/test_vercel.py
+++ b/tests/extensions/sandbox/test_vercel.py
@@ -30,9 +30,14 @@ from agents.sandbox.entries import (
 from agents.sandbox.entries.mounts.base import InContainerMountAdapter
 from agents.sandbox.errors import (
     ConfigurationError,
+    ErrorCode,
+    ExecTransportError,
+    ExposedPortUnavailableError,
     InvalidManifestPathError,
     MountCommandError,
     MountConfigError,
+    WorkspaceArchiveReadError,
+    WorkspaceArchiveWriteError,
 )
 from agents.sandbox.manifest import EnvEntry, Environment, StrEnvValue
 from agents.sandbox.materialization import MaterializedFile
@@ -832,7 +837,9 @@ def test_vercel_from_state_redacts_trusted_mount_credentials_from_failure_traceb
         sandbox_id="sandbox-existing",
     )
 
-    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+    with pytest.raises(
+        MountConfigError, match="sandbox mount configuration is invalid"
+    ) as exc_info:
         vercel_module.VercelSandboxSession.from_state(
             state,
             allow_s3_credential_exposure=allow_s3_credential_exposure,
@@ -875,7 +882,9 @@ def test_vercel_constructor_redacts_trusted_mount_credentials_from_failure_trace
         sandbox_id="sandbox-existing",
     )
 
-    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+    with pytest.raises(
+        MountConfigError, match="sandbox mount configuration is invalid"
+    ) as exc_info:
         vercel_module.VercelSandboxSession(
             state=state,
             allow_s3_credential_exposure=allow_s3_credential_exposure,
@@ -896,10 +905,24 @@ def test_vercel_constructor_redacts_trusted_mount_credentials_from_failure_trace
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("operation", ["exec", "read", "write", "resolve_exposed_port"])
+@pytest.mark.parametrize(
+    ("operation", "expected_type"),
+    [
+        ("exec", ExecTransportError),
+        ("read", WorkspaceArchiveReadError),
+        ("write", WorkspaceArchiveWriteError),
+        ("resolve_exposed_port", ExposedPortUnavailableError),
+    ],
+)
 async def test_vercel_protected_session_public_operations_redact_provider_failures(
     monkeypatch: pytest.MonkeyPatch,
     operation: str,
+    expected_type: type[
+        ExecTransportError
+        | WorkspaceArchiveReadError
+        | WorkspaceArchiveWriteError
+        | ExposedPortUnavailableError
+    ],
 ) -> None:
     vercel_module = _load_vercel_module(monkeypatch)
     package_module = importlib.import_module("agents.extensions.sandbox.vercel")
@@ -950,10 +973,11 @@ async def test_vercel_protected_session_public_operations_redact_provider_failur
         async def invoke() -> object:
             return await session.resolve_exposed_port(3000)
 
-    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+    with pytest.raises(expected_type, match="protected mount configuration") as exc_info:
         await invoke()
 
     assert sentinel not in str(exc_info.value)
+    assert exc_info.value.context == {}
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None
     _assert_base_exception_slots_cleared(source_error)
@@ -2692,7 +2716,9 @@ async def test_vercel_s3_mount_failure_redacts_full_activation_traceback(
     with pytest.raises(MountCommandError) as exc_info:
         await session.start()
 
-    assert exc_info.value.context["stderr"] == "sandbox provider command failed"
+    assert exc_info.value.error_code is ErrorCode.MOUNT_FAILED
+    assert exc_info.value.op == "materialize"
+    assert exc_info.value.context == {}
     assert transformed_secret not in str(exc_info.value)
     assert transformed_secret not in repr(exc_info.value.context)
     assert exc_info.value.retryable is True
@@ -2732,8 +2758,9 @@ async def test_vercel_s3_mount_failure_discards_transformed_stderr(
     with pytest.raises(MountCommandError) as exc_info:
         await session.start()
 
-    assert exc_info.value.context["stderr"] == "sandbox provider command failed"
-    assert exc_info.value.context["exit_code"] == 1
+    assert exc_info.value.error_code is ErrorCode.MOUNT_FAILED
+    assert exc_info.value.op == "materialize"
+    assert exc_info.value.context == {}
     assert transformed_secret not in str(exc_info.value)
     assert transformed_secret not in repr(exc_info.value.context)
     assert sandbox.stop_calls == 1
@@ -2784,7 +2811,9 @@ async def test_vercel_s3_mount_failure_ignores_hostile_exception_descriptors(
         await session.start()
 
     assert type(exc_info.value) is MountCommandError
-    assert exc_info.value.context["stderr"] == "sandbox provider command failed"
+    assert exc_info.value.error_code is ErrorCode.MOUNT_FAILED
+    assert exc_info.value.op == "materialize"
+    assert exc_info.value.context == {}
     assert exc_info.value.retryable is True
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None

--- a/tests/sandbox/test_docker.py
+++ b/tests/sandbox/test_docker.py
@@ -42,6 +42,7 @@ from agents.sandbox.entries import (
 )
 from agents.sandbox.entries.mounts.base import InContainerMountAdapter
 from agents.sandbox.errors import (
+    ErrorCode,
     ExecTimeoutError,
     ExecTransportError,
     InvalidManifestPathError,
@@ -2401,9 +2402,13 @@ async def test_docker_direct_persist_redacts_protected_mount_provider_error(
 
     monkeypatch.setattr(session, "_stage_workspace_copy", fail_stage_workspace_copy)
 
-    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+    with pytest.raises(
+        WorkspaceArchiveReadError, match="protected mount configuration"
+    ) as exc_info:
         await session.persist_workspace()
 
+    assert exc_info.value.error_code is ErrorCode.WORKSPACE_ARCHIVE_READ_ERROR
+    assert exc_info.value.context == {}
     assert sentinel not in str(exc_info.value)
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__context__ is None

--- a/tests/sandbox/test_mount_security.py
+++ b/tests/sandbox/test_mount_security.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import builtins
 import importlib
+import inspect
+import sys
 from pathlib import Path, PureWindowsPath
 from typing import Any, ClassVar, Literal, cast
 
@@ -14,6 +16,7 @@ from agents.extensions.sandbox.daytona.mounts import DaytonaCloudBucketMountStra
 from agents.extensions.sandbox.e2b.mounts import E2BCloudBucketMountStrategy
 from agents.extensions.sandbox.modal.mounts import ModalCloudBucketMountStrategy
 from agents.extensions.sandbox.runloop.mounts import RunloopCloudBucketMountStrategy
+from agents.run_config import SandboxRunConfig
 from agents.sandbox import Manifest
 from agents.sandbox._mount_security import (
     CREDENTIALLESS_MOUNT_AUTHORITY_KEY,
@@ -53,13 +56,31 @@ from agents.sandbox.entries.mounts.patterns import (
     MountPatternConfig,
     RcloneMountConfig,
 )
-from agents.sandbox.errors import MountConfigError
+from agents.sandbox.errors import (
+    ErrorCode,
+    ExecNonZeroError,
+    ExecTimeoutError,
+    ExecTransportError,
+    InvalidManifestPathError,
+    MountCommandError,
+    MountConfigError,
+    MountToolMissingError,
+    PtySessionNotFoundError,
+    SandboxError,
+)
 from agents.sandbox.manifest import Environment
+from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
 from agents.sandbox.session.sandbox_client import BaseSandboxClient
 from agents.sandbox.session.sandbox_session import SandboxSession
 from agents.sandbox.session.sandbox_session_state import SandboxSessionState
 from agents.sandbox.snapshot import NoopSnapshot, SnapshotBase, SnapshotSpec
+from agents.sandbox.types import ExecResult
 from tests.utils.factories import TestSessionState
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+else:
+    BaseExceptionGroup = builtins.BaseExceptionGroup
 
 
 class _SecurityTestClient(BaseSandboxClient[None]):
@@ -1085,9 +1106,11 @@ async def test_authority_detection_keeps_invalid_manifest_paths_inside_redaction
     async def validate(*, manifest: Manifest) -> None:
         validate_manifest_mount_credential_boundaries(manifest)
 
-    with pytest.raises(RuntimeError, match="protected mount configuration") as exc:
+    with pytest.raises(InvalidManifestPathError, match="protected mount configuration") as exc:
         await validate(manifest=manifest)
 
+    assert exc.value.error_code is ErrorCode.INVALID_MANIFEST_PATH
+    assert exc.value.context == {}
     assert sentinel not in str(exc.value)
     traceback_cursor = exc.value.__traceback__
     while traceback_cursor is not None:
@@ -2841,6 +2864,1017 @@ def test_raw_state_rejects_malformed_credential_file_locator() -> None:
 
     assert payload == {}
     assert "credential-file-secret" not in str(exc.value)
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.parametrize("error_kind", ["command", "tool_missing"])
+@pytest.mark.asyncio
+async def test_protected_structured_mount_error_preserves_safe_contract(
+    boundary: str,
+    error_kind: str,
+) -> None:
+    sentinel = f"{boundary}-{error_kind}-structured-mount-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+    child_error = RuntimeError(sentinel)
+    expected_type: type[SandboxError]
+    if error_kind == "command":
+        source_error: SandboxError = MountCommandError(
+            command=sentinel,
+            stderr=sentinel,
+            context={"credential": sentinel},
+            cause=child_error,
+            retryable=True,
+        )
+        expected_type = MountCommandError
+        expected_code = ErrorCode.MOUNT_FAILED
+        expected_retryable = True
+    else:
+        source_error = MountToolMissingError(
+            tool=sentinel,
+            context={"credential": sentinel},
+            cause=child_error,
+        )
+        expected_type = MountToolMissingError
+        expected_code = ErrorCode.MOUNT_MISSING_TOOL
+        expected_retryable = False
+    if sys.version_info >= (3, 11):
+        source_error.add_note(sentinel)
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(expected_type) as exc_info:
+            await fail(manifest=manifest)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(expected_type) as exc_info:
+            fail_sync(manifest=manifest)
+
+    safe_error = exc_info.value
+    assert type(safe_error) is expected_type
+    assert safe_error is not source_error
+    assert safe_error.error_code is expected_code
+    assert safe_error.op == "materialize"
+    assert safe_error.retryable is expected_retryable
+    assert safe_error.context == {}
+    assert safe_error.cause is None
+    assert safe_error.__cause__ is None
+    assert safe_error.__context__ is None
+    assert sentinel not in repr(safe_error)
+    assert cast(Any, BaseException.args).__get__(source_error, type(source_error)) == ()
+    assert cast(Any, BaseException.__traceback__).__get__(source_error, type(source_error)) is None
+    assert child_error.args == ()
+    assert child_error.__traceback__ is None
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.parametrize("invalid_state", ["missing_retryable", "invalid_op"])
+@pytest.mark.asyncio
+async def test_protected_malformed_mount_config_error_falls_back(
+    boundary: str,
+    invalid_state: str,
+) -> None:
+    sentinel = f"{boundary}-{invalid_state}-mount-config-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+    source_error = MountConfigError(message=sentinel)
+    if invalid_state == "missing_retryable":
+        del source_error.retryable
+    else:
+        cast(Any, source_error).op = "invalid"
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            await fail(manifest=manifest)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            fail_sync(manifest=manifest)
+
+    assert type(exc_info.value) is RuntimeError
+    assert sentinel not in repr(exc_info.value)
+    assert cast(Any, BaseException.args).__get__(source_error, type(source_error)) == ()
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.asyncio
+async def test_protected_mount_config_error_preserves_valid_structured_fields(
+    boundary: str,
+) -> None:
+    sentinel = f"{boundary}-mount-config-structured-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+    source_error = MountConfigError(message=sentinel)
+    source_error.error_code = ErrorCode.EXEC_TIMEOUT
+    source_error.op = "exec"
+    source_error.retryable = True
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(MountConfigError) as exc_info:
+            await fail(manifest=manifest)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(MountConfigError) as exc_info:
+            fail_sync(manifest=manifest)
+
+    safe_error = exc_info.value
+    assert safe_error is not source_error
+    assert safe_error.error_code is ErrorCode.EXEC_TIMEOUT
+    assert safe_error.op == "exec"
+    assert safe_error.retryable is True
+    assert sentinel not in repr(safe_error)
+    assert source_error.args == ()
+    assert source_error.__traceback__ is None
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.asyncio
+async def test_untrusted_nested_authority_owner_fails_closed_without_descriptor_access(
+    boundary: str,
+) -> None:
+    sentinel = f"{boundary}-untrusted-owner-descriptor-secret"
+
+    class OpaqueOwner:
+        descriptor_accessed = False
+
+        @property
+        def __dict__(self) -> dict[str, object]:  # type: ignore[override]
+            type(self).descriptor_accessed = True
+            raise AssertionError("untrusted owner descriptor was accessed")
+
+    client = _SecurityTestClient()
+    cast(Any, client).state = OpaqueOwner()
+    source_error = RuntimeError(sentinel)
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, client: _SecurityTestClient) -> None:
+            _ = client
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            await fail(client=client)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, client: _SecurityTestClient) -> None:
+            _ = client
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            fail_sync(client=client)
+
+    assert exc_info.value is not source_error
+    assert OpaqueOwner.descriptor_accessed is False
+    assert sentinel not in repr(exc_info.value)
+    assert source_error.args == ()
+
+
+@pytest.mark.parametrize(
+    ("error_kind", "expected_state"),
+    [
+        ("transport", {"command": ()}),
+        (
+            "nonzero",
+            {"command": (), "exit_code": 1, "stdout": b"", "stderr": b""},
+        ),
+        ("timeout", {"command": (), "timeout_s": None}),
+        ("pty", {"session_id": -1}),
+    ],
+)
+def test_protected_structured_sandbox_error_preserves_safe_subtype_state(
+    error_kind: str,
+    expected_state: dict[str, object],
+) -> None:
+    sentinel = f"{error_kind}-structured-sandbox-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+    if error_kind == "transport":
+        source_error: SandboxError = ExecTransportError(
+            command=(sentinel,),
+            message=sentinel,
+            retryable=True,
+        )
+    elif error_kind == "nonzero":
+        source_error = ExecNonZeroError(
+            ExecResult(stdout=sentinel.encode(), stderr=sentinel.encode(), exit_code=42),
+            command=(sentinel,),
+        )
+    elif error_kind == "timeout":
+        source_error = ExecTimeoutError(command=(sentinel,), timeout_s=42.0)
+    else:
+        source_error = PtySessionNotFoundError(session_id=42, context={"secret": sentinel})
+
+    @redact_mount_error_data_sync
+    def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise source_error
+
+    with pytest.raises(type(source_error)) as exc_info:
+        fail(manifest=manifest)
+
+    safe_error = exc_info.value
+    assert type(safe_error) is type(source_error)
+    assert safe_error is not source_error
+    for field_name, field_value in expected_state.items():
+        assert getattr(safe_error, field_name) == field_value
+    assert sentinel not in repr(safe_error)
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.parametrize("retryable_present", [False, True])
+@pytest.mark.asyncio
+async def test_protected_structured_sandbox_error_requires_retryable_field(
+    boundary: str,
+    retryable_present: bool,
+) -> None:
+    sentinel = f"{boundary}-{retryable_present}-missing-retryable-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+    source_error = SandboxError(
+        message=sentinel,
+        error_code=ErrorCode.EXEC_TRANSPORT_ERROR,
+        op="exec",
+        context={"secret": sentinel},
+        retryable=None,
+    )
+    if not retryable_present:
+        del source_error.retryable
+    expected_type: type[BaseException] = SandboxError if retryable_present else RuntimeError
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(expected_type) as exc_info:
+            await fail(manifest=manifest)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(expected_type) as exc_info:
+            fail_sync(manifest=manifest)
+
+    safe_error = exc_info.value
+    if retryable_present:
+        assert type(safe_error) is SandboxError
+        assert safe_error.retryable is None
+    else:
+        assert type(safe_error) is RuntimeError
+    assert sentinel not in repr(safe_error)
+    assert cast(Any, BaseException.args).__get__(source_error, type(source_error)) == ()
+
+
+@pytest.mark.asyncio
+async def test_protected_custom_sandbox_error_falls_back_without_source_state() -> None:
+    sentinel = "custom-sandbox-error-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    class CustomSandboxError(SandboxError):
+        pass
+
+    source_error = CustomSandboxError(
+        message=sentinel,
+        error_code=ErrorCode.MOUNT_FAILED,
+        op="materialize",
+        context={"credential": sentinel},
+        retryable=True,
+    )
+
+    @redact_mount_error_data
+    async def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise source_error
+
+    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+        await fail(manifest=manifest)
+
+    assert type(exc_info.value) is RuntimeError
+    assert sentinel not in repr(exc_info.value)
+    assert cast(Any, BaseException.args).__get__(source_error, type(source_error)) == ()
+    assert cast(Any, BaseException.__traceback__).__get__(source_error, type(source_error)) is None
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.asyncio
+async def test_protected_hostile_exception_type_cannot_escape_redaction(boundary: str) -> None:
+    sentinel = f"{boundary}-hostile-exception-type-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    class HostileMeta(type):
+        def __hash__(cls) -> int:
+            raise RuntimeError(sentinel)
+
+    class ProviderError(Exception, metaclass=HostileMeta):
+        pass
+
+    source_error = ProviderError(sentinel)
+    child_error = RuntimeError(sentinel)
+    source_error.__cause__ = child_error
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            await fail(manifest=manifest)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            fail_sync(manifest=manifest)
+
+    assert sentinel not in repr(exc_info.value)
+    assert cast(Any, BaseException.args).__get__(source_error, type(source_error)) == ()
+    assert cast(Any, BaseException.__traceback__).__get__(source_error, type(source_error)) is None
+    assert child_error.args == ()
+    assert child_error.__traceback__ is None
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.asyncio
+async def test_protected_hostile_exception_state_key_cannot_escape_redaction(
+    boundary: str,
+) -> None:
+    sentinel = f"{boundary}-hostile-exception-state-key-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    class HostileKey:
+        def __hash__(self) -> int:
+            return hash("_agents_data_redacted")
+
+        def __eq__(self, other: object) -> bool:
+            _ = other
+            raise RuntimeError(sentinel)
+
+    source_error = RuntimeError(sentinel)
+    cast(dict[object, object], source_error.__dict__)[HostileKey()] = sentinel
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            await fail(manifest=manifest)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            fail_sync(manifest=manifest)
+
+    assert sentinel not in repr(exc_info.value)
+    assert source_error.args == ()
+    assert source_error.__dict__ == {}
+    assert source_error.__traceback__ is None
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.asyncio
+async def test_protected_direct_manifest_precedes_opaque_owner_descriptors(
+    boundary: str,
+) -> None:
+    sentinel = f"{boundary}-opaque-owner-descriptor-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    class OpaqueOwner:
+        @property
+        def state(self) -> object:
+            raise KeyboardInterrupt(sentinel)
+
+        @property
+        def default_manifest(self) -> object:
+            raise KeyboardInterrupt(sentinel)
+
+        @property
+        def _sandbox_config(self) -> object:
+            raise KeyboardInterrupt(sentinel)
+
+    source_error = RuntimeError(sentinel)
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(owner: object, manifest: Manifest) -> None:
+            _ = (owner, manifest)
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            await fail(OpaqueOwner(), manifest)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(owner: object, manifest: Manifest) -> None:
+            _ = (owner, manifest)
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            fail_sync(OpaqueOwner(), manifest)
+
+    assert sentinel not in repr(exc_info.value)
+    assert source_error.args == ()
+    assert source_error.__traceback__ is None
+
+
+def test_protected_mount_config_error_cannot_forge_safe_message_marker() -> None:
+    sentinel = "forged-safe-mount-message-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+    source_error = MountConfigError(message=sentinel)
+    cast(Any, source_error)._agents_data_redacted = True
+    cast(Any, source_error)._agents_safe_mount_validation_message = True
+
+    @redact_mount_error_data_sync
+    def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise source_error
+
+    with pytest.raises(MountConfigError, match="sandbox mount configuration is invalid") as exc:
+        fail(manifest=manifest)
+
+    assert sentinel not in repr(exc.value)
+    assert source_error.args == ()
+    assert source_error.__traceback__ is None
+
+
+@pytest.mark.asyncio
+async def test_protected_exception_group_is_not_retained_by_safe_error() -> None:
+    sentinel = "protected-exception-group-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+    child_error = RuntimeError(sentinel)
+    source_error = BaseExceptionGroup(sentinel, [child_error])
+
+    @redact_mount_error_data
+    async def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise source_error
+
+    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+        await fail(manifest=manifest)
+
+    safe_error = exc_info.value
+    assert safe_error.__cause__ is None
+    assert safe_error.__context__ is None
+    assert sentinel not in repr(safe_error)
+    source_args = cast(Any, BaseException.args).__get__(source_error, type(source_error))
+    assert source_args[0] == "Error details are redacted."
+    assert child_error.args == ()
+    assert child_error.__traceback__ is None
+    traceback_cursor = safe_error.__traceback__
+    while traceback_cursor is not None:
+        frame_path = Path(traceback_cursor.tb_frame.f_code.co_filename).as_posix()
+        if "/src/agents/" in frame_path:
+            assert sentinel not in repr(traceback_cursor.tb_frame.f_locals)
+            assert source_error not in traceback_cursor.tb_frame.f_locals.values()
+        traceback_cursor = traceback_cursor.tb_next
+
+
+def test_protected_exception_group_children_are_collected_without_subclass_callbacks() -> None:
+    sentinel = "protected-exception-group-callback-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    class HostileGroup(BaseExceptionGroup):
+        callbacks = 0
+
+        def __getattribute__(self, name: str) -> Any:
+            if name == "_exceptions":
+                type(self).callbacks += 1
+                raise AssertionError("provider group state was accessed")
+            return super().__getattribute__(name)
+
+    child_error = RuntimeError(sentinel)
+    source_error = HostileGroup(sentinel, [child_error])
+    HostileGroup.callbacks = 0
+
+    @redact_mount_error_data_sync
+    def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise source_error
+
+    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+        fail(manifest=manifest)
+
+    assert HostileGroup.callbacks == 0
+    assert child_error.args == ()
+    assert child_error.__traceback__ is None
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+
+
+def test_protected_nested_exception_is_scrubbed_beside_hostile_object() -> None:
+    sentinel = "protected-nested-exception-secret"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    class HostileMeta(type):
+        def __hash__(cls) -> int:
+            raise RuntimeError(sentinel)
+
+    class Opaque(metaclass=HostileMeta):
+        pass
+
+    child_error = RuntimeError(sentinel)
+    source_error = RuntimeError([child_error, Opaque()])
+
+    @redact_mount_error_data_sync
+    def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise source_error
+
+    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+        fail(manifest=manifest)
+
+    assert sentinel not in repr(exc_info.value)
+    assert source_error.args == ()
+    assert source_error.__traceback__ is None
+    assert child_error.args == ()
+    assert child_error.__traceback__ is None
+
+
+@pytest.mark.parametrize(
+    ("source_error", "expected_type", "expected_args"),
+    [
+        (SystemExit("protected-system-exit-secret"), SystemExit, (1,)),
+        (GeneratorExit("protected-generator-exit-secret"), GeneratorExit, ()),
+        (KeyboardInterrupt("protected-keyboard-interrupt-secret"), KeyboardInterrupt, ()),
+    ],
+)
+def test_protected_process_control_is_replaced_without_payload(
+    source_error: BaseException,
+    expected_type: type[BaseException],
+    expected_args: tuple[object, ...],
+) -> None:
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key="protected-process-control-authority",
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    @redact_mount_error_data_sync
+    def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise source_error
+
+    with pytest.raises(expected_type) as exc_info:
+        fail(manifest=manifest)
+
+    assert type(exc_info.value) is expected_type
+    assert exc_info.value is not source_error
+    assert exc_info.value.args == expected_args
+    assert source_error.args == ()
+    assert source_error.__traceback__ is None
+
+
+def test_closing_protected_coroutine_preserves_generator_exit() -> None:
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key="protected-generator-exit-authority",
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+
+    @redact_mount_error_data
+    async def suspend(*, manifest: Manifest) -> None:
+        _ = manifest
+        await asyncio.sleep(0)
+
+    coroutine = suspend(manifest=manifest)
+    assert coroutine.send(None) is None
+    coroutine.close()
+    assert inspect.getcoroutinestate(coroutine) == inspect.CORO_CLOSED
+
+
+@pytest.mark.parametrize("protected", [False, True])
+@pytest.mark.asyncio
+async def test_slot_backed_session_state_preserves_mount_authority_classification(
+    protected: bool,
+) -> None:
+    sentinel = f"slot-backed-session-secret-{protected}"
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key=sentinel,
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+        if protected
+        else {}
+    )
+    source_error = RuntimeError(sentinel)
+
+    class SlotBackedSession(BaseSandboxSession):
+        __slots__ = ("state",)
+
+        async def _ensure_backend_started(self) -> None:
+            raise source_error
+
+    class SlotBackedSessionState(SandboxSessionState):
+        type: Literal["docker"] = "docker"
+
+    SlotBackedSession.__abstractmethods__ = frozenset()
+    session = cast(Any, SlotBackedSession)()
+    session.state = SlotBackedSessionState(
+        manifest=manifest,
+        snapshot=NoopSnapshot(id="slot-backed-session"),
+    )
+    assert vars(session) == {}
+
+    if protected:
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            await session.start()
+
+        assert exc_info.value is not source_error
+        assert source_error.args == ()
+        assert source_error.__traceback__ is None
+    else:
+        with pytest.raises(RuntimeError) as exc_info:
+            await session.start()
+
+        assert exc_info.value is source_error
+        assert source_error.args == (sentinel,)
+
+
+@pytest.mark.asyncio
+async def test_property_backed_session_state_fails_closed_without_descriptor_access() -> None:
+    sentinel = "property-backed-session-secret"
+    source_error = RuntimeError(sentinel)
+
+    class PropertyBackedSession(BaseSandboxSession):
+        state_accessed = False
+
+        @property
+        def state(self) -> SandboxSessionState:
+            type(self).state_accessed = True
+            raise AssertionError("state property was accessed during classification")
+
+        @state.setter
+        def state(self, value: SandboxSessionState) -> None:
+            _ = value
+            type(self).state_accessed = True
+            raise AssertionError("state property was accessed during classification")
+
+        async def _ensure_backend_started(self) -> None:
+            raise source_error
+
+    PropertyBackedSession.__abstractmethods__ = frozenset()
+    session = cast(Any, PropertyBackedSession)()
+
+    @redact_mount_error_data
+    async def fail(session: BaseSandboxSession) -> None:
+        _ = session
+        raise source_error
+
+    with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+        await fail(session)
+
+    assert exc_info.value is not source_error
+    assert PropertyBackedSession.state_accessed is False
+    assert source_error.args == ()
+    assert source_error.__traceback__ is None
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.parametrize(
+    ("construction_code", "active_code", "expected_args"),
+    [
+        ("protected-stale-system-exit-secret", 0, (0,)),
+        (0, "protected-active-system-exit-secret", (1,)),
+    ],
+)
+@pytest.mark.asyncio
+async def test_protected_system_exit_uses_active_safe_status(
+    boundary: str,
+    construction_code: object,
+    active_code: str | int | None,
+    expected_args: tuple[object, ...],
+) -> None:
+    manifest = Manifest(
+        entries={
+            "data": S3Mount(
+                bucket="bucket",
+                access_key_id="access-key",
+                secret_access_key="protected-system-exit-authority",
+                mount_strategy=DockerVolumeMountStrategy(driver="rclone"),
+            )
+        }
+    )
+    source_error = SystemExit(construction_code)
+    source_error.code = active_code
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(SystemExit) as exc_info:
+            await fail(manifest=manifest)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, manifest: Manifest) -> None:
+            _ = manifest
+            raise source_error
+
+        with pytest.raises(SystemExit) as exc_info:
+            fail_sync(manifest=manifest)
+
+    assert type(exc_info.value) is SystemExit
+    assert exc_info.value is not source_error
+    assert exc_info.value.args == expected_args
+    assert source_error.args == ()
+    assert source_error.__traceback__ is None
+
+
+def test_credentialless_structured_mount_error_is_unchanged() -> None:
+    source_error = MountCommandError(
+        command="credentialless-command",
+        stderr="credentialless-stderr",
+        retryable=True,
+    )
+
+    @redact_mount_error_data_sync
+    def fail(*, manifest: Manifest) -> None:
+        _ = manifest
+        raise source_error
+
+    with pytest.raises(MountCommandError) as exc_info:
+        fail(manifest=Manifest())
+
+    assert exc_info.value is source_error
+    assert source_error.retryable is True
+    assert source_error.context == {
+        "command": "credentialless-command",
+        "stderr": "credentialless-stderr",
+    }
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.parametrize("link_name", ["_client", "_inner", "session", "_session"])
+@pytest.mark.asyncio
+async def test_credentialless_external_client_ignores_opaque_provider_link(
+    boundary: str,
+    link_name: str,
+) -> None:
+    class ExternalClient(_SecurityTestClient):
+        pass
+
+    client = ExternalClient()
+    setattr(client, link_name, object())
+    source_error = MountCommandError(
+        command="credentialless-command",
+        stderr="credentialless-stderr",
+        retryable=True,
+    )
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(*, client: BaseSandboxClient[Any]) -> None:
+            _ = client
+            raise source_error
+
+        with pytest.raises(MountCommandError) as exc_info:
+            await fail(client=client)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(*, client: BaseSandboxClient[Any]) -> None:
+            _ = client
+            raise source_error
+
+        with pytest.raises(MountCommandError) as exc_info:
+            fail_sync(client=client)
+
+    assert exc_info.value is source_error
+    assert source_error.retryable is True
+    assert source_error.context == {
+        "command": "credentialless-command",
+        "stderr": "credentialless-stderr",
+    }
+
+
+@pytest.mark.parametrize("boundary", ["async", "sync"])
+@pytest.mark.parametrize("owner_kind", ["run_config", "external_client"])
+@pytest.mark.asyncio
+async def test_required_authority_carrier_dominates_aliased_optional_link(
+    boundary: str,
+    owner_kind: str,
+) -> None:
+    opaque = object()
+    if owner_kind == "run_config":
+        owner: object = SandboxRunConfig(
+            session=cast(Any, opaque),
+            session_state=cast(Any, opaque),
+        )
+    else:
+
+        class ExternalClient(_SecurityTestClient):
+            pass
+
+        client = ExternalClient()
+        cast(Any, client).state = opaque
+        cast(Any, client)._inner = opaque
+        owner = client
+
+    source_error = RuntimeError("protected-aliased-authority-secret")
+
+    if boundary == "async":
+
+        @redact_mount_error_data
+        async def fail(owner: object) -> None:
+            _ = owner
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            await fail(owner)
+    else:
+
+        @redact_mount_error_data_sync
+        def fail_sync(owner: object) -> None:
+            _ = owner
+            raise source_error
+
+        with pytest.raises(RuntimeError, match="protected mount configuration") as exc_info:
+            fail_sync(owner)
+
+    assert exc_info.value is not source_error
+    assert source_error.args == ()
+    assert source_error.__traceback__ is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes protected-mount failure redaction so supported sandbox errors retain their exact public subtype and safe structured metadata without exposing credential-bearing provider state.

It centralizes callback-resistant exception graph cleanup, preserves process-control semantics, handles ExceptionGroup storage across supported Python versions, and keeps credentialless provider diagnostics unchanged while required authority carriers fail closed.

It also adds sync and async regressions covering structured subtypes, hostile exception graphs, authority aliasing, and the Docker, Cloudflare, and Vercel boundaries.