### PR TITLE
fix: freeze public testing module contracts

### DIFF
--- a/integration_tests/_contract_support.py
+++ b/integration_tests/_contract_support.py
@@ -325,6 +325,13 @@ def _default_contract(value: object) -> dict[str, object]:
             "type": f"{type(value).__module__}.{type(value).__qualname__}",
             "value": value,
         }
+    voice_testing = sys.modules.get("agents.voice.testing")
+    if voice_testing is not None and value is getattr(voice_testing, "_START_NOT_CONFIGURED", None):
+        return {
+            "kind": "sentinel",
+            "identity": "agents.voice.testing._START_NOT_CONFIGURED",
+        }
+    value_type = f"{type(value).__module__}.{type(value).__qualname__}"
     from agents.mcp.server import _UNSET as mcp_failure_error_unset
     from agents.retry import _UNSET as retry_unset
     from agents.tool import _UNSET_FAILURE_ERROR_FUNCTION as failure_error_function_unset
@@ -339,7 +346,6 @@ def _default_contract(value: object) -> dict[str, object]:
     for sentinel, identity in sentinel_identities:
         if value is sentinel:
             return {"kind": "sentinel", "identity": identity}
-    value_type = f"{type(value).__module__}.{type(value).__qualname__}"
     if value_type == "pydantic.fields.FieldInfo":
         return {"kind": "repr", "type": value_type, "value": repr(value)}
     if isinstance(value, enum.Enum):
