### PR TITLE
fix(runner): close the model stream when a streamed turn ends in a terminal failure

### DIFF
--- a/src/agents/models/_run_context.py
+++ b/src/agents/models/_run_context.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncGenerator, Iterator
+from contextlib import aclosing, contextmanager
 from contextvars import ContextVar
 from typing import TypeVar
 
@@ -24,9 +24,12 @@ def get_model_run_owner() -> object | None:
 
 
 async def model_run_context_stream(
-    stream: AsyncIterator[T],
+    stream: AsyncGenerator[T, None],
     owner: object,
-) -> AsyncIterator[T]:
+) -> AsyncGenerator[T, None]:
+    # `aclosing` forwards an early `aclose()` on this generator to the delegate, so the
+    # delegate's cleanup runs deterministically instead of waiting for garbage collection.
     with model_run_context(owner):
-        async for item in stream:
-            yield item
+        async with aclosing(stream):
+            async for item in stream:
+                yield item

--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import random
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Mapping
 from inspect import isawaitable
 from typing import Any
 
@@ -569,7 +569,7 @@ async def stream_response_with_retry(
     conversation_id: str | None,
     failed_retry_attempts_out: list[int] | None = None,
     replay_unsafe_request: bool = False,
-) -> AsyncIterator[TResponseStreamEvent]:
+) -> AsyncGenerator[TResponseStreamEvent, None]:
     request_attempt = 1
     policy_attempt = 1
     failed_policy_attempts = 0

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses as _dc
 from collections.abc import Awaitable, Callable
+from contextlib import aclosing
 from functools import partial
 from typing import Any, TypeVar, cast
 from uuid import uuid4
@@ -1871,58 +1872,61 @@ async def run_single_turn_streamed(
         ),
     )
 
-    async for event in model_run_context_stream(retry_stream, tool_use_tracker):
-        streamed_result._event_queue.put_nowait(RawResponsesStreamEvent(data=event))
+    # Raising out of this loop leaves the model stream suspended at its yield, so close it
+    # explicitly instead of waiting for garbage collection to finalize the generator chain.
+    async with aclosing(model_run_context_stream(retry_stream, tool_use_tracker)) as model_events:
+        async for event in model_events:
+            streamed_result._event_queue.put_nowait(RawResponsesStreamEvent(data=event))
 
-        terminal_response: Response | None = None
-        is_completed_event = False
-        if isinstance(event, ResponseCompletedEvent):
-            is_completed_event = True
-            terminal_response = event.response
-        elif getattr(event, "type", None) in {"response.incomplete", "response.failed"}:
-            event_type = cast(str, event.type)
-            maybe_response = getattr(event, "response", None)
-            raise response_terminal_failure_error(
-                event_type,
-                maybe_response if isinstance(maybe_response, Response) else None,
-            )
-        elif getattr(event, "type", None) in {"error", "response.error"}:
-            raise response_error_event_failure_error(cast(str, event.type), event)
+            terminal_response: Response | None = None
+            is_completed_event = False
+            if isinstance(event, ResponseCompletedEvent):
+                is_completed_event = True
+                terminal_response = event.response
+            elif getattr(event, "type", None) in {"response.incomplete", "response.failed"}:
+                event_type = cast(str, event.type)
+                maybe_response = getattr(event, "response", None)
+                raise response_terminal_failure_error(
+                    event_type,
+                    maybe_response if isinstance(maybe_response, Response) else None,
+                )
+            elif getattr(event, "type", None) in {"error", "response.error"}:
+                raise response_error_event_failure_error(cast(str, event.type), event)
 
