### PR TITLE
feat(sandbox): add Modal sandbox resource options

### DIFF
--- a/src/agents/extensions/sandbox/modal/sandbox.py
+++ b/src/agents/extensions/sandbox/modal/sandbox.py
@@ -296,6 +296,8 @@ class ModalSandboxClientOptions(BaseSandboxClientOptions):
     use_sleep_cmd: bool = True
     image_builder_version: str | None = _DEFAULT_IMAGE_BUILDER_VERSION
     idle_timeout: int | None = None
+    cpu: float | tuple[float, float] | None = None
+    memory: int | tuple[int, int] | None = None
 
     def __init__(
         self,
@@ -311,6 +313,8 @@ class ModalSandboxClientOptions(BaseSandboxClientOptions):
         image_builder_version: str | None = _DEFAULT_IMAGE_BUILDER_VERSION,
         idle_timeout: int | None = None,
         *,
+        cpu: float | tuple[float, float] | None = None,
+        memory: int | tuple[int, int] | None = None,
         type: Literal["modal"] = "modal",
     ) -> None:
         super().__init__(
@@ -326,6 +330,8 @@ class ModalSandboxClientOptions(BaseSandboxClientOptions):
             use_sleep_cmd=use_sleep_cmd,
             image_builder_version=image_builder_version,
             idle_timeout=idle_timeout,
+            cpu=cpu,
+            memory=memory,
         )
 
 
@@ -460,6 +466,8 @@ class ModalSandboxSessionState(SandboxSessionState):
     use_sleep_cmd: bool = True
     image_builder_version: str | None = _DEFAULT_IMAGE_BUILDER_VERSION
     idle_timeout: int | None = None
+    cpu: float | tuple[float, float] | None = None
+    memory: int | tuple[int, int] | None = None
 
     def _sanitize_persisted_provider_identity(
         self,
@@ -730,6 +738,8 @@ class ModalSandboxSession(BaseSandboxSession):
             encrypted_ports=self.state.exposed_ports,
             volumes=volumes,
             gpu=self.state.gpu,
+            cpu=self.state.cpu,
+            memory=self.state.memory,
             timeout=self.state.timeout,
             idle_timeout=self.state.idle_timeout,
         )
@@ -1835,6 +1845,8 @@ class ModalSandboxSession(BaseSandboxSession):
                 encrypted_ports=self.state.exposed_ports,
                 volumes=self._modal_cloud_bucket_mounts_for_manifest(),
                 gpu=self.state.gpu,
+                cpu=self.state.cpu,
+                memory=self.state.memory,
                 timeout=self.state.timeout,
                 idle_timeout=self.state.idle_timeout,
             )
@@ -2090,6 +2102,8 @@ class ModalSandboxClient(BaseSandboxClient[ModalSandboxClientOptions]):
           (async timeout for snapshot restore call)
         - timeout: int (maximum sandbox lifetime in seconds, default 300)
         - idle_timeout: int | None (maximum sandbox inactivity in seconds, default None)
+        - cpu: float | tuple[float, float] | None (CPU request or request/limit pair)
+        - memory: int | tuple[int, int] | None (memory request or request/limit pair in MiB)
         - image_builder_version: str | None (Modal image builder version, default "2025.06")
         """
 
@@ -2213,6 +2227,8 @@ class ModalSandboxClient(BaseSandboxClient[ModalSandboxClientOptions]):
             use_sleep_cmd=options.use_sleep_cmd,
             image_builder_version=image_builder_version,
             idle_timeout=options.idle_timeout,
+            cpu=options.cpu,
+            memory=options.memory,
         )
         if sandbox_create_timeout_s is not None:
             state.sandbox_create_timeout_s = float(sandbox_create_timeout_s)

--- a/tests/extensions/sandbox/test_modal.py
+++ b/tests/extensions/sandbox/test_modal.py
@@ -503,6 +503,38 @@ async def test_modal_sandbox_create_passes_idle_timeout(
     assert session.state.idle_timeout == 60
 
 
+@pytest.mark.parametrize(
+    ("cpu", "memory"),
+    [
+        (1.0, 2048),
+        ((1.0, 4.0), (2048, 8192)),
+    ],
+    ids=["requests", "requests-and-limits"],
+)
+@pytest.mark.asyncio
+async def test_modal_sandbox_create_passes_resources(
+    monkeypatch: pytest.MonkeyPatch,
+    cpu: float | tuple[float, float],
+    memory: int | tuple[int, int],
+) -> None:
+    modal_module, create_calls, _registry_tags = _load_modal_module(monkeypatch)
+
+    client = modal_module.ModalSandboxClient()
+    session = await client.create(
+        options=modal_module.ModalSandboxClientOptions(
+            app_name="sandbox-tests",
+            cpu=cpu,
+            memory=memory,
+        ),
+    )
+
+    assert create_calls
+    assert create_calls[0]["cpu"] == cpu
+    assert create_calls[0]["memory"] == memory
+    assert session.state.cpu == cpu
+    assert session.state.memory == memory
+
+
 @pytest.mark.asyncio
 async def test_modal_sandbox_create_sets_default_cmd_for_custom_registry_image(
     monkeypatch: pytest.MonkeyPatch,
@@ -623,6 +655,30 @@ def test_modal_deserialize_session_state_defaults_missing_idle_timeout(
     )
 
     assert restored.idle_timeout is None
+
+
+def test_modal_deserialize_session_state_defaults_missing_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    modal_module, _create_calls, _registry_tags = _load_modal_module(monkeypatch)
+
+    state = modal_module.ModalSandboxSessionState(
+        manifest=Manifest(root="/workspace"),
+        snapshot=modal_module.resolve_snapshot(None, "snapshot"),
+        app_name="sandbox-tests",
+        cpu=(1.0, 4.0),
+        memory=(2048, 8192),
+    )
+    payload = state.model_dump(mode="json")
+    payload.pop("cpu")
+    payload.pop("memory")
+
+    restored = modal_module.ModalSandboxClient().deserialize_session_state(
+        cast(dict[str, object], payload)
+    )
+
+    assert restored.cpu is None
+    assert restored.memory is None
 
 
 @pytest.mark.asyncio
@@ -3444,6 +3500,8 @@ async def test_modal_snapshot_filesystem_restore_preserves_exposed_ports(
         workspace_persistence="snapshot_filesystem",
         exposed_ports=(8765,),
         idle_timeout=60,
+        cpu=(1.0, 4.0),
+        memory=(2048, 8192),
     )
     session = modal_module.ModalSandboxSession.from_state(state)
     call_names: list[str] = []
@@ -3470,6 +3528,8 @@ async def test_modal_snapshot_filesystem_restore_preserves_exposed_ports(
     assert create_calls
     assert create_calls[0]["encrypted_ports"] == (8765,)
     assert create_calls[0]["idle_timeout"] == 60
+    assert create_calls[0]["cpu"] == (1.0, 4.0)
+    assert create_calls[0]["memory"] == (2048, 8192)
     assert sys.modules["modal"].Image.from_id_calls == ["snap-123"]
     assert call_names == []
     assert call_timeouts == []

--- a/tests/sandbox/test_client_options.py
+++ b/tests/sandbox/test_client_options.py
@@ -58,6 +58,8 @@ def test_sandbox_client_options_exclude_unset_preserves_type_discriminator() -> 
         "use_sleep_cmd": True,
         "image_builder_version": "2025.06",
         "idle_timeout": None,
+        "cpu": None,
+        "memory": None,
     }
 
 

--- a/tests/sandbox/test_compatibility_guards.py
+++ b/tests/sandbox/test_compatibility_guards.py
@@ -453,6 +453,8 @@ def test_optional_sandbox_dataclass_constructor_field_order_is_stable(
                 "use_sleep_cmd",
                 "image_builder_version",
                 "idle_timeout",
+                "cpu",
+                "memory",
             ),
         ),
         (
@@ -628,6 +630,8 @@ def test_optional_sandbox_client_options_positional_field_order_is_stable(
                 "use_sleep_cmd",
                 "image_builder_version",
                 "idle_timeout",
+                "cpu",
+                "memory",
             ),
         ),
         (


### PR DESCRIPTION
### Summary

This pull request adds optional `cpu` and `memory` settings to `ModalSandboxClientOptions`, matching Modal's scalar request and request-and-limit tuple forms. The settings are persisted in Modal session state and forwarded through fresh and snapshot-restored sandbox creation, while omitted values continue to use Modal's defaults.

### Test plan

- `UV_CACHE_DIR=/tmp/openai-agents-uv-cache uv run pytest tests/test_released_api_contract.py tests/extensions/sandbox/test_modal.py tests/sandbox/test_client_options.py tests/sandbox/test_compatibility_guards.py`
- `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR