### PR TITLE
fix(sandbox): snapshot HTTP proxy headers

### DIFF
--- a/src/agents/sandbox/session/sinks.py
+++ b/src/agents/sandbox/session/sinks.py
@@ -290,7 +290,7 @@ class HttpProxySink(EventSink):
         payload_policy: EventPayloadPolicy | None = None,
     ) -> None:
         self.endpoint = endpoint
-        self.headers = headers or {}
+        self.headers = dict(headers or {})
         self.timeout_s = timeout_s
         self.spool_path = spool_path
         self.mode = mode

--- a/tests/sandbox/test_session_sinks.py
+++ b/tests/sandbox/test_session_sinks.py
@@ -6,7 +6,7 @@ import json
 import tarfile
 import uuid
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from inline_snapshot import snapshot
@@ -443,6 +443,20 @@ async def test_http_proxy_sink_spools_direct_timeout(tmp_path: Path) -> None:
     lines = spool_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     assert json.loads(lines[0])["seq"] == 1
+
+
+def test_http_proxy_sink_snapshots_headers() -> None:
+    headers = {"authorization": "Bearer original"}
+    sink = HttpProxySink("https://example.test/events", headers=headers)
+    headers["authorization"] = "Bearer changed"
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b""
+
+    with patch("agents.sandbox.session.sinks.urlopen", return_value=response) as urlopen:
+        sink._post(b"{}", None)
+
+    request = urlopen.call_args.args[0]
+    assert request.get_header("Authorization") == "Bearer original"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`HttpProxySink` retained the caller-owned headers dictionary. Mutating that dictionary after sink construction silently changed subsequent HTTP requests, including authorization headers.

Snapshot the header mapping in the constructor. Callers can still intentionally update `sink.headers`; only mutations through the original constructor argument are isolated.

### Test plan

- Added a network-free regression that mutates the source header mapping, patches `urlopen`, and verifies the request keeps the construction-time authorization value.
- Red on `upstream/main`: the request used `Bearer changed` instead of `Bearer original`.
- `tests/sandbox/test_session_sinks.py`: 22 passed.
- Format and lint passed.
- Mypy: clean for 305 source files; Pyright: 0 errors.
- Parallel suite: 8344 passed, 28 skipped.
- Serial suite: 77 passed, 11 skipped, 55 deselected.

### Issue number

No issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
