### PR TITLE
fix(tools): redact tool output value from output-type validation errors

### DIFF
--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2268,13 +2268,19 @@ def _validate_function_tool_output(
     """Validate a typed function output before it reaches hooks or serialization."""
     if output_type_adapter is None:
         return output
+    base_message = (
+        f"Function tool {tool_name} returned an output that does not match its declared output type"
+    )
     try:
         return output_type_adapter.validate_python(output)
     except ValidationError as error:
-        raise UserError(
-            f"Function tool {tool_name} returned an output that does not match its declared "
-            f"output type: {error}"
-        ) from error
+        if not _debug.DONT_LOG_TOOL_DATA:
+            raise UserError(f"{base_message}: {error}") from error
+    # Tool-data redaction is enabled: the ValidationError repr embeds the raw output value, so
+    # raise outside the ``except`` block. This keeps the payload-bearing ValidationError from
+    # being attached as the redacted error's ``__cause__``/``__context__`` (mirroring the tool
+    # argument validation path above).
+    raise UserError(base_message)
 
 
 def _validate_function_tool_callable_annotations(

--- a/src/agents/tool.py
+++ b/src/agents/tool.py
@@ -2276,10 +2276,12 @@ def _validate_function_tool_output(
     except ValidationError as error:
         if not _debug.DONT_LOG_TOOL_DATA:
             raise UserError(f"{base_message}: {error}") from error
-    # Tool-data redaction is enabled: the ValidationError repr embeds the raw output value, so
-    # raise outside the ``except`` block. This keeps the payload-bearing ValidationError from
-    # being attached as the redacted error's ``__cause__``/``__context__`` (mirroring the tool
-    # argument validation path above).
+    # Tool-data redaction is enabled: the ValidationError repr embeds the raw output value. Drop
+    # the payload-bearing ``output`` local and raise outside the ``except`` block so the value
+    # cannot be recovered from this frame's traceback locals, and the ValidationError is not
+    # attached as the redacted error's ``__cause__``/``__context__`` (mirroring the tool argument
+    # validation path above).
+    output = None
     raise UserError(base_message)
 
 
@@ -2644,11 +2646,17 @@ def function_tool(
                 else:
                     result = await asyncio.to_thread(the_func, *args, **kwargs_dict)
 
-            result = _validate_function_tool_output(
-                tool_name=tool_name,
-                output=result,
-                output_type_adapter=output_type_adapter,
-            )
+            try:
+                result = _validate_function_tool_output(
+                    tool_name=tool_name,
+                    output=result,
+                    output_type_adapter=output_type_adapter,
+                )
+            except UserError:
+                # Output validation failed. Drop the payload-bearing local so a redacted error
+                # cannot leak the raw output through this frame's traceback locals.
+                result = None
+                raise
 
             if _debug.DONT_LOG_TOOL_DATA:
                 logger.debug("Tool %s completed.", tool_name)

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -918,6 +918,7 @@ async def test_function_tool_output_validation_error_redacts_payload_when_tool_d
     assert _TOOL_OUTPUT_SECRET not in str(error)
     assert error.__cause__ is None
     assert error.__context__ is None
+    _assert_secret_absent_from_agents_traceback(error, _TOOL_OUTPUT_SECRET)
 
 
 @pytest.mark.asyncio

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -883,6 +883,66 @@ async def test_agent_tool_validation_error_preserves_diagnostics_when_tool_data_
     assert isinstance(error.__cause__, ValidationError)
 
 
+_TOOL_OUTPUT_SECRET = "SECRET_TOOL_OUTPUT_123"
+
+
+class _IntegerOutput(BaseModel):
+    value: int
+
+
+def _returns_wrong_typed_output(ignored: str = "") -> Any:
+    # The declared output type expects an ``int`` for ``value``; returning the secret string
+    # instead triggers output validation, whose ValidationError repr embeds the raw output value.
+    return {"value": _TOOL_OUTPUT_SECRET}
+
+
+@pytest.mark.asyncio
+async def test_function_tool_output_validation_error_redacts_payload_when_tool_data_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", True)
+    tool = function_tool(
+        _returns_wrong_typed_output,
+        name_override="output_tool",
+        output_type=_IntegerOutput,
+        failure_error_function=None,
+    )
+
+    with pytest.raises(UserError) as exc_info:
+        await tool.on_invoke_tool(
+            ToolContext(None, tool_name=tool.name, tool_call_id="1", tool_arguments="{}"),
+            "{}",
+        )
+
+    error = exc_info.value
+    assert _TOOL_OUTPUT_SECRET not in str(error)
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
+@pytest.mark.asyncio
+async def test_function_tool_output_validation_error_preserves_diagnostics_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+    tool = function_tool(
+        _returns_wrong_typed_output,
+        name_override="output_tool",
+        output_type=_IntegerOutput,
+        failure_error_function=None,
+    )
+
+    with pytest.raises(UserError) as exc_info:
+        await tool.on_invoke_tool(
+            ToolContext(None, tool_name=tool.name, tool_call_id="1", tool_arguments="{}"),
+            "{}",
+        )
+
+    error = exc_info.value
+    assert _TOOL_OUTPUT_SECRET in str(error)
+    assert isinstance(error.__cause__, ValidationError)
+
+
 _MODEL_OUTPUT_SECRET = "SECRET_MODEL_OUTPUT_123"
 _SENSITIVE_SCHEMA_SECRET = "SENSITIVE_HANDOFF_SCHEMA_SECRET_4207"
 _SENSITIVE_OUTPUT_SCHEMA_SECRET = "SENSITIVE_OUTPUT_SCHEMA_SECRET_4207"


### PR DESCRIPTION
### Summary

Function tools with a declared output type validate the returned value in `_validate_function_tool_output` (`src/agents/tool.py`). On a type mismatch, the raised `UserError` embedded the pydantic `ValidationError` in its message, and chained it as `__cause__`. A pydantic `ValidationError` repr includes the offending value (`input_value=...`), so this exposed the **tool's output value** in the exception message and traceback — even though `OPENAI_AGENTS_DONT_LOG_TOOL_DATA` is **on by default** and its documented contract is that tool call *inputs/outputs* are not exposed.

This is the output-side sibling of the already-merged tool *argument* redaction (#4182) and JSON-validation redaction (#4211). The same function already redacts argument-validation errors (both the message and the `__cause__`/`__context__` chain) and redacts the success-path output log three lines below the validation call, so the output-validation error path was the odd one out.

Behavior:
- `DONT_LOG_TOOL_DATA` enabled (default): raise a generic `UserError` (`Function tool <name> returned an output that does not match its declared output type`) with no `__cause__`/`__context__`, so the payload-bearing `ValidationError` is not reachable via the traceback.
- `DONT_LOG_TOOL_DATA` disabled: unchanged — the detailed message and `ValidationError` cause are preserved for debugging.

The redacted error is raised *outside* the `except` block so the `ValidationError` (which holds the output value) is not attached as `__cause__`/`__context__`, matching the existing argument path and `util/_json.py`.

Scope note: the only other typed tool-output validation site, `AgentToolUseTracker`/`RunItem.tool_call_output_item` in `items.py`, already uses a generic message and its `ValidationError` branch is not reached with invalid data on the invoke path (the value is validated here first), so no change is needed there.

### Test plan

Added two tests in `tests/test_error_logging_redaction.py`, mirroring the existing tool-argument redaction tests:

- `test_function_tool_output_validation_error_redacts_payload_when_tool_data_disabled` — with redaction on, the returned secret is absent from the error and `__cause__`/`__context__` are `None`. Fails on `main` (secret leaks via `input_value=...` and `__cause__`), passes with this change.
- `test_function_tool_output_validation_error_preserves_diagnostics_when_enabled` — with redaction off, the detail and `ValidationError` cause are preserved.

Verification (local, no API keys / paid calls / network):
- `uv run pytest tests/test_error_logging_redaction.py tests/test_function_tool.py tests/test_tool_output_conversion.py -q` → 209 passed
- `uv run pytest tests -q` → 8415 passed, 39 skipped
- `uv run ruff check src/agents/tool.py tests/test_error_logging_redaction.py` → passed
- `uv run ruff format --check` → already formatted
- `uv run mypy src` → no issues (305 files)
- `uv run pyright src/agents/tool.py` → 0 errors

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
