### PR TITLE
fix(memory): reject a second base-table pair in one AdvancedSQLiteSession database

### DIFF
--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -67,15 +67,16 @@ class AdvancedSQLiteSession(SQLiteSession):
             session_settings=session_settings,
             **kwargs,
         )
-        if create_tables:
-            try:
+        try:
+            if create_tables:
                 self._init_structure_tables()
+            self._verify_structure_tables_scope()
+        except BaseException:
+            try:
+                self.close()
             except BaseException:
-                try:
-                    self.close()
-                except BaseException:
-                    pass
-                raise
+                pass
+            raise
         self._current_branch_id = "main"
         # Synchronized with the durable session_clear_generations row whenever a
         # branch pointer is established or a write begins. A mismatch means
@@ -107,6 +108,34 @@ class AdvancedSQLiteSession(SQLiteSession):
             self._generation = durable_generation
             self._current_branch_id = branch_id
             return True
+
+    def _verify_structure_tables_scope(self) -> None:
+        """Reject a database file whose structure tables belong to other base tables.
+
+        ``message_structure`` and the other structure tables are not named after
+        ``sessions_table``/``messages_table``, so a database file can only hold the structure
+        rows of a single base-table pair. ``CREATE TABLE IF NOT EXISTS`` keeps the first pair's
+        foreign keys, so a second session configured with different base table names would join
+        ``message_structure`` against the wrong messages table and read back rows that belong to
+        the other pair.
+        """
+        with self._locked_connection() as conn:
+            references = {
+                row[3]: row[2] for row in conn.execute("PRAGMA foreign_key_list(message_structure)")
+            }
+        if not references:
+            return
+        if (
+            references.get("session_id") != self.sessions_table
+            or references.get("message_id") != self.messages_table
+        ):
+            raise ValueError(
+                f"The structure tables in {self.db_path} already belong to "
+                f"'{references.get('session_id')}'/'{references.get('message_id')}', not to the "
+                f"configured '{self.sessions_table}'/'{self.messages_table}'. Structure tables "
+                "are shared per database file, so give each sessions_table/messages_table pair "
+                "its own db_path."
+            )
 
     def _init_structure_tables(self):
         """Add structure and usage tracking tables.

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -39,6 +39,17 @@ def _content_preview(content: Any, max_length: int | None = None) -> str:
     return text
 
 
+def _existing_schema_names(db_path: str | Path) -> frozenset[str]:
+    """Names already present in a database file, before anything is created in it."""
+    if str(db_path) == ":memory:":
+        return frozenset()
+    path = Path(db_path)
+    if not path.exists():
+        return frozenset()
+    with closing(sqlite3.connect(str(path))) as conn:
+        return frozenset(row[0] for row in conn.execute("SELECT name FROM sqlite_master"))
+
+
 class AdvancedSQLiteSession(SQLiteSession):
     """Enhanced SQLite session with conversation branching and usage analytics."""
 
@@ -61,6 +72,9 @@ class AdvancedSQLiteSession(SQLiteSession):
             logger: The logger to use. Defaults to the module logger
             **kwargs: Additional keyword arguments to pass to the superclass
         """  # noqa: E501
+        # Captured before the base schema is created so a rejected construction can drop exactly
+        # what it added, rather than leaving the refused pair's tables behind.
+        preexisting_schema = _existing_schema_names(db_path)
         super().__init__(
             session_id=session_id,
             db_path=db_path,
@@ -74,6 +88,10 @@ class AdvancedSQLiteSession(SQLiteSession):
                 with self._locked_connection() as conn:
                     self._claim_structure_tables(conn)
         except BaseException:
+            try:
+                self._drop_schema_added_by_this_construction(preexisting_schema)
+            except BaseException:
+                pass
             try:
                 self.close()
             except BaseException:
@@ -165,6 +183,26 @@ class AdvancedSQLiteSession(SQLiteSession):
         """
         row = conn.execute("SELECT ? = ? COLLATE NOCASE", (left, right)).fetchone()
         return bool(row[0])
+
+    def _drop_schema_added_by_this_construction(self, preexisting: frozenset[str]) -> None:
+        """Remove the base tables this rejected construction created, and nothing else.
+
+        Only names absent from the pre-construction snapshot are dropped, so a pair that already
+        owned tables in the file keeps them.
+        """
+        candidates = [
+            f"idx_{self.messages_table}_session_id",
+            self.messages_table,
+            self.sessions_table,
+        ]
+        added = [name for name in candidates if name not in preexisting]
+        if not added:
+            return
+        with self._write_connection() as conn:
+            for name in added:
+                kind = "INDEX" if name.startswith("idx_") else "TABLE"
+                conn.execute(f"DROP {kind} IF EXISTS {name}")
+            conn.commit()
 
     def _init_structure_tables(self):
         """Add structure and usage tracking tables.

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -7,7 +7,7 @@ import sqlite3
 import time
 from contextlib import closing
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from agents.result import RunResult
 from agents.usage import Usage
@@ -72,7 +72,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                 self._init_structure_tables()
             else:
                 with self._locked_connection() as conn:
-                    self._verify_structure_tables_scope(conn)
+                    self._claim_structure_tables(conn)
         except BaseException:
             try:
                 self.close()
@@ -111,46 +111,60 @@ class AdvancedSQLiteSession(SQLiteSession):
             self._current_branch_id = branch_id
             return True
 
-    def _verify_structure_tables_scope(self, conn: sqlite3.Connection) -> None:
-        """Reject a database file whose structure tables belong to other base tables.
+    # The structure tables that record which base-table pair owns a database file, and the
+    # foreign keys that record it. `branch_reservations` and `session_clear_generations` carry no
+    # foreign keys, but enforcing one pair per file keeps them unambiguous too.
+    _STRUCTURE_TABLE_OWNERS: ClassVar[dict[str, tuple[str, ...]]] = {
+        "message_structure": ("session_id", "message_id"),
+        "turn_usage": ("session_id",),
+    }
+
+    def _claim_structure_tables(self, conn: sqlite3.Connection) -> None:
+        """Require a complete structure-table layout owned by the configured base-table pair.
 
         The structure tables are not named after ``sessions_table``/``messages_table``, so a
-        database file can only hold the structure rows of a single base-table pair. ``CREATE
-        TABLE IF NOT EXISTS`` keeps the first pair's foreign keys, so a second session configured
-        with different base table names would join ``message_structure`` against the wrong
-        messages table and read back rows that belong to the other pair.
+        database file can only hold the structure rows of a single pair. ``CREATE TABLE IF NOT
+        EXISTS`` keeps the first pair's foreign keys, so a second session configured with
+        different base table names would join ``message_structure`` against the wrong messages
+        table and read back rows that belong to the other pair.
 
-        Both owner-bearing structure tables are checked, so a file whose two structure tables were
-        created for different pairs is rejected instead of being accepted by whichever one happens
-        to match.
+        An incomplete layout is rejected rather than accepted, so a ``create_tables=False``
+        session cannot open a file before any pair has claimed it and then have another pair
+        claim it underneath.
         """
-        expected = {
-            "message_structure": {
-                "session_id": self.sessions_table,
-                "message_id": self.messages_table,
-            },
-            "turn_usage": {"session_id": self.sessions_table},
-        }
-        for table, expected_owners in expected.items():
-            # SQLite resolves table names case-insensitively but `PRAGMA foreign_key_list` reports
-            # the spelling used at CREATE time, so compare case-folded.
-            owners = {
-                row[3].casefold(): row[2]
-                for row in conn.execute(f"PRAGMA foreign_key_list({table})")
-            }
-            if not owners:
-                continue
+        owned_by = {"session_id": self.sessions_table, "message_id": self.messages_table}
+        for table, columns in self._STRUCTURE_TABLE_OWNERS.items():
+            owners = {row[3]: row[2] for row in conn.execute(f"PRAGMA foreign_key_list({table})")}
+            missing = [column for column in columns if column not in owners]
+            if missing:
+                raise ValueError(
+                    f"The `{table}` table in {self.db_path} does not exist yet or does not record "
+                    "which sessions_table/messages_table pair owns it. Construct an "
+                    "AdvancedSQLiteSession with create_tables=True to create and claim the "
+                    "structure tables before opening the database without them."
+                )
             if any(
-                owners.get(column, "").casefold() != owner.casefold()
-                for column, owner in expected_owners.items()
+                not self._identifiers_equal(conn, owners[column], owned_by[column])
+                for column in columns
             ):
-                found = "/".join(owners.get(column, "?") for column in expected_owners)
-                configured = "/".join(expected_owners.values())
+                found = "/".join(owners[column] for column in columns)
+                configured = "/".join(owned_by[column] for column in columns)
                 raise ValueError(
                     f"The `{table}` table in {self.db_path} already belongs to '{found}', not to "
                     f"the configured '{configured}'. Structure tables are shared per database "
                     "file, so give each sessions_table/messages_table pair its own db_path."
                 )
+
+    @staticmethod
+    def _identifiers_equal(conn: sqlite3.Connection, left: str, right: str) -> bool:
+        """Compare two table names the way SQLite compares identifiers.
+
+        SQLite folds identifiers with ASCII rules only, so `NOCASE` is asked directly rather than
+        reimplemented. Python's ``casefold()`` would equate names SQLite keeps distinct, for
+        example ``ßsessions`` and ``sssessions``.
+        """
+        row = conn.execute("SELECT ? = ? COLLATE NOCASE", (left, right)).fetchone()
+        return bool(row[0])
 
     def _init_structure_tables(self):
         """Add structure and usage tracking tables.
@@ -230,7 +244,7 @@ class AdvancedSQLiteSession(SQLiteSession):
                 ON turn_usage(session_id, branch_id, user_turn_number)
             """)
 
-            self._verify_structure_tables_scope(conn)
+            self._claim_structure_tables(conn)
 
             conn.commit()
 

--- a/src/agents/extensions/memory/advanced_sqlite_session.py
+++ b/src/agents/extensions/memory/advanced_sqlite_session.py
@@ -70,7 +70,9 @@ class AdvancedSQLiteSession(SQLiteSession):
         try:
             if create_tables:
                 self._init_structure_tables()
-            self._verify_structure_tables_scope()
+            else:
+                with self._locked_connection() as conn:
+                    self._verify_structure_tables_scope(conn)
         except BaseException:
             try:
                 self.close()
@@ -109,33 +111,46 @@ class AdvancedSQLiteSession(SQLiteSession):
             self._current_branch_id = branch_id
             return True
 
-    def _verify_structure_tables_scope(self) -> None:
+    def _verify_structure_tables_scope(self, conn: sqlite3.Connection) -> None:
         """Reject a database file whose structure tables belong to other base tables.
 
-        ``message_structure`` and the other structure tables are not named after
-        ``sessions_table``/``messages_table``, so a database file can only hold the structure
-        rows of a single base-table pair. ``CREATE TABLE IF NOT EXISTS`` keeps the first pair's
-        foreign keys, so a second session configured with different base table names would join
-        ``message_structure`` against the wrong messages table and read back rows that belong to
-        the other pair.
+        The structure tables are not named after ``sessions_table``/``messages_table``, so a
+        database file can only hold the structure rows of a single base-table pair. ``CREATE
+        TABLE IF NOT EXISTS`` keeps the first pair's foreign keys, so a second session configured
+        with different base table names would join ``message_structure`` against the wrong
+        messages table and read back rows that belong to the other pair.
+
+        Both owner-bearing structure tables are checked, so a file whose two structure tables were
+        created for different pairs is rejected instead of being accepted by whichever one happens
+        to match.
         """
-        with self._locked_connection() as conn:
-            references = {
-                row[3]: row[2] for row in conn.execute("PRAGMA foreign_key_list(message_structure)")
+        expected = {
+            "message_structure": {
+                "session_id": self.sessions_table,
+                "message_id": self.messages_table,
+            },
+            "turn_usage": {"session_id": self.sessions_table},
+        }
+        for table, expected_owners in expected.items():
+            # SQLite resolves table names case-insensitively but `PRAGMA foreign_key_list` reports
+            # the spelling used at CREATE time, so compare case-folded.
+            owners = {
+                row[3].casefold(): row[2]
+                for row in conn.execute(f"PRAGMA foreign_key_list({table})")
             }
-        if not references:
-            return
-        if (
-            references.get("session_id") != self.sessions_table
-            or references.get("message_id") != self.messages_table
-        ):
-            raise ValueError(
-                f"The structure tables in {self.db_path} already belong to "
-                f"'{references.get('session_id')}'/'{references.get('message_id')}', not to the "
-                f"configured '{self.sessions_table}'/'{self.messages_table}'. Structure tables "
-                "are shared per database file, so give each sessions_table/messages_table pair "
-                "its own db_path."
-            )
+            if not owners:
+                continue
+            if any(
+                owners.get(column, "").casefold() != owner.casefold()
+                for column, owner in expected_owners.items()
+            ):
+                found = "/".join(owners.get(column, "?") for column in expected_owners)
+                configured = "/".join(expected_owners.values())
+                raise ValueError(
+                    f"The `{table}` table in {self.db_path} already belongs to '{found}', not to "
+                    f"the configured '{configured}'. Structure tables are shared per database "
+                    "file, so give each sessions_table/messages_table pair its own db_path."
+                )
 
     def _init_structure_tables(self):
         """Add structure and usage tracking tables.
@@ -145,6 +160,11 @@ class AdvancedSQLiteSession(SQLiteSession):
         and usage analytics.
         """
         with self._write_connection() as conn:
+            # Take the database write lock before the first CREATE so two processes cannot each
+            # create part of the layout for a different base-table pair. Python's sqlite3 keeps
+            # DDL inside the open transaction, so the checked layout commits as one unit.
+            conn.execute("BEGIN IMMEDIATE")
+
             # Message structure with branch support
             conn.execute(f"""
                 CREATE TABLE IF NOT EXISTS message_structure (
@@ -209,6 +229,8 @@ class AdvancedSQLiteSession(SQLiteSession):
                 CREATE INDEX IF NOT EXISTS idx_turn_usage_session_turn
                 ON turn_usage(session_id, branch_id, user_turn_number)
             """)
+
+            self._verify_structure_tables_scope(conn)
 
             conn.commit()
 

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -3986,3 +3986,40 @@ async def test_concurrent_structure_table_claims_leave_one_coherent_owner(tmp_pa
             if process.is_alive():
                 process.terminate()
             process.join(timeout=5)
+
+
+async def test_rejected_construction_leaves_no_schema_behind(tmp_path: Path) -> None:
+    """A refused pair must not leave its base tables in a file it was never allowed to use."""
+    db_path = tmp_path / "advanced_rejected_schema.db"
+    owner = AdvancedSQLiteSession(
+        session_id="shared",
+        db_path=db_path,
+        create_tables=True,
+        sessions_table="first_sessions",
+        messages_table="first_messages",
+    )
+    try:
+        await owner.add_items([{"role": "user", "content": "first"}])
+
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            before = {row[0] for row in conn.execute("SELECT name FROM sqlite_master")}
+
+        with pytest.raises(ValueError):
+            AdvancedSQLiteSession(
+                session_id="shared",
+                db_path=db_path,
+                create_tables=True,
+                sessions_table="second_sessions",
+                messages_table="second_messages",
+            )
+
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            after = {row[0] for row in conn.execute("SELECT name FROM sqlite_master")}
+
+        assert after == before, sorted(after - before)
+        assert "second_sessions" not in after
+        assert "second_messages" not in after
+        # The owner is untouched.
+        assert await owner.get_items() == [{"role": "user", "content": "first"}]
+    finally:
+        owner.close()

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -3789,3 +3789,30 @@ async def test_clear_session_rolls_back_on_failure_after_earlier_delete(usage_da
         assert await session.get_items() == []
     finally:
         session.close()
+
+
+async def test_structure_tables_reject_a_second_base_table_pair(tmp_path: Path) -> None:
+    """A second base-table pair in one file would read the first pair's structure rows."""
+    db_path = tmp_path / "advanced_shared_structure.db"
+    first = AdvancedSQLiteSession(
+        session_id="shared",
+        db_path=db_path,
+        create_tables=True,
+        sessions_table="first_sessions",
+        messages_table="first_messages",
+    )
+    try:
+        await first.add_items([{"role": "user", "content": "first"}])
+
+        with pytest.raises(ValueError, match="first_sessions"):
+            AdvancedSQLiteSession(
+                session_id="shared",
+                db_path=db_path,
+                create_tables=True,
+                sessions_table="second_sessions",
+                messages_table="second_messages",
+            )
+
+        assert await first.get_items() == [{"role": "user", "content": "first"}]
+    finally:
+        first.close()

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -3816,3 +3816,31 @@ async def test_structure_tables_reject_a_second_base_table_pair(tmp_path: Path) 
         assert await first.get_items() == [{"role": "user", "content": "first"}]
     finally:
         first.close()
+
+
+async def test_structure_tables_accept_equivalent_identifier_casing(tmp_path: Path) -> None:
+    """SQLite resolves table names case-insensitively, so a recased pair is the same pair."""
+    db_path = tmp_path / "advanced_recased_structure.db"
+    first = AdvancedSQLiteSession(
+        session_id="shared",
+        db_path=db_path,
+        create_tables=True,
+        sessions_table="FooSessions",
+        messages_table="FooMessages",
+    )
+    try:
+        await first.add_items([{"role": "user", "content": "first"}])
+    finally:
+        first.close()
+
+    recased = AdvancedSQLiteSession(
+        session_id="shared",
+        db_path=db_path,
+        create_tables=True,
+        sessions_table="foosessions",
+        messages_table="foomessages",
+    )
+    try:
+        assert await recased.get_items() == [{"role": "user", "content": "first"}]
+    finally:
+        recased.close()

--- a/tests/extensions/memory/test_advanced_sqlite_session.py
+++ b/tests/extensions/memory/test_advanced_sqlite_session.py
@@ -33,6 +33,34 @@ from tests.test_responses import get_text_message
 pytestmark = pytest.mark.asyncio
 
 
+def _claim_structure_tables_in_process(
+    db_path: str,
+    sessions_table: str,
+    messages_table: str,
+    ready: Any,
+    start: Any,
+    results: Any,
+) -> None:
+    """Construct a create_tables session in a child process and report the outcome."""
+    ready.set()
+    start.wait(timeout=30)
+    try:
+        session = AdvancedSQLiteSession(
+            session_id="concurrent",
+            db_path=db_path,
+            create_tables=True,
+            sessions_table=sessions_table,
+            messages_table=messages_table,
+        )
+        session.close()
+    except ValueError:
+        results.put(("rejected", sessions_table))
+    except BaseException as exc:  # pragma: no cover - surfaced in the assertion below
+        results.put((f"error:{type(exc).__name__}", sessions_table))
+    else:
+        results.put(("claimed", sessions_table))
+
+
 def _multiprocessing_context() -> Any:
     method = "spawn" if sys.platform == "win32" else "forkserver"
     return multiprocessing.get_context(method)
@@ -3844,3 +3872,117 @@ async def test_structure_tables_accept_equivalent_identifier_casing(tmp_path: Pa
         assert await recased.get_items() == [{"role": "user", "content": "first"}]
     finally:
         recased.close()
+
+
+async def test_structure_tables_reject_distinct_non_ascii_identifiers(tmp_path: Path) -> None:
+    """SQLite folds identifiers with ASCII rules, so these are two different pairs.
+
+    Python's `casefold()` equates `ßsessions` and `sssessions`, which would let the second pair
+    through and restore the cross-table mixing this change prevents.
+    """
+    assert "ßsessions".casefold() == "sssessions".casefold()
+
+    db_path = tmp_path / "advanced_non_ascii_structure.db"
+    first = AdvancedSQLiteSession(
+        session_id="shared",
+        db_path=db_path,
+        create_tables=True,
+        sessions_table="ßsessions",
+        messages_table="ßmessages",
+    )
+    try:
+        await first.add_items([{"role": "user", "content": "first"}])
+
+        with pytest.raises(ValueError, match="ßsessions"):
+            AdvancedSQLiteSession(
+                session_id="shared",
+                db_path=db_path,
+                create_tables=True,
+                sessions_table="sssessions",
+                messages_table="ssmessages",
+            )
+
+        assert await first.get_items() == [{"role": "user", "content": "first"}]
+    finally:
+        first.close()
+
+
+async def test_no_create_session_rejects_a_database_without_an_owner(tmp_path: Path) -> None:
+    """A no-create session must not open a file before a pair has claimed the structure tables.
+
+    Accepting it would let another pair claim the tables afterwards, leaving this session writing
+    and reading structure rows owned by that other pair.
+    """
+    db_path = tmp_path / "advanced_unclaimed_structure.db"
+
+    with pytest.raises(ValueError, match="create_tables=True"):
+        AdvancedSQLiteSession(session_id="shared", db_path=db_path, create_tables=False)
+
+    owner = AdvancedSQLiteSession(session_id="shared", db_path=db_path, create_tables=True)
+    try:
+        await owner.add_items([{"role": "user", "content": "first"}])
+    finally:
+        owner.close()
+
+    # Once a pair owns the layout, the same pair may open it without creating anything.
+    reader = AdvancedSQLiteSession(session_id="shared", db_path=db_path, create_tables=False)
+    try:
+        assert await reader.get_items() == [{"role": "user", "content": "first"}]
+    finally:
+        reader.close()
+
+
+@pytest.mark.review_optional
+async def test_concurrent_structure_table_claims_leave_one_coherent_owner(tmp_path: Path) -> None:
+    """Two processes claiming a fresh file with different pairs must not split the layout."""
+    db_path = tmp_path / "advanced_concurrent_claim.db"
+    pairs = [("a_sessions", "a_messages"), ("b_sessions", "b_messages")]
+
+    # Create the file with WAL already enabled. Switching journal mode needs an exclusive lock,
+    # so two processes opening a brand-new file race there first, in SQLiteSession.__init__,
+    # before either reaches the structure tables. Settling it up front keeps this test about the
+    # claim.
+    with contextlib.closing(sqlite3.connect(db_path)) as setup_conn:
+        setup_conn.execute("PRAGMA journal_mode=WAL")
+
+    context = _multiprocessing_context()
+    start = context.Event()
+    results = context.Queue()
+    ready_events = [context.Event(), context.Event()]
+    processes = [
+        context.Process(
+            target=_claim_structure_tables_in_process,
+            args=(str(db_path), sessions_table, messages_table, ready, start, results),
+        )
+        for (sessions_table, messages_table), ready in zip(pairs, ready_events, strict=False)
+    ]
+
+    try:
+        for process in processes:
+            process.start()
+        for ready in ready_events:
+            assert ready.wait(timeout=30)
+        start.set()
+        for process in processes:
+            process.join(timeout=30)
+            assert process.exitcode == 0
+
+        outcomes = [results.get(timeout=5), results.get(timeout=5)]
+        claimed = [pair for status, pair in outcomes if status == "claimed"]
+        assert len(claimed) == 1, outcomes
+        assert all(status in {"claimed", "rejected"} for status, _ in outcomes), outcomes
+
+        # Every owner-bearing structure table must name the one pair that won.
+        winner = claimed[0]
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            for table in ("message_structure", "turn_usage"):
+                owners = {
+                    row[3]: row[2] for row in conn.execute(f"PRAGMA foreign_key_list({table})")
+                }
+                assert owners["session_id"] == winner, (table, owners)
+    finally:
+        start.set()
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)


### PR DESCRIPTION
### Summary

`AdvancedSQLiteSession` inherits the configurable `sessions_table` / `messages_table` from `SQLiteSession`, but its four structure tables (`message_structure`, `turn_usage`, `branch_reservations`, `session_clear_generations`) are hardcoded names created with `CREATE TABLE IF NOT EXISTS` (`advanced_sqlite_session.py:150`, `:170`). The first base-table pair to touch a database file therefore owns them, and every later session on that file silently reuses `message_structure` with the first pair's foreign keys regardless of how it was configured.

`get_items()` joins `message_structure` against the configured messages table (`advanced_sqlite_session.py:279`, `:297`, `:318`), so once two pairs share one file each session's join picks up structure rows written by the other one:

```python
a = AdvancedSQLiteSession(session_id="s1", db_path=p, create_tables=True,
                          sessions_table="a_sessions", messages_table="a_messages")
b = AdvancedSQLiteSession(session_id="s1", db_path=p, create_tables=True,
                          sessions_table="b_sessions", messages_table="b_messages")

await a.add_items([{"role": "user", "content": "from A"}])
await b.add_items([{"role": "user", "content": "from B"}])

await a.get_items()  # [{... 'from A'}, {... 'from A'}]  <- only one item was added
await b.get_items()  # [{... 'from B'}, {... 'from B'}]
```

Two `message_structure` rows now exist for session `s1`, both with `message_id = 1`, and each session matches both of them against its own messages table. Nothing errors, the history is just wrong. `turn_usage` collides the same way through its `UNIQUE(session_id, branch_id, user_turn_number)` constraint.

Namespacing the structure tables per base-table pair would mean renaming them in over 90 places in the module and would orphan the rows in every database file that already exists, so this takes the other direction: the layout really does only support one pair per file, so `__init__` now checks that instead of corrupting data. It reads `PRAGMA foreign_key_list(message_structure)` and raises a `ValueError` naming both pairs when the structure tables already belong to a different one.

Supported configurations are untouched, since the check only fires on a mismatch that is already broken today. Verified by hand: default table names with two sessions on one file, a custom pair on its own file, reopening that file with `create_tables=True` and with `create_tables=False`, a fresh file with no structure tables yet, and `:memory:`.

### Test plan

- Added `test_structure_tables_reject_a_second_base_table_pair`. Reverting the source change makes it fail with `DID NOT RAISE <class 'ValueError'>`, so it covers the fix rather than restating it.
- `uv run pytest tests/extensions/memory/ tests/memory/`: 613 passed, 11 skipped.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`: format and lint clean, pyright 0 errors, 8587 passed / 28 skipped.
- CI here waits on a maintainer to approve the workflow for a first-time contributor, so the checks above are the local run, not a green CI badge.

### Issue number

N/A, found while reading through the session backends.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

sorry in advance if I got any of this wrong. I worked through the logic myself and used Claude Code as a sounding board for the design call (validate vs rename the tables), and I confirmed the duplication with the snippet above before writing anything. happy to be corrected on the approach, still a freshman in college trying to be useful here :)
