### PR TITLE
feat(sandbox): allow Docker sandboxes to disable networking

### DIFF
--- a/src/agents/run_state.py
+++ b/src/agents/run_state.py
@@ -209,7 +209,10 @@ SCHEMA_VERSION_SUMMARIES: dict[str, str] = {
         "Persists canonical tool invocation identity plus sanitized mount authority and trusted "
         "rebind metadata, durable pending input, and resumable next-model-call state."
     ),
-    "1.16": "Lets an exact call approval decision override a sticky decision for the same tool.",
+    "1.16": (
+        "Persists Docker network-isolation state and lets an exact call approval decision "
+        "override a sticky decision for the same tool."
+    ),
 }
 SUPPORTED_SCHEMA_VERSIONS = frozenset(SCHEMA_VERSION_SUMMARIES)
 

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -173,6 +173,7 @@ class DockerSandboxSessionState(SandboxSessionState):
     type: Literal["docker"] = "docker"
     image: str
     container_id: str
+    network_mode: Literal["none"] | None = None
 
     def _sanitize_persisted_provider_identity(
         self,
@@ -193,18 +194,21 @@ class DockerSandboxClientOptions(BaseSandboxClientOptions):
     type: Literal["docker"] = "docker"
     image: str
     exposed_ports: tuple[int, ...] = ()
+    network_mode: Literal["none"] | None = None
 
     def __init__(
         self,
         image: str,
         exposed_ports: tuple[int, ...] = (),
         *,
+        network_mode: Literal["none"] | None = None,
         type: Literal["docker"] = "docker",
     ) -> None:
         super().__init__(
             type=type,
             image=image,
             exposed_ports=exposed_ports,
+            network_mode=network_mode,
         )
 
 
@@ -1502,6 +1506,7 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
                 image,
                 manifest=manifest,
                 exposed_ports=options.exposed_ports,
+                network_mode=options.network_mode,
                 session_id=session_id,
             )
             container.start()
@@ -1516,6 +1521,7 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
                 snapshot=snapshot_instance,
                 container_id=container_id,
                 exposed_ports=options.exposed_ports,
+                network_mode=options.network_mode,
             )
             inner = DockerSandboxSession(
                 docker_client=self.docker_client,
@@ -1642,6 +1648,7 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
                     state.image,
                     manifest=state.manifest,
                     exposed_ports=state.exposed_ports,
+                    network_mode=state.network_mode,
                     session_id=replacement_session_id,
                 )
                 container_id = container.id
@@ -1675,6 +1682,7 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
         *,
         manifest: Manifest | None = None,
         exposed_ports: tuple[int, ...] = (),
+        network_mode: Literal["none"] | None = None,
         session_id: uuid.UUID | None = None,
     ) -> Container:
         if manifest is not None:
@@ -1695,6 +1703,8 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
             "command": ["-f", "/dev/null"],
             "environment": environment,
         }
+        if network_mode is not None:
+            create_kwargs["network_mode"] = network_mode
         if manifest is not None:
             docker_mounts = _build_docker_volume_mounts(manifest, session_id=session_id)
             if docker_mounts:

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Final, Literal, Self, cast
+from typing import Any, Final, Literal, cast
 
 import docker.errors  # type: ignore[import-untyped]
 import docker.utils.socket as docker_socket  # type: ignore[import-untyped]
@@ -26,6 +26,7 @@ from docker.models.containers import Container  # type: ignore[import-untyped]
 from docker.types import DriverConfig, Mount as DockerSDKMount  # type: ignore[import-untyped]
 from docker.utils import parse_repository_tag
 from pydantic import model_validator
