### PR TITLE
fix(realtime): end session iteration when the server closes normally

### DIFF
--- a/src/agents/realtime/openai_realtime.py
+++ b/src/agents/realtime/openai_realtime.py
@@ -126,6 +126,7 @@ from .model_events import (
     RealtimeModelAudioEvent,
     RealtimeModelAudioInterruptedEvent,
     RealtimeModelCachedTokensDetails,
+    RealtimeModelConnectionStatusEvent,
     RealtimeModelErrorEvent,
     RealtimeModelEvent,
     RealtimeModelExceptionEvent,
@@ -746,8 +747,13 @@ class OpenAIRealtimeWebSocketModel(RealtimeModel):
                     )
 
         except websockets.exceptions.ConnectionClosedOK:
-            # Normal connection closure - no exception event needed
+            # A normal closure is not an error, so no exception event is emitted. Consumers still
+            # have to learn the transport ended, otherwise nothing further can ever reach
+            # `RealtimeSession.__aiter__` and it waits forever. `close()` clears `_websocket`
+            # before cancelling this task, so this only reports a server-initiated close.
             logger.debug("WebSocket connection closed normally")
+            if self._websocket is not None:
+                await self._emit_event(RealtimeModelConnectionStatusEvent(status="disconnected"))
         except websockets.exceptions.ConnectionClosed as e:
             await self._emit_event(
                 RealtimeModelExceptionEvent(

--- a/src/agents/realtime/session.py
+++ b/src/agents/realtime/session.py
@@ -227,6 +227,7 @@ class RealtimeSession(RealtimeModelListener):
         self._event_iterator_waiters = 0
         self._closing = False
         self._closed = False
+        self._transport_disconnected = False
         self._cleanup_task: asyncio.Task[None] | None = None
         self._stored_exception: BaseException | None = None
         self._pending_tool_calls: dict[str, _PendingToolCall] = {}
@@ -310,7 +311,7 @@ class RealtimeSession(RealtimeModelListener):
     async def __aiter__(self) -> AsyncIterator[RealtimeSessionEvent]:
         """Iterate over events from the session."""
         while True:
-            if self._closed and self._event_queue.empty():
+            if (self._closed or self._transport_disconnected) and self._event_queue.empty():
                 return
 
             # Check if there's a stored exception to raise
@@ -575,7 +576,12 @@ class RealtimeSession(RealtimeModelListener):
                 RealtimeHistoryUpdated(info=self._event_info, history=self._history)
             )
         elif event.type == "connection_status":
-            pass
+            if event.status == "disconnected":
+                # The transport is gone, so no further model events can arrive. End iteration
+                # instead of leaving `__aiter__` parked on a queue nothing can fill. Closing the
+                # session stays the caller's job, so `close()` still releases everything.
+                self._transport_disconnected = True
+                self._wake_event_iterators()
         elif event.type == "turn_started":
             is_late_start_for_active_response = (
                 event.response_id is not None

--- a/tests/realtime/test_openai_realtime.py
+++ b/tests/realtime/test_openai_realtime.py
@@ -3612,3 +3612,55 @@ class TestTransportIntegration:
         # Both should have completed successfully
         assert "fast" in connection_durations
         assert "slow" in connection_durations
+
+
+def _closing_websocket(closer: BaseException) -> AsyncMock:
+    """A websocket whose server hangs up as soon as the session is established."""
+    websocket = AsyncMock()
+    websocket.send = AsyncMock()
+    websocket.close = AsyncMock()
+
+    async def messages() -> Any:
+        await asyncio.sleep(0)
+        raise closer
+        yield  # pragma: no cover - never reached, keeps this an async generator
+
+    websocket.__aiter__ = lambda _self=None: messages()
+    return websocket
+
+
+@pytest.mark.asyncio
+async def test_normal_server_close_ends_session_iteration() -> None:
+    """A server that closes the socket normally must end iteration, not park it forever.
+
+    A normal closure is not an error, so no exception event is emitted for it. Without a
+    disconnect signal nothing further can reach the session queue, and `async for event in
+    session` waits on an event that can never arrive.
+    """
+    from agents.realtime import RealtimeAgent, RealtimeSession
+
+    websocket = _closing_websocket(websockets.exceptions.ConnectionClosedOK(None, None))
+
+    async def connect_websocket(*_args: Any, **_kwargs: Any) -> AsyncMock:
+        return websocket
+
+    with patch("websockets.connect", side_effect=connect_websocket):
+        session = RealtimeSession(
+            OpenAIRealtimeWebSocketModel(),
+            RealtimeAgent(name="agent"),
+            None,
+            model_config={
+                "api_key": "test-api-key",
+                "initial_model_settings": {"model_name": "gpt-4o-realtime-preview"},
+            },
+        )
+        await session.__aenter__()
+
+        async def consume() -> list[str]:
+            return [event.type async for event in session]
+
+        # Fails as a timeout rather than hanging the suite if the disconnect is ever dropped.
+        seen = await asyncio.wait_for(consume(), timeout=5)
+
+    assert "history_updated" in seen
+    await session.close()


### PR DESCRIPTION
### Summary

When the Realtime server closes the websocket normally, the application hangs with no error.

`_listen_for_messages` reports every other exit. An abnormal close emits a `RealtimeModelExceptionEvent`, which the session stores and raises out of `__aiter__`. A normal close only logs (`openai_realtime.py:749`):

```python
except websockets.exceptions.ConnectionClosedOK:
    # Normal connection closure - no exception event needed
    logger.debug("WebSocket connection closed normally")
```

Nothing else puts to `RealtimeSession._event_queue`, and `__aiter__` is parked on `await self._event_queue.get()`. The only thing that wakes it is `_wake_event_iterators()`, reachable only from `close()`. So after a clean server-side close, `async for event in session` waits on an event that can never arrive.

Reproduced on `main` with a websocket that hangs up right after the session is established, once per closure type:

```
CLEAN   (ConnectionClosedOK):    consumer STILL WAITING after 1.5s, events=['history_updated']
UNCLEAN (ConnectionClosedError): consumer raised ConnectionClosedError
```

Same server, same session, and the well-behaved shutdown is the one that hangs. A realtime server closing cleanly on an idle timeout, a session ending, or a deploy drain is ordinary, so this is not limited to network faults.

**The fix keeps a normal closure a normal closure.** No exception is invented for it, which is what the existing comment is right about. Instead the model emits `RealtimeModelConnectionStatusEvent(status="disconnected")`, an event type that is already defined and exported but never emitted, and the session ends iteration when it sees one. `close()` clears `_websocket` before cancelling the listener task, so this only reports a server-initiated close, not our own teardown.

Closing the session stays the caller's job. The session records that the transport is gone and lets `__aiter__` drain whatever is already queued and then return, rather than marking itself closed, so a later `await session.close()` still releases the model and background tasks normally.

Worth a maintainer opinion, since it picks semantics on a previously unused public event: I read `RealtimeModelConnectionStatusEvent` as the intended signal here, and `session.py` already had a `connection_status` branch waiting with `pass`. If you would rather the session auto-close, surface a distinct session-level event, or emit `connecting`/`connected` too, say so and I will redo it that way.

### Test plan

- `test_normal_server_close_ends_session_iteration` drives a real `RealtimeSession` over a patched `websockets.connect` whose server raises `ConnectionClosedOK`, and asserts iteration finishes. Against `main` it fails with `TimeoutError`; the `asyncio.wait_for` is there so a regression fails in five seconds instead of hanging CI.
- `uv run pytest tests/realtime/`: 504 passed. The abnormal-close path is unchanged and still raises.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck and the full test run all pass.
- CI here needs a maintainer to approve the workflow for a fork PR, so the above is the local run.

### Issue number

N/A, found while auditing `realtime/session.py` against `.agents/references/realtime-session-lifecycle.md`.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

flagging my own uncertainty: the hang itself I am confident about, I reproduced it both ways before touching anything. Where I am less sure is whether reusing `RealtimeModelConnectionStatusEvent` is the shape you want, since nothing emitted it before and I may be reading intent into dead code. I worked the diagnosis out myself and used Claude Code to pressure test the design options. happy to rework it, college freshman and still learning where these lines get drawn :)
