### PR TITLE
fix(tools): preserve empty description overrides

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -477,7 +477,11 @@ def function_schema(
     return FuncSchema(
         name=func_name,
         # Ensure description_override takes precedence even if docstring info is disabled.
-        description=description_override or (doc_info.description if doc_info else None),
+        description=(
+            description_override
+            if description_override is not None
+            else (doc_info.description if doc_info else None)
+        ),
         params_pydantic_model=dynamic_model,
         params_json_schema=json_schema,
         signature=sig,

--- a/src/agents/handoffs/__init__.py
+++ b/src/agents/handoffs/__init__.py
@@ -343,7 +343,11 @@ def handoff(
         return agent
 
     tool_name = tool_name_override or Handoff.default_tool_name(agent)
-    tool_description = tool_description_override or Handoff.default_tool_description(agent)
+    tool_description = (
+        tool_description_override
+        if tool_description_override is not None
+        else Handoff.default_tool_description(agent)
+    )
 
     # Always ensure the input JSON schema is in strict mode. If needed, we can make this
     # configurable in the future.

--- a/src/agents/realtime/handoffs.py
+++ b/src/agents/realtime/handoffs.py
@@ -183,7 +183,11 @@ def realtime_handoff(
         return agent
 
     tool_name = tool_name_override or Handoff.default_tool_name(agent)
-    tool_description = tool_description_override or Handoff.default_tool_description(agent)
+    tool_description = (
+        tool_description_override
+        if tool_description_override is not None
+        else Handoff.default_tool_description(agent)
+    )
 
     # Always ensure the input JSON schema is in strict mode
     # If there is a need, we can make this configurable in the future

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2588,8 +2588,11 @@ def function_tool(
         schema = function_schema(
             func=the_func,
             name_override=name_override,
-            description_override=description_override
-            or (callable_description if use_docstring_info else None),
+            description_override=(
+                description_override
+                if description_override is not None
+                else (callable_description if use_docstring_info else None)
+            ),
             docstring_style=docstring_style,
             use_docstring_info=use_docstring_info,
             strict_json_schema=strict_mode,

--- a/tests/realtime/test_realtime_handoffs.py
+++ b/tests/realtime/test_realtime_handoffs.py
@@ -47,6 +47,12 @@ def test_realtime_handoff_with_custom_params():
     assert handoff_obj.is_enabled is False
 
 
+def test_realtime_handoff_preserves_empty_description_override():
+    handoff_obj = realtime_handoff(RealtimeAgent(name="delegate"), tool_description_override="")
+
+    assert handoff_obj.tool_description == ""
+
+
 @pytest.mark.asyncio
 async def test_collect_enabled_handoffs_cancels_sibling_checks_on_error() -> None:
     slow_started = asyncio.Event()

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -336,6 +336,15 @@ def test_function_config_overrides():
     assert tool.description == "custom description"
 
 
+def test_function_config_preserves_empty_description_override():
+    def documented_function() -> None:
+        """Description that the caller explicitly suppresses."""
+
+    tool = function_tool(documented_function, description_override="")
+
+    assert tool.description == ""
+
+
 def test_func_schema_is_strict():
     tool = function_tool(simple_function)
     assert tool.strict_json_schema, "Should be strict by default"

--- a/tests/test_handoff_tool.py
+++ b/tests/test_handoff_tool.py
@@ -264,6 +264,12 @@ async def test_custom_handoff_setup():
     assert second_handoff.agent_name == agent_2.name
 
 
+def test_handoff_preserves_empty_description_override():
+    handoff_obj = handoff(Agent(name="delegate"), tool_description_override="")
+
+    assert handoff_obj.tool_description == ""
+
+
 class Foo(BaseModel):
     bar: str
 


### PR DESCRIPTION
### Summary

Explicit empty description overrides were treated as absent by function tools, handoffs, and realtime handoffs. For a documented function or named agent, passing `description_override=""` or `tool_description_override=""` silently restored the docstring or generated handoff description.

Resolve description fallbacks only when the override is `None`. Empty strings now remain explicit values; non-empty overrides and omitted overrides keep their existing behavior. Tool-name handling is unchanged.

### Test plan

- Added public regressions for function tools, standard handoffs, and realtime handoffs.
- Red on `upstream/main`: the function test restored its docstring; both handoff tests restored the generated description.
- Focused files: `115 passed`.
- `make format` and `make lint` passed.
- `make typecheck`: mypy clean for 305 source files; Pyright 0 errors.
- Parallel suite: `8339 passed, 28 skipped`.
- Serial suite: `77 passed, 11 skipped, 55 deselected`.
- `git diff --check` passed.

### Issue number

No issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
