### PR TITLE
Route max_turns handler output through the final-output session pipeline

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -1294,13 +1294,54 @@ class AgentRunner:
                             context_wrapper,
                             validated_output,
                         )
-                        await run_output_guardrails(
-                            current_agent.output_guardrails + (run_config.output_guardrails or []),
-                            current_agent,
-                            validated_output,
-                            context_wrapper,
-                            output_guardrail_results,
-                        )
+
+                        async def _persist_handler_output(
+                            _synthesized_item: RunItem = synthesized_item,
+                            _include_in_history: bool = include_in_history,
+                            _store_setting: bool | None = store_setting,
+                            _input_items: list[TResponseInputItem] | None = (
+                                session_input_items_for_persistence
+                            ),
+                        ) -> None:
+                            if not (session_persistence_enabled and _include_in_history):
+                                return
+                            handler_input_items_for_save: list[TResponseInputItem] = (
+                                _input_items if _input_items is not None else []
+                            )
+                            # The synthesized item is a fresh one-item list, not the
+                            # cumulative turn item list, so the run state's per-turn
+                            # persisted count must not be applied as a slice offset here.
+                            # Pass the reasoning item id policy explicitly instead, the same
+                            # way `save_resumed_turn_items` does.
+                            await save_result_to_session(
+                                session,
+                                handler_input_items_for_save,
+                                [_synthesized_item],
+                                None,
+                                response_id=None,
+                                reasoning_item_id_policy=resolved_reasoning_item_id_policy,
+                                store=_store_setting,
+                                wrapper=context_wrapper,
+                            )
+
+                        # Same output-guardrail session rules as any other final output: a
+                        # tripwire rejects the candidate message, so it must not be replayable,
+                        # while an ordinary guardrail error leaves the verdict unknown and the
+                        # completed message stays replayable.
+                        try:
+                            await run_output_guardrails(
+                                current_agent.output_guardrails
+                                + (run_config.output_guardrails or []),
+                                current_agent,
+                                validated_output,
+                                context_wrapper,
+                                output_guardrail_results,
+                            )
+                        except OutputGuardrailTripwireTriggered:
+                            raise
+                        except (Exception, asyncio.CancelledError):
+                            await _persist_handler_output()
+                            raise
                         current_step = getattr(run_state, "_current_step", None)
                         approvals_from_state = approvals_from_step(current_step)
                         result = RunResult(
@@ -1325,27 +1366,7 @@ class AgentRunner:
                         )
                         if run_state is not None:
                             result._trace_state = run_state._trace_state
