### PR TITLE
fix(sandbox): preserve falsy exception causes

### DIFF
--- a/src/agents/sandbox/util/retry.py
+++ b/src/agents/sandbox/util/retry.py
@@ -32,9 +32,10 @@ def iter_exception_chain(exc: BaseException) -> Iterable[BaseException]:
     while current is not None and id(current) not in seen:
         yield current
         seen.add(id(current))
+        cause = getattr(current, "__cause__", None)
         current = cast(
             BaseException | None,
-            getattr(current, "__cause__", None) or getattr(current, "__context__", None),
+            cause if cause is not None else getattr(current, "__context__", None),
         )
 
 

--- a/tests/sandbox/test_retry.py
+++ b/tests/sandbox/test_retry.py
@@ -30,6 +30,11 @@ class _ErrorWithHttpMetadata(Exception):
             self.response = type("_Response", (), {"status_code": response_status_code})()
 
 
+class _FalsyError(Exception):
+    def __bool__(self) -> bool:
+        return False
+
+
 def test_iter_exception_chain_supports_context_and_stops_on_cycles() -> None:
     outer = RuntimeError("outer")
     inner = ValueError("inner")
@@ -43,6 +48,16 @@ def test_iter_exception_chain_supports_context_and_stops_on_cycles() -> None:
     cyclical_inner.__cause__ = cyclical_outer
 
     assert list(iter_exception_chain(cyclical_outer)) == [cyclical_outer, cyclical_inner]
+
+
+def test_iter_exception_chain_preserves_falsy_explicit_cause() -> None:
+    outer = RuntimeError("outer")
+    cause = _FalsyError("cause")
+    context = ValueError("context")
+    outer.__cause__ = cause
+    outer.__context__ = context
+
+    assert list(iter_exception_chain(outer)) == [outer, cause]
 
 
 def test_exception_chain_helpers_detect_types_and_status_codes() -> None:


### PR DESCRIPTION
### Summary

This pull request fixes sandbox retry exception-chain traversal when an explicit cause implements falsey truthiness. The previous `cause or context` selection skipped that cause and could classify retries using an unrelated context exception; selecting by identity preserves Python's cause precedence without invoking `__bool__`.

### Test plan

- `uv run --no-dev --with pytest --with pytest-asyncio pytest -q tests/sandbox/test_retry.py` (8 passed)
- `uv run --no-dev --with ruff==0.9.2 ruff check src/agents/sandbox/util/retry.py tests/sandbox/test_retry.py`
- `uv run --no-dev --with ruff==0.9.2 ruff format --check src/agents/sandbox/util/retry.py tests/sandbox/test_retry.py`
- `git diff --check`

The full verification script could not start because this environment lacks a C compiler required to build the dev dependency `evdev`; the focused runtime tests and checks above passed.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
