### PR TITLE
fix: resume recursive agent tool approvals

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -746,21 +746,31 @@ class Agent(AgentBase, Generic[TContext]):
                 pending_run_result: RunResult | RunResultStreaming,
             ) -> Literal["approved", "pending", "rejected"]:
                 interruptions = pending_run_result.interruptions
-                nested_decision_context = pending_run_result.to_state()._context
+                nested_state = pending_run_result.to_state()
                 has_pending = False
                 has_decision = False
                 for interruption in interruptions:
-                    call_id = get_tool_approval_item_call_id(interruption)
+                    find_nested_owner = getattr(
+                        nested_state,
+                        "_find_nested_approval_state",
+                        None,
+                    )
+                    nested_owner = (
+                        find_nested_owner(interruption) if callable(find_nested_owner) else None
+                    )
+                    decision_state, decision_item = nested_owner or (nested_state, interruption)
+                    nested_decision_context = getattr(decision_state, "_context", None)
+                    call_id = get_tool_approval_item_call_id(decision_item)
                     if not call_id:
                         has_pending = True
                         continue
-                    tool_namespace = RunContextWrapper._resolve_tool_namespace(interruption)
+                    tool_namespace = RunContextWrapper._resolve_tool_namespace(decision_item)
                     status = (
                         nested_decision_context.get_approval_status(
-                            interruption.tool_name or "",
+                            decision_item.tool_name or "",
                             call_id,
                             tool_namespace=tool_namespace,
-                            existing_pending=interruption,
+                            existing_pending=decision_item,
                         )
                         if nested_decision_context is not None
                         else None
@@ -771,24 +781,24 @@ class Agent(AgentBase, Generic[TContext]):
                         and context._allow_legacy_approval_binding_reconstruction
                     ):
                         status = context.get_approval_status(
-                            interruption.tool_name or "",
+                            decision_item.tool_name or "",
                             call_id,
                             tool_namespace=tool_namespace,
-                            existing_pending=interruption,
+                            existing_pending=decision_item,
                         )
                         if status is not None:
                             legacy_namespace = RunContextWrapper._resolve_tool_namespace(
-                                interruption
+                                decision_item
                             )
