### PR TITLE
fix(run-state): isolate interruption results

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -458,7 +458,7 @@ class RunState(Generic[TContext, TAgent]):
 
         if self._current_step is None or not isinstance(self._current_step, NextStepInterruption):
             return []
-        return self._current_step.interruptions
+        return list(self._current_step.interruptions)
 
     @staticmethod
     def _approval_items_match(

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -1614,6 +1614,25 @@ class TestRunState:
         assert len(interruptions) == 1
         assert interruptions[0] == approval_item
 
+    def test_get_interruptions_returns_a_snapshot(self):
+        """Mutating returned interruptions must not change pending approvals."""
+        agent = Agent(name="SnapshotAgent")
+        approval_item = ToolApprovalItem(
+            agent=agent,
+            raw_item=ResponseFunctionToolCall(
+                type="function_call",
+                name="toolA",
+                call_id="cid-snapshot",
+                status="completed",
+                arguments="{}",
+            ),
+        )
+        state = make_state_with_interruptions(agent, [approval_item])
+
+        state.get_interruptions().clear()
+
+        assert state.get_interruptions() == [approval_item]
+
     async def test_serializes_and_restores_approvals(self):
         """Test that approval state is preserved through serialization."""
         context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})


### PR DESCRIPTION
### Summary

`RunState.get_interruptions()` returned the mutable list owned by the current interruption step. A caller could clear or append to that public result and silently change which tool approvals remained pending, bypassing `approve()` and `reject()`.

Return a shallow list snapshot instead. This preserves each `ToolApprovalItem` identity and the existing ordering while preventing callers from mutating the state's container.

### Test plan

- Added a regression that clears the returned list and verifies the pending approval remains available.
- Red on `upstream/main`: `1 failed, 348 deselected`.
- `uv run pytest tests/test_run_state.py -q` (`349 passed`).
- `make lint` (passed).
- `make typecheck` (mypy clean for 305 source files; Pyright 0 errors).
- `make tests` outside the restricted local sandbox (`8337 passed, 28 skipped`; serial `77 passed, 11 skipped`).
- `git diff --check` (passed).

### Issue number

No issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
