### PR TITLE
fix(sandbox): snapshot per-op audit policies

### DIFF
--- a/src/agents/sandbox/session/manager.py
+++ b/src/agents/sandbox/session/manager.py
@@ -25,7 +25,7 @@ class Instrumentation:
     ) -> None:
         self._sinks: list[EventSink] = list(sinks or [])
         self.payload_policy = payload_policy if payload_policy is not None else EventPayloadPolicy()
-        self.payload_policy_by_op = payload_policy_by_op or {}
+        self.payload_policy_by_op = dict(payload_policy_by_op or {})
         self._tasks: set[asyncio.Task[None]] = set()
 
     @property

--- a/tests/sandbox/test_session_manager.py
+++ b/tests/sandbox/test_session_manager.py
@@ -74,6 +74,36 @@ async def test_instrumentation_per_op_policy_overrides_default(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_instrumentation_snapshots_per_op_policy_mapping(tmp_path: Path) -> None:
+    events: list[SandboxSessionEvent] = []
+    session = _build_session(tmp_path)
+    sink = CallbackSink(lambda event, _session: events.append(event), mode="sync")
+    sink.bind(session)
+    policies = {"exec": EventPayloadPolicy(include_exec_output=False)}
+    instrumentation = Instrumentation(
+        sinks=[sink],
+        payload_policy=EventPayloadPolicy(include_exec_output=True),
+        payload_policy_by_op=policies,
+    )
+    policies.clear()
+    event = SandboxSessionFinishEvent(
+        session_id=uuid.uuid4(),
+        seq=1,
+        op="exec",
+        span_id="span_exec",
+        ok=True,
+        duration_ms=0.0,
+        stdout_bytes=b"secret",
+    )
+
+    await instrumentation.emit(event)
+
+    assert isinstance(events[0], SandboxSessionFinishEvent)
+    assert events[0].stdout is None
+    assert events[0].stdout_bytes is None
+
+
+@pytest.mark.asyncio
 async def test_instrumentation_per_sink_policy_overrides_per_op(tmp_path: Path) -> None:
     first: list[SandboxSessionEvent] = []
     second: list[SandboxSessionEvent] = []


### PR DESCRIPTION
### Summary

`Instrumentation` copied its configured sink sequence but retained the caller-owned `payload_policy_by_op` dictionary. Clearing or editing that source dictionary after construction silently changed later audit redaction; an exec event configured to hide output could start exposing its stdout.

Snapshot the mapping at construction. Policy objects and the public `instrumentation.payload_policy_by_op` mapping remain mutable, while mutations through the original constructor argument no longer alter instrumentation state.

### Test plan

- Added a regression that clears the source mapping, emits an exec-finish event, and verifies stdout and raw stdout bytes remain redacted.
- Red on `upstream/main`: the callback received `stdout="secret"` and raw bytes.
- `tests/sandbox/test_session_manager.py`: 10 passed.
- Format and lint passed.
- Mypy: clean for 305 source files; Pyright: 0 errors.
- Parallel suite: 8344 passed, 28 skipped.
- Serial suite: 77 passed, 11 skipped, 55 deselected.

### Issue number

No issue.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