-                            legacy_tool_name = RunContextWrapper._resolve_tool_name(interruption)
+                            legacy_tool_name = RunContextWrapper._resolve_tool_name(decision_item)
                             legacy_qualified_key = (
                                 f"{legacy_namespace}.{legacy_tool_name}"
                                 if legacy_namespace is not None
                                 else legacy_tool_name
                             )
                             approval_keys = (
-                                RunContextWrapper._resolve_approval_key(interruption),
-                                *RunContextWrapper._resolve_approval_keys(interruption),
+                                RunContextWrapper._resolve_approval_key(decision_item),
+                                *RunContextWrapper._resolve_approval_keys(decision_item),
                                 legacy_qualified_key,
                             )
                             approval_record = next(
@@ -802,7 +812,7 @@ class Agent(AgentBase, Generic[TContext]):
                             if status:
                                 RunContextWrapper.approve_tool(
                                     nested_decision_context,
-                                    interruption,
+                                    decision_item,
                                     always_approve=bool(
                                         approval_record and approval_record.approved is True
                                     ),
@@ -810,15 +820,15 @@ class Agent(AgentBase, Generic[TContext]):
                             else:
                                 RunContextWrapper.reject_tool(
                                     nested_decision_context,
-                                    interruption,
+                                    decision_item,
                                     always_reject=bool(
                                         approval_record and approval_record.rejected is True
                                     ),
                                     rejection_message=context.get_rejection_message(
-                                        interruption.tool_name or "",
+                                        decision_item.tool_name or "",
                                         call_id,
                                         tool_namespace=tool_namespace,
-                                        existing_pending=interruption,
+                                        existing_pending=decision_item,
                                     ),
                                 )
                     if status is False:

--- a/src/agents/run_internal/turn_resolution.py
+++ b/src/agents/run_internal/turn_resolution.py
@@ -1452,29 +1452,35 @@ async def resolve_interrupted_turn(
     ) -> Literal["approved", "pending", "rejected"]:
         interruptions = cast(Sequence[ToolApprovalItem], nested_run_result.interruptions)
         nested_state = nested_run_result.to_state()
-        nested_decision_context = getattr(nested_state, "_context", None)
         has_pending = False
         for interruption in interruptions:
-            call_id = get_tool_approval_item_call_id(interruption)
+            nested_owner = (
+                nested_state._find_nested_approval_state(interruption)
+                if isinstance(nested_state, RunState)
+                else None
+            )
+            decision_state, decision_item = nested_owner or (nested_state, interruption)
+            nested_decision_context = getattr(decision_state, "_context", None)
+            call_id = get_tool_approval_item_call_id(decision_item)
             if not call_id:
                 has_pending = True
                 continue
             status = (
                 nested_decision_context.get_approval_status(
-                    interruption.tool_name or "",
+                    decision_item.tool_name or "",
                     call_id,
-                    tool_namespace=interruption.tool_namespace,
-                    existing_pending=interruption,
+                    tool_namespace=decision_item.tool_namespace,
+                    existing_pending=decision_item,
                 )
                 if isinstance(nested_decision_context, RunContextWrapper)
                 else None
             )
             if status is None and context_wrapper._allow_legacy_approval_binding_reconstruction:
                 status = context_wrapper.get_approval_status(
-                    interruption.tool_name or "",
+                    decision_item.tool_name or "",
                     call_id,
-                    tool_namespace=interruption.tool_namespace,
-                    existing_pending=interruption,
+                    tool_namespace=decision_item.tool_namespace,
+                    existing_pending=decision_item,
                 )
             if status is False:
                 return "rejected"

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -1111,11 +1111,11 @@ class RunState(Generic[TContext, TAgent]):
             nested_state = to_state()
             if not isinstance(nested_state, RunState) or nested_state is self:
                 continue
-            nested_candidates.extend(
-                (nested_state, candidate)
-                for candidate in interruptions
-                if isinstance(candidate, ToolApprovalItem)
-            )
+            for candidate in interruptions:
+                if not isinstance(candidate, ToolApprovalItem):
+                    continue
+                recursive_owner = nested_state._find_nested_approval_state(candidate)
+                nested_candidates.append(recursive_owner or (nested_state, candidate))
 
         current_candidates = (
             self._current_step.interruptions

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -11464,6 +11464,91 @@ async def test_resume_nested_agent_as_tool_with_context_override() -> None:
     )
 
 
+@pytest.mark.parametrize("nesting_edges", [2, 3])
+@pytest.mark.parametrize("approval_timing", ["live", "before_restore", "after_restore"])
+@pytest.mark.parametrize("approve", [True, False])
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.asyncio
+async def test_resume_recursively_nested_agent_as_tool_decision(
+    streamed: bool,
+    approve: bool,
+    approval_timing: str,
+    nesting_edges: int,
+) -> None:
+    """Tool decisions reach a protected tool through nested agent tools."""
+    calls: list[str] = []
+
+    @function_tool(needs_approval=True)
+    async def protected(text: str) -> str:
+        calls.append(text)
+        return f"approved:{text}"
+
+    leaf_model = ScriptedModel()
+    leaf_model.extend(
+        [
+            [get_function_tool_call("protected", json.dumps({"text": "one"}), call_id="inner-1")],
+            [get_final_output_message("inner-done")],
+        ]
+    )
+    outer = Agent(name="inner", model=leaf_model, tools=[protected])
+    for edge in range(nesting_edges):
+        tool_name = f"agent_tool_{edge}"
+        model = ScriptedModel()
+        model.extend(
+            [
+                [
+                    get_function_tool_call(
+                        tool_name,
+                        json.dumps({"input": "go"}),
+                        call_id=f"agent-call-{edge}",
+                    )
+                ],
+                [get_final_output_message(f"done-{edge}")],
+            ]
+        )
+        outer = Agent(
+            name=f"agent-{edge}",
+            model=model,
+            tools=[outer.as_tool(tool_name=tool_name, tool_description="Run nested agent")],
+        )
+
+    if streamed:
+        first = Runner.run_streamed(outer, "start")
+        async for _ in first.stream_events():
+            pass
+    else:
+        first = await Runner.run(outer, "start")
+
+    state = first.to_state()
+    assert len(state.get_interruptions()) == 1
+
+    def apply_decision() -> None:
+        if approve:
+            state.approve(state.get_interruptions()[0])
+        else:
+            state.reject(state.get_interruptions()[0])
+
+    if approval_timing == "before_restore":
+        apply_decision()
+        state = await RunState.from_json(outer, state.to_json())
+    elif approval_timing == "after_restore":
+        state = await RunState.from_json(outer, state.to_json())
+        apply_decision()
+    else:
+        apply_decision()
+
+    if streamed:
+        resumed = Runner.run_streamed(outer, state)
+        async for _ in resumed.stream_events():
+            pass
+    else:
+        resumed = await Runner.run(outer, state)
+
+    assert resumed.final_output == f"done-{nesting_edges - 1}"
+    assert resumed.interruptions == []
+    assert calls == (["one"] if approve else [])
+
+
 @pytest.mark.asyncio
 async def test_hosted_mcp_approval_request_restores_matching_server_tool() -> None:
     class FalsyHostedMCPTool(HostedMCPTool):


### PR DESCRIPTION
This pull request fixes approval resume through recursively nested `Agent.as_tool` calls.

When a protected tool was nested behind two or more agent-tool edges, approving the flattened interruption from `RunResult.to_state()` could leave the same interruption pending or allow the outer run to continue without executing the protected tool. The resume path now resolves the deepest nested `RunState` that owns the approval and checks that owner’s decision ledger before deciding whether to rerun the pending agent tool.

The change preserves existing checkpoint isolation and serialized `RunState` behavior. Regression coverage verifies two- and three-edge nesting for both `Runner.run` and `Runner.run_streamed`, including exactly-once protected-tool execution.

ref: https://github.com/openai/openai-agents-python/pull/4413#issuecomment-5293064242