### PR TITLE
fix(strict-schema): reject $ref constraining siblings and non-convertible shapes

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -36,6 +36,63 @@ _UNVALIDATED_REF_ERROR = (
     "JSON schema contains a reference whose target was not validated for strict mode."
 )
 
+# Keywords that may legally sit alongside a `$ref` without changing the accepted values:
+# JSON Schema annotation keywords plus definition maps (which are inert metadata). Any
+# other sibling of a `$ref` is a *constraining* keyword (e.g. `properties`, `required`,
+# `type`, `enum`), which JSON Schema 2020-12 combines with the referent as an
+# intersection rather than as an override.
+_REF_ANNOTATION_SIBLINGS = frozenset(
+    {
+        "$comment",
+        "$defs",
+        "default",
+        "definitions",
+        "deprecated",
+        "description",
+        "examples",
+        "readOnly",
+        "title",
+        "writeOnly",
+    }
+)
+
+# Keywords OpenAI's strict mode cannot represent. Mirrors the unsupported-keyword list in
+# the vendor reference implementation (openai-node `toStrictJsonSchema`); a schema that
+# still contains any of these after conversion is not convertible and must be rejected so
+# callers (e.g. the MCP `convert_schemas_to_strict` path) fall back to the original
+# non-strict schema instead of shipping one the API will reject at request time.
+_STRICT_UNSUPPORTED_KEYWORDS = frozenset(
+    {
+        "$anchor",
+        "$dynamicAnchor",
+        "$dynamicRef",
+        "$recursiveAnchor",
+        "$recursiveRef",
+        "allOf",
+        "contains",
+        "contentEncoding",
+        "contentMediaType",
+        "contentSchema",
+        "dependentRequired",
+        "dependentSchemas",
+        "dependencies",
+        "else",
+        "if",
+        "maxContains",
+        "maxProperties",
+        "minContains",
+        "minProperties",
+        "not",
+        "patternProperties",
+        "prefixItems",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+        "uniqueItems",
+    }
+)
+
 
 class _NodeBudget:
     """Tracks conversion state across the recursion."""
