### PR TITLE
fix(sandbox): validate raster view_image content

### DIFF
--- a/src/agents/sandbox/capabilities/tools/view_image.py
+++ b/src/agents/sandbox/capabilities/tools/view_image.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import mimetypes
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -38,10 +37,6 @@ def _detect_image_mime_type(path: Path, payload: bytes) -> str | None:
     snippet = payload[:_SVG_SNIFF_BYTES].lstrip().lower()
     if snippet.startswith(b"<svg") or (snippet.startswith(b"<?xml") and b"<svg" in snippet):
         return "image/svg+xml"
-
-    guessed_type, _ = mimetypes.guess_type(path.name)
-    if isinstance(guessed_type, str) and guessed_type.startswith("image/"):
-        return guessed_type
     return None
 
 

--- a/src/agents/sandbox/capabilities/tools/view_image.py
+++ b/src/agents/sandbox/capabilities/tools/view_image.py
@@ -16,7 +16,6 @@ from ...workspace_paths import SandboxWorkspaceScope, coerce_posix_path, sandbox
 
 _MAX_IMAGE_BYTES = 10 * 1024 * 1024
 _MAX_IMAGE_SIZE_LABEL = "10MB"
-_SVG_SNIFF_BYTES = 2048
 
 
 def _consume_svg_prolog_construct(snippet: str) -> str | None:
@@ -49,7 +48,7 @@ def _consume_svg_prolog_construct(snippet: str) -> str | None:
 
 
 def _looks_like_svg(payload: bytes) -> bool:
-    snippet = payload[:_SVG_SNIFF_BYTES].decode("utf-8-sig", errors="ignore").lstrip()
+    snippet = payload.decode("utf-8-sig", errors="ignore").lstrip()
     while snippet:
         lowered = snippet.lower()
         if lowered.startswith("<svg"):

--- a/src/agents/sandbox/capabilities/tools/view_image.py
+++ b/src/agents/sandbox/capabilities/tools/view_image.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import base64
+import mimetypes
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, ClassVar
 
 from pydantic import BaseModel, Field
@@ -16,69 +18,10 @@ from ...workspace_paths import SandboxWorkspaceScope, coerce_posix_path, sandbox
 
 _MAX_IMAGE_BYTES = 10 * 1024 * 1024
 _MAX_IMAGE_SIZE_LABEL = "10MB"
+_SVG_SNIFF_BYTES = 2048
 
 
-def _consume_svg_prolog_construct(snippet: str) -> str | None:
-    lowered = snippet.lower()
-    if snippet.startswith("<!--"):
-        end = snippet.find("-->")
-        return None if end < 0 else snippet[end + 3 :]
-    if snippet.startswith("<?"):
-        end = snippet.find("?>")
-        return None if end < 0 else snippet[end + 2 :]
-    if not lowered.startswith("<!doctype"):
-        return None
-
-    quote: str | None = None
-    subset_depth = 0
-    for index, character in enumerate(snippet[len("<!doctype") :], start=len("<!doctype")):
-        if quote is not None:
-            if character == quote:
-                quote = None
-            continue
-        if character in {'"', "'"}:
-            quote = character
-        elif character == "[":
-            subset_depth += 1
-        elif character == "]" and subset_depth > 0:
-            subset_depth -= 1
-        elif character == ">" and subset_depth == 0:
-            return snippet[index + 1 :]
-    return None
-
-
-def _decode_svg_text(payload: bytes) -> str | None:
-    if payload.startswith((b"\xff\xfe", b"\xfe\xff")):
-        encoding = "utf-16"
-    elif payload.startswith(b"<\x00"):
-        encoding = "utf-16-le"
-    elif payload.startswith(b"\x00<"):
-        encoding = "utf-16-be"
-    else:
-        encoding = "utf-8-sig"
-    try:
-        return payload.decode(encoding)
-    except UnicodeDecodeError:
-        return None
-
-
-def _looks_like_svg(payload: bytes) -> bool:
-    decoded = _decode_svg_text(payload)
-    if decoded is None:
-        return False
-    snippet = decoded.lstrip()
-    while snippet:
-        lowered = snippet.lower()
-        if lowered.startswith("<svg"):
-            return len(snippet) == 4 or snippet[4].isspace() or snippet[4] in "/>"
-        remainder = _consume_svg_prolog_construct(snippet)
-        if remainder is None:
-            return False
-        snippet = remainder.lstrip()
-    return False
-
-
-def _detect_image_mime_type(payload: bytes) -> str | None:
+def _detect_image_mime_type(path: Path, payload: bytes) -> str | None:
     if payload.startswith(b"\x89PNG\r\n\x1a\n"):
         return "image/png"
     if payload.startswith(b"\xff\xd8\xff"):
