### PR TITLE
fix(realtime): handle non-finite audio rates

### DIFF
--- a/src/agents/realtime/audio_formats.py
+++ b/src/agents/realtime/audio_formats.py
@@ -35,7 +35,7 @@ def to_realtime_audio_format(
             rate = input_audio_format.get("rate")
             if fmt_type == "audio/pcm":
                 pcm_rate: Literal[24000] | None
-                if isinstance(rate, int | float) and int(rate) == 24000:
+                if isinstance(rate, int | float) and rate == 24000:
                     pcm_rate = 24000
                 elif rate is None:
                     pcm_rate = 24000

--- a/tests/realtime/test_audio_formats_unit.py
+++ b/tests/realtime/test_audio_formats_unit.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import Any
 
 import pytest
@@ -56,6 +57,14 @@ def test_to_realtime_audio_format_from_mapping():
     assert alaw.type == "audio/pcma"
 
     assert to_realtime_audio_format({"type": "audio/unknown", "rate": 8000}) is None
+
+
+@pytest.mark.parametrize("rate", [math.nan, math.inf, -math.inf])
+def test_to_realtime_audio_format_falls_back_for_non_finite_pcm_rate(rate: float) -> None:
+    result = to_realtime_audio_format({"type": "audio/pcm", "rate": rate})
+
+    assert isinstance(result, AudioPCM)
+    assert result.rate == 24000
 
 
 @pytest.mark.parametrize("tool_data_redacted", [False, True])


### PR DESCRIPTION
This pull request fixes realtime PCM audio-format normalization for non-finite numeric rates.

`NaN` and positive or negative infinity previously raised while being coerced with `int()`. They now follow the existing unsupported-rate path and safely fall back to the supported 24 kHz PCM format, with focused regression coverage.