### PR TITLE
docs: list Tuning Engines tracing integration

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -231,3 +231,4 @@ The following community and vendor integrations support the tracing API surface 
 -   [Datadog](https://docs.datadoghq.com/llm_observability/instrumentation/auto_instrumentation/?tab=python#openai-agents)
 -   [Latitude](https://docs.latitude.so/telemetry/frameworks/openai-agents)
 -   [DProvenanceKit](https://dprovenance.dev/openai-agents/)
+-   [Tuning Engines](https://github.com/cerebrixos-org/tuning-engines-cli/tree/main/packages/tuning-agents#openai-agents-sdk)


### PR DESCRIPTION
Adds Tuning Engines to the existing external tracing processors list. The published tuning-engines[openai-agents] integration implements the SDK's native batch trace processor surface, routes model calls through an OpenAI-compatible endpoint, and exports bounded metadata-only model, tool, handoff, guardrail, and workflow spans. Raw prompts, tool arguments, tool output, and hidden reasoning are excluded by the exporter. Documentation and install example are linked from the entry.