### PR TITLE
fix(EncryptedSession): add strict mode to reject non-encrypted items

### DIFF
--- a/src/agents/extensions/memory/encrypt_session.py
+++ b/src/agents/extensions/memory/encrypt_session.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 from typing import Any, Literal, TypeGuard, cast
 
 from cryptography.fernet import Fernet, InvalidToken
@@ -40,6 +41,8 @@ from ...items import TResponseInputItem
 from ...memory.session import SessionABC, _call_session_method, _get_session_wrapper
 from ...memory.session_settings import SessionSettings, resolve_session_limit
 from ...run_context import RunContextWrapper
+
+logger = logging.getLogger(__name__)
 
 
 class EncryptedEnvelope(TypedDict):
@@ -117,6 +120,7 @@ class EncryptedSession(SessionABC):
         underlying_session: SessionABC,
         encryption_key: str,
         ttl: int = 600,
+        allow_plaintext_passthrough: bool = True,
     ):
         """
         Args:
@@ -124,10 +128,15 @@ class EncryptedSession(SessionABC):
             underlying_session: The real session store (e.g. SQLiteSession, SQLAlchemySession)
             encryption_key: Master key (Fernet key or raw secret)
             ttl: Token time-to-live in seconds (default 10 min)
+            allow_plaintext_passthrough: When True (default), items without an encryption
+                envelope are returned verbatim, which supports migrating a plaintext store
+                to encrypted storage. When False, non-encrypted items are dropped with a
+                warning log so only authenticated ciphertext reaches the model.
         """
         self.session_id = session_id
         self.underlying_session = underlying_session
         self.ttl = ttl
+        self._allow_plaintext_passthrough = allow_plaintext_passthrough
 
         master = _ensure_fernet_key_bytes(encryption_key)
         self.cipher = _derive_session_fernet_key(master, session_id)
@@ -162,6 +171,12 @@ class EncryptedSession(SessionABC):
 
     def _unwrap(self, item: TResponseInputItem | EncryptedEnvelope) -> TResponseInputItem | None:
         if not _is_encrypted_envelope(item):
+            if not self._allow_plaintext_passthrough:
+                logger.warning(
+                    "EncryptedSession dropping non-encrypted item from session store "
+                    "(allow_plaintext_passthrough=False)."
+                )
+                return None
             return cast(TResponseInputItem, item)
 
         try:

--- a/tests/extensions/memory/test_encrypt_session.py
+++ b/tests/extensions/memory/test_encrypt_session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import tempfile
 from pathlib import Path
 from typing import Any, cast
@@ -641,3 +642,97 @@ async def test_runner_with_session_settings_override(encryption_key: str):
     assert len(history_items) == 2
 
     underlying.close()
+
+
+# ============================================================================
+# Strict mode (allow_plaintext_passthrough=False) tests
+# ============================================================================
+
+
+async def test_encrypted_session_plaintext_passthrough_by_default(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """Test that non-encrypted items pass through by default (migration support)."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+    )
+
+    await session.add_items([{"role": "user", "content": "encrypted"}])
+    await underlying_session.add_items([{"role": "user", "content": "plaintext"}])
+
+    items = await session.get_items()
+    assert [item.get("content") for item in items] == ["encrypted", "plaintext"]
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_strict_mode_drops_plaintext_with_warning(
+    encryption_key: str, underlying_session: SQLiteSession, caplog: pytest.LogCaptureFixture
+):
+    """Test that strict mode drops non-encrypted items and logs a warning."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+        allow_plaintext_passthrough=False,
+    )
+
+    await session.add_items([{"role": "user", "content": "encrypted"}])
+    await underlying_session.add_items([{"role": "user", "content": "plaintext"}])
+
+    with caplog.at_level(logging.WARNING, logger="agents.extensions.memory.encrypt_session"):
+        items = await session.get_items()
+
+    assert [item.get("content") for item in items] == ["encrypted"]
+    assert "dropping non-encrypted item" in caplog.text
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_strict_mode_reads_valid_envelopes(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """Test that strict mode still returns valid encrypted items."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+        allow_plaintext_passthrough=False,
+    )
+
+    await session.add_items(
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+    )
+
+    items = await session.get_items()
+    assert [item.get("content") for item in items] == ["Hello", "Hi there!"]
+
+    underlying_session.close()
+
+
+async def test_encrypted_session_strict_mode_pop_item_skips_plaintext(
+    encryption_key: str, underlying_session: SQLiteSession
+):
+    """Test that pop_item in strict mode skips non-encrypted items."""
+    session = EncryptedSession(
+        session_id="test_session",
+        underlying_session=underlying_session,
+        encryption_key=encryption_key,
+        allow_plaintext_passthrough=False,
+    )
+
+    await session.add_items([{"role": "user", "content": "encrypted"}])
+    await underlying_session.add_items([{"role": "user", "content": "plaintext"}])
+
+    popped = await session.pop_item()
+    assert popped is not None
+    assert popped.get("content") == "encrypted"
+
+    assert await session.pop_item() is None
+
+    underlying_session.close()


### PR DESCRIPTION
## Summary

`EncryptedSession` wraps an underlying session store with Fernet AEAD so stored conversation items are encrypted and integrity-protected at rest. The read path, however, currently returns any stored item that lacks the `__enc__` envelope completely verbatim: `_unwrap` passes non-envelope items straight through, so `get_items` and `pop_item` feed unauthenticated plaintext into model context with no signal to the operator.

That passthrough is useful when migrating a plaintext store onto encrypted storage, so this PR keeps it as the default and adds an opt-in strict mode rather than changing behavior:

- New constructor flag `allow_plaintext_passthrough` (default `True`, behavior identical to today).
- When set to `False`, non-envelope items are dropped with a warning log on both read paths (`get_items` via `_unwrap_valid_items`, and the `pop_item` retry loop), so only authenticated ciphertext reaches the model.

This is a hardening / fail-closed option, not a vulnerability fix: planting items already requires write access to the underlying store, but operators who treat the store as untrusted at rest now have a way to enforce the integrity the wrapper otherwise implies.

A minimum-length check for raw-string `encryption_key` values was considered but left out to avoid breaking existing deployments. Happy to add a short note to `docs/sessions/encrypted_session.md` if you would like that in this PR.

## Test plan

- [x] `pytest tests/extensions/memory/test_encrypt_session.py`: 24 passed (4 new)
- [x] New coverage: default passthrough unchanged, strict mode drops non-envelope items with a warning, strict mode still reads valid envelopes, `pop_item` skips non-envelope items
- [x] `ruff check`, `ruff format --check`, and `mypy` clean on touched files

Made with [Cursor](https://cursor.com)