### PR TITLE
fix(memory): handle zero conversation history limits

### DIFF
--- a/src/agents/memory/openai_conversations_session.py
+++ b/src/agents/memory/openai_conversations_session.py
@@ -86,6 +86,8 @@ class OpenAIConversationsSession(SessionABC):
         session_id = await self._get_session_id()
 
         session_limit = resolve_session_limit(limit, self.session_settings)
+        if session_limit == 0:
+            return []
 
         all_items = []
         if session_limit is None:

--- a/tests/memory/test_openai_conversations_session.py
+++ b/tests/memory/test_openai_conversations_session.py
@@ -219,6 +219,20 @@ class TestOpenAIConversationsSessionBasicOperations:
     """Test basic CRUD operations with simple mocking."""
 
     @pytest.mark.asyncio
+    async def test_get_items_zero_limit_returns_empty_without_api_call(self, mock_openai_client):
+        """A zero history limit must not be forwarded to the Conversations API."""
+        mock_openai_client.conversations.items.list = MagicMock(
+            side_effect=AssertionError("items.list must not receive limit=0")
+        )
+        session = OpenAIConversationsSession(openai_client=mock_openai_client)
+
+        assert await session.get_items(limit=0) == []
+
+        mock_openai_client.conversations.create.assert_awaited_once_with(items=[])
+        assert session.session_id == "test_conversation_id"
+        mock_openai_client.conversations.items.list.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_add_items_simple(self, mock_openai_client):
         """Test adding items to the conversation."""
         session = OpenAIConversationsSession(


### PR DESCRIPTION
### Summary

This pull request fixes `OpenAIConversationsSession.get_items(limit=0)` so the supported zero-history setting returns an empty list without forwarding an invalid zero limit to the Conversations API.

Previously, the session passed `limit=0` to `conversations.items.list`, whose supported range is 1 through 100. The early return remains after `_get_session_id()`, preserving the released behavior that `get_items()` initializes an uninitialized conversation.

### Test plan

- Confirmed the new regression fails on `upstream/main` because `items.list` receives `limit=0`.
- `pytest -q tests/memory/test_openai_conversations_session.py tests/memory/test_session_limit.py` (`53 passed`).
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` (`make format`, `make lint`, `make typecheck`, and `make tests` all passed).

### Issue number

N/A — no matching open issue or pull request was found.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