@@ -91,8 +34,14 @@ def _detect_image_mime_type(payload: bytes) -> str | None:
         return "image/bmp"
     if payload.startswith((b"II*\x00", b"MM\x00*")):
         return "image/tiff"
-    if _looks_like_svg(payload):
+
+    snippet = payload[:_SVG_SNIFF_BYTES].lstrip().lower()
+    if snippet.startswith(b"<svg") or (snippet.startswith(b"<?xml") and b"<svg" in snippet):
         return "image/svg+xml"
+
+    guessed_type, _ = mimetypes.guess_type(path.name)
+    if guessed_type == "image/svg+xml":
+        return guessed_type
     return None
 
 
@@ -204,7 +153,7 @@ class ViewImageTool(FunctionTool):
                 f"{_MAX_IMAGE_SIZE_LABEL}; resize or compress the image and try again"
             )
 
-        mime_type = _detect_image_mime_type(payload)
+        mime_type = _detect_image_mime_type(resolved_path, payload)
         if mime_type is None:
             return f"image path `{display_path}` is not a supported image file"
 

--- a/src/agents/sandbox/capabilities/tools/view_image.py
+++ b/src/agents/sandbox/capabilities/tools/view_image.py
@@ -47,8 +47,26 @@ def _consume_svg_prolog_construct(snippet: str) -> str | None:
     return None
 
 
+def _decode_svg_text(payload: bytes) -> str | None:
+    if payload.startswith((b"\xff\xfe", b"\xfe\xff")):
+        encoding = "utf-16"
+    elif payload.startswith(b"<\x00"):
+        encoding = "utf-16-le"
+    elif payload.startswith(b"\x00<"):
+        encoding = "utf-16-be"
+    else:
+        encoding = "utf-8-sig"
+    try:
+        return payload.decode(encoding)
+    except UnicodeDecodeError:
+        return None
+
+
 def _looks_like_svg(payload: bytes) -> bool:
-    snippet = payload.decode("utf-8-sig", errors="ignore").lstrip()
+    decoded = _decode_svg_text(payload)
+    if decoded is None:
+        return False
+    snippet = decoded.lstrip()
     while snippet:
         lowered = snippet.lower()
         if lowered.startswith("<svg"):

--- a/src/agents/sandbox/capabilities/tools/view_image.py
+++ b/src/agents/sandbox/capabilities/tools/view_image.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, ClassVar
 
 from pydantic import BaseModel, Field
@@ -20,7 +19,49 @@ _MAX_IMAGE_SIZE_LABEL = "10MB"
 _SVG_SNIFF_BYTES = 2048
 
 
-def _detect_image_mime_type(path: Path, payload: bytes) -> str | None:
+def _consume_svg_prolog_construct(snippet: str) -> str | None:
+    lowered = snippet.lower()
+    if snippet.startswith("<!--"):
+        end = snippet.find("-->")
+        return None if end < 0 else snippet[end + 3 :]
+    if snippet.startswith("<?"):
+        end = snippet.find("?>")
+        return None if end < 0 else snippet[end + 2 :]
+    if not lowered.startswith("<!doctype"):
+        return None
+
+    quote: str | None = None
+    subset_depth = 0
+    for index, character in enumerate(snippet[len("<!doctype") :], start=len("<!doctype")):
+        if quote is not None:
+            if character == quote:
+                quote = None
+            continue
+        if character in {'"', "'"}:
+            quote = character
+        elif character == "[":
+            subset_depth += 1
+        elif character == "]" and subset_depth > 0:
+            subset_depth -= 1
+        elif character == ">" and subset_depth == 0:
+            return snippet[index + 1 :]
+    return None
+
+
+def _looks_like_svg(payload: bytes) -> bool:
+    snippet = payload[:_SVG_SNIFF_BYTES].decode("utf-8-sig", errors="ignore").lstrip()
+    while snippet:
+        lowered = snippet.lower()
+        if lowered.startswith("<svg"):
+            return len(snippet) == 4 or snippet[4].isspace() or snippet[4] in "/>"
+        remainder = _consume_svg_prolog_construct(snippet)
+        if remainder is None:
+            return False
+        snippet = remainder.lstrip()
+    return False
+
+
+def _detect_image_mime_type(payload: bytes) -> str | None:
     if payload.startswith(b"\x89PNG\r\n\x1a\n"):
         return "image/png"
     if payload.startswith(b"\xff\xd8\xff"):
