### PR TITLE
fix: max-turn handler session semantics

### DIFF
--- a/src/agents/exceptions.py
+++ b/src/agents/exceptions.py
@@ -5,6 +5,7 @@ import builtins
 import sys
 import traceback
 import types
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
@@ -34,6 +35,10 @@ _DATA_REDACTED_ERROR_MESSAGE = "Error details are redacted."
 _TYPE_NAMESPACE_DESCRIPTOR = cast(Any, type).__dict__["__dict__"]
 _TYPE_MRO_DESCRIPTOR = cast(Any, type).__dict__["__mro__"]
 _SYSTEM_EXIT_CODE_DESCRIPTOR = cast(Any, SystemExit).__dict__["code"]
+
+
+class _RedactedExceptionCancellationError(asyncio.CancelledError, Exception):
+    """Payload-free cancellation that remains catchable as an Exception."""
 
 
 def _mark_error_to_drain_stream_events(error: BaseException) -> None:
@@ -151,6 +156,28 @@ def _detach_data_redacted_error_traceback(error: BaseException) -> None:
             descriptor.__set__(error, None)
 
 
+async def _await_data_redacted_error_boundary(
+    awaitable_factory: Callable[[], Awaitable[Any]],
+) -> Any:
+    """Create an awaitable lazily and re-raise marked failures without payload data."""
+    awaitable: Awaitable[Any] | None = None
+    redacted_error: BaseException | None = None
+    try:
+        awaitable = awaitable_factory()
+        return await awaitable
+    except BaseException as error:
+        if not _is_error_data_redacted(error):
+            raise
+        _detach_data_redacted_error_traceback(error)
+        redacted_error = error
+
+    awaitable_factory = cast(Any, None)
+    awaitable = None
+    assert redacted_error is not None
+    _detach_data_redacted_error_traceback(redacted_error)
+    _raise_data_redacted_error(redacted_error)
+
+
 def _prepare_data_redacted_error(
     error: BaseException,
     *,
@@ -188,13 +215,40 @@ def _prepare_data_redacted_error(
     return safe_error
 
 
-def _replace_data_redacted_process_control_error(
+def _base_exception_group_exceptions(
+    error: BaseException,
+) -> tuple[BaseException, ...] | None:
+    """Read exception-group children without invoking subclass descriptors."""
+    if not issubclass(type(error), BaseExceptionGroup):
+        return None
+    try:
+        if sys.version_info < (3, 11):
+            state = _base_exception_instance_dict(error)
+            raw_exceptions = (
+                _exact_string_state_value(state, "_exceptions") if state is not None else None
+            )
+        else:
+            descriptor = type.__getattribute__(BaseExceptionGroup, "__dict__")["exceptions"]
+            raw_exceptions = descriptor.__get__(error, type(error))
+    except BaseException:
+        return None
+    if type(raw_exceptions) is not tuple:
+        return None
+    if not all(issubclass(type(candidate), BaseException) for candidate in raw_exceptions):
+        return None
+    return cast(tuple[BaseException, ...], raw_exceptions)
+
+
+def _copy_data_redacted_process_control_error(
     error: BaseException,
 ) -> BaseException | None:
-    """Discard a process-control source and return a fresh value-free replacement."""
+    """Return a fresh process-control replacement without mutating the source."""
     error_type = type(error)
     if issubclass(error_type, asyncio.CancelledError):
-        safe_error: BaseException | None = asyncio.CancelledError()
+        if issubclass(error_type, Exception):
+            safe_error: BaseException | None = _RedactedExceptionCancellationError()
+        else:
+            safe_error = asyncio.CancelledError()
     elif issubclass(error_type, GeneratorExit):
         safe_error = GeneratorExit()
     elif issubclass(error_type, KeyboardInterrupt):
@@ -217,11 +271,21 @@ def _replace_data_redacted_process_control_error(
                 safe_error = SystemExit(effective_code)
 
     assert safe_error is not None
-    _discard_exception_graph(error)
     try:
         _mark_error_data_redacted(safe_error)
     except BaseException:
         pass
+    return safe_error
+
+
+def _replace_data_redacted_process_control_error(
+    error: BaseException,
+) -> BaseException | None:
+    """Discard a process-control source and return a fresh value-free replacement."""
+    safe_error = _copy_data_redacted_process_control_error(error)
+    if safe_error is None:
+        return None
+    _discard_exception_graph(error)
     return safe_error
 
 
@@ -268,30 +332,9 @@ def _discard_exception_graph(error: BaseException) -> None:
         group_exceptions: tuple[BaseException, ...] | None = None
         current_type = type(current)
         if issubclass(current_type, BaseExceptionGroup):
-            try:
-                if sys.version_info < (3, 11):
-                    group_state = _base_exception_instance_dict(current)
-                    raw_group_exceptions = (
-                        _exact_string_state_value(group_state, "_exceptions")
-                        if group_state is not None
-                        else None
-                    )
-                else:
-                    group_descriptor = type.__getattribute__(BaseExceptionGroup, "__dict__")[
-                        "exceptions"
-                    ]
-                    raw_group_exceptions = group_descriptor.__get__(current, current_type)
-                if type(raw_group_exceptions) is tuple:
-                    group_exceptions = tuple(
-                        cast(BaseException, candidate)
-                        for candidate in raw_group_exceptions
-                        if issubclass(type(candidate), BaseException)
-                    )
-                else:
-                    group_exceptions = ()
+            group_exceptions = _base_exception_group_exceptions(current)
+            if group_exceptions is not None:
                 linked.extend(group_exceptions)
-            except BaseException:
-                pass
         for descriptor in (
             cast(Any, BaseException.__cause__),
             cast(Any, BaseException.__context__),

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -18,6 +18,7 @@ from .exceptions import (
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
     RunErrorDetails,
+    _await_data_redacted_error_boundary,
     _detach_data_redacted_error_traceback,
     _is_error_data_redacted,
     _should_drain_stream_events_before_raising,
@@ -706,18 +707,28 @@ class RunResultStreaming(RunResultBase):
         async def _await_run_and_cleanup() -> Any:
             try:
                 result = await original_task
-            except asyncio.CancelledError:
+            except asyncio.CancelledError as error:
                 if not original_task.done():
                     original_task.cancel()
+                if _is_error_data_redacted(error):
+                    _detach_data_redacted_error_traceback(error)
                 raise
-            except Exception:
+            except Exception as error:
                 await self._run_sandbox_cleanup()
+                if _is_error_data_redacted(error):
+                    _detach_data_redacted_error_traceback(error)
+                raise
+            except BaseException as error:
+                if _is_error_data_redacted(error):
+                    _detach_data_redacted_error_traceback(error)
                 raise
 
             await self._run_sandbox_cleanup()
             return result
 
-        self.run_loop_task = asyncio.create_task(_await_run_and_cleanup())
+        self.run_loop_task = asyncio.create_task(
+            _await_data_redacted_error_boundary(_await_run_and_cleanup)
+        )
 
     @property
     def run_loop_exception(self) -> BaseException | None:
@@ -743,7 +754,7 @@ class RunResultStreaming(RunResultBase):
         if task is None or not task.done() or task.cancelled():
             return None
         error = task.exception()
-        if isinstance(error, Exception) and _is_error_data_redacted(error):
+        if error is not None and _is_error_data_redacted(error):
             _detach_data_redacted_error_traceback(error)
         return error
 

--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -18,9 +18,12 @@ from .exceptions import (
     OutputGuardrailTripwireTriggered,
     RunErrorDetails,
     UserError,
+    _await_data_redacted_error_boundary,
     _clear_data_redacted_error_traceback,
     _detach_data_redacted_error_traceback,
     _is_error_data_redacted,
+    _prepare_data_redacted_error,
+    _raise_data_redacted_error,
 )
 from .guardrail import (
     InputGuardrailResult,
@@ -80,10 +83,7 @@ from .run_internal.approvals import approvals_from_step
 from .run_internal.error_handlers import (
     attach_generic_agent_error,
     build_run_error_data,
-    create_message_output_item,
-    format_final_output_text,
     resolve_run_error_handler_result,
-    validate_handler_final_output,
 )
 from .run_internal.items import (
     copy_input_items,
@@ -96,11 +96,11 @@ from .run_internal.run_grouping import resolve_run_grouping_id
 from .run_internal.run_loop import (
     _retained_items_for_blocked_output,
     cleanup_models_after_run,
+    finalize_max_turns_handler_output,
     get_all_tools,
     get_output_schema,
     initialize_computer_tools,
     resolve_interrupted_turn,
-    run_final_output_hooks,
     run_input_guardrails,
     run_output_guardrails,
     run_single_turn,
@@ -175,6 +175,23 @@ def set_default_agent_runner(runner: AgentRunner | None) -> None:
     """
     global DEFAULT_AGENT_RUNNER
     DEFAULT_AGENT_RUNNER = runner if runner is not None else AgentRunner()
+
+
+def _data_redacted_sync_cancellation_source(error: BaseException) -> BaseException | None:
+    """Return the marked task cancellation wrapped by Python 3.10, if any."""
+    if not issubclass(type(error), asyncio.CancelledError):
+        return None
+    try:
+        context = cast(Any, BaseException.__context__).__get__(error, type(error))
+    except BaseException:
+        return None
+    if (
+        context is not None
+        and issubclass(type(context), asyncio.CancelledError)
+        and _is_error_data_redacted(context)
+    ):
+        return cast(BaseException, context)
+    return None
 
 
 def get_default_agent_runner() -> AgentRunner:
@@ -285,7 +302,7 @@ class Runner:
         """
 
         runner = DEFAULT_AGENT_RUNNER
-        redacted_error: AgentsException | None = None
+        redacted_error: BaseException | None = None
         try:
             return await runner.run(
                 starting_agent,
@@ -300,7 +317,7 @@ class Runner:
                 conversation_id=conversation_id,
                 session=session,
             )
-        except AgentsException as error:
+        except BaseException as error:
             if not _is_error_data_redacted(error):
                 raise
             _detach_data_redacted_error_traceback(error)
@@ -388,7 +405,7 @@ class Runner:
         """
 
         runner = DEFAULT_AGENT_RUNNER
-        redacted_error: AgentsException | None = None
+        redacted_error: BaseException | None = None
         try:
             return runner.run_sync(
                 starting_agent,
@@ -403,7 +420,7 @@ class Runner:
                 session=session,
                 auto_previous_response_id=auto_previous_response_id,
             )
-        except AgentsException as error:
+        except BaseException as error:
             if not _is_error_data_redacted(error):
                 raise
             _detach_data_redacted_error_traceback(error)
@@ -510,6 +527,29 @@ class AgentRunner:
     """
 
     async def run(
+        self,
+        starting_agent: Agent[TContext],
+        input: str | list[TResponseInputItem] | RunState[TContext],
+        **kwargs: Unpack[RunOptions[TContext]],
+    ) -> RunResult:
+        redacted_error: BaseException | None = None
+        try:
+            return await self._run_impl(starting_agent, input, **kwargs)
+        except BaseException as error:
+            if not _is_error_data_redacted(error):
+                raise
+            _detach_data_redacted_error_traceback(error)
+            redacted_error = error
+
+        self = cast(Any, None)
+        starting_agent = cast(Any, None)
+        input = cast(Any, None)
+        cast(dict[str, Any], kwargs).clear()
+        assert redacted_error is not None
+        _detach_data_redacted_error_traceback(redacted_error)
+        raise redacted_error from None
+
+    async def _run_impl(
         self,
         starting_agent: Agent[TContext],
         input: str | list[TResponseInputItem] | RunState[TContext],
@@ -829,7 +869,9 @@ class AgentRunner:
 
                 # Output guardrails run once, at the end of the run. Accumulate their results
                 # here so the failure handler below can report them on the raised exception.
-                output_guardrail_results: list[OutputGuardrailResult] = []
+                output_guardrail_results: list[OutputGuardrailResult] = (
+                    list(run_state._output_guardrail_results) if run_state is not None else []
+                )
                 tool_input_guardrail_results: list[ToolInputGuardrailResult] = (
                     list(getattr(run_state, "_tool_input_guardrail_results", []))
                     if run_state is not None
@@ -1278,29 +1320,51 @@ class AgentRunner:
                         if handler_result is None:
                             raise max_turns_error
 
-                        validated_output = validate_handler_final_output(
-                            current_agent, handler_result.final_output
-                        )
-                        output_text = format_final_output_text(current_agent, validated_output)
-                        synthesized_item = create_message_output_item(current_agent, output_text)
                         include_in_history = handler_result.include_in_history
-                        if include_in_history:
-                            generated_items.append(synthesized_item)
-                            session_items.append(synthesized_item)
+                        handler_output_recorded = False
+                        handler_persisted_item_count = 0
 
-                        await run_final_output_hooks(
-                            current_agent,
-                            hooks,
-                            context_wrapper,
+                        async def _save_max_turns_handler_output(
+                            items: list[RunItem],
+                            store_setting: bool | None = store_setting,
+                            generated_items: list[RunItem] = generated_items,
+                            session_items: list[RunItem] = session_items,
+                        ) -> None:
+                            nonlocal handler_output_recorded, handler_persisted_item_count
+                            handler_persisted_item_count = (
+                                await save_final_turn_items_after_guardrails(
+                                    session=session,
+                                    run_state=None,
+                                    session_persistence_enabled=session_persistence_enabled,
+                                    input_guardrail_results=_attempt_input_guardrail_results(),
+                                    items=items,
+                                    response_id=None,
+                                    reasoning_item_id_policy=resolved_reasoning_item_id_policy,
+                                    store=store_setting,
+                                    wrapper=context_wrapper,
+                                )
+                            )
+                            if not items:
+                                return
+                            generated_items.extend(items)
+                            session_items.extend(items)
+                            handler_output_recorded = True
+
+                        (
                             validated_output,
+                            synthesized_item,
+                        ) = await finalize_max_turns_handler_output(
+                            agent=current_agent,
+                            hooks=hooks,
+                            run_config=run_config,
+                            output=handler_result.final_output,
+                            context_wrapper=context_wrapper,
+                            output_guardrail_results=output_guardrail_results,
+                            save_items_after_guardrails=_save_max_turns_handler_output,
+                            include_in_history=include_in_history,
                         )
-                        await run_output_guardrails(
-                            current_agent.output_guardrails + (run_config.output_guardrails or []),
-                            current_agent,
-                            validated_output,
-                            context_wrapper,
-                            output_guardrail_results,
-                        )
+                        if include_in_history and not handler_output_recorded:
+                            await _save_max_turns_handler_output([synthesized_item])
                         current_step = getattr(run_state, "_current_step", None)
                         approvals_from_state = approvals_from_step(current_step)
                         result = RunResult(
@@ -1325,27 +1389,7 @@ class AgentRunner:
                         )
                         if run_state is not None:
                             result._trace_state = run_state._trace_state
-                        if session_persistence_enabled and include_in_history:
-                            handler_input_items_for_save: list[TResponseInputItem] = (
-                                session_input_items_for_persistence
-                                if session_input_items_for_persistence is not None
-                                else []
-                            )
-                            # The synthesized item is a fresh one-item list, not the
-                            # cumulative turn item list, so the run state's per-turn
-                            # persisted count must not be applied as a slice offset here.
-                            # Pass the reasoning item id policy explicitly instead, the same
-                            # way `save_resumed_turn_items` does.
-                            await save_result_to_session(
-                                session,
-                                handler_input_items_for_save,
-                                [synthesized_item],
-                                None,
-                                response_id=None,
-                                reasoning_item_id_policy=resolved_reasoning_item_id_policy,
-                                store=store_setting,
-                                wrapper=context_wrapper,
-                            )
+                        result._current_turn_persisted_item_count = handler_persisted_item_count
                         result._original_input = copy_input_items(original_input)
                         return _finalize_result(result)
 
@@ -1796,15 +1840,15 @@ class AgentRunner:
                         turn_result.new_step_items.clear()
             except BaseException as exc:
                 run_exception = exc
-                attach_generic_agent_error(
-                    current_span,
-                    exc,
-                    trace_include_sensitive_data=run_config.trace_include_sensitive_data,
-                )
-                if isinstance(exc, AgentsException):
-                    if _is_error_data_redacted(exc):
-                        _detach_data_redacted_error_traceback(exc)
-                    else:
+                if _is_error_data_redacted(exc):
+                    _detach_data_redacted_error_traceback(exc)
+                else:
+                    attach_generic_agent_error(
+                        current_span,
+                        exc,
+                        trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+                    )
+                    if isinstance(exc, AgentsException):
                         _clear_data_redacted_error_traceback(exc)
                         exc.run_data = RunErrorDetails(
                             input=original_input,
@@ -1870,6 +1914,37 @@ class AgentRunner:
                     current_task_span.finish(reset_current=True)
 
     def run_sync(
+        self,
+        starting_agent: Agent[TContext],
+        input: str | list[TResponseInputItem] | RunState[TContext],
+        **kwargs: Unpack[RunOptions[TContext]],
+    ) -> RunResult:
+        redacted_error: BaseException | None = None
+        redacted_source: BaseException | None
+        try:
+            return self._run_sync_impl(starting_agent, input, **kwargs)
+        except BaseException as error:
+            if _is_error_data_redacted(error):
+                redacted_source = error
+            else:
+                redacted_source = _data_redacted_sync_cancellation_source(error)
+            if redacted_source is None:
+                raise
+            if isinstance(redacted_source, asyncio.CancelledError):
+                redacted_error = _prepare_data_redacted_error(redacted_source)
+            else:
+                _detach_data_redacted_error_traceback(redacted_source)
+                redacted_error = redacted_source
+
+        self = cast(Any, None)
+        starting_agent = cast(Any, None)
+        input = cast(Any, None)
+        cast(dict[str, Any], kwargs).clear()
+        assert redacted_error is not None
+        _detach_data_redacted_error_traceback(redacted_error)
+        _raise_data_redacted_error(redacted_error)
+
+    def _run_sync_impl(
         self,
         starting_agent: Agent[TContext],
         input: str | list[TResponseInputItem] | RunState[TContext],
@@ -1948,7 +2023,7 @@ class AgentRunner:
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     default_loop.run_until_complete(task)
-            if isinstance(error, ModelBehaviorError):
+            if _is_error_data_redacted(error) or isinstance(error, ModelBehaviorError):
                 _detach_data_redacted_error_traceback(error)
             raise
         finally:
@@ -2185,23 +2260,25 @@ class AgentRunner:
 
         # Kick off the actual agent loop in the background and return the streamed result object.
         streamed_result.run_loop_task = asyncio.create_task(
-            start_streaming(
-                starting_input=input_for_result,
-                streamed_result=streamed_result,
-                starting_agent=starting_agent,
-                max_turns=max_turns,
-                hooks=hooks,
-                context_wrapper=context_wrapper,
-                run_config=run_config,
-                error_handlers=error_handlers,
-                previous_response_id=previous_response_id,
-                auto_previous_response_id=auto_previous_response_id,
-                conversation_id=conversation_id,
-                session=session,
-                run_state=run_state,
-                trace_workflow_name=trace_workflow_name,
-                is_resumed_state=is_resumed_state,
-                sandbox_runtime=sandbox_runtime,
+            _await_data_redacted_error_boundary(
+                lambda: start_streaming(
+                    starting_input=input_for_result,
+                    streamed_result=streamed_result,
+                    starting_agent=starting_agent,
+                    max_turns=max_turns,
+                    hooks=hooks,
+                    context_wrapper=context_wrapper,
+                    run_config=run_config,
+                    error_handlers=error_handlers,
+                    previous_response_id=previous_response_id,
+                    auto_previous_response_id=auto_previous_response_id,
+                    conversation_id=conversation_id,
+                    session=session,
+                    run_state=run_state,
+                    trace_workflow_name=trace_workflow_name,
+                    is_resumed_state=is_resumed_state,
+                    sandbox_runtime=sandbox_runtime,
+                )
             )
         )
         if sandbox_runtime.enabled:

--- a/src/agents/run_internal/agent_runner_helpers.py
+++ b/src/agents/run_internal/agent_runner_helpers.py
@@ -15,7 +15,7 @@ from ..items import ModelResponse, RunItem, ToolApprovalItem, TResponseInputItem
 from ..memory import Session
 from ..models.openai_agent_registration import add_openai_harness_id_to_metadata
 from ..result import RunResult
-from ..run_config import RunConfig
+from ..run_config import ReasoningItemIdPolicy, RunConfig
 from ..run_context import RunContextWrapper, TContext
 from ..run_state import RunState
 from ..tool_guardrails import ToolInputGuardrailResult, ToolOutputGuardrailResult
@@ -536,14 +536,15 @@ async def save_final_turn_items_after_guardrails(
     input_guardrail_results: list[InputGuardrailResult],
     items: list[RunItem],
     response_id: str | None,
+    reasoning_item_id_policy: ReasoningItemIdPolicy | None = None,
     store: bool | None = None,
     wrapper: RunContextWrapper[Any] | None = None,
-) -> None:
+) -> int:
     """Persist deferred final-turn items without skipping a partially persisted resumed turn."""
     if not session_persistence_enabled or not items:
-        return
+        return 0
     if input_guardrails_triggered(input_guardrail_results):
-        return
+        return 0
     if run_state is not None and run_state._current_turn_persisted_item_count > 0:
         run_state._current_turn_persisted_item_count = await save_resumed_turn_items(
             session=session,
@@ -554,13 +555,14 @@ async def save_final_turn_items_after_guardrails(
             store=store,
             wrapper=wrapper,
         )
-        return
-    await save_result_to_session(
+        return run_state._current_turn_persisted_item_count
+    return await save_result_to_session(
         session,
         [],
         list(items),
         run_state,
         response_id=response_id,
+        reasoning_item_id_policy=reasoning_item_id_policy,
         store=store,
         wrapper=wrapper,
     )

--- a/src/agents/run_internal/run_loop.py
+++ b/src/agents/run_internal/run_loop.py
@@ -30,17 +30,22 @@ from ..agent_output import AgentOutputSchemaBase
 from ..exceptions import (
     _DATA_REDACTED_ERROR_MESSAGE,
     AgentsException,
+    BaseExceptionGroup,
     InputGuardrailTripwireTriggered,
     MaxTurnsExceeded,
     ModelBehaviorError,
     OutputGuardrailTripwireTriggered,
     RunErrorDetails,
     UserError,
+    _base_exception_group_exceptions,
     _clear_data_redacted_error_traceback,
+    _copy_data_redacted_process_control_error,
     _detach_data_redacted_error_traceback,
     _is_error_data_redacted,
     _mark_error_data_redacted,
+    _prepare_data_redacted_error,
 )
+from ..guardrail import OutputGuardrailResult
 from ..handoffs import Handoff
 from ..items import (
     InputItem,
@@ -251,6 +256,7 @@ __all__ = [
     "get_model_tracing_impl",
     "validate_run_hooks",
     "cleanup_models_after_run",
+    "finalize_max_turns_handler_output",
     "maybe_filter_model_input",
     "run_input_guardrails_with_queue",
     "start_streaming",
@@ -522,6 +528,7 @@ async def _finalize_streamed_final_output(
     response_id: str | None,
     store_setting: bool | None,
     persist_before_output_guardrails: bool,
+    on_persisted_after_guardrails: Callable[[bool], None] | None = None,
 ) -> None:
     redacted_persistence_error: BaseException | None = None
     if persist_before_output_guardrails:
@@ -560,15 +567,9 @@ async def _finalize_streamed_final_output(
         if not persist_before_output_guardrails:
             try:
                 await save_items(items, response_id, store_setting)
-            except (Exception, asyncio.CancelledError) as persistence_error:
+            except BaseException as persistence_error:
                 if guardrail_error_is_redacted:
-                    if isinstance(persistence_error, asyncio.CancelledError):
-                        safe_persistence_error: BaseException = asyncio.CancelledError(
-                            _DATA_REDACTED_ERROR_MESSAGE
-                        )
-                    else:
-                        safe_persistence_error = UserError(_DATA_REDACTED_ERROR_MESSAGE)
-                    _mark_error_data_redacted(safe_persistence_error)
+                    safe_persistence_error = _safe_redacted_persistence_error(persistence_error)
                     if (
                         isinstance(safe_persistence_error, asyncio.CancelledError)
                         and streamed_result._cancel_mode != "immediate"
@@ -596,23 +597,212 @@ async def _finalize_streamed_final_output(
                     streamed_result._stored_exception = persistence_error
                 if redacted_persistence_error is None:
                     raise
+            else:
+                if on_persisted_after_guardrails is not None:
+                    on_persisted_after_guardrails(False)
         if redacted_persistence_error is None:
             raise
 
     if redacted_persistence_error is not None:
         raise redacted_persistence_error from None
 
-    streamed_result.output_guardrail_results = output_guardrail_results
-    streamed_result.final_output = output
-    streamed_result.is_complete = True
+    streamed_result.output_guardrail_results.extend(output_guardrail_results)
 
     if not persist_before_output_guardrails:
         # Saved as one ordered batch so the session mirrors the model response. Doing it in two
         # halves would both reorder the turn and, because the first save advances the turn's
         # persisted-item count, make the second one a no-op.
-        await save_items(items, response_id, store_setting)
+        if on_persisted_after_guardrails is None:
+            await save_items(items, response_id, store_setting)
+        else:
+            try:
+                await save_items(items, response_id, store_setting)
+            except asyncio.CancelledError as persistence_error:
+                if streamed_result._cancel_mode == "immediate":
+                    raise
+                streamed_result._stored_exception = persistence_error
+                streamed_result.is_complete = True
+                streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+                return
+
+    streamed_result.final_output = output
+    if on_persisted_after_guardrails is not None:
+        on_persisted_after_guardrails(True)
+    streamed_result.is_complete = True
 
     streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+
+
+def _safe_redacted_persistence_leaf_error(error: BaseException) -> BaseException:
+    """Snapshot a payload-free non-group replacement without mutating the source."""
+    safe_error = _copy_data_redacted_process_control_error(error)
+    if isinstance(safe_error, asyncio.CancelledError):
+        safe_error.args = (_DATA_REDACTED_ERROR_MESSAGE,)
+        _mark_error_data_redacted(safe_error)
+        return safe_error
+    if isinstance(safe_error, GeneratorExit | KeyboardInterrupt | SystemExit):
+        return safe_error
+
+    if issubclass(type(error), Exception):
+        safe_error = UserError(_DATA_REDACTED_ERROR_MESSAGE)
+        _mark_error_data_redacted(safe_error)
+        return safe_error
+
+    safe_error = BaseException()
+    _mark_error_data_redacted(safe_error)
+    return safe_error
+
+
+class _RedactedBaseExceptionGroup(BaseExceptionGroup):
+    """Payload-free group that remains outside the Exception hierarchy."""
+
+
+def _safe_redacted_persistence_error(error: BaseException) -> BaseException:
+    """Return a payload-free persistence failure without swallowing control flow."""
+    if _base_exception_group_exceptions(error) is None:
+        safe_error = _safe_redacted_persistence_leaf_error(error)
+        _prepare_data_redacted_error(error)
+        return safe_error
+
+    group_children: dict[int, tuple[BaseException, ...]] = {}
+    group_is_exception: dict[int, bool] = {}
+    leaf_errors: dict[int, BaseException] = {}
+    safe_errors: dict[int, BaseException] = {}
+    group_postorder: list[BaseException] = []
+    pending: list[tuple[BaseException, bool]] = [(error, False)]
+    try:
+        while pending:
+            current, expanded = pending.pop()
+            current_id = id(current)
+            children = _base_exception_group_exceptions(current)
+            if children is None:
+                leaf_errors.setdefault(current_id, current)
+                continue
+            if expanded:
+                group_postorder.append(current)
+                continue
+            if current_id in group_children:
+                continue
+            group_children[current_id] = children
+            group_is_exception[current_id] = issubclass(type(current), Exception)
+            pending.append((current, True))
+            pending.extend((child, False) for child in reversed(children))
+
+        # Snapshot the full group topology before clearing any source exception. On Python 3.10,
+        # the exceptiongroup backport stores children in the instance dictionary, so sanitizing a
+        # linked leaf can otherwise erase a group that has not been converted yet.
+        for current_id, current in leaf_errors.items():
+            safe_errors[current_id] = _safe_redacted_persistence_leaf_error(current)
+
+        # Clear the complete provider-owned graph before constructing replacement groups. Group
+        # messages are read-only, so the source objects must never cross the public boundary.
+        _prepare_data_redacted_error(error)
+
+        for group in group_postorder:
+            children = group_children[id(group)]
+            safe_children = [safe_errors[id(child)] for child in children]
+            if not safe_children:
+                safe_children = [BaseException()]
+            if group_is_exception[id(group)]:
+                safe_group: BaseException = BaseExceptionGroup(
+                    _DATA_REDACTED_ERROR_MESSAGE,
+                    safe_children,
+                )
+            else:
+                safe_group = _RedactedBaseExceptionGroup(
+                    _DATA_REDACTED_ERROR_MESSAGE,
+                    safe_children,
+                )
+            _mark_error_data_redacted(safe_group)
+            safe_errors[id(group)] = safe_group
+        return safe_errors[id(error)]
+    except BaseException as conversion_error:
+        # Fail closed if traversal or reconstruction itself fails. Preparing the conversion error
+        # also clears its implicit context, including any source group still referenced there.
+        _prepare_data_redacted_error(error)
+        safe_error = _safe_redacted_persistence_leaf_error(conversion_error)
+        _prepare_data_redacted_error(conversion_error)
+        return safe_error
+
+
+async def finalize_max_turns_handler_output(
+    *,
+    agent: Agent[TContext],
+    hooks: RunHooks[TContext],
+    run_config: RunConfig,
+    output: Any,
+    context_wrapper: RunContextWrapper[TContext],
+    output_guardrail_results: list[OutputGuardrailResult],
+    save_items_after_guardrails: Callable[[list[RunItem]], Awaitable[None]],
+    include_in_history: bool,
+) -> tuple[Any, RunItem]:
+    """Validate and finalize one synthesized max-turn handler output."""
+    validated_output = validate_handler_final_output(agent, output)
+    output_text = format_final_output_text(agent, validated_output)
+    synthesized_item = create_message_output_item(agent, output_text)
+
+    await run_final_output_hooks(agent, hooks, context_wrapper, validated_output)
+
+    redacted_persistence_error: BaseException | None = None
+    try:
+        await run_output_guardrails(
+            agent.output_guardrails + (run_config.output_guardrails or []),
+            agent,
+            validated_output,
+            context_wrapper,
+            output_guardrail_results,
+        )
+    except OutputGuardrailTripwireTriggered:
+        raise
+    except Exception as guardrail_error:
+        guardrail_error_is_redacted = _is_error_data_redacted(guardrail_error)
+        if guardrail_error_is_redacted:
+            _detach_data_redacted_error_traceback(guardrail_error)
+        try:
+            await save_items_after_guardrails([synthesized_item] if include_in_history else [])
+        except BaseException as persistence_error:
+            if not guardrail_error_is_redacted:
+                raise
+            redacted_persistence_error = _safe_redacted_persistence_error(persistence_error)
+        if redacted_persistence_error is None:
+            raise
+
+    if redacted_persistence_error is not None:
+        raise redacted_persistence_error from None
+    return validated_output, synthesized_item
+
+
+async def _persist_stream_input_if_needed(
+    *,
+    streamed_result: RunResultStreaming,
+    session: Session | None,
+    server_conversation_tracker: OpenAIServerConversationTracker | None,
+    context_wrapper: RunContextWrapper[TContext],
+) -> None:
+    if (
+        streamed_result._stream_input_persisted
+        or session is None
+        or server_conversation_tracker is not None
+        or streamed_result._original_input_for_persistence is None
+        or len(streamed_result._original_input_for_persistence) == 0
+    ):
+        return
+
+    input_items_to_save = [
+        ensure_input_item_format(item)
+        for item in ItemHelpers.input_to_new_input_list(
+            streamed_result._original_input_for_persistence
+        )
+    ]
+    if input_items_to_save:
+        await save_result_to_session(
+            session,
+            input_items_to_save,
+            [],
+            streamed_result._state,
+            wrapper=context_wrapper,
+        )
+    streamed_result._stream_input_persisted = True
 
 
 def _accumulate_tool_guardrail_results(
@@ -919,6 +1109,27 @@ async def start_streaming(
                 update_persisted_count=False,
                 store=store_setting,
             )
+
+        async def _save_max_turns_items(
+            items: list[RunItem], response_id: str | None, store_setting: bool | None
+        ) -> None:
+            if not await _should_persist_stream_items(
+                session=session,
+                server_conversation_tracker=server_conversation_tracker,
+                streamed_result=streamed_result,
+            ):
+                return
+            saved_count = await save_result_to_session(
+                session,
+                [],
+                list(items),
+                None,
+                response_id=response_id,
+                reasoning_item_id_policy=streamed_result._reasoning_item_id_policy,
+                store=store_setting,
+                wrapper=streamed_result.context_wrapper,
+            )
+            streamed_result._current_turn_persisted_item_count += saved_count
     except BaseException:
         if current_task_span is not None:
             attach_usage_to_span(
@@ -1280,48 +1491,61 @@ async def start_streaming(
                     streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
                     break
 
+                await _persist_stream_input_if_needed(
+                    streamed_result=streamed_result,
+                    session=session,
+                    server_conversation_tracker=server_conversation_tracker,
+                    context_wrapper=context_wrapper,
+                )
+
                 validated_output = validate_handler_final_output(
                     current_agent, handler_result.final_output
                 )
                 output_text = format_final_output_text(current_agent, validated_output)
                 synthesized_item = create_message_output_item(current_agent, output_text)
                 include_in_history = handler_result.include_in_history
-                if include_in_history:
-                    streamed_result._model_input_items.append(synthesized_item)
-                    streamed_result.new_items.append(synthesized_item)
-                    if run_state is not None:
-                        run_state._generated_items = list(streamed_result._model_input_items)
-                        run_state._clear_generated_items_last_processed_marker()
-                        run_state._session_items = list(streamed_result.new_items)
-                    stream_step_items_to_queue([synthesized_item], streamed_result._event_queue)
-                    store_setting = current_agent.model_settings.resolve(
-                        run_config.model_settings
-                    ).store
-                    if is_resumed_state:
-                        await _save_resumed_items([synthesized_item], None, store_setting)
-                    else:
-                        await _save_stream_items_with_count([synthesized_item], None, store_setting)
+                store_setting = current_agent.model_settings.resolve(
+                    run_config.model_settings
+                ).store
 
                 await run_final_output_hooks(
                     current_agent, hooks, context_wrapper, validated_output
                 )
-                output_guardrail_results = await _run_output_guardrails_for_stream(
+
+                def _record_max_turns_handler_output(
+                    publish_events: bool,
+                    include_in_history: bool = include_in_history,
+                    synthesized_item: RunItem = synthesized_item,
+                ) -> None:
+                    if not include_in_history:
+                        return
+                    streamed_result._model_input_items.append(synthesized_item)
+                    streamed_result.new_items.append(synthesized_item)
+                    if run_state is not None and not is_resumed_state:
+                        run_state._generated_items = list(streamed_result._model_input_items)
+                        run_state._clear_generated_items_last_processed_marker()
+                        run_state._session_items = list(streamed_result.new_items)
+                    if publish_events:
+                        stream_step_items_to_queue([synthesized_item], streamed_result._event_queue)
+
+                await _finalize_streamed_final_output(
+                    streamed_result=streamed_result,
                     agent=current_agent,
                     run_config=run_config,
                     output=validated_output,
                     context_wrapper=context_wrapper,
-                    streamed_result=streamed_result,
+                    save_items=_save_max_turns_items,
+                    items=[synthesized_item] if include_in_history else [],
+                    response_id=None,
+                    store_setting=store_setting,
+                    persist_before_output_guardrails=False,
+                    on_persisted_after_guardrails=_record_max_turns_handler_output,
                 )
-                streamed_result.output_guardrail_results = output_guardrail_results
-                streamed_result.final_output = validated_output
-                streamed_result.is_complete = True
-                streamed_result._stored_exception = None
                 streamed_result._max_turns_handled = True
                 streamed_result.current_turn = max_turns
-                if run_state is not None:
+                if run_state is not None and not is_resumed_state:
                     run_state._current_turn = max_turns
                     run_state._current_step = None
-                streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
                 break
 
             if current_turn == 1:
@@ -1585,13 +1809,20 @@ async def start_streaming(
             )
         raise
     except Exception as e:
-        attach_generic_agent_error(
-            current_span,
-            e,
-            trace_include_sensitive_data=run_config.trace_include_sensitive_data,
-        )
+        if _is_error_data_redacted(e):
+            _detach_data_redacted_error_traceback(e)
+        else:
+            attach_generic_agent_error(
+                current_span,
+                e,
+                trace_include_sensitive_data=run_config.trace_include_sensitive_data,
+            )
         streamed_result.is_complete = True
         streamed_result._event_queue.put_nowait(QueueCompleteSentinel())
+        raise
+    except BaseException as error:
+        if _is_error_data_redacted(error):
+            _detach_data_redacted_error_traceback(error)
         raise
     else:
         streamed_result.is_complete = True
@@ -1788,28 +2019,12 @@ async def run_single_turn_streamed(
         ),
     )
 
-    if (
-        not streamed_result._stream_input_persisted
-        and session is not None
-        and server_conversation_tracker is None
-        and streamed_result._original_input_for_persistence is not None
-        and len(streamed_result._original_input_for_persistence) > 0
-    ):
-        streamed_result._stream_input_persisted = True
-        input_items_to_save = [
-            ensure_input_item_format(item)
-            for item in ItemHelpers.input_to_new_input_list(
-                streamed_result._original_input_for_persistence
-            )
-        ]
-        if input_items_to_save:
-            await save_result_to_session(
-                session,
-                input_items_to_save,
-                [],
-                streamed_result._state,
-                wrapper=context_wrapper,
-            )
+    await _persist_stream_input_if_needed(
+        streamed_result=streamed_result,
+        session=session,
+        server_conversation_tracker=server_conversation_tracker,
+        context_wrapper=context_wrapper,
+    )
 
     previous_response_id = (
         server_conversation_tracker.previous_response_id

--- a/tests/test_error_logging_redaction.py
+++ b/tests/test_error_logging_redaction.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import logging
 import pickle
+import sys
 import threading
 import traceback
 import warnings
@@ -41,12 +42,18 @@ from agents import (
     RunErrorHandlerInput,
     RunErrorHandlerResult,
     Runner,
+    RunResultStreaming,
     UserError,
     function_tool,
     handoff,
     trace,
 )
 from agents.agent_output import AgentOutputSchema
+from agents.exceptions import (
+    BaseExceptionGroup,
+    _detach_data_redacted_error_traceback,
+    _mark_error_data_redacted,
+)
 from agents.logger import (
     log_model_action_debug,
     log_model_action_error,
@@ -60,6 +67,8 @@ from agents.logger import (
     log_tool_action_warning,
 )
 from agents.realtime import RealtimeAgent, realtime_handoff
+from agents.run import AgentRunner
+from agents.run_internal.run_loop import _safe_redacted_persistence_error
 from agents.run_internal.tool_execution import (
     log_tool_action_error,
     resolve_approval_rejection_message,
@@ -103,6 +112,20 @@ class _HostileException(Exception):
 class _HostileAttributeWriteException(Exception):
     def __setattr__(self, name: str, value: Any) -> None:
         raise RuntimeError("redacted handling mutated the handler exception")
+
+
+class _DirectBaseException(BaseException):
+    pass
+
+
+class _HostileClassBaseException(BaseException):
+    @property
+    def __class__(self) -> type[object]:
+        raise RuntimeError("hostile class descriptor secret")
+
+
+class _HybridCancelledError(asyncio.CancelledError, Exception):
+    pass
 
 
 class _TruthinessException(Exception):
@@ -1327,6 +1350,30 @@ def test_run_sync_surfaces_redacted_output_validation_error_without_runner_data(
     assert all(session is not value for frame in frame_locals for value in frame.values())
 
 
+def test_run_sync_preserves_redacted_hybrid_cancellation_catchability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hybrid_error = _HybridCancelledError("RUN_SYNC_HYBRID_SECRET")
+    _mark_error_data_redacted(hybrid_error)
+
+    async def raise_hybrid_error(*_args: Any, **_kwargs: Any) -> Any:
+        raise hybrid_error
+
+    monkeypatch.setattr(AgentRunner, "run", raise_hybrid_error)
+
+    with pytest.raises(Exception) as exc_info:
+        AgentRunner().run_sync(Agent(name="A"), "RUN_SYNC_INPUT_SECRET")
+
+    error = exc_info.value
+    assert isinstance(error, asyncio.CancelledError)
+    assert isinstance(error, Exception)
+    assert str(error) == ""
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    _assert_secret_absent_from_agents_traceback(error, "RUN_SYNC_HYBRID_SECRET")
+    _assert_secret_absent_from_agents_traceback(error, "RUN_SYNC_INPUT_SECRET")
+
+
 @pytest.mark.asyncio
 async def test_run_preserves_diagnostic_wrapper_traceback_locals(
     monkeypatch: pytest.MonkeyPatch,
@@ -1345,6 +1392,31 @@ async def test_run_preserves_diagnostic_wrapper_traceback_locals(
     frame_locals = _agents_traceback_frame_locals(error)
     assert any(frame.get("input") == diagnostic_input for frame in frame_locals)
     assert any(frame.get("session") is session for frame in frame_locals)
+
+
+@pytest.mark.asyncio
+async def test_streaming_redaction_boundary_defers_inner_coroutine_until_task_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start_streaming_called = False
+
+    async def inner_streaming() -> None:
+        return None
+
+    def start_streaming_factory(**_kwargs: Any) -> Any:
+        nonlocal start_streaming_called
+        start_streaming_called = True
+        return inner_streaming()
+
+    monkeypatch.setattr("agents.run.start_streaming", start_streaming_factory)
+    result = AgentRunner().run_streamed(Agent(name="A", model=ScriptedModel()), "go")
+    assert result.run_loop_task is not None
+
+    result.run_loop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await result.run_loop_task
+
+    assert not start_streaming_called
 
 
 def test_run_sync_preserves_diagnostic_wrapper_traceback_locals(
@@ -1612,6 +1684,748 @@ async def test_streamed_session_hostile_error_after_redacted_output_guardrail_is
     assert persistence_secret not in str(error)
     _assert_secret_absent_from_agents_traceback(error, persistence_secret)
     _assert_secret_absent_from_agents_traceback(error, _MODEL_OUTPUT_SECRET)
+
+
+def _persistence_failure(
+    kind: Literal["exception", "cancelled", "direct_base", "exception_group", "group"],
+    secret: str,
+) -> BaseException:
+    if kind == "exception":
+        return LookupError(f"session save failed: {secret}")
+    if kind == "cancelled":
+        return asyncio.CancelledError(f"session save cancelled: {secret}")
+    if kind == "direct_base":
+        return _DirectBaseException(f"session save aborted: {secret}")
+    if kind == "exception_group":
+        return BaseExceptionGroup(
+            f"session save exception group: {secret}",
+            [RuntimeError(f"session save child: {secret}")],
+        )
+    return BaseExceptionGroup(
+        f"session save group: {secret}",
+        [
+            RuntimeError(f"session save child: {secret}"),
+            asyncio.CancelledError(f"session save cancelled child: {secret}"),
+        ],
+    )
+
+
+def _exception_graph(error: BaseException) -> list[BaseException]:
+    graph: list[BaseException] = []
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        graph.append(current)
+        if isinstance(current, BaseExceptionGroup):
+            pending.extend(current.exceptions)
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+    return graph
+
+
+def _assert_secret_absent_from_value_graph(value: Any, secret: str) -> None:
+    pending = [value]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+
+        if isinstance(current, str):
+            assert secret not in current
+        elif isinstance(current, bytes):
+            assert secret.encode() not in current
+        elif isinstance(current, BaseExceptionGroup):
+            assert secret not in current.message
+            pending.extend(current.exceptions)
+            pending.extend(current.args)
+        elif isinstance(current, BaseException):
+            assert secret not in str(current)
+            assert secret not in repr(current)
+            pending.extend(current.args)
+        elif type(current) is dict:
+            pending.extend(current.keys())
+            pending.extend(current.values())
+        elif type(current) in {list, tuple, set, frozenset}:
+            pending.extend(current)
+        else:
+            assert secret not in repr(current)
+
+
+@pytest.mark.parametrize("redacted", [False, True])
+@pytest.mark.parametrize(
+    "failure_kind",
+    ["exception", "cancelled", "direct_base", "exception_group", "base_group"],
+)
+@pytest.mark.asyncio
+async def test_sandbox_cleanup_wrapper_preserves_redaction_boundary(
+    redacted: bool,
+    failure_kind: Literal["exception", "cancelled", "direct_base", "exception_group", "base_group"],
+) -> None:
+    secret = f"SANDBOX_WRAPPER_SECRET_{failure_kind}"
+    if failure_kind == "exception":
+        error: BaseException = RuntimeError()
+    elif failure_kind == "cancelled":
+        error = asyncio.CancelledError()
+    elif failure_kind == "direct_base":
+        error = _DirectBaseException()
+    elif failure_kind == "exception_group":
+        error = BaseExceptionGroup("Error details are redacted.", [RuntimeError()])
+    else:
+        error = BaseExceptionGroup(
+            "Error details are redacted.",
+            [asyncio.CancelledError()],
+        )
+
+    async def original_task() -> None:
+        payload = secret
+        assert payload
+        try:
+            raise error
+        except BaseException as caught:
+            if redacted:
+                _mark_error_data_redacted(caught)
+                _detach_data_redacted_error_traceback(caught)
+                payload = None
+            raise
+
+    async def cleanup() -> None:
+        return None
+
+    result = RunResultStreaming(
+        input=secret,
+        new_items=[],
+        raw_responses=[],
+        final_output=None,
+        input_guardrail_results=[],
+        output_guardrail_results=[],
+        tool_input_guardrail_results=[],
+        tool_output_guardrail_results=[],
+        context_wrapper=RunContextWrapper(context=None),
+        current_agent=Agent(name="test"),
+        current_turn=0,
+        max_turns=1,
+        _current_agent_output_schema=None,
+        trace=None,
+    )
+    result._sandbox_cleanup = cleanup
+    result.run_loop_task = asyncio.create_task(original_task())
+    result.ensure_sandbox_cleanup_on_completion()
+    assert result.run_loop_task is not None
+
+    callback_frame_locals: list[dict[str, Any]] = []
+    task_done = asyncio.Event()
+
+    def inspect_public_task(task: asyncio.Task[Any]) -> None:
+        try:
+            task.result()
+        except BaseException as caught:
+            callback_frame_locals.extend(_agents_traceback_frame_locals(caught))
+        finally:
+            task_done.set()
+
+    result.run_loop_task.add_done_callback(inspect_public_task)
+    await asyncio.wait_for(task_done.wait(), timeout=1)
+
+    if redacted:
+        for frame_locals in callback_frame_locals:
+            _assert_secret_absent_from_value_graph(frame_locals, secret)
+    else:
+        if failure_kind == "cancelled" and sys.version_info < (3, 11):
+            assert callback_frame_locals == []
+        else:
+            assert callback_frame_locals
+            assert any(secret in repr(frame) for frame in callback_frame_locals)
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("failure_kind", ["exception", "cancelled", "direct_base", "group"])
+@pytest.mark.asyncio
+async def test_max_turns_recovery_session_failure_preserves_complete_redaction_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    streamed: bool,
+    failure_kind: Literal["exception", "cancelled", "direct_base", "group"],
+) -> None:
+    persistence_secret = "MAX_TURNS_SESSION_FAILURE_SECRET"
+    fallback_secret = "MAX_TURNS_HANDLER_OUTPUT_SECRET"
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+    guardrail_failed = False
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    class FailingMaxTurnsSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if guardrail_failed:
+                raise _persistence_failure(failure_kind, persistence_secret)
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _agent_output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        AgentOutputSchema(_RequiredOutput).validate_json(payload)
+        raise AssertionError("validation should fail")  # pragma: no cover
+
+    caplog.set_level(logging.ERROR, logger="openai.agents")
+    agent = Agent(
+        name="A",
+        model=ScriptedModel(),
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = FailingMaxTurnsSession()
+
+    captured_error: BaseException | None = None
+    try:
+        if streamed:
+            result = Runner.run_streamed(
+                agent,
+                "go",
+                max_turns=0,
+                session=session,
+                error_handlers={"max_turns": lambda data: fallback_secret},
+            )
+            async for _ in result.stream_events():
+                pass
+        else:
+            await Runner.run(
+                agent,
+                "go",
+                max_turns=0,
+                session=session,
+                error_handlers={"max_turns": lambda data: fallback_secret},
+            )
+    except BaseException as error:
+        captured_error = error
+    else:  # pragma: no cover
+        raise AssertionError("the session failure must propagate")
+
+    assert captured_error is not None
+    error = captured_error
+    if failure_kind == "exception":
+        assert isinstance(error, UserError)
+    elif failure_kind == "cancelled":
+        assert isinstance(error, asyncio.CancelledError)
+    elif failure_kind == "direct_base":
+        assert type(error) is BaseException
+    else:
+        assert isinstance(error, BaseExceptionGroup)
+        assert not isinstance(error, Exception)
+        assert {type(child) for child in error.exceptions} == {
+            UserError,
+            asyncio.CancelledError,
+        }
+
+    error_graph = _exception_graph(error)
+    assert error_graph
+    for current in error_graph:
+        assert current.__cause__ is None
+        assert current.__context__ is None
+        assert persistence_secret not in str(current)
+        assert persistence_secret not in repr(current)
+        assert fallback_secret not in str(current)
+        assert fallback_secret not in repr(current)
+        assert _MODEL_OUTPUT_SECRET not in str(current)
+        assert _MODEL_OUTPUT_SECRET not in repr(current)
+        _assert_secret_absent_from_agents_traceback(
+            current,
+            persistence_secret,
+            require_agents_frames=False,
+        )
+        _assert_secret_absent_from_agents_traceback(
+            current,
+            fallback_secret,
+            require_agents_frames=False,
+        )
+        _assert_secret_absent_from_agents_traceback(
+            current,
+            _MODEL_OUTPUT_SECRET,
+            require_agents_frames=False,
+        )
+
+    for record in caplog.records:
+        rendered_record = logging.Formatter().format(record)
+        record_state = repr(record.__dict__)
+        for secret in (persistence_secret, fallback_secret, _MODEL_OUTPUT_SECRET):
+            assert secret not in rendered_record
+            assert secret not in record_state
+        assert record.exc_info is None
+
+
+def _direct_agent_runner_redaction_case(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: Literal["cancelled", "direct_base", "exception_group", "group"],
+) -> tuple[Agent[Any], SimpleListSession, str, tuple[str, str, str, str]]:
+    persistence_secret = f"DIRECT_AGENT_RUNNER_PERSISTENCE_SECRET_{failure_kind}"
+    fallback_secret = f"DIRECT_AGENT_RUNNER_FALLBACK_SECRET_{failure_kind}"
+    input_secret = f"DIRECT_AGENT_RUNNER_INPUT_SECRET_{failure_kind}"
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+    guardrail_failed = False
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    class FailingSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if guardrail_failed:
+                raise _persistence_failure(failure_kind, persistence_secret)
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _agent_output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        AgentOutputSchema(_RequiredOutput).validate_json(payload)
+        raise AssertionError("validation should fail")  # pragma: no cover
+
+    agent = Agent(
+        name="A",
+        model=ScriptedModel(),
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    secrets = (persistence_secret, fallback_secret, input_secret, _MODEL_OUTPUT_SECRET)
+    return agent, FailingSession(), input_secret, secrets
+
+
+def _assert_direct_agent_runner_redaction_boundary(
+    error: BaseException,
+    secrets: tuple[str, str, str, str],
+) -> None:
+    for current in _exception_graph(error):
+        assert current.__cause__ is None
+        assert current.__context__ is None
+        for secret in secrets:
+            assert secret not in str(current)
+            assert secret not in repr(current)
+            for frame_locals in _agents_traceback_frame_locals(current):
+                _assert_secret_absent_from_value_graph(frame_locals, secret)
+
+
+@pytest.mark.parametrize(
+    "failure_kind",
+    ["cancelled", "direct_base", "exception_group", "group"],
+)
+@pytest.mark.asyncio
+async def test_agent_runner_run_detaches_all_marked_recovery_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: Literal["cancelled", "direct_base", "exception_group", "group"],
+) -> None:
+    agent, session, input_secret, secrets = _direct_agent_runner_redaction_case(
+        monkeypatch, failure_kind
+    )
+
+    with pytest.raises(BaseException) as exc_info:
+        await AgentRunner().run(
+            agent,
+            input_secret,
+            max_turns=0,
+            session=session,
+            error_handlers={"max_turns": lambda data: secrets[1]},
+        )
+
+    _assert_direct_agent_runner_redaction_boundary(exc_info.value, secrets)
+
+
+@pytest.mark.parametrize(
+    "failure_kind",
+    ["cancelled", "direct_base", "exception_group", "group"],
+)
+def test_agent_runner_run_sync_detaches_all_marked_recovery_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: Literal["cancelled", "direct_base", "exception_group", "group"],
+) -> None:
+    agent, session, input_secret, secrets = _direct_agent_runner_redaction_case(
+        monkeypatch, failure_kind
+    )
+
+    with pytest.raises(BaseException) as exc_info:
+        AgentRunner().run_sync(
+            agent,
+            input_secret,
+            max_turns=0,
+            session=session,
+            error_handlers={"max_turns": lambda data: secrets[1]},
+        )
+
+    _assert_direct_agent_runner_redaction_boundary(exc_info.value, secrets)
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_max_turns_recovery_deep_exception_group_preserves_redaction_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    streamed: bool,
+) -> None:
+    persistence_secret = "DEEP_MAX_TURNS_SESSION_FAILURE_SECRET"
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+    guardrail_failed = False
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    class DeepGroupSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if guardrail_failed:
+                error: BaseException = asyncio.CancelledError(persistence_secret)
+                for _ in range(1200):
+                    error = BaseExceptionGroup(persistence_secret, [error])
+                raise error
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _agent_output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        AgentOutputSchema(_RequiredOutput).validate_json(payload)
+        raise AssertionError("validation should fail")  # pragma: no cover
+
+    caplog.set_level(logging.ERROR, logger="openai.agents")
+    agent = Agent(
+        name="A",
+        model=ScriptedModel(),
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = DeepGroupSession()
+
+    captured_error: BaseException | None = None
+    try:
+        if streamed:
+            result = Runner.run_streamed(
+                agent,
+                "go",
+                max_turns=0,
+                session=session,
+                error_handlers={"max_turns": lambda data: "fallback"},
+            )
+            async for _ in result.stream_events():
+                pass
+        else:
+            await Runner.run(
+                agent,
+                "go",
+                max_turns=0,
+                session=session,
+                error_handlers={"max_turns": lambda data: "fallback"},
+            )
+    except BaseException as error:
+        captured_error = error
+    else:  # pragma: no cover
+        raise AssertionError("the deep exception group must propagate")
+
+    assert isinstance(captured_error, BaseExceptionGroup)
+    error_graph = _exception_graph(captured_error)
+    assert len(error_graph) == 1201
+    for current in error_graph:
+        assert current.__cause__ is None
+        assert current.__context__ is None
+        if isinstance(current, BaseExceptionGroup):
+            assert current.message == "Error details are redacted."
+        else:
+            assert isinstance(current, asyncio.CancelledError)
+            assert persistence_secret not in str(current)
+            assert persistence_secret not in repr(current)
+        for frame_locals in _agents_traceback_frame_locals(current):
+            _assert_secret_absent_from_value_graph(frame_locals, persistence_secret)
+            _assert_secret_absent_from_value_graph(frame_locals, _MODEL_OUTPUT_SECRET)
+
+    for record in caplog.records:
+        assert persistence_secret not in logging.Formatter().format(record)
+        assert persistence_secret not in repr(record.__dict__)
+        assert _MODEL_OUTPUT_SECRET not in logging.Formatter().format(record)
+        assert _MODEL_OUTPUT_SECRET not in repr(record.__dict__)
+        assert record.exc_info is None
+
+
+@pytest.mark.parametrize("redacted", [False, True])
+@pytest.mark.parametrize("failure_kind", ["direct_base", "group"])
+@pytest.mark.asyncio
+async def test_max_turns_run_loop_exception_follows_redaction_policy_for_base_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+    redacted: bool,
+    failure_kind: Literal["direct_base", "group"],
+) -> None:
+    persistence_secret = "RUN_LOOP_EXCEPTION_PERSISTENCE_SECRET"
+    fallback_secret = "RUN_LOOP_EXCEPTION_FALLBACK_SECRET"
+    payload = f'{{"answer": "{_MODEL_OUTPUT_SECRET}"}}'
+    guardrail_failed = False
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", redacted)
+    monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", False)
+
+    class FailingMaxTurnsSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if guardrail_failed:
+                raise _persistence_failure(failure_kind, persistence_secret)
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _agent_output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        AgentOutputSchema(_RequiredOutput).validate_json(payload)
+        raise AssertionError("validation should fail")  # pragma: no cover
+
+    result = Runner.run_streamed(
+        Agent(
+            name="A",
+            model=ScriptedModel(),
+            output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+        ),
+        "go",
+        max_turns=0,
+        session=FailingMaxTurnsSession(),
+        error_handlers={"max_turns": lambda data: fallback_secret},
+    )
+    assert result.run_loop_task is not None
+    callback_frame_locals: list[dict[str, Any]] = []
+    run_loop_done = asyncio.Event()
+
+    def inspect_run_loop_task(task: asyncio.Task[Any]) -> None:
+        try:
+            task.result()
+        except BaseException as error:
+            callback_frame_locals.extend(_agents_traceback_frame_locals(error))
+        finally:
+            run_loop_done.set()
+
+    result.run_loop_task.add_done_callback(inspect_run_loop_task)
+    await asyncio.wait_for(run_loop_done.wait(), timeout=1)
+
+    error = result.run_loop_exception
+    assert error is not None
+    frame_locals = _agents_traceback_frame_locals(error)
+    if redacted:
+        for traceback_locals in callback_frame_locals + frame_locals:
+            for secret in (persistence_secret, fallback_secret, _MODEL_OUTPUT_SECRET):
+                _assert_secret_absent_from_value_graph(traceback_locals, secret)
+        for current in _exception_graph(error):
+            assert current.__cause__ is None
+            assert current.__context__ is None
+            if isinstance(current, BaseExceptionGroup):
+                assert current.message == "Error details are redacted."
+            else:
+                for secret in (persistence_secret, fallback_secret, _MODEL_OUTPUT_SECRET):
+                    assert secret not in str(current)
+                    assert secret not in repr(current)
+    else:
+        assert callback_frame_locals
+        assert any(fallback_secret in repr(frame) for frame in callback_frame_locals)
+        assert frame_locals
+        assert any(fallback_secret in repr(frame) for frame in frame_locals)
+        assert persistence_secret in str(error)
+
+    try:
+        async for _ in result.stream_events():
+            pass
+    except BaseException as streamed_error:
+        assert streamed_error is error
+    else:  # pragma: no cover
+        raise AssertionError("the session failure must propagate through the stream")
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_type"),
+    [
+        (asyncio.CancelledError("secret"), asyncio.CancelledError),
+        (GeneratorExit("secret"), GeneratorExit),
+        (KeyboardInterrupt("secret"), KeyboardInterrupt),
+        (SystemExit("secret"), SystemExit),
+        (_DirectBaseException("secret"), BaseException),
+    ],
+)
+def test_safe_redacted_persistence_error_preserves_process_control_semantics(
+    source: BaseException,
+    expected_type: type[BaseException],
+) -> None:
+    safe_error = _safe_redacted_persistence_error(source)
+
+    assert type(safe_error) is expected_type
+    assert "secret" not in str(safe_error)
+    assert "secret" not in repr(safe_error)
+    assert safe_error.__cause__ is None
+    assert safe_error.__context__ is None
+    assert safe_error.__traceback__ is None
+
+
+def test_safe_redacted_persistence_error_snapshots_linked_group_topology() -> None:
+    linked_group = BaseExceptionGroup(
+        "linked group secret",
+        [KeyboardInterrupt("process-control secret")],
+    )
+    first_child = RuntimeError("first child secret")
+    first_child.__context__ = linked_group
+    source = BaseExceptionGroup("root group secret", [first_child, linked_group])
+
+    safe_error = _safe_redacted_persistence_error(source)
+
+    assert isinstance(safe_error, BaseExceptionGroup)
+    assert len(safe_error.exceptions) == 2
+    assert isinstance(safe_error.exceptions[0], UserError)
+    safe_linked_group = safe_error.exceptions[1]
+    assert isinstance(safe_linked_group, BaseExceptionGroup)
+    assert len(safe_linked_group.exceptions) == 1
+    assert type(safe_linked_group.exceptions[0]) is KeyboardInterrupt
+    assert "secret" not in repr(safe_error)
+
+
+def test_safe_redacted_persistence_error_preserves_provider_group_catch_category() -> None:
+    class ProviderBaseExceptionGroup(BaseExceptionGroup):
+        pass
+
+    direct_source = ProviderBaseExceptionGroup(
+        "direct provider secret",
+        [RuntimeError("direct leaf secret")],
+    )
+    nested_source = BaseExceptionGroup(
+        "root group secret",
+        [
+            KeyboardInterrupt("process-control secret"),
+            ProviderBaseExceptionGroup(
+                "nested provider secret",
+                [RuntimeError("nested leaf secret")],
+            ),
+        ],
+    )
+
+    direct = _safe_redacted_persistence_error(direct_source)
+    nested = _safe_redacted_persistence_error(nested_source)
+
+    assert isinstance(direct, BaseExceptionGroup)
+    assert not isinstance(direct, Exception)
+    assert len(direct.exceptions) == 1
+    assert isinstance(direct.exceptions[0], UserError)
+    assert isinstance(nested, BaseExceptionGroup)
+    assert not isinstance(nested, Exception)
+    assert len(nested.exceptions) == 2
+    nested_provider = nested.exceptions[1]
+    assert isinstance(nested_provider, BaseExceptionGroup)
+    assert not isinstance(nested_provider, Exception)
+    assert len(nested_provider.exceptions) == 1
+    assert isinstance(nested_provider.exceptions[0], UserError)
+    assert "secret" not in repr(direct)
+    assert "secret" not in repr(nested)
+
+
+def test_safe_redacted_persistence_error_snapshots_linked_system_exit_code() -> None:
+    system_exit = SystemExit(7)
+    first_child = RuntimeError("first child secret")
+    first_child.__context__ = system_exit
+    source = BaseExceptionGroup("root group secret", [first_child, system_exit])
+
+    safe_error = _safe_redacted_persistence_error(source)
+
+    assert isinstance(safe_error, BaseExceptionGroup)
+    assert isinstance(safe_error.exceptions[0], UserError)
+    safe_system_exit = safe_error.exceptions[1]
+    assert type(safe_system_exit) is SystemExit
+    assert safe_system_exit.code == 7
+    assert safe_system_exit.args == (7,)
+    assert "secret" not in repr(safe_error)
+
+
+def test_safe_redacted_persistence_error_avoids_hostile_class_descriptor() -> None:
+    source = _HostileClassBaseException("persistence secret")
+
+    safe_error = _safe_redacted_persistence_error(source)
+
+    assert type(safe_error) is BaseException
+    assert safe_error.__cause__ is None
+    assert safe_error.__context__ is None
+    assert "secret" not in str(safe_error)
+    assert "secret" not in repr(safe_error)
+
+
+def test_safe_redacted_persistence_error_preserves_hybrid_cancellation() -> None:
+    direct_source = _HybridCancelledError("direct secret")
+    grouped_source = BaseExceptionGroup("group secret", [_HybridCancelledError("child secret")])
+    direct = _safe_redacted_persistence_error(direct_source)
+    grouped = _safe_redacted_persistence_error(grouped_source)
+
+    assert isinstance(direct, asyncio.CancelledError)
+    assert isinstance(direct, Exception) is isinstance(direct_source, Exception)
+    assert str(direct) == "Error details are redacted."
+    assert isinstance(grouped, BaseExceptionGroup)
+    assert isinstance(grouped, Exception) is isinstance(grouped_source, Exception)
+    assert len(grouped.exceptions) == 1
+    assert isinstance(grouped.exceptions[0], asyncio.CancelledError)
+    assert isinstance(grouped.exceptions[0], Exception)
+    assert "secret" not in repr(grouped)
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_max_turns_recovery_session_failure_preserves_diagnostic_context(
+    monkeypatch: pytest.MonkeyPatch,
+    streamed: bool,
+) -> None:
+    persistence_secret = "DIAGNOSTIC_MAX_TURNS_SESSION_SECRET"
+    guardrail_secret = "DIAGNOSTIC_MAX_TURNS_GUARDRAIL_SECRET"
+    guardrail_failed = False
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", False)
+
+    class FailingMaxTurnsSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if guardrail_failed:
+                raise LookupError(persistence_secret)
+            await super().add_items(items)
+
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _agent_output: Any,
+    ) -> GuardrailFunctionOutput:
+        nonlocal guardrail_failed
+        guardrail_failed = True
+        raise RuntimeError(guardrail_secret)
+
+    agent = Agent(
+        name="A",
+        model=ScriptedModel(),
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = FailingMaxTurnsSession()
+
+    if streamed:
+        result = Runner.run_streamed(
+            agent,
+            "go",
+            max_turns=0,
+            session=session,
+            error_handlers={"max_turns": lambda data: "fallback"},
+        )
+        with pytest.raises(LookupError, match=persistence_secret) as exc_info:
+            async for _ in result.stream_events():
+                pass
+    else:
+        with pytest.raises(LookupError, match=persistence_secret) as exc_info:
+            await Runner.run(
+                agent,
+                "go",
+                max_turns=0,
+                session=session,
+                error_handlers={"max_turns": lambda data: "fallback"},
+            )
+
+    guardrail_error = exc_info.value.__context__
+    assert isinstance(guardrail_error, RuntimeError)
+    assert guardrail_secret in str(guardrail_error)
 
 
 @pytest.mark.asyncio

--- a/tests/test_max_turns.py
+++ b/tests/test_max_turns.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import json
+from typing import Any, Literal
 
 import pytest
 from pydantic import BaseModel
@@ -8,10 +10,14 @@ from typing_extensions import TypedDict
 
 from agents import (
     Agent,
+    GuardrailFunctionOutput,
     ItemHelpers,
     MaxTurnsExceeded,
     MessageOutputItem,
     ModelRefusalError,
+    OutputGuardrail,
+    OutputGuardrailTripwireTriggered,
+    RunContextWrapper,
     RunErrorHandlerResult,
     Runner,
     SQLiteSession,
@@ -26,6 +32,7 @@ from .test_responses import (
     get_refusal_message,
     get_text_message,
 )
+from .utils.simple_session import SimpleListSession
 
 
 @pytest.mark.asyncio
@@ -545,3 +552,492 @@ async def test_streamed_max_turns_handler_persists_output_to_session():
     item_types = await _run_max_turns_handler_with_session(streamed=True)
 
     assert item_types == ["user", "function_call", "function_call_output", "message"]
+
+
+@pytest.mark.parametrize("include_in_history", [False, True])
+@pytest.mark.asyncio
+async def test_max_turns_handler_persisted_count_matches_after_tool_turn(
+    include_in_history: bool,
+) -> None:
+    async def run_once(streamed: bool) -> tuple[int, list[str]]:
+        model = ScriptedModel(
+            steps=[[get_function_tool_call("some_function", json.dumps({"a": "b"}))]]
+        )
+        agent = Agent(
+            name="test",
+            model=model,
+            tools=[get_function_tool("some_function", "result")],
+        )
+        session = SimpleListSession()
+        handler_result = RunErrorHandlerResult(
+            final_output="fallback answer",
+            include_in_history=include_in_history,
+        )
+
+        if streamed:
+            result = Runner.run_streamed(
+                agent,
+                "user_message",
+                max_turns=1,
+                session=session,
+                error_handlers={"max_turns": lambda data: handler_result},
+            )
+            async for _ in result.stream_events():
+                pass
+        else:
+            result = await Runner.run(
+                agent,
+                "user_message",
+                max_turns=1,
+                session=session,
+                error_handlers={"max_turns": lambda data: handler_result},
+            )
+
+        persisted_count = result.to_state()._current_turn_persisted_item_count
+        saved_types = [
+            str(item.get("type", item.get("role"))) for item in await session.get_items()
+        ]
+        return persisted_count, saved_types
+
+    non_streamed = await run_once(streamed=False)
+    streamed = await run_once(streamed=True)
+
+    expected_types = ["user", "function_call", "function_call_output"]
+    expected_count = 0
+    if include_in_history:
+        expected_types.append("message")
+        expected_count = 1
+    assert non_streamed == streamed == (expected_count, expected_types)
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("outcome", ["pass", "error", "tripwire"])
+@pytest.mark.asyncio
+async def test_max_turns_handler_output_guardrail_session_semantics(
+    streamed: bool,
+    outcome: Literal["pass", "error", "tripwire"],
+) -> None:
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        if outcome == "error":
+            raise RuntimeError("guardrail failed")
+        return GuardrailFunctionOutput(
+            output_info=outcome,
+            tripwire_triggered=outcome == "tripwire",
+        )
+
+    agent = Agent(
+        name="test",
+        model=ScriptedModel(),
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    session = SimpleListSession()
+    streamed_events: list[Any] = []
+    streamed_result: Any = None
+
+    async def run_once() -> Any:
+        nonlocal streamed_result
+        if not streamed:
+            return await Runner.run(
+                agent,
+                "user_message",
+                max_turns=0,
+                session=session,
+                error_handlers={"max_turns": lambda data: "fallback answer"},
+            )
+        streamed_result = Runner.run_streamed(
+            agent,
+            "user_message",
+            max_turns=0,
+            session=session,
+            error_handlers={"max_turns": lambda data: "fallback answer"},
+        )
+        streamed_events.extend([event async for event in streamed_result.stream_events()])
+        return streamed_result
+
+    if outcome == "error":
+        with pytest.raises(RuntimeError, match="guardrail failed"):
+            await run_once()
+    elif outcome == "tripwire":
+        with pytest.raises(OutputGuardrailTripwireTriggered):
+            await run_once()
+    else:
+        result = await run_once()
+        assert result.final_output == "fallback answer"
+        assert len(result.output_guardrail_results) == 1
+        assert result.to_state()._current_turn_persisted_item_count == 1
+
+    saved_items = await session.get_items()
+    saved_types = [str(item.get("type", item.get("role"))) for item in saved_items]
+    if outcome == "tripwire":
+        assert saved_types == ["user"]
+    else:
+        assert saved_types == ["user", "message"]
+
+    fallback_events = [
+        event
+        for event in streamed_events
+        if isinstance(event, RunItemStreamEvent)
+        and isinstance(event.item, MessageOutputItem)
+        and ItemHelpers.text_message_output(event.item) == "fallback answer"
+    ]
+    assert len(fallback_events) == (1 if streamed and outcome == "pass" else 0)
+
+    if streamed:
+        assert streamed_result is not None
+        expected_history_count = 0 if outcome == "tripwire" else 1
+        assert (
+            len([item for item in streamed_result.new_items if isinstance(item, MessageOutputItem)])
+            == expected_history_count
+        )
+        state = streamed_result.to_state()
+        assert (
+            len([item for item in state._session_items if isinstance(item, MessageOutputItem)])
+            == expected_history_count
+        )
+
+
+@pytest.mark.asyncio
+async def test_streamed_max_turns_handler_validation_failure_persists_input() -> None:
+    agent = Agent(name="test", model=ScriptedModel(), output_type=Foo)
+    session = SimpleListSession()
+    result = Runner.run_streamed(
+        agent,
+        "user_message",
+        max_turns=0,
+        session=session,
+        error_handlers={"max_turns": lambda data: {"summary": "invalid"}},
+    )
+
+    with pytest.raises(UserError):
+        async for _ in result.stream_events():
+            pass
+
+    saved_items = await session.get_items()
+    assert [item.get("type", item.get("role")) for item in saved_items] == ["user"]
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_max_turns_handler_records_equal_message_occurrences(streamed: bool) -> None:
+    model = ScriptedModel(
+        steps=[
+            [
+                get_text_message("same answer"),
+                get_function_tool_call("some_function", json.dumps({"a": "b"})),
+            ]
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=model,
+        tools=[get_function_tool("some_function", "result")],
+    )
+    session = SimpleListSession()
+
+    if streamed:
+        result = Runner.run_streamed(
+            agent,
+            "user_message",
+            max_turns=1,
+            session=session,
+            error_handlers={"max_turns": lambda data: "same answer"},
+        )
+        async for _ in result.stream_events():
+            pass
+    else:
+        await Runner.run(
+            agent,
+            "user_message",
+            max_turns=1,
+            session=session,
+            error_handlers={"max_turns": lambda data: "same answer"},
+        )
+
+    saved_items = await session.get_items()
+    messages = [item for item in saved_items if item.get("type") == "message"]
+    assert len(messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_streamed_max_turns_handler_can_skip_history_with_session() -> None:
+    agent = Agent(name="test", model=ScriptedModel())
+    session = SimpleListSession()
+    result = Runner.run_streamed(
+        agent,
+        "user_message",
+        max_turns=0,
+        session=session,
+        error_handlers={
+            "max_turns": lambda data: RunErrorHandlerResult(
+                final_output="fallback answer",
+                include_in_history=False,
+            )
+        },
+    )
+
+    events = [event async for event in result.stream_events()]
+
+    assert result.final_output == "fallback answer"
+    assert not any(isinstance(event, RunItemStreamEvent) for event in events)
+    saved_items = await session.get_items()
+    assert [item.get("type", item.get("role")) for item in saved_items] == ["user"]
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_max_turns_handler_session_cancellation_does_not_publish_output(
+    streamed: bool,
+) -> None:
+    class CancellingFinalSaveSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if any(item.get("type") == "message" for item in items):
+                raise asyncio.CancelledError("session save cancelled")
+            await super().add_items(items)
+
+    agent = Agent(name="test", model=ScriptedModel())
+    session = CancellingFinalSaveSession()
+    streamed_result: Any = None
+
+    with pytest.raises(asyncio.CancelledError, match="session save cancelled"):
+        if streamed:
+            streamed_result = Runner.run_streamed(
+                agent,
+                "user_message",
+                max_turns=0,
+                session=session,
+                error_handlers={"max_turns": lambda data: "fallback answer"},
+            )
+            async for _ in streamed_result.stream_events():
+                pass
+        else:
+            await Runner.run(
+                agent,
+                "user_message",
+                max_turns=0,
+                session=session,
+                error_handlers={"max_turns": lambda data: "fallback answer"},
+            )
+
+    saved_items = await session.get_items()
+    assert [item.get("type", item.get("role")) for item in saved_items] == ["user"]
+    if streamed:
+        assert streamed_result.final_output is None
+        assert streamed_result.new_items == []
+
+
+@pytest.mark.asyncio
+async def test_non_streamed_max_turns_handler_session_failure_does_not_record_output() -> None:
+    class FailingFinalSaveSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if any(item.get("type") == "message" for item in items):
+                raise UserError("session save failed")
+            await super().add_items(items)
+
+    agent = Agent(name="test", model=ScriptedModel())
+    session = FailingFinalSaveSession()
+
+    with pytest.raises(UserError, match="session save failed") as exc_info:
+        await Runner.run(
+            agent,
+            "user_message",
+            max_turns=0,
+            session=session,
+            error_handlers={"max_turns": lambda data: "fallback answer"},
+        )
+
+    saved_items = await session.get_items()
+    assert [item.get("type", item.get("role")) for item in saved_items] == ["user"]
+    assert exc_info.value.run_data is not None
+    assert ItemHelpers.text_message_outputs(exc_info.value.run_data.new_items) == ""
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize(
+    ("outcome", "include_in_history"),
+    [
+        ("success", True),
+        ("success", False),
+        ("guardrail_error", True),
+        ("session_failure", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_resumed_max_turns_handler_does_not_append_to_caller_state_items(
+    streamed: bool,
+    outcome: Literal["success", "guardrail_error", "session_failure"],
+    include_in_history: bool,
+) -> None:
+    fail_message_save = False
+
+    class FailingSession(SimpleListSession):
+        async def add_items(self, items: list[Any]) -> None:
+            if fail_message_save and any(item.get("type") == "message" for item in items):
+                raise UserError("session save failed")
+            await super().add_items(items)
+
+    model = ScriptedModel(steps=[[get_text_message("first response")]])
+    agent = Agent(name="test", model=model)
+    session = FailingSession()
+    first = await Runner.run(agent, "first input", max_turns=1, session=session)
+    state = first.to_state()
+    generated_items_before = state.to_json()["generated_items"]
+    session_items_before = state.to_json()["session_items"]
+
+    if outcome == "guardrail_error":
+
+        def fail_guardrail(
+            _context: RunContextWrapper[Any],
+            _agent: Agent[Any],
+            _output: Any,
+        ) -> GuardrailFunctionOutput:
+            raise RuntimeError("guardrail failed")
+
+        agent.output_guardrails = [OutputGuardrail(guardrail_function=fail_guardrail)]
+    fail_message_save = outcome == "session_failure"
+    handler_result = RunErrorHandlerResult(
+        final_output="fallback answer",
+        include_in_history=include_in_history,
+    )
+
+    if streamed:
+        result = Runner.run_streamed(
+            agent,
+            state,
+            session=session,
+            error_handlers={"max_turns": lambda data: handler_result},
+        )
+        if outcome == "guardrail_error":
+            with pytest.raises(RuntimeError, match="guardrail failed"):
+                async for _ in result.stream_events():
+                    pass
+        elif outcome == "session_failure":
+            with pytest.raises(UserError, match="session save failed"):
+                async for _ in result.stream_events():
+                    pass
+        else:
+            async for _ in result.stream_events():
+                pass
+            assert result.final_output == "fallback answer"
+    else:
+        if outcome == "guardrail_error":
+            with pytest.raises(RuntimeError, match="guardrail failed"):
+                await Runner.run(
+                    agent,
+                    state,
+                    session=session,
+                    error_handlers={"max_turns": lambda data: handler_result},
+                )
+        elif outcome == "session_failure":
+            with pytest.raises(UserError, match="session save failed"):
+                await Runner.run(
+                    agent,
+                    state,
+                    session=session,
+                    error_handlers={"max_turns": lambda data: handler_result},
+                )
+        else:
+            result = await Runner.run(
+                agent,
+                state,
+                session=session,
+                error_handlers={"max_turns": lambda data: handler_result},
+            )
+            assert result.final_output == "fallback answer"
+
+    assert state.to_json()["generated_items"] == generated_items_before
+    assert state.to_json()["session_items"] == session_items_before
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_resumed_max_turns_handler_preserves_output_guardrail_results(
+    streamed: bool,
+) -> None:
+    def output_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        output: Any,
+    ) -> GuardrailFunctionOutput:
+        return GuardrailFunctionOutput(output_info=output, tripwire_triggered=False)
+
+    agent = Agent(
+        name="test",
+        model=ScriptedModel(steps=[[get_text_message("first response")]]),
+        output_guardrails=[OutputGuardrail(guardrail_function=output_guardrail)],
+    )
+    first = await Runner.run(agent, "first input", max_turns=1)
+    if streamed:
+        result = Runner.run_streamed(
+            agent,
+            first.to_state(),
+            error_handlers={"max_turns": lambda data: "fallback answer"},
+        )
+        async for _ in result.stream_events():
+            pass
+    else:
+        result = await Runner.run(
+            agent,
+            first.to_state(),
+            error_handlers={"max_turns": lambda data: "fallback answer"},
+        )
+
+    assert [item.output.output_info for item in result.output_guardrail_results] == [
+        "first response",
+        "fallback answer",
+    ]
+    assert [item.output.output_info for item in result.to_state()._output_guardrail_results] == [
+        "first response",
+        "fallback answer",
+    ]
+
+
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_resumed_max_turns_handler_preserves_checkpoint_after_continuation(
+    streamed: bool,
+) -> None:
+    agent = Agent(
+        name="test",
+        model=ScriptedModel(steps=[[get_text_message("first response")]]),
+    )
+    first = await Runner.run(agent, "first input", max_turns=2)
+    state = first.to_state()
+    generated_before = state.to_json()["generated_items"]
+    session_before = state.to_json()["session_items"]
+    agent.model = ScriptedModel(
+        steps=[[get_function_tool_call("some_function", json.dumps({"a": "b"}))]]
+    )
+    agent.tools = [get_function_tool("some_function", "result")]
+
+    def fail_guardrail(
+        _context: RunContextWrapper[Any],
+        _agent: Agent[Any],
+        _output: Any,
+    ) -> GuardrailFunctionOutput:
+        raise RuntimeError("guardrail failed")
+
+    agent.output_guardrails = [OutputGuardrail(guardrail_function=fail_guardrail)]
+
+    if streamed:
+        result = Runner.run_streamed(
+            agent,
+            state,
+            error_handlers={"max_turns": lambda data: "fallback answer"},
+        )
+        with pytest.raises(RuntimeError, match="guardrail failed"):
+            async for _ in result.stream_events():
+                pass
+    else:
+        with pytest.raises(RuntimeError, match="guardrail failed"):
+            await Runner.run(
+                agent,
+                state,
+                error_handlers={"max_turns": lambda data: "fallback answer"},
+            )
+
+    assert state.to_json()["generated_items"] == generated_before
+    assert state.to_json()["session_items"] == session_before


### PR DESCRIPTION
This pull request fixes max-turn error-handler finalization so streaming and non-streaming runs preserve the same session, guardrail, event, and RunState history semantics. It persists accepted fallback output only after terminal validation and guardrails, excludes tripwire-rejected output, preserves replayable output on ordinary guardrail errors, and keeps recovery failures payload-safe without changing public APIs.

This pull request resolves #4393.
