### PR TITLE
release: 0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-agents"
-version = "0.19.4"
+version = "0.20.0"
 description = "OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/fixtures/released_api_contract.json
+++ b/tests/fixtures/released_api_contract.json
@@ -1,6 +1,6 @@
 {
-  "baseline": "v0.19.4",
-  "baseline_commit": "9bfad15ab8297fbb2afe389c983a5cb573eeef56",
+  "baseline": "v0.20.0",
+  "baseline_commit": "c0b876379e82095b164c78cec65fb659a699a98d",
   "callables": {
     "Agent": {
       "dataclass_fields": [
@@ -699,6 +699,15 @@
               },
               "kind": "KEYWORD_ONLY",
               "name": "tool_lookup_key"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "current_invocation"
             }
           ]
         },
@@ -3881,6 +3890,86 @@
         }
       ]
     },
+    "InputItem": {
+      "dataclass_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "init": true,
+          "name": "agent"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "init": true,
+          "name": "raw_item"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "input_item"
+          },
+          "init": true,
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "agents.items.InputItem.<lambda>",
+            "kind": "factory"
+          },
+          "init": true,
+          "name": "input_id"
+        }
+      ],
+      "kind": "class",
+      "members": {
+        "release_agent": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "to_input_item": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        }
+      },
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "agent"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "raw_item"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "input_item"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "input_id"
+        }
+      ]
+    },
     "ItemHelpers": {
       "dataclass_fields": [],
       "kind": "class",
@@ -4711,6 +4800,15 @@
           },
           "init": true,
           "name": "request_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "init": true,
+          "name": "raw_usage"
         }
       ],
       "kind": "class",
@@ -4751,6 +4849,15 @@
           },
           "kind": "POSITIONAL_OR_KEYWORD",
           "name": "request_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "raw_usage"
         }
       ]
     },
@@ -4800,6 +4907,15 @@
           },
           "init": true,
           "name": "normalized"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "init": true,
+          "name": "response_started"
         }
       ],
       "kind": "class",
@@ -4849,6 +4965,15 @@
           },
           "kind": "POSITIONAL_OR_KEYWORD",
           "name": "normalized"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "response_started"
         }
       ]
     },
@@ -5444,6 +5569,15 @@
           },
           "init": true,
           "name": "prompt_cache_options"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "init": true,
+          "name": "preserve_raw_usage"
         }
       ],
       "kind": "class",
@@ -5679,6 +5813,15 @@
           },
           "kind": "POSITIONAL_OR_KEYWORD",
           "name": "prompt_cache_options"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "preserve_raw_usage"
         }
       ]
     },
@@ -7399,6 +7542,15 @@
           },
           "init": true,
           "name": "reason"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "init": true,
+          "name": "approve_unsafe_replay"
         }
       ],
       "kind": "class",
@@ -7428,6 +7580,15 @@
           },
           "kind": "POSITIONAL_OR_KEYWORD",
           "name": "reason"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "approve_unsafe_replay"
         }
       ]
     },
@@ -7476,6 +7637,24 @@
           },
           "init": true,
           "name": "provider_advice"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "init": true,
+          "name": "previous_response_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "init": true,
+          "name": "conversation_id"
         }
       ],
       "kind": "class",
@@ -7524,6 +7703,24 @@
           },
           "kind": "POSITIONAL_OR_KEYWORD",
           "name": "provider_advice"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "previous_response_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "conversation_id"
         }
       ]
     },
@@ -8064,6 +8261,15 @@
               },
               "kind": "KEYWORD_ONLY",
               "name": "tool_lookup_key"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "current_invocation"
             }
           ]
         },
@@ -9403,6 +9609,19 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {
+        "add_input": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "input"
+            }
+          ]
+        },
         "approve": {
           "binding": "instance",
           "execution_kind": "sync",
@@ -9424,6 +9643,11 @@
               "name": "always_approve"
             }
           ]
+        },
+        "clear_pending_input": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
         },
         "from_json": {
           "binding": "static",
@@ -11211,6 +11435,15 @@
           },
           "kind": "POSITIONAL_OR_KEYWORD",
           "name": "tool_origin"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "_resolved_tool_name"
         }
       ]
     },
@@ -11852,6 +12085,48 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "file"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "file_data"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "file_url"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "file_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "filename"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -12076,6 +12351,40 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "image"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "image_url"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "file_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "detail"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -12119,6 +12428,22 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "text"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "text"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -13276,13 +13601,32 @@
               },
               "kind": "POSITIONAL_OR_KEYWORD",
               "name": "items"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "wrapper"
             }
           ]
         },
         "clear_session": {
           "binding": "instance",
           "execution_kind": "coroutine",
-          "parameters": []
+          "parameters": [
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "wrapper"
+            }
+          ]
         },
         "get_items": {
           "binding": "instance",
@@ -13296,13 +13640,32 @@
               },
               "kind": "POSITIONAL_OR_KEYWORD",
               "name": "limit"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "wrapper"
             }
           ]
         },
         "pop_item": {
           "binding": "instance",
           "execution_kind": "coroutine",
-          "parameters": []
+          "parameters": [
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "wrapper"
+            }
+          ]
         }
       },
       "parameters": [
@@ -13517,6 +13880,16 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "blaxel_drive"
+          },
+          "name": "type"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -14055,6 +14428,113 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "daytona_cloud_bucket"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "model",
+            "type": "agents.sandbox.entries.mounts.patterns.RcloneMountPattern",
+            "value": {
+              "items": [
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "type"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "rclone"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "mode"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "fuse"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "remote_name"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "extra_args"
+                  },
+                  {
+                    "items": [],
+                    "kind": "sequence",
+                    "type": "builtins.list"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "nfs_addr"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "nfs_mount_options"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "config_file_path"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ]
+              ],
+              "kind": "mapping",
+              "type": "builtins.dict"
+            }
+          },
+          "name": "pattern"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -14315,6 +14795,112 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "daytona"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "sandbox_snapshot_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "image"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "resources"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "env_vars"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "pause_on_exit"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 60
+          },
+          "name": "create_timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 60
+          },
+          "name": "start_timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 0
+          },
+          "name": "auto_stop_interval"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "timeouts"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 3600
+          },
+          "name": "exposed_port_url_ttl_s"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -14457,6 +15043,64 @@
             }
           ]
         },
