### PR TITLE
fix(tracing): reject non-positive max batch sizes

### DIFF
--- a/src/agents/tracing/processors.py
+++ b/src/agents/tracing/processors.py
@@ -562,6 +562,9 @@ class BatchTraceProcessor(TracingProcessor):
             schedule_delay: The delay between checks for new spans to export.
             export_trigger_ratio: The ratio of the queue size at which we will trigger an export.
         """
+        if max_batch_size <= 0:
+            raise ValueError("max_batch_size must be greater than 0")
+
         self._exporter = exporter
         self._queue: queue.Queue[Trace | Span[Any]] = queue.Queue(maxsize=max_queue_size)
         self._max_queue_size = max_queue_size

--- a/tests/test_trace_processor.py
+++ b/tests/test_trace_processor.py
@@ -66,6 +66,14 @@ def mocked_exporter():
     return exporter
 
 
+@pytest.mark.parametrize("max_batch_size", [0, -1])
+def test_batch_trace_processor_rejects_non_positive_max_batch_size(
+    mocked_exporter: MagicMock, max_batch_size: int
+) -> None:
+    with pytest.raises(ValueError, match="max_batch_size must be greater than 0"):
+        BatchTraceProcessor(exporter=mocked_exporter, max_batch_size=max_batch_size)
+
+
 def test_batch_trace_processor_on_trace_start(mocked_exporter):
     processor = BatchTraceProcessor(exporter=mocked_exporter, schedule_delay=0.1)
     test_trace = get_trace(processor)


### PR DESCRIPTION
### Summary

This pull request fixes `BatchTraceProcessor` silently stranding queued traces when `max_batch_size` is zero or negative. It now rejects non-positive batch sizes before creating the queue or worker thread, while preserving existing behavior for positive values.

### Test plan

- `pytest tests/test_trace_processor.py -q` — 58 passed
- `ruff format` and `ruff check` — passed
- `python .github/scripts/check_optional_truthiness.py src/agents` — passed
- Targeted mypy and Pyright checks for the changed runtime and test files — passed
- The repository verification wrapper could not complete on Windows because `make` is not installed. Its manual full-suite equivalent was attempted; unrelated Windows-only baseline failures (sandbox symlink privileges, existing full-project typing errors, and tracing test ordering also reproduced on unchanged upstream) remain outside this two-file change.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR