### PR TITLE
feat: opt-in strip_defaults for ensure_strict_json_schema (non-null defaults rejected by some providers)

### DIFF
--- a/src/agents/strict_schema.py
+++ b/src/agents/strict_schema.py
@@ -98,9 +98,12 @@ _ROOT_REF_NON_CONSTRAINING_SIBLINGS = _REF_NON_CONSTRAINING_SIBLINGS | {"$id"}
 class _NodeBudget:
     """Tracks conversion state across the recursion."""
 
-    def __init__(self, limit: int, *, reject_open_objects: bool = False) -> None:
+    def __init__(
+        self, limit: int, *, reject_open_objects: bool = False, strip_defaults: bool = False
+    ) -> None:
         self.remaining = limit
         self.reject_open_objects = reject_open_objects
+        self.strip_defaults = strip_defaults
 
     def spend(self) -> None:
         self.remaining -= 1
@@ -115,15 +118,29 @@ class _NodeBudget:
 def ensure_strict_json_schema(
     schema: dict[str, Any],
     *,
+    strip_defaults: bool = False,
     _reject_open_objects: bool = False,
 ) -> dict[str, Any]:
     """Mutates the given JSON schema to ensure it conforms to the `strict` standard
     that the OpenAI API expects.
+
+    Args:
+        schema: The JSON schema to convert in place.
+        strip_defaults: When True, remove every `default` keyword from the converted
+            schema, not just `None` defaults. Strict conversion forces all properties
+            into `required`, so a `default` can never take effect at runtime, and some
+            providers (for example Azure OpenAI deployments) reject strict schemas
+            that still carry one. Off by default to preserve the existing behavior of
+            keeping non-null defaults visible to the model.
     """
     _validate_json_schema_depth(schema)
     if schema == {}:
         return copy.deepcopy(_EMPTY_SCHEMA)