+        "model_validate_json": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "json_data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "strict"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "extra"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "context"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_alias"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_name"
+            }
+          ]
+        },
         "parse": {
           "binding": "class",
           "execution_kind": "sync",
@@ -14467,6 +15111,26 @@
               },
               "kind": "POSITIONAL_OR_KEYWORD",
               "name": "payload"
+            }
+          ]
+        },
+        "rebind_persisted_mount_authority": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "provider_backend_id"
             }
           ]
         },
@@ -14484,6 +15148,158 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "daytona"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "uuid.uuid4",
+            "kind": "factory"
+          },
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "factory": "builtins.tuple",
+            "kind": "factory"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "sandbox_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "sandbox_snapshot_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "image"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "base_env_vars"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "pause_on_exit"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 60
+          },
+          "name": "create_timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 60
+          },
+          "name": "start_timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "resources"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 0
+          },
+          "name": "auto_stop_interval"
+        },
+        {
+          "default": {
+            "factory": "agents.extensions.sandbox.daytona.sandbox.DaytonaSandboxTimeouts",
+            "kind": "factory"
+          },
+          "name": "timeouts"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 3600
+          },
+          "name": "exposed_port_url_ttl_s"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -14780,6 +15596,126 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "e2b"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "sandbox_type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "template"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "metadata"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "envs"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "secure"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "allow_internet_access"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "timeouts"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "pause_on_exit"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "pause"
+          },
+          "name": "on_timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "auto_resume"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mcp"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -14938,6 +15874,64 @@
             }
           ]
         },
+        "model_validate_json": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "json_data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "strict"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "extra"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "context"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_alias"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_name"
+            }
+          ]
+        },
         "parse": {
           "binding": "class",
           "execution_kind": "sync",
@@ -14948,6 +15942,26 @@
               },
               "kind": "POSITIONAL_OR_KEYWORD",
               "name": "payload"
+            }
+          ]
+        },
+        "rebind_persisted_mount_authority": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "provider_backend_id"
             }
           ]
         },
@@ -14965,6 +15979,174 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "e2b"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "uuid.uuid4",
+            "kind": "factory"
+          },
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "factory": "builtins.tuple",
+            "kind": "factory"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "sandbox_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "agents.extensions.sandbox.e2b.sandbox.E2BSandboxType",
+            "value": "e2b"
+          },
+          "name": "sandbox_type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "template"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "sandbox_timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "metadata"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "base_envs"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "secure"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "allow_internet_access"
+        },
+        {
+          "default": {
+            "factory": "agents.extensions.sandbox.e2b.sandbox.E2BSandboxTimeouts",
+            "kind": "factory"
+          },
+          "name": "timeouts"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "pause_on_exit"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "pause"
+          },
+          "name": "on_timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "auto_resume"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mcp"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -15181,6 +16363,5628 @@
           },
           "kind": "POSITIONAL_OR_KEYWORD",
           "name": "value"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.ModalCloudBucketMountStrategy": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "activate": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "base_dir"
