### PR TITLE
fix: Chat Completions reasoning replay

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -79,9 +79,10 @@ if TYPE_CHECKING:
 
 
 class InternalChatCompletionMessage(ChatCompletionMessage):
-    """Internal wrapper used to carry normalized reasoning content."""
+    """Internal wrapper used to carry normalized reasoning fields."""
 
     reasoning_content: str = ""
+    reasoning: str = ""
 
 
 def _usage_payload(response: Any) -> Any | None:
@@ -200,7 +201,7 @@ def _flatten_any_llm_reasoning_value(value: Any) -> str:
 
 def _extract_any_llm_reasoning_text(value: Any) -> str:
     direct_reasoning_content = getattr(value, "reasoning_content", None)
-    if isinstance(direct_reasoning_content, str):
+    if isinstance(direct_reasoning_content, str) and direct_reasoning_content:
         return direct_reasoning_content
 
     reasoning = getattr(value, "reasoning", None)
@@ -208,7 +209,7 @@ def _extract_any_llm_reasoning_text(value: Any) -> str:
         reasoning = value.get("reasoning")
         if reasoning is None:
             direct_reasoning_content = value.get("reasoning_content")
-            if isinstance(direct_reasoning_content, str):
+            if isinstance(direct_reasoning_content, str) and direct_reasoning_content:
                 return direct_reasoning_content
 
     if reasoning is None:
@@ -232,6 +233,11 @@ def _normalize_any_llm_message(message: ChatCompletionMessage) -> ChatCompletion
             _convert_any_llm_tool_call_to_openai(tool_call) for tool_call in message.tool_calls
         ]
 
+    reasoning_content = getattr(message, "reasoning_content", "")
+    if not isinstance(reasoning_content, str):
+        reasoning_content = ""
+    reasoning = "" if reasoning_content else _extract_any_llm_reasoning_text(message)
+
     return InternalChatCompletionMessage(
         content=message.content,
         refusal=message.refusal,
@@ -239,7 +245,8 @@ def _normalize_any_llm_message(message: ChatCompletionMessage) -> ChatCompletion
         annotations=message.annotations,
         audio=message.audio,
         tool_calls=tool_calls,
-        reasoning_content=_extract_any_llm_reasoning_text(message),
+        reasoning_content=reasoning_content,
+        reasoning=reasoning,
     )
 
 
@@ -1527,7 +1534,7 @@ class AnyLLMModel(Model):
                         if isinstance(tool_call, dict) and tool_call.get("id"):
                             # Create a separate assistant message for each tool call.
                             # Only the first split keeps the assistant text/thinking
-                            # blocks/reasoning content; the rest carry tool_calls only,
+                            # blocks/reasoning fields; the rest carry tool_calls only,
                             # to avoid duplicating signed thinking blocks (which
                             # Anthropic rejects) and assistant text in history.
                             single_tool_msg = message_dict.copy()
@@ -1537,6 +1544,7 @@ class AnyLLMModel(Model):
                                     "content",
                                     "thinking_blocks",
                                     "reasoning_content",
