### PR TITLE
fix: remove defaults from strict JSON schemas

### DIFF
--- a/.agents/references/function-and-output-schema.md
+++ b/.agents/references/function-and-output-schema.md
@@ -16,7 +16,7 @@ Schema behavior is a compatibility boundary shared by Python callables, Pydantic
 
 - Strict conversion closes object schemas with `additionalProperties: false` and marks their declared properties required. Reject an explicit `additionalProperties: true` instead of silently changing its meaning.
 - Preserve the meaning of unions, intersections, definitions, and references. Normalize `oneOf` where required, process `allOf`, retain chained references, and merge a referenced schema with sibling keys without discarding the siblings.
-- Remove defaults that only encode Python `None`; a nullable type must remain represented by its type schema rather than by an unsupported default.
+- Remove every `default` annotation from strict schemas while preserving Python runtime defaults and non-strict schemas; a nullable type must remain represented by its type schema rather than by an unsupported default.
 - `ensure_strict_json_schema()` may mutate a non-empty input dictionary. Copy caller-owned schemas at public boundaries before conversion. Empty-schema conversion must return a fresh object rather than shared mutable state.
 - Keep strictness explicit. If a tool or output schema opts out of strict mode, preserve that choice through provider conversion instead of partially applying strict normalization.
 

--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -361,9 +361,8 @@ def _ensure_strict_json_schema(
                 for i, entry in enumerate(all_of)
             ]
 
-    # strip `None` defaults as there's no meaningful distinction here
-    # the schema will still be `nullable` and the model will default
-    # to using `None` anyway
+    # Remove `None` defaults before reference handling, preserving the existing behavior
+    # where a `$ref` with no remaining siblings stays a reference.
     if json_schema.get("default", NOT_GIVEN) is None:
         json_schema.pop("default")
 
@@ -401,6 +400,10 @@ def _ensure_strict_json_schema(
 
     if budget.reject_open_objects and "$ref" in json_schema:
         raise UserError(_UNVALIDATED_REF_ERROR)
+
+    # Defaults are not supported in strict schemas. Non-null defaults must be removed
+    # after `$ref` expansion so they do not suppress validation of the referenced schema.
+    json_schema.pop("default", None)
 
     return json_schema
 

--- a/tests/test_function_schema.py
+++ b/tests/test_function_schema.py
@@ -501,7 +501,7 @@ def test_function_with_field_optional_with_default():
     optional_schema = properties.get("optional_param", {})
     assert optional_schema.get("type") == "number"
     assert optional_schema.get("minimum") == 0.0  # ge=0.0
-    assert optional_schema.get("default") == 5.0
+    assert "default" not in optional_schema
 
     # Valid input with default
     valid_input = {"required_param": "test"}
@@ -520,6 +520,19 @@ def test_function_with_field_optional_with_default():
     # Invalid input: negative value (should violate ge=0.0)
     with pytest.raises(ValidationError):
         fs.params_pydantic_model(**{"required_param": "test", "optional_param": -1.0})
+
+
+def test_non_strict_function_schema_preserves_default():
+    def func_with_default(value: int = 5) -> int:
+        return value
+
+    fs = function_schema(
+        func_with_default,
+        use_docstring_info=False,
+        strict_json_schema=False,
+    )
+
+    assert fs.params_json_schema["properties"]["value"]["default"] == 5
 
 
 def test_function_uses_annotated_descriptions_without_docstring() -> None:
@@ -675,13 +688,13 @@ def test_function_with_field_multiple_constraints():
     assert name_schema.get("type") == "string"
     assert name_schema.get("minLength") == 1
     assert name_schema.get("maxLength") == 50
-    assert name_schema.get("default") == "Unknown"
+    assert "default" not in name_schema
 
     # Check factor field
     factor_schema = properties.get("factor", {})
     assert factor_schema.get("type") == "number"
     assert factor_schema.get("exclusiveMinimum") == 0.0
-    assert factor_schema.get("default") == 1.0
+    assert "default" not in factor_schema
     assert factor_schema.get("description") == "Positive multiplier"
 
     # Valid input with defaults
@@ -761,7 +774,7 @@ def test_function_with_annotated_field_optional_with_default():
     optional_schema = properties.get("optional_param", {})
     assert optional_schema.get("type") == "number"
     assert optional_schema.get("minimum") == 0.0  # ge=0.0
-    assert optional_schema.get("default") == 5.0
+    assert "default" not in optional_schema
 
     # Valid input with default
     valid_input = {"required_param": "test"}
@@ -854,13 +867,13 @@ def test_function_with_annotated_field_multiple_constraints():
     assert name_schema.get("type") == "string"
     assert name_schema.get("minLength") == 1
     assert name_schema.get("maxLength") == 50
-    assert name_schema.get("default") == "Unknown"
+    assert "default" not in name_schema
 
     # Check factor field
     factor_schema = properties.get("factor", {})
     assert factor_schema.get("type") == "number"
     assert factor_schema.get("exclusiveMinimum") == 0.0
-    assert factor_schema.get("default") == 1.0
+    assert "default" not in factor_schema
     assert factor_schema.get("description") == "Positive multiplier"
 
     # Valid input with defaults

--- a/tests/test_function_tool_decorator.py
+++ b/tests/test_function_tool_decorator.py
@@ -9,6 +9,8 @@ import json
 import operator
 import sys
 from collections.abc import Callable
+from decimal import Decimal
+from enum import Enum
 from types import ModuleType
 from typing import Annotated, Any, Generic, TypeVar, cast
 
@@ -26,6 +28,16 @@ from agents.tool_context import ToolContext
 class DummyContext:
     def __init__(self):
         self.data = "something"
+
+
+class _StrictDefaultCurrency(str, Enum):
+    EUR = "EUR"
+    USD = "USD"
+
+
+class _StrictDefaultInvoice(BaseModel):
+    total: Decimal
+    currency: _StrictDefaultCurrency = _StrictDefaultCurrency.EUR
 
 
 def ctx_wrapper() -> ToolContext[DummyContext]:
@@ -406,6 +418,35 @@ async def test_extract_descriptions_from_docstring():
             "additionalProperties": False,
         }
     )
