### PR TITLE
fix(apply-diff): apply stacked anchors sequentially

### DIFF
--- a/src/agents/apply_diff.py
+++ b/src/agents/apply_diff.py
@@ -130,19 +130,20 @@ def _parse_update_diff(lines: list[str], input: str) -> ParsedUpdateDiff:
     cursor = 0
 
     while not _is_done(parser, END_SECTION_MARKERS):
-        anchor = _read_str(parser, "@@ ")
-        has_bare_anchor = (
-            anchor == "" and parser.index < len(parser.lines) and parser.lines[parser.index] == "@@"
-        )
-        if has_bare_anchor:
-            parser.index += 1
+        anchors, has_anchor = _read_anchors(parser)
 
-        if not (anchor or has_bare_anchor or cursor == 0):
+        if not (has_anchor or cursor == 0):
             current_line = parser.lines[parser.index] if parser.index < len(parser.lines) else ""
             raise ValueError(f"Invalid Line:\n{current_line}")
 
-        if anchor.strip():
-            cursor = _advance_cursor_to_anchor(anchor, input_lines, cursor, parser)
+        for index, anchor in enumerate(anchors):
+            cursor = _advance_cursor_to_anchor(
+                anchor,
+                input_lines,
+                cursor,
+                parser,
+                force_forward_search=index > 0,
+            )
 
         section = _read_section(parser.lines, parser.index)
         find_result = _find_context(input_lines, section.next_context, cursor, section.eof)
@@ -168,22 +169,62 @@ def _parse_update_diff(lines: list[str], input: str) -> ParsedUpdateDiff:
     return ParsedUpdateDiff(chunks=chunks, fuzz=parser.fuzz)
 
 
+def _read_anchors(parser: ParserState) -> tuple[list[str], bool]:
+    """Consume the ``@@`` header lines that introduce one hunk.
+
+    The patch format lets a hunk carry several stacked headers, so nested code can be
+    located when a single header plus context is still ambiguous::
+
+        @@ class BaseClass
+        @@     def method():
+
+    Returns the non-empty headers in the order they should narrow the search, plus
+    whether a usable header was seen at all.
+    """
+    anchors: list[str] = []
+    has_anchor = False
+
+    while True:
+        start_index = parser.index
+        anchor = _read_str(parser, "@@ ")
+        consumed = parser.index != start_index
+        bare = False
+
+        if not consumed and parser.index < len(parser.lines) and parser.lines[parser.index] == "@@":
+            parser.index += 1
+            consumed = bare = True
+
+        if not consumed:
+            break
+        if anchor or bare:
+            has_anchor = True
+        if anchor.strip():
+            anchors.append(anchor)
+
+    return anchors, has_anchor
+
+
 def _advance_cursor_to_anchor(
     anchor: str,
     input_lines: list[str],
     cursor: int,
     parser: ParserState,
+    *,
+    force_forward_search: bool = False,
 ) -> int:
     found = False
 
-    if not any(line == anchor for line in input_lines[:cursor]):
+    if force_forward_search or not any(line == anchor for line in input_lines[:cursor]):
         for i in range(cursor, len(input_lines)):
             if input_lines[i] == anchor:
                 cursor = i + 1
                 found = True
                 break
 
-    if not found and not any(line.strip() == anchor.strip() for line in input_lines[:cursor]):
+    if not found and (
+        force_forward_search
+        or not any(line.strip() == anchor.strip() for line in input_lines[:cursor])
+    ):
         for i in range(cursor, len(input_lines)):
             if input_lines[i].strip() == anchor.strip():
                 cursor = i + 1

--- a/tests/sandbox/test_apply_patch.py
+++ b/tests/sandbox/test_apply_patch.py
@@ -50,6 +50,45 @@ async def test_apply_patch_update_uses_anchor_jump() -> None:
 
 
 @pytest.mark.asyncio
+async def test_apply_patch_update_uses_stacked_anchor_jump() -> None:
+    """The tool description tells the model to stack ``@@`` headers when one is ambiguous."""
+    session = ApplyPatchSession()
+    session.files[Path("/workspace/stacked.py")] = (
+        b"class First\n"
+        b"    def target():\n"
+        b"        return 0\n"
+        b"\n"
+        b"class Second\n"
+        b"    def helper():\n"
+        b"        pass\n"
+        b"\n"
+        b"    def target():\n"
+        b"        pass\n"
+    )
+
+    await session.apply_patch(
+        ApplyPatchOperation(
+            type="update_file",
+            path="stacked.py",
+            diff="@@ class Second\n@@     def target():\n-        pass\n+        return 1\n",
+        )
+    )
+
+    assert session.files[Path("/workspace/stacked.py")] == (
+        b"class First\n"
+        b"    def target():\n"
+        b"        return 0\n"
+        b"\n"
+        b"class Second\n"
+        b"    def helper():\n"
+        b"        pass\n"
+        b"\n"
+        b"    def target():\n"
+        b"        return 1\n"
+    )
+
+
+@pytest.mark.asyncio
 async def test_apply_patch_update_matches_end_of_file_context() -> None:
     session = ApplyPatchSession()
     session.files[Path("/workspace/tail.txt")] = b"one\ntwo\nthree\n"

