### PR TITLE
docs: clarify PGP key location

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 For a more in-depth look at our security policy, please check out our [Coordinated Vulnerability Disclosure Policy](https://openai.com/security/disclosure/#:~:text=Disclosure%20Policy,-Security%20is%20essential&text=OpenAI%27s%20coordinated%20vulnerability%20disclosure%20policy,expect%20from%20us%20in%20return.).
 
-Our PGP key can located [at this address.](https://cdn.openai.com/security.txt)
+Our PGP key can be found [at this address](https://cdn.openai.com/security.txt).


### PR DESCRIPTION
### Summary

Clarify the sentence that directs security reporters to the project's PGP key. This fixes the missing verb and places sentence punctuation outside the link text.

AI assistance was used to identify and validate this documentation correction.

### Test plan

- `git diff --check`
- Confirmed `https://cdn.openai.com/security.txt` returns HTTP 200

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant (not relevant for this documentation-only change)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (not required for repo-meta documentation)
- [x] I've confirmed all applicable verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