-        if terminal_response is not None:
-            if is_completed_event and not terminal_response.output and streamed_response_output:
-                # Some streaming backends emit output items during item.done events while leaving
-                # the terminal response output empty. Preserve those items so the runner can
-                # resolve the completed step correctly.
-                terminal_response.output = list(streamed_response_output)
-            # Always fold retry attempts into usage, even when the terminal response omits
-            # provider usage (common for some Chat Completions / LiteLLM streams). Skipping
-            # apply_retry_attempt_usage here would drop failed-attempt accounting and diverge
-            # from the non-streaming get_response_with_retry path.
-            usage = apply_retry_attempt_usage(
-                (
-                    _response_usage_to_usage(terminal_response.usage)
-                    if terminal_response.usage
-                    # Defaults to zero requests, so adapters that fold several provider
-                    # responses into one and report counts separately are not double-counted.
-                    else Usage(requests=_requests_for_response_without_usage(terminal_response))
-                ),
-                stream_failed_retry_attempts[0],
-            )
-            final_response = ModelResponse(
-                output=terminal_response.output,
-                usage=usage,
-                response_id=terminal_response.id,
-                request_id=getattr(terminal_response, "_request_id", None),
-                raw_usage=(
-                    _extract_raw_usage_snapshot(terminal_response)
-                    if model_settings.preserve_raw_usage is True
-                    else None
-                ),
-            )
+            if terminal_response is not None:
+                if is_completed_event and not terminal_response.output and streamed_response_output:
+                    # Some streaming backends emit output items during item.done events while
+                    # leaving the terminal response output empty. Preserve those items so the
+                    # runner can resolve the completed step correctly.
+                    terminal_response.output = list(streamed_response_output)
+                # Always fold retry attempts into usage, even when the terminal response omits
+                # provider usage (common for some Chat Completions / LiteLLM streams). Skipping
+                # apply_retry_attempt_usage here would drop failed-attempt accounting and diverge
+                # from the non-streaming get_response_with_retry path.
+                usage = apply_retry_attempt_usage(
+                    (
+                        _response_usage_to_usage(terminal_response.usage)
+                        if terminal_response.usage
+                        # Defaults to zero requests, so adapters that fold several provider
+                        # responses into one and report counts separately are not double-counted.
+                        else Usage(requests=_requests_for_response_without_usage(terminal_response))
+                    ),
+                    stream_failed_retry_attempts[0],
+                )
+                final_response = ModelResponse(
+                    output=terminal_response.output,
+                    usage=usage,
+                    response_id=terminal_response.id,
+                    request_id=getattr(terminal_response, "_request_id", None),
+                    raw_usage=(
+                        _extract_raw_usage_snapshot(terminal_response)
+                        if model_settings.preserve_raw_usage is True
+                        else None
+                    ),
+                )
 
-        if isinstance(event, ResponseOutputItemDoneEvent):
-            streamed_response_output.append(event.item)
+            if isinstance(event, ResponseOutputItemDoneEvent):
+                streamed_response_output.append(event.item)
 
     if final_response is None:
         raise ModelBehaviorError("Model did not produce a final response!")

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -654,6 +654,70 @@ async def test_streamed_run_rejects_failed_terminal_response_payload_events_from
     assert result.raw_responses == []
 
 