+            }
+          ]
+        },
+        "build_docker_volume_driver_config": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        },
+        "deactivate": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "base_dir"
+            }
+          ]
+        },
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "restore_after_snapshot": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "supports_native_snapshot_detach": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        },
+        "teardown_for_snapshot": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "validate_mount": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "modal_cloud_bucket"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "secret_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "secret_environment_name"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "modal_cloud_bucket"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "secret_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "secret_environment_name"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.ModalSandboxClient": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "create": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "snapshot"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "options"
+            }
+          ]
+        },
+        "delete": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            }
+          ]
+        },
+        "deserialize_session_state": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "resume": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            }
+          ]
+        },
+        "serialize_session_state": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            }
+          ]
+        }
+      },
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "image"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "sandbox"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "instrumentation"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "dependencies"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.ModalSandboxClientOptions": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "modal"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "app_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "sandbox_create_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_filesystem_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_filesystem_restore_timeout_s"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "gpu"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 300
+          },
+          "name": "timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "use_sleep_cmd"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "2025.06"
+          },
+          "name": "image_builder_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "idle_timeout"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "app_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "sandbox_create_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "snapshot_filesystem_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "snapshot_filesystem_restore_timeout_s"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "gpu"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 300
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "use_sleep_cmd"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "2025.06"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "image_builder_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "idle_timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "modal"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.ModalSandboxSession": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "aclose": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "apply_manifest": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "only_ephemeral"
+            }
+          ]
+        },
+        "apply_patch": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "operations"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.str",
+                "value": "v4a"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "patch_format"
+            }
+          ]
+        },
+        "describe": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "exec": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "VAR_POSITIONAL",
+              "name": "command"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "timeout"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": true
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "shell"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "extract": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "compression_scheme"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "archive_limits"
+            }
+          ]
+        },
+        "from_state": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "image"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "sandbox"
+            }
+          ]
+        },
+        "hydrate_workspace": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            }
+          ]
+        },
+        "ls": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "mkdir": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "parents"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "normalize_path": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "for_write"
+            }
+          ]
+        },
+        "persist_workspace": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "provision_manifest_accounts": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "pty_exec_start": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "VAR_POSITIONAL",
+              "name": "command"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "timeout"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": true
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "shell"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "tty"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "yield_time_s"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "max_output_tokens"
+            }
+          ]
+        },
+        "pty_terminate_all": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "pty_write_stdin": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "session_id"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "chars"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "yield_time_s"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "max_output_tokens"
+            }
+          ]
+        },
+        "read": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "register_persist_workspace_skip_path": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "register_pre_stop_hook": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "hook"
+            }
+          ]
+        },
+        "resolve_exposed_port": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "port"
+            }
+          ]
+        },
+        "rm": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "recursive"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "run_pre_stop_hooks": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "running": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "set_dependencies": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dependencies"
+            }
+          ]
+        },
+        "should_provision_manifest_accounts_on_resume": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "shutdown": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "snapshot_filesystem": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "start": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "stop": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "supports_docker_volume_mounts": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "supports_pty": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "write": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        }
+      },
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "state"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "image"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "sandbox"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.ModalSandboxSessionState": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "assert_path_grants_rebound": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "model_post_init": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_ONLY",
+              "name": "context"
+            }
+          ]
+        },
+        "model_validate_json": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "json_data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "strict"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "extra"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "context"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_alias"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_name"
+            }
+          ]
+        },
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "rebind_persisted_mount_authority": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "provider_backend_id"
+            }
+          ]
+        },
+        "rebind_persisted_path_grants": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "modal"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "uuid.uuid4",
+            "kind": "factory"
+          },
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "factory": "builtins.tuple",
+            "kind": "factory"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "app_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "image_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "image_tag"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 30.0
+          },
+          "name": "sandbox_create_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "sandbox_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 60.0
+          },
+          "name": "snapshot_filesystem_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 60.0
+          },
+          "name": "snapshot_filesystem_restore_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "gpu"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 300
+          },
+          "name": "timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "use_sleep_cmd"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "2025.06"
+          },
+          "name": "image_builder_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "idle_timeout"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "modal"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "app_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "image_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "image_tag"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 30.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "sandbox_create_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "sandbox_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 60.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_filesystem_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 60.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_filesystem_restore_timeout_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "gpu"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 300
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "timeout"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "use_sleep_cmd"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "2025.06"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "image_builder_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "idle_timeout"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopAfterIdle": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "idle_time_seconds"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "on_idle"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "VAR_KEYWORD",
+          "name": "data"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopCloudBucketMountStrategy": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "activate": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "base_dir"
+            }
+          ]
+        },
+        "build_docker_volume_driver_config": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        },
+        "deactivate": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "base_dir"
+            }
+          ]
+        },
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "restore_after_snapshot": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "supports_native_snapshot_detach": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        },
+        "teardown_for_snapshot": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "validate_mount": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "runloop_cloud_bucket"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "model",
+            "type": "agents.sandbox.entries.mounts.patterns.RcloneMountPattern",
+            "value": {
+              "items": [
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "type"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "rclone"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "mode"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "fuse"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "remote_name"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "extra_args"
+                  },
+                  {
+                    "items": [],
+                    "kind": "sequence",
+                    "type": "builtins.list"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "nfs_addr"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "nfs_mount_options"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "config_file_path"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ]
+              ],
+              "kind": "mapping",
+              "type": "builtins.dict"
+            }
+          },
+          "name": "pattern"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "runloop_cloud_bucket"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "model",
+            "type": "agents.sandbox.entries.mounts.patterns.RcloneMountPattern",
+            "value": {
+              "items": [
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "type"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "rclone"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "mode"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "fuse"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "remote_name"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "extra_args"
+                  },
+                  {
+                    "items": [],
+                    "kind": "sequence",
+                    "type": "builtins.list"
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "nfs_addr"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "nfs_mount_options"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ],
+                [
+                  {
+                    "kind": "literal",
+                    "type": "builtins.str",
+                    "value": "config_file_path"
+                  },
+                  {
+                    "kind": "literal",
+                    "type": "builtins.NoneType",
+                    "value": null
+                  }
+                ]
+              ],
+              "kind": "mapping",
+              "type": "builtins.dict"
+            }
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "pattern"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopGatewaySpec": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "gateway"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "secret"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "gateway"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "secret"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopLaunchParameters": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "after_idle"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "architecture"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "available_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "custom_cpu_cores"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "custom_disk_size"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "custom_gb_memory"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "keep_alive_time_seconds"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "launch_commands"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "network_policy_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "required_services"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "resource_size_request"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "user_parameters"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "VAR_KEYWORD",
+          "name": "data"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopMcpSpec": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "mcp_config"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "secret"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "mcp_config"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "secret"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopPlatformClient": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {},
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "_sdk"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopSandboxClient": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "close": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "create": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "snapshot"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "options"
+            }
+          ]
+        },
+        "delete": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            }
+          ]
+        },
+        "deserialize_session_state": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "resume": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            }
+          ]
+        },
+        "serialize_session_state": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            }
+          ]
+        }
+      },
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "bearer_token"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "base_url"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "instrumentation"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "dependencies"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopSandboxClientOptions": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "runloop"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "blueprint_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "blueprint_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "env_vars"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "pause_on_exit"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "timeouts"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "user_parameters"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "launch_parameters"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "tunnel"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "gateways"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mcp"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "metadata"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "managed_secrets"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "blueprint_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "blueprint_name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "env_vars"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "pause_on_exit"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "name"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "timeouts"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "user_parameters"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "launch_parameters"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "tunnel"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "gateways"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "mcp"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "metadata"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "managed_secrets"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "runloop"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopSandboxSession": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "aclose": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "apply_manifest": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "only_ephemeral"
+            }
+          ]
+        },
+        "apply_patch": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "operations"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.str",
+                "value": "v4a"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "patch_format"
+            }
+          ]
+        },
+        "describe": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "exec": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "VAR_POSITIONAL",
+              "name": "command"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "timeout"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": true
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "shell"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "extract": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "compression_scheme"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "archive_limits"
+            }
+          ]
+        },
+        "from_state": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "sdk"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "devbox"
+            }
+          ]
+        },
+        "hydrate_workspace": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            }
+          ]
+        },
+        "ls": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "mkdir": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "parents"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "normalize_path": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "for_write"
+            }
+          ]
+        },
+        "persist_workspace": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "provision_manifest_accounts": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "pty_exec_start": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "VAR_POSITIONAL",
+              "name": "command"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "timeout"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": true
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "shell"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "tty"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "yield_time_s"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "max_output_tokens"
+            }
+          ]
+        },
+        "pty_terminate_all": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "pty_write_stdin": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "session_id"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "chars"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "yield_time_s"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "max_output_tokens"
+            }
+          ]
+        },
+        "read": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "register_persist_workspace_skip_path": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "register_pre_stop_hook": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "hook"
+            }
+          ]
+        },
+        "resolve_exposed_port": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "port"
+            }
+          ]
+        },
+        "rm": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "recursive"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "run_pre_stop_hooks": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "running": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "set_dependencies": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dependencies"
+            }
+          ]
+        },
+        "should_provision_manifest_accounts_on_resume": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "shutdown": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "start": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "stop": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "supports_docker_volume_mounts": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "supports_pty": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "write": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        }
+      },
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "state"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "sdk"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "devbox"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopSandboxSessionState": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "assert_path_grants_rebound": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "model_post_init": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_ONLY",
+              "name": "context"
+            }
+          ]
+        },
+        "model_validate_json": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "json_data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "strict"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "extra"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "context"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_alias"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_name"
+            }
+          ]
+        },
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "rebind_persisted_mount_authority": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "provider_backend_id"
+            }
+          ]
+        },
+        "rebind_persisted_path_grants": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "runloop"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "uuid.uuid4",
+            "kind": "factory"
+          },
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "factory": "builtins.tuple",
+            "kind": "factory"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "devbox_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "blueprint_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "blueprint_name"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "base_env_vars"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "pause_on_exit"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "name"
+        },
+        {
+          "default": {
+            "factory": "agents.extensions.sandbox.runloop.sandbox.RunloopTimeouts",
+            "kind": "factory"
+          },
+          "name": "timeouts"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "user_parameters"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "launch_parameters"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "tunnel"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "gateways"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "mcp"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "metadata"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "secret_refs"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "runloop"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "devbox_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "blueprint_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "blueprint_name"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "base_env_vars"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "pause_on_exit"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "name"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "timeouts"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "user_parameters"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "launch_parameters"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "tunnel"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "gateways"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "mcp"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "metadata"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "secret_refs"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopTimeouts": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 86400
+          },
+          "name": "exec_timeout_unbounded_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 300.0
+          },
+          "name": "create_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 10.0
+          },
+          "name": "keepalive_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 30.0
+          },
+          "name": "cleanup_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 30.0
+          },
+          "name": "fast_op_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 1800.0
+          },
+          "name": "file_upload_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 1800.0
+          },
+          "name": "file_download_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 300.0
+          },
+          "name": "snapshot_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 120.0
+          },
+          "name": "suspend_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 300.0
+          },
+          "name": "resume_s"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 86400
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "exec_timeout_unbounded_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 300.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "create_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 10.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "keepalive_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 30.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "cleanup_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 30.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "fast_op_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 1800.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "file_upload_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 1800.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "file_download_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 300.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 120.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "suspend_s"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.float",
+            "value": 300.0
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "resume_s"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopTunnelConfig": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "auth_mode"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "http_keep_alive"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "wake_on_http"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "auth_mode"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "http_keep_alive"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "wake_on_http"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.RunloopUserParameters": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "uid"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "username"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "VAR_KEYWORD",
+          "name": "data"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.VercelCloudBucketMountStrategy": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "activate": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "base_dir"
+            }
+          ]
+        },
+        "build_docker_volume_driver_config": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        },
+        "deactivate": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "base_dir"
+            }
+          ]
+        },
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "restore_after_snapshot": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "supports_native_snapshot_detach": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        },
+        "teardown_for_snapshot": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "validate_mount": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "mount"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "vercel_cloud_bucket"
+          },
+          "name": "type"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "vercel_cloud_bucket"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.VercelSandboxClient": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "create": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "snapshot"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "options"
+            }
+          ]
+        },
+        "delete": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "session"
+            }
+          ]
+        },
+        "deserialize_session_state": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "resume": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            }
+          ]
+        },
+        "serialize_session_state": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            }
+          ]
+        }
+      },
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "token"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "project_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "team_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "instrumentation"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "dependencies"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.VercelSandboxClientOptions": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "vercel"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "project_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "team_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 270000
+          },
+          "name": "timeout_ms"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "runtime"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "resources"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "env"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "interactive"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_expiration_ms"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "network_policy"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "allow_s3_credential_exposure"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "project_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "team_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 270000
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "timeout_ms"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "runtime"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "resources"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "env"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "interactive"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "snapshot_expiration_ms"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "network_policy"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "POSITIONAL_OR_KEYWORD",
+          "name": "allow_s3_credential_exposure"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "vercel"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.VercelSandboxSession": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "aclose": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "apply_manifest": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "only_ephemeral"
+            }
+          ]
+        },
+        "apply_patch": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "operations"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.str",
+                "value": "v4a"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "patch_format"
+            }
+          ]
+        },
+        "describe": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "exec": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "VAR_POSITIONAL",
+              "name": "command"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "timeout"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": true
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "shell"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "extract": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "compression_scheme"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "archive_limits"
+            }
+          ]
+        },
+        "from_state": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "state"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "sandbox"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "token"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "allow_s3_credential_exposure"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "trusted_s3_mounts"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "trusted_manifest"
+            }
+          ]
+        },
+        "hydrate_workspace": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            }
+          ]
+        },
+        "ls": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "mkdir": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "parents"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "normalize_path": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "for_write"
+            }
+          ]
+        },
+        "persist_workspace": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "provision_manifest_accounts": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "pty_exec_start": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "VAR_POSITIONAL",
+              "name": "command"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "timeout"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": true
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "shell"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "tty"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "yield_time_s"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "max_output_tokens"
+            }
+          ]
+        },
+        "pty_terminate_all": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "pty_write_stdin": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "session_id"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "chars"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "yield_time_s"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "max_output_tokens"
+            }
+          ]
+        },
+        "read": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "register_persist_workspace_skip_path": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            }
+          ]
+        },
+        "register_pre_stop_hook": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "hook"
+            }
+          ]
+        },
+        "resolve_exposed_port": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "port"
+            }
+          ]
+        },
+        "rm": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.bool",
+                "value": false
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "recursive"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        },
+        "run_pre_stop_hooks": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "running": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "set_dependencies": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "dependencies"
+            }
+          ]
+        },
+        "should_provision_manifest_accounts_on_resume": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "shutdown": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "start": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "stop": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": []
+        },
+        "supports_docker_volume_mounts": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "supports_pty": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "write": {
+          "binding": "instance",
+          "execution_kind": "coroutine",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "path"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "user"
+            }
+          ]
+        }
+      },
+      "parameters": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "state"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "sandbox"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "token"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "allow_s3_credential_exposure"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "trusted_s3_mounts"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "trusted_manifest"
+        }
+      ]
+    },
+    "agents.extensions.sandbox.VercelSandboxSessionState": {
+      "dataclass_fields": [],
+      "kind": "class",
+      "members": {
+        "assert_path_grants_rebound": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": []
+        },
+        "model_post_init": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_ONLY",
+              "name": "context"
+            }
+          ]
+        },
+        "model_validate_json": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "json_data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "strict"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "extra"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "context"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_alias"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_name"
+            }
+          ]
+        },
+        "parse": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "payload"
+            }
+          ]
+        },
+        "rebind_persisted_mount_authority": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "provider_backend_id"
+            }
+          ]
+        },
+        "rebind_persisted_path_grants": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            }
+          ]
+        }
+      },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "vercel"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "uuid.uuid4",
+            "kind": "factory"
+          },
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "factory": "builtins.tuple",
+            "kind": "factory"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "sandbox_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "project_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "team_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "timeout_ms"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "runtime"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "resources"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "env"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "interactive"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_expiration_ms"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "network_policy"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "s3_mounts_non_resumable"
+        }
+      ],
+      "parameters": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "vercel"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "kind": "factory"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "sandbox_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "project_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "team_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "timeout_ms"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "runtime"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "resources"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "env"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "interactive"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "tar"
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "workspace_persistence"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "snapshot_expiration_ms"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "network_policy"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "kind": "KEYWORD_ONLY",
+          "name": "s3_mounts_non_resumable"
         }
       ]
     },
@@ -17321,6 +24125,32 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "audio"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "audio"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "transcript"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -17362,6 +24192,52 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "item_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "previous_item_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "message"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "assistant"
+          },
+          "name": "role"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "status"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "content"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -17426,6 +24302,24 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "text"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "text"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -17458,6 +24352,24 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "input_text"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "text"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -17490,6 +24402,44 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "item_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "previous_item_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "message"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "user"
+          },
+          "name": "role"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "content"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -18076,6 +25026,30 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "run_as"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -18240,6 +25214,61 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "local_file"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "src"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -18320,6 +25349,22 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "local"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "base_path"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -18398,6 +25443,19 @@
           "execution_kind": "generator",
           "parameters": []
         },
+        "model_post_init": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_ONLY",
+              "name": "context"
+            }
+          ]
+        },
         "mount_targets": {
           "binding": "instance",
           "execution_kind": "sync",
@@ -18407,8 +25465,94 @@
           "binding": "instance",
           "execution_kind": "sync",
           "parameters": []
+        },
+        "with_in_container_mount_broad_credential_exposure_acknowledged": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "VAR_POSITIONAL",
+              "name": "mount_paths"
+            }
+          ]
+        },
+        "with_in_container_mount_credential_exposure_acknowledged": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "VAR_POSITIONAL",
+              "name": "mount_paths"
+            }
+          ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 1
+          },
+          "name": "version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "/workspace"
+          },
+          "name": "root"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "entries"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.manifest.Environment",
+            "kind": "factory"
+          },
+          "name": "environment"
+        },
+        {
+          "default": {
+            "factory": "builtins.list",
+            "kind": "factory"
+          },
+          "name": "users"
+        },
+        {
+          "default": {
+            "factory": "builtins.list",
+            "kind": "factory"
+          },
+          "name": "groups"
+        },
+        {
+          "default": {
+            "factory": "builtins.tuple",
+            "kind": "factory"
+          },
+          "name": "extra_path_grants"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.manifest.Manifest.<lambda>",
+            "kind": "factory"
+          },
+          "name": "remote_mount_command_allowlist"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -18644,6 +25788,22 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "remote"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "client_dependency_key"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -19218,6 +26378,38 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "path"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "read_only"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "host_path"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -19593,6 +26785,40 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "filesystem"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "run_as"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "configure_tools"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -19731,6 +26957,14 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "source"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -19852,6 +27086,53 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "memory"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "run_as"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.config.MemoryLayoutConfig",
+            "kind": "factory"
+          },
+          "name": "layout"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.config.MemoryReadConfig",
+            "kind": "factory"
+          },
+          "name": "read"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.config.MemoryGenerateConfig",
+            "kind": "factory"
+          },
+          "name": "generate"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -20001,6 +27282,40 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "shell"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "run_as"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "configure_tools"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -20164,6 +27479,63 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "skills"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "run_as"
+        },
+        {
+          "default": {
+            "factory": "builtins.list",
+            "kind": "factory"
+          },
+          "name": "skills"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "from_"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "lazy_from"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": ".agents"
+          },
+          "name": "skills_path"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -20338,6 +27710,40 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "compaction"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "run_as"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "policy"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -20488,6 +27894,53 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "memory"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "run_as"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.config.MemoryLayoutConfig",
+            "kind": "factory"
+          },
+          "name": "layout"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.config.MemoryReadConfig",
+            "kind": "factory"
+          },
+          "name": "read"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.config.MemoryGenerateConfig",
+            "kind": "factory"
+          },
+          "name": "generate"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -20637,6 +28090,40 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "shell"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "run_as"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "configure_tools"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -20962,6 +28449,113 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "azure_blob_mount"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mount_path"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "read_only"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "mount_strategy"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "account"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "container"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "endpoint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "identity_client_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "account_key"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -21146,6 +28740,62 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "dir"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "children"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -21387,6 +29037,29 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "docker_volume"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "driver"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "driver_options"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -21463,6 +29136,61 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "file"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "content"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -21597,6 +29325,120 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "fuse"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "allow_other"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "syslog"
+          },
+          "name": "log_type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "log_debug"
+          },
+          "name": "log_level"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "block_cache"
+          },
+          "name": "cache_type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "cache_path"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "cache_size_mb"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 16
+          },
+          "name": "block_cache_block_size_mb"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 3600
+          },
+          "name": "block_cache_disk_timeout_sec"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 120
+          },
+          "name": "file_cache_timeout_sec"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "file_cache_max_size_mb"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "attr_cache_timeout_sec"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "entry_cache_timeout_sec"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "negative_entry_cache_timeout_sec"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -21876,6 +29718,147 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "gcs_mount"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mount_path"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "read_only"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "mount_strategy"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "bucket"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "access_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "secret_access_key"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "prefix"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "region"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "endpoint_url"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "service_account_file"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "service_account_credentials"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "access_token"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -22098,6 +30081,83 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "git_repo"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "github.com"
+          },
+          "name": "host"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "repo"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "ref"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "subpath"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -22364,6 +30424,22 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "in_container"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "pattern"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -22455,6 +30531,63 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "local_dir"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "src"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -22569,6 +30702,61 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "local_file"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "src"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -22781,6 +30969,75 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mount_path"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "read_only"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "mount_strategy"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -22918,6 +31175,23 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "mountpoint"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.mounts.patterns.MountpointMountPattern.MountpointOptions",
+            "kind": "factory"
+          },
+          "name": "options"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -23087,6 +31361,113 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "r2_mount"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mount_path"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "read_only"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "mount_strategy"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "bucket"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "account_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "access_key_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "secret_access_key"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "custom_domain"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -23323,6 +31704,63 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "rclone"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "fuse"
+          },
+          "name": "mode"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "remote_name"
+        },
+        {
+          "default": {
+            "factory": "builtins.list",
+            "kind": "factory"
+          },
+          "name": "extra_args"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "nfs_addr"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "nfs_mount_options"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "config_file_path"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -23537,6 +31975,122 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "s3_files_mount"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mount_path"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "read_only"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "mount_strategy"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "file_system_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "subpath"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mount_target_ip"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "access_point"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "region"
+        },
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "extra_options"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -23726,6 +32280,23 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "s3files"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.mounts.patterns.S3FilesMountPattern.S3FilesOptions",
+            "kind": "factory"
+          },
+          "name": "options"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -23895,6 +32466,139 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "s3_mount"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "description"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "ephemeral"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "group"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "is_dir"
+        },
+        {
+          "default": {
+            "factory": "agents.sandbox.entries.base.BaseEntry.<lambda>",
+            "kind": "factory"
+          },
+          "name": "permissions"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "mount_path"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "read_only"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "mount_strategy"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "bucket"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "access_key_id"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "secret_access_key"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "session_token"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "prefix"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "region"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "endpoint_url"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "AWS"
+          },
+          "name": "s3_provider"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -24322,6 +33026,15 @@
           "parameters": []
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "factory": "builtins.dict",
+            "kind": "factory"
+          },
+          "name": "value"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -24461,6 +33174,24 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "unix_local"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "items": [],
+            "kind": "sequence",
+            "type": "builtins.tuple"
+          },
+          "name": "exposed_ports"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -24504,6 +33235,64 @@
             }
           ]
         },
+        "model_validate_json": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "json_data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "strict"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "extra"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "context"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_alias"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_name"
+            }
+          ]
+        },
         "parse": {
           "binding": "class",
           "execution_kind": "sync",
@@ -24514,6 +33303,26 @@
               },
               "kind": "POSITIONAL_OR_KEYWORD",
               "name": "payload"
+            }
+          ]
+        },
+        "rebind_persisted_mount_authority": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "provider_backend_id"
             }
           ]
         },
@@ -24531,6 +33340,74 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "unix_local"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "uuid.uuid4",
+            "kind": "factory"
+          },
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "factory": "builtins.tuple",
+            "kind": "factory"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "workspace_root_ready"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "workspace_root_owned"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -25467,6 +34344,40 @@
       "dataclass_fields": [],
       "kind": "class",
       "members": {},
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "include_exec_output"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 8000
+          },
+          "name": "max_stdout_chars"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.int",
+            "value": 8000
+          },
+          "name": "max_stderr_chars"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": true
+          },
+          "name": "include_write_len"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -27243,6 +36154,64 @@
             }
           ]
         },
+        "model_validate_json": {
+          "binding": "class",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "json_data"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "strict"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "extra"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "context"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_alias"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "by_name"
+            }
+          ]
+        },
         "parse": {
           "binding": "class",
           "execution_kind": "sync",
@@ -27253,6 +36222,26 @@
               },
               "kind": "POSITIONAL_OR_KEYWORD",
               "name": "payload"
