### PR TITLE
fix(apply-diff): reject partially matched stacked anchors

### DIFF
--- a/src/agents/apply_diff.py
+++ b/src/agents/apply_diff.py
@@ -130,18 +130,20 @@ def _parse_update_diff(lines: list[str], input: str) -> ParsedUpdateDiff:
     cursor = 0
 
     while not _is_done(parser, END_SECTION_MARKERS):
-        anchors, has_anchor = _read_anchors(parser)
+        anchors, anchor_count = _read_anchors(parser)
 
-        if not (has_anchor or cursor == 0):
+        if not (anchor_count > 0 or cursor == 0):
             current_line = parser.lines[parser.index] if parser.index < len(parser.lines) else ""
             raise ValueError(f"Invalid Line:\n{current_line}")
 
+        require_anchor_match = anchor_count > 1
         for index, anchor in enumerate(anchors):
             cursor = _advance_cursor_to_anchor(
                 anchor,
                 input_lines,
                 cursor,
                 parser,
+                require_match=require_anchor_match,
                 force_forward_search=index > 0,
             )
 
@@ -169,7 +171,7 @@ def _parse_update_diff(lines: list[str], input: str) -> ParsedUpdateDiff:
     return ParsedUpdateDiff(chunks=chunks, fuzz=parser.fuzz)
 
 
-def _read_anchors(parser: ParserState) -> tuple[list[str], bool]:
+def _read_anchors(parser: ParserState) -> tuple[list[str], int]:
     """Consume the ``@@`` header lines that introduce one hunk.
 
     The patch format lets a hunk carry several stacked headers, so nested code can be
@@ -179,29 +181,27 @@ def _read_anchors(parser: ParserState) -> tuple[list[str], bool]:
         @@     def method():
 
     Returns the non-empty headers in the order they should narrow the search, plus
-    whether a usable header was seen at all.
+    the total number of consumed headers, including bare ``@@`` markers.
     """
     anchors: list[str] = []
-    has_anchor = False
+    anchor_count = 0
 
     while True:
         start_index = parser.index
         anchor = _read_str(parser, "@@ ")
         consumed = parser.index != start_index
-        bare = False
 
         if not consumed and parser.index < len(parser.lines) and parser.lines[parser.index] == "@@":
             parser.index += 1
-            consumed = bare = True
+            consumed = True
 
         if not consumed:
             break
-        if anchor or bare:
-            has_anchor = True
+        anchor_count += 1
         if anchor.strip():
             anchors.append(anchor)
 
-    return anchors, has_anchor
+    return anchors, anchor_count
 
 
 def _advance_cursor_to_anchor(
@@ -210,27 +210,39 @@ def _advance_cursor_to_anchor(
     cursor: int,
     parser: ParserState,
     *,
+    require_match: bool = False,
     force_forward_search: bool = False,
 ) -> int:
     found = False
 
-    if force_forward_search or not any(line == anchor for line in input_lines[:cursor]):
+    has_exact_match_before_cursor = not force_forward_search and any(
+        line == anchor for line in input_lines[:cursor]
+    )
+    if has_exact_match_before_cursor:
+        found = True
+    else:
         for i in range(cursor, len(input_lines)):
             if input_lines[i] == anchor:
                 cursor = i + 1
                 found = True
                 break
 
-    if not found and (
-        force_forward_search
-        or not any(line.strip() == anchor.strip() for line in input_lines[:cursor])
-    ):
-        for i in range(cursor, len(input_lines)):
-            if input_lines[i].strip() == anchor.strip():
-                cursor = i + 1
-                parser.fuzz += 1
-                found = True
-                break
+    if not found:
+        has_trimmed_match_before_cursor = not force_forward_search and any(
+            line.strip() == anchor.strip() for line in input_lines[:cursor]
+        )
+        if has_trimmed_match_before_cursor:
+            found = True
+        else:
+            for i in range(cursor, len(input_lines)):
+                if input_lines[i].strip() == anchor.strip():
+                    cursor = i + 1
+                    parser.fuzz += 1
+                    found = True
+                    break
+
+    if require_match and not found:
+        raise ValueError(f"Invalid Anchor {cursor}:\n{anchor}")
 
     return cursor
 

--- a/tests/sandbox/test_apply_patch.py
+++ b/tests/sandbox/test_apply_patch.py
@@ -89,6 +89,29 @@ async def test_apply_patch_update_uses_stacked_anchor_jump() -> None:
 
 
 @pytest.mark.asyncio
+async def test_apply_patch_update_rejects_partially_matched_stacked_anchors() -> None:
+    session = ApplyPatchSession()
+    path = Path("/workspace/stacked.py")
+    original = (
+        b"class Target\n    def helper():\n        pass\n\n    def desired():\n        return 1\n"
+    )
+    session.files[path] = original
+
+    with pytest.raises(ApplyPatchDiffError, match="Invalid Anchor"):
+        await session.apply_patch(
+            ApplyPatchOperation(
+                type="update_file",
+                path="stacked.py",
+                diff=(
+                    "@@ class Target\n@@     def missing():\n-        pass\n+        return 99\n"
+                ),
+            )
+        )
+
+    assert session.files[path] == original
+
+
+@pytest.mark.asyncio
 async def test_apply_patch_update_matches_end_of_file_context() -> None:
     session = ApplyPatchSession()
     session.files[Path("/workspace/tail.txt")] = b"one\ntwo\nthree\n"

--- a/tests/test_apply_diff.py
+++ b/tests/test_apply_diff.py
@@ -81,6 +81,48 @@ def test_apply_diff_applies_stacked_anchors_from_the_tool_description() -> None:
     )
 
 
