### PR TITLE
fix: isolate RunState checkpoint tool decisions

### DIFF
--- a/src/agents/agent_tool_state.py
+++ b/src/agents/agent_tool_state.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 ToolCallSignature = tuple[str, str, str, str, str | None, str | None]
 ScopedToolCallSignature = tuple[str | None, ToolCallSignature]
+ScopedToolCallObject = tuple[str | None, int]
 
 
 @dataclass
@@ -34,14 +35,14 @@ _AGENT_TOOL_STATE_SCOPE_ATTR = "_agent_tool_state_scope_id"
 # Ephemeral maps linking tool call objects to nested agent results within the same run.
 # Store by object identity, and index by a stable signature to avoid call ID collisions.
 _agent_tool_run_results_by_obj: dict[
-    int, RunResult | RunResultStreaming | _AgentToolResumeCheckpoint
+    ScopedToolCallObject, RunResult | RunResultStreaming | _AgentToolResumeCheckpoint
 ] = {}
 _agent_tool_run_results_by_signature: dict[
     ScopedToolCallSignature,
-    set[int],
+    set[ScopedToolCallObject],
 ] = {}
 _agent_tool_run_result_signature_by_obj: dict[
-    int,
+    ScopedToolCallObject,
     ScopedToolCallSignature,
 ] = {}
 _agent_tool_call_refs_by_obj: dict[int, weakref.ReferenceType[ResponseFunctionToolCall]] = {}
