### PR TITLE
fix(models): omit parallel_tool_calls without tools on the Chat Completions path

### DIFF
--- a/src/agents/models/openai_chatcompletions.py
+++ b/src/agents/models/openai_chatcompletions.py
@@ -631,12 +631,6 @@ class OpenAIChatCompletionsModel(Model):
         if tracing.include_data():
             span.span_data.input = converted_messages
 
-        if model_settings.parallel_tool_calls and tools:
-            parallel_tool_calls: bool | Omit = True
-        elif model_settings.parallel_tool_calls is False:
-            parallel_tool_calls = False
-        else:
-            parallel_tool_calls = omit
         tool_choice = Converter.convert_tool_choice(model_settings.tool_choice)
         response_format = Converter.convert_response_format(output_schema)
 
@@ -647,6 +641,11 @@ class OpenAIChatCompletionsModel(Model):
 
         converted_tools = _to_dump_compatible(converted_tools)
         tools_param = converted_tools if converted_tools else omit
+        # Chat Completions rejects parallel_tool_calls unless tools are present, so derive it
+        # from the converted list, which also covers handoff-only turns.
+        parallel_tool_calls: bool | Omit = (
+            self._non_null_or_omit(model_settings.parallel_tool_calls) if converted_tools else omit
+        )
 
         if _debug.DONT_LOG_MODEL_DATA:
             logger.debug("Calling LLM")

