### PR TITLE
fix(models): gate AnyLLM parallel tool calls on converted tools

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -881,19 +881,13 @@ class AnyLLMModel(Model):
         if tracing.include_data():
             span.span_data.input = converted_messages
 
-        parallel_tool_calls = (
-            True
-            if model_settings.parallel_tool_calls and tools
-            else False
-            if model_settings.parallel_tool_calls is False
-            else None
-        )
         tool_choice = Converter.convert_tool_choice(model_settings.tool_choice)
         response_format = Converter.convert_response_format(output_schema)
         converted_tools = [Converter.tool_to_openai(tool) for tool in tools] if tools else []
         for handoff in handoffs:
             converted_tools.append(Converter.convert_handoff_tool(handoff))
         converted_tools = _to_dump_compatible(converted_tools)
+        parallel_tool_calls = model_settings.parallel_tool_calls if converted_tools else None
 
         if _debug.DONT_LOG_MODEL_DATA:
             logger.debug("Calling LLM")

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -45,6 +45,8 @@ from agents import (
     Tool,
     TResponseInputItem,
     __version__,
+    function_tool,
+    handoff,
     trace,
 )
 from agents.exceptions import UserError
@@ -279,6 +281,48 @@ async def test_user_agent_header_any_llm_chat(override_ua: str | None, monkeypat
             HEADERS_OVERRIDE.reset(token)
 
     assert provider.chat_calls[0]["extra_headers"]["User-Agent"] == expected_ua
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+@pytest.mark.parametrize("parallel_tool_calls", [True, False])
+@pytest.mark.parametrize("tool_source", ["none", "function", "handoff"])
+async def test_any_llm_chat_only_forwards_parallel_tool_calls_with_converted_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    parallel_tool_calls: bool,
+    tool_source: str,
+) -> None:
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=_chat_completion("Hello"))
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(
+        model="openrouter/openai/gpt-5.4-mini",
+        api="chat_completions",
+    )
+
+    tools: list[Tool] = (
+        [function_tool(lambda: "ok", name_override="test_tool")]
+        if tool_source == "function"
+        else []
+    )
+    handoffs = [handoff(Agent(name="handoff"))] if tool_source == "handoff" else []
+
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(parallel_tool_calls=parallel_tool_calls),
+        tools=tools,
+        output_schema=None,
+        handoffs=handoffs,
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    expected_parallel_tool_calls = parallel_tool_calls if tool_source != "none" else None
+    call = provider.chat_calls[0]
+    assert call["parallel_tool_calls"] is expected_parallel_tool_calls
+    assert (call["tools"] is not None) is (tool_source != "none")
 
 
 @pytest.mark.allow_call_model_methods


### PR DESCRIPTION
### Summary

This pull request fixes the AnyLLM Chat Completions adapter so `parallel_tool_calls` is forwarded only when the final converted tools payload is nonempty.

Previously, `parallel_tool_calls=False` was still sent when an agent had no tools, producing a request shape that OpenAI-compatible endpoints reject. The inverse also happened for handoff-only agents: `parallel_tool_calls=True` was dropped because the adapter checked the raw function-tool list before converting handoffs into tools.

Deriving the setting after both function tools and handoffs are converted aligns AnyLLM with the native OpenAI and LiteLLM Chat Completions adapters from #4359 and #4330. The AnyLLM Responses path is unchanged.

### Test plan

- Added a six-case matrix covering `parallel_tool_calls=True` and `False` with no tools, one function tool, and one handoff tool.
- Before the runtime fix, the focused matrix failed in the no-tools/`False` and handoff-only/`True` cases (`2 failed, 4 passed`).
- `env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` (`make format`, `make lint`, `make typecheck`, and `make tests` all passed; `8098 passed, 29 skipped`).

No API key, paid request, or live model call is required.

### Issue number

N/A — no matching open issue or pull request was found.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
