### PR TITLE
fix: reject unsafe strict-schema ref siblings

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, TypeGuard
+from typing import Any, TypeGuard, cast
 
 from openai import NOT_GIVEN
 
@@ -39,6 +39,10 @@ _OPEN_OBJECT_ERROR = (
 _UNVALIDATED_REF_ERROR = (
     "JSON schema contains a reference whose target was not validated for strict mode."
 )
+_NESTED_RESOURCE_REF_ERROR = (
+    "JSON schema contains a reference owned by or crossing a nested `$id` resource that cannot "
+    "be resolved against the document root."
+)
 
 _SCHEMA_DEPTH_ERROR = (
     "JSON schema is too deeply nested to process safely. Simplify or flatten the schema."
@@ -65,6 +69,30 @@ def _copy_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Copy a JSON schema only after verifying recursive copying is safe."""
     _validate_json_schema_depth(schema)
     return copy.deepcopy(schema)
+
+
+# Keywords that may legally sit alongside a `$ref` without adding validation constraints.
+# Definition maps are also allowed because they do not directly constrain an instance.
+_REF_NON_CONSTRAINING_SIBLINGS = frozenset(
+    {
+        "$anchor",
+        "$comment",
+        "$defs",
+        "$schema",
+        "contentEncoding",
+        "contentMediaType",
+        "contentSchema",
+        "default",
+        "definitions",
+        "deprecated",
+        "description",
+        "examples",
+        "readOnly",
+        "title",
+        "writeOnly",
+    }
+)
+_ROOT_REF_NON_CONSTRAINING_SIBLINGS = _REF_NON_CONSTRAINING_SIBLINGS | {"$id"}
 
 
 class _NodeBudget:
@@ -131,6 +159,7 @@ def _ensure_strict_json_schema(
     root: dict[str, object],
     budget: _NodeBudget | None = None,
     depth: int = 1,
+    inside_nested_resource: bool = False,
 ) -> dict[str, Any]:
     if depth > _MAX_SCHEMA_DEPTH:
         raise UserError(_SCHEMA_DEPTH_ERROR)
@@ -144,6 +173,25 @@ def _ensure_strict_json_schema(
         budget = _NodeBudget(_MAX_SCHEMA_NODES)
     budget.spend()
     next_depth = depth + 1
+    inside_nested_resource = inside_nested_resource or (
+        json_schema is not root and _declares_schema_resource(json_schema)
+    )
+
+    if "$ref" in json_schema:
+        if inside_nested_resource:
+            raise UserError(_NESTED_RESOURCE_REF_ERROR)
+        allowed_siblings = (
+            _ROOT_REF_NON_CONSTRAINING_SIBLINGS
+            if json_schema is root
+            else _REF_NON_CONSTRAINING_SIBLINGS
+        )
+        incompatible_siblings = set(json_schema) - {"$ref"} - allowed_siblings
+        if incompatible_siblings:
+            raise UserError(
+                "JSON schema contains a `$ref` with incompatible sibling keyword(s) "
+                f"({', '.join(sorted(incompatible_siblings))}) that cannot be merged "
+                "without changing its accepted values."
+            )
 
     defs = json_schema.get("$defs")
     if is_dict(defs):
@@ -154,6 +202,7 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 depth=next_depth,
+                inside_nested_resource=inside_nested_resource,
             )
 
     definitions = json_schema.get("definitions")
@@ -165,6 +214,7 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 depth=next_depth,
+                inside_nested_resource=inside_nested_resource,
             )
 
     typ = json_schema.get("type")
@@ -205,6 +255,7 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 depth=next_depth,
+                inside_nested_resource=inside_nested_resource,
             )
             for key, prop_schema in properties.items()
         }
@@ -214,7 +265,12 @@ def _ensure_strict_json_schema(
     items = json_schema.get("items")
     if is_dict(items):
         json_schema["items"] = _ensure_strict_json_schema(
-            items, path=(*path, "items"), root=root, budget=budget, depth=next_depth
+            items,
+            path=(*path, "items"),
+            root=root,
+            budget=budget,
+            depth=next_depth,
+            inside_nested_resource=inside_nested_resource,
         )
 
     # unions
@@ -227,6 +283,7 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 depth=next_depth,
+                inside_nested_resource=inside_nested_resource,
             )
             for i, variant in enumerate(any_of)
         ]
@@ -246,6 +303,7 @@ def _ensure_strict_json_schema(
                 root=root,
                 budget=budget,
                 depth=next_depth,
+                inside_nested_resource=inside_nested_resource,
             )
             for i, variant in enumerate(one_of)
         ]
@@ -255,18 +313,40 @@ def _ensure_strict_json_schema(
     all_of = json_schema.get("allOf")
     if is_list(all_of):
         if len(all_of) == 1:
-            json_schema.update(
-                _ensure_strict_json_schema(
-                    all_of[0],
+            entry = all_of[0]
+            if (
+                is_dict(entry)
+                and "$ref" in entry
+                and not (set(entry) - {"$ref"} - _REF_NON_CONSTRAINING_SIBLINGS)
+            ):
+                if inside_nested_resource:
+                    raise UserError(_NESTED_RESOURCE_REF_ERROR)
+                budget.spend()
+                strict_entry = _resolve_non_constraining_ref_chain(
+                    root=root,
+                    schema=entry,
+                    budget=budget,
+                )
+            else:
+                strict_entry = _ensure_strict_json_schema(
+                    entry,
                     path=(*path, "allOf", "0"),
                     root=root,
                     budget=budget,
                     depth=next_depth,
+                    inside_nested_resource=inside_nested_resource,
                 )
-            )
             json_schema.pop("allOf")
+            merged = _merge_single_all_of(entry=strict_entry, parent=json_schema)
+            json_schema.clear()
+            json_schema.update(merged)
             return _ensure_strict_json_schema(
-                json_schema, path=path, root=root, budget=budget, depth=next_depth
+                json_schema,
+                path=path,
+                root=root,
+                budget=budget,
+                depth=next_depth,
+                inside_nested_resource=inside_nested_resource,
             )
         else:
             json_schema["allOf"] = [
@@ -276,6 +356,7 @@ def _ensure_strict_json_schema(
                     root=root,
                     budget=budget,
                     depth=next_depth,
+                    inside_nested_resource=inside_nested_resource,
                 )
                 for i, entry in enumerate(all_of)
             ]
@@ -310,7 +391,12 @@ def _ensure_strict_json_schema(
         # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied
         # we call `_ensure_strict_json_schema` again to fix the inlined schema and ensure it's valid
         return _ensure_strict_json_schema(
-            json_schema, path=path, root=root, budget=budget, depth=next_depth
+            json_schema,
+            path=path,
+            root=root,
+            budget=budget,
+            depth=next_depth,
+            inside_nested_resource=inside_nested_resource,
         )
 
     if budget.reject_open_objects and "$ref" in json_schema:
@@ -325,14 +411,107 @@ def resolve_ref(*, root: dict[str, object], ref: str) -> object:
 
     path = ref[2:].split("/")
     resolved = root
-    for key in path:
+    for raw_key in path:
+        key = raw_key.replace("~1", "/").replace("~0", "~")
         value = resolved[key]
         assert is_dict(value), (
             f"encountered non-dictionary entry while resolving {ref} - {resolved}"
         )
         resolved = value
+        if _declares_schema_resource(resolved):
+            raise UserError(_NESTED_RESOURCE_REF_ERROR)
 
     return resolved
+
+
+def _declares_schema_resource(schema: dict[str, object]) -> bool:
+    return isinstance(schema.get("$id"), str)
+
+
+def _resolve_non_constraining_ref_chain(
+    *,
+    root: dict[str, object],
+    schema: dict[str, Any],
+    budget: _NodeBudget,
+) -> dict[str, Any]:
+    resolved = schema
+    seen_refs: set[str] = set()
+    carried_siblings: dict[str, Any] = {}
+    while True:
+        if "$ref" not in resolved:
+            break
+        if set(resolved) - {"$ref"} - _REF_NON_CONSTRAINING_SIBLINGS:
+            break
+
+        ref = resolved["$ref"]
+        assert isinstance(ref, str), f"Received non-string $ref - {ref}"
+        if ref in seen_refs:
+            raise UserError("JSON schema contains a circular `$ref` chain.")
+        seen_refs.add(ref)
+
+        carried_siblings = {
+            **{key: value for key, value in resolved.items() if key != "$ref"},
+            **carried_siblings,
+        }
+        budget.spend()
+        target = resolve_ref(root=root, ref=ref)
+        if not is_dict(target):
+            raise ValueError(f"Expected `$ref: {ref}` to resolved to a dictionary but got {target}")
+        resolved = target
+    return {**resolved, **carried_siblings}
+
+
+def _merge_single_all_of(
+    *,
+    entry: dict[str, Any],
+    parent: dict[str, Any],
+) -> dict[str, Any]:
+    merged = dict(entry)
+    incompatible_overlaps: list[str] = []
+    for key, parent_value in parent.items():
+        if key not in merged:
+            merged[key] = parent_value
+        elif key in _REF_NON_CONSTRAINING_SIBLINGS:
+            merged[key] = parent_value
+        elif _json_values_equal(parent_value, merged[key]):
+            continue
+        elif (key == "properties" and parent_value == {}) or (
+            key == "required" and parent_value == []
+        ):
+            continue
+        else:
+            incompatible_overlaps.append(key)
+
+    if incompatible_overlaps:
+        raise UserError(
+            "JSON schema contains a singleton `allOf` entry with incompatible parent "
+            f"keyword(s) ({', '.join(sorted(incompatible_overlaps))}) that cannot be merged "
+            "without changing its accepted values."
+        )
+    return merged
+
+
+def _json_values_equal(left: Any, right: Any) -> bool:
+    if isinstance(left, bool) or isinstance(right, bool):
+        return type(left) is type(right) and left == right
+    if isinstance(left, int | float) and isinstance(right, int | float):
+        return left == right
+    if isinstance(left, list) or isinstance(right, list):
+        if not isinstance(left, list) or not isinstance(right, list):
+            return False
+        return len(left) == len(right) and all(
+            _json_values_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right, strict=False)
+        )
+    if isinstance(left, dict) or isinstance(right, dict):
+        if not isinstance(left, dict) or not isinstance(right, dict):
+            return False
+        return left.keys() == right.keys() and all(
+            _json_values_equal(left[key], right[key]) for key in left
+        )
+    if type(left) is not type(right):
+        return False
+    return cast(bool, left == right)
 
 
 def is_dict(obj: object) -> TypeGuard[dict[str, object]]:

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -1924,6 +1924,327 @@ def test_to_function_tool_failed_strict_conversion_keeps_original_schema():
 
 
 @pytest.mark.parametrize(
+    "node_schema",
+    [
+        {
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+            "$ref": "#/$defs/T",
+        },
+        {
+            "$ref": "#/$defs/T",
+            "allOf": [{"$ref": "#/$defs/U"}],
+        },
+        {"$ref": "#/$defs/T", "additionalProperties": False},
+    ],
+    ids=["overlapping-properties", "singleton-all-of", "interacting-object-constraints"],
+)
+def test_to_function_tool_ref_sibling_falls_back_to_original_schema(node_schema):
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+            },
+            "U": {"type": "integer"},
+        },
+        "type": "object",
+        "properties": {"node": node_schema},
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_ref_with_schema_metadata_remains_strict():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "value": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$ref": "#/$defs/T",
+            }
+        },
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema["properties"]["value"] == {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string",
+    }
+    assert function_tool.params_json_schema["additionalProperties"] is False
+
+
+def test_to_function_tool_ref_with_nested_id_falls_back_to_original_schema():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "value": {
+                "$id": "https://example.test/nested",
+                "$defs": {"T": {"type": "integer"}},
+                "$ref": "#/$defs/T",
+            }
+        },
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_ref_with_anchor_remains_strict():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "value": {
+                "$anchor": "value",
+                "$ref": "#/$defs/T",
+            }
+        },
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema["properties"]["value"] == {
+        "$anchor": "value",
+        "type": "string",
+    }
+    assert function_tool.params_json_schema["additionalProperties"] is False
+
+
+def test_to_function_tool_single_all_of_annotated_alias_remains_strict():
+    schema = {
+        "components": {
+            "schemas": {
+                "Inner": {
+                    "type": "object",
+                    "description": "inner",
+                    "properties": {"value": {"type": "string"}},
+                    "additionalProperties": False,
+                },
+                "Outer": {
+                    "$ref": "#/components/schemas/Inner",
+                    "description": "outer",
+                },
+            }
+        },
+        "type": "object",
+        "allOf": [
+            {
+                "$ref": "#/components/schemas/Outer",
+                "title": "entry",
+            }
+        ],
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema["description"] == "outer"
+    assert function_tool.params_json_schema["title"] == "entry"
+    assert function_tool.params_json_schema["properties"] == {"value": {"type": "string"}}
+    assert function_tool.params_json_schema["required"] == ["value"]
+    assert function_tool.params_json_schema["additionalProperties"] is False
+    assert "$ref" not in function_tool.params_json_schema
+
+
+def test_to_function_tool_single_all_of_annotated_entry_conflict_falls_back():
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"inner": {"type": "string"}},
+                "additionalProperties": False,
+            }
+        },
+        "type": "object",
+        "properties": {"outer": {"type": "string"}},
+        "allOf": [{"$ref": "#/$defs/T", "description": "alias"}],
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_nested_single_all_of_conflict_falls_back():
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"inner": {"type": "string"}},
+                "additionalProperties": False,
+            }
+        },
+        "type": "object",
+        "properties": {"outer": {"type": "string"}},
+        "allOf": [{"allOf": [{"$ref": "#/$defs/T"}]}],
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_single_all_of_json_distinct_overlap_falls_back():
+    schema = {
+        "$defs": {"T": {"const": 1}},
+        "type": "object",
+        "const": True,
+        "properties": {},
+        "allOf": [{"$ref": "#/$defs/T"}],
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_single_all_of_nested_id_falls_back():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "contentSchema": {
+            "$id": "https://example.test/nested",
+            "$defs": {"T": {"type": "integer"}},
+            "type": "object",
+            "properties": {"value": {"$ref": "#/$defs/T"}},
+        },
+        "type": "object",
+        "properties": {},
+        "allOf": [{"$ref": "#/contentSchema"}],
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_single_all_of_nested_id_owner_falls_back():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "node": {
+                "$id": "https://example.test/nested",
+                "$defs": {"T": {"type": "integer"}},
+                "allOf": [{"$ref": "#/$defs/T"}],
+            }
+        },
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_single_all_of_descendant_nested_id_owner_falls_back():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "node": {
+                "$id": "https://example.test/nested",
+                "$defs": {"T": {"type": "integer"}},
+                "type": "object",
+                "properties": {
+                    "child": {
+                        "allOf": [{"$ref": "#/$defs/T"}],
+                    }
+                },
+                "additionalProperties": False,
+            }
+        },
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_single_all_of_target_below_nested_id_falls_back():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "contentSchema": {
+            "$id": "https://example.test/nested",
+            "$defs": {"T": {"type": "integer"}},
+            "target": {"$ref": "#/$defs/T"},
+        },
+        "type": "object",
+        "properties": {},
+        "allOf": [{"$ref": "#/contentSchema/target"}],
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is False
+    assert function_tool.params_json_schema == schema
+
+
+def test_to_function_tool_ref_allows_unrelated_id_definition_name():
+    schema = {
+        "$defs": {
+            "$id": {"type": "integer"},
+            "T": {"type": "string"},
+        },
+        "type": "object",
+        "properties": {
+            "value": {
+                "$ref": "#/$defs/T",
+                "description": "value",
+            }
+        },
+        "additionalProperties": False,
+    }
+    tool = MCPTool(name="test_tool", inputSchema=schema)
+
+    function_tool = MCPUtil.to_function_tool(tool, FakeMCPServer(), convert_schemas_to_strict=True)
+
+    assert function_tool.strict_json_schema is True
+    assert function_tool.params_json_schema["properties"]["value"] == {
+        "type": "string",
+        "description": "value",
+    }
+
+
+@pytest.mark.parametrize(
     "free_form_schema",
     [
         {"type": "object", "description": "key/value pairs"},

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -1,4 +1,5 @@
 import copy
+from collections import OrderedDict
 
 import pytest
 
@@ -344,6 +345,351 @@ def test_allOf_single_entry_merging():
     assert result["properties"]["a"]["type"] == "boolean"
 
 
+def test_allOf_single_ref_entry_merging():
+    schema = {
+        "$defs": {
+            "Inner": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+            },
+            "Outer": {"$ref": "#/$defs/Inner"},
+        },
+        "type": "object",
+        "allOf": [{"$ref": "#/$defs/Outer"}],
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert "allOf" not in result
+    assert "$ref" not in result
+    assert result["type"] == "object"
+    assert result["properties"] == {"b": {"type": "string"}}
+    assert result["required"] == ["b"]
+    assert result["additionalProperties"] is False
+
+
+def test_allOf_single_ref_entry_preserves_annotated_aliases():
+    schema = {
+        "components": {
+            "schemas": {
+                "Inner": {
+                    "type": "object",
+                    "description": "inner",
+                    "properties": {"value": {"type": "string"}},
+                },
+                "Outer": {
+                    "$ref": "#/components/schemas/Inner",
+                    "description": "outer",
+                },
+            }
+        },
+        "type": "object",
+        "allOf": [
+            {
+                "$ref": "#/components/schemas/Outer",
+                "title": "entry",
+            }
+        ],
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert "$ref" not in result
+    assert result["description"] == "outer"
+    assert result["title"] == "entry"
+    assert result["properties"] == {"value": {"type": "string"}}
+    assert result["required"] == ["value"]
+    assert result["additionalProperties"] is False
+
+
+def test_allOf_single_ref_entry_rejects_overlapping_parent_constraints():
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"inner": {"type": "string"}},
+            }
+        },
+        "type": "object",
+        "properties": {"outer": {"type": "string"}},
+        "allOf": [{"$ref": "#/$defs/T", "description": "alias"}],
+    }
+
+    with pytest.raises(UserError, match="singleton `allOf`"):
+        ensure_strict_json_schema(schema)
+
+
+def test_nested_single_allOf_rejects_overlapping_parent_constraints():
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"inner": {"type": "string"}},
+            }
+        },
+        "type": "object",
+        "properties": {"outer": {"type": "string"}},
+        "allOf": [{"allOf": [{"$ref": "#/$defs/T"}]}],
+    }
+
+    with pytest.raises(UserError, match="singleton `allOf`"):
+        ensure_strict_json_schema(schema)
+
+
+@pytest.mark.parametrize(
+    ("referenced_value", "parent_value"),
+    [
+        (1, True),
+        ({"nested": [1]}, {"nested": [True]}),
+    ],
+    ids=["top-level", "nested"],
+)
+def test_allOf_single_ref_entry_rejects_json_distinct_equal_python_values(
+    referenced_value, parent_value
+):
+    schema = {
+        "$defs": {"T": {"const": referenced_value}},
+        "const": parent_value,
+        "allOf": [{"$ref": "#/$defs/T"}],
+    }
+
+    with pytest.raises(UserError, match="singleton `allOf`"):
+        ensure_strict_json_schema(schema)
+
+
+def test_allOf_single_ref_entry_accepts_equal_json_numbers():
+    schema = {
+        "$defs": {"T": {"const": 1}},
+        "const": 1.0,
+        "allOf": [{"$ref": "#/$defs/T"}],
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["const"] == 1
+    assert isinstance(result["const"], int)
+
+
+def test_allOf_single_ref_entry_accepts_equal_mapping_subclasses():
+    schema = {
+        "$defs": {"T": {"const": OrderedDict([("nested", [1])])}},
+        "const": {"nested": [1]},
+        "allOf": [{"$ref": "#/$defs/T"}],
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["const"] == {"nested": [1]}
+
+
+def test_allOf_single_circular_ref_is_rejected():
+    schema = {
+        "$defs": {
+            "A": {"$ref": "#/$defs/B"},
+            "B": {"$ref": "#/$defs/A"},
+        },
+        "type": "object",
+        "allOf": [{"$ref": "#/$defs/A"}],
+    }
+
+    with pytest.raises(UserError, match="circular"):
+        ensure_strict_json_schema(schema)
+
+
+def test_allOf_single_annotated_circular_ref_is_rejected():
+    schema = {
+        "components": {
+            "schemas": {
+                "A": {"$ref": "#/components/schemas/B", "description": "a"},
+                "B": {"$ref": "#/components/schemas/A", "description": "b"},
+            }
+        },
+        "type": "object",
+        "allOf": [{"$ref": "#/components/schemas/A"}],
+    }
+
+    with pytest.raises(UserError, match="circular"):
+        ensure_strict_json_schema(schema)
+
+
+def test_allOf_single_ref_chain_spends_node_budget(monkeypatch):
+    monkeypatch.setattr("agents.strict_schema._MAX_SCHEMA_NODES", 4)
+    schema = {
+        "components": {
+            "schemas": {
+                "A": {"$ref": "#/components/schemas/B"},
+                "B": {"$ref": "#/components/schemas/C"},
+                "C": {"type": "object", "properties": {}},
+            }
+        },
+        "type": "object",
+        "allOf": [{"$ref": "#/components/schemas/A"}],
+    }
+
+    with pytest.raises(UserError, match="too large"):
+        ensure_strict_json_schema(schema)
+
+
+def test_allOf_single_ref_rejects_nested_id_before_promoting_target():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "contentSchema": {
+            "$id": "https://example.test/nested",
+            "$ref": "#/$defs/T",
+        },
+        "type": "object",
+        "allOf": [{"$ref": "#/contentSchema"}],
+    }
+
+    with pytest.raises(UserError, match=r"nested `\$id`"):
+        ensure_strict_json_schema(schema)
+
+
+def test_allOf_single_ref_rejects_nested_id_owner_before_resolution():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "node": {
+                "$id": "https://example.test/nested",
+                "$defs": {"T": {"type": "integer"}},
+                "allOf": [{"$ref": "#/$defs/T"}],
+            }
+        },
+    }
+
+    with pytest.raises(UserError, match=r"nested `\$id` resource"):
+        ensure_strict_json_schema(schema)
+
+
+def test_allOf_single_ref_rejects_descendant_nested_id_owner_before_resolution():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "node": {
+                "$id": "https://example.test/nested",
+                "$defs": {"T": {"type": "integer"}},
+                "type": "object",
+                "properties": {
+                    "child": {
+                        "allOf": [{"$ref": "#/$defs/T"}],
+                    }
+                },
+            }
+        },
+    }
+
+    with pytest.raises(UserError, match=r"nested `\$id` resource"):
+        ensure_strict_json_schema(schema)
+
+
+def test_allOf_single_ref_rejects_promoted_nested_id_with_descendant_ref():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "contentSchema": {
+            "$id": "https://example.test/nested",
+            "$defs": {"T": {"type": "integer"}},
+            "type": "object",
+            "properties": {"value": {"$ref": "#/$defs/T"}},
+        },
+        "type": "object",
+        "allOf": [{"$ref": "#/contentSchema"}],
+    }
+
+    with pytest.raises(UserError, match=r"nested `\$id` resource"):
+        ensure_strict_json_schema(schema)
+
+
+def test_allOf_single_ref_rejects_target_below_nested_id_resource():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "contentSchema": {
+            "$id": "https://example.test/nested",
+            "$defs": {"T": {"type": "integer"}},
+            "target": {"$ref": "#/$defs/T"},
+        },
+        "type": "object",
+        "allOf": [{"$ref": "#/contentSchema/target"}],
+    }
+
+    with pytest.raises(UserError, match=r"nested `\$id` resource"):
+        ensure_strict_json_schema(schema)
+
+
+@pytest.mark.parametrize(
+    ("container", "ref"),
+    [
+        ({"$defs": {"$id": {"type": "object", "properties": {}}}}, "#/$defs/$id"),
+        (
+            {"components": {"schemas": {"$id": {"type": "object", "properties": {}}}}},
+            "#/components/schemas/$id",
+        ),
+    ],
+    ids=["defs", "components-schemas"],
+)
+def test_allOf_single_ref_allows_id_as_schema_map_member_name(container, ref):
+    schema = {
+        **container,
+        "type": "object",
+        "allOf": [{"$ref": ref}],
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["type"] == "object"
+    assert result["properties"] == {}
+    assert result["additionalProperties"] is False
+
+
+def test_ref_allows_unrelated_id_definition_name():
+    schema = {
+        "$defs": {
+            "$id": {"type": "integer"},
+            "T": {"type": "string"},
+        },
+        "type": "object",
+        "properties": {
+            "value": {
+                "$ref": "#/$defs/T",
+                "description": "value",
+            }
+        },
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["properties"]["value"] == {
+        "type": "string",
+        "description": "value",
+    }
+
+
+@pytest.mark.parametrize(
+    ("definition_name", "ref_token"),
+    [("a/b", "a~1b"), ("a~b", "a~0b"), ("a~1b", "a~01b")],
+    ids=["slash", "tilde", "replacement-order"],
+)
+def test_allOf_single_ref_entry_decodes_json_pointer_tokens(definition_name, ref_token):
+    schema = {
+        "$defs": {
+            definition_name: {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            }
+        },
+        "type": "object",
+        "allOf": [{"$ref": f"#/$defs/{ref_token}"}],
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["properties"] == {"value": {"type": "string"}}
+    assert result["required"] == ["value"]
+    assert result["additionalProperties"] is False
+
+
 @pytest.mark.parametrize("additional_properties", [True, {}], ids=["true", "schema"])
 def test_allOf_single_entry_cannot_overwrite_strict_object(additional_properties):
     schema = {
@@ -436,3 +782,211 @@ def test_ref_expansion_bomb_is_rejected():
     }
     with pytest.raises(UserError):
         ensure_strict_json_schema(schema)
+
+
+def test_ref_with_incompatible_sibling_is_rejected():
+    # Parent-wins merging would silently discard the referenced constraints on `b`.
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+            }
+        },
+        "type": "object",
+        "properties": {
+            "node": {
+                "properties": {"a": {"type": "string"}},
+                "required": ["a"],
+                "$ref": "#/$defs/T",
+            }
+        },
+    }
+
+    with pytest.raises(UserError, match="incompatible sibling"):
+        ensure_strict_json_schema(schema)
+
+
+def test_ref_with_incompatible_type_sibling_is_rejected():
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+            }
+        },
+        "type": "object",
+        "properties": {"node": {"type": "string", "$ref": "#/$defs/T"}},
+    }
+
+    with pytest.raises(UserError, match="incompatible sibling"):
+        ensure_strict_json_schema(schema)
+
+
+def test_ref_with_single_all_of_sibling_is_rejected():
+    schema = {
+        "$defs": {
+            "A": {"type": "string"},
+            "B": {"type": "integer"},
+        },
+        "type": "object",
+        "properties": {
+            "node": {
+                "$ref": "#/$defs/A",
+                "allOf": [{"$ref": "#/$defs/B"}],
+            }
+        },
+    }
+
+    with pytest.raises(UserError, match="incompatible sibling"):
+        ensure_strict_json_schema(schema)
+
+
+def test_ref_with_validation_sibling_is_rejected():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {"node": {"$ref": "#/$defs/T", "minLength": 1}},
+    }
+
+    with pytest.raises(UserError, match="incompatible sibling"):
+        ensure_strict_json_schema(schema)
+
+
+def test_ref_with_interacting_object_sibling_is_rejected():
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+                "additionalProperties": False,
+            }
+        },
+        "type": "object",
+        "properties": {
+            "node": {
+                "$ref": "#/$defs/T",
+                "additionalProperties": False,
+            }
+        },
+    }
+
+    with pytest.raises(UserError, match="incompatible sibling"):
+        ensure_strict_json_schema(schema)
+
+
+def test_ref_with_annotation_sibling_is_still_expanded():
+    # Annotation-only siblings (description/title/... ) do not constrain the accepted
+    # values, so a `$ref` carrying them must keep expanding into the referent.
+    schema = {
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"b": {"type": "string"}},
+                "required": ["b"],
+            }
+        },
+        "type": "object",
+        "properties": {
+            "node": {
+                "contentMediaType": "application/json",
+                "description": "a node",
+                "title": "Node",
+                "$ref": "#/$defs/T",
+            }
+        },
+    }
+
+    result = ensure_strict_json_schema(schema)
+    node = result["properties"]["node"]
+    assert node["type"] == "object"
+    assert node["properties"] == {"b": {"type": "string"}}
+    assert node["required"] == ["b"]
+    assert node["description"] == "a node"
+    assert node["title"] == "Node"
+    assert node["contentMediaType"] == "application/json"
+    assert "$ref" not in node
+
+
+def test_ref_with_schema_metadata_is_still_expanded():
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            }
+        },
+        "$ref": "#/$defs/T",
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert result["type"] == "object"
+    assert result["properties"] == {"value": {"type": "string"}}
+    assert result["required"] == ["value"]
+    assert result["additionalProperties"] is False
+    assert "$ref" not in result
+
+
+def test_root_ref_with_id_is_still_expanded():
+    schema = {
+        "$id": "https://example.test/root",
+        "$defs": {
+            "T": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+            }
+        },
+        "$ref": "#/$defs/T",
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["$id"] == "https://example.test/root"
+    assert result["type"] == "object"
+    assert result["properties"] == {"value": {"type": "string"}}
+    assert result["required"] == ["value"]
+    assert result["additionalProperties"] is False
+    assert "$ref" not in result
+
+
+def test_nested_ref_with_id_is_rejected_before_resolution():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "value": {
+                "$id": "https://example.test/nested",
+                "$defs": {"T": {"type": "integer"}},
+                "$ref": "#/$defs/T",
+            }
+        },
+    }
+
+    with pytest.raises(UserError, match=r"nested `\$id` resource"):
+        ensure_strict_json_schema(schema)
+
+
+def test_ref_with_anchor_is_still_expanded():
+    schema = {
+        "$defs": {"T": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "value": {
+                "$anchor": "value",
+                "$ref": "#/$defs/T",
+            }
+        },
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["properties"]["value"] == {
+        "$anchor": "value",
+        "type": "string",
+    }


### PR DESCRIPTION
This pull request supersedes #4354 and fixes strict JSON Schema conversion that could silently discard constraints when a `$ref` had validation-bearing siblings.

It rejects unsupported sibling intersections before normalization, while preserving standard annotations such as `$schema`, chained references, and singleton `allOf` reference chains. Circular pure-reference chains now fail explicitly, and MCP conversion retains its existing fallback to the original non-strict schema.

Fixes #4353
