### PR TITLE
fix(voice): stop buffering audio when audio tracing is disabled

### DIFF
--- a/src/agents/voice/models/openai_stt.py
+++ b/src/agents/voice/models/openai_stt.py
@@ -280,7 +280,10 @@ class OpenAISTTTranscriptionSession(StreamedTranscriptionSession):
             if buffer is None:
                 break
 
-            self._turn_audio_buffer.append(buffer)
+            if self._trace_include_sensitive_audio_data:
+                # The buffer is only read back to populate the span input, so retaining it
+                # when audio tracing is off would hold a whole turn of PCM for nothing.
+                self._turn_audio_buffer.append(buffer)
             try:
                 await self._websocket.send(
                     json.dumps(

--- a/src/agents/voice/result.py
+++ b/src/agents/voice/result.py
@@ -143,7 +143,10 @@ class StreamedAudioResult:
 
                     if chunk:
                         buffer.append(chunk)
-                        full_audio_data.append(chunk)
+                        if self._voice_pipeline_config.trace_include_sensitive_audio_data:
+                            # Only read back to populate the span output, so retaining it when
+                            # audio tracing is off would hold a whole segment of PCM for nothing.
+                            full_audio_data.append(chunk)
                         if len(buffer) >= self._buffer_size:
                             combined = pending_byte + b"".join(buffer)
                             if len(combined) % 2 != 0:

--- a/tests/voice/test_openai_stt.py
+++ b/tests/voice/test_openai_stt.py
@@ -795,3 +795,46 @@ async def test_inactivity_timeout():
         assert len(collected_turns) == 0, "No transcripts expected, but we got something?"
 
         await session.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trace_include_sensitive_audio_data", [False, True])
+async def test_stream_audio_buffers_turn_audio_only_for_audio_tracing(
+    trace_include_sensitive_audio_data: bool,
+) -> None:
+    session = OpenAISTTTranscriptionSession(
+        input=StreamedAudioInput(),
+        client=AsyncMock(api_key="FAKE_KEY"),
+        model="whisper-1",
+        settings=STTModelSettings(),
+        trace_include_sensitive_data=False,
+        trace_include_sensitive_audio_data=trace_include_sensitive_audio_data,
+    )
+    session._websocket = AsyncMock()
+
+    frames: list[npt.NDArray[np.int16]] = [
+        np.zeros(2, dtype=np.int16),
+        np.ones(2, dtype=np.int16),
+    ]
+    audio_queue: asyncio.Queue[npt.NDArray[np.int16 | np.float32] | None] = asyncio.Queue()
+    for frame in frames:
+        await audio_queue.put(frame)
+    await audio_queue.put(None)
+
+    with patch(
+        "agents.voice.models.openai_stt.transcription_span",
+        return_value=MagicMock(),
+    ):
+        await session._stream_audio(audio_queue)
+
+    # Every frame still reaches the websocket regardless of the tracing setting.
+    assert session._websocket.send.await_count == len(frames)
+
+    if trace_include_sensitive_audio_data:
+        assert len(session._turn_audio_buffer) == len(frames)
+        assert all(
+            buffered is frame
+            for buffered, frame in zip(session._turn_audio_buffer, frames, strict=True)
+        )
+    else:
+        assert session._turn_audio_buffer == []

--- a/tests/voice/test_pipeline.py
+++ b/tests/voice/test_pipeline.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import logging
+import weakref
 from collections.abc import AsyncGenerator, AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
+from unittest.mock import patch
 
 import numpy as np
 import numpy.typing as npt
@@ -27,6 +30,7 @@ try:
         VoiceStreamEventAudio,
         VoiceStreamEventLifecycle,
     )
+    from agents.voice.testing import ScriptedTTSModel
 
     from .helpers import extract_events
     from .pipeline_test_models import (
@@ -1532,3 +1536,75 @@ async def test_voice_workflow_errors_apply_model_and_tool_logging_policies(
             assert error in record.args
             assert record.exc_info is not None
             assert record.exc_info[1] is error
+
+
+class _WeakrefableChunk(bytearray):
+    """A buffer subclass that supports weak references, unlike ``bytes`` itself."""
+
+
+class RetentionProbeTTSModel(ScriptedTTSModel):
+    """Report whether the previous chunk survived after the pipeline consumed it."""
+
+    def __init__(self, chunk_count: int = 4) -> None:
+        super().__init__(model_name="retention-probe-tts")
+        self.chunk_count = chunk_count
+        self.retained_after_consumption: list[bool] = []
+
+    async def run(self, text: str, settings: TTSModelSettings) -> AsyncIterator[bytes]:
+        chunk_refs: list[weakref.ref[_WeakrefableChunk]] = []
+        for _ in range(self.chunk_count):
+            chunk = _WeakrefableChunk(np.zeros(2, dtype=np.int16).tobytes())
+            chunk_refs.append(weakref.ref(chunk))
+            yield cast(bytes, chunk)
+            # Control returns here only once the consumer has finished with the chunk.
+            del chunk
+            gc.collect()
+            # The consumer's `async for` variable still holds the chunk just yielded, so
+            # probe the one before it: by now only the span accumulator could keep it alive.
+            if len(chunk_refs) >= 2:
+                self.retained_after_consumption.append(chunk_refs[-2]() is not None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trace_include_sensitive_audio_data", [False, True])
+async def test_segment_audio_is_retained_only_for_audio_tracing(
+    trace_include_sensitive_audio_data: bool,
+) -> None:
+    tts_model = RetentionProbeTTSModel()
+    result = StreamedAudioResult(
+        tts_model,
+        # A buffer size of 1 flushes every chunk immediately, so the only thing that can
+        # still hold one afterwards is the span's audio accumulator.
+        TTSModelSettings(buffer_size=1),
+        VoicePipelineConfig(
+            trace_include_sensitive_audio_data=trace_include_sensitive_audio_data,
+        ),
+    )
+    collected: list[list[bytes]] = []
+
+    def fake_audio_to_base64(audio_data: list[bytes]) -> str:
+        collected.append(list(audio_data))
+        return ""
+
+    local_queue: asyncio.Queue[VoiceStreamEvent | None] = asyncio.Queue()
+    with trace("test"):
+        with patch("agents.voice.result._audio_to_base64", fake_audio_to_base64):
+            await result._stream_audio("one two three", local_queue)
+
+    expected_chunk = np.zeros(2, dtype=np.int16).tobytes()
+    if trace_include_sensitive_audio_data:
+        assert tts_model.retained_after_consumption == [True, True, True]
+        assert collected == [[expected_chunk] * tts_model.chunk_count]
+    else:
+        assert tts_model.retained_after_consumption == [False, False, False]
+        assert collected == []
+
+    # The emitted audio is identical either way.
+    emitted: list[bytes] = []
+    while not local_queue.empty():
+        event = local_queue.get_nowait()
+        if event is None:
+            continue
+        if isinstance(event, VoiceStreamEventAudio) and event.data is not None:
+            emitted.append(event.data.tobytes())
+    assert emitted == [expected_chunk] * tts_model.chunk_count


### PR DESCRIPTION
### Summary

Both voice audio paths accumulate raw PCM for an entire span and then only read it back when `trace_include_sensitive_audio_data` is enabled. With that flag off — the default — the audio is retained and discarded unread.

**Root cause.** The accumulator and its only consumer are guarded inconsistently:

| Path | Accumulates | Read back |
|---|---|---|
| `OpenAISTTTranscriptionSession._stream_audio` | `self._turn_audio_buffer.append(buffer)` — unconditional, every inbound frame | `_end_turn`, only under `if self._trace_include_sensitive_audio_data` |
| `StreamedAudioResult._stream_audio` | `full_audio_data.append(chunk)` — unconditional, every TTS chunk | `_audio_to_base64(full_audio_data)`, only under `if self._voice_pipeline_config.trace_include_sensitive_audio_data` |

`_turn_audio_buffer` and `full_audio_data` have no other readers in the tree, so when the flag is off the accumulation has no observable purpose.

The STT side is the worse of the two. `_turn_audio_buffer` is cleared only inside `_end_turn`, which runs only when a non-empty transcript arrives (or at `close()`), so a long turn — or a session where transcription never completes a turn — grows the buffer for the whole session. At the 24 kHz PCM16 the session negotiates, that is ~48 KB per second of held audio. The TTS side is bounded by one synthesized segment, but is the same defect.

This is also the inconsistency `.agents/references/voice-pipeline-lifecycle.md` describes under *Trace Lifetime and Data*: "Text and audio sensitivity are independent controls … `trace_include_sensitive_audio_data` governs encoded audio payloads." Today that control governs only whether the payload is *encoded*, not whether it is *collected*.

**Fix.** Guard both appends with the same flag that guards their reads. Fixed at the two append sites rather than at the readers, since the readers are already correct — the collection is what should not happen.

Not changed, deliberately: no new configuration knob, no change to the audio actually sent to the websocket or emitted as `VoiceStreamEventAudio`, and no change to what a span contains when audio tracing *is* enabled.

Sibling check: `OpenAISTTModel.transcribe` (the static, non-streamed path) already gets this right — it calls `input.to_base64()` inline under the flag and never accumulates, so it needed no change.

### Test plan

`make format && make lint && make typecheck && make tests`, all clean. Full suite: **8387 passed, 30 skipped**, plus `tests-serial` 77 passed. No pre-existing failures reproduced on this branch.

Two new parametrized tests, each proven to fail without the source change (source stashed, suite re-run, restored):

- `tests/voice/test_openai_stt.py::test_stream_audio_buffers_turn_audio_only_for_audio_tracing` — drives `_stream_audio` with a frame queue and asserts `_turn_audio_buffer` stays empty when the flag is off and holds exactly the submitted frames when it is on. Also asserts every frame still reaches the websocket either way. Fails on `main` with `assert [array([0, 0], dtype=int16), ...] == []`.
- `tests/voice/test_pipeline.py::test_segment_audio_is_retained_only_for_audio_tracing` — a TTS model that yields weak-referenceable chunks and records, after the consumer has finished with each one, whether it is still alive. With `buffer_size=1` every chunk is flushed immediately, so the span accumulator is the only thing that can still hold it. Asserts `[False, False, False]` with the flag off and `[True, True, True]` with it on, plus that the emitted audio events are byte-identical either way. Fails on `main` with `assert [True, True, True] == [False, False, False]`.

The probe reads the chunk from two iterations back rather than the previous one, because the consumer's `async for` variable still holds the chunk it was most recently handed.

### Issue number

None — found by reading `src/agents/voice/` against `.agents/references/voice-pipeline-lifecycle.md`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
