### PR TITLE
ci: check prospective release contracts before merge

### DIFF
--- a/.github/scripts/run_integration_tests.py
+++ b/.github/scripts/run_integration_tests.py
@@ -10,10 +10,19 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from integration_tests._contract_support import (  # noqa: E402
+    SubmoduleExportPolicy,
+    load_submodule_export_policy,
+)
+
 WORKSPACE = ROOT / ".tmp" / "integration-tests"
 DIST = WORKSPACE / "dist"
 RESULTS = WORKSPACE / "results"
 TESTS = ROOT / "integration_tests"
+CONTRACT_POLICY = ROOT / "tests" / "fixtures" / "released_api_contract_policy.json"
+PROSPECTIVE_CONTRACT_ENV = "OPENAI_AGENTS_PROSPECTIVE_RELEASE_CONTRACT"
 EXTRAS = "any-llm,litellm,realtime,voice"
 OPTIONAL_EXTRAS = (
     "any-llm",
@@ -29,6 +38,8 @@ OPTIONAL_EXTRAS = (
 STRICT_PROFILES = frozenset({"release", "security"})
 PROFILES = (
     "packaging",
+    "prospective-contract",
+    "prospective-platform",
     "security",
     "mcp-v1",
     "core",
@@ -352,6 +363,15 @@ def main() -> None:
         help="Include configured direct Anthropic and Gemini providers alongside OpenRouter.",
     )
     args = parser.parse_args()
+    prospective_policy: SubmoduleExportPolicy | None = None
+    if args.profile in {"prospective-contract", "prospective-platform"}:
+        prospective_contract = os.environ.get(PROSPECTIVE_CONTRACT_ENV)
+        if not prospective_contract or not Path(prospective_contract).is_file():
+            raise RuntimeError(
+                "The prospective-contract profile requires "
+                f"{PROSPECTIVE_CONTRACT_ENV} to name an existing contract file."
+            )
+        prospective_policy = load_submodule_export_policy(CONTRACT_POLICY)
     if args.profile in STRICT_PROFILES:
         os.environ["OPENAI_AGENTS_INTEGRATION_STRICT"] = "1"
     shutil.rmtree(RESULTS / args.profile, ignore_errors=True)
@@ -381,6 +401,7 @@ def main() -> None:
 
     if args.profile in {
         "packaging",
+        "prospective-contract",
         "security",
         "core",
         "hosted",
@@ -396,6 +417,7 @@ def main() -> None:
         )
         selections = {
             "packaging": "packaging",
+            "prospective-contract": "packaging",
             "security": "security",
             "core": "packaging or core",
             "hosted": "packaging or hosted",
@@ -434,7 +456,15 @@ def main() -> None:
             profile=args.profile,
         )
 
-    if args.profile in {"packaging", "security", "full", "release", "nightly", "manual"}:
+    if args.profile in {
+        "packaging",
+        "prospective-contract",
+        "security",
+        "full",
+        "release",
+        "nightly",
+        "manual",
+    }:
         python = create_environment(
             "sdist",
             sdist,
@@ -457,6 +487,129 @@ def main() -> None:
             profile=args.profile,
         )
 
+    if args.profile == "prospective-contract":
+        assert prospective_policy is not None
+        for artifact_kind, distribution in (("wheel", wheel), ("sdist", sdist)):
+            for installation in prospective_policy.dependency_installations:
+                if not installation.is_supported_on_current_platform():
+                    print(
+                        "[integration] skipping optional dependency "
+                        f"{installation.dependency_module} on unsupported platform "
+                        f"{sys.platform}",
+                        flush=True,
+                    )
+                    continue
+                dependency_slug = re.sub(r"[^a-z0-9]+", "-", installation.dependency_module.lower())
+                environment_kind = f"{artifact_kind}-prospective-{dependency_slug}"
+                additional_requirements = (
+                    (installation.requirement,) if installation.requirement is not None else ()
+                )
+                python = create_environment(
+                    environment_kind,
+                    distribution,
+                    optional_extra=installation.extra,
+                    additional_requirements=additional_requirements,
+                )
+                installation_description = (
+                    f"extra {installation.extra}"
+                    if installation.extra is not None
+                    else f"requirement {installation.requirement}"
+                )
+                additional_env = {
+                    "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES": (
+                        installation.dependency_module
+                    ),
+                    "OPENAI_AGENTS_INTEGRATION_OPTIONAL_DEPENDENCY_INSTALLATION": (
+                        installation_description
+                    ),
+                }
+                if installation.extra is not None:
+                    additional_env["OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_EXTRA"] = (
+                        installation.extra
+                    )
+                run_suite(
+                    python,
+                    wheel,
+                    sdist,
+                    selection="packaging_dependency",
+                    environment_kind=environment_kind,
+                    additional_env=additional_env,
+                    profile=args.profile,
+                    require_no_skips=True,
+                )
+
+    if args.profile == "prospective-platform":
+        assert prospective_policy is not None
+        core_environment_kind = "wheel-prospective-platform-core"
+        core_python = create_environment(core_environment_kind, wheel)
+        run_suite(
+            core_python,
+            wheel,
+            sdist,
+            selection="packaging_dependency",
+            environment_kind=core_environment_kind,
+            profile=args.profile,
+            require_no_skips=True,
+        )
+
+        unsupported_installations = tuple(
+            installation
+            for installation in prospective_policy.dependency_installations
+            if not installation.is_supported_on_current_platform()
+        )
+        for installation in unsupported_installations:
+            print(
+                "[integration] skipping optional dependency "
+                f"{installation.dependency_module} on unsupported platform {sys.platform}",
+                flush=True,
+            )
+        supported_installations = tuple(
+            installation
+            for installation in prospective_policy.dependency_installations
+            if installation.is_supported_on_current_platform()
+        )
+        dependency_extras = sorted(
+            {
+                installation.extra
+                for installation in supported_installations
+                if installation.extra is not None
+            }
+        )
+        dependency_requirements = tuple(
+            sorted(
+                {
+                    installation.requirement
+                    for installation in supported_installations
+                    if installation.requirement is not None
+                }
+            )
+        )
+        dependency_modules = ",".join(
+            installation.dependency_module for installation in supported_installations
+        )
+        environment_kind = "wheel-prospective-platform"
+        python = create_environment(
+            environment_kind,
+            wheel,
+            optional_extra=",".join(dependency_extras) or None,
+            additional_requirements=dependency_requirements,
+        )
+        run_suite(
+            python,
+            wheel,
+            sdist,
+            selection="packaging_dependency",
+            environment_kind=environment_kind,
+            additional_env={
+                "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES": dependency_modules,
+                "OPENAI_AGENTS_INTEGRATION_OPTIONAL_DEPENDENCY_INSTALLATION": (
+                    "policy optional dependencies"
+                ),
+            },
+            profile=args.profile,
+            require_no_skips=True,
+        )
+
     if args.profile in {"packaging", "release"}:
         for artifact_kind, distribution in (("wheel", wheel), ("sdist", sdist)):
             environment_kind = f"{artifact_kind}-cloudflare"
@@ -471,7 +624,13 @@ def main() -> None:
                 sdist,
                 selection="packaging_dependency",
                 environment_kind=environment_kind,
-                additional_env={"OPENAI_AGENTS_INTEGRATION_REQUIRE_OPTIONAL_EXPORTS": "1"},
+                additional_env={
+                    "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES": "aiohttp",
+                    "OPENAI_AGENTS_INTEGRATION_OPTIONAL_DEPENDENCY_INSTALLATION": (
+                        "extra cloudflare"
+                    ),
+                    "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_EXTRA": "cloudflare",
+                },
                 profile=args.profile,
                 require_no_skips=True,
             )

--- a/.github/scripts/update_released_api_contract.py
+++ b/.github/scripts/update_released_api_contract.py
@@ -14,12 +14,14 @@ else:
 
 ROOT = Path(__file__).resolve().parents[2]
 CONTRACT = ROOT / "tests" / "fixtures" / "released_api_contract.json"
+POLICY = ROOT / "tests" / "fixtures" / "released_api_contract_policy.json"
 
 sys.path.insert(0, str(ROOT))
 
 from integration_tests._contract_support import (  # noqa: E402
     build_released_api_contract,
     load_api_contract,
+    load_submodule_export_policy,
 )
 
 
@@ -32,6 +34,11 @@ def _parse_args() -> argparse.Namespace:
         "--check",
         action="store_true",
         help="Fail instead of writing when the committed contract is out of date.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write a prospective contract to this path instead of changing the released fixture.",
     )
     return parser.parse_args()
 
@@ -58,6 +65,8 @@ def _render(contract: dict[str, object]) -> str:
 
 def main() -> int:
     args = _parse_args()
+    if args.check and args.output is not None:
+        raise SystemExit("--check and --output cannot be used together")
     version = args.version
     if (
         version.startswith("v")
@@ -70,17 +79,33 @@ def main() -> int:
         raise SystemExit(
             f"--version {version!r} does not match pyproject.toml version {project_version!r}"
         )
+    output = args.output.resolve() if args.output is not None else None
+    protected_outputs = {CONTRACT.resolve(), POLICY.resolve()}
+    if output in protected_outputs:
+        raise SystemExit(
+            "--output must not overwrite released API contract inputs: "
+            "tests/fixtures/released_api_contract.json or "
+            "tests/fixtures/released_api_contract_policy.json"
+        )
 
     current = load_api_contract(CONTRACT)
+    policy = load_submodule_export_policy(POLICY)
     try:
         updated = build_released_api_contract(
             current,
             baseline=f"v{version}",
             baseline_commit=_head_commit(),
+            submodule_export_policy=policy.modules,
         )
     except ValueError as error:
         raise SystemExit(str(error)) from None
     rendered = _render(updated)
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+        print(f"Wrote prospective released API contract to {output}.")
+        return 0
+
     existing = CONTRACT.read_text(encoding="utf-8")
     if rendered == existing:
         print(f"Released API contract is current for v{version}.")

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,6 +148,7 @@ jobs:
         run: echo "Skipping MCP v1 compatibility tests for non-code changes."
 
   packaged-contract:
+    needs: prospective-release-contract
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -172,12 +173,96 @@ jobs:
           enable-cache: true
           prune-cache: true
           python-version: ${{ matrix.python-version }}
-      - name: Run packaged compatibility contracts
+      - name: Download prospective release contract
         if: steps.changes.outputs.run == 'true'
-        run: make integration-tests-packaging
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: prospective-release-contract
+          path: .tmp
+      - name: Run packaged and prospective compatibility contracts
+        if: steps.changes.outputs.run == 'true'
+        env:
+          OPENAI_AGENTS_PROSPECTIVE_RELEASE_CONTRACT: ${{ github.workspace }}/.tmp/prospective_released_api_contract.json
+        run: make integration-tests-prospective-contract
       - name: Skip packaged compatibility contracts
         if: steps.changes.outputs.run != 'true'
         run: echo "Skipping packaged compatibility contracts for non-code changes."
+
+  packaged-contract-windows:
+    needs: prospective-release-contract
+    runs-on: windows-latest
+    timeout-minutes: 15
+    env:
+      OPENAI_AGENTS_INTEGRATION_PYTHON: "3.13"
+      OPENAI_API_KEY: fake-for-tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Detect code changes
+        id: changes
+        shell: bash
+        run: ./.github/scripts/detect-changes.sh code "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
+      - name: Setup uv
+        if: steps.changes.outputs.run == 'true'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # setup-uv v9.0.0; uv 0.11.14
+        with:
+          version: "0.11.14"
+          enable-cache: true
+          prune-cache: true
+          python-version: "3.13"
+      - name: Download prospective release contract
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: prospective-release-contract
+          path: .tmp
+      - name: Run Windows prospective contract smoke test
+        if: steps.changes.outputs.run == 'true'
+        env:
+          OPENAI_AGENTS_PROSPECTIVE_RELEASE_CONTRACT: ${{ github.workspace }}/.tmp/prospective_released_api_contract.json
+        run: uv run python .github/scripts/run_integration_tests.py --profile prospective-platform
+      - name: Skip Windows prospective contract smoke test
+        if: steps.changes.outputs.run != 'true'
+        run: echo "Skipping Windows prospective contract smoke test for non-code changes."
+
+  prospective-release-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      OPENAI_AGENTS_INTEGRATION_PYTHON: "3.12"
+      OPENAI_API_KEY: fake-for-tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Detect code changes
+        id: changes
+        run: ./.github/scripts/detect-changes.sh code "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
+      - name: Setup uv
+        if: steps.changes.outputs.run == 'true'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # setup-uv v9.0.0; uv 0.11.14
+        with:
+          version: "0.11.14"
+          enable-cache: true
+          prune-cache: true
+          python-version: "3.12"
+      - name: Install all optional dependencies
+        if: steps.changes.outputs.run == 'true'
+        run: make sync
+      - name: Generate prospective release contract
+        if: steps.changes.outputs.run == 'true'
+        run: make prepare-prospective-released-api-contract
+      - name: Upload prospective release contract
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: prospective-release-contract
+          path: .tmp/prospective_released_api_contract.json
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
+      - name: Skip prospective release contract
+        if: steps.changes.outputs.run != 'true'
+        run: echo "Skipping prospective release contract for non-code changes."
 
   tests-windows:
     runs-on: windows-latest

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,20 @@ check-released-api-contract:
 	@test -n "$(VERSION)" || (echo "VERSION is required, for example VERSION=0.20.0" >&2; exit 2)
 	uv run python .github/scripts/update_released_api_contract.py --version "$(VERSION)" --check
 
+PROSPECTIVE_RELEASED_API_CONTRACT ?= .tmp/prospective_released_api_contract.json
+
+.PHONY: prepare-prospective-released-api-contract
+prepare-prospective-released-api-contract:
+	@version="$$(uv run python -c 'from importlib.metadata import version; print(version("openai-agents"))')"; \
+	uv run python .github/scripts/update_released_api_contract.py \
+		--version "$$version" \
+		--output "$(PROSPECTIVE_RELEASED_API_CONTRACT)"
+
+.PHONY: check-prospective-released-api-contract
+check-prospective-released-api-contract: prepare-prospective-released-api-contract
+	OPENAI_AGENTS_PROSPECTIVE_RELEASE_CONTRACT="$(abspath $(PROSPECTIVE_RELEASED_API_CONTRACT))" \
+		$(MAKE) integration-tests-prospective-contract
+
 .PHONY: format
 format: 
 	uv run ruff format
@@ -102,6 +116,10 @@ integration-tests-manual:
 .PHONY: integration-tests-packaging
 integration-tests-packaging:
 	uv run python .github/scripts/run_integration_tests.py --profile packaging
+
+.PHONY: integration-tests-prospective-contract
+integration-tests-prospective-contract:
+	uv run python .github/scripts/run_integration_tests.py --profile prospective-contract
 
 .PHONY: integration-tests-security
 integration-tests-security:

--- a/integration_tests/_contract_support.py
+++ b/integration_tests/_contract_support.py
@@ -16,10 +16,138 @@ from types import FunctionType, TracebackType
 from typing import Any, cast
 
 
+@dataclasses.dataclass(frozen=True)
+class OptionalDependencyInstallation:
+    dependency_module: str
+    extra: str | None = None
+    requirement: str | None = None
+    unsupported_platforms: tuple[str, ...] = ()
+
+    def is_supported_on_current_platform(self) -> bool:
+        return sys.platform not in self.unsupported_platforms
+
+
+@dataclasses.dataclass(frozen=True)
+class SubmoduleExportPolicy:
+    modules: dict[str, dict[str, dict[str, str]]]
+    dependency_installations: tuple[OptionalDependencyInstallation, ...]
+
+
 def load_api_contract(path: Path) -> dict[str, Any]:
     contract = cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
     _add_legacy_literal_types(contract)
     return contract
+
+
+def load_submodule_export_policy(path: Path) -> SubmoduleExportPolicy:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("submodule export policy must be an object")
+    unknown_top_level_fields = sorted(set(value) - {"modules", "optional_dependencies"})
+    if unknown_top_level_fields:
+        raise ValueError(
+            f"submodule export policy has unknown fields: {unknown_top_level_fields!r}"
+        )
+    modules = value.get("modules")
+    if not isinstance(modules, dict):
+        raise ValueError("submodule export policy modules must be an object keyed by module name")
+    policy: dict[str, dict[str, dict[str, str]]] = {}
+    for module_name, declarations in modules.items():
+        if type(module_name) is not str or not module_name:
+            raise ValueError("submodule export policy module names must be non-empty strings")
+        if not isinstance(declarations, dict):
+            raise ValueError(f"submodule export policy for {module_name} must be an object")
+        unknown_fields = sorted(set(declarations) - {"optional_bindings", "optional_exports"})
+        if unknown_fields:
+            raise ValueError(
+                f"submodule export policy for {module_name} has unknown fields: {unknown_fields!r}"
+            )
+        policy[module_name] = {
+            "optional_bindings": _optional_dependency_modules(
+                declarations.get("optional_bindings", {}), field_name="optional_bindings"
+            ),
+            "optional_exports": _optional_dependency_modules(
+                declarations.get("optional_exports", {}), field_name="optional_exports"
+            ),
+        }
+
+    dependencies = value.get("optional_dependencies")
+    if not isinstance(dependencies, dict):
+        raise ValueError("submodule export policy optional_dependencies must be an object")
+    dependency_installations: list[OptionalDependencyInstallation] = []
+    for module_name, installation in dependencies.items():
+        if type(module_name) is not str or not module_name:
+            raise ValueError("optional dependency module names must be non-empty strings")
+        if not isinstance(installation, dict):
+            raise ValueError(
+                f"optional dependency installation for {module_name} must be an object"
+            )
+        unknown_fields = sorted(
+            set(installation) - {"extra", "requirement", "unsupported_platforms"}
+        )
+        if unknown_fields:
+            raise ValueError(
+                f"optional dependency installation for {module_name} has unknown fields: "
+                f"{unknown_fields!r}"
+            )
+        configured = [field for field in ("extra", "requirement") if field in installation]
+        if len(configured) != 1:
+            raise ValueError(
+                f"optional dependency installation for {module_name} must declare exactly one "
+                "of extra or requirement"
+            )
+        field_name = configured[0]
+        install_value = installation[field_name]
+        if type(install_value) is not str or not install_value:
+            raise ValueError(
+                f"optional dependency installation {field_name} for {module_name} must be a "
+                "non-empty string"
+            )
+        unsupported_platforms = installation.get("unsupported_platforms", [])
+        if (
+            not isinstance(unsupported_platforms, list)
+            or not all(type(platform) is str and platform for platform in unsupported_platforms)
+            or len(unsupported_platforms) != len(set(unsupported_platforms))
+        ):
+            raise ValueError(
+                f"optional dependency installation unsupported_platforms for {module_name} "
+                "must be a list of unique non-empty strings"
+            )
+        dependency_installations.append(
+            OptionalDependencyInstallation(
+                dependency_module=module_name,
+                extra=install_value if field_name == "extra" else None,
+                requirement=install_value if field_name == "requirement" else None,
+                unsupported_platforms=tuple(unsupported_platforms),
+            )
+        )
+
+    referenced_dependencies = {
+        dependency
+        for module_policy in policy.values()
+        for declarations in module_policy.values()
+        for dependency in declarations.values()
+    }
+    missing_installations = sorted(referenced_dependencies - set(dependencies))
+    unused_installations = sorted(set(dependencies) - referenced_dependencies)
+    if missing_installations:
+        raise ValueError(
+            "submodule export policy dependencies are missing installation declarations: "
+            f"{missing_installations!r}"
+        )
+    if unused_installations:
+        raise ValueError(
+            "submodule export policy has unused dependency installation declarations: "
+            f"{unused_installations!r}"
+        )
+    return SubmoduleExportPolicy(
+        modules=policy,
+        dependency_installations=tuple(
+            sorted(
+                dependency_installations, key=lambda installation: installation.dependency_module
+            )
+        ),
+    )
 
 
 def _add_legacy_literal_types(value: object) -> None:
@@ -39,13 +167,15 @@ def _redaction_observables(
     records: Iterable[logging.LogRecord],
 ) -> str:
     values: list[str] = []
-    seen: set[int] = set()
+    seen: dict[int, object] = {}
 
     def visit_exception_state(value: object) -> None:
         value_id = id(value)
         if value_id in seen:
             return
-        seen.add(value_id)
+        # Keep visited objects alive so a later temporary object cannot reuse an id and be
+        # mistaken for a cycle. Traceback frame locals are materialized as temporary dicts.
+        seen[value_id] = value
 
         if isinstance(value, BaseException):
             state = vars(value)
@@ -381,6 +511,7 @@ def build_released_api_contract(
     baseline: str,
     baseline_commit: str,
     agents_module: Any | None = None,
+    submodule_export_policy: Mapping[str, Mapping[str, Mapping[str, str]]] | None = None,
 ) -> dict[str, Any]:
     """Build the next rolling release contract from the current public surface."""
     agents = agents_module or importlib.import_module("agents")
@@ -445,8 +576,40 @@ def build_released_api_contract(
     updated["required_top_level_exports"] = ordered_exports
     updated["callables"] = callables
     excluded_submodule_exports = set(contract.get("submodule_export_exclusions", []))
+    public_modules = list(contract["public_modules"])
+    if submodule_export_policy is not None:
+        invalid_policy_modules = sorted(
+            module_name
+            for module_name in submodule_export_policy
+            if not module_name.startswith("agents.")
+        )
+        if invalid_policy_modules:
+            raise ValueError(
+                "new submodule export policy modules must be under the agents package: "
+                f"{invalid_policy_modules!r}"
+            )
+        released_public_modules = set(public_modules)
+        public_modules.extend(sorted(set(submodule_export_policy) - released_public_modules))
+        unavailable_policy_dependencies = sorted(
+            {
+                dependency_module
+                for module_policy in submodule_export_policy.values()
+                for field_name in ("optional_bindings", "optional_exports")
+                for dependency_module in _optional_dependency_modules(
+                    dict(module_policy.get(field_name, {})), field_name=field_name
+                ).values()
+                if not _optional_dependency_is_available(dependency_module)
+            }
+        )
+        if unavailable_policy_dependencies:
+            raise ValueError(
+                "submodule export policy dependency modules are unavailable: "
+                f"{unavailable_policy_dependencies!r}. Run `make sync` to install all "
+                "optional dependencies, or correct the dependency module names."
+            )
+    updated["public_modules"] = public_modules
     required_submodule_exports: dict[str, dict[str, Any]] = {}
-    for module_name in contract["public_modules"]:
+    for module_name in public_modules:
         if module_name == "agents" or module_name in excluded_submodule_exports:
             continue
         try:
@@ -454,14 +617,19 @@ def build_released_api_contract(
         except Exception as error:
             if _matches_platform_import_error(contract, module_name, error):
                 continue
+            if submodule_export_policy is not None and module_name in submodule_export_policy:
+                raise ValueError(
+                    f"Cannot import submodule export policy module {module_name}: {error!r}"
+                ) from None
             raise
-        previous_module_contract = contract.get("required_submodule_exports", {}).get(
-            module_name, {}
-        )
+        if submodule_export_policy is None:
+            module_policy = contract.get("required_submodule_exports", {}).get(module_name, {})
+        else:
+            module_policy = submodule_export_policy.get(module_name, {})
         module_contract = _submodule_export_contract(
             module,
-            optional_bindings=previous_module_contract.get("optional_bindings", {}),
-            optional_exports=previous_module_contract.get("optional_exports", {}),
+            optional_bindings=module_policy.get("optional_bindings", {}),
+            optional_exports=module_policy.get("optional_exports", {}),
         )
         if module_contract is not None:
             required_submodule_exports[module_name] = module_contract
@@ -644,7 +812,6 @@ def validate_released_api_contract(
     contract: dict[str, Any],
     *,
     agents_module: Any | None = None,
-    require_all_optional_exports: bool = False,
 ) -> list[str]:
     agents = agents_module or importlib.import_module("agents")
     errors: list[str] = []
@@ -718,17 +885,43 @@ def validate_released_api_contract(
                 f"Unable to inspect released {module_name} optional dependencies: {error!r}"
             )
             continue
-        if require_all_optional_exports and unavailable_optional_exports:
-            unavailable = sorted(
-                f"{name} -> {optional_exports[name]}" for name in unavailable_optional_exports
-            )
-            errors.append(
-                f"Required optional dependencies for released {module_name} "
-                f"are unavailable: {unavailable!r}"
-            )
-            continue
+        current_names = set(current["names"])
+        for name in sorted(unavailable_optional_exports & current_names):
+            try:
+                getattr(module, name)
+            except (AttributeError, ImportError):
+                errors.append(
+                    f"Invalid released {module_name} optional dependency declaration: "
+                    f"{name!r} remains in __all__ but its binding is unavailable; "
+                    "declare it in optional_bindings instead of optional_exports"
+                )
+            else:
+                errors.append(
+                    f"Invalid released {module_name} optional dependency declaration: "
+                    f"{name!r} remains in __all__ and its binding resolves; remove its "
+                    "optional declaration or correct its dependency module"
+                )
+        binding_only_names = set(optional_bindings) - set(optional_exports)
+        for name in sorted(unavailable_optional_bindings & binding_only_names):
+            if name not in current_names:
+                errors.append(
+                    f"Invalid released {module_name} optional dependency declaration: "
+                    f"{name!r} is absent from __all__; declare it in optional_exports "
+                    "instead of optional_bindings"
+                )
+                continue
+            try:
+                getattr(module, name)
+            except (AttributeError, ImportError):
+                pass
+            else:
+                errors.append(
+                    f"Invalid released {module_name} optional dependency declaration: "
+                    f"{name!r} remains in __all__ and its binding resolves; remove its "
+                    "optional declaration or correct its dependency module"
+                )
         missing_names = sorted(
-            set(released["names"]) - unavailable_optional_exports - set(current["names"])
+            set(released["names"]) - unavailable_optional_exports - current_names
         )
         if missing_names:
             errors.append(f"Missing released {module_name} exports: {missing_names!r}")

--- a/integration_tests/packaging/test_released_api_contract.py
+++ b/integration_tests/packaging/test_released_api_contract.py
@@ -1,8 +1,11 @@
 import os
-from importlib.metadata import version
+from importlib.metadata import metadata, requires, version
+from importlib.util import find_spec
 from pathlib import Path
 
 import pytest
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 from integration_tests._contract_support import (
     load_api_contract,
@@ -12,6 +15,164 @@ from integration_tests._contract_support import (
 pytestmark = pytest.mark.packaging
 
 CONTRACT = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "released_api_contract.json"
+PROSPECTIVE_CONTRACT_ENV = "OPENAI_AGENTS_PROSPECTIVE_RELEASE_CONTRACT"
+REQUIRED_OPTIONAL_DEPENDENCIES_ENV = "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES"
+OPTIONAL_DEPENDENCY_INSTALLATION_ENV = "OPENAI_AGENTS_INTEGRATION_OPTIONAL_DEPENDENCY_INSTALLATION"
+REQUIRED_OPTIONAL_EXTRA_ENV = "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_EXTRA"
+
+
+def _distributions_declared_by_extra(requirement_strings: list[str], extra: str) -> set[str]:
+    no_extra = "__openai_agents_no_extra__"
+    declared: set[str] = set()
+    for requirement_string in requirement_strings:
+        requirement = Requirement(requirement_string)
+        marker = requirement.marker
+        if (
+            marker is not None
+            and marker.evaluate({"extra": extra})
+            and not marker.evaluate({"extra": no_extra})
+        ):
+            declared.add(canonicalize_name(requirement.name))
+    return declared
+
+
+def _extra_metadata_error(
+    *,
+    extra: str,
+    dependency_module: str,
+    provided_extras: list[str],
+    requirement_strings: list[str],
+) -> str | None:
+    canonical_extra = canonicalize_name(extra)
+    if canonical_extra not in {
+        canonicalize_name(provided_extra) for provided_extra in provided_extras
+    }:
+        return (
+            f"The installed openai-agents artifact does not provide policy extra {extra!r}. "
+            "Correct its entry in tests/fixtures/released_api_contract_policy.json or add "
+            "the extra under [project.optional-dependencies]."
+        )
+
+    distribution_name = canonicalize_name(dependency_module)
+    declared_distributions = _distributions_declared_by_extra(requirement_strings, extra)
+    if distribution_name not in declared_distributions:
+        return (
+            f"The installed openai-agents artifact extra {extra!r} does not declare "
+            f"distribution {distribution_name!r} for policy dependency module "
+            f"{dependency_module!r}. Add it to [project.optional-dependencies].{extra}; "
+            "transitive or base-environment availability does not satisfy this check."
+        )
+    return None
+
+
+def _prospective_contract_failure_message(errors: list[str]) -> str:
+    details = "\n".join(f"- {error}" for error in errors)
+    return (
+        "Prospective release API contract check failed before release preparation.\n"
+        "The installed distribution does not match the generated public API contract:\n"
+        f"{details}\n\n"
+        "If a missing name is absent from the clean module's `__all__` because it depends "
+        "on an optional extra, add it to `tests/fixtures/released_api_contract_policy.json` "
+        "under the module's `optional_exports` mapping. If the name remains in `__all__` "
+        "but resolving its binding requires the optional dependency, add it under "
+        "`optional_bindings` instead. If the export is required, make its defining module "
+        "importable without the optional package. If the optional dependency package itself "
+        "does not support this runner platform, verify that upstream limitation and add the "
+        "platform to its `unsupported_platforms` list under `optional_dependencies`; do not "
+        "exclude SDK-owned platform failures. Then run `make sync` and "
+        "`make check-prospective-released-api-contract` again."
+    )
+
+
+@pytest.mark.packaging_dependency
+def test_artifact_installation_provides_its_declared_optional_dependencies() -> None:
+    configured_dependencies = os.environ.get(REQUIRED_OPTIONAL_DEPENDENCIES_ENV)
+    if not configured_dependencies:
+        return
+
+    installation = os.environ.get(OPTIONAL_DEPENDENCY_INSTALLATION_ENV, "configured installation")
+    dependency_modules = [
+        module_name.strip()
+        for module_name in configured_dependencies.split(",")
+        if module_name.strip()
+    ]
+    missing_dependencies = [
+        module_name for module_name in dependency_modules if find_spec(module_name) is None
+    ]
+    if missing_dependencies:
+        pytest.fail(
+            f"The artifact environment for {installation} does not provide declared "
+            f"optional dependency modules {missing_dependencies!r}. Update the corresponding "
+            "openai-agents extra or policy requirement."
+        )
+
+
+@pytest.mark.packaging_dependency
+def test_artifact_extra_declares_its_policy_dependency() -> None:
+    extra = os.environ.get(REQUIRED_OPTIONAL_EXTRA_ENV)
+    if not extra:
+        return
+
+    configured_dependencies = os.environ.get(REQUIRED_OPTIONAL_DEPENDENCIES_ENV, "")
+    dependency_modules = [
+        module_name.strip()
+        for module_name in configured_dependencies.split(",")
+        if module_name.strip()
+    ]
+    if len(dependency_modules) != 1:
+        pytest.fail(
+            f"Extra provenance validation requires exactly one dependency module, got "
+            f"{dependency_modules!r}. Fix the prospective-contract runner configuration."
+        )
+    dependency_module = dependency_modules[0]
+    error = _extra_metadata_error(
+        extra=extra,
+        dependency_module=dependency_module,
+        provided_extras=metadata("openai-agents").get_all("Provides-Extra") or [],
+        requirement_strings=requires("openai-agents") or [],
+    )
+    if error is not None:
+        pytest.fail(error)
+
+
+def test_extra_metadata_provenance_ignores_base_and_transitive_requirements() -> None:
+    assert _distributions_declared_by_extra(
+        [
+            "cryptography>=45",
+            "pyjwt[crypto]>=2; python_version >= '3.10'",
+            "redis>=7; extra == 'redis'",
+            "cryptography>=45; extra == 'encrypt'",
+        ],
+        "encrypt",
+    ) == {"cryptography"}
+
+    assert _extra_metadata_error(
+        extra="encrypt",
+        dependency_module="cryptography",
+        provided_extras=["encrypt"],
+        requirement_strings=[
+            "cryptography>=45",
+            "pyjwt[crypto]>=2; python_version >= '3.10'",
+        ],
+    ) == (
+        "The installed openai-agents artifact extra 'encrypt' does not declare distribution "
+        "'cryptography' for policy dependency module 'cryptography'. Add it to "
+        "[project.optional-dependencies].encrypt; transitive or base-environment availability "
+        "does not satisfy this check."
+    )
+
+
+def test_extra_metadata_provenance_rejects_unknown_extra() -> None:
+    assert _extra_metadata_error(
+        extra="missing",
+        dependency_module="cryptography",
+        provided_extras=["encrypt"],
+        requirement_strings=["cryptography>=45; extra == 'encrypt'"],
+    ) == (
+        "The installed openai-agents artifact does not provide policy extra 'missing'. Correct "
+        "its entry in tests/fixtures/released_api_contract_policy.json or add the extra under "
+        "[project.optional-dependencies]."
+    )
 
 
 @pytest.mark.packaging_dependency
@@ -20,11 +181,42 @@ def test_installed_distribution_preserves_released_public_api_contract() -> None
     assert contract["baseline"] == f"v{version('openai-agents')}"
     assert len(contract["baseline_commit"]) == 40
 
-    errors = validate_released_api_contract(
-        contract,
-        require_all_optional_exports=(
-            os.environ.get("OPENAI_AGENTS_INTEGRATION_REQUIRE_OPTIONAL_EXPORTS") == "1"
-        ),
-    )
+    errors = validate_released_api_contract(contract)
 
     assert errors == []
+
+
+@pytest.mark.packaging_dependency
+def test_installed_distribution_is_ready_for_prospective_release_contract() -> None:
+    configured_path = os.environ.get(PROSPECTIVE_CONTRACT_ENV)
+    if not configured_path:
+        return
+
+    path = Path(configured_path)
+    if not path.is_file():
+        pytest.fail(
+            f"Prospective release API contract does not exist: {path}. "
+            "Run `make check-prospective-released-api-contract` from the repository root."
+        )
+
+    contract = load_api_contract(path)
+    errors = validate_released_api_contract(contract)
+    if errors:
+        pytest.fail(_prospective_contract_failure_message(errors))
+
+
+def test_prospective_contract_failure_guidance_distinguishes_optional_shapes() -> None:
+    message = _prospective_contract_failure_message(
+        [
+            "Missing released agents.example exports: ['ConditionalExport']",
+            "Missing released agents.example bindings: ['LazyBinding']",
+        ]
+    )
+
+    assert "absent from the clean module's `__all__`" in message
+    assert "`optional_exports`" in message
+    assert "remains in `__all__`" in message
+    assert "`optional_bindings` instead" in message
+    assert "`unsupported_platforms`" in message
+    assert "do not exclude SDK-owned platform failures" in message
+    assert "make check-prospective-released-api-contract" in message

--- a/tests/fixtures/released_api_contract_policy.json
+++ b/tests/fixtures/released_api_contract_policy.json
@@ -1,0 +1,88 @@
+{
+  "optional_dependencies": {
+    "aiohttp": {
+      "extra": "cloudflare"
+    },
+    "aiosqlite": {
+      "requirement": "aiosqlite>=0.21.0"
+    },
+    "cryptography": {
+      "extra": "encrypt"
+    },
+    "dapr": {
+      "extra": "dapr"
+    },
+    "modal": {
+      "extra": "modal"
+    },
+    "pymongo": {
+      "extra": "mongodb"
+    },
+    "redis": {
+      "extra": "redis"
+    },
+    "runloop_api_client": {
+      "extra": "runloop"
+    },
+    "sqlalchemy": {
+      "extra": "sqlalchemy"
+    },
+    "vercel": {
+      "extra": "vercel",
+      "unsupported_platforms": [
+        "win32"
+      ]
+    }
+  },
+  "modules": {
+    "agents.extensions.memory": {
+      "optional_bindings": {
+        "AsyncSQLiteSession": "aiosqlite",
+        "DAPR_CONSISTENCY_EVENTUAL": "dapr",
+        "DAPR_CONSISTENCY_STRONG": "dapr",
+        "DaprSession": "dapr",
+        "EncryptedSession": "cryptography",
+        "MongoDBSession": "pymongo",
+        "RedisSession": "redis",
+        "SQLAlchemySession": "sqlalchemy"
+      },
+      "optional_exports": {}
+    },
+    "agents.extensions.sandbox": {
+      "optional_bindings": {},
+      "optional_exports": {
+        "CloudflareBucketMountConfig": "aiohttp",
+        "CloudflareBucketMountStrategy": "aiohttp",
+        "CloudflareSandboxClient": "aiohttp",
+        "CloudflareSandboxClientOptions": "aiohttp",
+        "CloudflareSandboxSession": "aiohttp",
+        "CloudflareSandboxSessionState": "aiohttp",
+        "DEFAULT_RUNLOOP_ROOT_WORKSPACE_ROOT": "runloop_api_client",
+        "DEFAULT_RUNLOOP_WORKSPACE_ROOT": "runloop_api_client",
+        "ModalCloudBucketMountStrategy": "modal",
+        "ModalSandboxClient": "modal",
+        "ModalSandboxClientOptions": "modal",
+        "ModalSandboxSession": "modal",
+        "ModalSandboxSessionState": "modal",
+        "RunloopAfterIdle": "runloop_api_client",
+        "RunloopCloudBucketMountStrategy": "runloop_api_client",
+        "RunloopGatewaySpec": "runloop_api_client",
+        "RunloopLaunchParameters": "runloop_api_client",
+        "RunloopMcpSpec": "runloop_api_client",
+        "RunloopPlatformClient": "runloop_api_client",
+        "RunloopSandboxClient": "runloop_api_client",
+        "RunloopSandboxClientOptions": "runloop_api_client",
+        "RunloopSandboxSession": "runloop_api_client",
+        "RunloopSandboxSessionState": "runloop_api_client",
+        "RunloopTimeouts": "runloop_api_client",
+        "RunloopTunnelConfig": "runloop_api_client",
+        "RunloopUserParameters": "runloop_api_client",
+        "VercelCloudBucketMountStrategy": "vercel",
+        "VercelSandboxClient": "vercel",
+        "VercelSandboxClientOptions": "vercel",
+        "VercelSandboxSession": "vercel",
+        "VercelSandboxSessionState": "vercel"
+      }
+    }
+  }
+}

--- a/tests/test_integration_runner.py
+++ b/tests/test_integration_runner.py
@@ -400,7 +400,12 @@ def test_packaging_profile_checks_dependency_present_contract_for_wheel_and_sdis
     ]
     assert all(suite["selection"] == "packaging_dependency" for suite in dependency_suites)
     assert all(
-        suite["additional_env"] == {"OPENAI_AGENTS_INTEGRATION_REQUIRE_OPTIONAL_EXPORTS": "1"}
+        suite["additional_env"]
+        == {
+            "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES": "aiohttp",
+            "OPENAI_AGENTS_INTEGRATION_OPTIONAL_DEPENDENCY_INSTALLATION": "extra cloudflare",
+            "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_EXTRA": "cloudflare",
+        }
         for suite in dependency_suites
     )
     assert all(suite["require_no_skips"] is True for suite in dependency_suites)
@@ -466,8 +471,251 @@ def test_release_profile_enforces_strict_security_for_wheel_and_sdist(
     assert len(dependency_suites) == 2
     assert all(suite["selection"] == "packaging_dependency" for suite in dependency_suites)
     assert all(
-        suite["additional_env"] == {"OPENAI_AGENTS_INTEGRATION_REQUIRE_OPTIONAL_EXPORTS": "1"}
+        suite["additional_env"]
+        == {
+            "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES": "aiohttp",
+            "OPENAI_AGENTS_INTEGRATION_OPTIONAL_DEPENDENCY_INSTALLATION": "extra cloudflare",
+            "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_EXTRA": "cloudflare",
+        }
         for suite in dependency_suites
     )
     assert all(suite["require_no_skips"] is True for suite in dependency_suites)
     assert namespace["STRICT_PROFILES"] == frozenset({"release", "security"})
+
+
+@pytest.mark.parametrize("platform", ["linux", "win32"])
+def test_prospective_contract_profile_isolates_each_policy_installation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    platform: str,
+) -> None:
+    namespace = runpy.run_path(str(RUNNER))
+    main = cast(Callable[[], None], namespace["main"])
+    wheel = tmp_path / "candidate.whl"
+    sdist = tmp_path / "candidate.tar.gz"
+    prospective_contract = tmp_path / "prospective-contract.json"
+    prospective_contract.write_text("{}", encoding="utf-8")
+    created: list[tuple[str, Path, str | None, tuple[str, ...]]] = []
+    suites: list[dict[str, Any]] = []
+
+    def fake_build_distributions() -> tuple[Path, Path]:
+        return wheel, sdist
+
+    def fake_create_environment(
+        name: str,
+        distribution: Path,
+        *,
+        extras: bool = False,
+        optional_extra: str | None = None,
+        additional_requirements: tuple[str, ...] = (),
+    ) -> Path:
+        _ = extras
+        created.append((name, distribution, optional_extra, additional_requirements))
+        return tmp_path / name / "python"
+
+    def fake_run_suite(*args: object, **kwargs: Any) -> None:
+        _ = args
+        suites.append(kwargs)
+
+    monkeypatch.setenv("OPENAI_AGENTS_PROSPECTIVE_RELEASE_CONTRACT", str(prospective_contract))
+    monkeypatch.setattr(sys, "argv", [str(RUNNER), "--profile", "prospective-contract"])
+    monkeypatch.setattr(main.__globals__["sys"], "platform", platform)
+    monkeypatch.setitem(main.__globals__, "build_distributions", fake_build_distributions)
+    monkeypatch.setitem(main.__globals__, "create_environment", fake_create_environment)
+    monkeypatch.setitem(main.__globals__, "run_suite", fake_run_suite)
+    monkeypatch.setattr(main.__globals__["shutil"], "rmtree", lambda *args, **kwargs: None)
+
+    main()
+
+    policy = namespace["load_submodule_export_policy"](namespace["CONTRACT_POLICY"])
+    supported_installations = tuple(
+        installation
+        for installation in policy.dependency_installations
+        if installation.is_supported_on_current_platform()
+    )
+    isolated = [entry for entry in created if "-prospective-" in entry[0]]
+    assert len(isolated) == 2 * len(supported_installations)
+    assert all(bool(extra) != bool(requirements) for _, _, extra, requirements in isolated)
+    assert ("wheel-prospective-aiohttp", wheel, "cloudflare", ()) in isolated
+    assert (
+        "wheel-prospective-aiosqlite",
+        wheel,
+        None,
+        ("aiosqlite>=0.21.0",),
+    ) in isolated
+    assert ("sdist-prospective-modal", sdist, "modal", ()) in isolated
+
+    isolated_suites = [suite for suite in suites if "-prospective-" in suite["environment_kind"]]
+    assert len(isolated_suites) == len(isolated)
+    assert all(suite["selection"] == "packaging_dependency" for suite in isolated_suites)
+    assert all(suite["require_no_skips"] is True for suite in isolated_suites)
+    assert {
+        suite["additional_env"]["OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES"]
+        for suite in isolated_suites
+    } == {installation.dependency_module for installation in supported_installations}
+    assert {
+        (
+            suite["additional_env"]["OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES"],
+            suite["additional_env"].get("OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_EXTRA"),
+        )
+        for suite in isolated_suites
+    } == {
+        (installation.dependency_module, installation.extra)
+        for installation in supported_installations
+    }
+
+
+@pytest.mark.parametrize("platform", ["linux", "win32"])
+def test_prospective_platform_profile_checks_core_before_combined_optional_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    platform: str,
+) -> None:
+    namespace = runpy.run_path(str(RUNNER))
+    main = cast(Callable[[], None], namespace["main"])
+    wheel = tmp_path / "candidate.whl"
+    sdist = tmp_path / "candidate.tar.gz"
+    prospective_contract = tmp_path / "prospective-contract.json"
+    prospective_contract.write_text("{}", encoding="utf-8")
+    created: list[tuple[str, Path, str | None, tuple[str, ...]]] = []
+    suites: list[dict[str, Any]] = []
+
+    def fake_build_distributions() -> tuple[Path, Path]:
+        return wheel, sdist
+
+    def fake_create_environment(
+        name: str,
+        distribution: Path,
+        *,
+        extras: bool = False,
+        optional_extra: str | None = None,
+        additional_requirements: tuple[str, ...] = (),
+    ) -> Path:
+        _ = extras
+        created.append((name, distribution, optional_extra, additional_requirements))
+        return tmp_path / name / "python"
+
+    def fake_run_suite(*args: object, **kwargs: Any) -> None:
+        _ = args
+        suites.append(kwargs)
+
+    monkeypatch.setenv("OPENAI_AGENTS_PROSPECTIVE_RELEASE_CONTRACT", str(prospective_contract))
+    monkeypatch.setattr(sys, "argv", [str(RUNNER), "--profile", "prospective-platform"])
+    monkeypatch.setattr(main.__globals__["sys"], "platform", platform)
+    monkeypatch.setitem(main.__globals__, "build_distributions", fake_build_distributions)
+    monkeypatch.setitem(main.__globals__, "create_environment", fake_create_environment)
+    monkeypatch.setitem(main.__globals__, "run_suite", fake_run_suite)
+    monkeypatch.setattr(main.__globals__["shutil"], "rmtree", lambda *args, **kwargs: None)
+
+    main()
+
+    policy = namespace["load_submodule_export_policy"](namespace["CONTRACT_POLICY"])
+    supported_installations = tuple(
+        installation
+        for installation in policy.dependency_installations
+        if installation.is_supported_on_current_platform()
+    )
+    expected_extras = ",".join(
+        sorted(
+            {
+                installation.extra
+                for installation in supported_installations
+                if installation.extra is not None
+            }
+        )
+    )
+    expected_requirements = tuple(
+        sorted(
+            {
+                installation.requirement
+                for installation in supported_installations
+                if installation.requirement is not None
+            }
+        )
+    )
+    assert created == [
+        (
+            "wheel-prospective-platform-core",
+            wheel,
+            None,
+            (),
+        ),
+        (
+            "wheel-prospective-platform",
+            wheel,
+            expected_extras,
+            expected_requirements,
+        ),
+    ]
+    assert len(suites) == 2
+    assert suites[0]["environment_kind"] == "wheel-prospective-platform-core"
+    assert suites[0]["selection"] == "packaging_dependency"
+    assert suites[0]["require_no_skips"] is True
+    assert "additional_env" not in suites[0]
+    assert suites[1]["environment_kind"] == "wheel-prospective-platform"
+    assert suites[1]["selection"] == "packaging_dependency"
+    assert suites[1]["require_no_skips"] is True
+    assert suites[1]["additional_env"] == {
+        "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES": ",".join(
+            installation.dependency_module for installation in supported_installations
+        ),
+        "OPENAI_AGENTS_INTEGRATION_OPTIONAL_DEPENDENCY_INSTALLATION": (
+            "policy optional dependencies"
+        ),
+    }
+
+
+def test_prospective_platform_profile_excludes_unsupported_optional_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    namespace = runpy.run_path(str(RUNNER))
+    main = cast(Callable[[], None], namespace["main"])
+    wheel = tmp_path / "candidate.whl"
+    sdist = tmp_path / "candidate.tar.gz"
+    prospective_contract = tmp_path / "prospective-contract.json"
+    prospective_contract.write_text("{}", encoding="utf-8")
+    created: list[tuple[str, Path, str | None, tuple[str, ...]]] = []
+    suites: list[dict[str, Any]] = []
+
+    def fake_create_environment(
+        name: str,
+        distribution: Path,
+        *,
+        extras: bool = False,
+        optional_extra: str | None = None,
+        additional_requirements: tuple[str, ...] = (),
+    ) -> Path:
+        _ = extras
+        created.append((name, distribution, optional_extra, additional_requirements))
+        return tmp_path / name / "python"
+
+    monkeypatch.setenv("OPENAI_AGENTS_PROSPECTIVE_RELEASE_CONTRACT", str(prospective_contract))
+    monkeypatch.setattr(sys, "argv", [str(RUNNER), "--profile", "prospective-platform"])
+    monkeypatch.setattr(main.__globals__["sys"], "platform", "win32")
+    monkeypatch.setitem(main.__globals__, "build_distributions", lambda: (wheel, sdist))
+    monkeypatch.setitem(main.__globals__, "create_environment", fake_create_environment)
+    monkeypatch.setitem(
+        main.__globals__, "run_suite", lambda *args, **kwargs: suites.append(kwargs)
+    )
+    monkeypatch.setattr(main.__globals__["shutil"], "rmtree", lambda *args, **kwargs: None)
+
+    main()
+
+    combined_environment = next(
+        environment for environment in created if environment[0] == "wheel-prospective-platform"
+    )
+    assert "vercel" not in (combined_environment[2] or "").split(",")
+    combined_suite = next(
+        suite for suite in suites if suite["environment_kind"] == "wheel-prospective-platform"
+    )
+    required_dependencies = combined_suite["additional_env"][
+        "OPENAI_AGENTS_INTEGRATION_REQUIRED_OPTIONAL_DEPENDENCIES"
+    ].split(",")
+    assert "vercel" not in required_dependencies
+    assert "aiohttp" in required_dependencies
+    assert (
+        "[integration] skipping optional dependency vercel on unsupported platform win32"
+        in capsys.readouterr().out
+    )

--- a/tests/test_released_api_contract.py
+++ b/tests/test_released_api_contract.py
@@ -1,6 +1,8 @@
+import json
+import subprocess
 import sys
 from collections.abc import AsyncIterator, Callable, Iterator
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum
 from importlib.metadata import version
 from pathlib import Path
@@ -20,6 +22,7 @@ from integration_tests._contract_support import (
     _validate_public_property_contract,
     build_released_api_contract,
     load_api_contract,
+    load_submodule_export_policy,
     validate_released_api_contract,
 )
 
@@ -1062,6 +1065,360 @@ def test_release_contract_update_promotes_selected_submodule_exports(
     }
 
 
+def test_release_contract_policy_preserves_new_optional_export_in_core_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = object()
+    optional = object()
+    agents_module = SimpleNamespace(__all__=[])
+    full_submodule = SimpleNamespace(
+        __all__=["Existing", "OptionalBackend"],
+        Existing=existing,
+        OptionalBackend=optional,
+    )
+    core_submodule = SimpleNamespace(__all__=["Existing"], Existing=existing)
+    imported_submodule = full_submodule
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents.submodule"],
+        "required_submodule_exports": {
+            "agents.submodule": {
+                "names": ["Existing"],
+                "optional_bindings": {},
+                "optional_exports": {},
+            }
+        },
+        "canonical_imports": [],
+        "callables": {},
+    }
+
+    def import_module(module_name: str, _agents_module: object) -> object:
+        return agents_module if module_name == "agents" else imported_submodule
+
+    monkeypatch.setattr(contract_support, "_import_contract_module", import_module)
+    dependency_available = True
+    monkeypatch.setattr(
+        contract_support,
+        "_optional_dependency_is_available",
+        lambda _module_name: dependency_available,
+    )
+    policy = {
+        "agents.submodule": {
+            "optional_bindings": {},
+            "optional_exports": {"OptionalBackend": "missing_optional_backend_dependency"},
+        }
+    }
+
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        submodule_export_policy=policy,
+    )
+    dependency_available = False
+    imported_submodule = core_submodule
+
+    assert updated["required_submodule_exports"]["agents.submodule"] == {
+        "names": ["Existing", "OptionalBackend"],
+        "optional_bindings": {},
+        "optional_exports": {"OptionalBackend": "missing_optional_backend_dependency"},
+    }
+    assert validate_released_api_contract(updated, agents_module=agents_module) == []
+
+
+def test_release_contract_policy_rejects_unavailable_dependency_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agents_module = SimpleNamespace(__all__=[])
+    submodule = SimpleNamespace(__all__=[])
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents.submodule"],
+        "canonical_imports": [],
+        "callables": {},
+    }
+    monkeypatch.setattr(
+        contract_support,
+        "_optional_dependency_is_available",
+        lambda _module_name: False,
+    )
+    monkeypatch.setattr(
+        contract_support,
+        "_import_contract_module",
+        lambda module_name, _agents_module: (
+            agents_module if module_name == "agents" else submodule
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="submodule export policy dependency modules are unavailable: "
+        r"\['mistyped_dependency'\]",
+    ):
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            submodule_export_policy={
+                "agents.submodule": {
+                    "optional_bindings": {},
+                    "optional_exports": {"OptionalBackend": "mistyped_dependency"},
+                }
+            },
+        )
+
+
+def test_release_contract_policy_adds_new_public_optional_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optional = object()
+    agents_module = SimpleNamespace(__all__=[])
+    submodule = SimpleNamespace(__all__=["OptionalBackend"], OptionalBackend=optional)
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "callables": {},
+    }
+    monkeypatch.setattr(
+        contract_support,
+        "_optional_dependency_is_available",
+        lambda _module_name: True,
+    )
+    monkeypatch.setattr(
+        contract_support,
+        "_import_contract_module",
+        lambda module_name, _agents_module: (
+            agents_module if module_name == "agents" else submodule
+        ),
+    )
+
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        submodule_export_policy={
+            "agents.new_submodule": {
+                "optional_bindings": {},
+                "optional_exports": {"OptionalBackend": "optional_backend"},
+            }
+        },
+    )
+
+    assert updated["public_modules"] == ["agents", "agents.new_submodule"]
+    assert updated["required_submodule_exports"]["agents.new_submodule"] == {
+        "names": ["OptionalBackend"],
+        "optional_bindings": {},
+        "optional_exports": {"OptionalBackend": "optional_backend"},
+    }
+
+
+def test_release_contract_policy_rejects_unimportable_new_public_module() -> None:
+    agents_module = SimpleNamespace(__all__=[])
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "callables": {},
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot import submodule export policy module agents\.typo: ModuleNotFoundError",
+    ):
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            submodule_export_policy={
+                "agents.typo": {"optional_bindings": {}, "optional_exports": {}}
+            },
+        )
+
+
+def test_release_contract_policy_rejects_new_module_outside_agents_package() -> None:
+    agents_module = SimpleNamespace(__all__=[])
+    contract: dict[str, Any] = {
+        "baseline": "v0.19.4",
+        "baseline_commit": "a" * 40,
+        "required_top_level_exports": [],
+        "public_modules": ["agents"],
+        "canonical_imports": [],
+        "callables": {},
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="new submodule export policy modules must be under the agents package: "
+        r"\['external_package'\]",
+    ):
+        build_released_api_contract(
+            contract,
+            baseline="v0.20.0",
+            baseline_commit="b" * 40,
+            agents_module=agents_module,
+            submodule_export_policy={
+                "external_package": {"optional_bindings": {}, "optional_exports": {}}
+            },
+        )
+
+
+def test_load_submodule_export_policy_rejects_unknown_fields(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        '{"modules": {"agents.submodule": {"optional_export": {}}}, "optional_dependencies": {}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"submodule export policy for agents.submodule has unknown fields: "
+        r"\['optional_export'\]",
+    ):
+        load_submodule_export_policy(policy_path)
+
+
+def test_load_submodule_export_policy_requires_dependency_installations(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        '{"modules": {"agents.submodule": {"optional_exports": '
+        '{"OptionalBackend": "optional_backend"}}}, "optional_dependencies": {}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="submodule export policy dependencies are missing installation declarations: "
+        r"\['optional_backend'\]",
+    ):
+        load_submodule_export_policy(policy_path)
+
+
+def test_load_submodule_export_policy_collects_artifact_installations(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        '{"modules": {"agents.submodule": {"optional_bindings": '
+        '{"LazyBinding": "binding_dependency"}, "optional_exports": '
+        '{"ConditionalExport": "export_dependency"}}}, "optional_dependencies": '
+        '{"binding_dependency": {"requirement": "binding-package>=1"}, '
+        '"export_dependency": {"extra": "export-extra"}}}',
+        encoding="utf-8",
+    )
+
+    policy = load_submodule_export_policy(policy_path)
+
+    assert policy.modules == {
+        "agents.submodule": {
+            "optional_bindings": {"LazyBinding": "binding_dependency"},
+            "optional_exports": {"ConditionalExport": "export_dependency"},
+        }
+    }
+    assert [asdict(installation) for installation in policy.dependency_installations] == [
+        {
+            "dependency_module": "binding_dependency",
+            "extra": None,
+            "requirement": "binding-package>=1",
+            "unsupported_platforms": (),
+        },
+        {
+            "dependency_module": "export_dependency",
+            "extra": "export-extra",
+            "requirement": None,
+            "unsupported_platforms": (),
+        },
+    ]
+
+
+def test_load_submodule_export_policy_collects_unsupported_platforms(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        '{"modules": {"agents.submodule": {"optional_exports": '
+        '{"ConditionalExport": "export_dependency"}}}, "optional_dependencies": '
+        '{"export_dependency": {"extra": "export-extra", '
+        '"unsupported_platforms": ["win32"]}}}',
+        encoding="utf-8",
+    )
+
+    policy = load_submodule_export_policy(policy_path)
+
+    assert policy.dependency_installations[0].unsupported_platforms == ("win32",)
+
+
+@pytest.mark.parametrize(
+    "unsupported_platforms",
+    ["win32", [""], ["win32", "win32"]],
+)
+def test_load_submodule_export_policy_rejects_invalid_unsupported_platforms(
+    tmp_path: Path, unsupported_platforms: object
+) -> None:
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "modules": {
+                    "agents.submodule": {
+                        "optional_exports": {"ConditionalExport": "export_dependency"}
+                    }
+                },
+                "optional_dependencies": {
+                    "export_dependency": {
+                        "extra": "export-extra",
+                        "unsupported_platforms": unsupported_platforms,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must be a list of unique non-empty strings"):
+        load_submodule_export_policy(policy_path)
+
+
+@pytest.mark.parametrize(
+    "protected_path",
+    [
+        CONTRACT,
+        CONTRACT.with_name("released_api_contract_policy.json"),
+    ],
+)
+def test_prospective_output_rejects_contract_input_path(protected_path: Path) -> None:
+    root = CONTRACT.parents[2]
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(root / ".github" / "scripts" / "update_released_api_contract.py"),
+            "--version",
+            version("openai-agents"),
+            "--output",
+            str(protected_path),
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr.strip() == (
+        "--output must not overwrite released API contract inputs: "
+        "tests/fixtures/released_api_contract.json or "
+        "tests/fixtures/released_api_contract_policy.json"
+    )
+
+
 def test_public_api_contract_allows_declared_optional_submodule_binding(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1120,6 +1477,73 @@ def test_public_api_contract_allows_declared_optional_submodule_export(
     assert validate_released_api_contract(contract, agents_module=agents_module) == []
 
 
+def test_public_api_contract_rejects_optional_export_that_remains_in_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agents_module = SimpleNamespace(__all__=[])
+    submodule = SimpleNamespace(__all__=["OptionalBackend"])
+    contract: dict[str, Any] = {
+        "required_top_level_exports": [],
+        "public_modules": ["agents.submodule"],
+        "required_submodule_exports": {
+            "agents.submodule": {
+                "names": ["OptionalBackend"],
+                "optional_bindings": {},
+                "optional_exports": {"OptionalBackend": "missing_optional_backend_dependency"},
+            }
+        },
+        "canonical_imports": [],
+        "callables": {},
+    }
+    monkeypatch.setattr(
+        contract_support,
+        "_import_contract_module",
+        lambda module_name, _agents_module: (
+            agents_module if module_name == "agents" else submodule
+        ),
+    )
+
+    assert validate_released_api_contract(contract, agents_module=agents_module) == [
+        "Invalid released agents.submodule optional dependency declaration: "
+        "'OptionalBackend' remains in __all__ but its binding is unavailable; "
+        "declare it in optional_bindings instead of optional_exports"
+    ]
+
+
+def test_public_api_contract_rejects_optional_binding_absent_from_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agents_module = SimpleNamespace(__all__=[])
+    submodule = SimpleNamespace(__all__=[])
+    contract: dict[str, Any] = {
+        "required_top_level_exports": [],
+        "public_modules": ["agents.submodule"],
+        "required_submodule_exports": {
+            "agents.submodule": {
+                "names": ["OptionalBackend"],
+                "optional_bindings": {"OptionalBackend": "missing_optional_backend_dependency"},
+                "optional_exports": {},
+            }
+        },
+        "canonical_imports": [],
+        "callables": {},
+    }
+    monkeypatch.setattr(
+        contract_support,
+        "_import_contract_module",
+        lambda module_name, _agents_module: (
+            agents_module if module_name == "agents" else submodule
+        ),
+    )
+
+    assert validate_released_api_contract(contract, agents_module=agents_module) == [
+        "Invalid released agents.submodule optional dependency declaration: "
+        "'OptionalBackend' is absent from __all__; declare it in optional_exports "
+        "instead of optional_bindings",
+        "Missing released agents.submodule exports: ['OptionalBackend']",
+    ]
+
+
 def test_public_api_contract_requires_available_optional_submodule_export(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1149,42 +1573,6 @@ def test_public_api_contract_requires_available_optional_submodule_export(
     assert validate_released_api_contract(contract, agents_module=agents_module) == [
         "Missing released agents.submodule exports: ['OptionalBackend']",
         "Missing released agents.submodule bindings: ['OptionalBackend']",
-    ]
-
-
-def test_public_api_contract_requires_declared_dependencies_in_strict_optional_profile(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    agents_module = SimpleNamespace(__all__=[])
-    submodule = SimpleNamespace(__all__=[])
-    contract: dict[str, Any] = {
-        "required_top_level_exports": [],
-        "public_modules": ["agents.submodule"],
-        "required_submodule_exports": {
-            "agents.submodule": {
-                "names": ["OptionalBackend"],
-                "optional_bindings": {},
-                "optional_exports": {"OptionalBackend": "mistyped_dependency_name"},
-            }
-        },
-        "canonical_imports": [],
-        "callables": {},
-    }
-    monkeypatch.setattr(
-        contract_support,
-        "_import_contract_module",
-        lambda module_name, _agents_module: (
-            agents_module if module_name == "agents" else submodule
-        ),
-    )
-
-    assert validate_released_api_contract(
-        contract,
-        agents_module=agents_module,
-        require_all_optional_exports=True,
-    ) == [
-        "Required optional dependencies for released agents.submodule are unavailable: "
-        "['OptionalBackend -> mistyped_dependency_name']"
     ]
 
 


### PR DESCRIPTION
This pull request adds a pre-merge prospective API contract gate so release-blocking packaging problems are detected before release preparation.

It generates one canonical prospective contract on Python 3.12 and validates it against isolated wheel and source-distribution installations on Python 3.10 and 3.14. Each policy-declared extra or direct requirement is tested independently so dependencies from another extra cannot mask packaging mistakes.

A lightweight Windows job validates the same contract against one clean wheel environment with all policy dependencies, covering platform-specific import failures without duplicating the Linux packaging matrix.

The policy can also declare newly public `agents.*` modules before the released fixture is updated. Unimportable modules, invalid dependency declarations, and modules outside the `agents` package fail with actionable errors.

The change also pins uv consistently and fixes nondeterministic Windows redaction-observable traversal caused by temporary object ID reuse.