@@ -65,7 +122,7 @@ def ensure_strict_json_schema(
     if schema == {}:
         return copy.deepcopy(_EMPTY_SCHEMA)
     budget = _NodeBudget(_MAX_SCHEMA_NODES, reject_open_objects=_reject_open_objects)
-    return _ensure_strict_root(
+    result = _ensure_strict_root(
         _ensure_strict_json_schema(
             schema,
             path=(),
@@ -73,6 +130,8 @@ def ensure_strict_json_schema(
             budget=budget,
         )
     )
+    _raise_if_strict_unsupported(result)
+    return result
 
 
 def _ensure_strict_root(schema: dict[str, Any]) -> dict[str, Any]:
@@ -92,6 +151,67 @@ def _ensure_strict_root(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
+def _raise_if_strict_unsupported(schema: dict[str, Any], *, path: tuple[str, ...] = ()) -> None:
+    """Raises ``UserError`` if any keyword OpenAI's strict mode cannot represent survived
+    conversion, so callers fall back to the original non-strict schema instead of shipping
+    one the API will reject at request time.
+    """
+    location = "/" + "/".join(path) if path else "<root>"
+    for keyword in _STRICT_UNSUPPORTED_KEYWORDS:
+        if keyword in schema:
+            raise UserError(
+                f"JSON schema at {location} contains keyword `{keyword}` which cannot be "
+                "represented in a strict schema."
+            )
+
+    # Tuple-form `items` (an array of schemas) has no strict-mode equivalent.
+    items = schema.get("items")
+    if is_list(items):
+        raise UserError(
+            f"JSON schema at {location} uses tuple-form `items`, which cannot be represented "
+            "in a strict schema."
+        )
+
+    # Draft 7 `additionalItems` only exists to extend a tuple; the API accepts one schema
+    # per array item and cannot represent it.
+    if "additionalItems" in schema:
+        raise UserError(
+            f"JSON schema at {location} uses keyword `additionalItems`, which cannot be "
+            "represented in a strict schema."
+        )
+
+    # An array with no `items` accepts arbitrary elements and is not strict.
+    typ = schema.get("type")
+    if (typ == "array" or (is_list(typ) and "array" in typ)) and "items" not in schema:
+        raise UserError(
+            f"JSON schema at {location} is an array without `items`, which cannot be "
+            "represented in a strict schema."
+        )
+
+    # A nested `$id` re-identifies a subschema and is not supported outside the root.
+    if path and "$id" in schema:
+        raise UserError(
+            f"JSON schema at {location} contains a nested `$id`, which cannot be represented "
+            "in a strict schema."
+        )
+
+    # Recurse into every schema-bearing container.
+    for container in ("$defs", "definitions", "properties"):
+        subschemas = schema.get(container)
+        if is_dict(subschemas):
+            for name, child in subschemas.items():
+                _raise_if_strict_unsupported(child, path=(*path, container, name))
+    for container in ("items", "additionalProperties", "not", "if", "then", "else"):
+        child = schema.get(container)
+        if is_dict(child):
+            _raise_if_strict_unsupported(child, path=(*path, container))
+    for container in ("anyOf", "oneOf", "allOf"):
+        variants = schema.get(container)
+        if is_list(variants):
+            for i, variant in enumerate(variants):
+                _raise_if_strict_unsupported(variant, path=(*path, container, str(i)))
+
+
 # Adapted from https://github.com/openai/openai-python/blob/main/src/openai/lib/_pydantic.py
 def _ensure_strict_json_schema(
     json_schema: object,
@@ -108,6 +228,19 @@ def _ensure_strict_json_schema(
     if budget is None:
         budget = _NodeBudget(_MAX_SCHEMA_NODES)
     budget.spend()
+
+    # A `$ref` with a *constraining* sibling is an intersection in JSON Schema 2020-12:
+    # a value must satisfy both the referent and the sibling. Inlining it parent-wins
+    # (as the code below does for annotation-only siblings) would silently delete the
+    # referent's own constraints and invert the accepted set, so reject it loudly.
+    if "$ref" in json_schema:
+        constraining_siblings = set(json_schema.keys()) - {"$ref"} - _REF_ANNOTATION_SIBLINGS
+        if constraining_siblings:
+            raise UserError(
+                "JSON schema contains a `$ref` with constraining sibling keyword(s) "
+                f"({', '.join(sorted(constraining_siblings))}) that cannot be represented "
+                "in a strict schema without changing its accepted values."
+            )
 
     defs = json_schema.get("$defs")
     if is_dict(defs):

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -396,3 +396,139 @@ def test_ref_expansion_bomb_is_rejected():
     }
     with pytest.raises(UserError):
         ensure_strict_json_schema(schema)
+
+
+def test_ref_with_constraining_sibling_is_rejected():
+    # A `$ref` with a *constraining* sibling (anything other than an annotation or a
+    # definition map) is an intersection in JSON Schema 2020-12: the accepted values are
+    # those that satisfy BOTH the referent AND the sibling. Merging parent-wins would
+    # silently drop the referent's own constraints (here `b`) and invert the accepted
+    # set, so strict conversion must reject it loudly instead of shipping a schema that
+    # accepts different values.
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+            }
+        },
+        "type": "object",
+        "properties": {
+            "node": {
+                "properties": {"a": {"type": "string"}},
+                "required": ["a"],
+                "$ref": "#/$defs/T",
+            }
+        },
+    }
+
+    with pytest.raises(UserError, match="constraining sibling"):
+        ensure_strict_json_schema(schema)
+
+
+def test_ref_with_constraining_type_sibling_is_rejected():
+    # A `type` sibling on a `$ref` is just as constraining as `properties`/`required`.
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+            }
+        },
+        "type": "object",
+        "properties": {"node": {"type": "string", "$ref": "#/$defs/T"}},
+    }
+
+    with pytest.raises(UserError, match="constraining sibling"):
+        ensure_strict_json_schema(schema)
+
+
+def test_ref_with_annotation_sibling_is_still_expanded():
+    # Annotation-only siblings (description/title/... ) do not constrain the accepted
+    # values, so a `$ref` carrying them must keep expanding into the referent.
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+            }
+        },
+        "type": "object",
+        "properties": {
+            "node": {"description": "a node", "title": "Node", "$ref": "#/$defs/T"}
+        },
+    }
+
+    result = ensure_strict_json_schema(schema)
+    node = result["properties"]["node"]
+    assert node["type"] == "object"
+    assert node["properties"] == {"b": {"type": "string"}}
+    assert node["required"] == ["b"]
+    assert node["description"] == "a node"
+    assert node["title"] == "Node"
+    assert "$ref" not in node
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        # OpenAPI-style `allOf` over two `$ref`s (a 2-member intersection).
+        {
+            "type": "object",
+            "properties": {
+                "val": {"allOf": [{"$ref": "#/$defs/A"}, {"$ref": "#/$defs/B"}]}
+            },
+            "$defs": {
+                "A": {"type": "object", "properties": {"a": {"type": "string"}}},
+                "B": {"type": "object", "properties": {"b": {"type": "string"}}},
+            },
+        },
+        {"type": "object", "properties": {"val": {"allOf": [{"type": "string"}, {"type": "integer"}]}}},
+        {"type": "object", "properties": {"tags": {"type": "array", "items": {"type": "string"}, "uniqueItems": True}}},
+        # Tuple-form `items` (an array instead of a single schema).
+        {"type": "object", "properties": {"pair": {"type": "array", "items": [{"type": "string"}, {"type": "number"}]}}},
+        # Draft 7 `additionalItems` (only meaningful next to a tuple, but rejected standalone).
+        {"type": "object", "properties": {"xs": {"type": "array", "items": {"type": "string"}, "additionalItems": {"type": "string"}}}},
+        # Array with no `items` at all.
+        {"type": "object", "properties": {"xs": {"type": "array"}}},
+        {"type": "object", "properties": {"xs": {"type": "array", "prefixItems": [{"type": "string"}]}}},
+        {"type": "object", "properties": {"obj": {"type": "object", "properties": {"a": {"type": "string"}}, "patternProperties": {"^x": {"type": "string"}}}}},
+        {"type": "object", "properties": {"obj": {"type": "object", "properties": {"a": {"type": "string"}}, "propertyNames": {"pattern": "^a"}}}},
+        {"type": "object", "properties": {"obj": {"type": "object", "properties": {"a": {"type": "string"}}, "unevaluatedProperties": False}}},
+        {"type": "object", "properties": {"val": {"not": {"type": "string"}}}},
+        {"type": "object", "properties": {"val": {"if": {"type": "string"}, "then": {"type": "string"}}}},
+        {"type": "object", "properties": {"xs": {"type": "array", "items": {"type": "number"}, "contains": {"type": "number"}}}},
+        {"type": "object", "properties": {"obj": {"type": "object", "properties": {"a": {"type": "string"}}, "minProperties": 1}}},
+        {"type": "object", "properties": {"obj": {"type": "object", "properties": {"a": {"type": "string"}}, "dependentRequired": {"a": ["b"]}}}},
+        # A `$id` nested below the schema root (root `$id` is allowed as metadata).
+        {"type": "object", "properties": {"x": {"$id": "https://example.com/x", "type": "string"}}},
+    ],
+    ids=[
+        "all-of-ref-ref",
+        "all-of-two-members",
+        "unique-items",
+        "tuple-form-items",
+        "additional-items",
+        "array-without-items",
+        "prefix-items",
+        "pattern-properties",
+        "property-names",
+        "unevaluated-properties",
+        "not",
+        "if-then",
+        "contains",
+        "min-properties",
+        "dependent-required",
+        "nested-id",
+    ],
+)
+def test_non_convertible_shapes_are_rejected(schema):
+    # These shapes cannot be represented in OpenAI's strict mode. Converting them to
+    # strict would either leave an unsupported keyword in place (which the API rejects
+    # at request time) or silently change the accepted values. They must raise so that
+    # the opt-in MCP fallback can serve the original non-strict schema instead.
+    with pytest.raises(UserError):
+        ensure_strict_json_schema(schema)