-    budget = _NodeBudget(_MAX_SCHEMA_NODES, reject_open_objects=_reject_open_objects)
+    budget = _NodeBudget(
+        _MAX_SCHEMA_NODES,
+        reject_open_objects=_reject_open_objects,
+        strip_defaults=strip_defaults,
+    )
     return _ensure_strict_root(
         _ensure_strict_json_schema(
             schema,
@@ -401,6 +418,15 @@ def _ensure_strict_json_schema(
 
     if budget.reject_open_objects and "$ref" in json_schema:
         raise UserError(_UNVALIDATED_REF_ERROR)
+
+    # Opt-in: strip any remaining `default`, regardless of its value. Strict conversion
+    # forces every property into `required`, so the model must always emit an explicit
+    # value and a `default` can never take effect; some providers (for example Azure
+    # OpenAI) reject strict schemas that still carry one. This runs after `$ref`
+    # handling so a non-null `default` sibling still triggers ref expansion above
+    # instead of leaving a pure `$ref` behind.
+    if budget.strip_defaults:
+        json_schema.pop("default", None)
 
     return json_schema
 

--- a/tests/test_strict_schema.py
+++ b/tests/test_strict_schema.py
@@ -990,3 +990,90 @@ def test_ref_with_anchor_is_still_expanded():
         "$anchor": "value",
         "type": "string",
     }
+
+
+def test_non_null_defaults_kept_by_default():
+    # Without opting in, non-null defaults are preserved (current behavior).
+    schema = {
+        "type": "object",
+        "properties": {"limit": {"type": "integer", "default": 10}},
+    }
+    result = ensure_strict_json_schema(schema)
+    assert result["properties"]["limit"] == {"type": "integer", "default": 10}
+
+
+def test_strip_defaults_removes_non_null_default_on_property():
+    schema = {
+        "type": "object",
+        "properties": {
+            "currency": {"type": "string", "enum": ["EUR", "USD"], "default": "EUR"},
+        },
+    }
+    result = ensure_strict_json_schema(schema, strip_defaults=True)
+    assert result["properties"]["currency"] == {"type": "string", "enum": ["EUR", "USD"]}
+    assert result["required"] == ["currency"]
+
+
+def test_strip_defaults_still_strips_none_defaults():
+    schema = {
+        "type": "object",
+        "properties": {"note": {"type": ["string", "null"], "default": None}},
+    }
+    result = ensure_strict_json_schema(schema, strip_defaults=True)
+    assert "default" not in result["properties"]["note"]
+
+
+def test_strip_defaults_in_nested_object_and_defs():
+    schema = {
+        "$defs": {
+            "Invoice": {
+                "type": "object",
+                "properties": {
+                    "total": {"type": "number", "default": 1.5},
+                    "meta": {
+                        "type": "object",
+                        "properties": {"kind": {"type": "string", "default": "std"}},
+                    },
+                },
+            }
+        },
+        "type": "object",
+        "properties": {"data": {"$ref": "#/$defs/Invoice"}},
+    }
+    result = ensure_strict_json_schema(schema, strip_defaults=True)
+    invoice = result["$defs"]["Invoice"]
+    assert "default" not in invoice["properties"]["total"]
+    assert "default" not in invoice["properties"]["meta"]["properties"]["kind"]
+
+
+def test_strip_defaults_in_any_of_variant():
+    schema = {
+        "type": "object",
+        "properties": {
+            "quantity": {
+                "anyOf": [
+                    {"type": "number"},
+                    {"type": "string", "default": "1"},
+                ],
+                "default": "1",
+            }
+        },
+    }
+    result = ensure_strict_json_schema(schema, strip_defaults=True)
+    quantity = result["properties"]["quantity"]
+    assert "default" not in quantity
+    assert all("default" not in variant for variant in quantity["anyOf"])
+
+
+def test_strip_defaults_ref_with_default_sibling_still_expands():
+    # A non-null `default` sibling must still trigger `$ref` expansion; stripping the
+    # default too early would leave a pure `$ref` behind unexpanded.
+    schema = {
+        "$defs": {"Currency": {"type": "string", "enum": ["EUR", "USD"]}},
+        "type": "object",
+        "properties": {
+            "currency": {"$ref": "#/$defs/Currency", "default": "EUR"},
+        },
+    }
+    result = ensure_strict_json_schema(schema, strip_defaults=True)
+    assert result["properties"]["currency"] == {"type": "string", "enum": ["EUR", "USD"]}


### PR DESCRIPTION
### Summary
Follow-up to #4390 and the discussion on #4391. Strict conversion forces every property into `required`, so a property-level `default` can never take effect at runtime — yet `ensure_strict_json_schema()` only strips defaults whose value is exactly `None`. Some providers reject strict schemas that still carry a non-null `default` (reported against Azure OpenAI deployments in #4390: a literal `'default' is not permitted within a property definition` rejection, plus a measured intermittent-500 correlation), while the official OpenAI API accepts them.

Since unconditionally removing defaults was deemed not right for real-world use cases (#4391), this PR takes the minimal opt-in route instead: a keyword-only `strip_defaults: bool = False` flag on `ensure_strict_json_schema()`.

- **Default behavior is completely unchanged** — non-null defaults remain visible to the model, and a test now pins that behavior.
- With `strip_defaults=True`, every remaining `default` is removed. The strip runs after `$ref` handling so a non-null `default` sibling still triggers ref expansion instead of leaving a pure `$ref` behind.
- Affected users (e.g. Azure) get an escape hatch without disabling `strict_mode` entirely. If maintainers want, a follow-up could thread this through `function_tool(...)`/`FunctionTool` — kept out of this PR to stay minimal.

### Tests
6 new tests in `tests/test_strict_schema.py`: current-behavior pin, property/nested-`$defs`/`anyOf` stripping, `None`-default parity, and the `$ref`-with-`default`-sibling expansion case. `ruff` and `mypy` clean; full `test_strict_schema.py` + `test_function_schema.py` suites pass (112 passed).

Addresses #4390.
