### PR TITLE
fix(sandbox): normalize symlink-resolved paths as POSIX

### DIFF
--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -251,7 +251,7 @@ class WorkspacePathPolicy:
                 if original is None:
                     raise self._invalid_path_error(windows_path)
             else:
-                original = Path(path)
+                original = posix_path_as_path(coerce_posix_path(path))
             result, grant = self._resolved_host_path_and_grant(original)
         else:
             if (windows_path := windows_absolute_path(path)) is not None:

--- a/tests/sandbox/test_workspace_paths.py
+++ b/tests/sandbox/test_workspace_paths.py
@@ -202,6 +202,11 @@ def test_normalize_path_with_symlink_resolution(tmp_path: Path) -> None:
             expected=target.resolve(),
         ),
         WorkspacePathCase(
+            name="backslash string path uses sandbox POSIX semantics",
+            path=r"nested\..\target.txt",
+            expected=target.resolve(),
+        ),
+        WorkspacePathCase(
             name="safe internal leaf symlink resolves to target",
             path="link.txt",
             expected=target.resolve(),

--- a/tests/sandbox/test_workspace_paths_pure_windows.py
+++ b/tests/sandbox/test_workspace_paths_pure_windows.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path, PureWindowsPath
+
+from agents.sandbox.workspace_paths import WorkspacePathPolicy
+
+
+def test_resolved_path_normalizes_pure_windows_input(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "target.txt"
+    target.write_text("hello", encoding="utf-8")
+
+    policy = WorkspacePathPolicy(root=workspace)
+
+    assert policy.normalize_path(
+        PureWindowsPath(r"nested\..\target.txt"),
+        resolve_symlinks=True,
+    ) == target.resolve()


### PR DESCRIPTION
### Summary

Keep symlink-resolving workspace path validation consistent with the sandbox POSIX path contract.

`WorkspacePathPolicy.normalize_path(..., resolve_symlinks=True)` currently passes raw string paths directly to host-native `pathlib.Path`. On POSIX hosts, a sandbox path such as `nested\\file.txt` is therefore interpreted as a literal backslash-containing filename instead of `nested/file.txt`, unlike the non-symlink-resolving path flow which first uses `coerce_posix_path()`.

This change POSIX-normalizes non-Windows sandbox paths before converting them to the host `Path` used for symlink resolution. Windows drive-absolute handling remains unchanged.

### Test plan

Focused validation passed on both `ubuntu-latest` and `windows-latest`:

- `uv run pytest tests/sandbox/test_workspace_paths.py -q`
- `uv run ruff check src/agents/sandbox/workspace_paths.py tests/sandbox/test_workspace_paths.py`
- `uv run ruff format --check src/agents/sandbox/workspace_paths.py tests/sandbox/test_workspace_paths.py`

The regression covers backslash-containing relative input with a real host workspace and `resolve_symlinks=True`.