### PR DESCRIPTION
Closes #4353

### Root cause

Two defects in `agents/strict_schema.py`, both about what counts as "not convertible" to OpenAI's strict mode:

1. **`$ref` sibling merge is parent-wins (default path, silent).** `_ensure_strict_json_schema` inlines a `$ref` via `json_schema.update({**resolved, **json_schema})`, so sibling keys override the referent. Under JSON Schema 2020-12 a `$ref` and its siblings form an *intersection*, not a precedence. For annotation-only siblings (`description`, `title`) parent-wins equals the intersection, which is why pydantic-emitted schemas are safe. But a *constraining* sibling (`properties`/`required`/`type`/`enum`) deletes the referent's own constraints: the repro in #4353 drops `T.b` and then closes the object with `additionalProperties: false`, turning a schema that accepted `{node:{a,b}}` into one that only accepts `{node:{a}}` — a silently inverted accept set with no 400, because the converted schema is itself valid strict-mode JSON Schema.

2. **`convert_schemas_to_strict` falls back on only 2 of the 17 shapes the issue sampled (opt-in path).** `mcp/util.py` decides "not convertible" by "did `ensure_strict_json_schema` raise?", but the function only raises for `additionalProperties` and non-dict subschemas; it never checks the strict keyword allowlist. The 15 shapes from the issue, plus Draft 7 `additionalItems` (which the vendor transformer also rejects) — 16 shapes total: `uniqueItems`, `prefixItems`, tuple-form `items`, `additionalItems`, `patternProperties`, `propertyNames`, `unevaluatedProperties`, `not`, `if`/`then`, `contains`, `minProperties`, `dependentRequired`, nested `$id`, multi-member `allOf`, the `allOf: [{$ref}, {$ref}]` OpenAPI idiom, and array-without-`items` — convert "successfully", get `strict_json_schema=True`, and are then rejected by the API at request time.

