### PR TITLE
fix(voice): reject incomplete multichannel audio frames

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -22,6 +22,12 @@ def _buffer_to_audio_file(
     if sample_width not in {1, 2, 3, 4}:
         raise UserError("Sample width must be between 1 and 4 bytes")
 
+    if buffer.dtype not in (np.int16, np.float32):
+        raise UserError("Buffer must be a numpy array of int16 or float32")
+
+    if channels > 0 and buffer.size % channels != 0:
+        raise UserError("Buffer must contain complete channel frames")
+
     if buffer.dtype == np.float32:
         clipped_buffer = np.clip(buffer, -1.0, 1.0)
         if sample_width == 1:
@@ -41,8 +47,6 @@ def _buffer_to_audio_file(
                 audio_bytes = pcm_32.view(np.uint8).reshape(-1, 4)[:, :3].tobytes()
             else:
                 audio_bytes = pcm_buffer.astype("<i4").tobytes()
-    elif buffer.dtype != np.int16:
-        raise UserError("Buffer must be a numpy array of int16 or float32")
     elif sample_width == 1:
         audio_bytes = ((buffer.astype(np.int32) >> 8) + 128).astype(np.uint8).tobytes()
     else:

--- a/tests/voice/test_input.py
+++ b/tests/voice/test_input.py
@@ -95,12 +95,28 @@ def test_buffer_to_audio_file_rejects_unsupported_sample_width():
         _buffer_to_audio_file(buffer, sample_width=5)
 
 
+def test_audio_input_validates_multichannel_frame_alignment():
+    complete_audio = AudioInput(buffer=np.array([1, 2, 3, 4], dtype=np.int16), channels=2)
+    _, audio_file, _ = complete_audio.to_audio_file()
+    with wave.open(audio_file, "rb") as wav_file:
+        assert wav_file.getnchannels() == 2
+        assert wav_file.getnframes() == 2
+
+    audio_input = AudioInput(buffer=np.array([1, 2, 3], dtype=np.int16), channels=2)
+
+    with pytest.raises(UserError, match="complete channel frames"):
+        audio_input.to_audio_file()
+
+
 def test_buffer_to_audio_file_invalid_dtype():
     # Create a buffer with invalid dtype (float64)
     buffer = np.array([1.0, 2.0, 3.0], dtype=np.float64)
 
     with pytest.raises(UserError, match="Buffer must be a numpy array of int16 or float32"):
         _buffer_to_audio_file(buffer=buffer)
+
+    with pytest.raises(UserError, match="Buffer must be a numpy array of int16 or float32"):
+        _buffer_to_audio_file(buffer=buffer, channels=2)
 
 
 class TestAudioInput:


### PR DESCRIPTION
This pull request supersedes #4367 and rejects incomplete multichannel audio frames before WAV construction or OpenAI transcription transport.

It also preserves the existing invalid-dtype validation precedence when an input has both an unsupported dtype and an incomplete frame count.

### Test plan

- Added coverage for complete and incomplete stereo audio frames.
- Added coverage preserving invalid-dtype validation for incomplete multichannel input.
- Verified with the live OpenAI transcription API:
  - Incomplete stereo input raised locally without sending a request.
  - Complete stereo input sent one request and received HTTP 200.
- Ran the complete local format, lint, typecheck, and test suite.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
