### PR TITLE
fix(sandbox): close the scandir iterator when a local dir listing fails

### DIFF
--- a/src/agents/sandbox/entries/artifacts.py
+++ b/src/agents/sandbox/entries/artifacts.py
@@ -371,64 +371,71 @@ class LocalDir(BaseEntry):
             | getattr(os, "O_NOFOLLOW", 0)
         )
         local_files: list[Path] = []
-        for entry in os.scandir(dir_fd):
-            rel_child = rel_dir / entry.name if rel_dir.parts else Path(entry.name)
-            try:
-                entry_stat = entry.stat(follow_symlinks=False)
-            except FileNotFoundError:
-                raise LocalDirReadError(
-                    src=src_root,
-                    context={"reason": "path_changed_during_copy", "child": rel_child.as_posix()},
-                ) from None
-            except OSError as e:
-                raise LocalDirReadError(src=src_root, cause=e) from e
-            if stat.S_ISLNK(entry_stat.st_mode):
-                raise LocalDirReadError(
-                    src=src_root,
-                    context={"reason": "symlink_not_supported", "child": rel_child.as_posix()},
-                )
-            if stat.S_ISREG(entry_stat.st_mode):
-                local_files.append(rel_child)
-                continue
-            if not stat.S_ISDIR(entry_stat.st_mode):
-                continue
-
-            child_fd: int | None = None
-            try:
-                child_fd = os.open(entry.name, dir_flags, dir_fd=dir_fd)
-                child_stat = os.fstat(child_fd)
-                if not stat.S_ISDIR(child_stat.st_mode):
+        with os.scandir(dir_fd) as entries:
+            for entry in entries:
+                rel_child = rel_dir / entry.name if rel_dir.parts else Path(entry.name)
+                try:
+                    entry_stat = entry.stat(follow_symlinks=False)
+                except FileNotFoundError:
                     raise LocalDirReadError(
                         src=src_root,
                         context={
                             "reason": "path_changed_during_copy",
                             "child": rel_child.as_posix(),
                         },
+                    ) from None
+                except OSError as e:
+                    raise LocalDirReadError(src=src_root, cause=e) from e
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    raise LocalDirReadError(
+                        src=src_root,
+                        context={"reason": "symlink_not_supported", "child": rel_child.as_posix()},
                     )
-                local_files.extend(
-                    self._list_local_dir_files_from_dir_fd(
+                if stat.S_ISREG(entry_stat.st_mode):
+                    local_files.append(rel_child)
+                    continue
+                if not stat.S_ISDIR(entry_stat.st_mode):
+                    continue
+
+                child_fd: int | None = None
+                try:
+                    child_fd = os.open(entry.name, dir_flags, dir_fd=dir_fd)
+                    child_stat = os.fstat(child_fd)
+                    if not stat.S_ISDIR(child_stat.st_mode):
+                        raise LocalDirReadError(
+                            src=src_root,
+                            context={
+                                "reason": "path_changed_during_copy",
+                                "child": rel_child.as_posix(),
+                            },
+                        )
+                    local_files.extend(
+                        self._list_local_dir_files_from_dir_fd(
+                            src_root=src_root,
+                            dir_fd=child_fd,
+                            rel_dir=rel_child,
+                        )
+                    )
+                except FileNotFoundError:
+                    raise LocalDirReadError(
+                        src=src_root,
+                        context={
+                            "reason": "path_changed_during_copy",
+                            "child": rel_child.as_posix(),
+                        },
+                    ) from None
+                except OSError as e:
+                    raise self._local_dir_open_error(
                         src_root=src_root,
-                        dir_fd=child_fd,
-                        rel_dir=rel_child,
-                    )
-                )
-            except FileNotFoundError:
-                raise LocalDirReadError(
-                    src=src_root,
-                    context={"reason": "path_changed_during_copy", "child": rel_child.as_posix()},
-                ) from None
-            except OSError as e:
-                raise self._local_dir_open_error(
-                    src_root=src_root,
-                    parent_fd=dir_fd,
-                    entry_name=entry.name,
-                    rel_child=rel_child,
-                    expect_dir=True,
-                    error=e,
-                ) from e
-            finally:
-                if child_fd is not None:
-                    os.close(child_fd)
+                        parent_fd=dir_fd,
+                        entry_name=entry.name,
+                        rel_child=rel_child,
+                        expect_dir=True,
+                        error=e,
+                    ) from e
+                finally:
+                    if child_fd is not None:
+                        os.close(child_fd)
         return local_files
 
     async def _copy_local_dir_file(

--- a/tests/sandbox/test_entries.py
+++ b/tests/sandbox/test_entries.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import gc
 import hashlib
 import io
 import os
+import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path, PureWindowsPath
 
@@ -442,6 +444,26 @@ async def test_local_file_rejects_symlinked_source_before_checksum(tmp_path: Pat
     assert excinfo.value.context["reason"] == "symlink_not_supported"
     assert excinfo.value.context["child"] == "link.txt"
     assert session.writes == {}
+
+
+def test_local_dir_listing_closes_scandir_when_a_child_is_rejected(tmp_path: Path) -> None:
+    src_root = tmp_path / "src"
+    src_root.mkdir()
+    (src_root / "safe.txt").write_text("safe", encoding="utf-8")
+    _symlink_or_skip(src_root / "link.txt", src_root / "safe.txt")
+
+    local_dir = LocalDir(src=Path("src"))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(LocalDirReadError) as excinfo:
+            local_dir._list_local_dir_files_pinned(base_dir=tmp_path, src_root=src_root)
+        gc.collect()
+
+    assert excinfo.value.context["reason"] == "symlink_not_supported"
+    assert not [
+        w for w in caught if issubclass(w.category, ResourceWarning) and "scandir" in str(w.message)
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`LocalDir._list_local_dir_files_from_dir_fd` iterates `os.scandir(dir_fd)`
without closing it. The iterator owns a directory file descriptor, and the loop
body raises `LocalDirReadError` on several ordinary paths — a symlinked child,
a child that disappears mid-walk, and an `OSError` from `entry.stat()`. Each of
those unwinds out of the loop with the iterator still open, so the descriptor
survives until the garbage collector happens to reclaim it.

The rest of the function is already careful with descriptors: `root_fd` in
`_list_local_dir_files_pinned` and `child_fd` in the recursive branch both use
`try` / `finally` with an explicit `os.close`. The scandir handle is the one
that is not. The other `os.scandir` call in the sandbox code, in
`sandboxes/unix_local.py`, already uses the `with` form.

The function recurses per subdirectory, so a rejected child deep in a tree
leaks one descriptor per level it unwinds through. A host that keeps rejecting
the same malformed source directory leaks steadily toward `EMFILE`.

Fixed by wrapping the loop in `with os.scandir(dir_fd) as entries:`. The large
diff is re-indentation; the only behavioural change is the two lines that open
the context manager.

Verified with `-X dev`: before the change, listing a directory containing a
symlink emits `ResourceWarning: unclosed scandir iterator`; after, it does not.
The regression test added here fails on the parent commit and passes on this
one. Full suite: 8664 passed, 33 skipped. `ruff check`, `ruff format --check`
and `mypy` are clean.