@@ -92,25 +93,26 @@ def _scoped_tool_call_signature(
 
 def _index_agent_tool_run_result(
     tool_call: ResponseFunctionToolCall,
-    tool_call_obj_id: int,
+    scoped_object: ScopedToolCallObject,
     *,
     scope_id: str | None,
 ) -> None:
     """Track tool call objects by signature for fallback lookup."""
     signature = _scoped_tool_call_signature(tool_call, scope_id=scope_id)
-    _agent_tool_run_result_signature_by_obj[tool_call_obj_id] = signature
-    _agent_tool_run_results_by_signature.setdefault(signature, set()).add(tool_call_obj_id)
+    _agent_tool_run_result_signature_by_obj[scoped_object] = signature
+    _agent_tool_run_results_by_signature.setdefault(signature, set()).add(scoped_object)
 
 
-def _drop_agent_tool_run_result(tool_call_obj_id: int) -> None:
+def _drop_agent_tool_run_result(scoped_object: ScopedToolCallObject | int) -> None:
     """Remove a tool call object from the fallback index."""
-    tool_call_refs = _agent_tool_call_refs_by_obj
-    if isinstance(tool_call_refs, dict):
-        tool_call_refs.pop(tool_call_obj_id, None)
     signature_by_obj = _agent_tool_run_result_signature_by_obj
     if not isinstance(signature_by_obj, dict):
         return
-    signature = signature_by_obj.pop(tool_call_obj_id, None)
+    if isinstance(scoped_object, int):
+        for candidate in [key for key in signature_by_obj if key[1] == scoped_object]:
+            _drop_agent_tool_run_result(candidate)
+        return
+    signature = signature_by_obj.pop(scoped_object, None)
     if signature is None:
         return
     results_by_signature = _agent_tool_run_results_by_signature
@@ -119,9 +121,11 @@ def _drop_agent_tool_run_result(tool_call_obj_id: int) -> None:
     candidate_ids = results_by_signature.get(signature)
     if not candidate_ids:
         return
-    candidate_ids.discard(tool_call_obj_id)
+    candidate_ids.discard(scoped_object)
     if not candidate_ids:
         results_by_signature.pop(signature, None)
+    if not any(key[1] == scoped_object[1] for key in _agent_tool_run_results_by_obj):
+        _agent_tool_call_refs_by_obj.pop(scoped_object[1], None)
 
 
 def _register_tool_call_ref(tool_call: ResponseFunctionToolCall, tool_call_obj_id: int) -> None:
@@ -130,8 +134,10 @@ def _register_tool_call_ref(tool_call: ResponseFunctionToolCall, tool_call_obj_i
     def _on_tool_call_gc(_ref: weakref.ReferenceType[ResponseFunctionToolCall]) -> None:
         run_results = _agent_tool_run_results_by_obj
         if isinstance(run_results, dict):
-            run_results.pop(tool_call_obj_id, None)
-        _drop_agent_tool_run_result(tool_call_obj_id)
+            scoped_objects = [key for key in run_results if key[1] == tool_call_obj_id]
+            for scoped_object in scoped_objects:
+                run_results.pop(scoped_object, None)
+                _drop_agent_tool_run_result(scoped_object)
 
     _agent_tool_call_refs_by_obj[tool_call_obj_id] = weakref.ref(tool_call, _on_tool_call_gc)
 
@@ -144,8 +150,9 @@ def record_agent_tool_run_result(
 ) -> None:
     """Store the nested agent run result by tool call identity."""
     tool_call_obj_id = id(tool_call)
-    _agent_tool_run_results_by_obj[tool_call_obj_id] = run_result
-    _index_agent_tool_run_result(tool_call, tool_call_obj_id, scope_id=scope_id)
+    scoped_object = (scope_id, tool_call_obj_id)
+    _agent_tool_run_results_by_obj[scoped_object] = run_result
+    _index_agent_tool_run_result(tool_call, scoped_object, scope_id=scope_id)
     _register_tool_call_ref(tool_call, tool_call_obj_id)
 
 
@@ -198,26 +205,17 @@ def agent_tool_resume_checkpoint_owns_approval(run_result: Any, approval_item: A
     return identity is not None and identity in run_result.approval_identities
 
 
-def _tool_call_obj_matches_scope(tool_call_obj_id: int, *, scope_id: str | None) -> bool:
-    scoped_signature = _agent_tool_run_result_signature_by_obj.get(tool_call_obj_id)
-    if scoped_signature is None:
-        # Fallback for unindexed entries.
-        return scope_id is None
-    return scoped_signature[0] == scope_id
-
-
 def consume_agent_tool_run_result(
     tool_call: ResponseFunctionToolCall,
     *,
     scope_id: str | None = None,
 ) -> RunResult | RunResultStreaming | _AgentToolResumeCheckpoint | None:
     """Return and drop the stored nested agent run result for the given tool call."""
-    obj_id = id(tool_call)
-    if _tool_call_obj_matches_scope(obj_id, scope_id=scope_id):
-        run_result = _agent_tool_run_results_by_obj.pop(obj_id, None)
-        if run_result is not None:
-            _drop_agent_tool_run_result(obj_id)
-            return run_result
+    scoped_object = (scope_id, id(tool_call))
+    run_result = _agent_tool_run_results_by_obj.pop(scoped_object, None)
+    if run_result is not None:
+        _drop_agent_tool_run_result(scoped_object)
+        return run_result
 
     signature = _scoped_tool_call_signature(tool_call, scope_id=scope_id)
     candidate_ids = _agent_tool_run_results_by_signature.get(signature)
@@ -227,10 +225,9 @@ def consume_agent_tool_run_result(
         return None
 
     candidate_id = next(iter(candidate_ids))
-    _agent_tool_run_results_by_signature.pop(signature, None)
-    _agent_tool_run_result_signature_by_obj.pop(candidate_id, None)
-    _agent_tool_call_refs_by_obj.pop(candidate_id, None)
-    return _agent_tool_run_results_by_obj.pop(candidate_id, None)
+    run_result = _agent_tool_run_results_by_obj.pop(candidate_id, None)
+    _drop_agent_tool_run_result(candidate_id)
+    return run_result
 
 
 def peek_agent_tool_run_result(
@@ -239,11 +236,10 @@ def peek_agent_tool_run_result(
     scope_id: str | None = None,
 ) -> RunResult | RunResultStreaming | _AgentToolResumeCheckpoint | None:
     """Return the stored nested agent run result without removing it."""
-    obj_id = id(tool_call)
-    if _tool_call_obj_matches_scope(obj_id, scope_id=scope_id):
-        run_result = _agent_tool_run_results_by_obj.get(obj_id)
-        if run_result is not None:
-            return run_result
+    scoped_object = (scope_id, id(tool_call))
+    run_result = _agent_tool_run_results_by_obj.get(scoped_object)
+    if run_result is not None:
+        return run_result
 
     signature = _scoped_tool_call_signature(tool_call, scope_id=scope_id)
     candidate_ids = _agent_tool_run_results_by_signature.get(signature)
@@ -262,12 +258,11 @@ def drop_agent_tool_run_result(
     scope_id: str | None = None,
 ) -> None:
     """Drop the stored nested agent run result, if present."""
-    obj_id = id(tool_call)
-    if _tool_call_obj_matches_scope(obj_id, scope_id=scope_id):
-        run_result = _agent_tool_run_results_by_obj.pop(obj_id, None)
-        if run_result is not None:
-            _drop_agent_tool_run_result(obj_id)
-            return
+    scoped_object = (scope_id, id(tool_call))
+    run_result = _agent_tool_run_results_by_obj.pop(scoped_object, None)
+    if run_result is not None:
+        _drop_agent_tool_run_result(scoped_object)
+        return
 
     signature = _scoped_tool_call_signature(tool_call, scope_id=scope_id)
     candidate_ids = _agent_tool_run_results_by_signature.get(signature)
@@ -277,7 +272,5 @@ def drop_agent_tool_run_result(
         return
 
     candidate_id = next(iter(candidate_ids))
-    _agent_tool_run_results_by_signature.pop(signature, None)
-    _agent_tool_run_result_signature_by_obj.pop(candidate_id, None)
-    _agent_tool_call_refs_by_obj.pop(candidate_id, None)
     _agent_tool_run_results_by_obj.pop(candidate_id, None)
+    _drop_agent_tool_run_result(candidate_id)

--- a/src/agents/result.py
+++ b/src/agents/result.py
@@ -172,6 +172,61 @@ def _populate_state_from_result(
     return state
 
 
+def _copy_pending_nested_agent_tool_states(state: RunState[Any], result: RunResultBase) -> None:
+    """Bind detached nested approval checkpoints to the new outer checkpoint scope."""
+    if state._last_processed_response is None:
+        return
+
+    from .agent_tool_state import (
+        drop_agent_tool_run_result,
+        get_agent_tool_resume_state,
+        get_agent_tool_state_scope,
+        peek_agent_tool_run_result,
+        record_agent_tool_resume_state,
+    )
+
+    source_scope = get_agent_tool_state_scope(result.context_wrapper)
+    templates = getattr(result, "_checkpoint_nested_state_templates", None)
+    if not isinstance(templates, dict):
+        templates = {}
+        result.__dict__["_checkpoint_nested_state_templates"] = templates
+    for function_run in state._last_processed_response.functions:
+        template = templates.get(id(function_run.tool_call))
+        if isinstance(template, RunState):
+            nested_state = template._copy_for_result_checkpoint()
+            resolved_interruptions = template.get_interruptions()
+        else:
+            pending_result = peek_agent_tool_run_result(
+                function_run.tool_call,
+                scope_id=source_scope,
+            )
+            pending_interruptions = getattr(pending_result, "interruptions", None)
+            to_state = getattr(pending_result, "to_state", None)
+            if (
+                not isinstance(pending_interruptions, list)
+                or not pending_interruptions
+                or not callable(to_state)
+            ):
+                continue
+            pending_state = get_agent_tool_resume_state(pending_result)
+            copy_for_checkpoint = getattr(pending_state, "_copy_for_result_checkpoint", None)
+            template = copy_for_checkpoint() if callable(copy_for_checkpoint) else to_state()
+            if not isinstance(template, RunState):
+                continue
+            templates[id(function_run.tool_call)] = template
+            drop_agent_tool_run_result(function_run.tool_call, scope_id=source_scope)
+            nested_state = template._copy_for_result_checkpoint()
+            resolved_interruptions = pending_interruptions
+        if not isinstance(nested_state, RunState) or nested_state is state:
+            continue
+        record_agent_tool_resume_state(
+            function_run.tool_call,
+            nested_state,
+            scope_id=state._agent_tool_state_scope_id,
+            approval_items=resolved_interruptions,
+        )
+
+
 ToInputListMode = Literal["preserve_all", "normalized"]
 
 
@@ -510,7 +565,7 @@ class RunResult(RunResultBase):
         # Create a RunState from the current result
         original_input_for_state = getattr(self, "_original_input", None)
         state = RunState(
-            context=self.context_wrapper,
+            context=self.context_wrapper._copy_for_run_state(),
             original_input=original_input_for_state
             if original_input_for_state is not None
             else self.input,
@@ -518,7 +573,7 @@ class RunResult(RunResultBase):
             max_turns=self.max_turns,
         )
 
-        return _populate_state_from_result(
+        state = _populate_state_from_result(
             state,
             self,
             current_turn=self._current_turn,
@@ -529,6 +584,8 @@ class RunResult(RunResultBase):
             previous_response_id=self._previous_response_id,
             auto_previous_response_id=self._auto_previous_response_id,
         )
+        _copy_pending_nested_agent_tool_states(state, self)
+        return state
 
     def __str__(self) -> str:
         return pretty_print_result(self)
@@ -1111,13 +1168,13 @@ class RunResultStreaming(RunResultBase):
         # Use _original_input (updated on handoffs/resume when input history changes).
         # This avoids serializing a mutated view of input history.
         state = RunState(
-            context=self.context_wrapper,
+            context=self.context_wrapper._copy_for_run_state(),
             original_input=self._original_input if self._original_input is not None else self.input,
             starting_agent=_starting_agent_for_state(self),
             max_turns=self.max_turns,
         )
 
-        return _populate_state_from_result(
+        state = _populate_state_from_result(
             state,
             self,
             current_turn=self.current_turn,
@@ -1128,3 +1185,5 @@ class RunResultStreaming(RunResultBase):
             previous_response_id=self._previous_response_id,
             auto_previous_response_id=self._auto_previous_response_id,
         )
+        _copy_pending_nested_agent_tool_states(state, self)
+        return state

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic
+from uuid import uuid4
 
 from typing_extensions import TypeVar
 
@@ -111,6 +113,17 @@ class RunContextWrapper(Generic[TContext]):
             self._allow_legacy_approval_binding_reconstruction
         )
         target._restored_unbound_approval_call_ids = self._restored_unbound_approval_call_ids
+
+    def _copy_for_run_state(self) -> RunContextWrapper[TContext]:
+        """Copy SDK-owned tool state for an independently resumable checkpoint."""
+        copied = copy.copy(self)
+        copied._approvals = copy.deepcopy(self._approvals)
+        copied._tool_invocations = copy.deepcopy(self._tool_invocations)
+        copied._restored_unbound_approval_call_ids = set(self._restored_unbound_approval_call_ids)
+        from .agent_tool_state import set_agent_tool_state_scope
+
+        set_agent_tool_state_scope(copied, uuid4().hex)
+        return copied
 
     @staticmethod
     def _to_str_or_none(value: Any) -> str | None:

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -889,6 +889,45 @@ class RunState(Generic[TContext, TAgent]):
 
         self._agent_tool_state_scope_id = get_agent_tool_state_scope(context)
 
+    def _copy_for_result_checkpoint(self) -> RunState[TContext, TAgent]:
+        """Copy SDK-owned decision state when nesting this checkpoint in a result snapshot."""
+        copied = copy.copy(self)
+        if self._context is None:
+            return copied
+        copied._context = self._context._copy_for_run_state()
+        from .agent_tool_state import (
+            get_agent_tool_resume_state,
+            get_agent_tool_state_scope,
+            peek_agent_tool_run_result,
+            record_agent_tool_resume_state,
+        )
+
+        copied._agent_tool_state_scope_id = get_agent_tool_state_scope(copied._context)
+        if self._last_processed_response is None:
+            return copied
+
+        for function_run in self._last_processed_response.functions:
+            pending_result = peek_agent_tool_run_result(
+                function_run.tool_call,
+                scope_id=self._agent_tool_state_scope_id,
+            )
+            interruptions = getattr(pending_result, "interruptions", None)
+            to_state = getattr(pending_result, "to_state", None)
+            if not isinstance(interruptions, list) or not interruptions or not callable(to_state):
+                continue
+            pending_state = get_agent_tool_resume_state(pending_result)
+            copy_for_checkpoint = getattr(pending_state, "_copy_for_result_checkpoint", None)
+            nested_state = copy_for_checkpoint() if callable(copy_for_checkpoint) else to_state()
+            if not isinstance(nested_state, RunState) or nested_state is self:
+                continue
+            record_agent_tool_resume_state(
+                function_run.tool_call,
+                nested_state,
+                scope_id=copied._agent_tool_state_scope_id,
+                approval_items=interruptions,
+            )
+        return copied
+
     @property
     def pending_input(self) -> list[TResponseInputItem]:
         """Return a copy of input currently staged for the next resumed model call."""

--- a/tests/test_agent_tool_state.py
+++ b/tests/test_agent_tool_state.py
@@ -86,6 +86,20 @@ def test_agent_tool_run_result_returns_none_for_ambiguous_signature_matches() ->
     assert tool_state.peek_agent_tool_run_result(restored_call, scope_id="other-scope") is None
 
 
+def test_agent_tool_run_result_keeps_same_call_isolated_by_scope() -> None:
+    tool_call = _function_tool_call("lookup_account", "{}", call_id="call-1")
+    first_result = cast(Any, object())
+    second_result = cast(Any, object())
+
+    tool_state.record_agent_tool_run_result(tool_call, first_result, scope_id="scope-1")
+    tool_state.record_agent_tool_run_result(tool_call, second_result, scope_id="scope-2")
+
+    assert tool_state.peek_agent_tool_run_result(tool_call, scope_id="scope-1") is first_result
+    assert tool_state.peek_agent_tool_run_result(tool_call, scope_id="scope-2") is second_result
+    assert tool_state.consume_agent_tool_run_result(tool_call, scope_id="scope-1") is first_result
+    assert tool_state.peek_agent_tool_run_result(tool_call, scope_id="scope-2") is second_result
+
+
 def test_agent_tool_run_result_is_dropped_when_tool_call_is_collected() -> None:
     tool_call = _function_tool_call("lookup_account", "{}", call_id="call-1")
     tool_call_ref = weakref.ref(tool_call)

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -6572,6 +6572,63 @@ class TestRunStateResumption:
 
         assert result2.final_output == "Second response"
 
+    @pytest.mark.parametrize("streamed", [False, True])
+    @pytest.mark.asyncio
+    async def test_result_to_state_detaches_tool_decision_ledgers(self, streamed: bool):
+        """States created from one result must not share approval decisions."""
+        model = ScriptedModel()
+        executions: list[str] = []
+
+        @function_tool(needs_approval=True)
+        async def approval_tool() -> str:
+            executions.append("executed")
+            return "approved"
+
+        agent = Agent(name="TestAgent", model=model, tools=[approval_tool])
+        model.enqueue([get_function_tool_call("approval_tool", "{}")])
+
+        if streamed:
+            result = Runner.run_streamed(agent, "First input")
+            async for _ in result.stream_events():
+                pass
+        else:
+            result = await Runner.run(agent, "First input")
+
+        decided = result.to_state()
+        untouched = result.to_state()
+        untouched_approvals_before = untouched.to_json()["context"]["approvals"]
+
+        decided.approve(decided.get_interruptions()[0])
+
+        assert decided._context is not untouched._context
+        assert decided._context is not None
+        assert untouched._context is not None
+        assert decided._context.context is untouched._context.context
+        assert decided._context._approvals is not untouched._context._approvals
+        assert decided._context._tool_invocations is not untouched._context._tool_invocations
+        assert untouched.to_json()["context"]["approvals"] == untouched_approvals_before
+
+        if streamed:
+            untouched_result = Runner.run_streamed(agent, untouched)
+            async for _ in untouched_result.stream_events():
+                pass
+        else:
+            untouched_result = await Runner.run(agent, untouched)
+
+        assert untouched_result.interruptions
+        assert executions == []
+
+    def test_nested_resume_checkpoint_to_state_keeps_its_owned_decision_ledger(self):
+        """A scoped nested checkpoint returns the state that resume will consume."""
+        from agents.agent_tool_state import _AgentToolResumeCheckpoint
+
+        agent = Agent(name="NestedAgent")
+        approval_item = make_tool_approval_item(agent, call_id="nested-call")
+        state = make_state_with_interruptions(agent, [approval_item])
+        checkpoint = _AgentToolResumeCheckpoint(state, frozenset())
+
+        assert checkpoint.to_state() is state
+
     @pytest.mark.asyncio
     async def test_resume_from_run_state_streamed(self):
         """Test resuming a run from a RunState using run_streamed."""


### PR DESCRIPTION
This pull request fixes approval and invocation ledger sharing between `RunState` checkpoints created from the same interrupted result.

`RunResult.to_state()` and `RunResultStreaming.to_state()` now detach SDK-owned approval state while preserving caller context and Agent identity. Nested Agent-as-tool approval checkpoints receive scope-qualified, recursively rebound state so approving or rejecting one checkpoint cannot affect another checkpoint or leave stale nested cache entries behind.

The change adds regression coverage for direct checkpoint isolation, streamed results, nested approval ownership, and scope-qualified agent-tool cache entries.

ref: https://github.com/openai/openai-agents-python/pull/4409#issuecomment-5291724795