+from typing_extensions import Self
 
 from .._mount_security import (
     _manifest_has_configured_mount_authority,
@@ -1648,6 +1649,10 @@ class DockerSandboxClient(BaseSandboxClient[DockerSandboxClientOptions]):
         reused_existing_container = container is not None
         if container is not None:
             _assert_existing_container_path_grants_match(container, state.manifest)
+            _assert_existing_container_network_configuration_matches(
+                container,
+                state.network_mode,
+            )
         owns_replacement = container is None
         replacement_session_id = (
             uuid.uuid4()
@@ -1866,6 +1871,28 @@ def _validate_docker_path_grants(manifest: Manifest) -> None:
             raise ValueError(
                 f"Docker sandbox path grant target conflicts with a manifest mount: {grant.path}"
             )
+
+
+def _assert_existing_container_network_configuration_matches(
+    container: Container,
+    network_mode: Literal["none"] | None,
+) -> None:
+    if network_mode is None:
+        return
+
+    container.reload()
+    attrs = getattr(container, "attrs", {}) or {}
+    host_config = attrs.get("HostConfig")
+    network_settings = attrs.get("NetworkSettings")
+    actual_network_mode = host_config.get("NetworkMode") if isinstance(host_config, dict) else None
+    networks = network_settings.get("Networks") if isinstance(network_settings, dict) else None
+    attached_networks = set(networks) if isinstance(networks, dict) else None
+
+    if actual_network_mode != "none" or attached_networks is None or attached_networks - {"none"}:
+        raise ValueError(
+            "Existing Docker sandbox network configuration does not match persisted "
+            "network_mode='none'; create a fresh sandbox session"
+        )
 
 
 def _assert_existing_container_path_grants_match(

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -201,8 +201,8 @@ class DockerSandboxClientOptions(BaseSandboxClientOptions):
         image: str,
         exposed_ports: tuple[int, ...] = (),
         *,
-        network_mode: Literal["none"] | None = None,
         type: Literal["docker"] = "docker",
+        network_mode: Literal["none"] | None = None,
     ) -> None:
         super().__init__(
             type=type,

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Final, Literal, cast
+from typing import Any, Final, Literal, Self, cast
 
 import docker.errors  # type: ignore[import-untyped]
 import docker.utils.socket as docker_socket  # type: ignore[import-untyped]
@@ -25,6 +25,7 @@ from docker.api.container import DEFAULT_DATA_CHUNK_SIZE  # type: ignore[import-
 from docker.models.containers import Container  # type: ignore[import-untyped]
 from docker.types import DriverConfig, Mount as DockerSDKMount  # type: ignore[import-untyped]
 from docker.utils import parse_repository_tag
+from pydantic import model_validator
 
 from .._mount_security import (
     _manifest_has_configured_mount_authority,
@@ -169,11 +170,28 @@ _PREPARE_USER_PTY_PID_SCRIPT = (
 )
 
 
+def _validate_docker_network_configuration(
+    *,
+    network_mode: Literal["none"] | None,
+    exposed_ports: tuple[int, ...],
+) -> None:
+    if network_mode == "none" and exposed_ports:
+        raise ValueError("exposed_ports cannot be used when network_mode='none'")
+
+
 class DockerSandboxSessionState(SandboxSessionState):
     type: Literal["docker"] = "docker"
     image: str
     container_id: str
     network_mode: Literal["none"] | None = None
+
+    @model_validator(mode="after")
+    def _validate_network_configuration(self) -> Self:
+        _validate_docker_network_configuration(
+            network_mode=self.network_mode,
+            exposed_ports=self.exposed_ports,
+        )
+        return self
 
     def _sanitize_persisted_provider_identity(
         self,
@@ -195,6 +213,14 @@ class DockerSandboxClientOptions(BaseSandboxClientOptions):
     image: str
     exposed_ports: tuple[int, ...] = ()
     network_mode: Literal["none"] | None = None
+
+    @model_validator(mode="after")
+    def _validate_network_configuration(self) -> Self:
+        _validate_docker_network_configuration(
+            network_mode=self.network_mode,
+            exposed_ports=self.exposed_ports,
+        )
+        return self
 
     def __init__(
         self,

--- a/tests/sandbox/test_compatibility_guards.py
+++ b/tests/sandbox/test_compatibility_guards.py
@@ -416,7 +416,7 @@ def test_optional_sandbox_dataclass_constructor_field_order_is_stable(
         (
             "agents.sandbox.sandboxes.docker",
             "DockerSandboxClientOptions",
-            ("image", "exposed_ports"),
+            ("image", "exposed_ports", "network_mode"),
         ),
         (
             "agents.extensions.sandbox.e2b",
@@ -573,6 +573,7 @@ def test_optional_sandbox_client_options_positional_field_order_is_stable(
                 "workspace_root_ready",
                 "image",
                 "container_id",
+                "network_mode",
             ),
         ),
         (

--- a/tests/sandbox/test_docker.py
+++ b/tests/sandbox/test_docker.py
@@ -2809,9 +2809,11 @@ async def test_docker_resume_applies_current_authority_with_fresh_volume_identit
         *,
         manifest: Manifest | None = None,
         exposed_ports: tuple[int, ...] = (),
+        network_mode: str | None = None,
         session_id: uuid.UUID | None = None,
     ) -> _StartedContainer:
         _ = (image, exposed_ports)
+        assert network_mode is None
         assert session_id == replacement_session_id
         assert stale_volume.remove_calls == 0
         assert manifest is state.manifest
@@ -4139,17 +4141,18 @@ async def test_docker_resume_resets_workspace_readiness_when_container_is_recrea
         docker_client=cast(object, _ResumeDockerClient(docker.errors.NotFound("missing")))
     )
     replacement = _ResumeContainer(status="created", container_id="replacement")
-    create_calls: list[tuple[str, Manifest | None, tuple[int, ...]]] = []
+    create_calls: list[tuple[str, Manifest | None, tuple[int, ...], str | None]] = []
 
     async def _fake_create_container(
         image: str,
         *,
         manifest: Manifest | None = None,
         exposed_ports: tuple[int, ...] = (),
+        network_mode: str | None = None,
         session_id: uuid.UUID | None = None,
     ) -> object:
         _ = session_id
-        create_calls.append((image, manifest, exposed_ports))
+        create_calls.append((image, manifest, exposed_ports, network_mode))
         return replacement
 
     monkeypatch.setattr(client, "_create_container", _fake_create_container)
@@ -4171,7 +4174,7 @@ async def test_docker_resume_resets_workspace_readiness_when_container_is_recrea
     assert inner.state.workspace_root_ready is False
     assert inner._workspace_root_ready is False
     assert inner.should_provision_manifest_accounts_on_resume() is True
-    assert create_calls == [(DEFAULT_PYTHON_SANDBOX_IMAGE, inner.state.manifest, (8765,))]
+    assert create_calls == [(DEFAULT_PYTHON_SANDBOX_IMAGE, inner.state.manifest, (8765,), None)]
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_docker_network_mode.py
+++ b/tests/sandbox/test_docker_network_mode.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import docker.errors  # type: ignore[import-untyped]
+import pytest
+
+from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE
+from agents.sandbox.manifest import Manifest
+from agents.sandbox.sandboxes.docker import (
+    DockerSandboxClient,
+    DockerSandboxClientOptions,
+    DockerSandboxSession,
+    DockerSandboxSessionState,
+)
+from agents.sandbox.session import BaseSandboxClientOptions
+from agents.sandbox.snapshot import NoopSnapshot
+
+
+class _Images:
+    def get(self, image: str) -> object:
+        _ = image
+        return object()
+
+    def pull(self, *args: object, **kwargs: object) -> None:
+        raise AssertionError(f"unexpected image pull: {args!r} {kwargs!r}")
+
+
+class _Container:
+    id = "replacement-container"
+    status = "created"
+    attrs: dict[str, object] = {"Mounts": []}
+
+    def reload(self) -> None:
+        return None
+
+    def start(self) -> None:
+        self.status = "running"
+
+
+class _Containers:
+    def __init__(self) -> None:
+        self.created = _Container()
+        self.create_calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs: object) -> _Container:
+        self.create_calls.append(dict(kwargs))
+        return self.created
+
+    def get(self, container_id: str) -> _Container:
+        _ = container_id
+        raise docker.errors.NotFound("container not found")
+
+
+class _DockerClient:
+    def __init__(self) -> None:
+        self.images = _Images()
+        self.containers = _Containers()
+
+
+def _client() -> tuple[DockerSandboxClient, _DockerClient]:
+    docker_client = _DockerClient()
+    client = DockerSandboxClient(docker_client=cast(object, docker_client))
+    return client, docker_client
+
+
+def _state(*, network_mode: str | None = None) -> DockerSandboxSessionState:
+    payload: dict[str, object] = {
+        "manifest": Manifest(),
+        "snapshot": NoopSnapshot(id="snapshot"),
+        "image": DEFAULT_PYTHON_SANDBOX_IMAGE,
+        "container_id": "missing-container",
+    }
+    if network_mode is not None:
+        payload["network_mode"] = network_mode
+    return DockerSandboxSessionState.model_validate(payload)
+
+
+def test_docker_options_accept_network_mode_none() -> None:
+    options = DockerSandboxClientOptions(
+        image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+        network_mode="none",
+    )
+
+    assert options.network_mode == "none"
+
+
+def test_docker_options_reject_other_network_modes() -> None:
+    with pytest.raises(ValueError):
+        DockerSandboxClientOptions(
+            image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+            network_mode=cast(Any, "bridge"),
+        )
+
+
+def test_docker_options_network_mode_round_trip() -> None:
+    options = DockerSandboxClientOptions(
+        image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+        network_mode="none",
+    )
+
+    restored = BaseSandboxClientOptions.parse(options.model_dump(mode="json"))
+
+    assert restored == options
+    assert isinstance(restored, DockerSandboxClientOptions)
+    assert restored.network_mode == "none"
+
+
+def test_docker_options_omitted_network_mode_preserves_default_behavior() -> None:
+    restored = BaseSandboxClientOptions.parse(
+        {
+            "type": "docker",
+            "image": DEFAULT_PYTHON_SANDBOX_IMAGE,
+        }
+    )
+
+    assert isinstance(restored, DockerSandboxClientOptions)
+    assert restored.network_mode is None
+
+
+@pytest.mark.asyncio
+async def test_docker_client_create_applies_and_persists_network_mode_none() -> None:
+    client, docker_client = _client()
+
+    session = await client.create(
+        options=DockerSandboxClientOptions(
+            image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+            network_mode="none",
+        )
+    )
+
+    assert docker_client.containers.create_calls[0]["network_mode"] == "none"
+    assert isinstance(session._inner, DockerSandboxSession)
+    assert session._inner.state.network_mode == "none"
+
+
+@pytest.mark.asyncio
+async def test_docker_create_container_passes_network_mode_none() -> None:
+    client, docker_client = _client()
+
+    container = await client._create_container(
+        DEFAULT_PYTHON_SANDBOX_IMAGE,
+        network_mode="none",
+    )
+
+    assert container is docker_client.containers.created
+    assert docker_client.containers.create_calls == [
+        {
+            "entrypoint": ["tail"],
+            "image": DEFAULT_PYTHON_SANDBOX_IMAGE,
+            "detach": True,
+            "command": ["-f", "/dev/null"],
+            "environment": None,
+            "network_mode": "none",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_docker_create_container_omits_network_mode_by_default() -> None:
+    client, docker_client = _client()
+
+    await client._create_container(DEFAULT_PYTHON_SANDBOX_IMAGE)
+
+    assert "network_mode" not in docker_client.containers.create_calls[0]
+
+
+def test_docker_session_state_network_mode_round_trip() -> None:
+    client, _ = _client()
+    state = _state(network_mode="none")
+
+    restored = client.deserialize_session_state(state.model_dump(mode="json"))
+
+    assert isinstance(restored, DockerSandboxSessionState)
+    assert restored.network_mode == "none"
+
+
+def test_docker_session_state_without_network_mode_preserves_old_payloads() -> None:
+    client, _ = _client()
+    payload = _state().model_dump(mode="json")
+    payload.pop("network_mode", None)
+
+    restored = client.deserialize_session_state(payload)
+
+    assert isinstance(restored, DockerSandboxSessionState)
+    assert restored.network_mode is None
+
+
+@pytest.mark.asyncio
+async def test_docker_resume_reapplies_network_mode_to_replacement_container() -> None:
+    client, docker_client = _client()
+    state = _state(network_mode="none")
+
+    await client.resume(state)
+
+    assert docker_client.containers.create_calls[0]["network_mode"] == "none"
+    assert state.container_id == "replacement-container"

--- a/tests/sandbox/test_docker_network_mode.py
+++ b/tests/sandbox/test_docker_network_mode.py
@@ -58,6 +58,11 @@ class _DockerClient:
         self.containers = _Containers()
 
 
+class _NoDockerProviderAccess:
+    def __getattr__(self, name: str) -> object:
+        raise AssertionError(f"unexpected Docker provider access: {name}")
+
+
 def _client() -> tuple[DockerSandboxClient, _DockerClient]:
     docker_client = _DockerClient()
     client = DockerSandboxClient(docker_client=cast(object, docker_client))
@@ -173,6 +178,15 @@ def test_docker_session_state_network_mode_round_trip() -> None:
 
     assert isinstance(restored, DockerSandboxSessionState)
     assert restored.network_mode == "none"
+
+
+def test_docker_session_state_rejects_invalid_network_mode_before_provider_access() -> None:
+    client = DockerSandboxClient(docker_client=cast(object, _NoDockerProviderAccess()))
+    payload = _state().model_dump(mode="json")
+    payload["network_mode"] = "bridge"
+
+    with pytest.raises(ValueError):
+        client.deserialize_session_state(payload)
 
 
 def test_docker_session_state_without_network_mode_preserves_old_payloads() -> None:

--- a/tests/sandbox/test_docker_network_mode.py
+++ b/tests/sandbox/test_docker_network_mode.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import ast
+from pathlib import Path
 from typing import Any, cast
 
 import docker.errors  # type: ignore[import-untyped]
 import pytest
 
+from agents import Agent
+from agents.run_context import RunContextWrapper
+from agents.run_state import RunState
 from agents.sandbox.config import DEFAULT_PYTHON_SANDBOX_IMAGE
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.sandboxes.docker import (
@@ -38,9 +43,17 @@ class _Container:
         self.status = "running"
 
 
+class _ExistingContainer(_Container):
+    def __init__(self, attrs: dict[str, object]) -> None:
+        self.id = "existing-container"
+        self.status = "running"
+        self.attrs = attrs
+
+
 class _Containers:
-    def __init__(self) -> None:
+    def __init__(self, existing: _Container | None = None) -> None:
         self.created = _Container()
+        self.existing = existing
         self.create_calls: list[dict[str, object]] = []
 
     def create(self, **kwargs: object) -> _Container:
@@ -49,13 +62,15 @@ class _Containers:
 
     def get(self, container_id: str) -> _Container:
         _ = container_id
+        if self.existing is not None:
+            return self.existing
         raise docker.errors.NotFound("container not found")
 
 
 class _DockerClient:
-    def __init__(self) -> None:
+    def __init__(self, existing: _Container | None = None) -> None:
         self.images = _Images()
-        self.containers = _Containers()
+        self.containers = _Containers(existing)
 
 
 class _NoDockerProviderAccess:
@@ -63,8 +78,10 @@ class _NoDockerProviderAccess:
         raise AssertionError(f"unexpected Docker provider access: {name}")
 
 
-def _client() -> tuple[DockerSandboxClient, _DockerClient]:
-    docker_client = _DockerClient()
+def _client(
+    existing: _Container | None = None,
+) -> tuple[DockerSandboxClient, _DockerClient]:
+    docker_client = _DockerClient(existing)
     client = DockerSandboxClient(docker_client=cast(object, docker_client))
     return client, docker_client
 
@@ -79,6 +96,28 @@ def _state(*, network_mode: str | None = None) -> DockerSandboxSessionState:
     if network_mode is not None:
         payload["network_mode"] = network_mode
     return DockerSandboxSessionState.model_validate(payload)
+
+
+def test_docker_module_imports_self_from_typing_extensions() -> None:
+    module_path = (
+        Path(__file__).parents[2] / "src" / "agents" / "sandbox" / "sandboxes" / "docker.py"
+    )
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    typing_names = {
+        alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module == "typing"
+        for alias in node.names
+    }
+    typing_extensions_names = {
+        alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module == "typing_extensions"
+        for alias in node.names
+    }
+
+    assert "Self" not in typing_names
+    assert "Self" in typing_extensions_names
 
 
 def test_docker_options_accept_network_mode_none() -> None:
@@ -227,3 +266,82 @@ async def test_docker_resume_reapplies_network_mode_to_replacement_container() -
 
     assert docker_client.containers.create_calls[0]["network_mode"] == "none"
     assert state.container_id == "replacement-container"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "attrs",
+    [
+        {
+            "Mounts": [],
+            "HostConfig": {"NetworkMode": "bridge"},
+            "NetworkSettings": {"Networks": {"bridge": {}}},
+        },
+        {
+            "Mounts": [],
+            "HostConfig": {"NetworkMode": "none"},
+            "NetworkSettings": {"Networks": {"bridge": {}}},
+        },
+        {
+            "Mounts": [],
+            "HostConfig": {"NetworkMode": "none"},
+            "NetworkSettings": {},
+        },
+    ],
+    ids=["wrong-host-network-mode", "attached-after-create", "missing-network-map"],
+)
+async def test_docker_resume_rejects_reused_container_that_is_not_network_isolated(
+    attrs: dict[str, object],
+) -> None:
+    existing = _ExistingContainer(attrs)
+    client, docker_client = _client(existing)
+    state = _state(network_mode="none")
+    state.container_id = existing.id
+
+    with pytest.raises(ValueError, match="network"):
+        await client.resume(state)
+
+    assert docker_client.containers.create_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("networks", [{}, {"none": {}}], ids=["empty", "none-network"])
+async def test_docker_resume_reuses_container_that_is_network_isolated(
+    networks: dict[str, object],
+) -> None:
+    existing = _ExistingContainer(
+        {
+            "Mounts": [],
+            "HostConfig": {"NetworkMode": "none"},
+            "NetworkSettings": {"Networks": networks},
+        }
+    )
+    client, docker_client = _client(existing)
+    state = _state(network_mode="none")
+    state.container_id = existing.id
+
+    await client.resume(state)
+
+    assert docker_client.containers.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_state_round_trip_preserves_docker_network_mode() -> None:
+    agent = Agent(name="sandbox")
+    run_state = RunState(
+        context=RunContextWrapper(context={}),
+        original_input="resume sandbox",
+        starting_agent=agent,
+    )
+    run_state._sandbox = {
+        "backend_id": "docker",
+        "current_agent_name": agent.name,
+        "session_state": _state(network_mode="none").model_dump(mode="json"),
+    }
+
+    restored = await RunState.from_json(agent, run_state.to_json())
+
+    assert restored._sandbox is not None
+    restored_session_state = restored._sandbox["session_state"]
+    assert isinstance(restored_session_state, dict)
+    assert restored_session_state["network_mode"] == "none"

--- a/tests/sandbox/test_docker_network_mode.py
+++ b/tests/sandbox/test_docker_network_mode.py
@@ -98,6 +98,15 @@ def test_docker_options_reject_other_network_modes() -> None:
         )
 
 
+def test_docker_options_reject_exposed_ports_with_network_mode_none() -> None:
+    with pytest.raises(ValueError, match="exposed_ports"):
+        DockerSandboxClientOptions(
+            image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+            exposed_ports=(8080,),
+            network_mode="none",
+        )
+
+
 def test_docker_options_network_mode_round_trip() -> None:
     options = DockerSandboxClientOptions(
         image=DEFAULT_PYTHON_SANDBOX_IMAGE,
@@ -184,6 +193,15 @@ def test_docker_session_state_rejects_invalid_network_mode_before_provider_acces
     client = DockerSandboxClient(docker_client=cast(object, _NoDockerProviderAccess()))
     payload = _state().model_dump(mode="json")
     payload["network_mode"] = "bridge"
+
+    with pytest.raises(ValueError):
+        client.deserialize_session_state(payload)
+
+
+def test_docker_state_rejects_no_network_exposed_ports_before_provider_access() -> None:
+    client = DockerSandboxClient(docker_client=cast(object, _NoDockerProviderAccess()))
+    payload = _state(network_mode="none").model_dump(mode="json")
+    payload["exposed_ports"] = [8080]
 
     with pytest.raises(ValueError):
         client.deserialize_session_state(payload)


### PR DESCRIPTION
### Summary

This pull request adds an opt-in way to create Docker sandboxes with networking completely disabled.

`DockerSandboxClientOptions` now accepts:

```python
DockerSandboxClientOptions(
    image="python:3.14-slim",
    network_mode="none",
)
```

The new option is deliberately narrow:

```python
network_mode: Literal["none"] | None = None
```

When omitted, Docker container creation remains unchanged and no `network_mode` argument is passed.

When set to `"none"`, the value is forwarded to `docker_client.containers.create()`, causing Docker to create the sandbox without networking.

The setting is also persisted in `DockerSandboxSessionState` and reapplied when `DockerSandboxClient.resume()` needs to recreate a missing container. This prevents a sandbox originally created without networking from silently regaining Docker's default network configuration after recreation.

Older serialized session states remain compatible because the new field defaults to `None`.

The public option intentionally does not expose arbitrary Docker networking modes such as `host`, `bridge`, or `container:<id>`.

### Test plan

Added regression coverage for:

- accepting `network_mode="none"`
- rejecting unsupported network modes
- propagating `"none"` through the public `DockerSandboxClient.create()` path
- passing `network_mode="none"` to Docker container creation
- preserving the existing Docker create kwargs when the option is omitted
- `DockerSandboxClientOptions` serialization and parsing
- `DockerSandboxSessionState` serialization
- backwards compatibility with serialized states that do not contain `network_mode`
- reapplying `network_mode="none"` when `resume()` recreates a missing container
- compatibility guards for the extended public options/state fields

Focused sandbox tests passed:

```text
86 passed
```

Full repository verification was run with:

```bash
env UV_DEFAULT_INDEX=https://pypi.org/simple \
  bash .agents/skills/code-change-verification/scripts/run.sh
```

All verification steps passed, including:

- formatting
- lint
- type checking
- full test suite

### Issue number

Closes #4451

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR (not applicable; this change was not prepared with Codex)