+            }
+          ]
+        },
+        "rebind_persisted_mount_authority": {
+          "binding": "instance",
+          "execution_kind": "sync",
+          "parameters": [
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "POSITIONAL_OR_KEYWORD",
+              "name": "trusted_manifest"
+            },
+            {
+              "default": {
+                "kind": "required"
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "provider_backend_id"
             }
           ]
         },
@@ -27270,6 +36259,64 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "factory": "uuid.uuid4",
+            "kind": "factory"
+          },
+          "name": "session_id"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "snapshot"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "manifest"
+        },
+        {
+          "default": {
+            "factory": "builtins.tuple",
+            "kind": "factory"
+          },
+          "name": "exposed_ports"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.NoneType",
+            "value": null
+          },
+          "name": "snapshot_fingerprint_version"
+        },
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.bool",
+            "value": false
+          },
+          "name": "workspace_root_ready"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -27353,6 +36400,16 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "literal",
+            "type": "builtins.str",
+            "value": "noop"
+          },
+          "name": "type"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -27435,6 +36492,20 @@
           ]
         }
       },
+      "model_fields": [
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "type"
+        },
+        {
+          "default": {
+            "kind": "required"
+          },
+          "name": "id"
+        }
+      ],
       "parameters": [
         {
           "default": {
@@ -27689,6 +36760,15 @@
               },
               "kind": "KEYWORD_ONLY",
               "name": "tool_lookup_key"
+            },
+            {
+              "default": {
+                "kind": "literal",
+                "type": "builtins.NoneType",
+                "value": null
+              },
+              "kind": "KEYWORD_ONLY",
+              "name": "current_invocation"
             }
           ]
         },
@@ -30539,8 +39619,97 @@
       "canonical_name": "TracingProcessor",
       "module": "agents.tracing",
       "name": "TracingProcessor"
+    },
+    {
+      "canonical_module": "agents",
+      "canonical_name": "InputItem",
+      "module": "agents.items",
+      "name": "InputItem"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.modal",
+      "canonical_name": "ModalCloudBucketMountStrategy",
+      "module": "agents.extensions.sandbox",
+      "name": "ModalCloudBucketMountStrategy"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.modal",
+      "canonical_name": "ModalSandboxClient",
+      "module": "agents.extensions.sandbox",
+      "name": "ModalSandboxClient"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.modal",
+      "canonical_name": "ModalSandboxClientOptions",
+      "module": "agents.extensions.sandbox",
+      "name": "ModalSandboxClientOptions"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.runloop",
+      "canonical_name": "RunloopAfterIdle",
+      "module": "agents.extensions.sandbox",
+      "name": "RunloopAfterIdle"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.runloop",
+      "canonical_name": "RunloopGatewaySpec",
+      "module": "agents.extensions.sandbox",
+      "name": "RunloopGatewaySpec"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.runloop",
+      "canonical_name": "RunloopLaunchParameters",
+      "module": "agents.extensions.sandbox",
+      "name": "RunloopLaunchParameters"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.runloop",
+      "canonical_name": "RunloopMcpSpec",
+      "module": "agents.extensions.sandbox",
+      "name": "RunloopMcpSpec"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.runloop",
+      "canonical_name": "RunloopSandboxClient",
+      "module": "agents.extensions.sandbox",
+      "name": "RunloopSandboxClient"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.runloop",
+      "canonical_name": "RunloopSandboxClientOptions",
+      "module": "agents.extensions.sandbox",
+      "name": "RunloopSandboxClientOptions"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.runloop",
+      "canonical_name": "RunloopTunnelConfig",
+      "module": "agents.extensions.sandbox",
+      "name": "RunloopTunnelConfig"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.runloop",
+      "canonical_name": "RunloopUserParameters",
+      "module": "agents.extensions.sandbox",
+      "name": "RunloopUserParameters"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.vercel",
+      "canonical_name": "VercelSandboxClient",
+      "module": "agents.extensions.sandbox",
+      "name": "VercelSandboxClient"
+    },
+    {
+      "canonical_module": "agents.extensions.sandbox.vercel",
+      "canonical_name": "VercelSandboxClientOptions",
+      "module": "agents.extensions.sandbox",
+      "name": "VercelSandboxClientOptions"
     }
   ],
+  "optional_dependency_unsupported_platforms": {
+    "vercel": [
+      "win32"
+    ]
+  },
   "platform_import_errors": [
     {
       "error_type": "ImportError",
@@ -30548,36 +39717,6 @@
       "module": "agents.sandbox.sandboxes.unix_local",
       "platforms": [
         "win32"
-      ]
-    }
-  ],
-  "public_properties": [
-    {
-      "class_name": "RunResultBase",
-      "module": "agents.result",
-      "names": [
-        "agent_tool_invocation",
-        "last_agent",
-        "last_response_id"
-      ]
-    },
-    {
-      "class_name": "RunResult",
-      "module": "agents.result",
-      "names": [
-        "agent_tool_invocation",
-        "last_agent",
-        "last_response_id"
-      ]
-    },
-    {
-      "class_name": "RunResultStreaming",
-      "module": "agents.result",
-      "names": [
-        "agent_tool_invocation",
-        "last_agent",
-        "last_response_id",
-        "run_loop_exception"
       ]
     }
   ],
@@ -30643,6 +39782,78 @@
     "agents.tool_guardrails",
     "agents.tracing"
   ],
+  "public_properties": [
+    {
+      "class_name": "RunResultBase",
+      "module": "agents.result",
+      "names": [
+        "agent_tool_invocation",
+        "last_agent",
+        "last_response_id"
+      ]
+    },
+    {
+      "class_name": "RunResult",
+      "module": "agents.result",
+      "names": [
+        "agent_tool_invocation",
+        "last_agent",
+        "last_response_id"
+      ]
+    },
+    {
+      "class_name": "RunResultStreaming",
+      "module": "agents.result",
+      "names": [
+        "agent_tool_invocation",
+        "last_agent",
+        "last_response_id",
+        "run_loop_exception"
+      ]
+    },
+    {
+      "class_name": "RunState",
+      "module": "agents.run_state",
+      "names": [
+        "pending_input"
+      ]
+    },
+    {
+      "class_name": "RetryPolicyContext",
+      "module": "agents.retry",
+      "names": [
+        "response_started",
+        "replay_safety",
+        "stateful_request"
+      ]
+    },
+    {
+      "class_name": "RunloopPlatformClient",
+      "module": "agents.extensions.sandbox",
+      "names": [
+        "axons",
+        "benchmarks",
+        "blueprints",
+        "network_policies",
+        "secrets"
+      ]
+    },
+    {
+      "class_name": "RunloopSandboxClient",
+      "module": "agents.extensions.sandbox",
+      "names": [
+        "platform"
+      ]
+    },
+    {
+      "class_name": "SandboxSessionState",
+      "module": "agents.sandbox.session.sandbox_session_state",
+      "names": [
+        "mount_authority_redacted",
+        "mount_authority_rebound"
+      ]
+    }
+  ],
   "required_submodule_exports": {
     "agents.decorators": {
       "names": [
@@ -30705,6 +39916,11 @@
         "E2BSandboxSessionState",
         "E2BSandboxTimeouts",
         "E2BSandboxType",
+        "ModalCloudBucketMountStrategy",
+        "ModalSandboxClient",
+        "ModalSandboxClientOptions",
+        "ModalSandboxSession",
+        "ModalSandboxSessionState",
         "DEFAULT_DAYTONA_WORKSPACE_ROOT",
         "DaytonaCloudBucketMountStrategy",
         "DaytonaSandboxResources",
@@ -30728,7 +39944,27 @@
         "CloudflareSandboxClient",
         "CloudflareSandboxClientOptions",
         "CloudflareSandboxSession",
-        "CloudflareSandboxSessionState"
+        "CloudflareSandboxSessionState",
+        "VercelCloudBucketMountStrategy",
+        "VercelSandboxClient",
+        "VercelSandboxClientOptions",
+        "VercelSandboxSession",
+        "VercelSandboxSessionState",
+        "DEFAULT_RUNLOOP_WORKSPACE_ROOT",
+        "DEFAULT_RUNLOOP_ROOT_WORKSPACE_ROOT",
+        "RunloopAfterIdle",
+        "RunloopGatewaySpec",
+        "RunloopLaunchParameters",
+        "RunloopMcpSpec",
+        "RunloopPlatformClient",
+        "RunloopCloudBucketMountStrategy",
+        "RunloopSandboxClient",
+        "RunloopSandboxClientOptions",
+        "RunloopSandboxSession",
+        "RunloopSandboxSessionState",
+        "RunloopTimeouts",
+        "RunloopTunnelConfig",
+        "RunloopUserParameters"
       ],
       "optional_bindings": {},
       "optional_exports": {
@@ -30737,7 +39973,32 @@
         "CloudflareSandboxClient": "aiohttp",
         "CloudflareSandboxClientOptions": "aiohttp",
         "CloudflareSandboxSession": "aiohttp",
-        "CloudflareSandboxSessionState": "aiohttp"
+        "CloudflareSandboxSessionState": "aiohttp",
+        "DEFAULT_RUNLOOP_ROOT_WORKSPACE_ROOT": "runloop_api_client",
+        "DEFAULT_RUNLOOP_WORKSPACE_ROOT": "runloop_api_client",
+        "ModalCloudBucketMountStrategy": "modal",
+        "ModalSandboxClient": "modal",
+        "ModalSandboxClientOptions": "modal",
+        "ModalSandboxSession": "modal",
+        "ModalSandboxSessionState": "modal",
+        "RunloopAfterIdle": "runloop_api_client",
+        "RunloopCloudBucketMountStrategy": "runloop_api_client",
+        "RunloopGatewaySpec": "runloop_api_client",
+        "RunloopLaunchParameters": "runloop_api_client",
+        "RunloopMcpSpec": "runloop_api_client",
+        "RunloopPlatformClient": "runloop_api_client",
+        "RunloopSandboxClient": "runloop_api_client",
+        "RunloopSandboxClientOptions": "runloop_api_client",
+        "RunloopSandboxSession": "runloop_api_client",
+        "RunloopSandboxSessionState": "runloop_api_client",
+        "RunloopTimeouts": "runloop_api_client",
+        "RunloopTunnelConfig": "runloop_api_client",
+        "RunloopUserParameters": "runloop_api_client",
+        "VercelCloudBucketMountStrategy": "vercel",
+        "VercelSandboxClient": "vercel",
+        "VercelSandboxClientOptions": "vercel",
+        "VercelSandboxSession": "vercel",
+        "VercelSandboxSessionState": "vercel"
       }
     },
     "agents.handoffs": {
@@ -31378,7 +40639,8 @@
     "gen_span_id",
     "default_tool_error_function",
     "sandbox",
-    "__version__"
+    "__version__",
+    "InputItem"
   ],
   "submodule_export_exclusions": [
     "agents.sandbox.sandboxes"

--- a/uv.lock
+++ b/uv.lock
@@ -2472,7 +2472,7 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.19.4"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "griffelib" },


### PR DESCRIPTION
### Release readiness review (v0.19.4 -> TARGET 8298b7858703e9a5c1065b9f3a59e96b43ad40f2)

This is a release readiness report done by `$final-release-review` skill.

### Diff

https://github.com/openai/openai-agents-python/compare/v0.19.4...8298b7858703e9a5c1065b9f3a59e96b43ad40f2

### Release intent

- Review mode: final candidate
- Intended release: minor, version 0.20.0
- Minimum required release type: minor
- Versioning verdict: compatible

### Release call

**🟢 GREEN LIGHT TO SHIP** The candidate correctly uses a minor version for its default-model and MCP dependency migration, provides usable compatibility paths, and has internally consistent release metadata and contract state.

### Scope summary

- 516 files changed (+117504/-9841); key areas include MCP compatibility, `RunState`, sandbox security, model defaults, sessions, Realtime, voice, packaging contracts, tests, examples, and documentation.

### Risk assessment (ordered by impact)

1. **MCP Python SDK v2 migration affects customized HTTP transports**
   - Risk: **🟢 LOW**. Applications using `httpx.Auth`, custom `httpx.AsyncClient` factories, or the v1-only initialized-notification option must migrate to `httpx2` or pin `mcp<2`.
   - Evidence: The dependency range expands to `mcp>=1.19.0,<3`; the compatibility adapter supports both major versions and validates incompatible custom HTTP objects before connecting. The packaged-contract matrix validates wheel and sdist environments.
   - Files: `pyproject.toml`, `src/agents/mcp/_compat.py`, `src/agents/mcp/server.py`, `integration_tests/packaging/`
   - Action: Publish the migration and fallback wording in #4280 after the SDK release.

2. **The implicit default model changes to `gpt-5.6-luna`**
   - Risk: **🟢 LOW**. Runs without an explicit model can change behavior or cost characteristics, while explicit agent models, run overrides, and `OPENAI_DEFAULT_MODEL` remain available.
   - Evidence: `get_default_model()` changes from `gpt-5.4-mini` to `gpt-5.6-luna` without changing the default reasoning-effort or verbosity settings.
   - Files: `src/agents/models/default_models.py`, related model tests
   - Action: Retain the override guidance and default-model notice in the release documentation.

3. **Durable resume and sandbox authority surfaces expand**
   - Risk: **🟢 LOW**. `RunState` gains durable pending input and schema versions through `1.15`, while sandbox state gains explicitly sanitized mount-authority and trusted-rebind behavior.
   - Evidence: Historical schema fixtures remain readable, new feature fixtures cover the added state, and the release contract freezes `InputItem`, `RunState.pending_input`, retry safety properties, and sandbox authority properties.
   - Files: `src/agents/run_state.py`, `src/agents/sandbox/`, `tests/fixtures/run_state/`, `tests/fixtures/released_api_contract.json`
   - Action: Preserve backward-read coverage and require trusted runtime rebinds rather than serialized credential authority.

### Documentation coverage (non-blocking)

- Coverage source: #4280 at head `de31d48c841f5549177c6b4a55d0ce10efd83ce1`
- Status: covered
- Covered obligations: default-model migration, MCP v1/v2 compatibility and HTTP migration, Realtime transcription options, sandbox credential acknowledgements and redaction, unsafe-replay approval, durable pending input, raw usage and request IDs, session behavior, and runtime reliability changes
- Gaps or post-release suggestions: none
- Publication timing: merge after version 0.20.0 is published because the changes describe unreleased behavior

### Key Changes draft

## Key Changes

Version 0.20.0 is a minor release because it changes the implicit default model and includes a potentially breaking MCP dependency migration for applications with customized local HTTP transports. MCP v1 remains supported, and affected applications can migrate to `httpx2` or pin `mcp<2`.

### Highlights:

-   The default model is now `gpt-5.6-luna`; explicit models, run-level overrides, and `OPENAI_DEFAULT_MODEL` continue to take precedence.
-   Local MCP connections support MCP Python SDK v1 and v2 across stdio, SSE, and Streamable HTTP transports.
-   Applications using custom MCP HTTP authentication or client factories must use the HTTP types owned by the installed MCP major version, or pin `mcp<2`.
-   `RunState.add_input()` can stage durable user input before a resumed model call, with guardrail, persistence, and serialization support.
-   Sandbox mount validation adds explicit credential-exposure acknowledgements and preserves redacted error contracts without serializing credential authority.
-   Realtime input transcription supports the GA transcription settings for `gpt-live-transcribe`, `gpt-transcribe`, and `gpt-realtime-whisper`.

### Notes

- The candidate is one three-file release commit ahead of current `origin/main`.
- Package metadata, lockfile version, contract baseline, and contract base commit agree on version 0.20.0 and parent `c0b876379e82095b164c78cec65fb659a699a98d`.
- Routine repository CI is assumed to have passed under the review policy; the release-specific prospective wheel/sdist contract gate passed independently.