### PR TITLE
fix: honour a per-call approval decision made after a sticky one

### DIFF
--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -1316,7 +1316,9 @@ class RunContextWrapper(Generic[TContext]):
                     call_id for call_id in decision if call_id not in self._tool_invocations
                 )
 
-    def _rebuild_hosted_mcp_approvals(self, approvals: Any) -> None:
+    def _rebuild_hosted_mcp_approvals(
+        self, approvals: Any, *, per_call_overrides_sticky: bool = True
+    ) -> None:
         """Restore typed hosted MCP approval records from serialized state."""
         if not isinstance(approvals, list):
             return
@@ -1351,7 +1353,9 @@ class RunContextWrapper(Generic[TContext]):
                 key = ("hosted_mcp_query", tool_name, request_id)
             else:
                 continue
-            self._approvals[key] = self._restore_approval_record(decision)
+            self._approvals[key] = self._restore_approval_record(
+                decision, per_call_overrides_sticky=per_call_overrides_sticky
+            )
 
     def _fork_with_tool_input(self, tool_input: Any) -> RunContextWrapper[TContext]:
         """Create a child context that shares approvals and usage with tool input set."""

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -676,6 +676,10 @@ class RunContextWrapper(Generic[TContext]):
 
     @staticmethod
     def _get_rejection_message_for_key(record: _ApprovalRecord, call_id: str) -> str | None:
+        # An approval recorded for this exact call overrides a sticky rejection, so there
+        # is no rejection reason to report for it.
+        if isinstance(record.approved, list) and call_id in record.approved:
+            return None
         if record.rejected is True:
             if call_id in record.rejection_messages:
                 return record.rejection_messages[call_id]
@@ -1001,17 +1005,19 @@ class RunContextWrapper(Generic[TContext]):
             if isinstance(opposite, list) and call_id in opposite:
                 opposite.remove(call_id)
 
-            # A sticky decision leaves a bool in this field, and a per-call decision
-            # taken afterwards still has to be recorded, so start a list for it.
+            # A sticky decision leaves a bool in this field. A per-call decision that
+            # agrees with it is already covered, so keep the sticky value; one that
+            # opposes it still has to be recorded, so start a list for it.
             target = approval_entry.approved if approve else approval_entry.rejected
-            if not isinstance(target, list):
-                target = []
-                if approve:
-                    approval_entry.approved = target
-                else:
-                    approval_entry.rejected = target
-            if call_id not in target:
-                target.append(call_id)
+            if target is not True:
+                if not isinstance(target, list):
+                    target = []
+                    if approve:
+                        approval_entry.approved = target
+                    else:
+                        approval_entry.rejected = target
+                if call_id not in target:
+                    target.append(call_id)
             if approve:
                 self._clear_rejection_message(approval_entry, call_id)
             elif call_id is not None:

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -616,6 +616,21 @@ class RunContextWrapper(Generic[TContext]):
         if approval_entry is None:
             return None
 
+        approved_ids = (
+            set(approval_entry.approved) if isinstance(approval_entry.approved, list) else set()
+        )
+        rejected_ids = (
+            set(approval_entry.rejected) if isinstance(approval_entry.rejected, list) else set()
+        )
+
+        # A decision made for this exact call is the more recent one, so it wins over a
+        # sticky value. Sticky decisions are stored as bools and per-call decisions as
+        # lists, so both forms can be present on the same record.
+        if call_id in approved_ids:
+            return True
+        if call_id in rejected_ids:
+            return False
+
         # Check for permanent approval/rejection
         if approval_entry.approved is True and approval_entry.rejected is True:
             # Approval takes precedence
@@ -627,17 +642,6 @@ class RunContextWrapper(Generic[TContext]):
         if approval_entry.rejected is True:
             return False
 