+
+
+def test_nested_model_non_null_default_is_removed_from_strict_schema() -> None:
+    @function_tool
+    def create_invoice(data: _StrictDefaultInvoice) -> str:
+        return data.currency.value
+
+    invoice_schema = create_invoice.params_json_schema["$defs"]["_StrictDefaultInvoice"]
+    currency_schema = invoice_schema["properties"]["currency"]
+    currency_definition = create_invoice.params_json_schema["$defs"]["_StrictDefaultCurrency"]
+    assert "default" not in currency_schema
+    assert currency_schema == currency_definition
+    assert currency_definition["enum"] == [
+        "EUR",
+        "USD",
+    ]
+    assert invoice_schema["required"] == [
+        "total",
+        "currency",
+    ]
+
+    @function_tool(strict_mode=False)
+    def create_invoice_non_strict(data: _StrictDefaultInvoice) -> str:
+        return data.currency.value
+
+    non_strict_invoice_schema = create_invoice_non_strict.params_json_schema["$defs"][
+        "_StrictDefaultInvoice"
+    ]
+    assert non_strict_invoice_schema["properties"]["currency"]["default"] == "EUR"
 
 
 @function_tool(

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -701,9 +701,10 @@ def test_allOf_single_entry_cannot_overwrite_strict_object(additional_properties
         ensure_strict_json_schema(schema)
 
 
-def test_default_removal_on_non_object():
-    # Test that "default": None is stripped from schemas that are not objects.
-    schema = {"type": "string", "default": None}
+@pytest.mark.parametrize("default", [None, 0, False, "value"])
+def test_default_removal_on_non_object(default):
+    # Defaults are unsupported annotations in strict schemas, regardless of their value.
+    schema = {"type": "string", "default": default}
     result = ensure_strict_json_schema(schema)
     assert result["type"] == "string"
     assert "default" not in result
@@ -723,6 +724,21 @@ def test_ref_expansion():
     assert a_schema["type"] == "string"
     assert a_schema["description"] == "desc"
     assert "default" not in a_schema
+
+
+@pytest.mark.parametrize("reject_open_objects", [False, True])
+def test_ref_with_non_null_default_expands_before_default_removal(reject_open_objects):
+    schema = {
+        "$defs": {"refObj": {"type": "string"}},
+        "type": "object",
+        "properties": {
+            "a": {"$ref": "#/$defs/refObj", "default": "fallback"},
+        },
+    }
+
+    result = ensure_strict_json_schema(schema, _reject_open_objects=reject_open_objects)
+
+    assert result["properties"]["a"] == {"type": "string"}
 
 
 def test_ref_no_expansion_when_alone():


### PR DESCRIPTION
### Summary

This pull request fixes strict JSON Schema conversion so every `default` annotation is removed before provider serialization, including non-null defaults generated for nested Pydantic models.

The conversion keeps `default: null` handling before reference processing to preserve pure references, while removing non-null defaults after `$ref` expansion so referenced schemas are still validated and normalized. Python runtime defaults and schemas created with strict mode disabled remain unchanged.

### Test plan

- Added regression coverage for `None`, numeric, boolean, and string defaults.
- Added coverage for `$ref` plus a non-null default in normal and `_reject_open_objects=True` conversion.
- Added public function-tool coverage for nested Pydantic enum defaults and non-strict parity.
- Focused schema tests: 176 passed.
- Ruff formatting and lint passed; serial tests passed.
- The full parallel suite reached 7,521 passed and 77 skipped. Its 19 Windows failures reproduce unchanged on the merge-base worktree and require symlink privileges or UTF-8 locale; full mypy/pyright likewise reproduces the same three pre-existing sandbox-file errors on the merge base.

### Issue number

Closes #4390

### Checks

- [x] I've added new tests, if relevant
- [x] I've run the Windows equivalent of `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
