### PR TITLE
fix(retry): bound a provider retry-after by the configured max_delay

### DIFF
--- a/src/agents/run_internal/model_retry.py
+++ b/src/agents/run_internal/model_retry.py
@@ -166,6 +166,16 @@ async def _call_retry_policy(
     return _coerce_retry_decision(decision)
 
 
+def _explicit_max_delay(backoff: ModelRetryBackoffInput | None) -> float | None:
+    """Return the caller's configured retry ceiling, or `None` when they did not set one.
+
+    The default ceiling exists to bound the SDK's own exponential growth. It is deliberately not
+    substituted here, so an unconfigured caller keeps honoring a provider's retry-after in full.
+    """
+    settings = _coerce_backoff_settings(backoff)
+    return settings.max_delay if settings is not None else None
+
+
 def _default_retry_delay(
     attempt: int,
     backoff: ModelRetryBackoffInput | None,
@@ -196,6 +206,17 @@ def _default_retry_delay(
     if not use_jitter:
         return base
     return min(max(base * (0.875 + random.random() * 0.25), 0.0), max_delay)
+
+
+def _capped_provider_delay(
+    retry_after: float,
+    backoff: ModelRetryBackoffInput | None,
+) -> float:
+    """Bound a provider-supplied retry-after by the caller's configured ceiling."""
+    max_delay = _explicit_max_delay(backoff)
+    if max_delay is None:
+        return retry_after
+    return min(retry_after, max_delay)
 
 
 async def _sleep_for_retry(delay: float) -> None:
@@ -372,8 +393,14 @@ async def _evaluate_retry(
         delay=(
             decision.delay
             if decision.delay is not None
+            # The policy did not name a delay, so the provider's retry-after is used on its
+            # behalf. That substitution still respects an explicitly configured ceiling;
+            # otherwise a single `Retry-After` header decides how long the run blocks, and
+            # `max_delay` silently stops being a maximum. A caller who configured no ceiling
+            # keeps honoring the provider in full, and a policy that returns its own delay
+            # keeps that delay.
             else (
-                normalized.retry_after
+                _capped_provider_delay(normalized.retry_after, retry_backoff)
                 if normalized.retry_after is not None
                 else _default_retry_delay(attempt, retry_backoff)
             )

--- a/tests/models/test_model_retry.py
+++ b/tests/models/test_model_retry.py
@@ -3004,3 +3004,97 @@ async def test_unsafe_replay_approval_does_not_lift_a_stateful_request_with_unkn
         )
 
     assert calls == 1
+
+
+async def _run_once_with_retry_after(
+    *,
+    retry_after: float,
+    backoff: ModelRetryBackoffSettings,
+    policy: Any = None,
+) -> list[float]:
+    """Fail once, then succeed, returning the delays the runner slept for."""
+    sleeps: list[float] = []
+    calls = 0
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    async def rewind() -> None:
+        return None
+
+    async def get_response() -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _connection_error()
+        return ModelResponse(
+            output=[get_text_message("ok")],
+            usage=Usage(requests=0),
+            response_id="resp_retry_after_cap",
+        )
+
+    original_sleep = asyncio.sleep
+    asyncio.sleep = fake_sleep  # type: ignore[assignment]
+    try:
+        await get_response_with_retry(
+            get_response=get_response,
+            rewind=rewind,
+            retry_settings=ModelRetrySettings(
+                max_retries=1,
+                backoff=backoff,
+                policy=policy or retry_policies.network_error(),
+            ),
+            get_retry_advice=lambda _request: ModelRetryAdvice(
+                suggested=True, retry_after=retry_after
+            ),
+            previous_response_id=None,
+            conversation_id=None,
+        )
+    finally:
+        asyncio.sleep = original_sleep  # type: ignore[assignment]
+    return sleeps
+
+
+@pytest.mark.asyncio
+async def test_provider_retry_after_is_capped_by_configured_max_delay() -> None:
+    """A configured `max_delay` bounds a provider retry-after the policy did not ask for."""
+    sleeps = await _run_once_with_retry_after(
+        retry_after=3600.0,
+        backoff=ModelRetryBackoffSettings(initial_delay=1.0, max_delay=5.0, jitter=False),
+    )
+    assert sleeps == [5.0]
+
+
+@pytest.mark.asyncio
+async def test_provider_retry_after_below_max_delay_is_unchanged() -> None:
+    """Capping must not round a provider retry-after up to the ceiling."""
+    sleeps = await _run_once_with_retry_after(
+        retry_after=1.5,
+        backoff=ModelRetryBackoffSettings(initial_delay=1.0, max_delay=5.0, jitter=False),
+    )
+    assert sleeps == [1.5]
+
+
+@pytest.mark.asyncio
+async def test_provider_retry_after_is_honored_without_a_configured_max_delay() -> None:
+    """Without an explicit ceiling the provider's retry-after is still honored in full.
+
+    The default ceiling bounds the SDK's own backoff growth. Substituting it here would shrink a
+    server's rate-limit instruction to the 2.0s default and retry far sooner than it asked.
+    """
+    sleeps = await _run_once_with_retry_after(
+        retry_after=45.0,
+        backoff=ModelRetryBackoffSettings(initial_delay=1.0, jitter=False),
+    )
+    assert sleeps == [45.0]
+
+
+@pytest.mark.asyncio
+async def test_policy_supplied_delay_is_not_capped_by_max_delay() -> None:
+    """An explicit `RetryDecision.delay` is the application's own number and is left alone."""
+    sleeps = await _run_once_with_retry_after(
+        retry_after=3600.0,
+        backoff=ModelRetryBackoffSettings(initial_delay=1.0, max_delay=5.0, jitter=False),
+        policy=lambda _context: RetryDecision(retry=True, delay=30.0),
+    )
+    assert sleeps == [30.0]


### PR DESCRIPTION
### Summary

`ModelRetryBackoffSettings.max_delay` documents itself as "Maximum delay in seconds between retry attempts", but a provider-supplied retry-after bypasses it entirely, so it is not actually a maximum.

In `_evaluate_retry`, when a retry policy returns `retry=True` without naming a delay, the runner substitutes the provider's value:

```python
delay=(
    decision.delay
    if decision.delay is not None
    else (
        normalized.retry_after          # straight from the response header, unbounded
        if normalized.retry_after is not None
        else _default_retry_delay(attempt, retry_backoff)   # this one is capped
    )
),
```

`normalized.retry_after` comes from `get_retry_after()`, which reads `retry-after-ms` / `retry-after` off the error chain. The neighbouring `_default_retry_delay` clamps with `min(..., max_delay)`; the retry-after branch does not. A caller that configured a five-second ceiling and hit a `Retry-After: 3600` blocks for an hour:

```python
ModelRetrySettings(
    max_retries=1,
    backoff=ModelRetryBackoffSettings(initial_delay=1.0, max_delay=5.0, jitter=False),
    policy=retry_policies.network_error(),
)
# server answers with Retry-After: 3600  ->  runner sleeps 3600s
```

Note the policy is `network_error()`. The application never asked for retry-after semantics; the SDK reached for the provider's number on its own and let it override the bound the application did set.

### What this changes

The substituted provider value is bounded by the caller's configured ceiling. Three cases are deliberately left alone, and each has a test:

- **No `max_delay` configured — unchanged.** The provider's retry-after is still honored in full. The default ceiling is `DEFAULT_MAX_DELAY_SECONDS = 2.0`, and it exists to bound the SDK's own exponential growth. Substituting it here would shrink an ordinary `Retry-After: 60` to two seconds and retry into a rate limit far sooner than the server asked — a worse failure than the one being fixed. So the cap keys on an *explicit* `max_delay`, via `_explicit_max_delay()` returning `None` rather than the default.
- **An explicit `RetryDecision.delay` — unchanged.** That number is the application's own, not the provider's.
- **`retry_policies.retry_after()` — unchanged.** Choosing that policy is an explicit request for server-driven delays. It also could not participate: `RetryPolicyContext` carries `max_retries` but no backoff settings, so the policy cannot see a ceiling. Threading settings through the policy context would widen the public context type for a case that reads as intended behavior, so it is left as-is rather than patched around.

Callers who set no ceiling see byte-identical behavior; the change is scoped to callers who stated a bound and were not getting it.

### Test plan

Four tests in `tests/models/test_model_retry.py`, sharing one `_run_once_with_retry_after` helper:

- `test_provider_retry_after_is_capped_by_configured_max_delay` — `retry_after=3600.0` against `max_delay=5.0` sleeps `5.0`.
- `test_provider_retry_after_below_max_delay_is_unchanged` — `1.5` against a `5.0` ceiling stays `1.5`, so the cap cannot pass by clamping everything to the ceiling.
- `test_provider_retry_after_is_honored_without_a_configured_max_delay` — `45.0` with no `max_delay` still sleeps `45.0`.
- `test_policy_supplied_delay_is_not_capped_by_max_delay` — an explicit `RetryDecision(delay=30.0)` survives a `5.0` ceiling.

Fail-first on `main` with the fix reverted: **1 failed, 3 passed** — only the first assertion is about the bug, and the other three are controls that must hold in both states. They do.

`tests/models/test_model_retry.py` goes 82 → 86 passed, +4 = exactly the new tests, no pre-existing test changed. `test_get_response_with_retry_prefers_retry_after_over_backoff` still passes and still asserts `[1.75]`: it sets no `max_delay`, so it lands on the untouched path.

Full stack via `.agents/skills/code-change-verification/scripts/run.sh`: `make format`, `make lint`, `make typecheck`, `make tests` all pass.

### Issue number

None — found while reading the backoff path.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

*Disclosure: this change was prepared with AI assistance. The bug, the fix, and the tests were verified locally as described above.*
