### PR TITLE
fix(models): reject a provider response with no choices in LiteLLM and AnyLLM

### DIFF
--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -607,8 +607,14 @@ class AnyLLMModel(Model):
             )
 
             if not response.choices:
+                # The provider error object can carry prompt text or credentials, so it is only
+                # attached when model-data logging is explicitly enabled.
                 provider_error = getattr(response, "error", None)
-                error_details = f": {provider_error}" if provider_error is not None else ""
+                error_details = (
+                    f": {provider_error}"
+                    if provider_error is not None and not _debug.DONT_LOG_MODEL_DATA
+                    else ""
+                )
                 raise ModelBehaviorError(
                     f"Chat completion response has no choices (possible provider error payload)"
                     f"{error_details}"

--- a/src/agents/extensions/models/any_llm_model.py
+++ b/src/agents/extensions/models/any_llm_model.py
@@ -606,6 +606,14 @@ class AnyLLMModel(Model):
                 prompt=prompt,
             )
 
+            if not response.choices:
+                provider_error = getattr(response, "error", None)
+                error_details = f": {provider_error}" if provider_error is not None else ""
+                raise ModelBehaviorError(
+                    f"Chat completion response has no choices (possible provider error payload)"
+                    f"{error_details}"
+                )
+
             message: ChatCompletionMessage | None = None
             first_choice: Choice | None = None
             if response.choices:

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -251,8 +251,14 @@ class LitellmModel(Model):
             )
 
             if not response.choices:
+                # The provider error object can carry prompt text or credentials, so it is only
+                # attached when model-data logging is explicitly enabled.
                 provider_error = getattr(response, "error", None)
-                error_details = f": {provider_error}" if provider_error is not None else ""
+                error_details = (
+                    f": {provider_error}"
+                    if provider_error is not None and not _debug.DONT_LOG_MODEL_DATA
+                    else ""
+                )
                 raise ModelBehaviorError(
                     f"LiteLLM response has no choices (possible provider error payload)"
                     f"{error_details}"

--- a/src/agents/extensions/models/litellm_model.py
+++ b/src/agents/extensions/models/litellm_model.py
@@ -250,6 +250,14 @@ class LitellmModel(Model):
                 prompt=prompt,
             )
 
+            if not response.choices:
+                provider_error = getattr(response, "error", None)
+                error_details = f": {provider_error}" if provider_error is not None else ""
+                raise ModelBehaviorError(
+                    f"LiteLLM response has no choices (possible provider error payload)"
+                    f"{error_details}"
+                )
+
             message: litellm.types.utils.Message | None = None
             first_choice: litellm.types.utils.Choices | None = None
             if response.choices and len(response.choices) > 0:

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -2205,3 +2205,38 @@ async def test_any_llm_responses_stream_with_usage_is_not_marked(monkeypatch) ->
     assert isinstance(terminal, ResponseCompletedEvent)
     assert terminal.response.usage is not None
     assert _requests_for_response_without_usage(terminal.response) == 0
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_provider_error_payload_without_choices_raises(monkeypatch) -> None:
+    """A provider error payload must not read as a successful empty turn.
+
+    Matches the OpenAI Chat Completions adapter, which already rejects a response with no
+    choices rather than handing back empty output.
+    """
+    from agents.exceptions import ModelBehaviorError
+
+    empty = ChatCompletion(
+        id="chatcmpl_empty",
+        created=0,
+        model="fake-model",
+        object="chat.completion",
+        choices=[],
+    )
+    empty.error = {"message": "upstream provider failed"}
+
+    provider = FakeAnyLLMProvider(supports_responses=False, chat_response=empty)
+    module, _create_calls = _import_any_llm_module(monkeypatch, provider)
+
+    with pytest.raises(ModelBehaviorError, match="no choices"):
+        await module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini").get_response(
+            system_instructions=None,
+            input=[],
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+        )

--- a/tests/models/test_any_llm_model.py
+++ b/tests/models/test_any_llm_model.py
@@ -2229,7 +2229,7 @@ async def test_provider_error_payload_without_choices_raises(monkeypatch) -> Non
     provider = FakeAnyLLMProvider(supports_responses=False, chat_response=empty)
     module, _create_calls = _import_any_llm_module(monkeypatch, provider)
 
-    with pytest.raises(ModelBehaviorError, match="no choices"):
+    with pytest.raises(ModelBehaviorError, match="no choices") as exc_info:
         await module.AnyLLMModel(model="openrouter/openai/gpt-5.4-mini").get_response(
             system_instructions=None,
             input=[],
@@ -2240,3 +2240,6 @@ async def test_provider_error_payload_without_choices_raises(monkeypatch) -> Non
             tracing=ModelTracing.DISABLED,
             previous_response_id=None,
         )
+
+    # Model data is not logged by default, so the provider payload stays out of the message.
+    assert "upstream provider failed" not in str(exc_info.value)

--- a/tests/models/test_litellm_content_filter.py
+++ b/tests/models/test_litellm_content_filter.py
@@ -108,7 +108,7 @@ async def test_provider_error_payload_without_choices_raises(monkeypatch) -> Non
 
     monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
-    with pytest.raises(ModelBehaviorError, match="no choices"):
+    with pytest.raises(ModelBehaviorError, match="no choices") as exc_info:
         await LitellmModel(model="test-model").get_response(
             system_instructions=None,
             input=[],
@@ -119,3 +119,6 @@ async def test_provider_error_payload_without_choices_raises(monkeypatch) -> Non
             tracing=ModelTracing.DISABLED,
             previous_response_id=None,
         )
+
+    # Model data is not logged by default, so the provider payload stays out of the message.
+    assert "upstream provider failed" not in str(exc_info.value)

--- a/tests/models/test_litellm_content_filter.py
+++ b/tests/models/test_litellm_content_filter.py
@@ -87,3 +87,35 @@ async def test_normal_stop_is_unaffected(monkeypatch):
         if isinstance(content, ResponseOutputRefusal)
     ]
     assert not refusals
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_provider_error_payload_without_choices_raises(monkeypatch) -> None:
+    """A provider error payload must not read as a successful empty turn.
+
+    Providers behind LiteLLM can answer with an error object and no choices. Returning an empty
+    output for that is indistinguishable from a model that legitimately said nothing, so the run
+    continues on a response that never happened.
+    """
+    from agents.exceptions import ModelBehaviorError
+
+    async def fake_acompletion(model, messages=None, **kwargs):
+        response = ModelResponse(choices=[])
+        response.choices = []
+        response.error = {"message": "upstream provider failed"}
+        return response
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+    with pytest.raises(ModelBehaviorError, match="no choices"):
+        await LitellmModel(model="test-model").get_response(
+            system_instructions=None,
+            input=[],
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+        )


### PR DESCRIPTION
### Summary

`OpenAIChatCompletionsModel` rejects a completion with no choices (`openai_chatcompletions.py:262`):

```python
if not response.choices:
    provider_error = getattr(response, "error", None)
    error_details = f": {provider_error}" if provider_error is not None else ""
    raise ModelBehaviorError(
        f"ChatCompletion response has no choices (possible provider error payload)"
        f"{error_details}"
    )
```

That guard arrived in #2850 for #604 and only ever landed in that one adapter. `LitellmModel` (`litellm_model.py:255`) and `AnyLLMModel` (`any_llm_model.py:611`) still take the other branch: `message` stays `None`, `items` comes out empty, and the caller gets a successful `ModelResponse` with no output.

Reproduced on `main` against LiteLLM with a provider error payload:

```
LiteLLM  -> returned ModelResponse, output = []  usage.requests = 1
```

No exception, and an empty turn is indistinguishable from a model that legitimately said nothing. The run keeps going on a turn that never happened, which usually surfaces later as an empty final output or a max-turns loop rather than as the provider error it actually was. These two adapters are the ones pointed at OpenAI-compatible gateways, so an error object plus an empty `choices` list is exactly the shape they meet in practice.

This adds the same guard to both, including the provider error object in the message when one is present. Nothing else changes: a genuinely empty-but-well-formed choice list of length one still flows through the existing `message is None` path and its debug log.

Both adapters were already brought in line on request accounting in #4290 and #4453, so this is the same three-adapter set, one behavior short.

### Test plan

- `test_provider_error_payload_without_choices_raises` in `tests/models/test_litellm_content_filter.py` and in `tests/models/test_any_llm_model.py`, each driving `get_response` against a mocked provider that returns an error object with `choices=[]`. Both fail against `main` and pass here.
- `uv run pytest tests/models/`: 823 passed.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck and the full test run all pass.
- CI here needs a maintainer to approve the workflow for a fork PR, so the above is the local run.

### Issue number

Same defect as #604, which was fixed for the OpenAI adapter only in #2850.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

one thing I am unsure about and would rather flag than hide: I kept the wording close to the OpenAI adapter's message so the three read the same, but LiteLLM normalizes a lot of providers, so if you would rather it stayed permissive there and only AnyLLM got the guard, say so and I will cut it back. found this comparing the three adapters after #4453, worked it through myself with Claude Code as a sounding board. freshman in college, still learning where consistency helps and where it just adds noise :)
