### PR TITLE
fix: reject schemas that exceed safe recursion depth

### DIFF
--- a/src/agents/mcp/util.py
+++ b/src/agents/mcp/util.py
@@ -19,7 +19,7 @@ from .._mcp_tool_metadata import resolve_mcp_tool_description_for_model, resolve
 from ..exceptions import AgentsException, MCPToolCancellationError, ModelBehaviorError, UserError
 from ..logger import log_tool_action_error, logger
 from ..run_context import RunContextWrapper
-from ..strict_schema import ensure_strict_json_schema
+from ..strict_schema import _copy_json_schema, ensure_strict_json_schema
 from ..tool import (
     FunctionTool,
     Tool,
@@ -535,7 +535,7 @@ class MCPUtil:
         effective_failure_error_function = server._get_failure_error_function(
             failure_error_function
         )
-        schema, is_strict = copy.deepcopy(tool_input_schema(tool)), False
+        schema, is_strict = _copy_json_schema(tool_input_schema(tool)), False
         input_schema_is_empty = schema == {}
 
         # MCP spec doesn't require the inputSchema to have `properties`, but OpenAI spec does.
@@ -550,7 +550,7 @@ class MCPUtil:
             # the original schema intact.
             try:
                 schema = ensure_strict_json_schema(
-                    copy.deepcopy(schema),
+                    _copy_json_schema(schema),
                     _reject_open_objects=not input_schema_is_empty,
                 )
                 is_strict = True

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -20,6 +20,10 @@ _EMPTY_SCHEMA = {
 # example, tool schemas advertised by a third-party MCP server).
 _MAX_SCHEMA_NODES = 100_000
 
+# Keep recursive copying and normalization comfortably below Python's recursion limit. This
+# counts every nested dictionary or list, including schema maps such as `properties` and `$defs`.
+_MAX_SCHEMA_DEPTH = 100
+
 _ADDITIONAL_PROPERTIES_ERROR = (
     "additionalProperties should not be set for object types. This could be because "
     "you're using an older version of Pydantic, or because you configured additional "
@@ -35,6 +39,32 @@ _OPEN_OBJECT_ERROR = (
 _UNVALIDATED_REF_ERROR = (
     "JSON schema contains a reference whose target was not validated for strict mode."
 )
+
+_SCHEMA_DEPTH_ERROR = (
+    "JSON schema is too deeply nested to process safely. Simplify or flatten the schema."
+)
+
+
+def _validate_json_schema_depth(schema: object) -> None:
+    """Reject container nesting that is unsafe for recursive schema processing."""
+    stack: list[tuple[object, int]] = [(schema, 1)]
+    while stack:
+        value, depth = stack.pop()
+        if depth > _MAX_SCHEMA_DEPTH:
+            raise UserError(_SCHEMA_DEPTH_ERROR)
+
+        if isinstance(value, dict):
+            stack.extend(
+                (child, depth + 1) for child in value.values() if isinstance(child, dict | list)
+            )
+        elif isinstance(value, list):
+            stack.extend((child, depth + 1) for child in value if isinstance(child, dict | list))
+
+
+def _copy_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Copy a JSON schema only after verifying recursive copying is safe."""
+    _validate_json_schema_depth(schema)
+    return copy.deepcopy(schema)
 
 
 class _NodeBudget:
@@ -62,6 +92,7 @@ def ensure_strict_json_schema(
     """Mutates the given JSON schema to ensure it conforms to the `strict` standard
     that the OpenAI API expects.
     """
+    _validate_json_schema_depth(schema)
     if schema == {}:
         return copy.deepcopy(_EMPTY_SCHEMA)
     budget = _NodeBudget(_MAX_SCHEMA_NODES, reject_open_objects=_reject_open_objects)
@@ -99,7 +130,11 @@ def _ensure_strict_json_schema(
     path: tuple[str, ...],
     root: dict[str, object],
     budget: _NodeBudget | None = None,
+    depth: int = 1,
 ) -> dict[str, Any]:
+    if depth > _MAX_SCHEMA_DEPTH:
+        raise UserError(_SCHEMA_DEPTH_ERROR)
+
     if not is_dict(json_schema):
         raise TypeError(f"Expected {json_schema} to be a dictionary; path={path}")
 
@@ -108,12 +143,17 @@ def _ensure_strict_json_schema(
     if budget is None:
         budget = _NodeBudget(_MAX_SCHEMA_NODES)
     budget.spend()
+    next_depth = depth + 1
 
     defs = json_schema.get("$defs")
     if is_dict(defs):
         for def_name, def_schema in defs.items():
             _ensure_strict_json_schema(
-                def_schema, path=(*path, "$defs", def_name), root=root, budget=budget
+                def_schema,
+                path=(*path, "$defs", def_name),
+                root=root,
+                budget=budget,
+                depth=next_depth,
             )
 
     definitions = json_schema.get("definitions")
@@ -124,6 +164,7 @@ def _ensure_strict_json_schema(
                 path=(*path, "definitions", definition_name),
                 root=root,
                 budget=budget,
+                depth=next_depth,
             )
 
     typ = json_schema.get("type")
@@ -159,7 +200,11 @@ def _ensure_strict_json_schema(
         json_schema["required"] = list(properties.keys())
         json_schema["properties"] = {
             key: _ensure_strict_json_schema(
-                prop_schema, path=(*path, "properties", key), root=root, budget=budget
+                prop_schema,
+                path=(*path, "properties", key),
+                root=root,
+                budget=budget,
+                depth=next_depth,
             )
             for key, prop_schema in properties.items()
         }
@@ -169,7 +214,7 @@ def _ensure_strict_json_schema(
     items = json_schema.get("items")
     if is_dict(items):
         json_schema["items"] = _ensure_strict_json_schema(
-            items, path=(*path, "items"), root=root, budget=budget
+            items, path=(*path, "items"), root=root, budget=budget, depth=next_depth
         )
 
     # unions
@@ -177,7 +222,11 @@ def _ensure_strict_json_schema(
     if is_list(any_of):
         json_schema["anyOf"] = [
             _ensure_strict_json_schema(
-                variant, path=(*path, "anyOf", str(i)), root=root, budget=budget
+                variant,
+                path=(*path, "anyOf", str(i)),
+                root=root,
+                budget=budget,
+                depth=next_depth,
             )
             for i, variant in enumerate(any_of)
         ]
@@ -192,7 +241,11 @@ def _ensure_strict_json_schema(
             existing_any_of = []
         json_schema["anyOf"] = existing_any_of + [
             _ensure_strict_json_schema(
-                variant, path=(*path, "oneOf", str(i)), root=root, budget=budget
+                variant,
+                path=(*path, "oneOf", str(i)),
+                root=root,
+                budget=budget,
+                depth=next_depth,
             )
             for i, variant in enumerate(one_of)
         ]
@@ -204,15 +257,25 @@ def _ensure_strict_json_schema(
         if len(all_of) == 1:
             json_schema.update(
                 _ensure_strict_json_schema(
-                    all_of[0], path=(*path, "allOf", "0"), root=root, budget=budget
+                    all_of[0],
+                    path=(*path, "allOf", "0"),
+                    root=root,
+                    budget=budget,
+                    depth=next_depth,
                 )
             )
             json_schema.pop("allOf")
-            return _ensure_strict_json_schema(json_schema, path=path, root=root, budget=budget)
+            return _ensure_strict_json_schema(
+                json_schema, path=path, root=root, budget=budget, depth=next_depth
+            )
         else:
             json_schema["allOf"] = [
                 _ensure_strict_json_schema(
-                    entry, path=(*path, "allOf", str(i)), root=root, budget=budget
+                    entry,
+                    path=(*path, "allOf", str(i)),
+                    root=root,
+                    budget=budget,
+                    depth=next_depth,
                 )
                 for i, entry in enumerate(all_of)
             ]
@@ -246,7 +309,9 @@ def _ensure_strict_json_schema(
         json_schema.update({**resolved, **json_schema})
         # Since the schema expanded from `$ref` might not have `additionalProperties: false` applied
         # we call `_ensure_strict_json_schema` again to fix the inlined schema and ensure it's valid
-        return _ensure_strict_json_schema(json_schema, path=path, root=root, budget=budget)
+        return _ensure_strict_json_schema(
+            json_schema, path=path, root=root, budget=budget, depth=next_depth
+        )
 
     if budget.reject_open_objects and "$ref" in json_schema:
         raise UserError(_UNVALIDATED_REF_ERROR)

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -66,7 +66,7 @@ from .exceptions import ModelBehaviorError, ToolTimeoutError, UserError
 from .function_schema import DocstringStyle, function_schema, generate_func_documentation
 from .logger import log_tool_action_warning, logger
 from .run_context import RunContextWrapper
-from .strict_schema import ensure_strict_json_schema
+from .strict_schema import _copy_json_schema, ensure_strict_json_schema
 from .tool_context import ToolContext
 from .tool_guardrails import ToolInputGuardrail, ToolOutputGuardrail
 from .tracing import SpanError
@@ -594,7 +594,7 @@ class FunctionTool:
             self.on_invoke_tool = bind_to_function_tool(self)
         if self.strict_json_schema:
             self.params_json_schema = ensure_strict_json_schema(
-                copy.deepcopy(self.params_json_schema)
+                _copy_json_schema(self.params_json_schema)
             )
         _validate_function_tool_timeout_config(self)
 
@@ -2199,7 +2199,7 @@ def _build_function_tool_output_type(
         output_json_schema = output_type_adapter.json_schema(mode="serialization")
         if not _json_schema_is_object(output_json_schema):
             raise UserError("the generated JSON Schema is not an object schema")
-        output_json_schema = ensure_strict_json_schema(copy.deepcopy(output_json_schema))
+        output_json_schema = ensure_strict_json_schema(_copy_json_schema(output_json_schema))
     except Exception as error:
         raise UserError(
             "Function tool output_type must define a strict JSON object schema. "
@@ -2234,7 +2234,7 @@ def _resolve_function_tool_output(
         return _build_function_tool_output_type(output_type)
 
     if output_json_schema is not None:
-        return copy.deepcopy(output_json_schema), None
+        return _copy_json_schema(output_json_schema), None
 
     if allowed_callers is None or "programmatic" not in allowed_callers:
         return None, None
@@ -2737,8 +2737,9 @@ def _normalize_function_tool_output_json_schema(
     """Copy and normalize a declared function output schema as a strict object schema."""
     if not isinstance(output_json_schema, dict) or not _json_schema_is_object(output_json_schema):
         raise UserError("Function tool output_json_schema must define a JSON object schema.")
+    copied_schema = _copy_json_schema(output_json_schema)
     try:
-        return ensure_strict_json_schema(copy.deepcopy(output_json_schema))
+        return ensure_strict_json_schema(copied_schema)
     except Exception as error:
         raise UserError(
             "Function tool output_json_schema must define a strict JSON object schema."

--- a/tests/mcp/test_mcp_util.py
+++ b/tests/mcp/test_mcp_util.py
@@ -60,6 +60,16 @@ def _convertible_schema() -> dict[str, Any]:
     return schema
 
 
+def _nested_object_schema(depth: int) -> dict[str, Any]:
+    root: dict[str, Any] = {"type": "object", "properties": {}}
+    current = root
+    for _ in range(depth):
+        child: dict[str, Any] = {"type": "object", "properties": {}}
+        current["properties"]["child"] = child
+        current = child
+    return root
+
+
 @pytest.mark.asyncio
 async def test_get_all_function_tools():
     """Test that the get_all_function_tools function returns all function tools from a list of MCP
@@ -1873,6 +1883,20 @@ def test_to_function_tool_does_not_mutate_mcp_input_schema():
     }
     assert schema == {"type": "object", "description": "Test tool"}
     assert tool_input_schema(tool) == {"type": "object", "description": "Test tool"}
+
+
+@pytest.mark.parametrize("convert_schemas_to_strict", [False, True])
+def test_to_function_tool_rejects_deep_schema_before_copying(
+    convert_schemas_to_strict: bool,
+):
+    tool = MCPTool(name="deep_tool", inputSchema=_nested_object_schema(1_000))
+
+    with pytest.raises(UserError, match="too deeply nested"):
+        MCPUtil.to_function_tool(
+            tool,
+            FakeMCPServer(),
+            convert_schemas_to_strict=convert_schemas_to_strict,
+        )
 
 
 def test_to_function_tool_failed_strict_conversion_keeps_original_schema():

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -40,6 +40,26 @@ def argless_function() -> str:
     return "ok"
 
 
+def _nested_object_schema(depth: int) -> dict[str, Any]:
+    root: dict[str, Any] = {"type": "object", "properties": {}}
+    current = root
+    for _ in range(depth):
+        child: dict[str, Any] = {"type": "object", "properties": {}}
+        current["properties"]["child"] = child
+        current = child
+    return root
+
+
+def _chained_ref_schema(depth: int) -> dict[str, Any]:
+    definitions: dict[str, Any] = {f"L{i}": {"$ref": f"#/$defs/L{i + 1}"} for i in range(depth)}
+    definitions[f"L{depth}"] = {"type": "string"}
+    return {
+        "$defs": definitions,
+        "type": "object",
+        "properties": {"value": {"$ref": "#/$defs/L0", "description": "value"}},
+    }
+
+
 def test_tool_namespace_copies_tools_with_metadata() -> None:
     tool = function_tool(argless_function)
 
@@ -1005,6 +1025,57 @@ def test_function_tool_does_not_mutate_params_json_schema() -> None:
     assert tool.params_json_schema is not schema
     assert tool.params_json_schema["additionalProperties"] is False
     assert tool.params_json_schema["required"] == ["x"]
+
+
+def test_function_tool_rejects_deep_schema_before_copying() -> None:
+    async def noop(ctx: ToolContext[Any], input: str) -> str:
+        return ""
+
+    schema = _nested_object_schema(1_000)
+
+    with pytest.raises(UserError, match="too deeply nested"):
+        FunctionTool(
+            name="strict_tool",
+            description="Uses a strict schema",
+            params_json_schema=schema,
+            on_invoke_tool=noop,
+        )
+
+    non_strict_tool = FunctionTool(
+        name="non_strict_tool",
+        description="Uses the original schema",
+        params_json_schema=schema,
+        on_invoke_tool=noop,
+        strict_json_schema=False,
+    )
+    assert non_strict_tool.params_json_schema is schema
+
+
+def test_function_tool_rejects_deeply_chained_refs_before_conversion() -> None:
+    async def noop(ctx: ToolContext[Any], input: str) -> str:
+        return ""
+
+    with pytest.raises(UserError, match="too deeply nested"):
+        FunctionTool(
+            name="strict_tool",
+            description="Uses a strict schema",
+            params_json_schema=_chained_ref_schema(1_000),
+            on_invoke_tool=noop,
+        )
+
+
+def test_function_tool_rejects_deep_output_schema_before_copying() -> None:
+    async def noop(ctx: ToolContext[Any], input: str) -> str:
+        return ""
+
+    with pytest.raises(UserError, match="too deeply nested"):
+        FunctionTool(
+            name="output_tool",
+            description="Uses a structured output schema",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=noop,
+            output_json_schema=_nested_object_schema(1_000),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -6,6 +6,28 @@ from agents.exceptions import UserError
 from agents.strict_schema import ensure_strict_json_schema
 
 
+def _nested_object_schema(depth: int) -> dict[str, object]:
+    root: dict[str, object] = {"type": "object", "properties": {}}
+    current = root
+    for _ in range(depth):
+        child: dict[str, object] = {"type": "object", "properties": {}}
+        properties = current["properties"]
+        assert isinstance(properties, dict)
+        properties["child"] = child
+        current = child
+    return root
+
+
+def _chained_ref_schema(depth: int) -> dict[str, object]:
+    definitions: dict[str, object] = {f"L{i}": {"$ref": f"#/$defs/L{i + 1}"} for i in range(depth)}
+    definitions[f"L{depth}"] = {"type": "string"}
+    return {
+        "$defs": definitions,
+        "type": "object",
+        "properties": {"value": {"$ref": "#/$defs/L0", "description": "value"}},
+    }
+
+
 def test_empty_schema_has_additional_properties_false():
     strict_schema = ensure_strict_json_schema({})
     assert strict_schema["additionalProperties"] is False
@@ -33,6 +55,24 @@ def test_empty_schema_returns_fresh_copy():
 def test_non_dict_schema_errors():
     with pytest.raises(TypeError):
         ensure_strict_json_schema([])  # type: ignore
+
+
+def test_deeply_nested_schema_is_rejected_before_recursive_conversion():
+    with pytest.raises(UserError, match="too deeply nested"):
+        ensure_strict_json_schema(_nested_object_schema(1_000))
+
+
+def test_reasonably_nested_schema_remains_supported():
+    schema = _nested_object_schema(10)
+
+    result = ensure_strict_json_schema(schema)
+
+    assert result["additionalProperties"] is False
+
+
+def test_deeply_chained_refs_are_rejected_before_recursive_conversion():
+    with pytest.raises(UserError, match="too deeply nested"):
+        ensure_strict_json_schema(_chained_ref_schema(1_000))
 
 
 def test_object_without_additional_properties():


### PR DESCRIPTION
This pull request fixes schema construction paths that could raise Python `RecursionError` when handling pathologically deep or recursively expanded JSON schemas. It adds a bounded, iterative container-depth check before recursive copies, applies the same safety bound during strict-schema normalization, and uses the checked copy path for `FunctionTool` input/output and MCP schemas while preserving non-strict `FunctionTool` behavior and the MCP best-effort fallback.

This pull request resolves #4357.