--- a/tests/models/test_kwargs_functionality.py
+++ b/tests/models/test_kwargs_functionality.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import Headers, Response
 from litellm.exceptions import RateLimitError
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
-from openai import APIConnectionError
+from openai import APIConnectionError, omit
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.completion_usage import CompletionUsage
@@ -108,6 +108,65 @@ async def test_litellm_only_forwards_parallel_tool_calls_with_converted_tools(
     expected_parallel_tool_calls = parallel_tool_calls if tool_source != "none" else None
     assert captured["parallel_tool_calls"] is expected_parallel_tool_calls
     assert (captured["tools"] is not None) is (tool_source != "none")
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("parallel_tool_calls", [True, False])
+@pytest.mark.parametrize("tool_source", ["none", "function", "handoff"])
+async def test_openai_only_forwards_parallel_tool_calls_with_converted_tools(
+    parallel_tool_calls: bool, tool_source: str
+):
+    captured: dict[str, object] = {}
+
+    class MockChatCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            msg = ChatCompletionMessage(role="assistant", content="test response")
+            return ChatCompletion(
+                id="test-id",
+                created=0,
+                model="gpt-4",
+                object="chat.completion",
+                choices=[Choice(index=0, message=msg, finish_reason="stop")],
+                usage=CompletionUsage(completion_tokens=5, prompt_tokens=10, total_tokens=15),
+            )
+
+    class MockChat:
+        def __init__(self):
+            self.completions = MockChatCompletions()
+
+    class MockClient:
+        def __init__(self):
+            self.chat = MockChat()
+            self.base_url = "https://api.openai.com/v1"
+
+    tools: list[Tool] = (
+        [function_tool(lambda: "ok", name_override="test_tool")]
+        if tool_source == "function"
+        else []
+    )
+    handoffs = [handoff(Agent(name="handoff"))] if tool_source == "handoff" else []
+
+    model = OpenAIChatCompletionsModel(model="gpt-4", openai_client=MockClient())  # type: ignore
+    await model.get_response(
+        system_instructions=None,
+        input="test input",
+        model_settings=ModelSettings(parallel_tool_calls=parallel_tool_calls),
+        tools=tools,
+        output_schema=None,
+        handoffs=handoffs,
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+    )
+
+    if tool_source == "none":
+        assert captured["parallel_tool_calls"] is omit
+        assert captured["tools"] is omit
+    else:
+        assert captured["parallel_tool_calls"] is parallel_tool_calls
+        assert captured["tools"] is not omit
 
 
 @pytest.mark.allow_call_model_methods

--- a/tests/models/test_openai_chatcompletions.py
+++ b/tests/models/test_openai_chatcompletions.py
@@ -46,6 +46,7 @@ from agents import (
     OpenAIProvider,
     Runner,
     __version__,
+    function_tool,
     generation_span,
     trace,
 )
@@ -53,6 +54,7 @@ from agents.exceptions import UserError
 from agents.models._retry_runtime import provider_managed_retries_disabled
 from agents.models.chatcmpl_helpers import HEADERS_OVERRIDE, ChatCmplHelpers
 from agents.models.fake_id import FAKE_RESPONSES_ID
+from agents.tool import Tool
 from tests.testing_processor import fetch_ordered_spans
 
 
@@ -74,6 +76,7 @@ def _minimal_chat_completion(content: str = "ok") -> ChatCompletion:
 
 async def _run_chat_completions_model_with_custom_base_url(
     model_settings: ModelSettings | dict[str, Any] | None = None,
+    tools: list[Tool] | None = None,
 ) -> dict[str, Any]:
     class DummyCompletions:
         def __init__(self) -> None:
@@ -105,7 +108,12 @@ async def _run_chat_completions_model_with_custom_base_url(
         model="gpt-4",
         openai_client=DummyClient(completions),  # type: ignore[arg-type]
     )
-    agent = Agent(name="test", model=model, model_settings=model_settings or ModelSettings())
+    agent = Agent(
+        name="test",
+        model=model,
+        model_settings=model_settings or ModelSettings(),
+        tools=tools or [],
+    )
 
     await Runner.run(agent, "hi")
 
@@ -1076,7 +1084,10 @@ async def test_chat_completions_requests_normalize_dictionary_agent_settings(
         },
     }
     kwargs = await _run_chat_completions_model_with_custom_base_url(
-        model_settings=settings if use_dictionary else ModelSettings(**settings)
+        model_settings=settings if use_dictionary else ModelSettings(**settings),
+        # parallel_tool_calls is only forwarded alongside tools, so this parity check
+        # needs a tool for that setting to reach the request.
+        tools=[function_tool(lambda: "ok", name_override="test_tool")],
     )
 
     assert kwargs["reasoning_effort"] == "high"

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -210,7 +210,9 @@ async def test_stream_response_forwards_dictionary_agent_model_settings(
             system_instructions=None,
             input="hi",
             model_settings=agent.model_settings,
-            tools=[],
+            # parallel_tool_calls is only forwarded alongside tools, so this parity check
+            # needs a tool for that setting to reach the request.
+            tools=[function_tool(lambda: "ok", name_override="test_tool")],
             output_schema=None,
             handoffs=[],
             tracing=ModelTracing.DISABLED,


### PR DESCRIPTION
### Summary

\#4326 reported that a Chat Completions request carrying `parallel_tool_calls` with no tools is rejected before generation:

```text
BadRequestError: Invalid value for 'parallel_tool_calls':
'parallel_tool_calls' is only allowed when 'tools' are specified.
```

\#4330 fixed `LitellmModel` by deriving the value from the converted tool list, and closed that issue. `OpenAIChatCompletionsModel` still carries the pre-fix shape, so the same request is produced without LiteLLM in the path.

The report came from Azure OpenAI, but the rejection is not Azure-specific. Against `api.openai.com` with `gpt-4o-mini`, released `openai-agents==0.19.4` fails an ordinary run whose agent has no function tools and no handoffs:

```python
agent = Agent(
    name="Summarizer",
    instructions="Reply with exactly: OK",
    model=OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=AsyncOpenAI()),
    model_settings=ModelSettings(parallel_tool_calls=False),
)
await Runner.run(agent, "Say OK.")
```

```text
v0.19.4:      BadRequestError: 400 'parallel_tool_calls' is only allowed when 'tools' are specified.
with this PR: final_output='OK'
```

So an app-wide `ModelSettings(parallel_tool_calls=False)` breaks any turn whose agent has no function tools and no handoffs.

Across the nine combinations of `parallel_tool_calls` (`False` / `True` / `None`) and tool source (none / one function tool / one handoff), sent live to the same endpoint, v0.19.4 fails exactly one cell — `False` with no tools — and this PR makes that case valid while preserving the provider outcome of the other eight combinations.

The `False` branch added in #513 does not apply the same `and tools` guard as the `True` branch. An explicit `False` is still forwarded whenever the request carries tools.

Deriving the value after tool conversion also fixes the inverse case in the same expression, exactly as #4330 does. The old condition tested the raw `tools` argument, which is empty for a handoff-only agent, so `parallel_tool_calls` was dropped even though the request did carry a converted `transfer_to_*` tool.

One side effect specific to this adapter: `parallel_tool_calls` now participates in the `extra_args` duplicate-key check only when tools are present.

Deliberately out of scope:

- `OpenAIResponsesModel` keeps its current expression. It is not in the rejected shape: that adapter always sends a `tools` array, empty when the agent has none, so `parallel_tool_calls` never travels without `tools`. Aligning it would change exactly one case, forwarding `true` for handoff-only agents.
- `AnyLLMModel` carries the same expression on its chat path, but for providers that advertise Responses support it selects the Responses path instead, which needs its own handling. Filing that separately rather than folding a second adapter in here.
- The synthetic `Response` built for tracing keeps `parallel_tool_calls or False`. It never reaches a provider; its traced value changes only for handoff-only agents, where it now reports `true`.

### Test plan

A new parametrized regression mirrors `test_litellm_only_forwards_parallel_tool_calls_with_converted_tools` from #4330 across `none` / `function` / `handoff`. On `main` it fails on two parametrizations: `parallel_tool_calls=False` with no tools, where the field is sent, and `parallel_tool_calls=True` with only a handoff, where the field is dropped.

Two existing dictionary-versus-typed parity tests set `parallel_tool_calls` among roughly a dozen settings while calling the model with no tools, so they asserted forwarding inside a request shape the provider rejects. Only their setup changed: each now passes one function tool, and their assertions, including `assert kwargs["parallel_tool_calls"] is False`, are untouched. `_run_chat_completions_model_with_custom_base_url` gained an optional `tools` parameter defaulting to empty, so the other tests sharing that helper are unaffected.

`.agents/skills/code-change-verification/scripts/run.sh` passes.

### Issue number

N/A. #4326 was closed by #4330, which scoped its fix to `LitellmModel`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR