### PR TITLE
fix(mcp): isolate manager lifecycle results

### DIFF
--- a/src/agents/mcp/manager.py
+++ b/src/agents/mcp/manager.py
@@ -300,7 +300,7 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
 
         self._refresh_active_servers()
 
-        return self._active_servers
+        return self.active_servers
 
     async def reconnect(self, *, failed_only: bool = True) -> list[MCPServer]:
         """Reconnect servers and return the active list.
@@ -336,7 +336,7 @@ class MCPServerManager(AbstractAsyncContextManager["MCPServerManager"]):
                     await self._attempt_connect(server)
         finally:
             self._refresh_active_servers()
-        return self._active_servers
+        return self.active_servers
 
     async def cleanup_all(self) -> None:
         """Cleanup all servers in reverse order."""

--- a/tests/mcp/test_mcp_server_manager.py
+++ b/tests/mcp/test_mcp_server_manager.py
@@ -1213,6 +1213,21 @@ def test_manager_accepts_one_shot_iterables() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["connect_all", "reconnect"])
+async def test_manager_lifecycle_results_do_not_mutate_active_servers(operation: str) -> None:
+    server = FlakyServer(failures=0)
+    manager = MCPServerManager([server])
+
+    if operation == "reconnect":
+        await manager.connect_all()
+
+    active_servers = await getattr(manager, operation)()
+    active_servers.clear()
+
+    assert manager.active_servers == [server]
+
+
+@pytest.mark.asyncio
 async def test_manager_connects_servers_from_a_one_shot_iterable() -> None:
     server_a = CleanupAwareServer()
     server_b = CleanupAwareServer()


### PR DESCRIPTION
### Summary

This pull request fixes `MCPServerManager.connect_all()` and `reconnect()` returning the manager's mutable internal active-server list. Mutating either returned list could silently corrupt `manager.active_servers`; both methods now return the existing defensive snapshot while preserving server identity and ordering.

### Test plan

- Added a parameterized regression test covering caller mutation after both `connect_all()` and `reconnect()`.
- Ran `uv run pytest tests/mcp/test_mcp_server_manager.py -q` (78 passed).
- Ran `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` (format, lint, typecheck, and tests all passed).
- Completed two independent final reviews against the frozen diff; both returned clean verdicts.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
