### PR TITLE
fix(mcp): isolate cached tool list results

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -842,7 +842,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
     @property
     def cached_tools(self) -> list[MCPTool] | None:
-        return self._tools_list
+        return list(self._tools_list) if self._tools_list is not None else None
 
     def __init__(
         self,
@@ -1444,7 +1444,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             filtered_tools = tools
             if self.tool_filter is not None:
                 filtered_tools = await self._apply_tool_filter(filtered_tools, run_context, agent)
-            return filtered_tools
+            return list(filtered_tools)
         except HTTP_STATUS_ERROR_TYPES as e:
             status_code = http_status_code(e)
             transport_error = UserError(

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -64,6 +64,36 @@ async def test_server_caching_works(
         assert result_tools == tools
 
 
+@pytest.mark.parametrize("result_source", ["list_tools", "cached_tools"])
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_cached_tool_results_do_not_expose_the_shared_cache(
+    mock_list_tools: AsyncMock,
+    mock_initialize: AsyncMock,
+    mock_stdio_client,
+    result_source: str,
+) -> None:
+    tools = [
+        MCPTool(name="tool1", inputSchema={}),
+        MCPTool(name="tool2", inputSchema={}),
+    ]
+    mock_list_tools.return_value = ListToolsResult(tools=tools)
+    server = MCPServerStdio(params={"command": tee}, cache_tools_list=True)
+
+    async with server:
+        listed_tools = await server.list_tools()
+        exposed_tools = listed_tools if result_source == "list_tools" else server.cached_tools
+        assert exposed_tools is not None
+        exposed_tools.pop()
+
+        assert await server.list_tools() == tools
+        assert server.cached_tools == tools
+
+    assert mock_list_tools.call_count == 1
+
+
 @pytest.mark.asyncio
 @patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
 @patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)


### PR DESCRIPTION
### Summary

Return snapshots from `MCPServer.list_tools()` and `cached_tools` so callers cannot mutate the server's shared tool cache through a public result.

The change preserves the tool objects, their order, filtering, cache invalidation, and fetch behavior while isolating only the returned list containers.

### Test plan

- Added a parameterized regression covering mutation through both `list_tools()` and `cached_tools`. On clean `upstream/main`, both cases failed because removing one of two returned tools removed it from subsequent cached results without another server request.
- `uv run pytest tests/mcp/test_caching.py::test_cached_tool_results_do_not_expose_the_shared_cache -q` — 2 passed.
- `uv run pytest tests/mcp/test_caching.py -q` — 4 passed.
- Repeated the focused async regression 10 times — 20 parameterized cases passed.
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` — format, lint, typecheck, and full tests passed.

No API keys, paid calls, or live services were used.

### Issue number

N/A — focused fix with a deterministic local regression.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
