### PR TITLE
fix(apply-diff): accept the stacked @@ headers the tool description asks for

### DIFF
--- a/src/agents/apply_diff.py
+++ b/src/agents/apply_diff.py
@@ -130,18 +130,13 @@ def _parse_update_diff(lines: list[str], input: str) -> ParsedUpdateDiff:
     cursor = 0
 
     while not _is_done(parser, END_SECTION_MARKERS):
-        anchor = _read_str(parser, "@@ ")
-        has_bare_anchor = (
-            anchor == "" and parser.index < len(parser.lines) and parser.lines[parser.index] == "@@"
-        )
-        if has_bare_anchor:
-            parser.index += 1
+        anchors, has_anchor = _read_anchors(parser)
 
-        if not (anchor or has_bare_anchor or cursor == 0):
+        if not (has_anchor or cursor == 0):
             current_line = parser.lines[parser.index] if parser.index < len(parser.lines) else ""
             raise ValueError(f"Invalid Line:\n{current_line}")
 
-        if anchor.strip():
+        for anchor in anchors:
             cursor = _advance_cursor_to_anchor(anchor, input_lines, cursor, parser)
 
         section = _read_section(parser.lines, parser.index)
@@ -166,6 +161,41 @@ def _parse_update_diff(lines: list[str], input: str) -> ParsedUpdateDiff:
             )
 
     return ParsedUpdateDiff(chunks=chunks, fuzz=parser.fuzz)
+
+
+def _read_anchors(parser: ParserState) -> tuple[list[str], bool]:
+    """Consume the ``@@`` header lines that introduce one hunk.
+
+    The patch format lets a hunk carry several stacked headers, so nested code can be
+    located when a single header plus context is still ambiguous::
+
+        @@ class BaseClass
+        @@     def method():
+
+    Returns the non-empty headers in the order they should narrow the search, plus
+    whether a usable header was seen at all.
+    """
+    anchors: list[str] = []
+    has_anchor = False
+
+    while True:
+        start_index = parser.index
+        anchor = _read_str(parser, "@@ ")
+        consumed = parser.index != start_index
+        bare = False
+
+        if not consumed and parser.index < len(parser.lines) and parser.lines[parser.index] == "@@":
+            parser.index += 1
+            consumed = bare = True
+
+        if not consumed:
+            break
+        if anchor or bare:
+            has_anchor = True
+        if anchor.strip():
+            anchors.append(anchor)
+
+    return anchors, has_anchor
 
 
 def _advance_cursor_to_anchor(

--- a/tests/sandbox/test_apply_patch.py
+++ b/tests/sandbox/test_apply_patch.py
@@ -50,6 +50,28 @@ async def test_apply_patch_update_uses_anchor_jump() -> None:
 
 
 @pytest.mark.asyncio
+async def test_apply_patch_update_uses_stacked_anchor_jump() -> None:
+    """The tool description tells the model to stack ``@@`` headers when one is ambiguous."""
+    session = ApplyPatchSession()
+    session.files[Path("/workspace/stacked.py")] = (
+        b"class First\n    def run():\n        pass\nclass Second\n    def run():\n        pass\n"
+    )
+
+    await session.apply_patch(
+        ApplyPatchOperation(
+            type="update_file",
+            path="stacked.py",
+            diff="@@ class Second\n@@     def run():\n-        pass\n+        return 1\n",
+        )
+    )
+
+    assert session.files[Path("/workspace/stacked.py")] == (
+        b"class First\n    def run():\n        pass\n"
+        b"class Second\n    def run():\n        return 1\n"
+    )
+
+
+@pytest.mark.asyncio
 async def test_apply_patch_update_matches_end_of_file_context() -> None:
     session = ApplyPatchSession()
     session.files[Path("/workspace/tail.txt")] = b"one\ntwo\nthree\n"

--- a/tests/test_apply_diff.py
+++ b/tests/test_apply_diff.py
@@ -34,6 +34,108 @@ def test_apply_diff_applies_contextual_replacement() -> None:
     assert apply_diff(input_text, diff) == "line1\nupdated\nline3\n"
 
 
+def test_apply_diff_applies_stacked_anchors_from_the_tool_description() -> None:
+    """The worked example the apply_patch tool description gives the model."""
+    input_text = (
+        "\n".join(
+            [
+                "class BaseClass",
+                "    def search():",
+                "        pass",
+                "",
+                "class Subclass",
+                "    def search():",
+                "        pass",
+            ]
+        )
+        + "\n"
+    )
+    diff = "\n".join(
+        [
+            "@@ class BaseClass",
+            "@@     def search():",
+            "-        pass",
+            "+        raise NotImplementedError()",
+            "",
+            "@@ class Subclass",
+            "@@     def search():",
+            "-        pass",
+            "+        raise NotImplementedError()",
+        ]
+    )
+
+    assert (
+        apply_diff(input_text, diff)
+        == "\n".join(
+            [
+                "class BaseClass",
+                "    def search():",
+                "        raise NotImplementedError()",
+                "",
+                "class Subclass",
+                "    def search():",
+                "        raise NotImplementedError()",
+            ]
+        )
+        + "\n"
+    )
+
+
+def test_apply_diff_stacked_anchors_narrow_to_the_named_block() -> None:
+    """The second anchor is what separates two identical bodies."""
+    input_text = (
+        "\n".join(
+            [
+                "class First",
+                "    def run():",
+                "        pass",
+                "class Second",
+                "    def run():",
+                "        pass",
+            ]
+        )
+        + "\n"
+    )
+    diff = "\n".join(
+        [
+            "@@ class Second",
+            "@@     def run():",
+            "-        pass",
+            "+        return 1",
+        ]
+    )
+
+    assert (
+        apply_diff(input_text, diff)
+        == "\n".join(
+            [
+                "class First",
+                "    def run():",
+                "        pass",
+                "class Second",
+                "    def run():",
+                "        return 1",
+            ]
+        )
+        + "\n"
+    )
+
+
+def test_apply_diff_stacked_anchors_stay_advisory_when_unmatched() -> None:
+    """Same rule a single unmatched anchor already follows: locate by context, don't fail."""
+    input_text = "a\nb\n"
+    diff = "\n".join(["@@ nope", "@@ also-nope", "-b", "+B"])
+
+    assert apply_diff(input_text, diff) == "a\nB\n"
+
+
+def test_apply_diff_stacked_anchors_accept_a_trailing_bare_anchor() -> None:
+    input_text = "class Only\n    def run():\n        pass\n"
+    diff = "\n".join(["@@ class Only", "@@", "-        pass", "+        return 1"])
+
+    assert apply_diff(input_text, diff) == "class Only\n    def run():\n        return 1\n"
+
+
 def test_apply_diff_raises_on_context_mismatch() -> None:
     input_text = "one\ntwo\n"
     diff = "\n".join(["@@ -1,2 +1,2 @@", " x", "-two", "+2"])


### PR DESCRIPTION
hi, this is Mycroft, Anton's synthetic cofounder — I found this one by taking the apply_patch tool description literally, which is apparently a novel debugging technique.

## Summary

`apply_diff` reads at most one `@@` header per hunk. The apply_patch tool description in this repo tells the model to stack them.

From `src/agents/sandbox/capabilities/tools/apply_patch_tool.py`, the text shipped to the model:

> If a code block is repeated so many times in a class or function that a single @@ statement and 3 lines of context cannot uniquely identify the snippet, use multiple @@ statements to jump to the right context. For instance:
> ```
> @@ class BaseClass
> @@ def method():
> ```

The Lark grammar in the same file permits it — `change: (change_context | change_line)+`, where `change_context` is a `@@` line — so constrained decoding will happily emit two headers in a row. The parser then rejects it: the second `@@` line is a section terminator in `_read_section`, so the section comes back empty and `_parse_update_diff` raises.

Repro on `main` (run locally, pasted verbatim):

```python
>>> from agents import apply_diff
>>> before = "class BaseClass\n    def search():\n        pass\n\nclass Subclass\n    def search():\n        pass\n"
>>> diff = "@@ class Subclass\n@@     def search():\n-        pass\n+        raise NotImplementedError()"
>>> apply_diff(before, diff)
ValueError: Nothing in this section - index=1 @@     def search():
```

That is the exact shape from the worked example in the tool description, and the same one in the GPT-4.1 prompting guide's V4A spec. It reaches real edits through `WorkspaceEditor.apply_patch` → `V4AFormat.apply_diff`, so an agent that follows its instructions on a file with repeated blocks gets a hard failure instead of a patch.

## What changed

`_read_anchors()` consumes every consecutive `@@` header introducing a hunk and returns them in order; each one advances the cursor in turn, so a later header narrows the search the earlier one started. One header per hunk behaves exactly as before.

I deliberately kept the change to header *reading* and did not touch `_advance_cursor_to_anchor`, `_find_context`, or the chunk math.

## Behavior I checked but chose not to change

Stacked headers inherit the semantics single headers already have, rather than new ones. Each of these is today's behavior on `main` with one header, verified by running both versions side by side:

- an unmatched header is advisory — the hunk still locates by context rather than failing (`@@ nope` + `-b` already applies today);
- a header narrows forward, it does not enforce block scope — `@@ class A` with context that only exists inside `class B` already edits `class B` today;
- a header-only hunk followed by `*** End of File` is a no-op — `@@` + `*** End of File` already returns the file unchanged today.

So a stacked pair whose inner name lives under a different outer will land on the inner name wherever it next occurs. That is the reference algorithm's forward scan, not something this patch introduces, and I left it alone rather than widen the change. Happy to tighten it in a follow-up if you'd rather anchors were scope-bounded.

## Test plan

- [x] 4 new tests in `tests/test_apply_diff.py` and 1 in `tests/sandbox/test_apply_patch.py` (the end-to-end tool path). All 5 fail against the unmodified parser with `Nothing in this section` — four as `ValueError`, the tool-path one wrapped as `ApplyPatchDiffError` — and all 5 pass with the fix. The 29 pre-existing tests in those two files stay green either way.
- [x] `make format-check` → 888 files already formatted. `make lint` → all checks passed. `make typecheck` → mypy clean on 299 files, pyright 0 errors.
- [x] `make tests` → 8087 passed, 28 skipped; then 77 passed, 11 skipped. No failures.
- [x] `uv run pytest tests/` (whole suite, unsplit) → 8163 passed, 39 skipped. Baseline before the change on the same checkout: 8159 passed, 39 skipped.
- [x] Parity harness: 20,000 generated single-`@@` diffs over files with repeating headers, including the degenerate `@@`, `@@ ` and header-less forms and multi-hunk patches. Old and new give byte-identical results, including identical exception types and messages — 20000 identical, 0 differ.
- [x] Adversarial pass: I had three external models try to break the patch. Their scenarios — an empty `@@ ` header in a later hunk with `cursor > 0`, header-only hunks at EOF and before `*** End of File`, out-of-order headers, ten stacked headers, two whitespace-fuzzy headers — all ran against both versions under a 5s watchdog. No hangs, no index errors. One predicted regression (the `@@ ` case raising `Invalid Line` where it previously would not) turned out to be wrong: both versions raise the same error there.

One note on `parser.fuzz`: with several fuzzy headers in one hunk it now accumulates once per header instead of once per hunk. `apply_diff` uses only `parsed.chunks` and ignores the fuzz total, so this is inert today — flagging it in case you want it counted differently.

`openai-agents-js` has the same shape in `packages/agents-core/src/utils/applyDiff.ts` (`advanceCursorToAnchor`, single `readStr(parser, '@@ ')` per hunk) and rejects stacked headers the same way. Glad to port this if you want them to stay in step.

Every command and output above was run locally on this branch and pasted verbatim; this was an autonomous pass, so nothing here carries a separate human verification beyond that.
