### PR TITLE
fix(sandbox): canonicalize shell approval workdir

### DIFF
--- a/src/agents/sandbox/capabilities/tools/shell_tool.py
+++ b/src/agents/sandbox/capabilities/tools/shell_tool.py
@@ -7,11 +7,17 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from ....run_context import RunContextWrapper
 from ....tool import FunctionTool
-from ...errors import ExecTimeoutError, ExecTransportError, PtySessionNotFoundError
+from ....util._approvals import evaluate_needs_approval_setting
+from ...errors import (
+    ExecTimeoutError,
+    ExecTransportError,
+    InvalidManifestPathError,
+    PtySessionNotFoundError,
+)
 from ...session.base_sandbox_session import BaseSandboxSession
 from ...types import User
 from ...util.token_truncation import formatted_truncate_text_with_token_count
@@ -66,6 +72,23 @@ def _normalize_output(stdout: bytes, stderr: bytes) -> str:
     return decoded_stdout or decoded_stderr
 
 
+def _resolve_workdir(
+    *,
+    session: BaseSandboxSession,
+    workspace_scope: SandboxWorkspaceScope,
+    workdir: str | None,
+) -> str | None:
+    if workdir is None or workdir.strip() == "":
+        if workspace_scope.cwd is None:
+            return None
+        workdir = "."
+
+    resolved_workdir = session.normalize_path(
+        sandbox_path_str(workspace_scope.anchor(coerce_posix_path(workdir)))
+    )
+    return sandbox_path_str(resolved_workdir)
+
+
 def _resolve_workdir_command(
     *,
     session: BaseSandboxSession,
@@ -74,15 +97,14 @@ def _resolve_workdir_command(
     workdir: str | None,
 ) -> str:
     workspace_scope = workspace_scope or SandboxWorkspaceScope()
-    if workdir is None or workdir.strip() == "":
-        if workspace_scope.cwd is None:
-            return command
-        workdir = "."
-
-    resolved_workdir = session.normalize_path(
-        sandbox_path_str(workspace_scope.anchor(coerce_posix_path(workdir)))
+    resolved_workdir = _resolve_workdir(
+        session=session,
+        workspace_scope=workspace_scope,
+        workdir=workdir,
     )
-    return f"cd {shlex.quote(sandbox_path_str(resolved_workdir))} && {command}"
+    if resolved_workdir is None:
+        return command
+    return f"cd {shlex.quote(resolved_workdir)} && {command}"
 
 
 def _resolve_shell(shell: str | None, login: bool) -> bool | list[str]:
@@ -185,13 +207,44 @@ class ExecCommandTool(FunctionTool):
         self.session = session
         self.user = user
         self.workspace_scope = workspace_scope or SandboxWorkspaceScope()
+
+        runtime_needs_approval = needs_approval
+        if callable(needs_approval):
+            approval_setting = needs_approval
+            approval_session = self.session
+            approval_scope = self.workspace_scope
+
+            async def canonical_needs_approval(
+                ctx_wrapper: RunContextWrapper[Any],
+                tool_parameters: dict[str, Any],
+                call_id: str,
+            ) -> bool:
+                try:
+                    args = self.args_model.model_validate(tool_parameters)
+                    canonical_parameters = args.model_dump()
+                    canonical_parameters["workdir"] = _resolve_workdir(
+                        session=approval_session,
+                        workspace_scope=approval_scope,
+                        workdir=args.workdir,
+                    )
+                except (ValidationError, InvalidManifestPathError):
+                    return False
+                return await evaluate_needs_approval_setting(
+                    approval_setting,
+                    ctx_wrapper,
+                    canonical_parameters,
+                    call_id,
+                )
+
+            runtime_needs_approval = canonical_needs_approval
+
         super().__init__(
             name=self.tool_name,
             description=self.tool_description,
             params_json_schema=self.args_model.model_json_schema(),
             on_invoke_tool=self._invoke,
             strict_json_schema=False,
-            needs_approval=needs_approval,
+            needs_approval=runtime_needs_approval,
         )
 
     async def _invoke(self, _: object, raw_input: str) -> str:

--- a/src/agents/sandbox/capabilities/tools/view_image.py
+++ b/src/agents/sandbox/capabilities/tools/view_image.py
@@ -7,10 +7,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from ....run_context import RunContextWrapper
 from ....tool import FunctionTool, ToolOutputImage
+from ....util._approvals import evaluate_needs_approval_setting
 from ...errors import InvalidManifestPathError, WorkspaceReadNotFoundError
 from ...session.base_sandbox_session import BaseSandboxSession
 from ...types import User
@@ -72,6 +73,17 @@ class ViewImageArgs(BaseModel):
     )
 
 
+def _resolve_view_image_path(
+    *,
+    session: BaseSandboxSession,
+    workspace_scope: SandboxWorkspaceScope,
+    input_path: str,
+) -> tuple[object, Path]:
+    scoped_path = workspace_scope.anchor(coerce_posix_path(input_path))
+    resolved_path = session._workspace_path_policy().normalize_path(scoped_path)
+    return scoped_path, resolved_path
+
+
 @dataclass(init=False)
 class ViewImageTool(FunctionTool):
     tool_name: ClassVar[str] = "view_image"
@@ -102,13 +114,45 @@ class ViewImageTool(FunctionTool):
         self.session = session
         self.user = user
         self.workspace_scope = workspace_scope or SandboxWorkspaceScope()
+
+        runtime_needs_approval = needs_approval
+        if callable(needs_approval):
+            approval_setting = needs_approval
+            approval_session = self.session
+            approval_scope = self.workspace_scope
+
+            async def canonical_needs_approval(
+                ctx_wrapper: RunContextWrapper[Any],
+                tool_parameters: dict[str, Any],
+                call_id: str,
+            ) -> bool:
+                try:
+                    args = self.args_model.model_validate(tool_parameters)
+                    _, resolved_path = _resolve_view_image_path(
+                        session=approval_session,
+                        workspace_scope=approval_scope,
+                        input_path=args.path,
+                    )
+                except (ValidationError, InvalidManifestPathError):
+                    return False
+                canonical_parameters = args.model_dump()
+                canonical_parameters["path"] = sandbox_path_str(resolved_path)
+                return await evaluate_needs_approval_setting(
+                    approval_setting,
+                    ctx_wrapper,
+                    canonical_parameters,
+                    call_id,
+                )
+
+            runtime_needs_approval = canonical_needs_approval
+
         super().__init__(
             name=self.tool_name,
             description=self.tool_description,
             params_json_schema=self.args_model.model_json_schema(),
             on_invoke_tool=self._invoke,
             strict_json_schema=False,
-            needs_approval=needs_approval,
+            needs_approval=runtime_needs_approval,
         )
 
     async def _invoke(self, _: object, raw_input: str) -> ToolOutputImage | str:
@@ -116,9 +160,12 @@ class ViewImageTool(FunctionTool):
 
     async def run(self, args: ViewImageArgs) -> ToolOutputImage | str:
         input_path = args.path
-        scoped_path = self.workspace_scope.anchor(coerce_posix_path(input_path))
+        scoped_path, resolved_path = _resolve_view_image_path(
+            session=self.session,
+            workspace_scope=self.workspace_scope,
+            input_path=input_path,
+        )
         path_policy = self.session._workspace_path_policy()
-        resolved_path = path_policy.normalize_path(scoped_path)
         try:
             workspace_relative_path = path_policy.relative_path(scoped_path)
             display_path = self.workspace_scope.display_path(

--- a/src/agents/sandbox/capabilities/tools/view_image.py
+++ b/src/agents/sandbox/capabilities/tools/view_image.py
@@ -7,11 +7,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 
 from ....run_context import RunContextWrapper
 from ....tool import FunctionTool, ToolOutputImage
-from ....util._approvals import evaluate_needs_approval_setting
 from ...errors import InvalidManifestPathError, WorkspaceReadNotFoundError
 from ...session.base_sandbox_session import BaseSandboxSession
 from ...types import User
@@ -73,17 +72,6 @@ class ViewImageArgs(BaseModel):
     )
 
 
-def _resolve_view_image_path(
-    *,
-    session: BaseSandboxSession,
-    workspace_scope: SandboxWorkspaceScope,
-    input_path: str,
-) -> tuple[Any, Path]:
-    scoped_path = workspace_scope.anchor(coerce_posix_path(input_path))
-    resolved_path = session._workspace_path_policy().normalize_path(scoped_path)
-    return scoped_path, resolved_path
-
-
 @dataclass(init=False)
 class ViewImageTool(FunctionTool):
     tool_name: ClassVar[str] = "view_image"
@@ -114,45 +102,13 @@ class ViewImageTool(FunctionTool):
         self.session = session
         self.user = user
         self.workspace_scope = workspace_scope or SandboxWorkspaceScope()
-
-        runtime_needs_approval = needs_approval
-        if callable(needs_approval):
-            approval_setting = needs_approval
-            approval_session = self.session
-            approval_scope = self.workspace_scope
-
-            async def canonical_needs_approval(
-                ctx_wrapper: RunContextWrapper[Any],
-                tool_parameters: dict[str, Any],
-                call_id: str,
-            ) -> bool:
-                try:
-                    args = self.args_model.model_validate(tool_parameters)
-                    _, resolved_path = _resolve_view_image_path(
-                        session=approval_session,
-                        workspace_scope=approval_scope,
-                        input_path=args.path,
-                    )
-                except (ValidationError, InvalidManifestPathError):
-                    return False
-                canonical_parameters = args.model_dump()
-                canonical_parameters["path"] = sandbox_path_str(resolved_path)
-                return await evaluate_needs_approval_setting(
-                    approval_setting,
-                    ctx_wrapper,
-                    canonical_parameters,
-                    call_id,
-                )
-
-            runtime_needs_approval = canonical_needs_approval
-
         super().__init__(
             name=self.tool_name,
             description=self.tool_description,
             params_json_schema=self.args_model.model_json_schema(),
             on_invoke_tool=self._invoke,
             strict_json_schema=False,
-            needs_approval=runtime_needs_approval,
+            needs_approval=needs_approval,
         )
 
     async def _invoke(self, _: object, raw_input: str) -> ToolOutputImage | str:
@@ -160,12 +116,9 @@ class ViewImageTool(FunctionTool):
 
     async def run(self, args: ViewImageArgs) -> ToolOutputImage | str:
         input_path = args.path
-        scoped_path, resolved_path = _resolve_view_image_path(
-            session=self.session,
-            workspace_scope=self.workspace_scope,
-            input_path=input_path,
-        )
+        scoped_path = self.workspace_scope.anchor(coerce_posix_path(input_path))
         path_policy = self.session._workspace_path_policy()
+        resolved_path = path_policy.normalize_path(scoped_path)
         try:
             workspace_relative_path = path_policy.relative_path(scoped_path)
             display_path = self.workspace_scope.display_path(

--- a/src/agents/sandbox/capabilities/tools/view_image.py
+++ b/src/agents/sandbox/capabilities/tools/view_image.py
@@ -78,7 +78,7 @@ def _resolve_view_image_path(
     session: BaseSandboxSession,
     workspace_scope: SandboxWorkspaceScope,
     input_path: str,
-) -> tuple[object, Path]:
+) -> tuple[Any, Path]:
     scoped_path = workspace_scope.anchor(coerce_posix_path(input_path))
     resolved_path = session._workspace_path_policy().normalize_path(scoped_path)
     return scoped_path, resolved_path

--- a/tests/sandbox/test_tool_approval_paths.py
+++ b/tests/sandbox/test_tool_approval_paths.py
@@ -6,7 +6,6 @@ import pytest
 
 from agents.run_context import RunContextWrapper
 from agents.sandbox import Manifest
-from agents.sandbox.capabilities.tools import ViewImageTool
 from agents.sandbox.capabilities.tools.shell_tool import ExecCommandTool
 from agents.sandbox.workspace_paths import SandboxWorkspaceScope
 from agents.testing import scripted_sandbox_session
@@ -60,30 +59,3 @@ async def test_exec_command_approval_receives_run_cwd_when_workdir_is_omitted() 
 
     assert not await approval(RunContextWrapper(context=None), {"cmd": "pwd"}, "call-2")
     assert seen["workdir"] == "/workspace/tasks/task-a"
-
-
-@pytest.mark.asyncio
-async def test_view_image_approval_receives_effective_path() -> None:
-    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
-    seen: dict[str, Any] = {}
-
-    async def needs_approval(
-        _ctx: RunContextWrapper[Any], parameters: dict[str, Any], _call_id: str
-    ) -> bool:
-        seen.update(parameters)
-        return False
-
-    tool = ViewImageTool(
-        session=session,
-        needs_approval=needs_approval,
-        workspace_scope=SandboxWorkspaceScope.from_cwd("tasks/task-a"),
-    )
-    approval = tool.needs_approval
-    assert callable(approval)
-
-    assert not await approval(
-        RunContextWrapper(context=None),
-        {"path": r"images\plot.png"},
-        "call-3",
-    )
-    assert seen["path"] == "/workspace/tasks/task-a/images/plot.png"

--- a/tests/sandbox/test_tool_approval_paths.py
+++ b/tests/sandbox/test_tool_approval_paths.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agents.run_context import RunContextWrapper
+from agents.sandbox import Manifest
+from agents.sandbox.capabilities.tools import ViewImageTool
+from agents.sandbox.capabilities.tools.shell_tool import ExecCommandTool
+from agents.sandbox.workspace_paths import SandboxWorkspaceScope
+from agents.testing import scripted_sandbox_session
+
+
+@pytest.mark.asyncio
+async def test_exec_command_approval_receives_effective_workdir() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    seen: dict[str, Any] = {}
+
+    async def needs_approval(
+        _ctx: RunContextWrapper[Any], parameters: dict[str, Any], _call_id: str
+    ) -> bool:
+        seen.update(parameters)
+        return False
+
+    tool = ExecCommandTool(
+        session=session,
+        needs_approval=needs_approval,
+        workspace_scope=SandboxWorkspaceScope.from_cwd("tasks/task-a"),
+    )
+    approval = tool.needs_approval
+    assert callable(approval)
+
+    assert not await approval(
+        RunContextWrapper(context=None),
+        {"cmd": "pwd", "workdir": r"nested\project"},
+        "call-1",
+    )
+    assert seen["workdir"] == "/workspace/tasks/task-a/nested/project"
+
+
+@pytest.mark.asyncio
+async def test_exec_command_approval_receives_run_cwd_when_workdir_is_omitted() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    seen: dict[str, Any] = {}
+
+    async def needs_approval(
+        _ctx: RunContextWrapper[Any], parameters: dict[str, Any], _call_id: str
+    ) -> bool:
+        seen.update(parameters)
+        return False
+
+    tool = ExecCommandTool(
+        session=session,
+        needs_approval=needs_approval,
+        workspace_scope=SandboxWorkspaceScope.from_cwd("tasks/task-a"),
+    )
+    approval = tool.needs_approval
+    assert callable(approval)
+
+    assert not await approval(RunContextWrapper(context=None), {"cmd": "pwd"}, "call-2")
+    assert seen["workdir"] == "/workspace/tasks/task-a"
+
+
+@pytest.mark.asyncio
+async def test_view_image_approval_receives_effective_path() -> None:
+    session = scripted_sandbox_session(manifest=Manifest(root="/workspace"))
+    seen: dict[str, Any] = {}
+
+    async def needs_approval(
+        _ctx: RunContextWrapper[Any], parameters: dict[str, Any], _call_id: str
+    ) -> bool:
+        seen.update(parameters)
+        return False
+
+    tool = ViewImageTool(
+        session=session,
+        needs_approval=needs_approval,
+        workspace_scope=SandboxWorkspaceScope.from_cwd("tasks/task-a"),
+    )
+    approval = tool.needs_approval
+    assert callable(approval)
+
+    assert not await approval(
+        RunContextWrapper(context=None),
+        {"path": r"images\plot.png"},
+        "call-3",
+    )
+    assert seen["path"] == "/workspace/tasks/task-a/images/plot.png"


### PR DESCRIPTION
### Summary

Make `exec_command` path-sensitive approval callbacks inspect the same effective working directory that execution uses.

The tool previously exposed the raw model-provided `workdir` to `needs_approval`, even though execution normalizes separators and anchors relative paths beneath the run-scoped sandbox cwd. When `workdir` was omitted, the approval callback saw `None` while execution could still run inside a configured cwd.

This change resolves the effective workdir before invoking callable approval policies. Approval receives the normalized absolute sandbox workdir, including the run cwd when the model omits `workdir`. Boolean approval settings are unchanged. Invalid inputs continue into the normal tool path rather than invoking a path-sensitive approval callback with a misleading representation.

### Test plan

Added focused regression coverage for:

- shell approval with backslash-separated model input under a run-scoped cwd
- shell approval when `workdir` is omitted under a run-scoped cwd

Repository CI is used for full verification because this environment has GitHub connector access but no materialized dependency checkout.

### Issue number

None. Found while auditing sandbox authorization consistency after run-scoped cwd support landed.