### PR TITLE
fix(voice): honor sample width in AudioInput.to_base64

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -5,7 +5,6 @@ import base64
 import io
 import wave
 from dataclasses import dataclass
-from typing import cast
 
 from ..exceptions import UserError
 from .imports import np, npt
@@ -13,12 +12,11 @@ from .imports import np, npt
 DEFAULT_SAMPLE_RATE = 24000
 
 
-def _buffer_to_audio_file(
+def _buffer_to_pcm_bytes(
     buffer: npt.NDArray[np.int16 | np.float32 | np.float64],
-    frame_rate: int = DEFAULT_SAMPLE_RATE,
     sample_width: int = 2,
-    channels: int = 1,
-) -> tuple[str, io.BytesIO, str]:
+) -> bytes:
+    """Encode a sample buffer as little-endian PCM at the requested sample width."""
     if sample_width not in {1, 2, 3, 4}:
         raise UserError("Sample width must be between 1 and 4 bytes")
 
@@ -55,6 +53,17 @@ def _buffer_to_audio_file(
         else:
             audio_bytes = pcm_buffer.astype("<i4").tobytes()
 
+    return audio_bytes
+
+
+def _buffer_to_audio_file(
+    buffer: npt.NDArray[np.int16 | np.float32 | np.float64],
+    frame_rate: int = DEFAULT_SAMPLE_RATE,
+    sample_width: int = 2,
+    channels: int = 1,
+) -> tuple[str, io.BytesIO, str]:
+    audio_bytes = _buffer_to_pcm_bytes(buffer, sample_width)
+
     audio_file = io.BytesIO()
     with wave.open(audio_file, "w") as wav_file:
         wav_file.setnchannels(channels)
@@ -90,16 +99,14 @@ class AudioInput:
         return _buffer_to_audio_file(self.buffer, self.frame_rate, self.sample_width, self.channels)
 
     def to_base64(self) -> str:
-        """Returns the audio data as a base64 encoded string."""
-        if self.buffer.dtype == np.float32:
-            # convert to int16 without mutating the caller's buffer
-            int16_buffer = (np.clip(self.buffer, -1.0, 1.0) * 32767).astype(np.int16)
-        elif self.buffer.dtype == np.int16:
-            int16_buffer = cast("npt.NDArray[np.int16]", self.buffer)
-        else:
-            raise UserError("Buffer must be a numpy array of int16 or float32")
+        """Returns the audio data as a base64 encoded string.
 
-        return base64.b64encode(int16_buffer.tobytes()).decode("utf-8")
+        Encoded at this input's ``sample_width``, so the bytes match the frames
+        ``to_audio_file`` writes for the same buffer. The caller's buffer is never mutated.
+        """
+        return base64.b64encode(_buffer_to_pcm_bytes(self.buffer, self.sample_width)).decode(
+            "utf-8"
+        )
 
 
 class StreamedAudioInput:

--- a/tests/voice/test_input.py
+++ b/tests/voice/test_input.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import wave
 
@@ -190,3 +191,39 @@ class TestStreamedAudioInput:
         assert retrieved_audio2 is not None
         assert np.array_equal(retrieved_audio2, audio2)
         assert streamed_input.queue.empty()
+
+
+class TestAudioInputBase64SampleWidth:
+    """`to_base64` must encode at the input's declared width, like `to_audio_file`."""
+
+    @pytest.mark.parametrize("sample_width", [1, 2, 3, 4])
+    @pytest.mark.parametrize("dtype", [np.int16, np.float32])
+    def test_base64_matches_the_wav_frames_for_every_width(self, sample_width, dtype):
+        if dtype is np.int16:
+            buffer = np.array([0, 1000, -1000, 32767, -32768], dtype=np.int16)
+        else:
+            buffer = np.array([0.0, 0.5, -0.5, 1.0, -1.0], dtype=np.float32)
+        audio_input = AudioInput(buffer=buffer, sample_width=sample_width)
+
+        encoded = base64.b64decode(audio_input.to_base64())
+        _, audio_file, _ = audio_input.to_audio_file()
+        audio_file.seek(0)
+        with wave.open(audio_file, "rb") as wav_file:
+            frames = wav_file.readframes(wav_file.getnframes())
+
+        # Same object, same declared width, so the two encodings must agree byte for byte.
+        assert encoded == frames
+        assert len(encoded) == len(buffer) * sample_width
+
+    def test_default_width_encoding_is_unchanged(self):
+        # The 16-bit default must keep producing exactly what it produced before.
+        buffer = np.array([0.0, 0.5, -0.5, 1.0, -1.0], dtype=np.float32)
+        expected = (np.clip(buffer, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+
+        assert base64.b64decode(AudioInput(buffer=buffer).to_base64()) == expected
+
+    def test_invalid_sample_width_is_rejected(self):
+        audio_input = AudioInput(buffer=np.array([1, 2], dtype=np.int16), sample_width=5)
+
+        with pytest.raises(UserError):
+            audio_input.to_base64()


### PR DESCRIPTION
### Summary

#4361 made `to_audio_file` respect `AudioInput.sample_width`, but `to_base64` on the same class still hardcodes a PCM16 conversion. One object with one declared width now produces two different encodings:

| `sample_width` | `to_audio_file()` frames | `to_base64()` bytes |
| --- | --- | --- |
| 1 | 8 | **16** |
| 2 | 16 | 16 |
| 3 | 24 | **16** |
| 4 | 32 | **16** |

(5-sample buffer.)

### Why it matters

`to_base64` is what feeds the transcription span input when `trace_include_sensitive_audio_data` is enabled:

```python
input=input.to_base64() if trace_include_sensitive_audio_data else "",
```

That span also records `input_format = "pcm"`. So for an input declared as 1, 3 or 4 bytes per sample, the traced audio is 16-bit data labelled as the session's PCM format, and cannot be played back correctly from the trace. #4361 validated `sample_width` into `{1, 2, 3, 4}` and made those widths a supported, exercised configuration, which is what turns this from a latent inconsistency into a reachable one.

### Fix

The width conversion is extracted from `_buffer_to_audio_file` into `_buffer_to_pcm_bytes` and shared by both paths, so they cannot drift again. No conversion logic changed; it only moved.

Preserved exactly:

- the 16-bit default is byte for byte what it was before, asserted against the previous expression
- the caller's buffer is still never mutated (the existing regression test for that still passes)
- an unsupported dtype or sample width still raises `UserError`, now from the shared encoder instead of a duplicated check

### Test plan

New `TestAudioInputBase64SampleWidth` in `tests/voice/test_input.py`:

- `test_base64_matches_the_wav_frames_for_every_width`, parametrized over widths 1-4 and both `int16` and `float32`, asserting the base64 bytes are byte-identical to the WAV frames for the same object. 7 of these fail on `main`.
- `test_default_width_encoding_is_unchanged`, pinning the 16-bit output against the old expression; passes both with and without the change.
- `test_invalid_sample_width_is_rejected`, which also fails on `main` because `to_base64` never validated the width at all.

| Command | Result |
| --- | --- |
| `make format` / `make lint` | clean |
| `make mypy` / `make pyright` | 0 issues in the touched files |
| `uv run pytest tests/voice/` | 131 passed |
| `make tests` | 7314 passed |

Run on Windows against a `main` baseline captured at the same commit. One test differed, `tests/test_trace_processor.py::test_backend_span_exporter_deadline_stops_during_5xx_retry_backoff`; it is a wall-clock deadline test that passes 4/4 in isolation on this branch and 6/6 on unmodified `main`, and only fails under `-n 6` load.

### Issue number

None. Found while auditing #4361.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script shells out to `make`; I ran the underlying steps individually, with the results above.