-        approved_ids = (
-            set(approval_entry.approved) if isinstance(approval_entry.approved, list) else set()
-        )
-        rejected_ids = (
-            set(approval_entry.rejected) if isinstance(approval_entry.rejected, list) else set()
-        )
-
-        if call_id in approved_ids:
-            return True
-        if call_id in rejected_ids:
-            return False
         # Per-call approvals are scoped to the exact call ID, so other calls require a new decision.
         return None
 
@@ -997,8 +1001,16 @@ class RunContextWrapper(Generic[TContext]):
             if isinstance(opposite, list) and call_id in opposite:
                 opposite.remove(call_id)
 
+            # A sticky decision leaves a bool in this field, and a per-call decision
+            # taken afterwards still has to be recorded, so start a list for it.
             target = approval_entry.approved if approve else approval_entry.rejected
-            if isinstance(target, list) and call_id not in target:
+            if not isinstance(target, list):
+                target = []
+                if approve:
+                    approval_entry.approved = target
+                else:
+                    approval_entry.rejected = target
+            if call_id not in target:
                 target.append(call_id)
             if approve:
                 self._clear_rejection_message(approval_entry, call_id)

--- a/src/agents/run_context.py
+++ b/src/agents/run_context.py
@@ -1224,7 +1224,7 @@ class RunContextWrapper(Generic[TContext]):
             return status
         return status
 
-    def _rebuild_approvals(self, approvals: Any) -> None:
+    def _rebuild_approvals(self, approvals: Any, *, per_call_overrides_sticky: bool = True) -> None:
         """Restore approvals from serialized state."""
         self._approvals = {}
         if not isinstance(approvals, Mapping):
@@ -1232,13 +1232,24 @@ class RunContextWrapper(Generic[TContext]):
         for tool_name, record_dict in approvals.items():
             if not isinstance(tool_name, str) or not isinstance(record_dict, dict):
                 continue
-            self._approvals[tool_name] = self._restore_approval_record(record_dict)
+            self._approvals[tool_name] = self._restore_approval_record(
+                record_dict, per_call_overrides_sticky=per_call_overrides_sticky
+            )
 
     @classmethod
-    def _restore_approval_record(cls, record_dict: Mapping[str, Any]) -> _ApprovalRecord:
+    def _restore_approval_record(
+        cls, record_dict: Mapping[str, Any], *, per_call_overrides_sticky: bool = True
+    ) -> _ApprovalRecord:
         record = _ApprovalRecord()
         record.approved = cls._restore_approval_value(record_dict.get("approved", []))
         record.rejected = cls._restore_approval_value(record_dict.get("rejected", []))
+        if not per_call_overrides_sticky:
+            # Snapshots written before the per-call override resolved these as sticky, so
+            # drop the opposing per-call list to resume them the way they were written.
+            if record.approved is True and isinstance(record.rejected, list):
+                record.rejected = []
+            elif record.rejected is True and isinstance(record.approved, list):
+                record.approved = []
         rejection_messages = record_dict.get("rejection_messages", {})
         if isinstance(rejection_messages, dict):
             record.rejection_messages = {

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -3365,7 +3365,11 @@ async def _build_run_state_from_json(
         int(part) for part in _HOSTED_MCP_APPROVALS_MIN_SCHEMA_VERSION.split(".", maxsplit=1)
     )
     if (schema_major, schema_minor) >= (hosted_mcp_major, hosted_mcp_minor):
-        context._rebuild_hosted_mcp_approvals(context_data.get("hosted_mcp_approvals", []))
+        context._rebuild_hosted_mcp_approvals(
+            context_data.get("hosted_mcp_approvals", []),
+            per_call_overrides_sticky=(schema_major, schema_minor)
+            >= (per_call_major, per_call_minor),
+        )
     if (schema_major, schema_minor) >= (1, 15):
         context._mark_restored_unbound_approval_call_ids()
     serialized_tool_input = context_data.get("tool_input")

--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -177,9 +177,10 @@ def _default_run_state_validation_error(
 # 3. to_json() always emits CURRENT_SCHEMA_VERSION.
 # 4. Forward compatibility is intentionally fail-fast (older SDKs reject newer or unsupported
 #    versions).
-CURRENT_SCHEMA_VERSION = "1.15"
+CURRENT_SCHEMA_VERSION = "1.16"
 _PROGRAMMATIC_TOOL_CALLING_MIN_SCHEMA_VERSION = "1.13"
 _HOSTED_MCP_APPROVALS_MIN_SCHEMA_VERSION = "1.14"
+_PER_CALL_APPROVAL_OVERRIDE_MIN_SCHEMA_VERSION = "1.16"
 # Keep this mapping in chronological order. Every schema bump must add a one-line summary here.
 SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
     "1.0": "Initial RunState snapshot format for HITL pause/resume flows.",
@@ -207,6 +208,7 @@ SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
         "Persists canonical tool invocation identity plus sanitized mount authority and trusted "
         "rebind metadata, durable pending input, and resumable next-model-call state."
     ),
+    "1.16": "Lets a per-call approval decision override a sticky one for the same tool.",
 }
 SUPPORTED_SCHEMA_VERSIONS = frozenset(SCHEMA_VERSION_SUMMARIES)
 
