### PR TITLE
fix(voice): reject non-positive audio frame rates

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -22,6 +22,9 @@ def _buffer_to_audio_file(
     if sample_width not in {1, 2, 3, 4}:
         raise UserError("Sample width must be between 1 and 4 bytes")
 
+    if frame_rate <= 0:
+        raise UserError("Frame rate must be greater than zero")
+
     if buffer.dtype not in (np.int16, np.float32):
         raise UserError("Buffer must be a numpy array of int16 or float32")
 

--- a/tests/voice/test_input.py
+++ b/tests/voice/test_input.py
@@ -116,6 +116,14 @@ def test_audio_input_rejects_non_positive_channels(channels):
         audio_input.to_audio_file()
 
 
+@pytest.mark.parametrize("frame_rate", [0, -8000])
+def test_audio_input_rejects_non_positive_frame_rate(frame_rate):
+    audio_input = AudioInput(buffer=np.zeros(4, dtype=np.int16), frame_rate=frame_rate)
+
+    with pytest.raises(UserError, match="Frame rate must be greater than zero"):
+        audio_input.to_audio_file()
+
+
 def test_buffer_to_audio_file_invalid_dtype():
     # Create a buffer with invalid dtype (float64)
     buffer = np.array([1.0, 2.0, 3.0], dtype=np.float64)


### PR DESCRIPTION
### Summary

`_buffer_to_audio_file` in `agents/voice/input.py` validates the sample width, buffer dtype, channel count, and multichannel frame completeness, and raises `UserError` for each. It does not validate the frame rate. A `frame_rate` of `0` or a negative value passes straight to `wave.setframerate`, so the caller sees a low-level `wave.Error` ("sampling rate not specified") instead of the `UserError` the sibling validations raise. This adds an up-front `frame_rate <= 0` check so a bad sample rate fails the same consistent, actionable way, completing the input validation added in #4361, #4370, and #4372.

### Test plan

Added `test_audio_input_rejects_non_positive_frame_rate` in `tests/voice/test_input.py`, parametrized over `0` and `-8000`, mirroring the existing non-positive-channels test. It asserts `AudioInput.to_audio_file()` raises `UserError` matching "Frame rate must be greater than zero". The test fails on `main` (a `wave.Error` leaks) and passes with this change. The full `tests/voice/test_input.py` suite stays green.

```
uv run pytest tests/voice/test_input.py
```

### Issue number

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
