### PR TITLE
fix(voice): reject non-positive audio frame rates

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -22,6 +22,9 @@ def _buffer_to_audio_file(
     if sample_width not in {1, 2, 3, 4}:
         raise UserError("Sample width must be between 1 and 4 bytes")
 
+    if frame_rate <= 0:
+        raise UserError("Frame rate must be greater than zero")
+
     if buffer.dtype not in (np.int16, np.float32):
         raise UserError("Buffer must be a numpy array of int16 or float32")
 

--- a/tests/voice/test_input.py
+++ b/tests/voice/test_input.py
@@ -116,6 +116,14 @@ def test_audio_input_rejects_non_positive_channels(channels):
         audio_input.to_audio_file()
 
 
+@pytest.mark.parametrize("frame_rate", [0, -8000])
+def test_audio_input_rejects_non_positive_frame_rate(frame_rate):
+    audio_input = AudioInput(buffer=np.zeros(4, dtype=np.int16), frame_rate=frame_rate)
+
+    with pytest.raises(UserError, match="Frame rate must be greater than zero"):
+        audio_input.to_audio_file()
+
+
 def test_buffer_to_audio_file_invalid_dtype():
     # Create a buffer with invalid dtype (float64)
     buffer = np.array([1.0, 2.0, 3.0], dtype=np.float64)


### PR DESCRIPTION
### Summary

`_buffer_to_audio_file` validates sample width, buffer dtype, channel count, and multichannel frame completeness, but previously did not validate the frame rate. A zero or negative `frame_rate` reached `wave.setframerate` and surfaced as a low-level `wave.Error` instead of the `UserError` used by the adjacent input validations.

This adds an up-front `frame_rate <= 0` check so invalid rates fail consistently and actionably. Valid audio conversion is unchanged.

The earlier negative-history-limit changes have been removed to preserve the released SQLite behavior documented by v0.20.0 and #4001.

### Test plan

- Added `test_audio_input_rejects_non_positive_frame_rate`, parametrized over `0` and `-8000`.
- `uv run pytest -q tests/voice/test_input.py` — 24 passed.
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh` — passed:
  - Ruff format: 897 files unchanged.
  - Ruff lint: passed.
  - mypy and Pyright: passed.
  - Full test suite: passed.
- `git diff --check` — passed.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