@@ -3342,7 +3344,13 @@ async def _build_run_state_from_json(
     context.usage = usage
     context._restored_unbound_approval_call_ids = set()
     context._allow_legacy_approval_binding_reconstruction = (schema_major, schema_minor) < (1, 15)
-    context._rebuild_approvals(context_data.get("approvals", {}))
+    per_call_major, per_call_minor = (
+        int(part) for part in _PER_CALL_APPROVAL_OVERRIDE_MIN_SCHEMA_VERSION.split(".", maxsplit=1)
+    )
+    context._rebuild_approvals(
+        context_data.get("approvals", {}),
+        per_call_overrides_sticky=(schema_major, schema_minor) >= (per_call_major, per_call_minor),
+    )
     if (schema_major, schema_minor) >= (1, 15):
         context._rebuild_tool_invocations(
             context_data.get("tool_invocations", {}),

--- a/tests/test_run_context_wrapper.py
+++ b/tests/test_run_context_wrapper.py
@@ -207,3 +207,32 @@ def test_tool_approval_item_preserves_positional_type_argument() -> None:
     assert approval.type == "tool_approval_item"
     assert approval.tool_name == "lookup_account"
     assert approval.tool_namespace == "billing"
+
+
+def test_run_context_per_call_decision_overrides_sticky_decision() -> None:
+    wrapper: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    agent = make_agent()
+
+    def approval(call_id: str) -> ToolApprovalItem:
+        return ToolApprovalItem(
+            agent=agent,
+            raw_item={
+                "type": "function_call",
+                "name": "tool_call",
+                "call_id": call_id,
+                "arguments": "{}",
+            },
+        )
+
+    # Rejecting one call after approving the tool for the session applies to that call only.
+    wrapper.approve_tool(approval("call-1"), always_approve=True)
+    wrapper.reject_tool(approval("call-2"), rejection_message="denied by user")
+    assert wrapper.is_tool_approved("tool_call", "call-2") is False
+    assert wrapper.is_tool_approved("tool_call", "call-3") is True
+
+    # The same holds in the other direction.
+    other: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    other.reject_tool(approval("call-4"), always_reject=True)
+    other.approve_tool(approval("call-5"))
+    assert other.is_tool_approved("tool_call", "call-5") is True
+    assert other.is_tool_approved("tool_call", "call-6") is False

--- a/tests/test_run_context_wrapper.py
+++ b/tests/test_run_context_wrapper.py
@@ -230,9 +230,38 @@ def test_run_context_per_call_decision_overrides_sticky_decision() -> None:
     assert wrapper.is_tool_approved("tool_call", "call-2") is False
     assert wrapper.is_tool_approved("tool_call", "call-3") is True
 
-    # The same holds in the other direction.
+    # The same holds in the other direction, and the approved call reports no
+    # rejection reason even though the sticky rejection carried one.
     other: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
-    other.reject_tool(approval("call-4"), always_reject=True)
+    other.reject_tool(approval("call-4"), always_reject=True, rejection_message="denied")
     other.approve_tool(approval("call-5"))
     assert other.is_tool_approved("tool_call", "call-5") is True
+    assert other.get_rejection_message("tool_call", "call-5") is None
     assert other.is_tool_approved("tool_call", "call-6") is False
+    assert other.get_rejection_message("tool_call", "call-6") == "denied"
+
+
+def test_run_context_per_call_decision_keeps_matching_sticky_decision() -> None:
+    agent = make_agent()
+
+    def approval(call_id: str) -> ToolApprovalItem:
+        return ToolApprovalItem(
+            agent=agent,
+            raw_item={
+                "type": "function_call",
+                "name": "tool_call",
+                "call_id": call_id,
+                "arguments": "{}",
+            },
+        )
+
+    # A per-call decision that agrees with the sticky one must leave it in place.
+    approved: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    approved.approve_tool(approval("call-1"), always_approve=True)
+    approved.approve_tool(approval("call-2"))
+    assert approved.is_tool_approved("tool_call", "call-3") is True
+
+    rejected: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    rejected.reject_tool(approval("call-4"), always_reject=True)
+    rejected.reject_tool(approval("call-5"))
+    assert rejected.is_tool_approved("tool_call", "call-6") is False

--- a/tests/test_run_context_wrapper.py
+++ b/tests/test_run_context_wrapper.py
@@ -265,3 +265,32 @@ def test_run_context_per_call_decision_keeps_matching_sticky_decision() -> None:
     rejected.reject_tool(approval("call-4"), always_reject=True)
     rejected.reject_tool(approval("call-5"))
     assert rejected.is_tool_approved("tool_call", "call-6") is False
+
+
+def test_run_context_same_call_decision_reverses_in_both_directions() -> None:
+    agent = make_agent()
+
+    def approval(call_id: str) -> ToolApprovalItem:
+        return ToolApprovalItem(
+            agent=agent,
+            raw_item={
+                "type": "function_call",
+                "name": "tool_call",
+                "call_id": call_id,
+                "arguments": "{}",
+            },
+        )
+
+    approve_then_reject: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    approve_then_reject.approve_tool(approval("call-1"))
+    assert approve_then_reject.is_tool_approved("tool_call", "call-1") is True
+    approve_then_reject.reject_tool(approval("call-1"), rejection_message="denied")
+    assert approve_then_reject.is_tool_approved("tool_call", "call-1") is False
+    assert approve_then_reject.get_rejection_message("tool_call", "call-1") == "denied"
+
+    reject_then_approve: RunContextWrapper[dict[str, object]] = RunContextWrapper(context={})
+    reject_then_approve.reject_tool(approval("call-2"), rejection_message="denied")
+    assert reject_then_approve.is_tool_approved("tool_call", "call-2") is False
+    reject_then_approve.approve_tool(approval("call-2"))
+    assert reject_then_approve.is_tool_approved("tool_call", "call-2") is True
+    assert reject_then_approve.get_rejection_message("tool_call", "call-2") is None

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -1671,6 +1671,65 @@ class TestRunState:
         assert new_state._context.is_tool_approved(tool_name="tool2", call_id="cid2") is False
         assert new_state._context.get_rejection_message("tool2", "cid2") is None
 
+    async def test_per_call_approval_after_sticky_round_trips(self):
+        """A per-call override survives serialization and resumes the same way."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="PerCallApprovalAgent")
+        state = make_state(agent, context=context, original_input="test")
+
+        def approval(call_id: str) -> ToolApprovalItem:
+            return ToolApprovalItem(
+                agent=agent,
+                raw_item=ResponseFunctionToolCall(
+                    type="function_call",
+                    name="tool1",
+                    call_id=call_id,
+                    status="completed",
+                    arguments="",
+                ),
+            )
+
+        state.approve(approval("cid1"), always_approve=True)
+        state.reject(approval("cid2"), rejection_message="denied")
+
+        json_data = state.to_json()
+        assert json_data["$schemaVersion"] == CURRENT_SCHEMA_VERSION
+
+        new_state = await RunState.from_string(agent, state.to_string())
+        assert new_state._context is not None
+        assert new_state._context.is_tool_approved(tool_name="tool1", call_id="cid2") is False
+        assert new_state._context.get_rejection_message("tool1", "cid2") == "denied"
+        assert new_state._context.is_tool_approved(tool_name="tool1", call_id="cid3") is True
+
+    async def test_older_schema_resolves_mixed_approval_record_as_sticky(self):
+        """A pre-1.16 snapshot keeps the sticky answer it was written with."""
+        context: RunContextWrapper[dict[str, str]] = RunContextWrapper(context={})
+        agent = Agent(name="LegacyMixedApprovalAgent")
+        state = make_state(agent, context=context, original_input="test")
+
+        def approval(call_id: str) -> ToolApprovalItem:
+            return ToolApprovalItem(
+                agent=agent,
+                raw_item=ResponseFunctionToolCall(
+                    type="function_call",
+                    name="tool1",
+                    call_id=call_id,
+                    status="completed",
+                    arguments="",
+                ),
+            )
+
+        state.approve(approval("cid1"), always_approve=True)
+        state.reject(approval("cid2"), rejection_message="denied")
+
+        json_data = state.to_json()
+        json_data["$schemaVersion"] = "1.15"
+
+        new_state = await RunState.from_json(agent, json_data)
+        assert new_state._context is not None
+        assert new_state._context.is_tool_approved(tool_name="tool1", call_id="cid2") is True
+        assert new_state._context.is_tool_approved(tool_name="tool1", call_id="cid3") is True
+
     async def test_schema_1_13_restores_pending_approval_binding_from_interruption(self):
         """A 1.13 snapshot may resume only the exact invocation that was approved."""
         agent = Agent(name="ApprovalLegacyAgent")
@@ -7123,6 +7182,7 @@ class TestRunStateSerializationEdgeCases:
                 "1.12",
                 "1.13",
                 "1.14",
+                "1.15",
                 CURRENT_SCHEMA_VERSION,
             }
         )


### PR DESCRIPTION

### Summary

Sticky and per-call approval decisions share the same two fields on `_ApprovalRecord` but use different shapes: `always_approve` and `always_reject` store a bool, while a per-call decision stores call IDs in a list. Once a sticky decision existed, a later per-call decision on the same tool was lost.

Rejecting one call after `always_approve` was ignored on read. `get_approval_status` returned at `approval_entry.approved is True` before reaching `rejected_ids`, so the rejection and its message were stored but never read, and the tool ran. In the other direction, `always_reject` leaves the bool `False` in `approved`, so the writer's `isinstance(target, list)` guard was false and a later `approve_tool` was dropped before it reached state.

Rejecting a single call from the interruption list after approving a tool for the session is a normal human in the loop flow, so this reads as a safety issue rather than a cosmetic one.

The reader now checks a decision recorded for the exact call before falling back to the sticky value, and the writer starts a list when the field still holds a bool. Sticky behaviour for every other call is unchanged, and `always_approve` followed by `always_reject` still resolves to `False`.

### Test plan

Added `test_run_context_per_call_decision_overrides_sticky_decision`, which covers both directions and asserts that other calls keep following the sticky decision. It fails on main and passes here.

`.agents/skills/code-change-verification/scripts/run.sh` passes: format, lint, typecheck and the full test suite.

### Issue number

Closes #4429

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
