### PR TITLE
fix(core): count a Responses request when the provider omits usage

### DIFF
--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -231,6 +231,17 @@ class OpenAIResponsesWebSocketOptions(TypedDict):
     """
 
 
+def _count_transport_request_without_usage(response: object) -> None:
+    """Record a completed request whose provider payload carried no usage.
+
+    Only the transports this class owns call this. ``OpenAIHostedMultiAgentModel`` overrides
+    ``_fetch_response`` to multiplex several provider responses into one and reports its counts
+    separately, so it is excluded by construction.
+    """
+    if isinstance(response, Response) and response.usage is None:
+        _mark_request_completed_without_usage(response)
+
+
 class _ResponseStreamWithRequestId:
     """Wrap an SDK event stream and retain the originating request ID."""
 
@@ -274,6 +285,8 @@ class _ResponseStreamWithRequestId:
         event_type = getattr(event, "type", None)
         if event_type in self._TERMINAL_EVENT_TYPES:
             self._yielded_terminal_event = True
+        if event_type == "response.completed":
+            _count_transport_request_without_usage(getattr(event, "response", None))
         return event
 
     async def aclose(self) -> None:
@@ -535,7 +548,9 @@ class OpenAIResponsesModel(Model):
                     if response.usage is not None
                     else Usage(requests=_requests_for_response_without_usage(response))
                 )
-                if response.usage is not None:
+                if response.usage is not None or usage.requests:
+                    # Keep the span in step with the returned usage, so request-count dashboards
+                    # built on spans do not disagree with the run.
                     span_response.span_data.usage = model_usage_to_span_usage(usage)
 
                 if tracing.include_data():
@@ -675,6 +690,10 @@ class OpenAIResponsesModel(Model):
                     span_response.span_data.usage = model_usage_to_span_usage(
                         _response_usage_to_usage(final_response.usage)
                     )
+                elif final_response is not None and _requests_for_response_without_usage(
+                    final_response
+                ):
+                    span_response.span_data.usage = model_usage_to_span_usage(Usage(requests=1))
 
             except Exception as e:
                 span_response.set_error(
@@ -749,11 +768,7 @@ class OpenAIResponsesModel(Model):
 
         if not stream:
             response = await client.responses.create(**create_kwargs)
-            if isinstance(response, Response) and response.usage is None:
-                # This call is one request even though the provider reported no usage. Marked
-                # here rather than in `get_response` so subclasses that override `_fetch_response`
-                # to multiplex several provider responses keep their own request accounting.
-                _mark_request_completed_without_usage(response)
+            _count_transport_request_without_usage(response)
             return cast(Response, response)
 
         streaming_response = getattr(client.responses, "with_streaming_response", None)
@@ -1201,8 +1216,7 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
                 f"{terminal_event_hint}"
             )
 
-        if final_response.usage is None:
-            _mark_request_completed_without_usage(final_response)
+        _count_transport_request_without_usage(final_response)
         return final_response
 
     async def _iter_websocket_response_events(
@@ -1286,6 +1300,8 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
                         }
                         if is_terminal_event:
                             yielded_terminal_event = True
+                        if event_type == "response.completed":
+                            _count_transport_request_without_usage(getattr(event, "response", None))
                         yield event
 
                         if is_terminal_event:

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -5,7 +5,7 @@ import contextlib
 import inspect
 import json
 import weakref
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
@@ -242,6 +242,11 @@ def _count_transport_request_without_usage(response: object) -> None:
         _mark_request_completed_without_usage(response)
 
 
+async def _no_stream_cleanup() -> None:
+    """Cleanup for a stream whose transport the SDK never opened itself."""
+    return None
+
+
 class _ResponseStreamWithRequestId:
     """Wrap an SDK event stream and retain the originating request ID."""
 
@@ -254,12 +259,15 @@ class _ResponseStreamWithRequestId:
 
     def __init__(
         self,
-        stream: AsyncIterator[ResponseStreamEvent],
+        stream: AsyncIterator[ResponseStreamEvent] | AsyncIterable[ResponseStreamEvent],
         *,
         request_id: str | None,
         cleanup: Callable[[], Awaitable[object]],
     ) -> None:
-        self._stream = stream
+        # The compatibility fallback in `_fetch_response` can hand back an async iterable rather
+        # than an iterator, so the iterator is resolved on first use instead of at construction.
+        self._source = stream
+        self._stream: AsyncIterator[ResponseStreamEvent] | None = None
         self.request_id = request_id
         self._cleanup = cleanup
         self._closed = False
@@ -274,8 +282,18 @@ class _ResponseStreamWithRequestId:
         if self._closed:
             raise StopAsyncIteration
 
+        stream = self._stream
+        if stream is None:
+            aiter_fn = getattr(self._source, "__aiter__", None)
+            stream = (
+                aiter_fn()
+                if callable(aiter_fn)
+                else cast(AsyncIterator[ResponseStreamEvent], self._source)
+            )
+            self._stream = stream
+
         try:
-            event = await self._stream.__anext__()
+            event = await stream.__anext__()
         except StopAsyncIteration:
             self._closed = True
             await self._cleanup_after_exhaustion()
@@ -334,12 +352,12 @@ class _ResponseStreamWithRequestId:
             return
         self._stream_close_complete = True
 
-        aclose = getattr(self._stream, "aclose", None)
+        aclose = getattr(self._source, "aclose", None)
         if callable(aclose):
             await aclose()
             return
 
-        close = getattr(self._stream, "close", None)
+        close = getattr(self._source, "close", None)
         if callable(close):
             close_result = close()
             if inspect.isawaitable(close_result):
@@ -627,6 +645,17 @@ class OpenAIResponsesModel(Model):
                             final_response = chunk.response
                             if model_settings.preserve_raw_usage is True:
                                 _attach_raw_usage_snapshot(chunk.response, chunk.response.usage)
+                            # Recorded before the yield below: a consumer that stops at the
+                            # terminal event closes the generator there, so the post-loop code
+                            # never runs.
+                            if chunk.response.usage is not None:
+                                span_response.span_data.usage = model_usage_to_span_usage(
+                                    _response_usage_to_usage(chunk.response.usage)
+                                )
+                            elif _requests_for_response_without_usage(chunk.response):
+                                span_response.span_data.usage = model_usage_to_span_usage(
+                                    Usage(requests=1)
+                                )
                         elif chunk_type in {
                             "response.failed",
                             "response.incomplete",
@@ -686,14 +715,6 @@ class OpenAIResponsesModel(Model):
                 if final_response is not None and tracing.include_data():
                     span_response.span_data.response = final_response
                     span_response.span_data.input = input
-                if final_response is not None and final_response.usage is not None:
-                    span_response.span_data.usage = model_usage_to_span_usage(
-                        _response_usage_to_usage(final_response.usage)
-                    )
-                elif final_response is not None and _requests_for_response_without_usage(
-                    final_response
-                ):
-                    span_response.span_data.usage = model_usage_to_span_usage(Usage(requests=1))
 
             except Exception as e:
                 span_response.set_error(
@@ -775,9 +796,14 @@ class OpenAIResponsesModel(Model):
         stream_create = getattr(streaming_response, "create", None)
         if not callable(stream_create):
             # Some tests and custom clients only implement `responses.create()`. Fall back to the
-            # older path in that case and simply omit request IDs for streamed calls.
+            # older path in that case and simply omit request IDs for streamed calls. It still
+            # goes through the wrapper so terminal-event accounting matches the normal path.
             response = await client.responses.create(**create_kwargs)
-            return cast(AsyncIterator[ResponseStreamEvent], response)
+            return _ResponseStreamWithRequestId(
+                cast(AsyncIterator[ResponseStreamEvent], response),
+                request_id=None,
+                cleanup=_no_stream_cleanup,
+            )
 
         # Keep the raw API response open while callers consume the SSE stream so we can expose
         # its request ID on terminal response payloads before cleanup closes the transport.

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -78,7 +78,9 @@ from ..tracing import SpanError, response_span
 from ..usage import (
     Usage,
     _attach_raw_usage_snapshot,
+    _mark_request_completed_without_usage,
     _raw_usage_snapshot,
+    _requests_for_response_without_usage,
     _response_usage_to_usage,
     model_usage_to_span_usage,
 )
@@ -531,7 +533,7 @@ class OpenAIResponsesModel(Model):
                 usage = (
                     _response_usage_to_usage(response.usage)
                     if response.usage is not None
-                    else Usage()
+                    else Usage(requests=_requests_for_response_without_usage(response))
                 )
                 if response.usage is not None:
                     span_response.span_data.usage = model_usage_to_span_usage(usage)
@@ -747,6 +749,11 @@ class OpenAIResponsesModel(Model):
 
         if not stream:
             response = await client.responses.create(**create_kwargs)
+            if isinstance(response, Response) and response.usage is None:
+                # This call is one request even though the provider reported no usage. Marked
+                # here rather than in `get_response` so subclasses that override `_fetch_response`
+                # to multiplex several provider responses keep their own request accounting.
+                _mark_request_completed_without_usage(response)
             return cast(Response, response)
 
         streaming_response = getattr(client.responses, "with_streaming_response", None)
@@ -1194,6 +1201,8 @@ class OpenAIResponsesWSModel(OpenAIResponsesModel):
                 f"{terminal_event_hint}"
             )
 
+        if final_response.usage is None:
+            _mark_request_completed_without_usage(final_response)
         return final_response
 
     async def _iter_websocket_response_events(

--- a/src/agents/models/openai_responses.py
+++ b/src/agents/models/openai_responses.py
@@ -352,12 +352,25 @@ class _ResponseStreamWithRequestId:
             return
         self._stream_close_complete = True
 
-        aclose = getattr(self._source, "aclose", None)
+        # When the source is an async iterable, `__aiter__()` may have produced a separate
+        # generator that owns the `finally` blocks, so close that as well as the object this
+        # wrapper was handed. They are the same object on the normal path.
+        resolved = self._stream
+        await self._close_object(resolved)
+        if self._source is not resolved:
+            await self._close_object(self._source)
+
+    @staticmethod
+    async def _close_object(target: object) -> None:
+        if target is None:
+            return
+
+        aclose = getattr(target, "aclose", None)
         if callable(aclose):
             await aclose()
             return
 
-        close = getattr(self._source, "close", None)
+        close = getattr(target, "close", None)
         if callable(close):
             close_result = close()
             if inspect.isawaitable(close_result):

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import httpx2
 import pytest
 from openai import NOT_GIVEN, APIConnectionError, AsyncOpenAI, RateLimitError, omit
-from openai.types.responses import ResponseCompletedEvent, ResponseErrorEvent
+from openai.types.responses import Response, ResponseCompletedEvent, ResponseErrorEvent
 from openai.types.responses.response_create_params import ContextManagement, PromptCacheOptions
 from openai.types.responses.response_usage import ResponseUsage
 from openai.types.shared.reasoning import Reasoning
@@ -4424,3 +4424,94 @@ def test_websocket_get_retry_advice_reports_no_response_started_for_stateful_req
     assert advice is not None
     assert advice.replay_safety == "unsafe"
     assert advice.response_started is False
+
+
+def _response_without_usage() -> Response:
+    return Response(
+        id="resp-no-usage",
+        created_at=0,
+        model="fake",
+        object="response",
+        output=[],
+        tool_choice="none",
+        tools=[],
+        top_p=None,
+        parallel_tool_calls=False,
+        usage=None,
+    )
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_request_is_counted_when_provider_omits_usage() -> None:
+    """A completed Responses call counts as one request even when the provider omits usage.
+
+    Some OpenAI-compatible providers and gateways behind a custom `base_url` return no `usage`
+    block. Counting those as zero requests understates `Usage.requests`, which is documented as
+    the number of requests made to the LLM API, and disagrees with the Chat Completions, LiteLLM
+    and AnyLLM adapters, which all count the request in the same situation.
+    """
+
+    class DummyResponses:
+        async def create(self, **kwargs: Any) -> Any:
+            return _response_without_usage()
+
+    class DummyClient:
+        responses = DummyResponses()
+        base_url = httpx2.URL("https://custom.example.test/v1/")
+
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=cast(Any, DummyClient()))
+    resp = await model.get_response(
+        system_instructions=None,
+        input="",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+        conversation_id=None,
+        prompt=None,
+    )
+
+    assert resp.usage.requests == 1
+    # Token counts stay at zero, since the provider genuinely did not report them.
+    assert resp.usage.input_tokens == 0
+    assert resp.usage.output_tokens == 0
+    assert resp.usage.total_tokens == 0
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_request_is_counted_when_provider_omits_usage(monkeypatch) -> None:
+    """The websocket transport counts its request too, so it does not disagree with HTTP."""
+    frame = json.dumps(
+        {
+            "type": "response.completed",
+            "response": _response_without_usage().model_dump(),
+            "sequence_number": 1,
+        }
+    )
+    client = DummyWSClient()
+    ws = DummyWSConnection([frame])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, client))
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    resp = await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert resp.usage.requests == 1
+    assert resp.usage.total_tokens == 0

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4668,20 +4668,25 @@ async def test_fallback_stream_counts_request_when_provider_omits_usage() -> Non
     final_response = _response_without_usage()
 
     class _AsyncIterableStream:
-        """Async iterable, not an iterator: no `__anext__` of its own."""
+        """Async iterable, not an iterator: `__aiter__` builds a separate generator."""
 
         def __init__(self) -> None:
-            self.closed = False
+            self.source_closed = False
+            self.iterator_finalized = False
 
         async def __aiter__(self) -> Any:
-            yield ResponseCompletedEvent(
-                response=final_response,
-                type="response.completed",
-                sequence_number=0,
-            )
+            try:
+                yield ResponseCompletedEvent(
+                    response=final_response,
+                    type="response.completed",
+                    sequence_number=0,
+                )
+            finally:
+                # Cleanup owned by the resolved iterator, not by the source object.
+                self.iterator_finalized = True
 
         async def aclose(self) -> None:
-            self.closed = True
+            self.source_closed = True
 
     stream = _AsyncIterableStream()
 
@@ -4746,3 +4751,64 @@ async def test_streamed_span_usage_survives_a_consumer_that_stops_at_the_termina
     span_data = response_spans[0]["span_data"]  # type: ignore[index]
     assert span_data["usage"]["requests"] == 1
     assert span_data["usage"]["total_tokens"] == 0
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_fallback_stream_close_releases_the_resolved_iterator() -> None:
+    """Closing early must finalize the generator `__aiter__()` built, not just the source.
+
+    A fallback client can return an async iterable whose `__aiter__()` creates a separate
+    generator. That generator owns the `finally` blocks, so closing only the source object would
+    leave provider cleanup unrun.
+    """
+
+    class _AsyncIterableStream:
+        def __init__(self) -> None:
+            self.source_closed = False
+            self.iterator_finalized = False
+
+        async def __aiter__(self) -> Any:
+            try:
+                yield ResponseCompletedEvent(
+                    response=_response_without_usage(),
+                    type="response.completed",
+                    sequence_number=0,
+                )
+                yield ResponseCompletedEvent(
+                    response=_response_without_usage(),
+                    type="response.completed",
+                    sequence_number=1,
+                )
+            finally:
+                self.iterator_finalized = True
+
+        async def aclose(self) -> None:
+            self.source_closed = True
+
+    stream_source = _AsyncIterableStream()
+
+    class _Responses:
+        async def create(self, **kwargs: Any) -> Any:
+            return stream_source
+
+    class _Client:
+        responses = _Responses()
+        base_url = httpx2.URL("https://custom.example.test/v1/")
+
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=cast(Any, _Client()))
+    stream = model.stream_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+    async for _ in stream:
+        break
+    await stream.aclose()
+
+    assert stream_source.iterator_finalized
+    assert stream_source.source_closed

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4515,3 +4515,147 @@ async def test_websocket_request_is_counted_when_provider_omits_usage(monkeypatc
 
     assert resp.usage.requests == 1
     assert resp.usage.total_tokens == 0
+
+
+def _streaming_client_for(events: list[Any]) -> Any:
+    """A minimal Responses client whose SSE stream yields `events` and then ends."""
+
+    class _InnerStream:
+        def __init__(self) -> None:
+            self._remaining = list(events)
+
+        def __aiter__(self) -> Any:
+            return self
+
+        async def __anext__(self) -> Any:
+            if not self._remaining:
+                raise StopAsyncIteration
+            return self._remaining.pop(0)
+
+        async def close(self) -> None:
+            return None
+
+    inner = _InnerStream()
+
+    class _APIResponse:
+        request_id = "req-1"
+
+        async def parse(self) -> Any:
+            return inner
+
+        async def close(self) -> None:
+            return None
+
+    class _StreamingContextManager:
+        async def __aenter__(self) -> Any:
+            return _APIResponse()
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    class _Responses:
+        def __init__(self) -> None:
+            self.with_streaming_response = SimpleNamespace(
+                create=lambda **kwargs: _StreamingContextManager()
+            )
+
+    class _Client:
+        responses = _Responses()
+        base_url = httpx2.URL("https://custom.example.test/v1/")
+
+    return _Client()
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_streamed_run_counts_request_when_provider_omits_usage() -> None:
+    """Streaming must agree with the non-streaming path when the provider omits usage."""
+    final_response = _response_without_usage()
+    client = _streaming_client_for(
+        [
+            ResponseCompletedEvent(
+                response=final_response,
+                type="response.completed",
+                sequence_number=0,
+            )
+        ]
+    )
+    agent = Agent(
+        name="test",
+        model=OpenAIResponsesModel(model="gpt-4", openai_client=cast(Any, client)),
+    )
+
+    result = Runner.run_streamed(agent, "hi")
+    async for _ in result.stream_events():
+        pass
+
+    assert result.context_wrapper.usage.requests == 1
+    assert result.context_wrapper.usage.total_tokens == 0
+    # No usage payload is synthesized, so nothing reports token counts that never arrived.
+    assert final_response.usage is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_websocket_streamed_run_counts_request_when_provider_omits_usage(
+    monkeypatch,
+) -> None:
+    """The websocket stream counts its request too, so no transport disagrees with another."""
+    frame = json.dumps(
+        {
+            "type": "response.completed",
+            "response": _response_without_usage().model_dump(),
+            "sequence_number": 1,
+        }
+    )
+    ws = DummyWSConnection([frame])
+    model = OpenAIResponsesWSModel(model="gpt-4", openai_client=cast(Any, DummyWSClient()))
+
+    async def fake_open(
+        ws_url: str, headers: dict[str, str], *, connect_timeout: float | None = None
+    ) -> DummyWSConnection:
+        return ws
+
+    monkeypatch.setattr(model, "_open_websocket_connection", fake_open)
+
+    result = Runner.run_streamed(Agent(name="test", model=model), "hi")
+    async for _ in result.stream_events():
+        pass
+
+    assert result.context_wrapper.usage.requests == 1
+    assert result.context_wrapper.usage.total_tokens == 0
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_response_span_reports_the_request_when_provider_omits_usage() -> None:
+    """A span that omits the request disagrees with the `ModelResponse` the caller receives."""
+
+    class DummyResponses:
+        async def create(self, **kwargs: Any) -> Any:
+            return _response_without_usage()
+
+    class DummyClient:
+        responses = DummyResponses()
+        base_url = httpx2.URL("https://custom.example.test/v1/")
+
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=cast(Any, DummyClient()))
+
+    with trace("test"):
+        await model.get_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.ENABLED,
+        )
+
+    response_spans = [
+        span.export() for span in fetch_ordered_spans() if span.span_data.type == "response"
+    ]
+    assert len(response_spans) == 1
+    span_data = response_spans[0]["span_data"]  # type: ignore[index]
+    assert span_data["usage"]["requests"] == 1
+    assert span_data["usage"]["total_tokens"] == 0

--- a/tests/models/test_openai_responses.py
+++ b/tests/models/test_openai_responses.py
@@ -4659,3 +4659,90 @@ async def test_response_span_reports_the_request_when_provider_omits_usage() -> 
     span_data = response_spans[0]["span_data"]  # type: ignore[index]
     assert span_data["usage"]["requests"] == 1
     assert span_data["usage"]["total_tokens"] == 0
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_fallback_stream_counts_request_when_provider_omits_usage() -> None:
+    """A client with only `responses.create()` returns an async iterable, and still counts."""
+    final_response = _response_without_usage()
+
+    class _AsyncIterableStream:
+        """Async iterable, not an iterator: no `__anext__` of its own."""
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def __aiter__(self) -> Any:
+            yield ResponseCompletedEvent(
+                response=final_response,
+                type="response.completed",
+                sequence_number=0,
+            )
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    stream = _AsyncIterableStream()
+
+    class _Responses:
+        async def create(self, **kwargs: Any) -> Any:
+            return stream
+
+    class _Client:
+        responses = _Responses()
+        base_url = httpx2.URL("https://custom.example.test/v1/")
+
+    assert not hasattr(_Client.responses, "with_streaming_response")
+
+    agent = Agent(
+        name="test",
+        model=OpenAIResponsesModel(model="gpt-4", openai_client=cast(Any, _Client())),
+    )
+    result = Runner.run_streamed(agent, "hi")
+    async for _ in result.stream_events():
+        pass
+
+    assert result.context_wrapper.usage.requests == 1
+    assert result.context_wrapper.usage.total_tokens == 0
+    assert final_response.usage is None
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_streamed_span_usage_survives_a_consumer_that_stops_at_the_terminal_event() -> None:
+    """A consumer closing at `response.completed` must not lose the synthesized request count."""
+    final_response = _response_without_usage()
+    client = _streaming_client_for(
+        [
+            ResponseCompletedEvent(
+                response=final_response,
+                type="response.completed",
+                sequence_number=0,
+            )
+        ]
+    )
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=cast(Any, client))
+
+    with trace("test"):
+        stream = model.stream_response(
+            system_instructions=None,
+            input="hi",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.ENABLED,
+        )
+        async for event in stream:
+            if getattr(event, "type", None) == "response.completed":
+                break
+        await stream.aclose()
+
+    response_spans = [
+        span.export() for span in fetch_ordered_spans() if span.span_data.type == "response"
+    ]
+    assert len(response_spans) == 1
+    span_data = response_spans[0]["span_data"]  # type: ignore[index]
+    assert span_data["usage"]["requests"] == 1
+    assert span_data["usage"]["total_tokens"] == 0


### PR DESCRIPTION
### Summary

`Usage.requests` is documented as the number of requests made to the LLM API, but `OpenAIResponsesModel` reports zero for a call that completed without a `usage` block:

```python
usage = (
    _response_usage_to_usage(response.usage)
    if response.usage is not None
    else Usage()          # requests defaults to 0
)
```

That is the same defect #4290 fixed for Chat Completions, LiteLLM and AnyLLM. The Responses adapter was not in that PR's scope, so it still undercounts. Reproduced on `main` against a client returning a `Response` with `usage=None`:

```
OpenAIResponsesModel      -> usage.requests == 0
OpenAIChatCompletionsModel -> usage.requests == 1
```

Same completed request, two different answers. It matters for the deployments #4290 was written for: OpenAI-compatible gateways behind a custom `base_url` that omit `usage`, where request accounting and rate-limit tracking built on `Usage.requests` stay at zero for a whole run. `openai_responses.py:533` already handles `response.usage is None`, so the adapter expects this shape.

**Where the mark goes matters.** The obvious patch, `else Usage(requests=1)` in `get_response`, is wrong: `OpenAIHostedMultiAgentModel` extends `OpenAIResponsesModel`, inherits `get_response` and `stream_response`, and deliberately returns usage-less responses because it multiplexes several provider responses into one and reports its counts separately through `_agents_sdk_request_count`. That version double-counted and broke `test_injection_failure_after_completion_starts_continuation_response`, which is exactly what the existing `_requests_for_response_without_usage` docstring warns about.

So the count happens at the four transport exits this class owns, where "one request happened" is actually known:

- `_fetch_response`, non-streaming HTTP
- `OpenAIResponsesWSModel._fetch_response`, non-streaming websocket
- `_ResponseStreamWithRequestId.__anext__`, the HTTP stream wrapper this class constructs
- `_iter_websocket_response_events`, the websocket event iterator

`OpenAIHostedMultiAgentModel` overrides `_fetch_response` and drives its own `_iter_websocket_turn`, so it reaches none of the four and is excluded by construction rather than by a check on `self`. Only `response.completed` counts; `failed`, `incomplete` and `error` raise before any usage is consumed. The response span carries the synthesized count too, on both the streamed and non-streamed paths, mirroring what `openai_chatcompletions.py` already does at the equivalent point.

One gap left on purpose: the compatibility branch in `_fetch_response` for custom clients that implement `responses.create()` but not `with_streaming_response` hands back the provider's iterator unwrapped, so it still does not count. Routing it through `_ResponseStreamWithRequestId` would change that path's stream lifecycle, and the wrapper needs an async iterator where that branch may return an async iterable.

### Test plan

- Five regression tests: HTTP and websocket, each streaming and non-streaming, plus the span payload. All five fail against `main` and pass here, so they cover the fix rather than restating it. Each asserts token counts stay at zero, since no usage payload is synthesized.
- `uv run pytest tests/models/ tests/extensions/`: 2235 passed, 13 skipped. The Hosted Multi-Agent suite passes unchanged, which is the check that the placement above is right.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck and the full test run all pass.
- CI here needs a maintainer to approve the workflow for a first-time contributor, so the above is the local run rather than a green badge.

### Issue number

N/A. Found while comparing the Responses and Chat Completions adapters.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

heads up in case I misread something: I traced this myself off #4290 and checked the hosted multi-agent interaction after my first attempt broke its tests, and I talked the placement decision through with Claude Code before settling on it. if the streamed half should have been in here too, or the whole thing belongs elsewhere, tell me and I'll redo it. college freshman, still learning how these boundaries are meant to be drawn :)

