### PR TITLE
fix(items): guard non-string type before tool_search set membership

### DIFF
--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -231,7 +231,12 @@ def _output_item_to_input_item(raw_item: Any) -> TResponseInputItem:
     item_type = (
         raw_item.get("type") if isinstance(raw_item, dict) else getattr(raw_item, "type", None)
     )
-    if item_type in {"tool_search_call", "tool_search_output"}:
+    # ``item_type`` comes from an untrusted raw item, so it may be a non-string
+    # (for example ``{"type": []}``). Guarding on ``isinstance`` keeps the set
+    # membership test from raising ``TypeError: unhashable type`` before the
+    # dict/BaseModel handling below can produce the payload or raise the
+    # documented ``AgentsException``.
+    if isinstance(item_type, str) and item_type in {"tool_search_call", "tool_search_output"}:
         return _tool_search_item_to_input_item(raw_item)
 
     if isinstance(raw_item, dict):

--- a/tests/test_items_helpers.py
+++ b/tests/test_items_helpers.py
@@ -53,7 +53,12 @@ from agents import (
     TResponseInputItem,
     Usage,
 )
-from agents.items import ToolCallItem, ToolCallOutputItem, TResponseOutputItem
+from agents.items import (
+    ToolCallItem,
+    ToolCallOutputItem,
+    TResponseOutputItem,
+    _output_item_to_input_item,
+)
 
 
 def make_message(
@@ -841,3 +846,16 @@ def test_tool_call_output_item_call_id_returns_none_when_missing() -> None:
     }
     item = ToolCallOutputItem(agent=agent, raw_item=raw, output="ok")
     assert item.call_id is None
+
+
+@pytest.mark.parametrize("bad_type", [[], {}, 5, None])
+def test_output_item_to_input_item_non_string_type_does_not_crash(bad_type: Any) -> None:
+    """A raw item whose ``type`` is a non-string value must not crash the
+    tool_search set-membership check with a raw ``TypeError`` (unhashable type).
+
+    The converter is defensive about the raw item's outer shape, so a malformed
+    ``type`` should fall through to the normal dict handling rather than raise.
+    """
+    raw = {"type": bad_type, "id": "x"}
+    result = _output_item_to_input_item(raw)
+    assert result == raw


### PR DESCRIPTION
## Summary

`_output_item_to_input_item` reads a raw item's `type` and tests it against a set of tool_search type strings before its own dict / `BaseModel` handling runs. The raw item is untrusted, so `type` can be a non-string, unhashable value. Set membership then raises `TypeError: unhashable type` instead of the converter falling through to produce the payload or raising the documented `AgentsException`.

```python
from agents.items import _output_item_to_input_item

_output_item_to_input_item({"type": [], "id": "x"})
# TypeError: unhashable type: 'list'
```

The converter is otherwise defensive about the raw item's outer shape (it raises `AgentsException` for a non-dict / non-`BaseModel` item), so this is a gap in that same contract one level in: the guard protects the container but not the `type` value it reads out of it.

## Fix

Guard the membership test with `isinstance(item_type, str)`. A malformed `type` now falls through to the normal dict handling rather than crashing, and every well-formed item is unchanged.

```python
if isinstance(item_type, str) and item_type in {"tool_search_call", "tool_search_output"}:
    return _tool_search_item_to_input_item(raw_item)
```

## Tests

`test_output_item_to_input_item_non_string_type_does_not_crash` in `tests/test_items_helpers.py`, parametrized over `[]`, `{}`, `5`, and `None`. The unhashable cases raise a raw `TypeError` at `items.py:234` without this change and pass with it. `tests/test_items_helpers.py` is green (41 passed); `ruff check`, `ruff format --check`, and `mypy` on the changed files are clean.

## Note on scope

The same `raw.get("type") in {...}` set-membership pattern, guarded on the container being a dict / `Mapping` but not on `type` being a string, appears at other item and state deserialization sites:

- `src/agents/run_state.py` (`_raw_item_uses_programmatic_tool_calling`, and the `item.get("type") in {...}` check nearby)
- `src/agents/handoffs/history.py` (`input_item.get("type") in {...}`)
- `src/agents/run_internal/oai_conversation.py` (`_is_tool_search_item`)

They share the same failure mode on a non-string `type`. I kept this PR focused on the one converter I could exercise directly with a regression test; happy to extend the same guard to those sites in this PR or a follow-up, whichever the maintainers prefer.
