### PR TITLE
fix(sessions): prevent duplicate pop_item results under concurrent access in SQLAlchemySession

### DIFF
--- a/src/agents/extensions/memory/sqlalchemy_session.py
+++ b/src/agents/extensions/memory/sqlalchemy_session.py
@@ -416,9 +416,8 @@ class SQLAlchemySession(SessionABC):
         async with self._session_factory() as sess:
             async with sess.begin():
                 while True:
-                    # Fallback for all dialects - get ID first, then delete
-                    subq = (
-                        select(self._messages.c.id)
+                    stmt = (
+                        select(self._messages.c.id, self._messages.c.message_data)
                         .where(self._messages.c.session_id == self.session_id)
                         .order_by(
                             self._messages.c.created_at.desc(),
@@ -426,21 +425,25 @@ class SQLAlchemySession(SessionABC):
                         )
                         .limit(1)
                     )
-                    res = await sess.execute(subq)
-                    row_id = res.scalar_one_or_none()
-                    if row_id is None:
-                        return None
-                    # Fetch data before deleting
-                    res_data = await sess.execute(
-                        select(self._messages.c.message_data).where(self._messages.c.id == row_id)
-                    )
-                    row = res_data.scalar_one_or_none()
-                    await sess.execute(delete(self._messages).where(self._messages.c.id == row_id))
+                    if self._engine.dialect.name != "sqlite":
+                        stmt = stmt.with_for_update()
 
+                    res = await sess.execute(stmt)
+                    row = res.one_or_none()
                     if row is None:
+                        return None
+
+                    row_id, message_data = row
+                    delete_res = await sess.execute(
+                        delete(self._messages).where(self._messages.c.id == row_id)
+                    )
+
+                    if delete_res.rowcount == 0:
+                        # Another concurrent reader popped/deleted this row first.
                         continue
+
                     try:
-                        return await self._deserialize_item(row)
+                        return await self._deserialize_item(message_data)
                     except (json.JSONDecodeError, TypeError):
                         continue
 

--- a/tests/extensions/memory/test_sqlalchemy_session.py
+++ b/tests/extensions/memory/test_sqlalchemy_session.py
@@ -990,3 +990,44 @@ async def test_runner_with_session_settings_override(agent: Agent):
     history_items = [item for item in last_input if item.get("content") != "New question"]
     # Should have 2 history items (last two from the 10 we added)
     assert len(history_items) == 2
+
+
+async def test_pop_item_concurrency(tmp_path):
+    """Test that concurrent pop_item calls do not return duplicate items."""
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'concurrency_pop.db'}"
+    session = SQLAlchemySession.from_url(
+        "concurrency_pop_test",
+        url=db_url,
+        create_tables=True,
+    )
+    # Add a set of items
+    items: list[TResponseInputItem] = [{"role": "user", "content": f"msg-{i}"} for i in range(10)]
+    await session.add_items(items)
+
+    # Let's perform concurrent pop_item operations
+    async def worker() -> list[str]:
+        res = []
+        for _ in range(5):
+            val = await session.pop_item()
+            if val is not None:
+                content = val.get("content")
+                if isinstance(content, str):
+                    res.append(content)
+        return res
+
+    results = await asyncio.gather(
+        worker(),
+        worker(),
+        worker(),
+    )
+
+    # Flatten results
+    popped_contents = [content for res in results for content in res]
+
+    # Verify that we popped exactly 10 items (or all unique items)
+    assert len(popped_contents) == 10
+    # Verify that all popped contents are unique
+    assert len(set(popped_contents)) == 10
+    # Clean up
+    await session.engine.dispose()
+


### PR DESCRIPTION
Combine SELECT statements into one query, apply with_for_update for non-sqlite dialects, and check rowcount on delete to prevent concurrency issues and race conditions. Added unit test test_pop_item_concurrency.