### PR TITLE
fix: freeze Runloop platform properties

### DIFF
--- a/integration_tests/_contract_support.py
+++ b/integration_tests/_contract_support.py
@@ -1060,11 +1060,19 @@ def _import_contract_module(module_name: str, agents_module: Any | None) -> Any:
 def _validate_public_property_contract(
     contract: dict[str, Any],
     agents_module: Any | None,
+    *,
+    unsupported_platforms: Mapping[str, tuple[str, ...]] | None = None,
 ) -> list[str]:
     errors: list[str] = []
+    unsupported_platforms = unsupported_platforms or {}
     for entry in contract.get("public_properties", []):
         module_name = entry["module"]
         class_name = entry["class_name"]
+        optional_dependency = _optional_dependency_for_binding(contract, module_name, class_name)
+        if optional_dependency is not None and not _optional_dependency_is_available_for_contract(
+            optional_dependency, unsupported_platforms
+        ):
+            continue
         try:
             module = _import_contract_module(module_name, agents_module)
         except Exception as error:
@@ -1182,7 +1190,13 @@ def validate_released_api_contract(
         errors.append(f"Invalid released optional dependency platform declarations: {error}")
         unsupported_platforms = {}
 
-    errors.extend(_validate_public_property_contract(contract, agents_module))
+    errors.extend(
+        _validate_public_property_contract(
+            contract,
+            agents_module,
+            unsupported_platforms=unsupported_platforms,
+        )
+    )
 
     missing_exports = sorted(set(contract["required_top_level_exports"]) - set(agents.__all__))
     if missing_exports:

--- a/tests/fixtures/released_api_contract_policy.json
+++ b/tests/fixtures/released_api_contract_policy.json
@@ -189,6 +189,24 @@
       ]
     },
     {
+      "class_name": "RunloopPlatformClient",
+      "module": "agents.extensions.sandbox",
+      "names": [
+        "axons",
+        "benchmarks",
+        "blueprints",
+        "network_policies",
+        "secrets"
+      ]
+    },
+    {
+      "class_name": "RunloopSandboxClient",
+      "module": "agents.extensions.sandbox",
+      "names": [
+        "platform"
+      ]
+    },
+    {
       "class_name": "SandboxSessionState",
       "module": "agents.sandbox.session.sandbox_session_state",
       "names": [

--- a/tests/test_released_api_contract.py
+++ b/tests/test_released_api_contract.py
@@ -302,6 +302,48 @@ def test_curated_public_property_contract_detects_removed_or_changed_properties(
     ]
 
 
+def test_curated_public_property_contract_honors_optional_dependency_availability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class OptionalClient:
+        pass
+
+    contract: dict[str, Any] = {
+        "required_submodule_exports": {
+            "agents.optional": {
+                "names": ["OptionalClient"],
+                "optional_bindings": {},
+                "optional_exports": {"OptionalClient": "optional_backend"},
+            }
+        },
+        "public_properties": [
+            {
+                "module": "agents.optional",
+                "class_name": "OptionalClient",
+                "names": ["status"],
+            }
+        ],
+    }
+    agents_module = SimpleNamespace(__all__=[])
+    optional_module = SimpleNamespace(OptionalClient=OptionalClient)
+    monkeypatch.setattr(
+        contract_support,
+        "_import_contract_module",
+        lambda module_name, _agents_module: (
+            agents_module if module_name == "agents" else optional_module
+        ),
+    )
+    monkeypatch.setattr(contract_support, "_optional_dependency_is_available", lambda _name: False)
+
+    assert _validate_public_property_contract(contract, agents_module) == []
+
+    monkeypatch.setattr(contract_support, "_optional_dependency_is_available", lambda _name: True)
+
+    assert _validate_public_property_contract(contract, agents_module) == [
+        "agents.optional.OptionalClient.status removed or changed a released public property"
+    ]
+
+
 def test_public_class_member_contract_tracks_only_sdk_owned_inherited_methods() -> None:
     class ExternalBase:
         def external_method(self) -> None:
@@ -2040,6 +2082,16 @@ def test_repository_release_policy_declares_v020_contract_surfaces() -> None:
             "class_name": "RetryPolicyContext",
             "module": "agents.retry",
             "names": ["response_started", "replay_safety", "stateful_request"],
+        },
+        {
+            "class_name": "RunloopPlatformClient",
+            "module": "agents.extensions.sandbox",
+            "names": ["axons", "benchmarks", "blueprints", "network_policies", "secrets"],
+        },
+        {
+            "class_name": "RunloopSandboxClient",
+            "module": "agents.extensions.sandbox",
+            "names": ["platform"],
         },
         {
             "class_name": "SandboxSessionState",


### PR DESCRIPTION
This pull request fixes the prospective release contract so it freezes `RunloopSandboxClient.platform` and the documented `RunloopPlatformClient` resource accessors.

It also derives optional-dependency ownership from the existing submodule export contract. Core wheel and source-distribution validation therefore continues to work without the Runloop extra, while Runloop-enabled environments validate every property descriptor.