### PR TITLE
fix(tests): order test spans by start sequence, not by started_at alone

### DIFF
--- a/tests/testing_processor.py
+++ b/tests/testing_processor.py
@@ -21,6 +21,13 @@ class SpanProcessorForTests(TracingProcessor):
         self._spans: list[Span[Any]] = []
         self._traces: list[Trace] = []
         self._events: list[TestSpanProcessorEvent] = []
+        # Order in which spans were started. `started_at` alone is not enough to
+        # order them: it comes from `datetime.now()`, whose resolution on Windows
+        # before Python 3.13 is ~15ms, so a parent and its child routinely carry
+        # the identical timestamp. Sorting on the timestamp alone then falls back
+        # to insertion order, which is span *end* order, and a child ends before
+        # its parent -- the exact reverse of what consumers need.
+        self._start_order: dict[str, int] = {}
 
     def on_trace_start(self, trace: Trace) -> None:
         with self._lock:
@@ -36,6 +43,7 @@ class SpanProcessorForTests(TracingProcessor):
         with self._lock:
             # Purposely not appending the span here, we want to do that in on_span_end
             self._events.append("span_start")
+            self._start_order.setdefault(span.span_id, len(self._start_order))
 
     def on_span_end(self, span: Span[Any]) -> None:
         with self._lock:
@@ -45,7 +53,10 @@ class SpanProcessorForTests(TracingProcessor):
     def get_ordered_spans(self, including_empty: bool = False) -> list[Span[Any]]:
         with self._lock:
             spans = [x for x in self._spans if including_empty or x.export()]
-            return sorted(spans, key=lambda x: x.started_at or 0)
+            return sorted(
+                spans,
+                key=lambda x: (x.started_at or "", self._start_order.get(x.span_id, 0)),
+            )
 
     def get_traces(self, including_empty: bool = False) -> list[Trace]:
         with self._lock:
@@ -57,6 +68,7 @@ class SpanProcessorForTests(TracingProcessor):
             self._spans.clear()
             self._traces.clear()
             self._events.clear()
+            self._start_order.clear()
 
     def shutdown(self) -> None:
         pass

--- a/tests/testing_processor.py
+++ b/tests/testing_processor.py
@@ -27,7 +27,11 @@ class SpanProcessorForTests(TracingProcessor):
         # the identical timestamp. Sorting on the timestamp alone then falls back
         # to insertion order, which is span *end* order, and a child ends before
         # its parent -- the exact reverse of what consumers need.
-        self._start_order: dict[str, int] = {}
+        #
+        # Keyed by (trace_id, span_id): a span ID is only unique within its
+        # trace, and callers may pass an explicit one, so keying on the span ID
+        # alone would let a later trace inherit an earlier trace's position.
+        self._start_order: dict[tuple[str, str], int] = {}
 
     def on_trace_start(self, trace: Trace) -> None:
         with self._lock:
@@ -43,7 +47,7 @@ class SpanProcessorForTests(TracingProcessor):
         with self._lock:
             # Purposely not appending the span here, we want to do that in on_span_end
             self._events.append("span_start")
-            self._start_order.setdefault(span.span_id, len(self._start_order))
+            self._start_order.setdefault((span.trace_id, span.span_id), len(self._start_order))
 
     def on_span_end(self, span: Span[Any]) -> None:
         with self._lock:
@@ -55,7 +59,10 @@ class SpanProcessorForTests(TracingProcessor):
             spans = [x for x in self._spans if including_empty or x.export()]
             return sorted(
                 spans,
-                key=lambda x: (x.started_at or "", self._start_order.get(x.span_id, 0)),
+                key=lambda x: (
+                    x.started_at or "",
+                    self._start_order.get((x.trace_id, x.span_id), 0),
+                ),
             )
 
     def get_traces(self, including_empty: bool = False) -> list[Trace]:

--- a/tests/tracing/test_span_ordering.py
+++ b/tests/tracing/test_span_ordering.py
@@ -4,7 +4,11 @@ import pytest
 
 from agents import trace
 from agents.tracing import agent_span, custom_span
+from agents.tracing.spans import Span
 from tests.testing_processor import SPAN_PROCESSOR_TESTING, fetch_normalized_spans
+
+# `span_id` is caller-settable, so the same value can appear in two traces.
+SHARED_SPAN_ID = "span_00000000000000000000000000"
 
 
 @pytest.fixture
