### PR TITLE
fix: align Responses parallel tool calls with converted tools

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -1051,14 +1051,6 @@ class AnyLLMModel(Model):
         list_input = _to_dump_compatible(list_input)
         list_input = self._sanitize_any_llm_responses_input(list_input)
 
-        parallel_tool_calls = (
-            True
-            if model_settings.parallel_tool_calls and tools
-            else False
-            if model_settings.parallel_tool_calls is False
-            else None
-        )
-
         tool_choice = OpenAIResponsesConverter.convert_tool_choice(
             model_settings.tool_choice,
             tools=tools,
@@ -1073,6 +1065,9 @@ class AnyLLMModel(Model):
             tool_choice=model_settings.tool_choice,
         )
         converted_tools_payload = _materialize_responses_tool_params(converted_tools.tools)
+        parallel_tool_calls = (
+            model_settings.parallel_tool_calls if converted_tools_payload else None
+        )
 
         include_set = set(converted_tools.includes)
         if model_settings.response_include is not None:

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -790,13 +790,6 @@ class OpenAIResponsesModel(Model):
         list_input = _to_dump_compatible(list_input)
         list_input = self._remove_openai_responses_api_incompatible_fields(list_input)
 
-        if model_settings.parallel_tool_calls and tools:
-            parallel_tool_calls: bool | Omit = True
-        elif model_settings.parallel_tool_calls is False:
-            parallel_tool_calls = False
-        else:
-            parallel_tool_calls = omit
-
         should_omit_model = prompt is not None and not self._model_is_explicit
         effective_request_model: str | ChatModel | None = None if should_omit_model else self.model
         effective_computer_tool_model = Converter.resolve_computer_tool_model(
@@ -825,6 +818,11 @@ class OpenAIResponsesModel(Model):
                 tool_choice=model_settings.tool_choice,
             )
         converted_tools_payload = _materialize_responses_tool_params(converted_tools.tools)
+        parallel_tool_calls: bool | Omit = (
+            self._non_null_or_omit(model_settings.parallel_tool_calls)
+            if prompt is not None or converted_tools_payload
+            else omit
+        )
         response_format = Converter.get_response_format(output_schema)
         model_param: str | ChatModel | Omit = (
             effective_request_model if effective_request_model is not None else omit

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -714,6 +714,44 @@ async def test_any_llm_responses_path_is_used_when_supported(monkeypatch) -> Non
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+@pytest.mark.parametrize("parallel_tool_calls", [True, False, None])
+@pytest.mark.parametrize("tool_source", ["none", "function", "handoff"])
+async def test_any_llm_responses_parallel_tool_calls_follow_converted_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    parallel_tool_calls: bool | None,
+    tool_source: str,
+) -> None:
+    provider = FakeAnyLLMProvider(supports_responses=True, responses_response=_response("Hello"))
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(model="openai/gpt-5.4-mini", api="responses")
+    tools: list[Tool] = (
+        [function_tool(lambda: "ok", name_override="test_tool")]
+        if tool_source == "function"
+        else []
+    )
+    handoffs = [handoff(Agent(name="handoff"))] if tool_source == "handoff" else []
+
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(parallel_tool_calls=parallel_tool_calls),
+        tools=tools,
+        output_schema=None,
+        handoffs=handoffs,
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    params = provider.private_responses_calls[0]["params"]
+    expected_parallel_tool_calls = parallel_tool_calls if tool_source != "none" else None
+    assert params.parallel_tool_calls is expected_parallel_tool_calls
+    assert bool(params.tools) is (tool_source != "none")
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 @pytest.mark.parametrize("payload_type", ["dict", "basemodel"])
 async def test_any_llm_responses_path_defaults_missing_cache_write_tokens(
     monkeypatch: pytest.MonkeyPatch, payload_type: str

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -21,8 +21,11 @@ from agents import (
     ModelSettings,
     ModelTracing,
     Runner,
+    Tool,
     ToolSearchTool,
     __version__,
+    function_tool,
+    handoff,
     trace,
 )
 from agents.exceptions import ModelBehaviorError, UserError
@@ -178,6 +181,63 @@ def _connection_closed_error(message: str) -> Exception:
 
     ConnectionClosedError.__module__ = "websockets.client"
     return ConnectionClosedError(message)
+
+
+@pytest.mark.parametrize("parallel_tool_calls", [True, False, None])
+@pytest.mark.parametrize("tool_source", ["none", "function", "handoff"])
+def test_parallel_tool_calls_follow_converted_responses_tools(
+    parallel_tool_calls: bool | None,
+    tool_source: str,
+) -> None:
+    tools: list[Tool] = (
+        [function_tool(lambda: "ok", name_override="test_tool")]
+        if tool_source == "function"
+        else []
+    )
+    handoffs = [handoff(Agent(name="handoff"))] if tool_source == "handoff" else []
+    model = OpenAIResponsesModel(
+        model="gpt-4",
+        openai_client=cast(Any, object()),
+    )
+
+    kwargs = model._build_response_create_kwargs(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(parallel_tool_calls=parallel_tool_calls),
+        tools=tools,
+        output_schema=None,
+        handoffs=handoffs,
+    )
+
+    expected_parallel_tool_calls = (
+        parallel_tool_calls if tool_source != "none" and parallel_tool_calls is not None else omit
+    )
+    assert kwargs["parallel_tool_calls"] is expected_parallel_tool_calls
+    assert bool(kwargs["tools"]) is (tool_source != "none")
+
+
+@pytest.mark.parametrize("parallel_tool_calls", [True, False, None])
+def test_parallel_tool_calls_preserve_stored_prompt_overrides(
+    parallel_tool_calls: bool | None,
+) -> None:
+    model = OpenAIResponsesModel(
+        model="gpt-4",
+        openai_client=cast(Any, object()),
+    )
+
+    kwargs = model._build_response_create_kwargs(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(parallel_tool_calls=parallel_tool_calls),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        prompt={"id": "pmpt_123"},
+    )
+
+    expected_parallel_tool_calls = parallel_tool_calls if parallel_tool_calls is not None else omit
+    assert kwargs["parallel_tool_calls"] is expected_parallel_tool_calls
+    assert kwargs["tools"] is omit
 
 
 @pytest.mark.allow_call_model_methods
@@ -985,7 +1045,7 @@ async def test_responses_requests_normalize_dictionary_agent_settings(use_dictio
     assert kwargs["top_p"] == 1.0
     assert kwargs["max_output_tokens"] == 64
     assert "max_tokens" not in kwargs
-    assert kwargs["parallel_tool_calls"] is False
+    assert kwargs["parallel_tool_calls"] is omit
     assert kwargs["extra_headers"]["x-model-settings-parity"] == "preserved"
     assert kwargs["extra_query"] == {"model_settings_parity": "verified"}
     assert kwargs["extra_body"] == {"prompt_cache_key": "extra-body-cache-key"}


### PR DESCRIPTION
This pull request fixes Responses request construction so `parallel_tool_calls` is derived from the actual converted provider tool payload instead of the raw SDK tool list.

Handoff-only requests now preserve explicit `True` and `False` settings, while requests without converted tools omit the setting. The change applies consistently to the core OpenAI Responses and AnyLLM Responses paths, preserves shared streaming and non-streaming behavior, and leaves Chat Completions unchanged.

It also adds focused matrices covering no tools, function tools, and handoff-only tools with `True`, `False`, and `None`.