+def test_apply_diff_reuses_a_prior_parent_anchor_across_stacked_hunks() -> None:
+    input_text = (
+        "\n".join(
+            [
+                "class Target",
+                "    def first():",
+                "        pass",
+                "",
+                "    def second():",
+                "        pass",
+            ]
+        )
+        + "\n"
+    )
+    diff = "\n".join(
+        [
+            "@@ class Target",
+            "@@     def first():",
+            "-        pass",
+            "+        return 1",
+            "@@ class Target",
+            "@@     def second():",
+            "-        pass",
+            "+        return 2",
+        ]
+    )
+
+    assert apply_diff(input_text, diff) == (
+        "\n".join(
+            [
+                "class Target",
+                "    def first():",
+                "        return 1",
+                "",
+                "    def second():",
+                "        return 2",
+            ]
+        )
+        + "\n"
+    )
+
+
 def test_apply_diff_stacked_anchors_narrow_to_the_named_block() -> None:
     """The second anchor skips an earlier matching body inside the selected class."""
     input_text = (

--- a/tests/test_apply_diff.py
+++ b/tests/test_apply_diff.py
@@ -129,12 +129,62 @@ def test_apply_diff_stacked_anchors_narrow_to_the_named_block() -> None:
     )
 
 
-def test_apply_diff_stacked_anchors_stay_advisory_when_unmatched() -> None:
-    """Same rule a single unmatched anchor already follows: locate by context, don't fail."""
+def test_apply_diff_single_anchor_stays_advisory_when_unmatched() -> None:
+    """A single unmatched anchor keeps its established context fallback."""
     input_text = "a\nb\n"
-    diff = "\n".join(["@@ nope", "@@ also-nope", "-b", "+B"])
+    diff = "\n".join(["@@ nope", "-b", "+B"])
 
     assert apply_diff(input_text, diff) == "a\nB\n"
+
+
+def test_apply_diff_rejects_partially_matched_stacked_anchors() -> None:
+    input_text = (
+        "\n".join(
+            [
+                "class Target",
+                "    def helper():",
+                "        pass",
+                "",
+                "    def desired():",
+                "        return 1",
+            ]
+        )
+        + "\n"
+    )
+    diff = "\n".join(
+        [
+            "@@ class Target",
+            "@@     def missing():",
+            "-        pass",
+            "+        return 99",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Invalid Anchor"):
+        apply_diff(input_text, diff)
+
+
+def test_apply_diff_rejects_stacked_anchors_when_the_first_is_missing() -> None:
+    input_text = "class Wrong\n    def desired():\n        pass\n"
+    diff = "\n".join(
+        [
+            "@@ class Target",
+            "@@     def desired():",
+            "-        pass",
+            "+        return 99",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Invalid Anchor"):
+        apply_diff(input_text, diff)
+
+
+def test_apply_diff_rejects_a_missing_anchor_followed_by_a_bare_marker() -> None:
+    input_text = "a\nb\n"
+    diff = "\n".join(["@@ missing", "@@", "-b", "+B"])
+
+    with pytest.raises(ValueError, match="Invalid Anchor"):
+        apply_diff(input_text, diff)
 
 
 def test_apply_diff_stacked_anchors_accept_a_trailing_bare_anchor() -> None:


### PR DESCRIPTION
### Summary

This pull request fixes stacked `@@` anchors so every non-empty anchor in a stack must match in sequence. Previously, if one anchor matched and a later anchor did not, `apply_diff` continued from the partial match and could apply the hunk body to unrelated nearby content.

Single unmatched anchors keep their existing context fallback. Bare anchors, whitespace-fuzzy matches, and fully matched stacks also keep their existing behavior. A partially matched stack now raises `ValueError` before edited content is returned; the sandbox boundary converts that error to `ApplyPatchDiffError` before writing the file.

This brings the Python parser in line with the same safety rule added in openai/openai-agents-js#1655.

### Test plan

- [x] Added direct parser coverage for partial stacks, missing first anchors, missing anchors followed by bare markers, and single-anchor compatibility.
- [x] Added sandbox coverage proving a rejected partial stack leaves the original file unchanged.
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh` with format, lint, typecheck, and the complete test suite passing.

### Issue number

N/A. Found while comparing stacked-anchor behavior across the Python and JavaScript SDKs.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
