### PR TITLE
fix: strip defaults from strict JSON schemas

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import copy
 from typing import Any, TypeGuard, cast
 
-from openai import NOT_GIVEN
-
 from .exceptions import UserError
 
 _EMPTY_SCHEMA = {
@@ -361,11 +359,9 @@ def _ensure_strict_json_schema(
                 for i, entry in enumerate(all_of)
             ]
 
-    # strip `None` defaults as there's no meaningful distinction here
-    # the schema will still be `nullable` and the model will default
-    # to using `None` anyway
-    if json_schema.get("default", NOT_GIVEN) is None:
-        json_schema.pop("default")
+    # Defaults are not part of the JSON Schema subset accepted in strict mode.
+    # Every object property is required above, so defaults do not affect model output.
+    json_schema.pop("default", None)
 
     # we can't use `$ref`s if there are also other properties defined, e.g.
     # `{"$ref": "...", "description": "my description"}`

--- a/tests/test_strict_schema_defaults.py
+++ b/tests/test_strict_schema_defaults.py
@@ -1,0 +1,41 @@
+from enum import Enum
+
+import pytest
+from pydantic import BaseModel
+
+from agents.strict_schema import ensure_strict_json_schema
+
+
+@pytest.mark.parametrize("default", [None, "EUR", 3, False])
+def test_strict_schema_strips_property_defaults(default: object) -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "value": {
+                "type": "string",
+                "default": default,
+            }
+        },
+    }
+
+    result = ensure_strict_json_schema(schema)
+
+    assert "default" not in result["properties"]["value"]
+
+
+def test_strict_schema_strips_pydantic_enum_default() -> None:
+    class Currency(str, Enum):
+        EUR = "EUR"
+        USD = "USD"
+
+    class Invoice(BaseModel):
+        total: int
+        currency: Currency = Currency.EUR
+
+    schema = Invoice.model_json_schema()
+    assert schema["properties"]["currency"]["default"] == "EUR"
+
+    result = ensure_strict_json_schema(schema)
+
+    assert "default" not in result["properties"]["currency"]
+    assert result["required"] == ["total", "currency"]


### PR DESCRIPTION
This pull request fixes strict JSON schema conversion so property `default` annotations are removed regardless of their value. Strict conversion already marks every object property as required, so these schema defaults do not affect generated model output but can leave the resulting schema outside the strict subset.

It also removes the now-unused `NOT_GIVEN` import and adds regression coverage for null, string, numeric, boolean, and Pydantic enum defaults.

This pull request resolves #4390.