+def _terminal_failure_event(event_type: str) -> Any:
+    """Build the terminal event the streamed run loop rejects for `event_type`."""
+    if event_type == "response.incomplete":
+        return ResponseIncompleteEvent(
+            response=get_response_obj([], response_id="resp-terminal"),
+            sequence_number=0,
+            type="response.incomplete",
+        )
+    if event_type == "response.failed":
+        return ResponseFailedEvent(
+            response=get_response_obj([], response_id="resp-terminal"),
+            sequence_number=0,
+            type="response.failed",
+        )
+    if event_type == "error":
+        return ResponseErrorEvent(
+            code=None, message="boom", param=None, sequence_number=0, type="error"
+        )
+    # `response.error` is not a literal the SDK models, but the run loop rejects it too.
+    return ResponseErrorEvent.model_construct(
+        code=None, message="boom", param=None, sequence_number=0, type="response.error"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "terminal_event_type",
+    ["response.incomplete", "response.failed", "error", "response.error"],
+)
+async def test_streamed_terminal_failure_closes_the_model_stream(terminal_event_type: str) -> None:
+    """The run loop must close the model stream itself before a terminal failure leaves the loop.
+
+    Comparing the closing task with the iterating one keeps this honest: an abandoned generator
+    is still finalized eventually, but by asyncio's async-generator hook, in another task and
+    context, which is what leaves the response span unended.
+    """
+    iterating_task: asyncio.Task[Any] | None = None
+    closing_task: asyncio.Task[Any] | None = None
+
+    class TerminalFailureModel(Model):
+        async def get_response(self, *args: Any, **kwargs: Any) -> Any:
+            raise NotImplementedError
+
+        async def stream_response(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+            nonlocal iterating_task, closing_task
+            iterating_task = asyncio.current_task()
+            try:
+                yield _terminal_failure_event(terminal_event_type)
+            finally:
+                closing_task = asyncio.current_task()
+
+    agent = Agent(name="test", model=TerminalFailureModel())
+    result = Runner.run_streamed(agent, input="test")
+
+    with pytest.raises(ModelBehaviorError, match=terminal_event_type):
+        async for _ in result.stream_events():
+            pass
+
+    assert closing_task is not None and closing_task is iterating_task, (
+        "the run loop must close the model stream in its own task; it was left open or finalized "
+        "later by asyncio's async-generator hook"
+    )
+
+
 @pytest.mark.asyncio
 async def test_subsequent_runs():
     model = FakeModel()

--- a/tests/test_agent_runner_streamed.py
+++ b/tests/test_agent_runner_streamed.py
@@ -108,6 +108,23 @@ def _find_reasoning_input_item(
     return None
 
 
+class _DummyWSClient:
+    """Stand-in for `AsyncOpenAI` that the websocket model only reads connection settings from."""
+
+    def __init__(self) -> None:
+        self.base_url = httpx.URL("https://api.openai.com/v1/")
+        self.websocket_base_url = None
+        self.default_query: dict[str, Any] = {}
+        self.default_headers = {
+            "Authorization": "Bearer test-key",
+            "User-Agent": "AsyncOpenAI/Python test",
+        }
+        self.timeout: Any = None
+
+    async def _refresh_api_key(self) -> None:
+        return None
+
+
 def _ws_terminal_response_frame(event_type: str, response_id: str, sequence_number: int) -> str:
     response = get_response_obj([get_text_message("partial final")], response_id=response_id)
     return json.dumps(
@@ -612,22 +629,8 @@ async def test_streamed_run_rejects_failed_terminal_response_payload_events_from
             if self.close_code is None:
                 self.close_code = 1000
 
-    class DummyWSClient:
-        def __init__(self) -> None:
-            self.base_url = httpx.URL("https://api.openai.com/v1/")
-            self.websocket_base_url = None
-            self.default_query: dict[str, Any] = {}
-            self.default_headers = {
-                "Authorization": "Bearer test-key",
-                "User-Agent": "AsyncOpenAI/Python test",
-            }
-            self.timeout: Any = None
-
-        async def _refresh_api_key(self) -> None:
-            return None
-
     ws = DummyWSConnection([_ws_terminal_response_frame(terminal_event_type, "resp-ws", 1)])
-    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=DummyWSClient())  # type: ignore[arg-type]
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=_DummyWSClient())  # type: ignore[arg-type]
 
     async def fake_open(
         _ws_url: str,
@@ -652,6 +655,112 @@ async def test_streamed_run_rejects_failed_terminal_response_payload_events_from
     assert stream_events[1].data.type == terminal_event_type
     assert result.final_output is None
     assert result.raw_responses == []
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_ws_terminal_failure_frees_the_request_lock_for_a_waiting_run(monkeypatch) -> None:
+    """A terminal failure must hand the shared websocket back to a run already waiting for it.
+
+    Run A holds `_ws_request_lock` while run B blocks on it. A then fails terminally, and B has
+    to complete on the surviving connection, which only happens if A's cleanup actually ran.
+    """
+    release_run_a = asyncio.Event()
+    run_a_holds_lock = asyncio.Event()
+    run_b_waiting_on_lock = asyncio.Event()
+
+    class SharedWSConnection:
+        def __init__(self) -> None:
+            self.close_code: int | None = None
+            self.send_calls = 0
+            self.recv_calls = 0
+
+        async def send(self, payload: str) -> None:
+            self.send_calls += 1
+            if self.send_calls == 1:
+                run_a_holds_lock.set()
+            return None
+
+        async def recv(self) -> str:
+            self.recv_calls += 1
+            if self.recv_calls == 1:
+                # Keep run A in-flight until run B is queued behind the request lock.
+                await release_run_a.wait()
+                return _ws_terminal_response_frame("response.incomplete", "resp-a", 1)
+            return _ws_terminal_response_frame("response.completed", "resp-b", 1)
+
+        async def close(self) -> None:
+            if self.close_code is None:
+                self.close_code = 1000
+
+    ws = SharedWSConnection()
+    open_calls = 0
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=_DummyWSClient())  # type: ignore[arg-type]
+    request_lock = model._get_ws_request_lock()
+
+    async def fake_open(
+        _ws_url: str,
+        _headers: dict[str, str],
+        *,
+        connect_timeout: float | None = None,
+    ) -> SharedWSConnection:
+        nonlocal open_calls
+        open_calls += 1
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+    original_await_websocket_with_timeout = model._await_websocket_with_timeout
+
+    async def observed_await_websocket_with_timeout(
+        awaitable: Any,
+        timeout_seconds: float | None,
+        phase: str,
+    ) -> Any:
+        if phase == "request lock wait" and request_lock.locked():
+            run_b_waiting_on_lock.set()
+        return await original_await_websocket_with_timeout(awaitable, timeout_seconds, phase)
+
+    monkeypatch.setattr(
+        model, "_await_websocket_with_timeout", observed_await_websocket_with_timeout
+    )
+    agent = Agent(name="test", model=model)
+
+    async def run_a() -> None:
+        result = Runner.run_streamed(agent, input="a")
+        with pytest.raises(ModelBehaviorError, match="response.incomplete"):
+            async for _ in result.stream_events():
+                pass
+
+    async def run_b() -> tuple[Any, list[str | None]]:
+        result = Runner.run_streamed(agent, input="b")
+        async for _ in result.stream_events():
+            pass
+        return result.final_output, [response.response_id for response in result.raw_responses]
+
+    task_a = asyncio.create_task(run_a())
+    try:
+        await asyncio.wait_for(run_a_holds_lock.wait(), timeout=5)
+        assert request_lock.locked(), "run A released the request lock before run B started"
+
+        task_b = asyncio.create_task(run_b())
+        await asyncio.wait_for(run_b_waiting_on_lock.wait(), timeout=5)
+        assert not task_b.done(), "run B was expected to be waiting on the request lock"
+    finally:
+        release_run_a.set()
+
+    await task_a
+    try:
+        # Only a hang guard: run B needs event loop turns, not wall-clock time.
+        output, response_ids = await asyncio.wait_for(task_b, timeout=5)
+    except TimeoutError:
+        pytest.fail("run A's terminal failure left `_ws_request_lock` held, so run B never woke")
+
+    assert output == "partial final", "run B did not complete on the surviving connection"
+    assert response_ids == ["resp-b"], "run B did not receive its own response"
+    assert not request_lock.locked(), "the request lock was left held after both runs finished"
+    assert ws.close_code is None, "the shared connection should survive a terminal failure"
+    assert open_calls == 1, "run B should reuse the websocket connection opened by run A"
+    assert ws.send_calls == 2, "run B should complete on the existing websocket connection"
 
 
 def _terminal_failure_event(event_type: str) -> Any:


### PR DESCRIPTION
### Summary

On the streamed path, `run_single_turn_streamed` iterates the model stream with a bare `async for` and raises from inside the loop body when a turn ends in `response.incomplete`, `response.failed`, `error` or `response.error`. `async for` does not close its iterator, so the generator chain stays suspended at its yield and the provider's `finally` never runs.

With the default `OpenAIResponsesModel`, a turn truncated by `max_output_tokens` therefore leaves the httpx SSE response open, and the `ResponseSpanData` is never ended:

```text
span_start ResponseSpanData ... (no span_end) ... span_end TurnSpanData ... trace_end
close calls immediately after run: []
close calls after gc.collect():    []
```

The adapter annotates that span deliberately, and says why it depends on the consumer:

> A consumer that stops at this event closes the generator, which raises `GeneratorExit` at the yield below and skips the raise after the loop, so the span has to be annotated here or not at all.

So `record_model_error_on_span` runs, and the span carrying that error is then dropped instead of exported, on a turn that ended for an ordinary reason.

Against `api.openai.com` with `gpt-4o-mini`, an agent configured with `ModelSettings(max_tokens=16)` and instructions that ask for a long answer reaches this on the first try:

```text
before: trace_start ... start:ResponseSpanData -> end:TurnSpanData -> end:AgentSpanData -> trace_end
after:  trace_start ... start:ResponseSpanData -> end:ResponseSpanData -> end:TurnSpanData -> ... -> trace_end
```

The parent spans close over a response span that never ends, and the teardown also raises `ValueError: <Token ...> was created in a different Context`. Both stop with this change.

`OpenAIResponsesWSModel` is the severe case: `_ws_request_lock` is acquired for the request and released in the same skipped `finally`, so the lock stays held until a collection finalizes the abandoned generator. A run started before that blocks on it.

```text
after the failed turn: _ws_request_lock.locked() = True
turn 2 on the same model instance: hangs on the request lock
```

This is the consumer half of a contract the provider side already implements. #3689, #4066, #4077, #4133, #4156 and #4221 made provider streams and trace scopes close deterministically; `stream_response_with_retry` already re-raises `GeneratorExit` after closing its inner stream, and the Responses websocket generator has a dedicated branch for being closed at a terminal event. This PR reconnects that cleanup chain at the two consumer-side delegation points where the close is currently not propagated.

**Why both hops.** Each one fixes a different half. `model_run_context_stream` delegates with a bare `async for ... yield`, which does not forward `aclose()`, so closing only at the call site never reaches the provider. Closing only in the delegate releases the resources, but the run loop still abandons its generator, so the close runs in asyncio's async-generator finalizer task, in another context: the response span is then ended after `trace_end` instead of inside its parent, and the `ValueError` below still fires.

| `_run_context.py` | `run_loop.py` | ws lock released | httpx `close()` | `ResponseSpanData` ended in order |
| --- | --- | --- | --- | --- |
| — | — | no, next run blocks | `[]` | no |
| — | yes | no, next run blocks | `[]` | no |
| yes | — | yes | `['close']` | no, arrives after `trace_end` |
| yes | yes | yes | `['close']` | yes |

The new regression fails in the first three rows and passes in the last.

This mirrors #4133, which wrapped its delegating generators in `contextlib.aclosing` and narrowed their return annotations to `AsyncGenerator[..., None]` so `aclosing` type-checks. The `model_retry.py` annotation here exists for that same reason and nothing else. Neither `agents.run_internal.*` nor `agents.models._run_context` appears in `tests/fixtures/released_api_contract.json`.

**On the `ValueError` this removes.** Today the abandoned generator is finalized later by the async-generator hook, in a fresh context, so `_MODEL_RUN_OWNER.reset(token)` raises `ValueError: <Token ...> was created in a different Context`. Closing in the owning task makes that reset valid, so the error disappears rather than being suppressed; this PR does not add a `try/except` around the reset (cf. #3235, #4221).

Provider cleanup now runs inline on the terminal-failure path. For the built-in adapters that is bounded: the websocket path releases a lock synchronously, and the HTTP path closes through `_close_stream_allowing_background_completion` (added in #4133, ported to this adapter in #4156), so a cancellation arriving during that close is already handled. One consequence worth naming: a `BaseException` escaping a provider's own `finally` now surfaces in place of the terminal `ModelBehaviorError`, since the close runs while that error propagates. Suppressing it here would hide a cancellation, so this PR leaves it.

The `run_loop.py` diff is ~55 lines, of which all but a few are re-indentation of the existing loop body; `git diff -w` shows the semantic change.

Deliberately out of scope:

- The runner's non-streamed path wraps a coroutine with `model_run_context(...)`, so it has no equivalent gap. `OpenAIResponsesWSModel._fetch_response(stream=False)` does have the same shape — a bare `async for` over `_iter_websocket_response_events` that raises from inside the loop, skipping the `finally` that releases `_ws_request_lock` — and is left out deliberately, so this PR stays on the runner and one demonstrated failure.
- A consumer that breaks out of `stream_events()` without `cancel()` still leaks. That is the documented caller-side contract, and `cancel()` already closes the provider stream; neither changes here.

### Test plan

`test_streamed_terminal_failure_closes_the_model_stream` drives a model whose `stream_response` records `asyncio.current_task()` where it starts iterating and again in its `finally`, over `response.incomplete`, `response.failed`, `error` and `response.error`. Asserting that those are the same task distinguishes a close performed by the run loop from a later finalization by asyncio's async-generator hook, so it does not call `aclose()` and does not force a collection. It fails on all four parametrizations when either hop is reverted, which is the third row of the table above.

`.agents/skills/code-change-verification/scripts/run.sh` passes.

### Issue number

N/A. Found while auditing the streamed run loop against `.agents/references/runner-lifecycle.md`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