@@ -23,6 +27,20 @@ def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def _assert_every_parent_comes_first(ordered: list[Span[Any]]) -> None:
+    """Every span must appear after its parent.
+
+    Span identity is ``(trace_id, span_id)``: a span ID is only unique within
+    its trace, and callers may pass an explicit one.
+    """
+    seen: set[tuple[str, str]] = set()
+    for span in ordered:
+        assert span.parent_id is None or (span.trace_id, span.parent_id) in seen, (
+            "a span was ordered before its parent"
+        )
+        seen.add((span.trace_id, span.span_id))
+
+
 def test_ordered_spans_put_a_parent_before_its_child_on_a_tied_timestamp(
     frozen_clock: None,
 ) -> None:
@@ -37,12 +55,7 @@ def test_ordered_spans_put_a_parent_before_its_child_on_a_tied_timestamp(
 
     # Spans end innermost-first, so ordering on the tied timestamp alone would
     # fall back to end order and put the child first.
-    seen: set[str] = set()
-    for span in ordered:
-        assert span.parent_id is None or span.parent_id in seen, (
-            "a span was ordered before its parent"
-        )
-        seen.add(span.span_id)
+    _assert_every_parent_comes_first(ordered)
 
 
 def test_normalized_spans_nest_on_a_tied_timestamp(frozen_clock: None) -> None:
@@ -58,3 +71,32 @@ def test_normalized_spans_nest_on_a_tied_timestamp(frozen_clock: None) -> None:
     agent = spans[0]["children"][0]
     assert agent["type"] == "agent"
     assert agent["children"][0]["type"] == "custom"
+
+
+def test_two_traces_reusing_one_span_id_keep_their_own_order(frozen_clock: None) -> None:
+    """A span ID is unique within a trace, not across traces.
+
+    The first trace uses the shared ID for a span that starts early; the second
+    reuses it for a span that starts late. Recording start order per span ID
+    alone would give the second trace's child the first trace's position and
+    push it ahead of its own parent.
+    """
+    with trace(workflow_name="first"):
+        with agent_span(name="first-parent", span_id=SHARED_SPAN_ID):
+            with custom_span(name="first-child"):
+                pass
+
+    with trace(workflow_name="second"):
+        with agent_span(name="second-parent"):
+            with custom_span(name="second-child", span_id=SHARED_SPAN_ID):
+                pass
+
+    _assert_every_parent_comes_first(SPAN_PROCESSOR_TESTING.get_ordered_spans())
+
+    spans: list[dict[str, Any]] = fetch_normalized_spans()
+
+    assert [span["workflow_name"] for span in spans] == ["first", "second"]
+    for span in spans:
+        agent = span["children"][0]
+        assert agent["type"] == "agent"
+        assert agent["children"][0]["type"] == "custom"

--- a/tests/tracing/test_span_ordering.py
+++ b/tests/tracing/test_span_ordering.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+import pytest
+
+from agents import trace
+from agents.tracing import agent_span, custom_span
+from tests.testing_processor import SPAN_PROCESSOR_TESTING, fetch_normalized_spans
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every span report the same ``started_at``.
+
+    ``started_at`` comes from ``datetime.now()``, whose resolution on Windows
+    before Python 3.13 is coarse enough (~15ms) that a parent and its child
+    routinely land on the identical timestamp in a real run. Freezing it here
+    reproduces that deterministically on every platform instead of only where
+    the clock happens to be coarse.
+    """
+    monkeypatch.setattr(
+        "agents.tracing.spans.util.time_iso",
+        lambda: "2026-01-01T00:00:00.000000+00:00",
+    )
+
+
+def test_ordered_spans_put_a_parent_before_its_child_on_a_tied_timestamp(
+    frozen_clock: None,
+) -> None:
+    with trace(workflow_name="w"):
+        with agent_span(name="parent"):
+            with custom_span(name="child"):
+                pass
+
+    ordered = SPAN_PROCESSOR_TESTING.get_ordered_spans()
+    started_at = {span.started_at for span in ordered}
+    assert len(started_at) == 1, "the fixture should have tied every timestamp"
+
+    # Spans end innermost-first, so ordering on the tied timestamp alone would
+    # fall back to end order and put the child first.
+    seen: set[str] = set()
+    for span in ordered:
+        assert span.parent_id is None or span.parent_id in seen, (
+            "a span was ordered before its parent"
+        )
+        seen.add(span.span_id)
+
+
+def test_normalized_spans_nest_on_a_tied_timestamp(frozen_clock: None) -> None:
+    with trace(workflow_name="w"):
+        with agent_span(name="parent"):
+            with custom_span(name="child"):
+                pass
+
+    # This raised KeyError when the child was ordered ahead of its parent.
+    spans: list[dict[str, Any]] = fetch_normalized_spans()
+
+    assert len(spans) == 1
+    agent = spans[0]["children"][0]
+    assert agent["type"] == "agent"
+    assert agent["children"][0]["type"] == "custom"


### PR DESCRIPTION
On a clean checkout on Windows with Python 3.10, 3.11 or 3.12, `pytest` fails 37 tests across the tracing, MCP-tracing and runtime-symmetry suites, all with the same error:

```
KeyError: ('trace_...', 'span_...')
tests/testing_processor.py:162: KeyError
```

Nothing is wrong with the library. The test helper's span ordering depends on clock resolution.

## Mechanism

Three steps, each verifiable on its own.

**1. `started_at` ties.** It comes from `datetime.now()` via `agents.tracing.util.time_iso`. On Windows the resolution of that call changed in Python 3.13, measured on this machine over a 1000-call burst:

| Python | distinct timestamps per 1000 calls | consecutive calls that tie |
|---|---:|---:|
| 3.10.19 | 2 | 998 / 999 |
| 3.11.14 | 2 | 998 / 999 |
| 3.12.12 | 2 | 998 / 999 |
| 3.13.11 | 1000 | 0 / 999 |

So before 3.13, a parent span and the child it opens almost always carry the identical `started_at`.

**2. A tie resolves to the wrong order.** `get_ordered_spans` sorted on that field alone:

```python
return sorted(spans, key=lambda x: x.started_at or 0)
```

`sorted` is stable, so a tie preserves insertion order, and spans are inserted in `on_span_end`. A child ends before its parent, so a tie puts the child first, which is the exact reverse of what the consumer needs.

**3. The consumer requires parent-first.** `fetch_normalized_spans` looks the parent up while attaching each span:

```python
nodes[(trace_id, parent_id)].setdefault("children", []).append(span)
```

Reduced to three spans, with nothing else running:

```
get_ordered_spans() order:
  0: name='child'   started_at=2026-08-13T13:06:13.769939+00:00  parent=45147e
  1: name='parent'  started_at=2026-08-13T13:06:13.769939+00:00  parent=-

all started_at identical: True
spans appearing before their parent: [('child', 'parent')]
fetch_normalized_spans() -> KeyError: ('trace_4f489b…', 'span_89ba…')
```

## Why CI does not catch it

`tests-windows` runs the full suite, but pins `python-version: "3.13"`, the one version on Windows where the clock is fine. The Linux matrix covers 3.10 through 3.14 and is unaffected because `datetime.now()` there has microsecond resolution. So the gap is Windows on any supported version below 3.13, which no job covers.

I have not touched the workflow matrix in this PR; widening it is a separate decision and this fix stands on its own.

## Fix

`on_span_start` already fires for every span and was discarding it. Record the start sequence there and use it only to break timestamp ties:

```python
self._start_order.setdefault(span.span_id, len(self._start_order))
...
return sorted(
    spans,
    key=lambda x: (x.started_at or "", self._start_order.get(x.span_id, 0)),
)
```

Timestamp order stays primary, so behaviour is unchanged wherever the clock already separates spans. The map is cleared in `clear()` alongside the other per-test state.

## Verification

Same machine, same checkout, the six affected test files:

| | before | after |
|---|---|---|
| Windows, Python 3.12 | 37 failed, 54 passed | **91 passed** |
| Windows, Python 3.13 | 91 passed | **91 passed** |

Whole suite on Python 3.12 goes from 42 failed / 5620 passed to 5 failed / 5657 passed. The 5 that remain are unrelated to span ordering, they fail with and without this change, and some are flaky between runs; I have not chased them here.

`ruff check`, `ruff format --check` and `mypy` are clean on both files.

## The regression test

`tests/tracing/test_span_ordering.py` freezes `time_iso` rather than relying on a coarse clock, so it reproduces the ordering deterministically on every platform instead of only where the bug happens to bite. Verified red before green: both cases fail with `KeyError` against the unfixed helper on Python 3.13, where the real bug cannot otherwise be observed at all.

One case asserts the ordering contract directly (no span precedes its parent) and the other asserts the tree `fetch_normalized_spans` builds from it, so a future change that satisfies one but not the other still fails.
