### PR TITLE
fix: preserve scripted annotation streaming across Python SDK releases

### DIFF
--- a/src/agents/testing/model.py
+++ b/src/agents/testing/model.py
@@ -1007,14 +1007,16 @@ def _stream_events_for_step(
                         events.append(
                             cast(
                                 TResponseStreamEvent,
-                                ResponseOutputTextAnnotationAddedEvent(
-                                    type="response.output_text.annotation.added",
-                                    item_id=output_item.id,
-                                    output_index=output_index,
-                                    content_index=content_index,
-                                    annotation_index=annotation_index,
-                                    annotation=copy.deepcopy(annotation),
-                                    sequence_number=sequence_number,
+                                ResponseOutputTextAnnotationAddedEvent.model_validate(
+                                    {
+                                        "type": "response.output_text.annotation.added",
+                                        "item_id": output_item.id,
+                                        "output_index": output_index,
+                                        "content_index": content_index,
+                                        "annotation_index": annotation_index,
+                                        "annotation": annotation.model_dump(),
+                                        "sequence_number": sequence_number,
+                                    }
                                 ),
                             )
                         )

--- a/tests/test_scripted_model.py
+++ b/tests/test_scripted_model.py
@@ -1987,7 +1987,9 @@ async def test_scripted_model_automatic_stream_emits_text_annotation_events() ->
     assert isinstance(added_part.part, ResponseOutputText)
     assert added_part.part.annotations == []
     assert [event.annotation_index for event in annotation_events] == [0, 1]
-    assert [event.annotation for event in annotation_events] == annotations
+    assert [event.model_dump()["annotation"] for event in annotation_events] == [
+        annotation.model_dump() for annotation in annotations
+    ]
     assert all(event.item_id == "message_1" for event in annotation_events)
     assert all(event.output_index == 0 for event in annotation_events)
     assert all(event.content_index == 0 for event in annotation_events)


### PR DESCRIPTION
This pull request fixes scripted annotation streaming before the next Python SDK release introduces accurately typed annotation-added events (openai/openai-python#3617).

The current helper passes output-text annotation models directly into streaming events. That works while the released SDK accepts an untyped annotation, but the upcoming SDK validates events against distinct event-specific annotation classes. As a result, the existing helper both fails static type checking and raises a validation error at runtime.

- Preserve annotation contents, event ordering, and sequence numbers across both the released and upcoming Python SDKs.
- Construct events from their serialized payload so each installed SDK applies its own event schema without relying on imports that do not exist in the current release.
- Compare annotation payloads by their public serialized representation instead of requiring unrelated generated model classes to share an identity.
