### PR TITLE
fix(mcp): stop handing the tools cache to callers

### DIFF
--- a/src/agents/mcp/server.py
+++ b/src/agents/mcp/server.py
@@ -854,7 +854,11 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
 
     @property
     def cached_tools(self) -> list[MCPTool] | None:
-        return self._tools_list
+        """A snapshot of the cached tools list, or `None` when nothing is cached.
+
+        This returns a new list so callers cannot mutate the server's cache in place.
+        """
+        return None if self._tools_list is None else list(self._tools_list)
 
     def __init__(
         self,
@@ -1474,6 +1478,11 @@ class _MCPServerWithClientSession(MCPServer, abc.ABC):
             filtered_tools = tools
             if self.tool_filter is not None:
                 filtered_tools = await self._apply_tool_filter(filtered_tools, run_context, agent)
+            if filtered_tools is self._tools_list:
+                # The filters build a new list, but an absent filter — or a static filter with
+                # neither key set — passes the cached list straight through. Returning it would
+                # let a caller mutate the cache and corrupt every later `list_tools()` result.
+                return list(filtered_tools)
             return filtered_tools
         except mcp_compat.HTTP_STATUS_ERROR_TYPES as e:
             status_code = http_status_code(e)

--- a/tests/mcp/test_caching.py
+++ b/tests/mcp/test_caching.py
@@ -95,3 +95,102 @@ async def test_paginated_tools_are_cached_before_filtering(
         call(),
         call(params=PaginatedRequestParams(cursor="")),
     ]
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_list_tools_does_not_expose_the_tools_cache(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    """Mutating the list returned by `list_tools()` must not corrupt the server's cache."""
+    server = MCPServerStdio(params={"command": tee}, cache_tools_list=True)
+    mock_list_tools.return_value = ListToolsResult(
+        tools=[MCPTool(name="tool1", inputSchema={}), MCPTool(name="tool2", inputSchema={})]
+    )
+
+    async with server:
+        run_context = RunContextWrapper(context=None)
+        agent = Agent(name="test_agent", instructions="Test agent")
+
+        returned = await server.list_tools(run_context, agent)
+        assert returned is not server.cached_tools
+        returned.pop()
+
+        assert [tool.name for tool in await server.list_tools(run_context, agent)] == [
+            "tool1",
+            "tool2",
+        ]
+        assert mock_list_tools.call_count == 1, "the cache should still be serving both tools"
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_list_tools_does_not_expose_the_cache_with_a_no_op_static_filter(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    """A static filter that sets neither key passes the cached list straight through."""
+    server = MCPServerStdio(params={"command": tee}, cache_tools_list=True, tool_filter={})
+    mock_list_tools.return_value = ListToolsResult(
+        tools=[MCPTool(name="tool1", inputSchema={}), MCPTool(name="tool2", inputSchema={})]
+    )
+
+    async with server:
+        run_context = RunContextWrapper(context=None)
+        agent = Agent(name="test_agent", instructions="Test agent")
+
+        returned = await server.list_tools(run_context, agent)
+        returned.clear()
+
+        assert [tool.name for tool in await server.list_tools(run_context, agent)] == [
+            "tool1",
+            "tool2",
+        ]
+        assert mock_list_tools.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_cached_tools_returns_a_snapshot(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    """`cached_tools` must not hand out the live cache: appending to it would inject a tool."""
+    server = MCPServerStdio(params={"command": tee}, cache_tools_list=True)
+    mock_list_tools.return_value = ListToolsResult(
+        tools=[MCPTool(name="tool1", inputSchema={}), MCPTool(name="tool2", inputSchema={})]
+    )
+
+    async with server:
+        run_context = RunContextWrapper(context=None)
+        agent = Agent(name="test_agent", instructions="Test agent")
+        await server.list_tools(run_context, agent)
+
+        snapshot = server.cached_tools
+        assert snapshot is not None
+        snapshot.append(MCPTool(name="injected", inputSchema={}))
+
+        assert [tool.name for tool in (server.cached_tools or [])] == ["tool1", "tool2"]
+        assert [tool.name for tool in await server.list_tools(run_context, agent)] == [
+            "tool1",
+            "tool2",
+        ]
+
+
+@pytest.mark.asyncio
+@patch("mcp.client.stdio.stdio_client", return_value=DummyStreamsContextManager())
+@patch("mcp.client.session.ClientSession.initialize", new_callable=AsyncMock, return_value=None)
+@patch("mcp.client.session.ClientSession.list_tools")
+async def test_cached_tools_is_none_before_the_first_list(
+    mock_list_tools: AsyncMock, mock_initialize: AsyncMock, mock_stdio_client
+):
+    """The snapshot must preserve the `None` sentinel rather than reporting an empty cache."""
+    server = MCPServerStdio(params={"command": tee}, cache_tools_list=True)
+    mock_list_tools.return_value = ListToolsResult(tools=[])
+
+    async with server:
+        assert server.cached_tools is None


### PR DESCRIPTION
### Summary

`_MCPServerWithClientSession` hands its live tools cache to callers, so ordinary use of the returned list corrupts the server's cache.

Two exits return the cached list object itself:

- `list_tools()` sets `filtered_tools = tools` and returns it unchanged when there is no tool filter. `tools` is `self._tools_list` on a cache hit, and on a miss it is the same list that was just assigned to `self._tools_list`, so the alias exists whether or not the cache was warm — and whether or not `cache_tools_list` is set, since the fetch path always populates `_tools_list`.
- The `cached_tools` property returns `self._tools_list` directly.

A caller that mutates what it was given silently changes what every later call returns:

```python
tools = await server.list_tools(run_context, agent)
tools.pop()                      # drop a tool this caller does not want to use
await server.list_tools(run_context, agent)   # the dropped tool is gone for everyone
```

The `cached_tools` direction is the worse of the two, because the mutation flows *toward* the model rather than away from it — appending an entry injects a tool definition that is then served as if the MCP server had advertised it:

```python
snapshot = server.cached_tools
snapshot.append(MCPTool(name="injected", inputSchema={}))
await server.list_tools(run_context, agent)   # -> [tool1, tool2, injected]
```

Both are one-line consequences of the same missing boundary: the cache is internal state and must not leave the object.

### What this changes

`cached_tools` returns a new list, preserving the `None` sentinel that distinguishes "nothing fetched yet" from "fetched, empty".

`list_tools()` copies only when the value it is about to return is the cache itself:

```python
if filtered_tools is self._tools_list:
    return list(filtered_tools)
return filtered_tools
```

The identity check is deliberate rather than an unconditional `list(...)`. Both filter paths already build new lists (`_apply_static_tool_filter` uses comprehensions, `_apply_dynamic_tool_filter` accumulates into a fresh list), so copying again would allocate on every filtered call for no benefit. The check also covers the one filtered case that *does* alias: a static filter dict carrying neither `allowed_tool_names` nor `blocked_tool_names` falls through `_apply_static_tool_filter` and returns its input unchanged. That case is covered by a test rather than left to the reader.

### Scope

Only the two places that leak the cache. `list_tools()` returns a shallow copy — the `MCPTool` objects are still shared, which matches how the rest of the SDK passes tool definitions around, and the reported failure is list mutation, not tool mutation. Deep-copying every tool on every call would be a real cost for a case with no evidence behind it.

`cached_tools` on the `MCPServer` base class returns `None` and needed no change.

### Test plan

Four tests in `tests/mcp/test_caching.py`:

- `test_list_tools_does_not_expose_the_tools_cache` — `pop()` on the returned list; the next call still returns both tools, and `mock_list_tools.call_count` stays at 1 so the assertion cannot pass by silently refetching.
- `test_list_tools_does_not_expose_the_cache_with_a_no_op_static_filter` — same, through `tool_filter={}`, pinning the aliasing filter path.
- `test_cached_tools_returns_a_snapshot` — `append()` on the snapshot; neither `cached_tools` nor `list_tools()` reports the injected tool.
- `test_cached_tools_is_none_before_the_first_list` — negative control that the copy preserves `None` instead of returning `[]`.

Fail-first: the first three fail on `main` with the fix reverted and the fourth passes, confirming it is a control rather than a second assertion of the same bug. The `call_count` assertion matters — a caller calling `clear()` instead of `pop()` happens to self-heal, because the cache-hit branch tests `self._tools_list` for truthiness and an emptied cache falls through to a refetch. `pop()` and `append()` leave the cache truthy and corrupt.

`tests/mcp/` is 456 passed / 24 skipped, unchanged from `main`. The two existing `cached_tools is None` assertions in `test_server_errors.py` and `test_client_session_retries.py` still hold, and `test_paginated_tools_are_cached_before_filtering` compares with `==` rather than `is`, so the snapshot does not disturb it.

Full stack via `.agents/skills/code-change-verification/scripts/run.sh`: `make format`, `make lint`, `make typecheck`, `make tests` all pass.

### Issue number

None — found while reading the caching path.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

*Disclosure: this change was prepared with AI assistance. The bug, the fix, and the tests were verified locally as described above.*
