### PR TITLE
feat(sandbox): add run-scoped working directory

### DIFF
--- a/src/agents/run_config.py
+++ b/src/agents/run_config.py
@@ -218,6 +218,14 @@ class SandboxRunConfig:
     Use `SandboxArchiveLimits()` to enable SDK defaults.
     """
 
+    cwd: str | None = None
+    """Run-scoped base directory for model-facing relative sandbox paths.
+
+    Relative shell workdirs, image paths, and apply-patch paths are interpreted beneath this
+    directory. Absolute paths keep the existing workspace and path-grant validation behavior.
+    This setting does not change `Manifest.root` or direct sandbox-session operations.
+    """
+
     if TYPE_CHECKING:
 
         def __init__(
@@ -230,6 +238,7 @@ class SandboxRunConfig:
             snapshot: SnapshotSpec | SnapshotBase | dict[str, Any] | None = None,
             concurrency_limits: SandboxConcurrencyLimits | dict[str, Any] = ...,
             archive_limits: SandboxArchiveLimits | dict[str, Any] | None = None,
+            cwd: str | None = None,
         ) -> None: ...
 
     def __post_init__(self) -> None:

--- a/src/agents/sandbox/capabilities/_run_cwd_tools.py
+++ b/src/agents/sandbox/capabilities/_run_cwd_tools.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import replace
+from pathlib import PurePath, PurePosixPath
+from typing import Any, cast
+
+from ...editor import ApplyPatchOperation
+from ...run_context import RunContextWrapper
+from ...tool import ToolOutputImage
+from ..session.base_sandbox_session import BaseSandboxSession
+from ..types import User
+from ..workspace_paths import coerce_posix_path, windows_absolute_path
+from .tools import (
+    ExecCommandArgs,
+    ExecCommandTool,
+    SandboxApplyPatchTool,
+    ViewImageArgs,
+    ViewImageTool,
+)
+
+ApprovalFunction = Callable[[RunContextWrapper[Any], dict[str, Any], str], Awaitable[bool]]
+
+
+def _rebase_run_cwd_path(path: str | PurePath, cwd: PurePosixPath | None) -> str:
+    path_str = path.as_posix() if isinstance(path, PurePath) else path
+    if cwd is None:
+        return path_str
+    if windows_absolute_path(path) is not None:
+        return path_str
+
+    posix_path = coerce_posix_path(path)
+    if posix_path.is_absolute():
+        return path_str
+    return (cwd / posix_path).as_posix()
+
+
+def _rebase_exec_params(params: dict[str, Any], cwd: PurePosixPath | None) -> dict[str, Any]:
+    if cwd is None:
+        return params
+    effective = dict(params)
+    raw_workdir = effective.get("workdir")
+    if raw_workdir is None or (isinstance(raw_workdir, str) and raw_workdir.strip() == ""):
+        effective["workdir"] = cwd.as_posix()
+    elif isinstance(raw_workdir, str):
+        effective["workdir"] = _rebase_run_cwd_path(raw_workdir, cwd)
+    return effective
+
+
+def _wrap_approval(
+    approval: bool | ApprovalFunction,
+    transform: Callable[[dict[str, Any]], dict[str, Any]],
+) -> bool | ApprovalFunction:
+    if isinstance(approval, bool):
+        return approval
+
+    async def wrapped(
+        ctx: RunContextWrapper[Any], params: dict[str, Any], call_id: str
+    ) -> bool:
+        return await approval(ctx, transform(params), call_id)
+
+    return wrapped
+
+
+class RunCwdExecCommandTool(ExecCommandTool):
+    def __init__(
+        self,
+        *,
+        session: BaseSandboxSession,
+        user: str | User | None = None,
+        cwd: PurePosixPath | None = None,
+    ) -> None:
+        self._run_cwd = cwd
+        super().__init__(session=session, user=user)
+
+    def finalize_run_cwd(self) -> None:
+        self.needs_approval = _wrap_approval(
+            cast(bool | ApprovalFunction, self.needs_approval),
+            lambda params: _rebase_exec_params(params, self._run_cwd),
+        )
+
+    async def run(self, args: ExecCommandArgs) -> str:
+        workdir = args.workdir
+        if self._run_cwd is not None:
+            if workdir is None or workdir.strip() == "":
+                workdir = self._run_cwd.as_posix()
+            else:
+                workdir = _rebase_run_cwd_path(workdir, self._run_cwd)
+        return await super().run(args.model_copy(update={"workdir": workdir}))
+
+
+class RunCwdViewImageTool(ViewImageTool):
+    def __init__(
+        self,
+        *,
+        session: BaseSandboxSession,
+        user: str | User | None = None,
+        cwd: PurePosixPath | None = None,
+    ) -> None:
+        self._run_cwd = cwd
+        super().__init__(session=session, user=user)
+
+    def finalize_run_cwd(self) -> None:
+        def transform(params: dict[str, Any]) -> dict[str, Any]:
+            effective = dict(params)
+            raw_path = effective.get("path")
+            if isinstance(raw_path, str):
+                effective["path"] = _rebase_run_cwd_path(raw_path, self._run_cwd)
+            return effective
+
+        self.needs_approval = _wrap_approval(
+            cast(bool | ApprovalFunction, self.needs_approval),
+            transform,
+        )
+
+    async def run(self, args: ViewImageArgs) -> ToolOutputImage | str:
+        path = _rebase_run_cwd_path(args.path, self._run_cwd)
+        return await super().run(args.model_copy(update={"path": path}))
+
+
+class RunCwdSandboxApplyPatchTool(SandboxApplyPatchTool):
+    def __init__(
+        self,
+        *,
+        session: BaseSandboxSession,
+        user: str | User | None = None,
+        cwd: PurePosixPath | None = None,
+    ) -> None:
+        self._run_cwd = cwd
+        super().__init__(session=session, user=user)
+
+    def parse_custom_input(self, raw_input: str) -> list[ApplyPatchOperation]:
+        operations = super().parse_custom_input(raw_input)
+        if self._run_cwd is None:
+            return operations
+        return [
+            replace(
+                operation,
+                path=_rebase_run_cwd_path(operation.path, self._run_cwd),
+                move_to=(
+                    _rebase_run_cwd_path(operation.move_to, self._run_cwd)
+                    if operation.move_to is not None
+                    else None
+                ),
+            )
+            for operation in operations
+        ]

--- a/src/agents/sandbox/capabilities/capability.py
+++ b/src/agents/sandbox/capabilities/capability.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import threading
+from pathlib import PurePosixPath
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -18,6 +19,7 @@ class Capability(BaseModel):
     type: str
     session: BaseSandboxSession | None = Field(default=None, exclude=True)
     run_as: User | None = Field(default=None, exclude=True)
+    run_cwd: PurePosixPath | None = Field(default=None, exclude=True)
 
     def clone(self) -> "Capability":
         """Return a per-run copy of this capability."""
@@ -33,6 +35,10 @@ class Capability(BaseModel):
     def bind_run_as(self, user: User | None) -> None:
         """Bind the sandbox user identity for model-facing operations."""
         self.run_as = user
+
+    def bind_run_cwd(self, cwd: PurePosixPath | None) -> None:
+        """Bind the run-local base for model-facing relative workspace paths."""
+        self.run_cwd = cwd
 
     def required_capability_types(self) -> set[str]:
         """Return capability types that must be present alongside this capability."""

--- a/src/agents/sandbox/capabilities/filesystem.py
+++ b/src/agents/sandbox/capabilities/filesystem.py
@@ -7,6 +7,7 @@ from typing import Literal
 from pydantic import Field
 
 from ...tool import Tool
+from ._run_cwd_tools import RunCwdSandboxApplyPatchTool, RunCwdViewImageTool
 from .capability import Capability
 from .tools import SandboxApplyPatchTool, ViewImageTool
 
@@ -32,10 +33,20 @@ class Filesystem(Capability):
             raise ValueError("Filesystem capability is not bound to a SandboxSession")
 
         toolset = FilesystemToolSet(
-            view_image=ViewImageTool(session=self.session, user=self.run_as),
-            apply_patch=SandboxApplyPatchTool(session=self.session, user=self.run_as),
+            view_image=RunCwdViewImageTool(
+                session=self.session,
+                user=self.run_as,
+                cwd=self.run_cwd,
+            ),
+            apply_patch=RunCwdSandboxApplyPatchTool(
+                session=self.session,
+                user=self.run_as,
+                cwd=self.run_cwd,
+            ),
         )
         if self.configure_tools is not None:
             self.configure_tools(toolset)
+        if isinstance(toolset.view_image, RunCwdViewImageTool):
+            toolset.view_image.finalize_run_cwd()
 
         return [toolset.view_image, toolset.apply_patch]

--- a/src/agents/sandbox/capabilities/shell.py
+++ b/src/agents/sandbox/capabilities/shell.py
@@ -9,6 +9,7 @@ from pydantic import Field
 
 from ...tool import Tool
 from ..manifest import Manifest
+from ._run_cwd_tools import RunCwdExecCommandTool
 from .capability import Capability
 from .tools import ExecCommandTool, WriteStdinTool
 
@@ -45,13 +46,19 @@ class Shell(Capability):
         if self.session is None:
             raise ValueError("Shell capability is not bound to a SandboxSession")
         toolset = ShellToolSet(
-            exec_command=ExecCommandTool(session=self.session, user=self.run_as),
+            exec_command=RunCwdExecCommandTool(
+                session=self.session,
+                user=self.run_as,
+                cwd=self.run_cwd,
+            ),
             write_stdin=WriteStdinTool(session=self.session)
             if self.session.supports_pty()
             else None,
         )
         if self.configure_tools is not None:
             self.configure_tools(toolset)
+        if isinstance(toolset.exec_command, RunCwdExecCommandTool):
+            toolset.exec_command.finalize_run_cwd()
         tools: list[Tool] = [toolset.exec_command]
         if toolset.write_stdin is not None:
             tools.append(toolset.write_stdin)

--- a/src/agents/sandbox/runtime.py
+++ b/src/agents/sandbox/runtime.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Any, Generic, cast
 
 from ..agent import Agent
@@ -22,6 +23,7 @@ from ..run_state import RunState
 from ..tracing import custom_span, get_current_trace
 from .capabilities import Capability
 from .capabilities.memory import Memory
+from .errors import InvalidManifestPathError
 from .memory.manager import SandboxMemoryGenerationManager, get_or_create_memory_generation_manager
 from .memory.rollouts import (
     RolloutTerminalMetadata,
@@ -36,6 +38,7 @@ from .runtime_session_manager import SandboxRuntimeSessionManager
 from .sandbox_agent import SandboxAgent
 from .session.base_sandbox_session import BaseSandboxSession
 from .types import User
+from .workspace_paths import coerce_posix_path
 
 logger = logging.getLogger(__name__)
 
@@ -213,18 +216,24 @@ class SandboxRuntime(Generic[TContext]):
                 capabilities=prepared_capabilities,
                 is_resumed_state=is_resumed_state,
             )
+            run_cwd = _resolve_run_cwd(
+                session,
+                self._sandbox_config.cwd if self._sandbox_config is not None else None,
+            )
             if (
                 prepared_agent is not None
                 and self._prepared_sessions.get(id(current_agent)) is session
             ):
                 # Reuse the cached execution agent's bound capability instances so context
                 # processing can depend on live session state and preserve per-run state.
+                cached_capabilities = cast(SandboxAgent[TContext], prepared_agent).capabilities
                 _bind_capability_run_as(
-                    cast(SandboxAgent[TContext], prepared_agent).capabilities,
+                    cached_capabilities,
                     _coerce_run_as_user(current_agent.run_as),
                 )
+                _bind_capability_run_cwd(cached_capabilities, run_cwd)
                 prepared_input = prepare_sandbox_input(
-                    cast(SandboxAgent[TContext], prepared_agent).capabilities,
+                    cached_capabilities,
                     current_input,
                 )
                 return _SandboxPreparedAgent(
@@ -241,6 +250,7 @@ class SandboxRuntime(Generic[TContext]):
             for capability in prepared_capabilities:
                 capability.bind(session)
             _bind_capability_run_as(prepared_capabilities, run_as)
+            _bind_capability_run_cwd(prepared_capabilities, run_cwd)
             prepared_input = prepare_sandbox_input(prepared_capabilities, current_input)
             prepared_agent = prepare_sandbox_agent(
                 agent=current_agent,
@@ -290,6 +300,23 @@ def _coerce_run_as_user(run_as: User | str | None) -> User | None:
     return User(name=run_as)
 
 
+def _resolve_run_cwd(session: BaseSandboxSession, cwd: str | None) -> PurePosixPath | None:
+    if cwd is None:
+        return None
+    try:
+        relative = session._workspace_path_policy().relative_path(cwd)
+    except InvalidManifestPathError as exc:
+        raise UserError(f"sandbox.cwd must resolve within the sandbox workspace: {cwd}") from exc
+    return coerce_posix_path(relative)
+
+
 def _bind_capability_run_as(capabilities: Sequence[Capability], user: User | None) -> None:
     for capability in capabilities:
         capability.bind_run_as(user)
+
+
+def _bind_capability_run_cwd(
+    capabilities: Sequence[Capability], cwd: PurePosixPath | None
+) -> None:
+    for capability in capabilities:
+        capability.bind_run_cwd(cwd)

--- a/tests/sandbox/test_compatibility_guards.py
+++ b/tests/sandbox/test_compatibility_guards.py
@@ -368,6 +368,7 @@ def test_sandbox_dataclass_constructor_field_order_is_stable() -> None:
         "snapshot",
         "concurrency_limits",
         "archive_limits",
+        "cwd",
     )
 
 

--- a/tests/sandbox/test_run_cwd.py
+++ b/tests/sandbox/test_run_cwd.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import PurePosixPath
+from typing import Any, cast
+
+import pytest
+
+from agents.exceptions import UserError
+from agents.run_config import RunConfig, SandboxRunConfig
+from agents.run_context import RunContextWrapper
+from agents.sandbox import Manifest, SandboxAgent
+from agents.sandbox.capabilities import Filesystem, Shell
+from agents.sandbox.capabilities._run_cwd_tools import (
+    RunCwdExecCommandTool,
+    RunCwdSandboxApplyPatchTool,
+    RunCwdViewImageTool,
+)
+from agents.sandbox.capabilities.tools import ExecCommandArgs, ViewImageArgs
+from agents.sandbox.runtime import SandboxRuntime
+from agents.sandbox.types import ExecResult
+from agents.testing import scripted_sandbox_session
+from agents.tool import ToolOutputImage
+
+_PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a84QAAAAASUVORK5CYII="
+)
+_PNG_BYTES = base64.b64decode(_PNG_BASE64)
+
+
+@pytest.mark.asyncio
+async def test_exec_command_defaults_to_run_cwd() -> None:
+    session = scripted_sandbox_session(
+        [{"method": "exec", "result": ExecResult(stdout=b"ok\n", stderr=b"", exit_code=0)}],
+        manifest=Manifest(root="/workspace"),
+    )
+    tool = RunCwdExecCommandTool(session=session, cwd=PurePosixPath("tasks/a"))
+
+    output = await tool.run(ExecCommandArgs(cmd="pwd"))
+
+    assert session.calls[0].args == ("cd /workspace/tasks/a && pwd",)
+    assert "ok" in output
+    session.assert_complete()
+
+
+@pytest.mark.asyncio
+async def test_exec_command_rebases_relative_workdir_beneath_run_cwd() -> None:
+    session = scripted_sandbox_session(
+        [{"method": "exec", "result": ExecResult(stdout=b"", stderr=b"", exit_code=0)}],
+        manifest=Manifest(root="/workspace"),
+    )
+    tool = RunCwdExecCommandTool(session=session, cwd=PurePosixPath("tasks/a"))
+
+    await tool.run(ExecCommandArgs(cmd="pwd", workdir="nested"))
+
+    assert session.calls[0].args == ("cd /workspace/tasks/a/nested && pwd",)
+    session.assert_complete()
+
+
+@pytest.mark.asyncio
+async def test_exec_command_approval_sees_effective_workdir() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    seen: list[dict[str, Any]] = []
+
+    async def needs_approval(
+        _ctx: RunContextWrapper[Any], params: dict[str, Any], _call_id: str
+    ) -> bool:
+        seen.append(params)
+        return True
+
+    tool = RunCwdExecCommandTool(session=session, cwd=PurePosixPath("tasks/a"))
+    tool.needs_approval = needs_approval
+    tool.finalize_run_cwd()
+    approval = cast(Any, tool.needs_approval)
+
+    assert await approval(cast(RunContextWrapper[Any], None), {"cmd": "pwd"}, "call") is True
+    assert seen == [{"cmd": "pwd", "workdir": "tasks/a"}]
+
+
+@pytest.mark.asyncio
+async def test_view_image_rebases_relative_path_beneath_run_cwd() -> None:
+    session = scripted_sandbox_session(
+        [{"method": "read", "result": io.BytesIO(_PNG_BYTES)}],
+        manifest=Manifest(root="/workspace"),
+    )
+    tool = RunCwdViewImageTool(session=session, cwd=PurePosixPath("tasks/a"))
+
+    output = await tool.run(ViewImageArgs(path="plot.png"))
+
+    assert isinstance(output, ToolOutputImage)
+    assert session.calls[0].args[0].as_posix() == "/workspace/tasks/a/plot.png"
+    session.assert_complete()
+
+
+@pytest.mark.asyncio
+async def test_view_image_approval_sees_effective_path() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    seen: list[dict[str, Any]] = []
+
+    async def needs_approval(
+        _ctx: RunContextWrapper[Any], params: dict[str, Any], _call_id: str
+    ) -> bool:
+        seen.append(params)
+        return True
+
+    tool = RunCwdViewImageTool(session=session, cwd=PurePosixPath("tasks/a"))
+    tool.needs_approval = needs_approval
+    tool.finalize_run_cwd()
+    approval = cast(Any, tool.needs_approval)
+
+    assert await approval(
+        cast(RunContextWrapper[Any], None), {"path": "plot.png"}, "call"
+    ) is True
+    assert seen == [{"path": "tasks/a/plot.png"}]
+
+
+def test_apply_patch_rebases_paths_before_approval_and_execution() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    tool = RunCwdSandboxApplyPatchTool(session=session, cwd=PurePosixPath("tasks/a"))
+
+    operations = tool.parse_custom_input(
+        "*** Begin Patch\n"
+        "*** Update File: notes.md\n"
+        "*** Move to: archive/notes.md\n"
+        "@@\n"
+        "-old\n"
+        "+new\n"
+        "*** End Patch\n"
+    )
+
+    assert len(operations) == 1
+    assert operations[0].path == "tasks/a/notes.md"
+    assert operations[0].move_to == "tasks/a/archive/notes.md"
+
+
+def test_run_config_dict_coercion_accepts_cwd() -> None:
+    config = RunConfig(sandbox={"cwd": "tasks/a"})
+
+    assert isinstance(config.sandbox, SandboxRunConfig)
+    assert config.sandbox.cwd == "tasks/a"
+
+
+@pytest.mark.asyncio
+async def test_runtime_rejects_cwd_outside_workspace() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    agent = SandboxAgent(name="sandbox", capabilities=[Shell()])
+    runtime = SandboxRuntime[object](
+        starting_agent=agent,
+        run_config=RunConfig(sandbox=SandboxRunConfig(session=session, cwd="/tmp")),
+        run_state=None,
+    )
+
+    with pytest.raises(UserError, match="sandbox.cwd must resolve within the sandbox workspace"):
+        await runtime.prepare_agent(
+            current_agent=agent,
+            current_input="inspect the workspace",
+            context_wrapper=cast(RunContextWrapper[object], None),
+            is_resumed_state=False,
+        )
+
+    await runtime.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_runtime_binds_cwd_to_per_run_capability_clones() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    agent = SandboxAgent(name="sandbox", capabilities=[Shell(), Filesystem()])
+    runtime = SandboxRuntime[object](
+        starting_agent=agent,
+        run_config=RunConfig(sandbox=SandboxRunConfig(session=session, cwd="tasks/a")),
+        run_state=None,
+    )
+
+    prepared = await runtime.prepare_agent(
+        current_agent=agent,
+        current_input="inspect the workspace",
+        context_wrapper=cast(RunContextWrapper[object], None),
+        is_resumed_state=False,
+    )
+    execution_agent = cast(SandboxAgent[object], prepared.bindings.execution_agent)
+
+    assert [capability.run_cwd for capability in execution_agent.capabilities] == [
+        PurePosixPath("tasks/a"),
+        PurePosixPath("tasks/a"),
+    ]
+    assert [capability.run_cwd for capability in agent.capabilities] == [None, None]
+    await runtime.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_shared_live_session_keeps_run_cwds_independent() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    agent_a = SandboxAgent(name="a", capabilities=[Shell()])
+    agent_b = SandboxAgent(name="b", capabilities=[Shell()])
+    runtime_a = SandboxRuntime[object](
+        starting_agent=agent_a,
+        run_config=RunConfig(sandbox=SandboxRunConfig(session=session, cwd="tasks/a")),
+        run_state=None,
+    )
+    runtime_b = SandboxRuntime[object](
+        starting_agent=agent_b,
+        run_config=RunConfig(sandbox=SandboxRunConfig(session=session, cwd="tasks/b")),
+        run_state=None,
+    )
+
+    prepared_a = await runtime_a.prepare_agent(
+        current_agent=agent_a,
+        current_input="a",
+        context_wrapper=cast(RunContextWrapper[object], None),
+        is_resumed_state=False,
+    )
+    prepared_b = await runtime_b.prepare_agent(
+        current_agent=agent_b,
+        current_input="b",
+        context_wrapper=cast(RunContextWrapper[object], None),
+        is_resumed_state=False,
+    )
+
+    execution_a = cast(SandboxAgent[object], prepared_a.bindings.execution_agent)
+    execution_b = cast(SandboxAgent[object], prepared_b.bindings.execution_agent)
+    assert execution_a.capabilities[0].run_cwd == PurePosixPath("tasks/a")
+    assert execution_b.capabilities[0].run_cwd == PurePosixPath("tasks/b")
+    assert session.state.manifest.root == "/workspace"
+
+    await runtime_a.cleanup()
+    await runtime_b.cleanup()


### PR DESCRIPTION
### Summary

Add `SandboxRunConfig.cwd` as a run-scoped base directory for model-facing sandbox paths.

Relative shell workdirs, `view_image` paths, and `apply_patch` paths are resolved beneath the configured cwd while `Manifest.root`, direct session operations, snapshots, and session lifecycle remain unchanged. The scope is bound to per-run capability clones, so separate runs can reuse the same caller-owned live session with different working directories without mutating session-global state.

`cwd=None` preserves existing behavior. Absolute paths retain the existing workspace/path-grant validation. Approval callbacks for shell and image tools receive the effective cwd-scoped path, and apply-patch approval/execution uses the same rebased operations.

### Test plan

Added focused regression coverage for:

- default and explicit relative shell workdirs
- image path rebasing
- apply-patch path and move target rebasing
- cwd-aware approval inputs
- dict configuration coercion
- rejection of cwd values outside the workspace
- per-run capability clone binding
- independent cwd scopes on two runs sharing one live session
- stable `SandboxRunConfig` constructor field order

The full repository verification is left to CI because this environment cannot materialize the repository dependencies locally.

### Issue number

Closes #4401

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR