### PR TITLE
examples: add MCP agent discovery example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -69,6 +69,7 @@ Check out a variety of sample implementations that use the SDK in the examples s
     -   Prefetching all MCP tools with `MCPUtil.get_all_function_tools` (`examples/mcp/get_all_mcp_tools_example`)
     -   Using `MCPServerManager` in a FastAPI application (`examples/mcp/manager_example`)
     -   MCP tool filtering (`examples/mcp/tool_filter_example`)
+    -   Discovering third-party agents in a registry, then trust-checking them (`examples/mcp/aidress_example`)
 
 - **[memory](https://github.com/openai/openai-agents-python/tree/main/examples/memory):** Examples of different memory implementations for agents, including:
 

--- a/examples/mcp/aidress_example/README.md
+++ b/examples/mcp/aidress_example/README.md
@@ -1,0 +1,18 @@
+# MCP Agent Discovery Example
+
+Connects to [Aidress](https://api.aidress.ai), a public registry of third-party agents, over the Streamable HTTP transport (`https://api.aidress.ai/mcp-http/mcp`), and uses it to discover agents that can do a task the user needs done.
+
+Discovery is the point of the example: the agent does not start from a list of known counterparts, it searches the registry by capability and finds out at runtime who exists and what they offer. Because the candidates it turns up are agents the user has never worked with, the second step is due diligence — each candidate's trust score, verification status, completed transaction count, and flags — before one is recommended. The registry holds real third-party agents, so the results and the numbers change over time and the example does not hard-code any agent id.
+
+The registry also exposes tools that mutate its state, including registering an agent and proxying a call to one. Discovery needs none of them, so the example passes `create_static_tool_filter` and the agent can reach only the read-only lookups.
+
+Run it with:
+
+```bash
+uv run python examples/mcp/aidress_example/main.py
+```
+
+Prerequisites:
+
+- `OPENAI_API_KEY` set for the model calls.
+- No registry credentials. The read-only tools used here are public; the tools this example filters out are the ones that require a key.

--- a/examples/mcp/aidress_example/main.py
+++ b/examples/mcp/aidress_example/main.py
@@ -1,0 +1,63 @@
+import asyncio
+
+from agents import Agent, Runner, gen_trace_id, trace
+from agents.mcp import MCPServerStreamableHttp
+from agents.mcp.util import create_static_tool_filter
+
+# The registry exposes both read-only lookups and tools that mutate registry state, such as
+# registering an agent or proxying a paid call. Discovery only needs the read-only subset, so the
+# filter keeps the agent from reaching the mutating tools at all.
+READ_ONLY_TOOLS = [
+    # Discovery: find candidates by capability, or page through the whole registry.
+    "match_agents",
+    "list_registry",
+    # Due diligence on a candidate that discovery surfaced.
+    "verify_agent",
+    "get_agent",
+    "protocol_reference",
+]
+
+
+async def main():
+    async with MCPServerStreamableHttp(
+        name="Aidress Agent Registry MCP Server",
+        params={
+            "url": "https://api.aidress.ai/mcp-http/mcp",
+            # Allow more time for remote tool responses.
+            "timeout": 15,
+            "sse_read_timeout": 300,
+        },
+        tool_filter=create_static_tool_filter(allowed_tool_names=READ_ONLY_TOOLS),
+        # Retry slow/unstable remote calls a couple of times.
+        max_retry_attempts=2,
+        retry_backoff_seconds_base=2.0,
+        client_session_timeout_seconds=15,
+    ) as server:
+        agent = Agent(
+            name="Agent Discovery Assistant",
+            instructions=(
+                "You find third-party agents that can do a task the user needs done. "
+                "Start by searching the registry for agents offering the required capability, and "
+                "report what you found: how many candidates there are and what each one does. "
+                "Then, because the user has not worked with any of them before, check each "
+                "candidate's trust score, whether it is verified, how many transactions it has "
+                "completed, and any flags. "
+                "Close with the candidate you would pick and the evidence behind the choice. "
+                "Report only the values the tools return; never invent an agent or a score."
+            ),
+            mcp_servers=[server],
+        )
+
+        trace_id = gen_trace_id()
+        with trace(workflow_name="Aidress Agent Discovery Example", trace_id=trace_id):
+            print(f"View trace: https://platform.openai.com/logs/trace?trace_id={trace_id}\n")
+            result = await Runner.run(
+                agent,
+                "I need a web research task done, but I don't know which agents offer that. "
+                "Find the ones that do, then tell me which of them I can trust with the job.",
+            )
+            print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### Summary

Adds `examples/mcp/aidress_example`, a Streamable HTTP example showing an agent **discovering other agents at runtime** — searching a public registry by capability to find third-party agents it had no prior knowledge of, then vetting the ones it finds.

The gap it fills: every current MCP example connects to a server whose tools the author already knew about. This one shows the discovery case — the agent starts with a task and no candidates, queries the registry for who can do it, and works from whatever comes back. On the transport side it also combines two existing examples that are separate today: a remote hosted server (`streamable_http_remote_example` against DeepWiki, `sse_remote_example`) whose tool surface mixes read-only and state-changing operations, which `tool_filter_example` only demonstrates against a local stdio server.

What the example does, in order: searches the registry for agents offering the capability the user needs and reports what it found; then, since these are agents the user has never worked with, checks each candidate's trust score, verification status, completed transaction count, and flags; then picks one and states the evidence. No agent id is hard-coded — the candidate set is whatever discovery returns, and the registry holds real third-party agents whose numbers move over time.

Two deliberate choices worth flagging for review:

- **The tool filter is doing real work, not decoration.** The server exposes 16 tools; the 5 discovery and lookup tools are read-only and the rest mutate registry state (registering an agent, rotating keys, proxying a paid call to another agent). `examples/run_examples.py` discovers and runs this file unattended, and remote examples like `streamable_http_remote_example/main.py` are not in `DEFAULT_AUTO_SKIP`. `create_static_tool_filter(allowed_tool_names=READ_ONLY_TOOLS)` means an unattended run cannot write to a live registry. Happy to add it to `DEFAULT_AUTO_SKIP` instead if maintainers prefer, but the filter seemed like the better demonstration.
- **No credentials beyond `OPENAI_API_KEY`.** The five read-only tools are public; the tools that need a key are exactly the ones filtered out. So the example runs in the auto-runner with no additional setup, same as the DeepWiki example.

Disclosure: I'm one of the authors of the registry this example connects to. I've kept the example about the SDK pattern rather than the service, and the README states plainly what the service is. If maintainers would rather this live somewhere other than `examples/mcp/`, or not land at all, that's entirely your call and no hard feelings.

### Test plan

Ran `.agents/skills/code-change-verification/scripts/run.sh`:

```
make format     All checks passed!
make lint       All checks passed!
make typecheck  Success: no issues found in 305 source files
make tests      8568 passed, 1 failed, 28 skipped
```

The one failure is pre-existing on `main` and unrelated to this PR:

```
FAILED tests/sandbox/test_snapshot.py::test_start_reapplies_only_ephemeral_manifest_when_preserved_probe_succeeds
```

It reproduces on a clean `upstream/main` at `50d65f6` with this branch's changes stashed, in isolation and without xdist, so it is not caused by this change and is not a parallelism flake:

```
uv run pytest -p no:randomly -q "tests/sandbox/test_snapshot.py::test_start_reapplies_only_ephemeral_manifest_when_preserved_probe_succeeds"
1 failed in 0.34s
```

Deselecting only that test: `8652 passed, 32 skipped, 1 deselected in 124.47s`. If it passes in your CI, then it is specific to my environment and I am happy to re-run the full untouched stack.

`make build-docs` succeeds for the one-line `docs/examples.md` addition (exit 0). Its 14 warnings are pre-existing missing anchors under the generated `docs/zh/` tree, untouched by this change.

The live discovery path was verified against the deployed endpoint through the SDK's own `MCPServerStreamableHttp`, using the exact params and filter from the example. The candidate list below is what discovery actually returned for "web research" — none of it is hard-coded in the example:

```
server exposes 16 tools: ['call_agent', 'claim_bearer_key', 'get_agent', 'import_agent', 'list_org_agents', 'list_registry', 'match_agents', 'preview_sandbox_match', 'promote_sandbox_agent', 'protocol_reference', 'register_agent', 'review_transaction', 'rotate_agent_key', 'set_agent_key', 'update_agent', 'verify_agent']

after filter: 5 tools: ['get_agent', 'list_registry', 'match_agents', 'protocol_reference', 'verify_agent']

match_agents returned 8 candidates (first 5 shown):
  agent_exa_ai                       trust=76  verified=True  tx=14  flags=[]
  agent_parallel_ai                  trust=72  verified=True  tx=16  flags=[]
  agent_ydc_index_io                 trust=75  verified=True  tx=1   flags=[]
  agent_trytako_com                  trust=72  verified=True  tx=1   flags=[]
  agent_google_serper_dev            trust=75  verified=True  tx=0   flags=[]
```

Running `examples/mcp/aidress_example/main.py` connects the server, applies the filter, and prints the trace URL as expected. I'll add the full end-to-end run output in a comment shortly.

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant — no unit tests, consistent with the sibling example directories
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass — everything passes except the pre-existing `tests/sandbox/test_snapshot.py` failure described above, which is why this box is left unchecked
- [ ] If using Codex, I've run `/review` before submitting this PR
