### PR TITLE
docs(sandbox): show Docker network isolation

### DIFF
--- a/examples/sandbox/docker/docker_runner.py
+++ b/examples/sandbox/docker/docker_runner.py
@@ -107,7 +107,12 @@ async def main(model: str, question: str) -> None:
     # We pass the same manifest here so the container knows which files to materialize.
     sandbox = await docker_client.create(
         manifest=manifest,
-        options=DockerSandboxClientOptions(image=DEFAULT_PYTHON_SANDBOX_IMAGE),
+        options=DockerSandboxClientOptions(
+            image=DEFAULT_PYTHON_SANDBOX_IMAGE,
+            # Uncomment to disable networking for the container.
+            # Do not combine network_mode="none" with exposed_ports.
+            # network_mode="none",
+        ),
     )
     try:
         # `async with sandbox` keeps the example on the public session lifecycle API.


### PR DESCRIPTION
### Summary

Document the Docker sandbox network-isolation option added in #4452 in the starter example linked from the sandbox client guide.

The example now shows `network_mode="none"` as an opt-in commented configuration and notes that it cannot be combined with `exposed_ports`. Keeping the option commented preserves the current connected Docker starter while making the isolation control discoverable where new sandbox users are directed.

### Test plan

- The example remains syntactically valid with `network_mode` commented out.
- The documented option and incompatibility match `DockerSandboxClientOptions` and `_validate_docker_network_configuration`.
- Runtime behavior is unchanged.

### Issue number

Related to #4452.