### PR TITLE
fix(voice): reject incomplete multichannel audio frames

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -21,6 +21,8 @@ def _buffer_to_audio_file(
 ) -> tuple[str, io.BytesIO, str]:
     if sample_width not in {1, 2, 3, 4}:
         raise UserError("Sample width must be between 1 and 4 bytes")
+    if channels > 0 and buffer.size % channels != 0:
+        raise UserError("Buffer must contain complete channel frames")
 
     if buffer.dtype == np.float32:
         clipped_buffer = np.clip(buffer, -1.0, 1.0)

--- a/tests/voice/test_input.py
+++ b/tests/voice/test_input.py
@@ -95,6 +95,19 @@ def test_buffer_to_audio_file_rejects_unsupported_sample_width():
         _buffer_to_audio_file(buffer, sample_width=5)
 
 
+def test_audio_input_validates_multichannel_frame_alignment():
+    complete_audio = AudioInput(buffer=np.array([1, 2, 3, 4], dtype=np.int16), channels=2)
+    _, audio_file, _ = complete_audio.to_audio_file()
+    with wave.open(audio_file, "rb") as wav_file:
+        assert wav_file.getnchannels() == 2
+        assert wav_file.getnframes() == 2
+
+    audio_input = AudioInput(buffer=np.array([1, 2, 3], dtype=np.int16), channels=2)
+
+    with pytest.raises(UserError, match="complete channel frames"):
+        audio_input.to_audio_file()
+
+
 def test_buffer_to_audio_file_invalid_dtype():
     # Create a buffer with invalid dtype (float64)
     buffer = np.array([1.0, 2.0, 3.0], dtype=np.float64)


### PR DESCRIPTION
### Summary

`AudioInput.to_audio_file()` could write a multichannel WAV whose data chunk ended with a partial frame when the buffer's scalar sample count was not divisible by `channels`. For example, three `int16` samples with two channels produced a header reporting one frame while retaining six payload bytes, which is not divisible by the four-byte stereo frame size.

This pull request validates frame alignment before sample conversion or WAV writing. Valid mono and multichannel input is unchanged; incomplete frames now raise `UserError` instead of returning a malformed audio file. No padding or truncation is introduced.

The regression test covers both sides of the boundary through the public `AudioInput.to_audio_file()` method: four stereo samples still produce two frames, while three stereo samples are rejected.

### Test plan

- Pre-fix regression: `uv run pytest tests/voice/test_input.py::test_audio_input_rejects_incomplete_multichannel_frame -q` — failed with `DID NOT RAISE UserError` on `upstream/main` at `863b96cf`.
- Focused voice input suite: `uv run pytest tests/voice/test_input.py -q` — 20 passed.
- Independent final review: two clean reviews on the same diff fingerprint, including shaped NumPy arrays, empty buffers, invalid dtypes, nonpositive channel behavior, exception ordering, and valid multichannel byte preservation.
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`:
  - format: 889 files unchanged; Ruff autofix found no changes
  - lint: passed
  - typecheck: mypy found no issues in 299 source files; Pyright reported 0 errors
  - parallel tests: 8094 passed, 28 skipped
  - serial tests: 77 passed, 11 skipped, 55 deselected
- `git diff --check` — passed.

No API key, paid call, or live service was used.

### Issue number

None; this is a small, locally reproducible correctness fix.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
