### PR TITLE
fix(run): align max-turns handler session finalization

### DIFF
--- a/src/agents/exceptions.py
+++ b/src/agents/exceptions.py
@@ -9,9 +9,10 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 if sys.version_info < (3, 11):
-    from exceptiongroup import BaseExceptionGroup
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 else:
     BaseExceptionGroup = builtins.BaseExceptionGroup
+    ExceptionGroup = builtins.ExceptionGroup
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -155,9 +156,17 @@ def _prepare_data_redacted_error(
     error: BaseException,
     *,
     trusted_error_message: str | None = None,
+    preserve_exception_groups: bool = False,
+    preserve_base_exceptions: bool = False,
 ) -> BaseException:
     """Detach payload-owned state and return a safe error for a public boundary."""
     error_type = type(error)
+    if preserve_exception_groups and issubclass(error_type, BaseExceptionGroup):
+        return _replace_data_redacted_exception_group(
+            cast(BaseExceptionGroup, error),
+            trusted_error_message=trusted_error_message,
+            preserve_base_exceptions=preserve_base_exceptions,
+        )
     process_control_error = _replace_data_redacted_process_control_error(error)
     if process_control_error is not None:
         return process_control_error
@@ -181,11 +190,48 @@ def _prepare_data_redacted_error(
         safe_error = UserError(safe_message)
     elif error_type is ValueError and safe_message is not None:
         safe_error = ValueError(safe_message)
+    elif preserve_base_exceptions and not issubclass(error_type, Exception):
+        safe_error = BaseException(_DATA_REDACTED_ERROR_MESSAGE)
     try:
         _mark_error_data_redacted(safe_error)
     except BaseException:
         pass
     return safe_error
+
+
+def _replace_data_redacted_exception_group(
+    error: BaseExceptionGroup,
+    *,
+    trusted_error_message: str | None,
+    preserve_base_exceptions: bool,
+) -> BaseExceptionGroup:
+    """Discard an exception group source and return a payload-free group replacement."""
+    group_exceptions = _base_exception_group_exceptions(error)
+    safe_exceptions = tuple(
+        _prepare_data_redacted_error(
+            child,
+            trusted_error_message=trusted_error_message,
+            preserve_exception_groups=True,
+            preserve_base_exceptions=preserve_base_exceptions,
+        )
+        for child in group_exceptions
+    )
+    _discard_exception_graph(error)
+    safe_group: BaseExceptionGroup
+    if isinstance(error, ExceptionGroup) and all(
+        isinstance(child, Exception) for child in safe_exceptions
+    ):
+        safe_group = ExceptionGroup(
+            _DATA_REDACTED_ERROR_MESSAGE,
+            cast(tuple[Exception, ...], safe_exceptions),
+        )
+    else:
+        safe_group = BaseExceptionGroup(_DATA_REDACTED_ERROR_MESSAGE, safe_exceptions)
+    try:
+        _mark_error_data_redacted(safe_group)
+    except BaseException:
+        pass
+    return safe_group
 
 
 def _replace_data_redacted_process_control_error(
@@ -223,6 +269,30 @@ def _replace_data_redacted_process_control_error(
     except BaseException:
         pass
     return safe_error
+
+
+def _base_exception_group_exceptions(error: BaseExceptionGroup) -> tuple[BaseException, ...]:
+    error_type = type(error)
+    try:
+        if sys.version_info < (3, 11):
+            group_state = _base_exception_instance_dict(error)
+            raw_group_exceptions = (
+                _exact_string_state_value(group_state, "_exceptions")
+                if group_state is not None
+                else None
+            )
+        else:
+            group_descriptor = type.__getattribute__(BaseExceptionGroup, "__dict__")["exceptions"]
+            raw_group_exceptions = group_descriptor.__get__(error, error_type)
+        if type(raw_group_exceptions) is tuple:
+            return tuple(
+                cast(BaseException, candidate)
+                for candidate in raw_group_exceptions
+                if issubclass(type(candidate), BaseException)
+            )
+        return ()
+    except BaseException:
+        return ()
 
 
 def _collect_nested_exceptions(value: object, linked: list[BaseException]) -> None:
@@ -268,30 +338,8 @@ def _discard_exception_graph(error: BaseException) -> None:
         group_exceptions: tuple[BaseException, ...] | None = None
         current_type = type(current)
         if issubclass(current_type, BaseExceptionGroup):
-            try:
-                if sys.version_info < (3, 11):
-                    group_state = _base_exception_instance_dict(current)
-                    raw_group_exceptions = (
-                        _exact_string_state_value(group_state, "_exceptions")
-                        if group_state is not None
-                        else None
-                    )
-                else:
-                    group_descriptor = type.__getattribute__(BaseExceptionGroup, "__dict__")[
-                        "exceptions"
-                    ]
-                    raw_group_exceptions = group_descriptor.__get__(current, current_type)
-                if type(raw_group_exceptions) is tuple:
-                    group_exceptions = tuple(
-                        cast(BaseException, candidate)
-                        for candidate in raw_group_exceptions
-                        if issubclass(type(candidate), BaseException)
-                    )
-                else:
-                    group_exceptions = ()
-                linked.extend(group_exceptions)
-            except BaseException:
-                pass
+            group_exceptions = _base_exception_group_exceptions(cast(BaseExceptionGroup, current))
+            linked.extend(group_exceptions)
         for descriptor in (
             cast(Any, BaseException.__cause__),
             cast(Any, BaseException.__context__),

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -80,10 +80,7 @@ from .run_internal.approvals import approvals_from_step
 from .run_internal.error_handlers import (
     attach_generic_agent_error,
     build_run_error_data,
-    create_message_output_item,
-    format_final_output_text,
     resolve_run_error_handler_result,
-    validate_handler_final_output,
 )
 from .run_internal.items import (
     copy_input_items,
@@ -96,11 +93,11 @@ from .run_internal.run_grouping import resolve_run_grouping_id
 from .run_internal.run_loop import (
     _retained_items_for_blocked_output,
     cleanup_models_after_run,
+    finalize_max_turns_handler_output,
     get_all_tools,
     get_output_schema,
     initialize_computer_tools,
     resolve_interrupted_turn,
-    run_final_output_hooks,
     run_input_guardrails,
     run_output_guardrails,
     run_single_turn,
@@ -285,7 +282,7 @@ class Runner:
         """
 
         runner = DEFAULT_AGENT_RUNNER
-        redacted_error: AgentsException | None = None
+        redacted_error: BaseException | None = None
         try:
             return await runner.run(
                 starting_agent,
@@ -300,7 +297,7 @@ class Runner:
                 conversation_id=conversation_id,
                 session=session,
             )
-        except AgentsException as error:
+        except BaseException as error:
             if not _is_error_data_redacted(error):
                 raise
             _detach_data_redacted_error_traceback(error)
@@ -388,7 +385,7 @@ class Runner:
         """
 
         runner = DEFAULT_AGENT_RUNNER
-        redacted_error: AgentsException | None = None
+        redacted_error: BaseException | None = None
         try:
             return runner.run_sync(
                 starting_agent,
@@ -403,7 +400,7 @@ class Runner:
                 session=session,
                 auto_previous_response_id=auto_previous_response_id,
             )
-        except AgentsException as error:
+        except BaseException as error:
             if not _is_error_data_redacted(error):
                 raise
             _detach_data_redacted_error_traceback(error)
@@ -1278,29 +1275,54 @@ class AgentRunner:
                         if handler_result is None:
                             raise max_turns_error
 
-                        validated_output = validate_handler_final_output(
-                            current_agent, handler_result.final_output
-                        )
-                        output_text = format_final_output_text(current_agent, validated_output)
-                        synthesized_item = create_message_output_item(current_agent, output_text)
                         include_in_history = handler_result.include_in_history
-                        if include_in_history:
+                        handler_output_recorded = False
+
+                        async def _save_items_after_max_turn_guardrails(
+                            items: list[RunItem],
+                            *,
+                            run_state=run_state,
+                            store_setting=store_setting,
+                            generated_items=generated_items,
+                            session_items=session_items,
+                            context_wrapper=context_wrapper,
+                        ) -> None:
+                            nonlocal handler_output_recorded
+                            await save_final_turn_items_after_guardrails(
+                                session=session,
+                                run_state=run_state,
+                                session_persistence_enabled=session_persistence_enabled,
+                                input_guardrail_results=_attempt_input_guardrail_results(),
+                                items=items,
+                                response_id=None,
+                                store=store_setting,
+                                wrapper=context_wrapper,
+                            )
+                            if items:
+                                generated_items.extend(items)
+                                session_items.extend(items)
+                                handler_output_recorded = True
+                                if run_state is not None:
+                                    run_state._generated_items = list(generated_items)
+                                    run_state._session_items = list(session_items)
+                                    run_state._clear_generated_items_last_processed_marker()
+
+                        (
+                            validated_output,
+                            synthesized_item,
+                        ) = await finalize_max_turns_handler_output(
+                            agent=current_agent,
+                            hooks=hooks,
+                            run_config=run_config,
+                            output=handler_result.final_output,
+                            context_wrapper=context_wrapper,
+                            output_guardrail_results=output_guardrail_results,
+                            save_items_after_guardrails=_save_items_after_max_turn_guardrails,
+                            include_in_history=include_in_history,
+                        )
+                        if include_in_history and not handler_output_recorded:
                             generated_items.append(synthesized_item)
                             session_items.append(synthesized_item)
-
-                        await run_final_output_hooks(
-                            current_agent,
-                            hooks,
-                            context_wrapper,
-                            validated_output,
-                        )
-                        await run_output_guardrails(
-                            current_agent.output_guardrails + (run_config.output_guardrails or []),
-                            current_agent,
-                            validated_output,
-                            context_wrapper,
-                            output_guardrail_results,
-                        )
                         current_step = getattr(run_state, "_current_step", None)
                         approvals_from_state = approvals_from_step(current_step)
                         result = RunResult(

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -6,7 +6,9 @@ approvals, and turn processing; all symbols here are internal and not part of th
 from __future__ import annotations
 
 import asyncio
+import builtins
 import dataclasses as _dc
+import sys
 from collections.abc import Awaitable, Callable
 from contextlib import aclosing
 from functools import partial
@@ -20,6 +22,11 @@ from openai.types.responses import (
 )
 from openai.types.responses.response_output_item import ResponseOutputItem
 from openai.types.responses.response_prompt_param import ResponsePromptParam
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+else:
+    BaseExceptionGroup = builtins.BaseExceptionGroup
 
 from .._tool_identity import (
     get_tool_trace_name_for_tool,
@@ -566,13 +573,7 @@ async def _finalize_streamed_final_output(
                 await save_items(items, response_id, store_setting)
                 if on_persisted_after_guardrails is not None:
                     on_persisted_after_guardrails(False)
-            except (
-                Exception,
-                asyncio.CancelledError,
-                SystemExit,
-                KeyboardInterrupt,
-                GeneratorExit,
-            ) as persistence_error:
+            except BaseException as persistence_error:
                 if guardrail_error_is_redacted:
                     safe_persistence_error = _safe_redacted_persistence_error(persistence_error)
                     if (
@@ -606,6 +607,11 @@ async def _finalize_streamed_final_output(
             raise
 
     if redacted_persistence_error is not None:
+        if not isinstance(redacted_persistence_error, Exception):
+            streamed_result._stored_exception = redacted_persistence_error
+            streamed_result.is_complete = True
+            streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+            return
         raise redacted_persistence_error from None
 
     streamed_result.output_guardrail_results = output_guardrail_results
@@ -634,10 +640,13 @@ async def _finalize_streamed_final_output(
 
 
 def _safe_redacted_persistence_error(error: BaseException) -> BaseException:
-    if isinstance(error, asyncio.CancelledError):
-        safe_error: BaseException = asyncio.CancelledError(_DATA_REDACTED_ERROR_MESSAGE)
-        _mark_error_data_redacted(safe_error)
-        return safe_error
+    if isinstance(error, BaseExceptionGroup):
+        return _prepare_data_redacted_error(
+            error,
+            trusted_error_message=_DATA_REDACTED_ERROR_MESSAGE,
+            preserve_exception_groups=True,
+            preserve_base_exceptions=True,
+        )
     if isinstance(error, Exception):
         safe_error = UserError(_DATA_REDACTED_ERROR_MESSAGE)
         _mark_error_data_redacted(safe_error)
@@ -645,6 +654,8 @@ def _safe_redacted_persistence_error(error: BaseException) -> BaseException:
     return _prepare_data_redacted_error(
         error,
         trusted_error_message=_DATA_REDACTED_ERROR_MESSAGE,
+        preserve_exception_groups=True,
+        preserve_base_exceptions=True,
     )
 
 
@@ -687,13 +698,7 @@ async def finalize_max_turns_handler_output(
             _detach_data_redacted_error_traceback(guardrail_error)
         try:
             await save_items_after_guardrails([synthesized_item] if include_in_history else [])
-        except (
-            Exception,
-            asyncio.CancelledError,
-            SystemExit,
-            KeyboardInterrupt,
-            GeneratorExit,
-        ) as persistence_error:
+        except BaseException as persistence_error:
             if not guardrail_error_is_redacted:
                 raise
             redacted_persistence_error = _safe_redacted_persistence_error(persistence_error)

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -40,7 +40,9 @@ from ..exceptions import (
     _detach_data_redacted_error_traceback,
     _is_error_data_redacted,
     _mark_error_data_redacted,
+    _prepare_data_redacted_error,
 )
+from ..guardrail import OutputGuardrailResult
 from ..handoffs import Handoff
 from ..items import (
     InputItem,
@@ -251,6 +253,7 @@ __all__ = [
     "get_model_tracing_impl",
     "validate_run_hooks",
     "cleanup_models_after_run",
+    "finalize_max_turns_handler_output",
     "maybe_filter_model_input",
     "run_input_guardrails_with_queue",
     "start_streaming",
@@ -522,6 +525,7 @@ async def _finalize_streamed_final_output(
     response_id: str | None,
     store_setting: bool | None,
     persist_before_output_guardrails: bool,
+    on_persisted_after_guardrails: Callable[[bool], None] | None = None,
 ) -> None:
     redacted_persistence_error: BaseException | None = None
     if persist_before_output_guardrails:
@@ -560,15 +564,17 @@ async def _finalize_streamed_final_output(
         if not persist_before_output_guardrails:
             try:
                 await save_items(items, response_id, store_setting)
-            except (Exception, asyncio.CancelledError) as persistence_error:
+                if on_persisted_after_guardrails is not None:
+                    on_persisted_after_guardrails(False)
+            except (
+                Exception,
+                asyncio.CancelledError,
+                SystemExit,
+                KeyboardInterrupt,
+                GeneratorExit,
+            ) as persistence_error:
                 if guardrail_error_is_redacted:
-                    if isinstance(persistence_error, asyncio.CancelledError):
-                        safe_persistence_error: BaseException = asyncio.CancelledError(
-                            _DATA_REDACTED_ERROR_MESSAGE
-                        )
-                    else:
-                        safe_persistence_error = UserError(_DATA_REDACTED_ERROR_MESSAGE)
-                    _mark_error_data_redacted(safe_persistence_error)
+                    safe_persistence_error = _safe_redacted_persistence_error(persistence_error)
                     if (
                         isinstance(safe_persistence_error, asyncio.CancelledError)
                         and streamed_result._cancel_mode != "immediate"
@@ -603,16 +609,134 @@ async def _finalize_streamed_final_output(
         raise redacted_persistence_error from None
 
     streamed_result.output_guardrail_results = output_guardrail_results
-    streamed_result.final_output = output
-    streamed_result.is_complete = True
 
     if not persist_before_output_guardrails:
         # Saved as one ordered batch so the session mirrors the model response. Doing it in two
         # halves would both reorder the turn and, because the first save advances the turn's
         # persisted-item count, make the second one a no-op.
-        await save_items(items, response_id, store_setting)
+        try:
+            await save_items(items, response_id, store_setting)
+        except asyncio.CancelledError as persistence_error:
+            if streamed_result._cancel_mode != "immediate":
+                streamed_result._stored_exception = persistence_error
+                streamed_result.is_complete = True
+                streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+                return
+            raise
 
+    streamed_result.final_output = output
+
+    if on_persisted_after_guardrails is not None:
+        on_persisted_after_guardrails(True)
+
+    streamed_result.is_complete = True
     streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+
+
+def _safe_redacted_persistence_error(error: BaseException) -> BaseException:
+    if isinstance(error, asyncio.CancelledError):
+        safe_error: BaseException = asyncio.CancelledError(_DATA_REDACTED_ERROR_MESSAGE)
+        _mark_error_data_redacted(safe_error)
+        return safe_error
+    if isinstance(error, Exception):
+        safe_error = UserError(_DATA_REDACTED_ERROR_MESSAGE)
+        _mark_error_data_redacted(safe_error)
+        return safe_error
+    return _prepare_data_redacted_error(
+        error,
+        trusted_error_message=_DATA_REDACTED_ERROR_MESSAGE,
+    )
+
+
+async def finalize_max_turns_handler_output(
+    *,
+    agent: Agent[TContext],
+    hooks: RunHooks[TContext],
+    run_config: RunConfig,
+    output: Any,
+    context_wrapper: RunContextWrapper[TContext],
+    output_guardrail_results: list[OutputGuardrailResult],
+    save_items_after_guardrails: Callable[[list[RunItem]], Awaitable[None]],
+    include_in_history: bool,
+) -> tuple[Any, RunItem]:
+    validated_output = validate_handler_final_output(agent, output)
+    output_text = format_final_output_text(agent, validated_output)
+    synthesized_item = create_message_output_item(agent, output_text)
+
+    await run_final_output_hooks(
+        agent,
+        hooks,
+        context_wrapper,
+        validated_output,
+    )
+
+    redacted_persistence_error: BaseException | None = None
+    try:
+        guardrail_results = await run_output_guardrails(
+            agent.output_guardrails + (run_config.output_guardrails or []),
+            agent,
+            validated_output,
+            context_wrapper,
+            output_guardrail_results,
+        )
+    except OutputGuardrailTripwireTriggered:
+        raise
+    except Exception as guardrail_error:
+        guardrail_error_is_redacted = _is_error_data_redacted(guardrail_error)
+        if guardrail_error_is_redacted:
+            _detach_data_redacted_error_traceback(guardrail_error)
+        try:
+            await save_items_after_guardrails([synthesized_item] if include_in_history else [])
+        except (
+            Exception,
+            asyncio.CancelledError,
+            SystemExit,
+            KeyboardInterrupt,
+            GeneratorExit,
+        ) as persistence_error:
+            if not guardrail_error_is_redacted:
+                raise
+            redacted_persistence_error = _safe_redacted_persistence_error(persistence_error)
+        if redacted_persistence_error is None:
+            raise
+
+    if redacted_persistence_error is not None:
+        raise redacted_persistence_error from None
+    output_guardrail_results[:] = guardrail_results
+    return validated_output, synthesized_item
+
+
+async def _persist_stream_input_if_needed(
+    *,
+    streamed_result: RunResultStreaming,
+    session: Session | None,
+    server_conversation_tracker: OpenAIServerConversationTracker | None,
+    context_wrapper: RunContextWrapper[TContext],
+) -> None:
+    if (
+        streamed_result._stream_input_persisted
+        or session is None
+        or server_conversation_tracker is not None
+        or streamed_result._original_input_for_persistence is None
+        or len(streamed_result._original_input_for_persistence) == 0
+    ):
+        return
+
+    input_items_to_save = [
+        ensure_input_item_format(item)
+        for item in ItemHelpers.input_to_new_input_list(
+            streamed_result._original_input_for_persistence
+        )
+    ]
+    if input_items_to_save:
+        await save_result_to_session(
+            session,
+            input_items_to_save,
+            [],
+            streamed_result._state,
+            wrapper=context_wrapper,
+        )
+    streamed_result._stream_input_persisted = True
 
 
 def _accumulate_tool_guardrail_results(
@@ -1280,48 +1404,65 @@ async def start_streaming(
                     streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
                     break
 
+                await _persist_stream_input_if_needed(
+                    streamed_result=streamed_result,
+                    session=session,
+                    server_conversation_tracker=server_conversation_tracker,
+                    context_wrapper=context_wrapper,
+                )
                 validated_output = validate_handler_final_output(
                     current_agent, handler_result.final_output
                 )
                 output_text = format_final_output_text(current_agent, validated_output)
                 synthesized_item = create_message_output_item(current_agent, output_text)
                 include_in_history = handler_result.include_in_history
+                store_setting = None
                 if include_in_history:
+                    store_setting = current_agent.model_settings.resolve(
+                        run_config.model_settings
+                    ).store
+
+                await run_final_output_hooks(
+                    current_agent, hooks, context_wrapper, validated_output
+                )
+
+                def _record_max_turns_handler_output(
+                    publish_events: bool,
+                    *,
+                    include_in_history=include_in_history,
+                    synthesized_item=synthesized_item,
+                ) -> None:
+                    if not include_in_history:
+                        return
                     streamed_result._model_input_items.append(synthesized_item)
                     streamed_result.new_items.append(synthesized_item)
                     if run_state is not None:
                         run_state._generated_items = list(streamed_result._model_input_items)
                         run_state._clear_generated_items_last_processed_marker()
                         run_state._session_items = list(streamed_result.new_items)
-                    stream_step_items_to_queue([synthesized_item], streamed_result._event_queue)
-                    store_setting = current_agent.model_settings.resolve(
-                        run_config.model_settings
-                    ).store
-                    if is_resumed_state:
-                        await _save_resumed_items([synthesized_item], None, store_setting)
-                    else:
-                        await _save_stream_items_with_count([synthesized_item], None, store_setting)
+                    if publish_events:
+                        stream_step_items_to_queue([synthesized_item], streamed_result._event_queue)
 
-                await run_final_output_hooks(
-                    current_agent, hooks, context_wrapper, validated_output
-                )
-                output_guardrail_results = await _run_output_guardrails_for_stream(
+                await _finalize_streamed_final_output(
+                    streamed_result=streamed_result,
                     agent=current_agent,
                     run_config=run_config,
                     output=validated_output,
                     context_wrapper=context_wrapper,
-                    streamed_result=streamed_result,
+                    save_items=(
+                        _save_resumed_items if is_resumed_state else _save_stream_items_with_count
+                    ),
+                    items=[synthesized_item] if include_in_history else [],
+                    response_id=None,
+                    store_setting=store_setting,
+                    persist_before_output_guardrails=False,
+                    on_persisted_after_guardrails=_record_max_turns_handler_output,
                 )
-                streamed_result.output_guardrail_results = output_guardrail_results
-                streamed_result.final_output = validated_output
-                streamed_result.is_complete = True
-                streamed_result._stored_exception = None
                 streamed_result._max_turns_handled = True
                 streamed_result.current_turn = max_turns
                 if run_state is not None:
                     run_state._current_turn = max_turns
                     run_state._current_step = None
-                streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
                 break
 
             if current_turn == 1:
@@ -1788,28 +1929,12 @@ async def run_single_turn_streamed(
         ),
     )
 
-    if (
-        not streamed_result._stream_input_persisted
-        and session is not None
-        and server_conversation_tracker is None
-        and streamed_result._original_input_for_persistence is not None
-        and len(streamed_result._original_input_for_persistence) > 0
-    ):
-        streamed_result._stream_input_persisted = True
-        input_items_to_save = [
-            ensure_input_item_format(item)
-            for item in ItemHelpers.input_to_new_input_list(
-                streamed_result._original_input_for_persistence
-            )
-        ]
-        if input_items_to_save:
-            await save_result_to_session(
-                session,
-                input_items_to_save,
-                [],
-                streamed_result._state,
-                wrapper=context_wrapper,
-            )
+    await _persist_stream_input_if_needed(
+        streamed_result=streamed_result,
+        session=session,
+        server_conversation_tracker=server_conversation_tracker,
+        context_wrapper=context_wrapper,
+    )
 
     previous_response_id = (
         server_conversation_tracker.previous_response_id

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -1553,6 +1553,98 @@ async def test_streamed_session_hostile_error_after_redacted_output_guardrail_is
     _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
 
 
+@pytest.mark.parametrize(
+    ("persistence_failure", "expected_error_type"),
+    [
+        ("error", UserError),
+        ("cancelled", asyncio.CancelledError),
+        ("system_exit", SystemExit),
+        ("keyboard_interrupt", KeyboardInterrupt),
+        ("generator_exit", GeneratorExit),
+    ],
+)
+@pytest.mark.asyncio
+async def test_non_streamed_max_turns_session_error_after_redacted_guardrail_is_replaced(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    persistence_failure: Literal[
+        "error",
+        "cancelled",
+        "system_exit",
+        "keyboard_interrupt",
+        "generator_exit",
+    ],
+    expected_error_type: type[BaseException],
+) -> None:
+    persistence_secret = "MAX_TURNS_SESSION_FAILURE_SECRET"
+    handler_output_secret = "MAX_TURNS_HANDLER_OUTPUT_SECRET"
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    guardrail_failed = False
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+
+    class FailingFinalTurnSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if guardrail_failed:
+                cause = RuntimeError(f"session save cause: {persistence_secret}")
+                if persistence_failure == "cancelled":
+                    raise asyncio.CancelledError(
+                        f"session save cancelled: {persistence_secret}"
+                    ) from cause
+                if persistence_failure == "system_exit":
+                    raise SystemExit(f"session save exited: {persistence_secret}") from cause
+                if persistence_failure == "keyboard_interrupt":
+                    raise KeyboardInterrupt(
+                        f"session save interrupted: {persistence_secret}"
+                    ) from cause
+                if persistence_failure == "generator_exit":
+                    raise GeneratorExit(f"session save closed: {persistence_secret}") from cause
+                raise LookupError(f"session save failed: {persistence_secret}") from cause
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _agent_output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        AgentOutputSchema(_RequiredOutput).validate_json(payload)
+        raise AssertionError("validation should fail")  # pragma: no cover
+
+    agent = Agent(
+        name="A",
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    caplog.set_level(logging.ERROR, logger="openai.agents")
+
+    with pytest.raises(expected_error_type) as exc_info:
+        await Runner.run(
+            agent,
+            "go",
+            max_turns=0,
+            session=FailingFinalTurnSession(),
+            error_handlers={"max_turns": lambda _data: handler_output_secret},
+        )
+
+    error = exc_info.value
+    if isinstance(error, UserError | RuntimeError | asyncio.CancelledError):
+        assert str(error) == "Error details are redacted."
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert persistence_secret not in str(error)
+    assert _MODEL_OUTPUT_SECRET not in str(error)
+    assert handler_output_secret not in str(error)
+    _assert_secret_absent_from_agents_traceback(error, persistence_secret)
+    _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
+    _assert_secret_absent_from_agents_traceback(error, handler_output_secret)
+    for record in caplog.records:
+        assert persistence_secret not in repr(record.__dict__)
+        assert _MODEL_OUTPUT_SECRET not in repr(record.__dict__)
+        assert handler_output_secret not in repr(record.__dict__)
+        assert record.exc_info is None
+
+
 @pytest.mark.asyncio
 async def test_streamed_input_guardrail_omits_run_data_from_redacted_error(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -9,9 +9,11 @@ statements honor ``_debug.DONT_LOG_MODEL_DATA`` / ``_debug.DONT_LOG_TOOL_DATA``.
 from __future__ import annotations
 
 import asyncio
+import builtins
 import json
 import logging
 import pickle
+import sys
 import threading
 import traceback
 import warnings
@@ -47,6 +49,7 @@ from agents import (
     trace,
 )
 from agents.agent_output import AgentOutputSchema
+from agents.exceptions import _is_error_data_redacted
 from agents.logger import (
     log_model_action_debug,
     log_model_action_error,
@@ -74,6 +77,12 @@ from agents.tracing.traces import Trace
 
 from .test_responses import get_function_tool_call, get_text_message
 from .utils.simple_session import SimpleListSession
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
+else:
+    BaseExceptionGroup = builtins.BaseExceptionGroup
+    ExceptionGroup = builtins.ExceptionGroup
 
 _SECRET = "super secret prompt content"
 
@@ -103,6 +112,10 @@ class _HostileException(Exception):
 class _HostileAttributeWriteException(Exception):
     def __setattr__(self, name: str, value: Any) -> None:
         raise RuntimeError("redacted handling mutated the handler exception")
+
+
+class _CustomBaseException(BaseException):
+    pass
 
 
 class _TruthinessException(Exception):
@@ -934,6 +947,46 @@ def _agents_traceback_frame_locals(error: BaseException) -> list[dict[str, Any]]
     return frame_locals
 
 
+def _exception_graph(error: BaseException) -> list[BaseException]:
+    errors: list[BaseException] = []
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        errors.append(current)
+        cause = current.__cause__
+        context = current.__context__
+        if cause is not None:
+            pending.append(cause)
+        if context is not None:
+            pending.append(context)
+        if isinstance(current, BaseExceptionGroup):
+            pending.extend(current.exceptions)
+    return errors
+
+
+def _assert_redacted_exception_graph_is_payload_free(
+    error: BaseException,
+    *secrets: str,
+) -> None:
+    graph = _exception_graph(error)
+    assert graph
+    for graph_error in graph:
+        assert _is_error_data_redacted(graph_error)
+        assert graph_error.__cause__ is None
+        assert graph_error.__context__ is None
+        for secret in secrets:
+            assert secret not in str(graph_error)
+            _assert_secret_absent_from_agents_traceback(
+                graph_error,
+                secret,
+                require_agents_frames=False,
+            )
+
+
 def _assert_handoff_closure_absent_from_traceback(
     error: BaseException,
     *,
@@ -1471,7 +1524,8 @@ async def test_streamed_session_error_after_output_guardrail_respects_redaction(
         else "session save failed"
     )
 
-    with pytest.raises(expected_error_type, match=expected_message) as exc_info:
+    expected_match = None if redacted and persistence_failure == "cancelled" else expected_message
+    with pytest.raises(expected_error_type, match=expected_match) as exc_info:
         async for _ in result.stream_events():
             pass
 
@@ -1482,7 +1536,7 @@ async def test_streamed_session_error_after_output_guardrail_respects_redaction(
         assert guardrail_error is None
         assert error.__cause__ is None
         assert _MODEL_OUTPUT_SECRET not in str(error)
-        _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
+        _assert_redacted_exception_graph_is_payload_free(error, _MODEL_OUTPUT_SECRET)
         for record in caplog.records:
             assert _MODEL_OUTPUT_SECRET not in repr(record.__dict__)
             assert _MODEL_OUTPUT_SECRET not in logging.Formatter().format(record)
@@ -1553,6 +1607,7 @@ async def test_streamed_session_hostile_error_after_redacted_output_guardrail_is
     _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
 
 
+@pytest.mark.parametrize("streamed", [False, True])
 @pytest.mark.parametrize(
     ("persistence_failure", "expected_error_type"),
     [
@@ -1561,18 +1616,25 @@ async def test_streamed_session_hostile_error_after_redacted_output_guardrail_is
         ("system_exit", SystemExit),
         ("keyboard_interrupt", KeyboardInterrupt),
         ("generator_exit", GeneratorExit),
+        ("base_exception", BaseException),
+        ("exception_group", ExceptionGroup),
+        ("base_exception_group", BaseExceptionGroup),
     ],
 )
 @pytest.mark.asyncio
-async def test_non_streamed_max_turns_session_error_after_redacted_guardrail_is_replaced(
+async def test_max_turns_session_error_after_redacted_guardrail_is_replaced(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    streamed: bool,
     persistence_failure: Literal[
         "error",
         "cancelled",
         "system_exit",
         "keyboard_interrupt",
         "generator_exit",
+        "base_exception",
+        "exception_group",
+        "base_exception_group",
     ],
     expected_error_type: type[BaseException],
 ) -> None:
@@ -1599,6 +1661,26 @@ async def test_non_streamed_max_turns_session_error_after_redacted_guardrail_is_
                     ) from cause
                 if persistence_failure == "generator_exit":
                     raise GeneratorExit(f"session save closed: {persistence_secret}") from cause
+                if persistence_failure == "base_exception":
+                    raise _CustomBaseException(
+                        f"session save base exception: {persistence_secret}"
+                    ) from cause
+                if persistence_failure == "exception_group":
+                    raise ExceptionGroup(
+                        f"session save exception group: {persistence_secret}",
+                        [LookupError(f"session save failed: {persistence_secret}")],
+                    ) from cause
+                if persistence_failure == "base_exception_group":
+                    raise BaseExceptionGroup(
+                        f"session save base exception group: {persistence_secret}",
+                        [
+                            LookupError(f"session save failed: {persistence_secret}"),
+                            SystemExit(f"session save exited: {persistence_secret}"),
+                            _CustomBaseException(
+                                f"session save base exception: {persistence_secret}"
+                            ),
+                        ],
+                    ) from cause
                 raise LookupError(f"session save failed: {persistence_secret}") from cause
             await super().add_items(items)
 
@@ -1618,26 +1700,39 @@ async def test_non_streamed_max_turns_session_error_after_redacted_guardrail_is_
     )
     caplog.set_level(logging.ERROR, logger="openai.agents")
 
-    with pytest.raises(expected_error_type) as exc_info:
-        await Runner.run(
+    if streamed:
+        result = Runner.run_streamed(
             agent,
             "go",
             max_turns=0,
             session=FailingFinalTurnSession(),
             error_handlers={"max_turns": lambda _data: handler_output_secret},
         )
+        with pytest.raises(expected_error_type) as exc_info:
+            async for _ in result.stream_events():
+                pass
+    else:
+        with pytest.raises(expected_error_type) as exc_info:
+            await Runner.run(
+                agent,
+                "go",
+                max_turns=0,
+                session=FailingFinalTurnSession(),
+                error_handlers={"max_turns": lambda _data: handler_output_secret},
+            )
 
     error = exc_info.value
-    if isinstance(error, UserError | RuntimeError | asyncio.CancelledError):
+    if isinstance(error, UserError | RuntimeError):
         assert str(error) == "Error details are redacted."
-    assert error.__cause__ is None
-    assert error.__context__ is None
     assert persistence_secret not in str(error)
     assert _MODEL_OUTPUT_SECRET not in str(error)
     assert handler_output_secret not in str(error)
-    _assert_secret_absent_from_agents_traceback(error, persistence_secret)
-    _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
-    _assert_secret_absent_from_agents_traceback(error, handler_output_secret)
+    _assert_redacted_exception_graph_is_payload_free(
+        error,
+        persistence_secret,
+        _MODEL_OUTPUT_SECRET,
+        handler_output_secret,
+    )
     for record in caplog.records:
         assert persistence_secret not in repr(record.__dict__)
         assert _MODEL_OUTPUT_SECRET not in repr(record.__dict__)

--- a/tests/test_max_turns.py
+++ b/tests/test_max_turns.py
@@ -667,9 +667,7 @@ async def test_streamed_max_turns_session_save_failure_does_not_expose_output(
             pass
 
     expected_error = asyncio.CancelledError if failure_type == "cancel" else RuntimeError
-    expected_message = (
-        "session save cancelled" if failure_type == "cancel" else "session save failed"
-    )
+    expected_message = None if failure_type == "cancel" else "session save failed"
     with pytest.raises(expected_error, match=expected_message):
         await asyncio.wait_for(consume_stream(), timeout=1)
 

--- a/tests/test_max_turns.py
+++ b/tests/test_max_turns.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -8,11 +9,16 @@ from typing_extensions import TypedDict
 
 from agents import (
     Agent,
+    GuardrailFunctionOutput,
     ItemHelpers,
     MaxTurnsExceeded,
     MessageOutputItem,
     ModelRefusalError,
+    ModelSettings,
+    OutputGuardrail,
+    OutputGuardrailTripwireTriggered,
     RunErrorHandlerResult,
+    RunHooks,
     Runner,
     SQLiteSession,
     UserError,
@@ -26,6 +32,168 @@ from .test_responses import (
     get_refusal_message,
     get_text_message,
 )
+from .utils.simple_session import SimpleListSession
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("tripwire", [False, True], ids=["error", "tripwire"])
+async def test_max_turns_handler_output_follows_output_guardrail_session_semantics(
+    streamed: bool,
+    tripwire: bool,
+) -> None:
+    def check_handler_output(_context, _agent, _output):
+        if tripwire:
+            return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+        raise RuntimeError("output check failed")
+
+    model = ScriptedModel(
+        steps=[[get_function_tool_call("some_function", json.dumps({"a": "b"}), "call-1")]]
+    )
+    session = SimpleListSession(session_id=f"max-turns-{streamed}-{tripwire}")
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+        output_guardrails=[OutputGuardrail(guardrail_function=check_handler_output)],
+    )
+    expected_error = OutputGuardrailTripwireTriggered if tripwire else RuntimeError
+    result = None
+
+    with pytest.raises(expected_error):
+        if streamed:
+            result = Runner.run_streamed(
+                agent,
+                input="user_message",
+                max_turns=1,
+                session=session,
+                error_handlers={"max_turns": lambda _data: "handler output"},
+            )
+            async for _ in result.stream_events():
+                pass
+        else:
+            await Runner.run(
+                agent,
+                input="user_message",
+                max_turns=1,
+                session=session,
+                error_handlers={"max_turns": lambda _data: "handler output"},
+            )
+
+    if streamed and not tripwire:
+        assert result is not None
+        state = result.to_state()
+        assert ItemHelpers.text_message_outputs(state._generated_items).endswith("handler output")
+        assert ItemHelpers.text_message_outputs(state._session_items).endswith("handler output")
+
+    saved_items = await session.get_items()
+    saved_types = [
+        item.get("type") or item.get("role") for item in saved_items if isinstance(item, dict)
+    ]
+    expected_types = ["user"]
+    expected_types.extend(["function_call", "function_call_output"])
+    if not tripwire:
+        expected_types.append("message")
+    assert saved_types == expected_types
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure_point",
+    ["validation", "hook", "guardrail"],
+)
+async def test_streamed_zero_turn_persists_input_before_terminal_callbacks(
+    failure_point: str,
+) -> None:
+    session = SimpleListSession(session_id=f"zero-turn-streamed-{failure_point}")
+
+    def check_handler_output(_context, _agent, _output):
+        if failure_point == "guardrail":
+            return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=False)
+
+    class FailingFinalOutputHook(RunHooks):
+        async def on_agent_end(self, _context, _agent, _output):
+            if failure_point == "hook":
+                raise RuntimeError("final output hook failed")
+
+    agent = Agent(
+        name="test",
+        output_type=FooModel if failure_point == "validation" else None,
+        output_guardrails=[OutputGuardrail(guardrail_function=check_handler_output)],
+    )
+    expected_error = (
+        UserError
+        if failure_point == "validation"
+        else RuntimeError
+        if failure_point == "hook"
+        else OutputGuardrailTripwireTriggered
+    )
+
+    result = Runner.run_streamed(
+        agent,
+        input="user_message",
+        max_turns=0,
+        session=session,
+        hooks=FailingFinalOutputHook(),
+        error_handlers={
+            "max_turns": lambda _data: (
+                {"summary": 1} if failure_point == "validation" else "handler output"
+            )
+        },
+    )
+    if failure_point == "validation":
+        with pytest.warns(UserWarning, match="Pydantic serializer warnings"):
+            with pytest.raises(expected_error):
+                async for _ in result.stream_events():
+                    pass
+    else:
+        with pytest.raises(expected_error):
+            async for _ in result.stream_events():
+                pass
+
+    saved_items = await session.get_items()
+    assert [item.get("role") for item in saved_items] == ["user"]
+    assert all("handler output" not in json.dumps(item) for item in saved_items)
+    assert all("summary" not in json.dumps(item) for item in saved_items)
+
+
+@pytest.mark.asyncio
+async def test_streamed_zero_turn_tripwire_does_not_emit_handler_output() -> None:
+    session = SimpleListSession(session_id="zero-turn-streamed-tripwire-events")
+
+    def check_handler_output(_context, _agent, _output):
+        return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+
+    agent = Agent(
+        name="test",
+        output_guardrails=[OutputGuardrail(guardrail_function=check_handler_output)],
+    )
+
+    result = Runner.run_streamed(
+        agent,
+        input="user_message",
+        max_turns=0,
+        session=session,
+        error_handlers={"max_turns": lambda _data: "handler output"},
+    )
+    events = []
+    with pytest.raises(OutputGuardrailTripwireTriggered):
+        async for event in result.stream_events():
+            events.append(event)
+
+    run_item_events = [event for event in events if isinstance(event, RunItemStreamEvent)]
+    assert all(
+        not (
+            event.name == "message_output_created"
+            and isinstance(event.item, MessageOutputItem)
+            and ItemHelpers.text_message_output(event.item) == "handler output"
+        )
+        for event in run_item_events
+    )
+    saved_items = await session.get_items()
+    assert [item.get("role") for item in saved_items] == ["user"]
+    assert all("handler output" not in json.dumps(item) for item in saved_items)
 
 
 @pytest.mark.asyncio
@@ -384,6 +552,28 @@ async def test_non_streamed_max_turns_handler_skip_history():
 
 
 @pytest.mark.asyncio
+async def test_streamed_max_turns_handler_skip_history():
+    agent = Agent(name="test_1", model=ScriptedModel())
+
+    result = Runner.run_streamed(
+        agent,
+        input="user_message",
+        max_turns=0,
+        error_handlers={
+            "max_turns": lambda data: RunErrorHandlerResult(
+                final_output="summary",
+                include_in_history=False,
+            ),
+        },
+    )
+    async for _ in result.stream_events():
+        pass
+
+    assert result.final_output == "summary"
+    assert result.new_items == []
+
+
+@pytest.mark.asyncio
 async def test_non_streamed_max_turns_handler_raw_output():
     model = ScriptedModel()
     agent = Agent(name="test_1", model=model)
@@ -435,6 +625,59 @@ async def test_streamed_max_turns_handler_returns_output():
     assert run_item_events[0].name == "message_output_created"
     assert isinstance(run_item_events[0].item, MessageOutputItem)
     assert ItemHelpers.text_message_output(run_item_events[0].item) == "summary"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_type", ["error", "cancel"])
+async def test_streamed_max_turns_session_save_failure_does_not_expose_output(
+    failure_type: str,
+) -> None:
+    class FailingFinalTurnSession(SimpleListSession):
+        async def add_items(self, items):
+            if "summary" in json.dumps(items):
+                if failure_type == "cancel":
+                    raise asyncio.CancelledError("session save cancelled")
+                raise RuntimeError("session save failed")
+            await super().add_items(items)
+
+    def check_handler_output(_context, _agent, _output):
+        return GuardrailFunctionOutput(output_info="checked", tripwire_triggered=False)
+
+    model = ScriptedModel()
+    agent = Agent(
+        name="test_1",
+        model=model,
+        model_settings=ModelSettings(store=True),
+        output_guardrails=[OutputGuardrail(guardrail_function=check_handler_output)],
+    )
+    session = FailingFinalTurnSession(session_id=f"max-turns-failed-final-save-{failure_type}")
+
+    result = Runner.run_streamed(
+        agent,
+        input="user_message",
+        max_turns=0,
+        session=session,
+        error_handlers={
+            "max_turns": lambda data: RunErrorHandlerResult(final_output="summary"),
+        },
+    )
+
+    async def consume_stream() -> None:
+        async for _ in result.stream_events():
+            pass
+
+    expected_error = asyncio.CancelledError if failure_type == "cancel" else RuntimeError
+    expected_message = (
+        "session save cancelled" if failure_type == "cancel" else "session save failed"
+    )
+    with pytest.raises(expected_error, match=expected_message):
+        await asyncio.wait_for(consume_stream(), timeout=1)
+
+    assert result.is_complete is True
+    assert result.final_output is None
+    assert len(result.output_guardrail_results) == 1
+    assert result.output_guardrail_results[0].output.output_info == "checked"
+    assert await session.get_items() == [{"content": "user_message", "role": "user"}]
 
 
 @pytest.mark.asyncio
@@ -537,6 +780,29 @@ async def test_non_streamed_max_turns_handler_persists_output_to_session():
     item_types = await _run_max_turns_handler_with_session(streamed=False)
 
     assert item_types == ["user", "function_call", "function_call_output", "message"]
+
+
+@pytest.mark.asyncio
+async def test_non_streamed_max_turns_handler_records_equal_output_occurrence():
+    model = ScriptedModel()
+    agent = Agent(
+        name="test_1",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+    )
+    model.extend(
+        [[get_text_message("summary"), get_function_tool_call("some_function", json.dumps({}))]]
+    )
+
+    result = await Runner.run(
+        agent,
+        input="user_message",
+        max_turns=1,
+        error_handlers={"max_turns": lambda data: "summary"},
+    )
+
+    assert result.final_output == "summary"
+    assert ItemHelpers.text_message_outputs(result.new_items) == "summarysummary"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

This pull request aligns `max_turns` error-handler output with the existing final-output guardrail and session persistence pipeline.

The dedicated `max_turns` branches previously finalized their synthesized output in different orders. Non-streamed runs omitted the handler message when an output guardrail raised an ordinary exception, while streamed runs persisted the message before guardrails and therefore retained it even when a tripwire rejected it.

The change reuses the existing final-turn helpers so both runner modes follow the documented behavior:

- tripwires exclude the rejected handler message while retaining input and completed tool records;
- ordinary output guardrail exceptions preserve the completed handler message;
- passing output guardrails keep the existing behavior.

The recovery path now preserves error-data redaction if that recovery session write fails. For redacted recovery boundaries, arbitrary `BaseException`, `ExceptionGroup`, and `BaseExceptionGroup` failures are replaced with payload-free errors while preserving process-control and group semantics. The default shared redaction behavior remains unchanged unless a caller explicitly opts into preserving group/base-exception semantics.

Streamed max-turn handler output is published only after terminal hooks, output guardrails, and session persistence succeed, so rejected handler output is not exposed through stream events. If the final streamed session write fails or is cancelled, the stream is completed and surfaces that persistence failure instead of hanging or exposing a partial final output, while preserving completed output guardrail results. No public API or wire format changes are introduced. The existing guardrail documentation already describes the intended behavior, so no documentation update is required.

### Test plan

- Added focused regression coverage for non-streamed and streamed `max_turns` terminal finalization, including tripwires, ordinary guardrail errors, redacted persistence failures, zero-turn input persistence, stream-event exposure, equal handler-output occurrences, and failure/cancellation during final streamed session persistence.
- Added redaction coverage for arbitrary `BaseException`, `ExceptionGroup`, and `BaseExceptionGroup` recovery persistence failures, including complete exception graphs, traceback frames, and log records.
- `uv run --frozen pytest tests/test_error_logging_redaction.py tests/test_max_turns.py tests/test_run_state_compatibility_corpus.py tests/test_run_step_execution.py -q` (`388 passed, 1 skipped`)
- `env NO_PROXY='*' no_proxy='*' ALL_PROXY='' all_proxy='' HTTP_PROXY='' http_proxy='' HTTPS_PROXY='' https_proxy='' UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`
  - format passed
  - lint passed
  - typecheck passed
  - full test suite passed

### Issue number

Closes #4393

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