@@ -33,9 +74,7 @@ def _detect_image_mime_type(path: Path, payload: bytes) -> str | None:
         return "image/bmp"
     if payload.startswith((b"II*\x00", b"MM\x00*")):
         return "image/tiff"
-
-    snippet = payload[:_SVG_SNIFF_BYTES].lstrip().lower()
-    if snippet.startswith(b"<svg") or (snippet.startswith(b"<?xml") and b"<svg" in snippet):
+    if _looks_like_svg(payload):
         return "image/svg+xml"
     return None
 
@@ -148,7 +187,7 @@ class ViewImageTool(FunctionTool):
                 f"{_MAX_IMAGE_SIZE_LABEL}; resize or compress the image and try again"
             )
 
-        mime_type = _detect_image_mime_type(resolved_path, payload)
+        mime_type = _detect_image_mime_type(payload)
         if mime_type is None:
             return f"image path `{display_path}` is not a supported image file"
 

--- a/tests/sandbox/test_view_image_content_validation.py
+++ b/tests/sandbox/test_view_image_content_validation.py
@@ -12,6 +12,7 @@ from agents.tool import ToolOutputImage
 _PNG_BYTES = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a84QAAAAASUVORK5CYII="
 )
+_SVG_BODY = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
 
 
 @pytest.mark.asyncio
@@ -38,4 +39,27 @@ async def test_view_image_accepts_image_signature_without_image_extension() -> N
 
     assert isinstance(output, ToolOutputImage)
     assert output.image_url.startswith("data:image/png;base64,")
+    session.assert_complete()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "svg_payload",
+    [
+        b"\xef\xbb\xbf" + _SVG_BODY,
+        b"<!-- generated -->\n" + _SVG_BODY,
+        b'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "svg11.dtd">\n' + _SVG_BODY,
+    ],
+    ids=["utf8-bom", "comment", "doctype"],
+)
+async def test_view_image_accepts_svg_prolog_forms(svg_payload: bytes) -> None:
+    session = scripted_sandbox_session(
+        [{"method": "read", "result": io.BytesIO(svg_payload)}]
+    )
+    tool = ViewImageTool(session=session)
+
+    output = await tool.run(ViewImageArgs(path="images/vector.svg"))
+
+    assert isinstance(output, ToolOutputImage)
+    assert output.image_url.startswith("data:image/svg+xml;base64,")
     session.assert_complete()

--- a/tests/sandbox/test_view_image_content_validation.py
+++ b/tests/sandbox/test_view_image_content_validation.py
@@ -49,8 +49,9 @@ async def test_view_image_accepts_image_signature_without_image_extension() -> N
         b"\xef\xbb\xbf" + _SVG_BODY,
         b"<!-- generated -->\n" + _SVG_BODY,
         b'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "svg11.dtd">\n' + _SVG_BODY,
+        b"<!--" + (b"x" * 4096) + b"-->\n" + _SVG_BODY,
     ],
-    ids=["utf8-bom", "comment", "doctype"],
+    ids=["utf8-bom", "comment", "doctype", "long-comment"],
 )
 async def test_view_image_accepts_svg_prolog_forms(svg_payload: bytes) -> None:
     session = scripted_sandbox_session(

--- a/tests/sandbox/test_view_image_content_validation.py
+++ b/tests/sandbox/test_view_image_content_validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import gzip
 import io
 
 import pytest
@@ -17,7 +18,7 @@ _SVG_BODY = _SVG_TEXT.encode()
 
 
 @pytest.mark.asyncio
-async def test_view_image_rejects_non_image_bytes_with_image_extension() -> None:
+async def test_view_image_rejects_non_image_bytes_with_raster_extension() -> None:
     session = scripted_sandbox_session(
         [{"method": "read", "result": io.BytesIO(b"not an image\n")}]
     )
@@ -30,7 +31,7 @@ async def test_view_image_rejects_non_image_bytes_with_image_extension() -> None
 
 
 @pytest.mark.asyncio
-async def test_view_image_accepts_image_signature_without_image_extension() -> None:
+async def test_view_image_accepts_raster_signature_without_image_extension() -> None:
     session = scripted_sandbox_session(
         [{"method": "read", "result": io.BytesIO(_PNG_BYTES)}]
     )
@@ -50,19 +51,32 @@ async def test_view_image_accepts_image_signature_without_image_extension() -> N
         b"\xef\xbb\xbf" + _SVG_BODY,
         b"<!-- generated -->\n" + _SVG_BODY,
         b'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "svg11.dtd">\n' + _SVG_BODY,
-        b"<!--" + (b"x" * 4096) + b"-->\n" + _SVG_BODY,
         _SVG_TEXT.encode("utf-16"),
-        b"\xfe\xff" + _SVG_TEXT.encode("utf-16-be"),
     ],
-    ids=["utf8-bom", "comment", "doctype", "long-comment", "utf16-le", "utf16-be"],
+    ids=["utf8-bom", "comment", "doctype", "utf16"],
 )
-async def test_view_image_accepts_svg_prolog_forms(svg_payload: bytes) -> None:
+async def test_view_image_preserves_svg_filename_compatibility(svg_payload: bytes) -> None:
     session = scripted_sandbox_session(
         [{"method": "read", "result": io.BytesIO(svg_payload)}]
     )
     tool = ViewImageTool(session=session)
 
     output = await tool.run(ViewImageArgs(path="images/vector.svg"))
+
+    assert isinstance(output, ToolOutputImage)
+    assert output.image_url.startswith("data:image/svg+xml;base64,")
+    session.assert_complete()
+
+
+@pytest.mark.asyncio
+async def test_view_image_preserves_svgz_filename_compatibility() -> None:
+    svgz_payload = gzip.compress(_SVG_BODY)
+    session = scripted_sandbox_session(
+        [{"method": "read", "result": io.BytesIO(svgz_payload)}]
+    )
+    tool = ViewImageTool(session=session)
+
+    output = await tool.run(ViewImageArgs(path="images/vector.svgz"))
 
     assert isinstance(output, ToolOutputImage)
     assert output.image_url.startswith("data:image/svg+xml;base64,")

--- a/tests/sandbox/test_view_image_content_validation.py
+++ b/tests/sandbox/test_view_image_content_validation.py
@@ -12,7 +12,8 @@ from agents.tool import ToolOutputImage
 _PNG_BYTES = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a84QAAAAASUVORK5CYII="
 )
-_SVG_BODY = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+_SVG_TEXT = '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+_SVG_BODY = _SVG_TEXT.encode()
 
 
 @pytest.mark.asyncio
@@ -50,8 +51,10 @@ async def test_view_image_accepts_image_signature_without_image_extension() -> N
         b"<!-- generated -->\n" + _SVG_BODY,
         b'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "svg11.dtd">\n' + _SVG_BODY,
         b"<!--" + (b"x" * 4096) + b"-->\n" + _SVG_BODY,
+        _SVG_TEXT.encode("utf-16"),
+        b"\xfe\xff" + _SVG_TEXT.encode("utf-16-be"),
     ],
-    ids=["utf8-bom", "comment", "doctype", "long-comment"],
+    ids=["utf8-bom", "comment", "doctype", "long-comment", "utf16-le", "utf16-be"],
 )
 async def test_view_image_accepts_svg_prolog_forms(svg_payload: bytes) -> None:
     session = scripted_sandbox_session(

--- a/tests/sandbox/test_view_image_content_validation.py
+++ b/tests/sandbox/test_view_image_content_validation.py
@@ -32,14 +32,13 @@ async def test_view_image_rejects_non_image_bytes_with_raster_extension() -> Non
 
 @pytest.mark.asyncio
 async def test_view_image_accepts_raster_signature_without_image_extension() -> None:
-    session = scripted_sandbox_session(
-        [{"method": "read", "result": io.BytesIO(_PNG_BYTES)}]
-    )
+    session = scripted_sandbox_session([{"method": "read", "result": io.BytesIO(_PNG_BYTES)}])
     tool = ViewImageTool(session=session)
 
     output = await tool.run(ViewImageArgs(path="images/payload.bin"))
 
     assert isinstance(output, ToolOutputImage)
+    assert output.image_url is not None
     assert output.image_url.startswith("data:image/png;base64,")
     session.assert_complete()
 
@@ -56,14 +55,13 @@ async def test_view_image_accepts_raster_signature_without_image_extension() -> 
     ids=["utf8-bom", "comment", "doctype", "utf16"],
 )
 async def test_view_image_preserves_svg_filename_compatibility(svg_payload: bytes) -> None:
