### PR TITLE
fix(models): close all MultiProvider children after failures

### DIFF
--- a/src/agents/models/multi_provider.py
+++ b/src/agents/models/multi_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Literal, cast
 
 from openai import AsyncOpenAI
@@ -258,6 +259,7 @@ class MultiProvider(ModelProvider):
         providers.extend(self._fallback_providers.values())
 
         seen: set[int] = set()
+        first_error: Exception | None = None
         for provider in providers:
             if provider is self:
                 continue
@@ -265,4 +267,13 @@ class MultiProvider(ModelProvider):
             if provider_id in seen:
                 continue
             seen.add(provider_id)
-            await provider.aclose()
+            try:
+                await provider.aclose()
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+
+        if first_error is not None:
+            raise first_error

--- a/tests/models/test_map.py
+++ b/tests/models/test_map.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, cast
 
 import pytest
@@ -228,3 +229,75 @@ def test_multi_provider_rejects_invalid_prefix_modes():
 
     with pytest.raises(UserError, match="unknown_prefix_mode"):
         MultiProvider(unknown_prefix_mode=bad_unknown_prefix_mode)
+
+
+@pytest.mark.asyncio
+async def test_multi_provider_aclose_continues_and_preserves_first_failure():
+    close_error = RuntimeError("close failed")
+    later_error = ValueError("later close failed")
+
+    class CloseTrackingProvider:
+        def __init__(self, error: Exception | None = None):
+            self.error = error
+            self.closed = False
+
+        def get_model(self, model_name: str | None):
+            return object()
+
+        async def aclose(self) -> None:
+            self.closed = True
+            if self.error is not None:
+                raise self.error
+
+    failing_provider = CloseTrackingProvider(close_error)
+    later_provider = CloseTrackingProvider(later_error)
+    provider_map = MultiProviderMap()
+    provider_map.add_provider("failing", cast(Any, failing_provider))
+    provider_map.add_provider("later", cast(Any, later_provider))
+    provider = MultiProvider(provider_map=provider_map, openai_api_key="test")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await provider.aclose()
+
+    assert exc_info.value is close_error
+    assert failing_provider.closed
+    assert later_provider.closed
+
+
+@pytest.mark.asyncio
+async def test_multi_provider_aclose_propagates_hybrid_cancellation():
+    closed: list[str] = []
+
+    class HybridCancellation(asyncio.CancelledError, Exception):
+        pass
+
+    class CloseTrackingProvider:
+        def __init__(self, name: str, error: BaseException | None = None):
+            self.name = name
+            self.error = error
+
+        def get_model(self, model_name: str | None):
+            return object()
+
+        async def aclose(self) -> None:
+            closed.append(self.name)
+            if self.error is not None:
+                raise self.error
+
+    cancellation = HybridCancellation("cancelled")
+    provider_map = MultiProviderMap()
+    provider_map.add_provider(
+        "failing",
+        cast(Any, CloseTrackingProvider("failing", RuntimeError("close failed"))),
+    )
+    provider_map.add_provider(
+        "cancelling", cast(Any, CloseTrackingProvider("cancelling", cancellation))
+    )
+    provider_map.add_provider("later", cast(Any, CloseTrackingProvider("later")))
+    provider = MultiProvider(provider_map=provider_map, openai_api_key="test")
+
+    with pytest.raises(HybridCancellation) as exc_info:
+        await provider.aclose()
+
+    assert exc_info.value is cancellation
+    assert closed == ["failing", "cancelling"]


### PR DESCRIPTION
### Summary

This pull request fixes `MultiProvider.aclose()` so one child provider's ordinary cleanup failure does not prevent later child providers from releasing their resources.

- Closes unique child providers in the existing stable order and preserves identity deduplication.
- Re-raises the exact first ordinary exception after the remaining close attempts finish.
- Continues to propagate direct `asyncio.CancelledError` immediately.
- Adds regressions for multiple ordinary failures and cancellation after an earlier failure.

### Test plan

Passed:

- `uv run pytest -q tests/models/test_map.py` (17 passed)
- `uv run pytest -q tests/models/test_responses_websocket_session.py` (11 passed)
- `uv run ruff check`
- `uv run python .github/scripts/check_optional_truthiness.py src/agents`
- `uv run ruff format` and `uv run ruff check --fix` (900 files unchanged)
- `uv run mypy src/agents/models/multi_provider.py`

The full Windows test run reached 7,208 passed and 77 skipped, with remaining failures caused by local platform prerequisites unrelated to this change: the Unix `tee` command is unavailable, symlink creation is not permitted, two UTF-8 examples are decoded with the system GBK code page, and existing realtime Windows tests fail. Full mypy/pyright also report existing errors in untouched sandbox modules; pyright's only error is `src/agents/sandbox/util/tar_utils.py:161`.

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR