### PR TITLE
fix(sandbox): preserve zero-length archive reads

### DIFF
--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -12,7 +12,7 @@ import threading
 import time
 import uuid
 from collections import deque
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1446,10 +1446,34 @@ class DockerSandboxSession(BaseSandboxSession):
             headers={"Accept-Encoding": "identity"},
         )
         api._raise_for_status(response)
-        return IteratorIO(it=self._iter_archive_chunks(api, response), on_close=on_close)
+        response_closed = False
+
+        def close_response() -> None:
+            nonlocal response_closed
+            if response_closed:
+                return
+            response_closed = True
+            try:
+                response.close()
+            except Exception:
+                pass
+
+        def finalize() -> None:
+            close_response()
+            if on_close is not None:
+                on_close()
+
+        return IteratorIO(
+            it=self._iter_archive_chunks(api, response, close_response),
+            on_close=finalize,
+        )
 
     @staticmethod
-    def _iter_archive_chunks(api: Any, response: Any) -> Iterator[bytes]:
+    def _iter_archive_chunks(
+        api: Any,
+        response: Any,
+        close_response: Callable[[], None],
+    ) -> Iterator[bytes]:
         try:
             yield from api._stream_raw_result(
                 response,
@@ -1457,10 +1481,7 @@ class DockerSandboxSession(BaseSandboxSession):
                 decode=False,
             )
         finally:
-            try:
-                response.close()
-            except Exception:
-                pass
+            close_response()
 
 
 class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):

--- a/src/agents/sandbox/util/iterator_io.py
+++ b/src/agents/sandbox/util/iterator_io.py
@@ -68,7 +68,7 @@ class IteratorIO(io.IOBase):
         return out
 
     def readinto(self, b: bytearray) -> int:
-        if self._closed:
+        if self._closed or len(b) == 0:
             return 0
 
         # Fill buffer until we have something or iterator is exhausted

--- a/tests/sandbox/test_docker.py
+++ b/tests/sandbox/test_docker.py
@@ -775,6 +775,28 @@ async def test_docker_persist_workspace_closes_archive_http_response_after_norma
 
 
 @pytest.mark.asyncio
+async def test_docker_archive_zero_length_read_then_close_closes_http_response(
+    tmp_path: Path,
+) -> None:
+    session = _HostBackedDockerSession(
+        host_root=tmp_path / "container",
+        manifest=Manifest(root="/workspace"),
+    )
+    response = _StreamingArchiveResponse([b"archive"])
+    api = _StreamingArchiveAPI(response)
+    session._fake_container.client = _StreamingArchiveContainerClient(api)
+    session._fake_container.id = "container"
+
+    archive = session._workspace_archive_stream(Path("/workspace"))
+
+    assert archive.readinto(bytearray()) == 0
+    assert response.close_calls == 0
+
+    archive.close()
+    assert response.close_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_docker_persist_workspace_defers_stage_cleanup_until_archive_close(
     tmp_path: Path,
 ) -> None:

--- a/tests/sandbox/test_iterator_io.py
+++ b/tests/sandbox/test_iterator_io.py
@@ -1,0 +1,19 @@
+from agents.sandbox.util.iterator_io import IteratorIO
+
+
+def test_zero_length_readinto_does_not_advance_iterator() -> None:
+    chunks = iter([b"archive"])
+    finalized = False
+
+    def on_close() -> None:
+        nonlocal finalized
+        finalized = True
+
+    stream = IteratorIO(chunks, on_close=on_close)
+
+    assert stream.readinto(bytearray()) == 0
+    assert finalized is False
+    assert next(chunks) == b"archive"
+
+    stream.close()
+    assert finalized is True


### PR DESCRIPTION
This pull request fixes zero-length `IteratorIO.readinto()` calls so they return immediately without advancing or blocking on the underlying archive iterator.

It also keeps Docker archive response ownership correct when such a stream is closed before iteration starts by sharing one idempotent response finalizer between iterator exhaustion and explicit close. Regression coverage verifies both the zero-length read contract and HTTP response cleanup.