### Fix

- **Finding 1 — raise on constraining `$ref` siblings.** When a `$ref` carries any sibling outside the annotation/definition-map allowlist, `_ensure_strict_json_schema` raises `UserError` instead of silently merging parent-wins. Annotation-only siblings still expand exactly as before. This takes the issue's preferred option: a loud failure beats a tool whose accept set quietly inverted, and it composes with the existing MCP fallback.

- **Finding 2 — validate the converted result against the strict keyword allowlist.** `ensure_strict_json_schema` now walks the converted schema and raises `UserError` if any strict-unsupported keyword survives conversion (plus tuple-form `items`, `additionalItems`, array-without-`items`, and nested `$id`). The existing `except` in `mcp/util.py` then serves the original non-strict schema, so `convert_schemas_to_strict=True` falls back correctly on all 15 shapes.

### Tests

Added to `tests/test_strict_schema.py`:

- `test_ref_with_constraining_sibling_is_rejected` and `test_ref_with_constraining_type_sibling_is_rejected` — constraining siblings raise. The control `test_ref_with_annotation_sibling_is_still_expanded` proves annotation-only siblings still expand.
- `test_non_convertible_shapes_are_rejected` — parametrized over the 16 non-convertible shapes, all must raise.

All 18 new cases fail on `main` and pass with the fix. Full suites pass: `tests/test_strict_schema.py` (53), `tests/test_strict_schema_oneof.py`, `tests/test_function_schema.py`, `tests/test_function_tool.py`, `tests/test_function_tool_decorator.py`, `tests/test_output_tool.py`, and `tests/mcp/test_mcp_util.py` (109).