-    session = scripted_sandbox_session(
-        [{"method": "read", "result": io.BytesIO(svg_payload)}]
-    )
+    session = scripted_sandbox_session([{"method": "read", "result": io.BytesIO(svg_payload)}])
     tool = ViewImageTool(session=session)
 
     output = await tool.run(ViewImageArgs(path="images/vector.svg"))
 
     assert isinstance(output, ToolOutputImage)
+    assert output.image_url is not None
     assert output.image_url.startswith("data:image/svg+xml;base64,")
     session.assert_complete()
 
@@ -71,13 +69,12 @@ async def test_view_image_preserves_svg_filename_compatibility(svg_payload: byte
 @pytest.mark.asyncio
 async def test_view_image_preserves_svgz_filename_compatibility() -> None:
     svgz_payload = gzip.compress(_SVG_BODY)
-    session = scripted_sandbox_session(
-        [{"method": "read", "result": io.BytesIO(svgz_payload)}]
-    )
+    session = scripted_sandbox_session([{"method": "read", "result": io.BytesIO(svgz_payload)}])
     tool = ViewImageTool(session=session)
 
     output = await tool.run(ViewImageArgs(path="images/vector.svgz"))
 
     assert isinstance(output, ToolOutputImage)
+    assert output.image_url is not None
     assert output.image_url.startswith("data:image/svg+xml;base64,")
     session.assert_complete()

--- a/tests/sandbox/test_view_image_content_validation.py
+++ b/tests/sandbox/test_view_image_content_validation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+
+from agents.sandbox.capabilities.tools import ViewImageArgs, ViewImageTool
+from agents.testing import scripted_sandbox_session
+from agents.tool import ToolOutputImage
+
+_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a84QAAAAASUVORK5CYII="
+)
+
+
+@pytest.mark.asyncio
+async def test_view_image_rejects_non_image_bytes_with_image_extension() -> None:
+    session = scripted_sandbox_session(
+        [{"method": "read", "result": io.BytesIO(b"not an image\n")}]
+    )
+    tool = ViewImageTool(session=session)
+
+    output = await tool.run(ViewImageArgs(path="images/fake.png"))
+
+    assert output == "image path `images/fake.png` is not a supported image file"
+    session.assert_complete()
+
+
+@pytest.mark.asyncio
+async def test_view_image_accepts_image_signature_without_image_extension() -> None:
+    session = scripted_sandbox_session(
+        [{"method": "read", "result": io.BytesIO(_PNG_BYTES)}]
+    )
+    tool = ViewImageTool(session=session)
+
+    output = await tool.run(ViewImageArgs(path="images/payload.bin"))
+
+    assert isinstance(output, ToolOutputImage)
+    assert output.image_url.startswith("data:image/png;base64,")
+    session.assert_complete()


### PR DESCRIPTION
### Summary

Require `view_image` to identify signature-bearing raster image formats from the bytes it reads instead of trusting a raster-looking filename.

The previous detector checked known image signatures first, then accepted any filename whose MIME type began with `image/`. That meant arbitrary bytes stored as `report.png`, `photo.jpg`, or another raster image extension could be returned as structured image data.

This change narrows the filename fallback to SVG only. PNG, JPEG, GIF, WebP, BMP, and TIFF require their existing byte signatures. SVG and SVGZ retain the established filename fallback because SVG has no single binary magic value and SVGZ is compressed, so removing filename inference entirely would break valid BOM/prolog/alternate-encoding and compressed SVG inputs that were already supported.

### Test plan

Added regression coverage showing that:

- non-image bytes named `fake.png` are rejected
- valid PNG bytes named `payload.bin` are accepted as PNG
- SVG inputs beginning with a UTF-8 BOM, comment, or `DOCTYPE` remain accepted
- UTF-16 SVG remains accepted
- compressed SVGZ remains accepted

Repository CI is used for full verification because this environment has GitHub connector access but no materialized dependency checkout.

### Issue number

None. Found during a sandbox content-validation audit.