-                        if session_persistence_enabled and include_in_history:
-                            handler_input_items_for_save: list[TResponseInputItem] = (
-                                session_input_items_for_persistence
-                                if session_input_items_for_persistence is not None
-                                else []
-                            )
-                            # The synthesized item is a fresh one-item list, not the
-                            # cumulative turn item list, so the run state's per-turn
-                            # persisted count must not be applied as a slice offset here.
-                            # Pass the reasoning item id policy explicitly instead, the same
-                            # way `save_resumed_turn_items` does.
-                            await save_result_to_session(
-                                session,
-                                handler_input_items_for_save,
-                                [synthesized_item],
-                                None,
-                                response_id=None,
-                                reasoning_item_id_policy=resolved_reasoning_item_id_policy,
-                                store=store_setting,
-                                wrapper=context_wrapper,
-                            )
+                        await _persist_handler_output()
                         result._original_input = copy_input_items(original_input)
                         return _finalize_result(result)
 

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -1286,6 +1286,9 @@ async def start_streaming(
                 output_text = format_final_output_text(current_agent, validated_output)
                 synthesized_item = create_message_output_item(current_agent, output_text)
                 include_in_history = handler_result.include_in_history
+                store_setting = current_agent.model_settings.resolve(
+                    run_config.model_settings
+                ).store
                 if include_in_history:
                     streamed_result._model_input_items.append(synthesized_item)
                     streamed_result.new_items.append(synthesized_item)
@@ -1294,34 +1297,44 @@ async def start_streaming(
                         run_state._clear_generated_items_last_processed_marker()
                         run_state._session_items = list(streamed_result.new_items)
                     stream_step_items_to_queue([synthesized_item], streamed_result._event_queue)
-                    store_setting = current_agent.model_settings.resolve(
-                        run_config.model_settings
-                    ).store
-                    if is_resumed_state:
-                        await _save_resumed_items([synthesized_item], None, store_setting)
-                    else:
-                        await _save_stream_items_with_count([synthesized_item], None, store_setting)
 
                 await run_final_output_hooks(
                     current_agent, hooks, context_wrapper, validated_output
                 )
-                output_guardrail_results = await _run_output_guardrails_for_stream(
-                    agent=current_agent,
-                    run_config=run_config,
-                    output=validated_output,
-                    context_wrapper=context_wrapper,
-                    streamed_result=streamed_result,
-                )
-                streamed_result.output_guardrail_results = output_guardrail_results
-                streamed_result.final_output = validated_output
-                streamed_result.is_complete = True
+
+                async def _save_handler_items(
+                    items: list[RunItem],
+                    response_id: str | None,
+                    store: bool | None,
+                    _is_resumed_state: bool = is_resumed_state,
+                ) -> None:
+                    if _is_resumed_state:
+                        await _save_resumed_items(items, response_id, store)
+                    else:
+                        await _save_stream_items_with_count(items, response_id, store)
+
                 streamed_result._stored_exception = None
                 streamed_result._max_turns_handled = True
                 streamed_result.current_turn = max_turns
                 if run_state is not None:
                     run_state._current_turn = max_turns
                     run_state._current_step = None
-                streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+                # Persisted through the shared final-output pipeline so the handler's output
+                # follows the same output-guardrail session rules as any other final output:
+                # a tripwire excludes the rejected message, while a guardrail error leaves the
+                # verdict unknown and keeps the completed message replayable.
+                await _finalize_streamed_final_output(
+                    streamed_result=streamed_result,
+                    agent=current_agent,
+                    run_config=run_config,
+                    output=validated_output,
+                    context_wrapper=context_wrapper,
+                    save_items=_save_handler_items,
+                    items=[synthesized_item] if include_in_history else [],
+                    response_id=None,
+                    store_setting=store_setting,
+                    persist_before_output_guardrails=False,
+                )
                 break
 
             if current_turn == 1:

--- a/tests/test_max_turns.py
+++ b/tests/test_max_turns.py
@@ -8,10 +8,13 @@ from typing_extensions import TypedDict
 
 from agents import (
     Agent,
+    GuardrailFunctionOutput,
     ItemHelpers,
     MaxTurnsExceeded,
     MessageOutputItem,
     ModelRefusalError,
+    OutputGuardrail,
+    OutputGuardrailTripwireTriggered,
     RunErrorHandlerResult,
     Runner,
     SQLiteSession,
@@ -543,5 +546,76 @@ async def test_non_streamed_max_turns_handler_persists_output_to_session():
 async def test_streamed_max_turns_handler_persists_output_to_session():
     """The streamed path already persists the synthesized output; keep both paths aligned."""
     item_types = await _run_max_turns_handler_with_session(streamed=True)
+
+    assert item_types == ["user", "function_call", "function_call_output", "message"]
+
+
+def _rejecting_output_guardrail(*, tripwire: bool) -> OutputGuardrail:
+    """A guardrail that either trips its wire or fails outright."""
+
+    def check_output(_context, _agent, _output):
+        if tripwire:
+            return GuardrailFunctionOutput(output_info=None, tripwire_triggered=True)
+        raise RuntimeError("output check failed")
+
+    return OutputGuardrail(guardrail_function=check_output)
+
+
+async def _run_max_turns_handler_with_guardrail(*, streamed: bool, tripwire: bool) -> list[str]:
+    """Run one tool turn, trip max turns, and have the output guardrail reject or fail."""
+    model = ScriptedModel()
+    agent = Agent(
+        name="test_1",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+        output_guardrails=[_rejecting_output_guardrail(tripwire=tripwire)],
+    )
+    model.extend([[get_function_tool_call("some_function", json.dumps({"a": "b"}))]])
+    session = SQLiteSession(f"max-turns-guardrail-{streamed}-{tripwire}", ":memory:")
+    expected_error: type[Exception] = OutputGuardrailTripwireTriggered if tripwire else RuntimeError
+    try:
+        with pytest.raises(expected_error):
+            if streamed:
+                streamed_result = Runner.run_streamed(
+                    agent,
+                    input="user_message",
+                    max_turns=1,
+                    session=session,
+                    error_handlers={"max_turns": lambda data: "fallback answer"},
+                )
+                async for _ in streamed_result.stream_events():
+                    pass
+            else:
+                await Runner.run(
+                    agent,
+                    input="user_message",
+                    max_turns=1,
+                    session=session,
+                    error_handlers={"max_turns": lambda data: "fallback answer"},
+                )
+
+        return [str(item.get("type", item.get("role"))) for item in await session.get_items()]
+    finally:
+        session.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_max_turns_handler_output_excluded_when_guardrail_trips(streamed: bool):
+    """A tripwire judges the handler output undeliverable, so it must not be replayable.
+
+    The completed local tool turn is already persisted and stays that way: the next run has
+    to see that side effect rather than re-issue it.
+    """
+    item_types = await _run_max_turns_handler_with_guardrail(streamed=streamed, tripwire=True)
+
+    assert item_types == ["user", "function_call", "function_call_output"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_max_turns_handler_output_retained_when_guardrail_errors(streamed: bool):
+    """A guardrail error leaves the verdict unknown, so the handler output stays replayable."""
+    item_types = await _run_max_turns_handler_with_guardrail(streamed=streamed, tripwire=False)
 
     assert item_types == ["user", "function_call", "function_call_output", "message"]


### PR DESCRIPTION
### Summary

When a `max_turns` error handler returns a final output, that output did not follow the documented output-guardrail session behavior, and the two runners disagreed with each other:

| Output guardrail result | `Runner.run()` | `Runner.run_streamed()` |
| --- | --- | --- |
| Guardrail function raises | handler message missing | handler message retained |
| Guardrail returns a tripwire | handler message excluded | handler message retained |

The expected rule is the same one every other final output follows: a tripwire rejects the candidate message, while an ordinary guardrail exception leaves the verdict unknown, so the completed candidate stays replayable. Only two of the four cells were right.

The cause is that both dedicated `max_turns` branches implement their own finalization order rather than using the shared final-output session pipeline — and each got it wrong in the opposite direction:

- **`Runner.run()`** ran `run_output_guardrails` outside any handler and persisted afterwards, so *any* guardrail raise skipped the save.
- **`run_streamed()`** persisted the synthesized item *before* running the guardrails, so nothing they did could exclude it.

### Changes

- **`src/agents/run.py`** — the non-streamed branch now wraps the guardrail call the same way the shared pipeline does: a tripwire re-raises without persisting; any other exception (including `CancelledError`) persists the handler output first. The existing save moved into a small local helper so both the success and error paths use one code path.
- **`src/agents/run_internal/run_loop.py`** — the streamed branch now delegates to `_finalize_streamed_final_output`, which already implements exactly these semantics (including `_retained_items_for_blocked_output` on tripwire), instead of open-coding a different order. The synthesized item is passed as the turn's items and persisted through the same `save_items` callback.

A completed local tool turn is unaffected in both paths — its records are already persisted by the time the handler runs, and the next run still has to see that side effect rather than re-issue it. That's asserted explicitly.

The reproduction from the issue now prints:

```text
streamed=False, guardrail exception -> True
streamed=True,  guardrail exception -> True
streamed=False, tripwire            -> False
streamed=True,  tripwire            -> False
```

### Test plan

Added to `tests/test_max_turns.py`, parametrized over streamed/non-streamed, built on the existing `ScriptedModel` + `SQLiteSession` pattern already used by the `max_turns` session tests (one completed tool turn, then `max_turns` trips):

- `test_max_turns_handler_output_excluded_when_guardrail_trips` — session ends as `["user", "function_call", "function_call_output"]`: the rejected message is gone, the tool turn survives.
- `test_max_turns_handler_output_retained_when_guardrail_errors` — session ends as `["user", "function_call", "function_call_output", "message"]`.

Against the unfixed code these fail on exactly the two cells the issue identified (`tripwire[streamed=True]` and `guardrail-error[streamed=False]`) and pass on the two that were already correct.

Verification:

- `ruff format` / `ruff check src/agents tests/test_max_turns.py` — clean
- `mypy src/agents/run.py src/agents/run_internal/run_loop.py` — clean
- `pytest tests/` — **4238 passed, 7 skipped**

Two pre-existing failures in `tests/test_released_api_contract.py` (`test_repository_release_policy_declares_public_testing_modules`, `test_voice_testing_start_sentinel_has_stable_contract_identity`) reproduce on a clean checkout of this branch's base — they need the voice extras, which my local `uv` (0.9.3) could not install because this repo's `[tool.uv] exclude-newer-package` syntax requires a newer `uv`. Unrelated to this change. `tests/voice`, `tests/sandbox`, `tests/mcp`, `tests/models`, and `tests/extensions` were excluded from the run for the same missing-optional-dependency reason.

### Issue number

Fixes #4393

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