--- a/tests/test_apply_diff.py
+++ b/tests/test_apply_diff.py
@@ -34,6 +34,116 @@ def test_apply_diff_applies_contextual_replacement() -> None:
     assert apply_diff(input_text, diff) == "line1\nupdated\nline3\n"
 
 
+def test_apply_diff_applies_stacked_anchors_from_the_tool_description() -> None:
+    """The worked example the apply_patch tool description gives the model."""
+    input_text = (
+        "\n".join(
+            [
+                "class BaseClass",
+                "    def search():",
+                "        pass",
+                "",
+                "class Subclass",
+                "    def search():",
+                "        pass",
+            ]
+        )
+        + "\n"
+    )
+    diff = "\n".join(
+        [
+            "@@ class BaseClass",
+            "@@     def search():",
+            "-        pass",
+            "+        raise NotImplementedError()",
+            "",
+            "@@ class Subclass",
+            "@@     def search():",
+            "-        pass",
+            "+        raise NotImplementedError()",
+        ]
+    )
+
+    assert (
+        apply_diff(input_text, diff)
+        == "\n".join(
+            [
+                "class BaseClass",
+                "    def search():",
+                "        raise NotImplementedError()",
+                "",
+                "class Subclass",
+                "    def search():",
+                "        raise NotImplementedError()",
+            ]
+        )
+        + "\n"
+    )
+
+
+def test_apply_diff_stacked_anchors_narrow_to_the_named_block() -> None:
+    """The second anchor skips an earlier matching body inside the selected class."""
+    input_text = (
+        "\n".join(
+            [
+                "class First",
+                "    def target():",
+                "        return 0",
+                "",
+                "class Second",
+                "    def helper():",
+                "        pass",
+                "",
+                "    def target():",
+                "        pass",
+            ]
+        )
+        + "\n"
+    )
+    diff = "\n".join(
+        [
+            "@@ class Second",
+            "@@     def target():",
+            "-        pass",
+            "+        return 1",
+        ]
+    )
+
+    assert (
+        apply_diff(input_text, diff)
+        == "\n".join(
+            [
+                "class First",
+                "    def target():",
+                "        return 0",
+                "",
+                "class Second",
+                "    def helper():",
+                "        pass",
+                "",
+                "    def target():",
+                "        return 1",
+            ]
+        )
+        + "\n"
+    )
+
+
+def test_apply_diff_stacked_anchors_stay_advisory_when_unmatched() -> None:
+    """Same rule a single unmatched anchor already follows: locate by context, don't fail."""
+    input_text = "a\nb\n"
+    diff = "\n".join(["@@ nope", "@@ also-nope", "-b", "+B"])
+
+    assert apply_diff(input_text, diff) == "a\nB\n"
+
+
+def test_apply_diff_stacked_anchors_accept_a_trailing_bare_anchor() -> None:
+    input_text = "class Only\n    def run():\n        pass\n"
+    diff = "\n".join(["@@ class Only", "@@", "-        pass", "+        return 1"])
+
+    assert apply_diff(input_text, diff) == "class Only\n    def run():\n        return 1\n"
+
+
 def test_apply_diff_raises_on_context_mismatch() -> None:
     input_text = "one\ntwo\n"
     diff = "\n".join(["@@ -1,2 +1,2 @@", " x", "-two", "+2"])


### PR DESCRIPTION
This pull request supersedes #4360 and fixes `apply_diff` so consecutive `@@` headers described by the apply-patch tool are consumed as one hunk prefix and applied as sequential forward filters.

The released parser rejected the second header. The original contribution accepted the syntax, but a later anchor could be ignored when the same text appeared earlier in the file, allowing generic hunk context to update the wrong method. This version preserves existing single, bare, unmatched, and fuzzy anchor behavior while ensuring each later non-empty anchor searches from the cursor selected by the previous anchor.

It adds direct parser and sandbox apply-patch regression coverage, including a repeated-code case where the inner anchor is necessary to avoid changing an unrelated method.