+                                    "reasoning",
                                 ):
                                     single_tool_msg.pop(shared_field, None)
                             tool_call_messages[str(tool_call["id"])] = (

--- a/src/agents/models/chatcmpl_converter.py
+++ b/src/agents/models/chatcmpl_converter.py
@@ -62,6 +62,7 @@ from ..tool import (
 from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
 from .reasoning_content_replay import (
+    _CHAT_COMPLETIONS_REASONING_FIELD_KEY,
     ReasoningContentReplayContext,
     ReasoningContentSource,
     ShouldReplayReasoningContent,
@@ -138,8 +139,9 @@ class Converter:
 
         # Check if message is agents.extensions.models.litellm_model.InternalChatCompletionMessage.
         # We can't actually import it here because litellm is an optional dependency.
-        # So we use hasattr to check for reasoning_content and thinking_blocks.
+        # So we use hasattr to check for provider-specific reasoning fields.
         reasoning_content = getattr(message, "reasoning_content", "")
+        raw_reasoning = getattr(message, "reasoning", "")
         raw_thinking_blocks = getattr(message, "thinking_blocks", None)
         thinking_blocks = (
             [deepcopy(block) for block in raw_thinking_blocks if isinstance(block, dict)]
@@ -147,7 +149,18 @@ class Converter:
             else []
         )
 
-        if reasoning_content or thinking_blocks:
+        # Prefer the existing structured/provider-native representations when a provider
+        # includes more than one reasoning field on the same message.
+        reasoning = (
+            raw_reasoning
+            if isinstance(raw_reasoning, str)
+            and raw_reasoning
+            and not reasoning_content
+            and not thinking_blocks
+            else ""
+        )
+
+        if reasoning_content or reasoning or thinking_blocks:
             reasoning_kwargs: dict[str, Any] = {
                 "id": FAKE_RESPONSES_ID,
                 "summary": (
@@ -157,8 +170,12 @@ class Converter:
                 ),
                 "type": "reasoning",
             }
+            if reasoning:
+                reasoning_kwargs["content"] = [Content(text=reasoning, type="reasoning_text")]
 
             reasoning_provider_data = dict(provider_data or {})
+            if reasoning:
+                reasoning_provider_data[_CHAT_COMPLETIONS_REASONING_FIELD_KEY] = "reasoning"
             if thinking_blocks:
                 # The normalized reasoning fields below cannot represent empty thinking text or
                 # redacted_thinking blocks. Keep the complete provider sequence as the replay
@@ -574,27 +591,33 @@ class Converter:
         pending_thinking_blocks: list[dict[str, Any]] | None = None
         pending_thinking_blocks_are_native = False
         pending_reasoning_content: str | None = None  # For DeepSeek reasoning_content
+        pending_reasoning: str | None = None
         normalized_base_url = base_url.rstrip("/") if base_url is not None else None
 
-        def flush_assistant_message(*, clear_pending_reasoning: bool = True) -> None:
-            nonlocal current_assistant_msg, pending_reasoning_content
+        def clear_pending_reasoning_state() -> None:
+            nonlocal pending_reasoning, pending_reasoning_content
             nonlocal pending_thinking_blocks, pending_thinking_blocks_are_native
+            pending_reasoning = None
+            pending_reasoning_content = None
+            pending_thinking_blocks = None
+            pending_thinking_blocks_are_native = False
+
+        def flush_assistant_message(*, clear_pending_reasoning: bool = True) -> None:
+            nonlocal current_assistant_msg, pending_reasoning, pending_reasoning_content
             if current_assistant_msg is not None:
                 # The API doesn't support empty arrays for tool_calls
                 if not current_assistant_msg.get("tool_calls"):
                     del current_assistant_msg["tool_calls"]
                     # prevents stale reasoning_content from contaminating later turns
                     pending_reasoning_content = None
+                    pending_reasoning = None
                 result.append(current_assistant_msg)
                 current_assistant_msg = None
-            elif clear_pending_reasoning:
-                pending_reasoning_content = None
             if clear_pending_reasoning:
                 # Thinking blocks belong to the assistant turn that produced them, so a
                 # reasoning item that is not directly followed by that turn's assistant
                 # message must not leak its signed blocks into a later one.
-                pending_thinking_blocks = None
-                pending_thinking_blocks_are_native = False
+                clear_pending_reasoning_state()
 
         def apply_pending_thinking_blocks(
             assistant_msg: ChatCompletionAssistantMessageParam,
@@ -629,10 +652,13 @@ class Converter:
         def apply_pending_reasoning_content(
             assistant_msg: ChatCompletionAssistantMessageParam,
         ) -> None:
-            nonlocal pending_reasoning_content
+            nonlocal pending_reasoning, pending_reasoning_content
             if pending_reasoning_content:
                 assistant_msg["reasoning_content"] = pending_reasoning_content  # type: ignore[typeddict-unknown-key]
                 pending_reasoning_content = None
+            if pending_reasoning:
+                assistant_msg["reasoning"] = pending_reasoning  # type: ignore[typeddict-unknown-key]
+                pending_reasoning = None
 
         def ensure_assistant_message() -> ChatCompletionAssistantMessageParam:
             nonlocal current_assistant_msg, pending_thinking_blocks
@@ -836,18 +862,32 @@ class Converter:
 
             # 7) reasoning message => extract thinking blocks if present
             elif reasoning_item := cls.maybe_reasoning_message(item):
+                clear_pending_reasoning_state()
                 # Reconstruct thinking blocks from content (text) and encrypted_content (signature)
                 content_items = reasoning_item.get("content", [])
                 encrypted_content = reasoning_item.get("encrypted_content")
 
                 item_provider_data: dict[str, Any] = reasoning_item.get("provider_data", {})  # type: ignore[assignment]
                 item_model = item_provider_data.get("model", "")
+                reasoning_field = item_provider_data.get(_CHAT_COMPLETIONS_REASONING_FIELD_KEY)
                 origin_provider_data = {
                     key: value
                     for key, value in item_provider_data.items()
                     if key != "thinking_blocks"
                 }
                 should_replay = False
+
+                if reasoning_field == "reasoning" and model == item_model:
+                    reasoning_texts = []
+                    for content_item in content_items:
+                        if (
+                            isinstance(content_item, dict)
+                            and content_item.get("type") == "reasoning_text"
+                            and content_item.get("text")
+                        ):
+                            reasoning_texts.append(content_item["text"])
+                    if reasoning_texts:
+                        pending_reasoning = "\n".join(reasoning_texts)
 
                 if (
                     model
@@ -864,9 +904,10 @@ class Converter:
                         and complete_thinking_blocks
                         and all(isinstance(block, dict) for block in complete_thinking_blocks)
                     ):
+                        pending_reasoning = None
                         pending_thinking_blocks = deepcopy(complete_thinking_blocks)
                         pending_thinking_blocks_are_native = True
-                    elif content_items:
+                    elif content_items and reasoning_field != "reasoning":
                         signatures = encrypted_content.split("\n") if encrypted_content else []
 
                         reconstructed_thinking_blocks: list[dict[str, Any]] = []

--- a/src/agents/models/chatcmpl_stream_handler.py
+++ b/src/agents/models/chatcmpl_stream_handler.py
@@ -60,6 +60,7 @@ from ..usage import (
 )
 from .chatcmpl_helpers import ChatCmplHelpers
 from .fake_id import FAKE_RESPONSES_ID
+from .reasoning_content_replay import _CHAT_COMPLETIONS_REASONING_FIELD_KEY
 
 
 # Define a Part class for internal use
@@ -556,6 +557,20 @@ class ChatCmplStreamHandler:
         if last_signature:
             reasoning_item.encrypted_content = last_signature
 
+    @staticmethod
+    def _discard_plaintext_reasoning_replay_marker(
+        reasoning_item: ResponseReasoningItem,
+    ) -> None:
+        provider_data = getattr(reasoning_item, "provider_data", None)
+        if not isinstance(provider_data, dict):
+            return
+        if provider_data.get(_CHAT_COMPLETIONS_REASONING_FIELD_KEY) != "reasoning":
+            return
+
+        reasoning_provider_data = provider_data.copy()
+        del reasoning_provider_data[_CHAT_COMPLETIONS_REASONING_FIELD_KEY]
+        reasoning_item.provider_data = reasoning_provider_data  # type: ignore[attr-defined]
+
     @classmethod
     def _finish_reasoning_item(
         cls,
@@ -682,8 +697,8 @@ class ChatCmplStreamHandler:
                 raise AgentsException("Audio is not currently supported")
 
             # Handle thinking blocks from Anthropic (for preserving signatures)
+            has_thinking_block = False
             if hasattr(delta, "thinking_blocks") and delta.thinking_blocks:
-                has_thinking_block = False
                 for block in delta.thinking_blocks:
                     if isinstance(block, dict):
                         has_thinking_block |= state.accumulate_thinking_block(block)
@@ -703,10 +718,14 @@ class ChatCmplStreamHandler:
                         type="response.output_item.added",
                         sequence_number=sequence_number.get_and_increment(),
                     )
+                if has_thinking_block and state.reasoning_content_index_and_output:
+                    cls._discard_plaintext_reasoning_replay_marker(
+                        state.reasoning_content_index_and_output[1]
+                    )
 
             # Handle reasoning content for reasoning summaries
-            if hasattr(delta, "reasoning_content"):
-                reasoning_content = delta.reasoning_content
+            reasoning_content = getattr(delta, "reasoning_content", None)
+            if reasoning_content is not None:
                 if reasoning_content and not state.reasoning_content_index_and_output:
                     reasoning_item = ResponseReasoningItem(
                         id=FAKE_RESPONSES_ID,
@@ -725,6 +744,7 @@ class ChatCmplStreamHandler:
 
                 if reasoning_content and state.reasoning_content_index_and_output:
                     reasoning_item = state.reasoning_content_index_and_output[1]
+                    cls._discard_plaintext_reasoning_replay_marker(reasoning_item)
                     if state.active_reasoning_summary_index is None:
                         summary_index = len(reasoning_item.summary)
                         reasoning_item.summary.append(Summary(text="", type="summary_text"))
@@ -758,6 +778,8 @@ class ChatCmplStreamHandler:
             # Handle reasoning content from 3rd party platforms
             if hasattr(delta, "reasoning"):
                 reasoning_text = delta.reasoning
+                if not isinstance(reasoning_text, str):
+                    reasoning_text = ""
                 if reasoning_text and not state.reasoning_content_index_and_output:
                     reasoning_item = ResponseReasoningItem(
                         id=FAKE_RESPONSES_ID,
@@ -765,8 +787,9 @@ class ChatCmplStreamHandler:
                         content=[Content(text="", type="reasoning_text")],
                         type="reasoning",
                     )
-                    if state.provider_data:
-                        reasoning_item.provider_data = state.provider_data.copy()  # type: ignore[attr-defined]
+                    reasoning_provider_data = state.provider_data.copy()
+                    reasoning_provider_data[_CHAT_COMPLETIONS_REASONING_FIELD_KEY] = "reasoning"
+                    reasoning_item.provider_data = reasoning_provider_data  # type: ignore[attr-defined]
                     state.reasoning_content_index_and_output = (0, reasoning_item)
                     yield ResponseOutputItemAddedEvent(
                         item=reasoning_item,

--- a/src/agents/models/reasoning_content_replay.py
+++ b/src/agents/models/reasoning_content_replay.py
@@ -4,6 +4,8 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
+_CHAT_COMPLETIONS_REASONING_FIELD_KEY = "_chat_completions_reasoning_field"
+
 
 @dataclass
 class ReasoningContentSource:

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -639,6 +639,58 @@ async def test_any_llm_chat_path_normalizes_non_stream_payloads(
 
 @pytest.mark.allow_call_model_methods
 @pytest.mark.asyncio
+async def test_any_llm_chat_path_preserves_plaintext_reasoning_for_replay(monkeypatch) -> None:
+    chat_response = _chat_completion("The answer is 42.")
+    chat_response.choices[0].message = ChatCompletionMessage.model_validate(
+        {
+            "role": "assistant",
+            "content": "The answer is 42.",
+            "reasoning_content": "",
+            "reasoning": "I should calculate this carefully.",
+        }
+    )
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=chat_response)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    model = module.AnyLLMModel(model="openrouter/reasoning-model")
+
+    model_settings = ModelSettings(reasoning=Reasoning(effort="high"))
+    response = await model.get_response(
+        system_instructions=None,
+        input="What is six times seven?",
+        model_settings=model_settings,
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+    await model.get_response(
+        system_instructions=None,
+        input=response.to_input_items(),
+        model_settings=model_settings,
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    replayed_messages = provider.chat_calls[1]["messages"]
+    assert replayed_messages == [
+        {
+            "role": "assistant",
+            "content": "The answer is 42.",
+            "reasoning": "I should calculate this carefully.",
+        }
+    ]
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
 async def test_any_llm_chat_path_preserves_gemini_tool_call_metadata(monkeypatch) -> None:
     provider = FakeAnyLLMProvider(
         supports_responses=False,
@@ -1396,6 +1448,46 @@ def test_any_llm_reasoning_objects_prefer_content_attributes_over_iterable_pairs
     assert _extract_any_llm_reasoning_text(delta) == "用户"
 
 
+def test_any_llm_stream_flattens_reasoning_object_when_reasoning_content_is_empty(
+    monkeypatch,
+) -> None:
+    provider = FakeAnyLLMProvider(supports_responses=False)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    delta = ChoiceDelta.model_construct(
+        reasoning_content="",
+        reasoning=pytypes.SimpleNamespace(content="Plaintext reasoning"),
+    )
+    chunk = ChatCompletionChunk(
+        id="chunk-id",
+        created=1,
+        model="fake",
+        object="chat.completion.chunk",
+        choices=[ChunkChoice(index=0, delta=delta)],
+    )
+
+    normalized = module.AnyLLMModel(model="openrouter/reasoning-model")._normalize_chat_chunk(chunk)
+
+    assert normalized.choices[0].delta.reasoning == "Plaintext reasoning"
+
+
+def test_any_llm_nonstream_preserves_native_reasoning_content_field(monkeypatch) -> None:
+    provider = FakeAnyLLMProvider(supports_responses=False)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+    message = ChatCompletionMessage.model_validate(
+        {
+            "role": "assistant",
+            "content": "Answer",
+            "reasoning": "Plaintext reasoning",
+            "reasoning_content": "Native reasoning content",
+        }
+    )
+
+    normalized = module._normalize_any_llm_message(message)
+
+    assert normalized.reasoning_content == "Native reasoning content"
+    assert normalized.reasoning == ""
+
+
 def test_any_llm_split_does_not_duplicate_content_or_thinking(monkeypatch) -> None:
     """Splitting multi-tool assistant messages must not duplicate text/thinking blocks.
 
@@ -1416,6 +1508,7 @@ def test_any_llm_split_does_not_duplicate_content_or_thinking(monkeypatch) -> No
             "content": "Looking up both queries.",
             "thinking_blocks": [{"type": "thinking", "thinking": "plan", "signature": "sig_abc"}],
             "reasoning_content": "internal plan",
+            "reasoning": "plaintext plan",
             "tool_calls": [
                 {
                     "id": "call_1",
@@ -1441,10 +1534,12 @@ def test_any_llm_split_does_not_duplicate_content_or_thinking(monkeypatch) -> No
     assert assistants[0].get("content") == "Looking up both queries."
     assert "thinking_blocks" in assistants[0]
     assert "reasoning_content" in assistants[0]
+    assert "reasoning" in assistants[0]
     # Second split must NOT duplicate them.
     assert "content" not in assistants[1]
     assert "thinking_blocks" not in assistants[1]
     assert "reasoning_content" not in assistants[1]
+    assert "reasoning" not in assistants[1]
     # Tool calls are still split one-per-message.
     assert assistants[0]["tool_calls"][0]["id"] == "call_1"
     assert assistants[1]["tool_calls"][0]["id"] == "call_2"

--- a/tests/models/test_openai_chatcompletions_stream.py
+++ b/tests/models/test_openai_chatcompletions_stream.py
@@ -911,6 +911,13 @@ async def test_stream_handler_converts_third_party_reasoning_text() -> None:
             object="chat.completion.chunk",
             choices=[Choice(index=0, delta=reasoning_delta2)],
         ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(content="answer"))],
+        ),
     ]
 
     events = await _collect_handler_events(*chunks, model="third-party")
@@ -937,9 +944,121 @@ async def test_stream_handler_converts_third_party_reasoning_text() -> None:
     assert completed_reasoning_item.content
     assert cast(Any, completed_reasoning_item.content[0]).text == "think hard"
     assert completed_reasoning_item.model_dump().get("provider_data") == {
+        "_chat_completions_reasoning_field": "reasoning",
         "model": "third-party",
         "response_id": "chunk-id",
     }
+
+    replayed_messages = Converter.items_to_messages(
+        [item.model_dump() for item in completed_event.response.output],
+        model="third-party",
+    )
+    assert len(replayed_messages) == 1
+    assert replayed_messages[0]["reasoning"] == "think hard"  # type: ignore[typeddict-item]
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_ignores_non_string_plaintext_reasoning() -> None:
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta.model_construct(reasoning={"bad": 1}))],
+        ),
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=ChoiceDelta(content="answer"))],
+        ),
+    ]
+
+    events = await _collect_handler_events(*chunks, model="third-party")
+
+    assert not any(
+        event.type in {"response.reasoning_text.delta", "response.reasoning_text.done"}
+        for event in events
+    )
+    completed_event = next(event for event in events if event.type == "response.completed")
+    assert len(completed_event.response.output) == 1
+    assert isinstance(completed_event.response.output[0], ResponseOutputMessage)
+    assert completed_event.response.output[0].content[0].text == "answer"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("split_across_chunks", [False, True])
+async def test_stream_handler_prefers_reasoning_content_over_plaintext_reasoning(
+    split_across_chunks: bool,
+) -> None:
+    if split_across_chunks:
+        reasoning_deltas = [
+            ChoiceDelta.model_construct(reasoning="raw"),
+            ChoiceDelta.model_construct(reasoning_content="summary"),
+        ]
+    else:
+        reasoning_deltas = [
+            ChoiceDelta.model_construct(reasoning="raw", reasoning_content="summary")
+        ]
+    chunks = [
+        ChatCompletionChunk(
+            id="chunk-id",
+            created=1,
+            model="fake",
+            object="chat.completion.chunk",
+            choices=[Choice(index=0, delta=delta)],
+        )
+        for delta in [*reasoning_deltas, ChoiceDelta(content="answer")]
+    ]
+
+    events = await _collect_handler_events(*chunks, model="deepseek-r1")
+    completed_event = next(event for event in events if event.type == "response.completed")
+    reasoning_item = completed_event.response.output[0]
+    assert isinstance(reasoning_item, ResponseReasoningItem)
+    assert reasoning_item.summary[0].text == "summary"
+    assert reasoning_item.content
+    assert [part.text for part in reasoning_item.content] == ["raw"]
+    assert "_chat_completions_reasoning_field" not in cast(Any, reasoning_item).provider_data
+
+    replayed_messages = Converter.items_to_messages(
+        [item.model_dump() for item in completed_event.response.output],
+        model="deepseek-r1",
+    )
+    assert len(replayed_messages) == 1
+    assert replayed_messages[0]["reasoning_content"] == "summary"  # type: ignore[typeddict-item]
+    assert "reasoning" not in replayed_messages[0]
+
+
+@pytest.mark.asyncio
+async def test_stream_handler_prefers_later_thinking_blocks_over_plaintext_reasoning() -> None:
+    chunks = [
+        _thinking_chunk(reasoning="raw"),
+        _thinking_chunk(
+            thinking_blocks=[{"type": "thinking", "thinking": "hidden", "signature": "sig"}]
+        ),
+        _thinking_chunk(content="answer"),
+    ]
+
+    events = await _collect_handler_events(*chunks, model="anthropic/claude-4-opus")
+    completed_event = next(event for event in events if event.type == "response.completed")
+    reasoning_item = completed_event.response.output[0]
+    assert isinstance(reasoning_item, ResponseReasoningItem)
+    assert reasoning_item.content
+    assert [part.text for part in reasoning_item.content] == ["raw", "hidden"]
+    assert "_chat_completions_reasoning_field" not in cast(Any, reasoning_item).provider_data
+
+    replayed_messages = Converter.items_to_messages(
+        [item.model_dump() for item in completed_event.response.output],
+        model="anthropic/claude-4-opus",
+        preserve_thinking_blocks=True,
+    )
+    assert len(replayed_messages) == 1
+    assert replayed_messages[0]["thinking_blocks"] == [  # type: ignore[typeddict-item]
+        {"type": "thinking", "thinking": "hidden", "signature": "sig"}
+    ]
+    assert "reasoning" not in replayed_messages[0]
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_reasoning_content.py
+++ b/tests/models/test_reasoning_content.py
@@ -19,9 +19,317 @@ from openai.types.responses import (
 )
 
 from agents.model_settings import ModelSettings
+from agents.models.chatcmpl_converter import Converter
 from agents.models.interface import ModelTracing
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_provider import OpenAIProvider
+
+
+def test_plaintext_reasoning_round_trips_on_its_assistant_message() -> None:
+    message = ChatCompletionMessage.model_validate(
+        {
+            "role": "assistant",
+            "content": "The answer is 42.",
+            "reasoning": "I should calculate this carefully.",
+        }
+    )
+
+    items = Converter.message_to_output_items(
+        message,
+        provider_data={"model": "openrouter/reasoning-model", "response_id": "chatcmpl-test"},
+    )
+    messages = Converter.items_to_messages(
+        [item.model_dump() for item in items], model="openrouter/reasoning-model"
+    )
+
+    assert len(items) == 2
+    assert isinstance(items[0], ResponseReasoningItem)
+    assert items[0].content
+    assert items[0].content[0].text == "I should calculate this carefully."
+    assert messages == [
+        {
+            "role": "assistant",
+            "content": "The answer is 42.",
+            "reasoning": "I should calculate this carefully.",
+        }
+    ]
+
+
+def test_plaintext_reasoning_round_trips_with_a_tool_call() -> None:
+    message = ChatCompletionMessage.model_validate(
+        {
+            "role": "assistant",
+            "content": None,
+            "reasoning": "I should call the weather tool.",
+            "tool_calls": [
+                {
+                    "id": "call-weather",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
+                }
+            ],
+        }
+    )
+
+    items = Converter.message_to_output_items(
+        message,
+        provider_data={"model": "openrouter/reasoning-model"},
+    )
+    messages = Converter.items_to_messages(
+        [item.model_dump() for item in items], model="openrouter/reasoning-model"
+    )
+
+    assert len(messages) == 1
+    assistant = messages[0]
+    assert assistant["role"] == "assistant"
+    assert assistant["content"] is None
+    assert assistant["reasoning"] == "I should call the weather tool."  # type: ignore[typeddict-item]
+    assert len(assistant["tool_calls"]) == 1  # type: ignore[typeddict-item]
+
+
+def test_plaintext_reasoning_is_not_replayed_to_a_different_model() -> None:
+    message = ChatCompletionMessage.model_validate(
+        {"role": "assistant", "content": "Answer", "reasoning": "Private reasoning"}
+    )
+    items = Converter.message_to_output_items(
+        message,
+        provider_data={"model": "openrouter/model-a"},
+    )
+
+    messages = Converter.items_to_messages(
+        [item.model_dump() for item in items], model="openrouter/model-b"
+    )
+
+    assert len(messages) == 1
+    assert "reasoning" not in messages[0]
+
+
+@pytest.mark.parametrize(
+    "intervening_reasoning",
+    [
+        {
+            "id": "__fake_id__",
+            "summary": [],
+            "type": "reasoning",
+            "content": [{"text": "Foreign reasoning", "type": "reasoning_text"}],
+            "provider_data": {
+                "model": "openrouter/model-b",
+                "_chat_completions_reasoning_field": "reasoning",
+            },
+        },
+        {
+            "id": "__fake_id__",
+            "summary": [{"text": "Higher-fidelity reasoning", "type": "summary_text"}],
+            "type": "reasoning",
+            "content": None,
+            "provider_data": {"model": "openrouter/model-a"},
+        },
+    ],
+)
+def test_intervening_reasoning_item_clears_pending_plaintext_reasoning(
+    intervening_reasoning: dict[str, Any],
+) -> None:
+    items: list[Any] = [
+        {
+            "id": "__fake_id__",
+            "summary": [],
+            "type": "reasoning",
+            "content": [{"text": "Stale reasoning", "type": "reasoning_text"}],
+            "provider_data": {
+                "model": "openrouter/model-a",
+                "_chat_completions_reasoning_field": "reasoning",
+            },
+        },
+        intervening_reasoning,
+        {
+            "id": "__fake_id__",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Answer",
+                    "annotations": [],
+                    "logprobs": [],
+                }
+            ],
+        },
+    ]
+
+    messages = Converter.items_to_messages(items, model="openrouter/model-a")
+
+    assert len(messages) == 1
+    assert "reasoning" not in messages[0]
+
+
+def test_plaintext_reasoning_item_clears_pending_native_reasoning_content() -> None:
+    items: list[Any] = [
+        {
+            "id": "__fake_id__",
+            "summary": [{"text": "Stale native reasoning", "type": "summary_text"}],
+            "type": "reasoning",
+            "content": None,
+            "provider_data": {"model": "deepseek-r1"},
+        },
+        {
+            "id": "__fake_id__",
+            "summary": [],
+            "type": "reasoning",
+            "content": [{"text": "Fresh plaintext reasoning", "type": "reasoning_text"}],
+            "provider_data": {
+                "model": "deepseek-r1",
+                "_chat_completions_reasoning_field": "reasoning",
+            },
+        },
+        {
+            "id": "__fake_id__",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Answer",
+                    "annotations": [],
+                    "logprobs": [],
+                }
+            ],
+        },
+    ]
+
+    messages = Converter.items_to_messages(items, model="deepseek-r1")
+
+    assert len(messages) == 1
+    assert messages[0]["reasoning"] == "Fresh plaintext reasoning"  # type: ignore[typeddict-item]
+    assert "reasoning_content" not in messages[0]
+
+
+def test_native_thinking_blocks_take_precedence_over_marked_plaintext_reasoning() -> None:
+    items: list[Any] = [
+        {
+            "id": "__fake_id__",
+            "summary": [],
+            "type": "reasoning",
+            "content": [{"text": "Plaintext reasoning", "type": "reasoning_text"}],
+            "provider_data": {
+                "model": "anthropic/claude-x",
+                "_chat_completions_reasoning_field": "reasoning",
+                "thinking_blocks": [
+                    {"type": "thinking", "thinking": "Native thinking", "signature": "sig"}
+                ],
+            },
+        },
+        {
+            "id": "__fake_id__",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Answer",
+                    "annotations": [],
+                    "logprobs": [],
+                }
+            ],
+        },
+    ]
+
+    messages = Converter.items_to_messages(
+        items,
+        model="anthropic/claude-x",
+        preserve_thinking_blocks=True,
+    )
+
+    assert len(messages) == 1
+    assert messages[0]["thinking_blocks"] == [  # type: ignore[typeddict-item]
+        {"type": "thinking", "thinking": "Native thinking", "signature": "sig"}
+    ]
+    assert "reasoning" not in messages[0]
+
+
+@pytest.mark.parametrize("native_thinking_blocks", [False, True])
+def test_plaintext_reasoning_item_clears_pending_thinking_blocks(
+    native_thinking_blocks: bool,
+) -> None:
+    provider_data: dict[str, Any] = {"model": "anthropic/claude-x"}
+    if native_thinking_blocks:
+        provider_data["thinking_blocks"] = [
+            {"type": "thinking", "thinking": "Stale thinking", "signature": "sig"}
+        ]
+    items: list[Any] = [
+        {
+            "id": "__fake_id__",
+            "summary": [],
+            "type": "reasoning",
+            "content": [{"text": "Stale thinking", "type": "reasoning_text"}],
+            "provider_data": provider_data,
+        },
+        {
+            "id": "__fake_id__",
+            "summary": [],
+            "type": "reasoning",
+            "content": [{"text": "Fresh plaintext reasoning", "type": "reasoning_text"}],
+            "provider_data": {
+                "model": "anthropic/claude-x",
+                "_chat_completions_reasoning_field": "reasoning",
+            },
+        },
+        {
+            "id": "__fake_id__",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Answer",
+                    "annotations": [],
+                    "logprobs": [],
+                }
+            ],
+        },
+    ]
+
+    messages = Converter.items_to_messages(
+        items,
+        model="anthropic/claude-x",
+        preserve_thinking_blocks=True,
+    )
+
+    assert messages == [
+        {
+            "role": "assistant",
+            "content": "Answer",
+            "reasoning": "Fresh plaintext reasoning",
+        }
+    ]
+
+
+def test_reasoning_content_takes_precedence_over_plaintext_reasoning() -> None:
+    message = ChatCompletionMessage.model_validate(
+        {
+            "role": "assistant",
+            "content": "Answer",
+            "reasoning": "Plaintext reasoning",
+            "reasoning_content": "Existing reasoning content",
+        }
+    )
+
+    items = Converter.message_to_output_items(
+        message,
+        provider_data={"model": "deepseek-reasoner"},
+    )
+    messages = Converter.items_to_messages(
+        [item.model_dump() for item in items], model="deepseek-reasoner"
+    )
+
+    reasoning_item = cast(ResponseReasoningItem, items[0])
+    assert reasoning_item.content is None
+    assert reasoning_item.summary[0].text == "Existing reasoning content"
+    assert messages[0]["reasoning_content"] == "Existing reasoning content"  # type: ignore[typeddict-item]
+    assert "reasoning" not in messages[0]
 
 
 # Helper functions to create test objects consistently


### PR DESCRIPTION
This pull request fixes the Python Chat Completions adapter so that plaintext `reasoning` returned by OpenAI-compatible providers is preserved and replayed on its directly associated assistant message, matching the behavior introduced by openai/openai-agents-js#1669.

It supports streaming and non-streaming responses, assistant text and tool-call messages, and persisted session history. Replay is limited to the originating model and is invalidated by unrelated or intervening reasoning items.

Existing `reasoning_content` and `thinking_blocks` behavior remains unchanged. Empty and non-string values are ignored, and no public API is added.