### PR TITLE
feat(sandbox): resolve manifest environment values from the process environment

### DIFF
--- a/src/agents/sandbox/manifest.py
+++ b/src/agents/sandbox/manifest.py
@@ -1,5 +1,6 @@
 import abc
 import inspect
+import os
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePath, PurePosixPath
@@ -145,6 +146,19 @@ class StrEnvValue(EnvValue):
 
     async def resolve(self) -> str:
         return self.value
+
+
+class OsEnvValue(EnvValue):
+    """Reads the value from the environment of the process creating the sandbox.
+
+    An unset variable resolves to the empty string.
+    """
+
+    type: Literal["os_env"] = "os_env"
+    name: str
+
+    async def resolve(self) -> str:
+        return os.environ.get(self.name, "")
 
 
 def _serialize_env_value_with_type(value: EnvValue, serialized: object) -> dict[str, Any]:

--- a/tests/sandbox/test_compatibility_guards.py
+++ b/tests/sandbox/test_compatibility_guards.py
@@ -40,7 +40,7 @@ from agents.sandbox.entries.mounts.patterns import (
     RcloneMountPattern,
     S3FilesMountPattern,
 )
-from agents.sandbox.manifest import EnvValue, StrEnvValue
+from agents.sandbox.manifest import EnvValue, OsEnvValue, StrEnvValue
 from agents.sandbox.session.sandbox_client import BaseSandboxClientOptions
 from agents.sandbox.session.sandbox_session_state import SandboxSessionState
 from agents.sandbox.snapshot import LocalSnapshot, NoopSnapshot, RemoteSnapshot, SnapshotBase
@@ -894,6 +894,7 @@ def test_core_discriminator_type_strings_are_stable() -> None:
         InContainerMountStrategy: "in_container",
         DockerVolumeMountStrategy: "docker_volume",
         StrEnvValue: "str",
+        OsEnvValue: "os_env",
     }
 
     for cls, expected_type in expected_types.items():

--- a/tests/sandbox/test_manifest.py
+++ b/tests/sandbox/test_manifest.py
@@ -16,7 +16,14 @@ from agents.sandbox.entries import (
     MountpointMountPattern,
 )
 from agents.sandbox.errors import InvalidManifestPathError
-from agents.sandbox.manifest import EnvEntry, Environment, EnvValue, Manifest, StrEnvValue
+from agents.sandbox.manifest import (
+    EnvEntry,
+    Environment,
+    EnvValue,
+    Manifest,
+    OsEnvValue,
+    StrEnvValue,
+)
 from agents.sandbox.manifest_render import _truncate_manifest_description
 
 
@@ -337,6 +344,62 @@ def test_manifest_round_trips_str_env_value() -> None:
     assert restored.environment.value == {
         "PLAIN": "plain",
         "TYPED": StrEnvValue(value="typed"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_os_env_value_resolves_from_the_process_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_TEST_OS_ENV_VALUE", "from-host")
+
+    assert await OsEnvValue(name="SANDBOX_TEST_OS_ENV_VALUE").resolve() == "from-host"
+
+
+@pytest.mark.asyncio
+async def test_os_env_value_resolves_unset_and_empty_variables_to_an_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SANDBOX_TEST_OS_ENV_VALUE", raising=False)
+
+    assert await OsEnvValue(name="SANDBOX_TEST_OS_ENV_VALUE").resolve() == ""
+
+    monkeypatch.setenv("SANDBOX_TEST_OS_ENV_VALUE", "")
+
+    assert await OsEnvValue(name="SANDBOX_TEST_OS_ENV_VALUE").resolve() == ""
+
+
+def test_manifest_round_trips_os_env_value() -> None:
+    manifest = Manifest(
+        environment=Environment(value={"TOKEN": OsEnvValue(name="SANDBOX_TEST_OS_ENV_VALUE")})
+    )
+
+    payload = manifest.model_dump(mode="json")
+    restored = Manifest.model_validate(payload)
+
+    assert payload["environment"] == {
+        "value": {"TOKEN": {"type": "os_env", "name": "SANDBOX_TEST_OS_ENV_VALUE"}}
+    }
+    assert type(restored.environment.value["TOKEN"]) is OsEnvValue
+
+
+@pytest.mark.asyncio
+async def test_environment_resolves_os_env_values_alongside_literals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_TEST_OS_ENV_VALUE", "from-host")
+    environment = Environment(
+        value={
+            "PLAIN": "literal",
+            "DIRECT": OsEnvValue(name="SANDBOX_TEST_OS_ENV_VALUE"),
+            "ENTRY": EnvEntry(value=OsEnvValue(name="SANDBOX_TEST_OS_ENV_VALUE")),
+        }
+    )
+
+    assert await environment.resolve() == {
+        "PLAIN": "literal",
+        "DIRECT": "from-host",
+        "ENTRY": "from-host",
     }
 
 


### PR DESCRIPTION
### Summary

`Environment` can only hold literal values today. `StrEnvValue` is the only concrete `EnvValue`, so anything a sandbox needs in its environment has to be written into the manifest itself, and it travels with the manifest wherever that gets persisted or handed across a boundary.

This adds `OsEnvValue`, which names a variable instead. The backend clients pick it up where they already call `manifest.environment.resolve()`, at create, exec and resume, so the value is read on the machine actually building the sandbox. It also seemed like the obvious second implementation of an interface whose `resolve()` is `async`, which only earns the keyword if resolution can do more than return a field.

Three choices I would rather hear your view on than assume:

- an unset variable resolves to `""` rather than raising, matching shell expansion instead of adding a new failure mode to sandbox creation
- `"os_env"` for the discriminator, which departs from `StrEnvValue`'s class-name-minus-suffix rule but reads better in a serialized manifest. `"os"` is just as easy if consistency matters more, and it is a wire string, so cheaper to settle now than later
- `name` for the field, since no existing model carries a single variable name and `name` is the identifier field used elsewhere in the package

Note: this touches `test_core_discriminator_type_strings_are_stable`, because that table maps every core discriminated class and leaving `OsEnvValue` out would have made it the only one missing. I left the members list in `docs/ref/sandbox/manifest.md` alone under the Documentation Release Timing rule in `AGENTS.md`; let me know if you would like that as a separate PR when it is due.

### Test plan

Five tests in `tests/sandbox/test_manifest.py`: resolving a variable that is set, unset and empty both resolving to `""`, round-tripping through `Manifest` serialization with the discriminator intact and coming back as `OsEnvValue`, and resolving through `Environment.resolve()` alongside a bare literal and an `EnvEntry` wrapper.

`.agents/skills/code-change-verification/scripts/run.sh` passes: format, lint, typecheck and tests all green.

Two notes about my environment rather than the change, in case they show up elsewhere: building `cffi` needed `libffi-dev` installed, and my container sets `no_proxy` to a value `httpx2` cannot parse (`Invalid port: ':1]'`), which takes out around 138 unrelated tests in `test_config.py`, `tracing/`, `mcp/` and `voice/` until those variables are cleared.

### Issue number

None.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR