### PR TITLE
fix(voice): reject non-positive audio channels

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -25,7 +25,10 @@ def _buffer_to_audio_file(
     if buffer.dtype not in (np.int16, np.float32):
         raise UserError("Buffer must be a numpy array of int16 or float32")
 
-    if channels > 0 and buffer.size % channels != 0:
+    if channels <= 0:
+        raise UserError("Channels must be greater than zero")
+
+    if buffer.size % channels != 0:
         raise UserError("Buffer must contain complete channel frames")
 
     if buffer.dtype == np.float32:

--- a/tests/voice/test_input.py
+++ b/tests/voice/test_input.py
@@ -108,6 +108,14 @@ def test_audio_input_validates_multichannel_frame_alignment():
         audio_input.to_audio_file()
 
 
+@pytest.mark.parametrize("channels", [0, -1])
+def test_audio_input_rejects_non_positive_channels(channels):
+    audio_input = AudioInput(buffer=np.zeros(4, dtype=np.int16), channels=channels)
+
+    with pytest.raises(UserError, match="Channels must be greater than zero"):
+        audio_input.to_audio_file()
+
+
 def test_buffer_to_audio_file_invalid_dtype():
     # Create a buffer with invalid dtype (float64)
     buffer = np.array([1.0, 2.0, 3.0], dtype=np.float64)


### PR DESCRIPTION
### Summary

This pull request fixes `AudioInput.to_audio_file()` so non-positive channel counts raise the SDK's `UserError` before WAV creation. Previously, zero or negative values reached Python's `wave` writer and leaked `wave.Error`, with cleanup potentially masking the original error.

The change preserves valid positive-channel behavior and existing incomplete-frame validation.

### Test plan

- `python -m pytest -q tests/voice/test_input.py` — 22 passed
- `python -m pytest -q tests/voice` — 134 passed
- Ruff format/lint and optional-truthiness checks passed
- Mypy and Pyright pass for the changed files
- Repository serial tests passed
- Full Windows verification is not green because the unchanged upstream baseline currently has a `tar_utils.py:161` typeshed error and Windows-specific symlink, locale, and tracing/xdist test failures. Linux CI is expected to provide the authoritative full-suite result.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR