### PR TITLE
fix(mcp): stop retry backoff from doubling without a ceiling

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -515,6 +515,10 @@ class _UnsetType:
 
 _UNSET = _UnsetType()
 
+# Retry backoff stops doubling once this many backoffs have been taken, so the delay never
+# exceeds `retry_backoff_seconds_base` times 2**_MAX_RETRY_BACKOFF_EXPONENT.
+_MAX_RETRY_BACKOFF_EXPONENT = 6
+
 if TYPE_CHECKING:
     from ..agent import AgentBase
 
@@ -880,7 +884,8 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             max_retry_attempts: Number of times to retry failed list_tools/call_tool calls.
                 Defaults to no retries.
             retry_backoff_seconds_base: The base delay, in seconds, used for exponential
-                backoff between retries.
+                backoff between retries. The delay stops doubling once it reaches 64 times
+                this value.
             message_handler: Optional handler invoked for session messages as delivered by the
                 ClientSession.
             require_approval: Approval policy for tools on this server. Accepts "always"/"never",
@@ -1187,6 +1192,17 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
         assert transport_error is not None
         self._raise_mapped_transport_error(transport_error, None)
 
+    def _retry_backoff_seconds(self, backoffs_taken: int) -> float:
+        """Return the delay before the next retry, given how many backoffs already happened.
+
+        The multiplier stops doubling at `_MAX_RETRY_BACKOFF_EXPONENT`. Without that ceiling an
+        unlimited retry budget (`max_retry_attempts=-1`) stops retrying in practice, because the
+        delay keeps doubling past any usable duration. A finite budget bounds the exponent on its
+        own and reaches the ceiling only when it allows more retries than the ceiling permits.
+        """
+        multiplier: int = 2 ** min(backoffs_taken, _MAX_RETRY_BACKOFF_EXPONENT)
+        return self.retry_backoff_seconds_base * multiplier
+
     async def _run_with_retries(self, func: Callable[[], Awaitable[T]]) -> T:
         attempts = 0
         while True:
@@ -1196,8 +1212,7 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
                 attempts += 1
                 if self.max_retry_attempts != -1 and attempts > self.max_retry_attempts:
                     raise
-                backoff = self.retry_backoff_seconds_base * (2 ** (attempts - 1))
-                await asyncio.sleep(backoff)
+                await asyncio.sleep(self._retry_backoff_seconds(attempts - 1))
 
     @asynccontextmanager
     async def _client_session_context(self, read_timeout: timedelta | float | None):
@@ -1874,7 +1889,8 @@ class MCPServerStdio(_MCPServerWithClientSession):
             max_retry_attempts: Number of times to retry failed list_tools/call_tool calls.
                 Defaults to no retries.
             retry_backoff_seconds_base: The base delay, in seconds, for exponential
-                backoff between retries.
+                backoff between retries. The delay stops doubling once it reaches 64 times
+                this value.
             message_handler: Optional handler invoked for session messages as delivered by the
                 ClientSession.
             require_approval: Approval policy for tools on this server. Accepts "always"/"never",
@@ -2005,7 +2021,8 @@ class MCPServerSse(_MCPServerWithClientSession):
             max_retry_attempts: Number of times to retry failed list_tools/call_tool calls.
                 Defaults to no retries.
             retry_backoff_seconds_base: The base delay, in seconds, for exponential
-                backoff between retries.
+                backoff between retries. The delay stops doubling once it reaches 64 times
+                this value.
             message_handler: Optional handler invoked for session messages as delivered by the
                 ClientSession.
             require_approval: Approval policy for tools on this server. Accepts "always"/"never",
@@ -2163,7 +2180,8 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
             max_retry_attempts: Number of times to retry failed list_tools/call_tool calls.
                 Defaults to no retries.
             retry_backoff_seconds_base: The base delay, in seconds, for exponential
-                backoff between retries.
+                backoff between retries. The delay stops doubling once it reaches 64 times
+                this value.
             message_handler: Optional handler invoked for session messages as delivered by the
                 ClientSession.
             require_approval: Approval policy for tools on this server. Accepts "always"/"never",
@@ -2391,13 +2409,13 @@ class MCPServerStreamableHttp(_MCPServerWithClientSession):
                         if exc.__cause__ is not None:
                             raise exc.__cause__ from exc
                         raise
-                    backoff = self.retry_backoff_seconds_base * (2**backoffs_taken)
+                    backoff = self._retry_backoff_seconds(backoffs_taken)
                     backoffs_taken += 1
                     await asyncio.sleep(backoff)
                 except Exception:
                     if self.max_retry_attempts != -1 and retries_used >= self.max_retry_attempts:
                         raise
-                    backoff = self.retry_backoff_seconds_base * (2**backoffs_taken)
+                    backoff = self._retry_backoff_seconds(backoffs_taken)
                     backoffs_taken += 1
                     await asyncio.sleep(backoff)
                 first_attempt = False

--- a/tests/mcp/test_client_session_retries.py
+++ b/tests/mcp/test_client_session_retries.py
@@ -747,3 +747,41 @@ async def test_streamable_http_backoff_matches_generic_schedule_on_isolated_retr
         await server.call_tool("tool", None)
 
     assert delays == [1.0, 2.0, 4.0]
+
+
+@pytest.mark.asyncio
+async def test_backoff_stops_doubling_with_unlimited_retries(monkeypatch):
+    delays: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+
+    session = DummySession(fail_call_tool=9)
+    server = DummyServer(session, retries=-1)
+    server.retry_backoff_seconds_base = 1.0
+
+    await server.call_tool("tool", None)
+
+    # Unlimited retries only keep running if the delay stops growing at some point.
+    assert delays == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 64.0, 64.0]
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_backoff_stops_doubling_with_unlimited_retries(monkeypatch):
+    delays: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+
+    shared_session = FlakyRuntimeErrorSession(failures=9)
+    server = DummyStreamableHttpServer(shared_session, TimeoutSession())
+    server.max_retry_attempts = -1
+    server.retry_backoff_seconds_base = 1.0
+
+    await server.call_tool("tool", None)
+
+    assert delays == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 64.0, 64.0]


### PR DESCRIPTION
### Summary

The retry backoff multiplier grows without a ceiling, so `max_retry_attempts=-1` stops retrying in practice instead of retrying indefinitely.

Both retry loops compute the delay as `retry_backoff_seconds_base * 2**n` with nothing bounding `n`:

- `_MCPServerWithClientSession._run_with_retries` — the generic `list_tools()` / `call_tool()` path
- `MCPServerStreamableHttp.call_tool` — the streamable HTTP override, in both of its retry branches

With a finite `max_retry_attempts` the budget bounds the exponent, so the schedule stays reasonable. With `max_retry_attempts=-1` nothing does. At the default `retry_backoff_seconds_base=1.0`, the 10th delay is about 8.5 minutes, the 20th about 6 days, and the 30th about 34 years. A server that is down long enough for the budget to be unlimited is exactly the case where the loop should keep polling, and it is the case where it silently stops.

This is the behavior `.agents/references/local-mcp-server-lifecycle.md` describes as "Generic `list_tools()` and `call_tool()` retries use the configured attempt count and backoff" — the configured attempt count of "unlimited" is not actually honored once the delay outgrows the process.

The fix clamps the multiplier at 64 times the configured base, in one shared `_retry_backoff_seconds()` helper that replaces the three copies of the unbounded expression. The ceiling is expressed as a multiplier rather than an absolute number of seconds so that `retry_backoff_seconds_base` keeps its meaning at any scale: a base of `0.1` still tops out at 6.4s, a base of `5.0` at 320s. No new constructor parameter is added; `_MAX_RETRY_BACKOFF_EXPONENT` is a module-private constant, so the exact ceiling is easy to adjust if you would prefer a different one.

Only the unlimited-retry mode changes behavior. Any finite `max_retry_attempts` of 7 or less produces an identical schedule to before.

### Test plan

Two tests added to `tests/mcp/test_client_session_retries.py`, one per retry loop, each driving 9 consecutive failures with `max_retry_attempts=-1` and `retry_backoff_seconds_base=1.0` and asserting the recorded sleep schedule is `[1, 2, 4, 8, 16, 32, 64, 64, 64]`.

Both fail on `main` at index 7 with `128.0 != 64.0`, verified by stashing only `src/agents/mcp/server.py` and re-running the new tests against the unmodified source:

```
FAILED tests/mcp/test_client_session_retries.py::test_backoff_stops_doubling_with_unlimited_retries
FAILED tests/mcp/test_client_session_retries.py::test_streamable_http_backoff_stops_doubling_with_unlimited_retries
2 failed, 29 deselected
```

The existing retry tests cannot catch this: they either pin `retry_backoff_seconds_base=0` or stop after three failures, before the exponent grows far enough to matter.

`.agents/skills/code-change-verification/scripts/run.sh` run in full. `make format`, `make lint` and `make typecheck` are clean.

`make tests` reports one failure, `tests/test_run_step_execution.py::test_multiple_tool_calls_bound_cancelled_sibling_self_rescheduling_cleanup`. It is **pre-existing and unrelated** to this change:

- it reproduces on clean `main` with the same command and no diff applied (`1 failed, 8113 passed`)
- with this change applied the same run is `1 failed, 8115 passed` — the delta is exactly the two tests added here
- it passes when run on its own, so it depends on full-suite `-n auto` load
- this change touches only `src/agents/mcp/server.py`; the failing test exercises the `HostedMCPTool` approval flow, which does not reach the local MCP client-session retry path

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass — all steps pass except the pre-existing `test_run_step_execution.py` failure documented above, which also fails on clean `main`
- [ ] If using Codex, I've run `/review` before submitting this PR
