### PR TITLE
fix(sessions): include compaction usage in run totals

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -11,6 +11,7 @@ from ..items import TResponseInputItem
 from ..logger import log_model_and_tool_action_warning
 from ..models._openai_shared import get_default_openai_client
 from ..run_internal.items import normalize_input_items_for_api
+from ..usage import _response_usage_to_usage
 from .openai_conversations_session import OpenAIConversationsSession
 from .session import (
     OpenAIResponsesCompactionArgs,
@@ -19,6 +20,7 @@ from .session import (
 )
 
 if TYPE_CHECKING:
+    from ..run_context import RunContextWrapper
     from .session import Session
 
 logger = logging.getLogger("openai-agents.openai.compaction")
@@ -165,8 +167,17 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             return "input"
         return _resolve_compaction_mode(mode, response_id=response_id, store=store)
 
-    async def run_compaction(self, args: OpenAIResponsesCompactionArgs | None = None) -> None:
-        """Run compaction using responses.compact API."""
+    async def run_compaction(
+        self,
+        args: OpenAIResponsesCompactionArgs | None = None,
+        *,
+        wrapper: RunContextWrapper[Any] | None = None,
+    ) -> None:
+        """Run compaction using responses.compact API.
+
+        When a run context is provided, the billed compaction request contributes to
+        that run's usage totals.
+        """
         if args and args.get("response_id"):
             self._response_id = args["response_id"]
         requested_mode = args.get("compaction_mode") if args else None
@@ -225,6 +236,10 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
             compact_kwargs["input"] = session_items
 
         compacted = await self.client.responses.compact(**compact_kwargs)
+
+        compacted_usage = getattr(compacted, "usage", None)
+        if wrapper is not None and compacted_usage is not None:
+            wrapper.usage.add(_response_usage_to_usage(compacted_usage))
 
         output_items = _strip_orphaned_assistant_ids(
             _normalize_compaction_output_items(compacted.output or [])

--- a/src/agents/run_internal/session_persistence.py
+++ b/src/agents/run_internal/session_persistence.py
@@ -565,6 +565,7 @@ async def save_result_to_session(
     if session is None:
         return 0
 
+    compaction_wrapper = wrapper
     wrapper = _get_session_wrapper(session, wrapper)
 
     new_run_items: list[RunItem]
@@ -691,7 +692,7 @@ async def save_result_to_session(
         await _call_session_method(
             session.run_compaction,
             compaction_args,
-            wrapper=wrapper,
+            wrapper=compaction_wrapper,
         )
 
     return saved_run_items_count

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -8,6 +8,11 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai.types.responses.response_usage import (
+    InputTokensDetails,
+    OutputTokensDetails,
+    ResponseUsage,
+)
 
 import agents._debug as _debug
 from agents import Agent, Runner
@@ -1452,6 +1457,16 @@ class TestOpenAIResponsesCompactionSession:
         underlying = SimpleListSession()
         compacted = SimpleNamespace(
             output=[{"type": "compaction", "encrypted_content": "enc"}],
+            usage=ResponseUsage(
+                input_tokens=150_000,
+                input_tokens_details=InputTokensDetails(
+                    cached_tokens=50_000,
+                    cache_write_tokens=0,
+                ),
+                output_tokens=42_000,
+                output_tokens_details=OutputTokensDetails(reasoning_tokens=10_000),
+                total_tokens=192_000,
+            ),
         )
         mock_client = MagicMock()
         mock_client.responses.compact = AsyncMock(return_value=compacted)
@@ -1466,9 +1481,17 @@ class TestOpenAIResponsesCompactionSession:
         model = ScriptedModel(steps=[[get_text_message("ok")]])
         agent = Agent(name="assistant", model=model)
 
-        await Runner.run(agent, "hello", session=session)
+        result = await Runner.run(agent, "hello", session=session)
 
         mock_client.responses.compact.assert_awaited_once()
+        assert result.context_wrapper.usage.requests == 2
+        assert result.context_wrapper.usage.input_tokens == 150_000
+        assert result.context_wrapper.usage.output_tokens == 42_000
+        assert result.context_wrapper.usage.total_tokens == 192_000
+        assert result.context_wrapper.usage.input_tokens_details.cached_tokens == 50_000
+        assert result.context_wrapper.usage.output_tokens_details.reasoning_tokens == 10_000
+        assert len(result.context_wrapper.usage.request_usage_entries) == 1
+        assert result.context_wrapper.usage.request_usage_entries[0].total_tokens == 192_000
         items = await session.get_items()
         assert any(isinstance(item, dict) and item.get("type") == "compaction" for item in items)
 


### PR DESCRIPTION
This pull request supersedes #4435 and fixes run-wide usage accounting for OpenAI Responses compaction. Automatic compaction now passes the current run wrapper only to the compaction method, converts the official response usage through the existing Responses usage pipeline, and records one request with its token details in `result.context_wrapper.usage`.

Legacy session history calls remain unscoped, and the public compaction-aware session protocol stays unchanged.

Fixes #4434