@@ -718,6 +724,27 @@ def _optional_dependency_for_binding_in_modules(
     return None
 
 
+def _optional_dependency_for_module_import(
+    contract: Mapping[str, Any], module_name: str
+) -> str | None:
+    modules = contract.get("required_submodule_exports", {})
+    module_contract = modules.get(module_name, {})
+    names = module_contract.get("names", [])
+    try:
+        optional_bindings = _optional_dependency_modules(
+            module_contract.get("optional_bindings", {}), field_name="optional_bindings"
+        )
+        optional_exports = _optional_dependency_modules(
+            module_contract.get("optional_exports", {}), field_name="optional_exports"
+        )
+    except ValueError:
+        return None
+    dependencies = {optional_bindings.get(name) or optional_exports.get(name) for name in names}
+    if names and len(dependencies) == 1 and None not in dependencies:
+        return cast(str, next(iter(dependencies)))
+    return None
+
+
 def _preserve_released_callable_for_promotion(
     contract: Mapping[str, Any],
     callables: dict[str, Any],
@@ -879,14 +906,7 @@ def build_released_api_contract(
             continue
         try:
             _signature(value)
-        except (TypeError, ValueError) as error:
-            _preserve_released_callable_for_promotion(
-                contract,
-                callables,
-                qualified_name,
-                fail_if_missing=is_new_canonical_import,
-                unavailable_reason=f"its signature cannot be inspected: {error!r}",
-            )
+        except (TypeError, ValueError):
             continue
         callables[qualified_name] = _callable_contract(value)
 
@@ -1265,6 +1285,13 @@ def validate_released_api_contract(
             imported_modules[module_name] = _import_contract_module(module_name, agents_module)
         except Exception as error:
             if _matches_platform_import_error(contract, module_name, error):
+                continue
+            optional_dependency = _optional_dependency_for_module_import(contract, module_name)
+            if optional_dependency is not None and not (
+                _optional_dependency_is_available_for_contract(
+                    optional_dependency, unsupported_platforms
+                )
+            ):
                 continue
             errors.append(f"Failed to import released module {module_name}: {error!r}")
 

--- a/src/agents/testing/model.py
+++ b/src/agents/testing/model.py
@@ -1196,3 +1196,17 @@ def _response_usage_for_usage(usage: Any) -> ResponseUsage:
             reasoning_tokens=getattr(usage.output_tokens_details, "reasoning_tokens", 0)
         ),
     )
+
+
+__all__ = [
+    "InvalidModelStep",
+    "ModelCall",
+    "ModelScriptError",
+    "ModelStep",
+    "ModelStepSpec",
+    "ScriptedModel",
+    "UnconsumedModelSteps",
+    "UnexpectedModelCall",
+    "assistant_message",
+    "function_call",
+]

--- a/src/agents/testing/sandbox.py
+++ b/src/agents/testing/sandbox.py
@@ -568,3 +568,15 @@ def scripted_sandbox_session(
     """
     normalized = [_normalize_step(step, index) for index, step in enumerate(steps)]
     return _ScriptedSandboxSession(normalized, manifest=manifest)
+
+
+__all__ = [
+    "InvalidSandboxStep",
+    "SandboxCall",
+    "SandboxCallMatcherError",
+    "SandboxScriptError",
+    "SandboxStepSpec",
+    "UnconsumedSandboxSteps",
+    "UnexpectedSandboxCall",
+    "scripted_sandbox_session",
+]

--- a/tests/fixtures/released_api_contract_policy.json
+++ b/tests/fixtures/released_api_contract_policy.json
@@ -7,6 +7,114 @@
       "name": "InputItem"
     },
     {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "InvalidModelStep",
+      "module": "agents.testing",
+      "name": "InvalidModelStep"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "ModelCall",
+      "module": "agents.testing",
+      "name": "ModelCall"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "ModelScriptError",
+      "module": "agents.testing",
+      "name": "ModelScriptError"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "ModelStep",
+      "module": "agents.testing",
+      "name": "ModelStep"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "ModelStepSpec",
+      "module": "agents.testing",
+      "name": "ModelStepSpec"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "ScriptedModel",
+      "module": "agents.testing",
+      "name": "ScriptedModel"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "UnconsumedModelSteps",
+      "module": "agents.testing",
+      "name": "UnconsumedModelSteps"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "UnexpectedModelCall",
+      "module": "agents.testing",
+      "name": "UnexpectedModelCall"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "assistant_message",
+      "module": "agents.testing",
+      "name": "assistant_message"
+    },
+    {
+      "canonical_module": "agents.testing.model",
+      "canonical_name": "function_call",
+      "module": "agents.testing",
+      "name": "function_call"
+    },
+    {
+      "canonical_module": "agents.testing.sandbox",
+      "canonical_name": "InvalidSandboxStep",
+      "module": "agents.testing",
+      "name": "InvalidSandboxStep"
+    },
+    {
+      "canonical_module": "agents.testing.sandbox",
+      "canonical_name": "SandboxCall",
+      "module": "agents.testing",
+      "name": "SandboxCall"
+    },
+    {
+      "canonical_module": "agents.testing.sandbox",
+      "canonical_name": "SandboxCallMatcherError",
+      "module": "agents.testing",
+      "name": "SandboxCallMatcherError"
+    },
+    {
+      "canonical_module": "agents.testing.sandbox",
+      "canonical_name": "SandboxScriptError",
+      "module": "agents.testing",
+      "name": "SandboxScriptError"
+    },
+    {
+      "canonical_module": "agents.testing.sandbox",
+      "canonical_name": "SandboxStepSpec",
+      "module": "agents.testing",
+      "name": "SandboxStepSpec"
+    },
+    {
+      "canonical_module": "agents.testing.sandbox",
+      "canonical_name": "UnconsumedSandboxSteps",
+      "module": "agents.testing",
+      "name": "UnconsumedSandboxSteps"
+    },
+    {
+      "canonical_module": "agents.testing.sandbox",
+      "canonical_name": "UnexpectedSandboxCall",
+      "module": "agents.testing",
+      "name": "UnexpectedSandboxCall"
+    },
+    {
+      "canonical_module": "agents.testing.sandbox",
+      "canonical_name": "scripted_sandbox_session",
+      "module": "agents.testing",
+      "name": "scripted_sandbox_session"
+    },
+    {
       "canonical_module": "agents.extensions.sandbox.modal",
       "canonical_name": "ModalCloudBucketMountStrategy",
       "module": "agents.extensions.sandbox",
@@ -101,6 +209,9 @@
     "modal": {
       "extra": "modal"
     },
+    "numpy": {
+      "extra": "voice"
+    },
     "pymongo": {
       "extra": "mongodb"
     },
@@ -170,6 +281,39 @@
         "VercelSandboxSession": "vercel",
         "VercelSandboxSessionState": "vercel"
       }
+    },
+    "agents.realtime.testing": {
+      "optional_bindings": {},
+      "optional_exports": {}
+    },
+    "agents.testing": {
+      "optional_bindings": {},
+      "optional_exports": {}
+    },
+    "agents.testing.model": {
+      "optional_bindings": {},
+      "optional_exports": {}
+    },
+    "agents.testing.sandbox": {
+      "optional_bindings": {},
+      "optional_exports": {}
+    },
+    "agents.voice.testing": {
+      "optional_bindings": {
+        "STTCall": "numpy",
+        "STTSessionCall": "numpy",
+        "ScriptedSTTModel": "numpy",
+        "ScriptedTTSModel": "numpy",
+        "ScriptedTranscriptionSession": "numpy",
+        "ScriptedVoiceWorkflow": "numpy",
+        "TTSCall": "numpy",
+        "TTSResult": "numpy",
+        "UnconsumedVoiceSteps": "numpy",
+        "UnexpectedVoiceCall": "numpy",
+        "VoiceScriptError": "numpy",
+        "pcm16_samples": "numpy"
+      },
+      "optional_exports": {}
     }
   },
   "public_properties": [

--- a/tests/test_released_api_contract.py
+++ b/tests/test_released_api_contract.py
@@ -1,3 +1,5 @@
+import builtins
+import importlib
 import json
 import subprocess
 import sys
@@ -1724,7 +1726,7 @@ def test_release_contract_policy_rejects_new_callable_on_unsupported_platform(
         )
 
 
-def test_release_contract_policy_rejects_new_callable_with_uninspectable_signature(
+def test_release_contract_policy_promotes_new_uninspectable_canonical_surface(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class UninspectableMeta(type):
@@ -1756,35 +1758,31 @@ def test_release_contract_policy_rejects_new_callable_with_uninspectable_signatu
         lambda module_name, _agents_module: modules[module_name],
     )
 
-    with pytest.raises(
-        ValueError,
-        match=(
-            r"Cannot promote new canonical callable agents\.submodule\.Uninspectable because "
-            r"its signature cannot be inspected.*release preparation host"
+    canonical_entry = {
+        "canonical_module": "agents.submodule.impl",
+        "canonical_name": "Uninspectable",
+        "module": "agents.submodule",
+        "name": "Uninspectable",
+    }
+
+    updated = build_released_api_contract(
+        contract,
+        baseline="v0.20.0",
+        baseline_commit="b" * 40,
+        agents_module=agents_module,
+        release_policy=_release_policy(
+            {
+                "agents.submodule": {
+                    "optional_bindings": {},
+                    "optional_exports": {},
+                }
+            },
+            canonical_imports=(canonical_entry,),
         ),
-    ):
-        build_released_api_contract(
-            contract,
-            baseline="v0.20.0",
-            baseline_commit="b" * 40,
-            agents_module=agents_module,
-            release_policy=_release_policy(
-                {
-                    "agents.submodule": {
-                        "optional_bindings": {},
-                        "optional_exports": {},
-                    }
-                },
-                canonical_imports=(
-                    {
-                        "canonical_module": "agents.submodule.impl",
-                        "canonical_name": "Uninspectable",
-                        "module": "agents.submodule",
-                        "name": "Uninspectable",
-                    },
-                ),
-            ),
-        )
+    )
+
+    assert updated["canonical_imports"] == [canonical_entry]
+    assert "agents.submodule.Uninspectable" not in updated["callables"]
 
 
 def test_release_contract_policy_keeps_existing_uninspectable_canonical_surface(
@@ -2285,7 +2283,7 @@ def test_repository_release_policy_declares_v020_contract_surfaces() -> None:
         for installation in policy.dependency_installations
         if installation.dependency_module == "vercel"
     ).unsupported_platforms == ("win32",)
-    assert {(entry["module"], entry["name"]) for entry in policy.canonical_imports} == {
+    assert {(entry["module"], entry["name"]) for entry in policy.canonical_imports} >= {
         ("agents.items", "InputItem"),
         ("agents.extensions.sandbox", "ModalCloudBucketMountStrategy"),
         ("agents.extensions.sandbox", "ModalSandboxClient"),
@@ -2328,6 +2326,91 @@ def test_repository_release_policy_declares_v020_contract_surfaces() -> None:
             "names": ["mount_authority_redacted", "mount_authority_rebound"],
         },
     )
+
+
+def test_repository_release_policy_declares_public_testing_modules() -> None:
+    policy = load_submodule_export_policy(CONTRACT.with_name("released_api_contract_policy.json"))
+    expected_modules = {
+        "agents.realtime.testing",
+        "agents.testing",
+        "agents.testing.model",
+        "agents.testing.sandbox",
+        "agents.voice.testing",
+    }
+
+    assert expected_modules <= policy.modules.keys()
+    assert policy.modules["agents.voice.testing"] == {
+        "optional_bindings": {
+            export: "numpy" for export in importlib.import_module("agents.voice.testing").__all__
+        },
+        "optional_exports": {},
+    }
+    assert (
+        next(
+            installation
+            for installation in policy.dependency_installations
+            if installation.dependency_module == "numpy"
+        ).extra
+        == "voice"
+    )
+    for module_name in expected_modules:
+        module = importlib.import_module(module_name)
+        assert module.__all__
+        assert all(type(export) is str for export in module.__all__)
+
+    expected_canonical_imports = {
+        ("agents.testing", name, "agents.testing.model", name)
+        for name in importlib.import_module("agents.testing.model").__all__
+    } | {
+        ("agents.testing", name, "agents.testing.sandbox", name)
+        for name in importlib.import_module("agents.testing.sandbox").__all__
+    }
+    actual_canonical_imports = {
+        (
+            entry["module"],
+            entry["name"],
+            entry["canonical_module"],
+            entry["canonical_name"],
+        )
+        for entry in policy.canonical_imports
+        if entry["module"] == "agents.testing"
+    }
+
+    assert actual_canonical_imports == expected_canonical_imports
+    for module_name, name, canonical_module_name, canonical_name in actual_canonical_imports:
+        module = importlib.import_module(module_name)
+        canonical_module = importlib.import_module(canonical_module_name)
+        assert getattr(module, name) is getattr(canonical_module, canonical_name)
+
+
+def test_voice_testing_start_sentinel_has_stable_contract_identity() -> None:
+    from agents.voice.testing import _START_NOT_CONFIGURED
+
+    assert _default_contract(_START_NOT_CONFIGURED) == {
+        "kind": "sentinel",
+        "identity": "agents.voice.testing._START_NOT_CONFIGURED",
+    }
+    with pytest.raises(TypeError, match="Unsupported public API default value: builtins.object"):
+        _default_contract(object())
+
+
+def test_default_contract_does_not_import_voice_testing_for_unrelated_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def guarded_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "agents.voice.testing":
+            raise AssertionError("Unrelated defaults must not import the optional Voice package.")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    assert _default_contract(()) == {
+        "kind": "sequence",
+        "type": "builtins.tuple",
+        "items": [],
+    }
 
 
 @pytest.mark.parametrize(
@@ -2418,6 +2501,37 @@ def test_public_api_contract_allows_declared_optional_submodule_binding(
             agents_module if module_name == "agents" else submodule
         ),
     )
+
+    assert validate_released_api_contract(contract, agents_module=agents_module) == []
+
+
+def test_public_api_contract_skips_fully_optional_unimportable_submodule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agents_module = SimpleNamespace(__all__=[])
+    contract: dict[str, Any] = {
+        "required_top_level_exports": [],
+        "public_modules": ["agents.optional_submodule"],
+        "required_submodule_exports": {
+            "agents.optional_submodule": {
+                "names": ["OptionalClient", "OptionalConfig"],
+                "optional_bindings": {
+                    "OptionalClient": "missing_optional_dependency",
+                    "OptionalConfig": "missing_optional_dependency",
+                },
+                "optional_exports": {},
+            }
+        },
+        "canonical_imports": [],
+        "callables": {},
+    }
+
+    def import_module(module_name: str, _agents_module: object) -> object:
+        if module_name == "agents":
+            return agents_module
+        raise ImportError("The optional dependency is unavailable.")
+
+    monkeypatch.setattr(contract_support, "_import_contract_module", import_module)
 
     assert validate_released_api_contract(contract, agents_module=agents_module) == []
 


### PR DESCRIPTION
This pull request fixes release-contract coverage for the public testing APIs planned for v0.21.0.

It adds the five public testing modules to the explicit release policy, defines the intended exports for the model and sandbox testing modules, and freezes their callable signatures. It also models Voice testing as dependent on the `voice` extra, allowing core installations to validate the contract without importing optional Voice dependencies.
