### PR TITLE
fix(run_state): serialize mapping contexts holding models and dataclasses

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -842,8 +842,17 @@ class RunState(Generic[TContext, TAgent]):
             )
 
         if isinstance(raw_context_payload, Mapping):
+            # Convert the values, not just the mapping itself. A shallow ``dict()`` leaves any
+            # Pydantic model or dataclass held in the mapping in place, and ``to_string`` then
+            # fails inside ``json.dumps`` with a bare ``TypeError`` that never mentions the
+            # context. This mirrors what tool outputs already do, so models and dataclasses
+            # survive as structured data rather than as reprs.
+            serialized_mapping = {
+                key: _ensure_json_compatible(_serialize_output_value(value))
+                for key, value in raw_context_payload.items()
+            }
             return (
-                dict(raw_context_payload),
+                serialized_mapping,
                 _build_context_meta(
                     raw_context_payload,
                     serialized_via="mapping",

--- a/tests/test_run_state_context_serialization.py
+++ b/tests/test_run_state_context_serialization.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+from pydantic import BaseModel
+
+from agents import Agent, Runner, function_tool
+from agents.run_state import RunState
+
+from .fake_model import FakeModel
+from .test_responses import get_function_tool_call, get_text_message
+
+
+class _User(BaseModel):
+    name: str
+    tier: str = "free"
+
+
+@dataclasses.dataclass
+class _Team:
+    label: str
+
+
+@function_tool(needs_approval=True)
+def _guarded(x: str) -> str:
+    """Guarded.
+
+    Args:
+        x: value
+    """
+    return "ok"
+
+
+def _interrupting_agent() -> Agent:
+    model = FakeModel()
+    model.add_multiple_turn_outputs(
+        [
+            [get_function_tool_call("_guarded", json.dumps({"x": "1"}), call_id="c1")],
+            [get_text_message("done")],
+        ]
+    )
+    return Agent(name="A", model=model, tools=[_guarded])
+
+
+@pytest.mark.asyncio
+async def test_mapping_context_holding_models_serializes_as_structured_data():
+    """A mapping context holding models must serialize rather than crash.
+
+    The mapping branch shallow-copied with `dict()`, leaving Pydantic models and dataclasses
+    in place, so `to_string()` failed inside `json.dumps` with a bare `TypeError` that never
+    mentioned the context.
+    """
+    agent = _interrupting_agent()
+    context = {
+        "user": _User(name="ada"),
+        "roles": [_User(name="b", tier="pro")],
+        "teams": {"core": [_Team(label="t")]},
+    }
+
+    result = await Runner.run(agent, "hi", context=context)
+    payload = result.to_state().to_string()
+
+    stored = json.loads(payload)["context"]["context"]
+    # Structured data rather than reprs, with defaulted fields preserved.
+    assert stored["user"] == {"name": "ada", "tier": "free"}
+    assert stored["roles"] == [{"name": "b", "tier": "pro"}]
+    assert stored["teams"] == {"core": [{"label": "t"}]}
+
+
+@pytest.mark.asyncio
+async def test_mapping_context_state_round_trips_and_resumes():
+    agent = _interrupting_agent()
+    result = await Runner.run(agent, "hi", context={"user": _User(name="ada")})
+
+    payload = result.to_state().to_string()
+    restored = await RunState.from_string(agent, payload)
+    assert (
+        json.loads(restored.to_string())["context"]["context"]
+        == (json.loads(payload)["context"]["context"])
+    )
+
+    restored.approve(result.interruptions[0])
+    resumed = await Runner.run(agent, restored)
+    assert resumed.final_output == "done"
+
+
+@pytest.mark.asyncio
+async def test_plain_json_mapping_context_is_unchanged():
+    """Contexts that were already JSON-compatible must serialize exactly as before."""
+    agent = _interrupting_agent()
+    context = {"a": 1, "b": ["x", {"c": True}], "d": None}
+
+    result = await Runner.run(agent, "hi", context=context)
+    stored = json.loads(result.to_state().to_string())["context"]["context"]
+
+    assert stored == context


### PR DESCRIPTION
### Summary

`RunState.to_string()` raises a bare `TypeError` when the run context is a mapping holding a Pydantic model or a dataclass:

```python
context = {"user": User(name="ada")}
result = await Runner.run(agent, "hi", context=context)
result.to_state().to_string()
```

```
TypeError: Object of type User is not JSON serializable
```

The traceback ends inside `json/encoder.py`. It never mentions the context, so there is no indication which value is at fault or that a `context_serializer` would fix it.

`_serialize_context_payload` shallow-copies the mapping:

```python
if isinstance(raw_context_payload, Mapping):
    return (dict(raw_context_payload), ...)
```

Every other branch converts before returning: a model context goes through `model_dump`, a dataclass context through `dataclasses.asdict`, and a custom context through the caller's serializer. Only the mapping branch, which is the most ordinary shape a context takes, hands its values back untouched.

Which shapes crash, on `main`:

| context | before | after |
| --- | --- | --- |
| `{"k": Model()}` | **TypeError** | serialized |
| `{"k": [Model()]}` | **TypeError** | serialized |
| `{"a": {"b": Model()}}` | **TypeError** | serialized |
| `{"k": [Dataclass()]}` | **TypeError** | serialized |
| `[Model()]`, `(Model(),)`, `[[Model()]]`, `[{"k": Model()}]` | already fine | unchanged |

The list and tuple shapes already worked, which is what makes the mapping gap easy to miss.

### Why it matters

`RunState` serialization is the supported way to persist an interrupted run across processes for human-in-the-loop approval. The crash therefore lands on the resume path, after the model call and the interruption, rather than at the start of the run.

### Fix

Mapping values go through `_serialize_output_value` and `_ensure_json_compatible`, the same pair tool outputs already use since #4339. Models and dataclasses survive as structured data with defaulted fields intact rather than degrading to reprs, and anything genuinely unserializable falls back to a string instead of raising.

```python
{"user": {"name": "ada", "tier": "free"}, "roles": [{"name": "b", "tier": "pro"}]}
```

`serialized_via="mapping"` and `requires_deserializer=False` are unchanged, so restore-time behaviour is untouched.

### Test plan

New `tests/test_run_state_context_serialization.py`:

- `test_mapping_context_holding_models_serializes_as_structured_data`, covering a model, a list of models and a dict of lists of dataclasses; fails on `main` with the `TypeError`
- `test_mapping_context_state_round_trips_and_resumes`, asserting `to_string` → `from_string` → `to_string` stability and that the run still resumes to completion after approval; also fails on `main`
- `test_plain_json_mapping_context_is_unchanged`, pinning that already-JSON contexts serialize exactly as before; passes both with and without the change

The tests live in their own module because `tests/test_run_state.py` cannot be collected on Windows (`UnixLocalSandbox is not supported on Windows` at import time).

| Command | Result |
| --- | --- |
| `make format` / `make lint` | clean |
| `make mypy` / `make pyright` | 0 issues in the touched files |
| `make tests` | 6950 passed |

Run on Windows against a `main` baseline captured at the same commit. Two tests differed between the runs and both are pre-existing flakes, not related to this change: `tests/test_tracing_errors_streamed.py::test_max_turns_exceeded` passes in isolation, and `tests/realtime/test_openai_realtime.py::TestSendEventAndConfig::test_interrupt_honors_falsy_present_session_auto_cancellation` fails 3 out of 6 isolated runs on unmodified `main`.

### Issue number

None reported; found while auditing the recent `run_state` serialization work.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script shells out to `make`; I ran the underlying steps individually, with the results above.
