### PR TITLE
fix: strip non-null defaults from strict JSON schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -361,9 +361,8 @@ def _ensure_strict_json_schema(
                 for i, entry in enumerate(all_of)
             ]
 
-    # strip `None` defaults as there's no meaningful distinction here
-    # the schema will still be `nullable` and the model will default
-    # to using `None` anyway
+    # Strip `None` defaults before the `$ref` handling below so that a `$ref` whose only
+    # sibling is a `default: null` stays a pure `$ref` and is preserved instead of expanded.
     if json_schema.get("default", NOT_GIVEN) is None:
         json_schema.pop("default")
 
@@ -401,6 +400,14 @@ def _ensure_strict_json_schema(
 
     if budget.reject_open_objects and "$ref" in json_schema:
         raise UserError(_UNVALIDATED_REF_ERROR)
+
+    # Strip any remaining `default`, whatever its value: every property is forced into
+    # `required` above, so the model always emits an explicit value and a default never
+    # takes effect. The OpenAI API rejects strict schemas that carry a non-null `default`
+    # ("'default' is not permitted within a property definition"). This runs after the
+    # `$ref` handling so a `default` sibling still triggers the expansion above; the
+    # recursive pass then strips it from the expanded result.
+    json_schema.pop("default", None)
 
     return json_schema
 

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -501,7 +501,9 @@ def test_function_with_field_optional_with_default():
     optional_schema = properties.get("optional_param", {})
     assert optional_schema.get("type") == "number"
     assert optional_schema.get("minimum") == 0.0  # ge=0.0
-    assert optional_schema.get("default") == 5.0
+    # Strict mode strips "default" from the JSON schema; the runtime default
+    # below still applies.
+    assert "default" not in optional_schema
 
     # Valid input with default
     valid_input = {"required_param": "test"}
@@ -520,6 +522,36 @@ def test_function_with_field_optional_with_default():
     # Invalid input: negative value (should violate ge=0.0)
     with pytest.raises(ValidationError):
         fs.params_pydantic_model(**{"required_param": "test", "optional_param": -1.0})
+
+
+def test_strict_schema_strips_non_null_defaults():
+    """Non-null parameter defaults must not leak into a strict JSON schema.
+
+    The OpenAI API rejects strict schemas that carry a "default" key with
+    "'default' is not permitted within a property definition".
+    """
+
+    def func_with_non_null_default(query: str, limit: int = 10) -> str:
+        return f"{query}: {limit}"
+
+    fs = function_schema(func_with_non_null_default, use_docstring_info=False)
+
+    properties = fs.params_json_schema.get("properties", {})
+    assert "default" not in properties.get("limit", {})
+    # Every parameter is required in a strict schema.
+    assert fs.params_json_schema.get("required") == ["query", "limit"]
+
+    # The Python-level default still applies when the argument is omitted.
+    parsed = fs.params_pydantic_model(**{"query": "test"})
+    args, kwargs_dict = fs.to_call_args(parsed)
+    assert func_with_non_null_default(*args, **kwargs_dict) == "test: 10"
+
+    # Non-strict schemas keep the default annotation.
+    non_strict_fs = function_schema(
+        func_with_non_null_default, use_docstring_info=False, strict_json_schema=False
+    )
+    non_strict_properties = non_strict_fs.params_json_schema.get("properties", {})
+    assert non_strict_properties.get("limit", {}).get("default") == 10
 
 
 def test_function_uses_annotated_descriptions_without_docstring() -> None:
@@ -675,13 +707,15 @@ def test_function_with_field_multiple_constraints():
     assert name_schema.get("type") == "string"
     assert name_schema.get("minLength") == 1
     assert name_schema.get("maxLength") == 50
-    assert name_schema.get("default") == "Unknown"
+    # Strict mode strips "default" from the JSON schema; the runtime default
+    # below still applies.
+    assert "default" not in name_schema
 
     # Check factor field
     factor_schema = properties.get("factor", {})
     assert factor_schema.get("type") == "number"
     assert factor_schema.get("exclusiveMinimum") == 0.0
-    assert factor_schema.get("default") == 1.0
+    assert "default" not in factor_schema
     assert factor_schema.get("description") == "Positive multiplier"
 
     # Valid input with defaults
@@ -761,7 +795,9 @@ def test_function_with_annotated_field_optional_with_default():
     optional_schema = properties.get("optional_param", {})
     assert optional_schema.get("type") == "number"
     assert optional_schema.get("minimum") == 0.0  # ge=0.0
-    assert optional_schema.get("default") == 5.0
+    # Strict mode strips "default" from the JSON schema; the runtime default
+    # below still applies.
+    assert "default" not in optional_schema
 
     # Valid input with default
     valid_input = {"required_param": "test"}
@@ -854,13 +890,15 @@ def test_function_with_annotated_field_multiple_constraints():
     assert name_schema.get("type") == "string"
     assert name_schema.get("minLength") == 1
     assert name_schema.get("maxLength") == 50
-    assert name_schema.get("default") == "Unknown"
+    # Strict mode strips "default" from the JSON schema; the runtime default
+    # below still applies.
+    assert "default" not in name_schema
 
     # Check factor field
     factor_schema = properties.get("factor", {})
     assert factor_schema.get("type") == "number"
     assert factor_schema.get("exclusiveMinimum") == 0.0
-    assert factor_schema.get("default") == 1.0
+    assert "default" not in factor_schema
     assert factor_schema.get("description") == "Positive multiplier"
 
     # Valid input with defaults

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -709,6 +709,32 @@ def test_default_removal_on_non_object():
     assert "default" not in result
 
 
+def test_non_null_default_removal():
+    # Non-null defaults must be stripped as well: every property is forced into
+    # "required", so a default never takes effect, and the OpenAI API rejects
+    # strict schemas that carry one ("'default' is not permitted within a
+    # property definition").
+    schema = {
+        "type": "object",
+        "properties": {
+            "currency": {"type": "string", "enum": ["EUR", "USD"], "default": "EUR"},
+            "count": {"type": "integer", "default": 1},
+        },
+    }
+    result = ensure_strict_json_schema(schema)
+    assert "default" not in result["properties"]["currency"]
+    assert "default" not in result["properties"]["count"]
+    assert result["required"] == ["currency", "count"]
+
+
+def test_non_null_default_removal_on_non_object():
+    # Non-null defaults are stripped from non-object schemas as well.
+    schema = {"type": "string", "default": "fallback"}
+    result = ensure_strict_json_schema(schema)
+    assert result["type"] == "string"
+    assert "default" not in result
+
+
 def test_ref_expansion():
     # Construct a schema with a definitions section and a property with a $ref.
     schema = {
@@ -723,6 +749,31 @@ def test_ref_expansion():
     assert a_schema["type"] == "string"
     assert a_schema["description"] == "desc"
     assert "default" not in a_schema
+
+
+def test_ref_expansion_with_non_null_default():
+    # A $ref whose only extra sibling is a non-null default must still be
+    # expanded, and the default must not survive into the expanded schema.
+    schema = {
+        "$defs": {"currency": {"type": "string"}},
+        "type": "object",
+        "properties": {"a": {"$ref": "#/$defs/currency", "default": "EUR"}},
+    }
+    result = ensure_strict_json_schema(schema)
+    assert result["properties"]["a"] == {"type": "string"}
+
+
+def test_ref_expansion_with_non_null_default_when_rejecting_open_objects():
+    # The non-null default sibling still triggers ref expansion in
+    # _reject_open_objects mode instead of leaving behind a pure $ref, which
+    # that mode rejects.
+    schema = {
+        "$defs": {"currency": {"type": "string"}},
+        "type": "object",
+        "properties": {"a": {"$ref": "#/$defs/currency", "default": "EUR"}},
+    }
+    result = ensure_strict_json_schema(schema, _reject_open_objects=True)
+    assert result["properties"]["a"] == {"type": "string"}
 
 
 def test_ref_no_expansion_when_alone():


### PR DESCRIPTION
### Summary

`ensure_strict_json_schema()` only stripped a property's `default` when its value was exactly `None`. Any field with a non-null default (an enum, an `int`, a string, a `Decimal`, ...) kept its `default` key in the generated strict schema, and the OpenAI API then rejects the request at call time with `'default' is not permitted within a property definition`. This forced users to disable `strict_mode` for any tool whose Pydantic model has a field with a non-null default.

Strict conversion already forces every property into `required`, so the model must always emit an explicit value and a `default` can never take effect — it is dead weight in a strict schema regardless of its value. This change strips any remaining `default` unconditionally.

Implementation notes:

- The unconditional strip runs at the end of `_ensure_strict_json_schema`, after `$ref` handling. Stripping earlier (at the site of the old `is None` check) would reduce a `{"$ref": ..., "default": <non-null>}` node to a pure `$ref`, which would skip expansion and get rejected by `_reject_open_objects` mode. Placing it at the end keeps the `default` sibling as the expansion trigger, and the recursive pass strips it from the expanded result.
- The existing early strip of `default: None` is kept in place so a `$ref` whose only sibling is `default: null` continues to be preserved as a pure `$ref` instead of being expanded (unchanged behavior).
- Python-level runtime defaults are unaffected: omitted arguments are still filled in by the generated Pydantic model. Non-strict schemas (`strict_json_schema=False`) keep their `default` annotations.

### Test plan

- New tests in `tests/test_strict_schema.py`: non-null defaults are stripped from properties and non-object schemas, and a `$ref` with a non-null `default` sibling still expands, both in default mode and in `_reject_open_objects` mode.
- New test in `tests/test_function_schema.py` mirroring the issue repro: the strict schema carries no `default`, all parameters are required, the runtime default still applies when the argument is omitted, and a non-strict schema keeps the `default`.
- Updated the existing `test_function_schema.py` assertions that previously pinned the buggy behavior (non-null defaults surviving strict conversion into schemas the API rejects).
- All new and updated tests fail before the fix and pass after it.
- Ran the verification stack locally (`ruff format`, `ruff check`, optional-truthiness check, `mypy`, `pyright`, full parallel + serial pytest suites). Notes from this environment (Windows, commands run directly since `make` is unavailable): mypy/pyright report a handful of pre-existing errors only in untouched `src/agents/sandbox` modules (platform-specific tempfile typing), and the parallel suite has pre-existing local tracing/realtime failures — verified identical on a clean `main` checkout via stash-baseline diff. No check regressions are introduced by this change.

### Issue number

Closes #4390

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh` (ran the equivalent command stack directly on Windows; see test plan)
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

