### PR TITLE
fix(voice): reject non-finite audio samples

### DIFF
--- a/src/agents/voice/input.py
+++ b/src/agents/voice/input.py
@@ -28,6 +28,9 @@ def _buffer_to_audio_file(
     if buffer.dtype not in (np.int16, np.float32):
         raise UserError("Buffer must be a numpy array of int16 or float32")
 
+    if buffer.dtype == np.float32 and not np.isfinite(buffer).all():
+        raise UserError("Buffer must contain only finite values")
+
     if channels <= 0:
         raise UserError("Channels must be greater than zero")
 
@@ -102,6 +105,8 @@ class AudioInput:
     def to_base64(self) -> str:
         """Returns the audio data as a base64 encoded string."""
         if self.buffer.dtype == np.float32:
+            if not np.isfinite(self.buffer).all():
+                raise UserError("Buffer must contain only finite values")
             # convert to int16 without mutating the caller's buffer
             int16_buffer = (np.clip(self.buffer, -1.0, 1.0) * 32767).astype(np.int16)
         elif self.buffer.dtype == np.int16:

--- a/tests/voice/test_input.py
+++ b/tests/voice/test_input.py
@@ -135,6 +135,22 @@ def test_buffer_to_audio_file_invalid_dtype():
         _buffer_to_audio_file(buffer=buffer, channels=2)
 
 
+@pytest.mark.parametrize("value", [np.nan, np.inf, -np.inf])
+def test_buffer_to_audio_file_rejects_non_finite_float_samples(value):
+    buffer = np.array([0.0, value], dtype=np.float32)
+
+    with pytest.raises(UserError, match="finite values"):
+        _buffer_to_audio_file(buffer)
+
+
+@pytest.mark.parametrize("value", [np.nan, np.inf, -np.inf])
+def test_audio_input_to_base64_rejects_non_finite_float_samples(value):
+    audio_input = AudioInput(buffer=np.array([0.0, value], dtype=np.float32))
+
+    with pytest.raises(UserError, match="finite values"):
+        audio_input.to_base64()
+
+
 class TestAudioInput:
     def test_audio_input_default_params(self):
         # Create a simple sine wave


### PR DESCRIPTION
### Summary

This pull request fixes `AudioInput` conversion by rejecting `NaN` and infinite `float32` samples before converting buffers to WAV or base64 PCM. Previously those values reached NumPy's integer cast, emitted a runtime warning for `NaN`, and silently produced invalid PCM samples.

### Test plan

- `uv run --no-sync pytest -q tests/voice/test_input.py` (30 passed)
- parallel suite: 8,380 passed, 39 skipped
- serial suite: 77 passed, 5 skipped
- Ruff lint/format and focused mypy check passed
- Full mypy reported three pre-existing errors in unrelated files; pyright could not start because this ARM host lacks `libatomic.so.1`

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
