### PR TITLE
feat(realtime): support GA transcription options

### DIFF
--- a/src/agents/realtime/config.py
+++ b/src/agents/realtime/config.py
@@ -79,11 +79,32 @@ class RealtimeInputAudioTranscriptionConfig(TypedDict):
     language: NotRequired[str]
     """The language code for transcription."""
 
-    model: NotRequired[Literal["gpt-4o-transcribe", "gpt-4o-mini-transcribe", "whisper-1"] | str]
+    model: NotRequired[
+        Literal[
+            "gpt-transcribe",
+            "gpt-live-transcribe",
+            "gpt-4o-transcribe",
+            "gpt-4o-mini-transcribe",
+            "gpt-4o-mini-transcribe-2025-12-15",
+            "gpt-4o-transcribe-diarize",
+            "gpt-realtime-whisper",
+            "whisper-1",
+        ]
+        | str
+    ]
     """The transcription model to use."""
 
     prompt: NotRequired[str]
     """An optional prompt to guide transcription."""
+
+    keywords: NotRequired[list[str]]
+    """Literal terms that may appear in the audio."""
+
+    languages: NotRequired[list[str]]
+    """Expected input languages for transcription."""
+
+    delay: NotRequired[Literal["minimal", "low", "medium", "high", "xhigh"]]
+    """The latency and accuracy tradeoff for streaming transcription."""
 
 
 class RealtimeInputAudioNoiseReductionConfig(TypedDict):
@@ -130,7 +151,8 @@ class RealtimeAudioInputConfig(TypedDict, total=False):
     format: RealtimeAudioFormat | OpenAIRealtimeAudioFormats
     noise_reduction: RealtimeInputAudioNoiseReductionConfig | None
     transcription: RealtimeInputAudioTranscriptionConfig
-    turn_detection: RealtimeTurnDetectionConfig
+    turn_detection: RealtimeTurnDetectionConfig | None
+    """Configuration for detecting conversation turns, or ``None`` to disable detection."""
 
 
 class RealtimeAudioOutputConfig(TypedDict, total=False):
@@ -201,8 +223,8 @@ class RealtimeSessionModelSettings(TypedDict):
     input_audio_noise_reduction: NotRequired[RealtimeInputAudioNoiseReductionConfig | None]
     """Noise reduction configuration for input audio."""
 
-    turn_detection: NotRequired[RealtimeTurnDetectionConfig]
-    """Configuration for detecting conversation turns."""
+    turn_detection: NotRequired[RealtimeTurnDetectionConfig | None]
+    """Configuration for detecting conversation turns, or ``None`` to disable detection."""
 
     tool_choice: NotRequired[ToolChoice]
     """How the model should choose which tools to call."""

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -14,6 +14,7 @@ from pydantic import TypeAdapter
 from agents import Agent, WebSearchTool, function_tool
 from agents.exceptions import UserError
 from agents.handoffs import handoff
+from agents.realtime import RealtimeSessionModelSettings
 from agents.realtime.model import RealtimeModelConfig, RealtimePlaybackTracker
 from agents.realtime.model_events import (
     RealtimeModelAudioEvent,
@@ -476,7 +477,7 @@ class TestConnectionLifecycle(TestOpenAIRealtimeWebSocketModel):
     @pytest.mark.asyncio
     async def test_session_update_disable_turn_detection(self, model, mock_websocket):
         """Session.update should allow users to disable turn-detection."""
-        config = {
+        config: RealtimeModelConfig = {
             "api_key": "test-api-key-123",
             "initial_model_settings": {
                 "model_name": "gpt-4o-realtime-preview",
@@ -2807,6 +2808,65 @@ class TestSendEventAndConfig(TestOpenAIRealtimeWebSocketModel):
         assert payload["model"] == "gpt-realtime-2.1"
         assert payload["parallel_tool_calls"] is False
         assert payload["reasoning"] == {"effort": "low"}
+
+    def test_session_config_forwards_ga_input_audio_transcription_options(self, model):
+        contextual_settings: RealtimeSessionModelSettings = {
+            "audio": {
+                "input": {
+                    "transcription": {
+                        "model": "gpt-transcribe",
+                        "keywords": ["LegalOn", "TomoniAI"],
+                        "languages": ["ja", "en"],
+                        "prompt": "A Japanese conversation about LegalOn and TomoniAI.",
+                    }
+                }
+            }
+        }
+        low_latency_settings: RealtimeSessionModelSettings = {
+            "audio": {
+                "input": {
+                    "transcription": {
+                        "model": "gpt-live-transcribe",
+                    },
+                    "turn_detection": None,
+                }
+            }
+        }
+        whisper_settings: RealtimeSessionModelSettings = {
+            "audio": {
+                "input": {
+                    "transcription": {
+                        "model": "gpt-realtime-whisper",
+                        "delay": "low",
+                    },
+                    "turn_detection": None,
+                }
+            }
+        }
+
+        contextual_payload = model._get_session_config(contextual_settings).model_dump(
+            exclude_unset=True
+        )
+        low_latency_payload = model._get_session_config(low_latency_settings).model_dump(
+            exclude_unset=True
+        )
+        whisper_payload = model._get_session_config(whisper_settings).model_dump(exclude_unset=True)
+
+        assert contextual_payload["audio"]["input"]["transcription"] == {
+            "model": "gpt-transcribe",
+            "keywords": ["LegalOn", "TomoniAI"],
+            "languages": ["ja", "en"],
+            "prompt": "A Japanese conversation about LegalOn and TomoniAI.",
+        }
+        assert low_latency_payload["audio"]["input"]["transcription"] == {
+            "model": "gpt-live-transcribe",
+        }
+        assert low_latency_payload["audio"]["input"]["turn_detection"] is None
+        assert whisper_payload["audio"]["input"]["transcription"] == {
+            "model": "gpt-realtime-whisper",
+            "delay": "low",
+        }
+        assert whisper_payload["audio"]["input"]["turn_detection"] is None
 
     def test_session_config_passes_max_output_tokens(self, model):
         # Integer cap is forwarded verbatim to the server payload.


### PR DESCRIPTION
This pull request adds typed support for GA Realtime input transcription configuration, mirroring openai/openai-agents-js#1635.

- Add `keywords`, `languages`, and the documented `delay` levels while retaining singular `language`.
- Add current GA transcription model IDs while preserving arbitrary string model names.
- Verify that contextual and low-latency transcription options are preserved in generated session payloads.

Model-specific validation remains owned by the Realtime API.