### PR TITLE
fix(core): close all cached websocket models when one close fails

### DIFF
--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -170,17 +170,38 @@ class OpenAIProvider(ModelProvider):
             await self._close_models(models)
             return
         if loop.is_running():
+            first_error: Exception | None = None
             for model in models:
                 future = asyncio.run_coroutine_threadsafe(model.close(), loop)
-                await asyncio.wrap_future(future)
+                try:
+                    await asyncio.wrap_future(future)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    if first_error is None:
+                        first_error = error
+            if first_error is not None:
+                raise first_error
             return
         # Do not run an inactive foreign loop on another thread. This also covers closed loops.
         # Close from the current loop and rely on model-specific cross-loop cleanup fallbacks.
         await self._close_models(models)
 
     async def _close_models(self, models: list[Model]) -> None:
+        # Close every model even when one close() fails, then raise the first
+        # failure — a raise mid-loop would leak the remaining cached websocket
+        # models (same cleanup contract as MultiProvider.aclose()).
+        first_error: Exception | None = None
         for model in models:
-            await model.close()
+            try:
+                await model.close()
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
     def _clear_ws_loop_cache_entry(
         self, loop: asyncio.AbstractEventLoop, loop_cache: _WSLoopModelCache
@@ -277,7 +298,16 @@ class OpenAIProvider(ModelProvider):
         current_loop = self._get_running_loop()
         if current_loop is None:
             return
+        first_error: Exception | None = None
         for loop, loop_cache in list(self._ws_model_cache_by_loop.items()):
             models_to_close = self._collect_unique_cached_models(loop_cache, seen)
-            await self._close_ws_models_for_loop(loop, models_to_close, current_loop)
+            try:
+                await self._close_ws_models_for_loop(loop, models_to_close, current_loop)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
             self._clear_ws_loop_cache_entry(loop, loop_cache)
+        if first_error is not None:
+            raise first_error

--- a/tests/models/test_openai_provider_ws_close.py
+++ b/tests/models/test_openai_provider_ws_close.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agents.models.interface import Model
+from agents.models.openai_provider import OpenAIProvider
+
+
+class _CloseTrackingModel(Model):
+    """Fake model whose close() raises on demand and records invocation."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self._error = error
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+        if self._error is not None:
+            raise self._error
+
+    # Unused Model machinery for these tests
+    async def get_response(
+        self,
+        agent_runner,  # noqa: ANN001
+        system_instructions,  # noqa: ANN001
+        input,  # noqa: ANN001
+        model_settings,  # noqa: ANN001
+        tools,  # noqa: ANN001
+        output_schema,  # noqa: ANN001
+        previous_response_id,  # noqa: ANN001
+        trace_include_sensitive_data,  # noqa: ANN001
+    ):
+        raise NotImplementedError
+
+    async def stream_response(
+        self,
+        agent_runner,  # noqa: ANN001
+        system_instructions,  # noqa: ANN001
+        input,  # noqa: ANN001
+        model_settings,  # noqa: ANN001
+        tools,  # noqa: ANN001
+        output_schema,  # noqa: ANN001
+        previous_response_id,  # noqa: ANN001
+        trace_include_sensitive_data,  # noqa: ANN001
+    ):
+        raise NotImplementedError
+        yield  # pragma: no cover
+
+
+@pytest.mark.asyncio
+async def test_close_models_closes_all_and_raises_first_error():
+    first = _CloseTrackingModel(RuntimeError("first close failed"))
+    second = _CloseTrackingModel()
+
+    with pytest.raises(RuntimeError, match="first close failed"):
+        await OpenAIProvider._close_models(None, [first, second])
+
+    assert first.closed
+    assert second.closed, "a failing close must not leak the remaining models"
+
+
+@pytest.mark.asyncio
+async def test_close_models_reraises_without_cancelling_others():
+    failing = _CloseTrackingModel(ValueError("boom"))
+    also_failing = _CloseTrackingModel(RuntimeError("second"))
+
+    with pytest.raises(ValueError, match="boom"):
+        await OpenAIProvider._close_models(None, [failing, also_failing])
+
+    assert failing.closed and also_failing.closed
+
+
+@pytest.mark.asyncio
+async def test_close_models_all_succeed():
+    models = [_CloseTrackingModel() for _ in range(3)]
+
+    await OpenAIProvider._close_models(None, models)
+
+    assert all(m.closed for m in models)
+
+
+@pytest.mark.asyncio
+async def test_close_ws_models_same_loop_uses_resilient_close():
+    provider = object.__new__(OpenAIProvider)
+    first = _CloseTrackingModel(RuntimeError("ws close failed"))
+    second = _CloseTrackingModel()
+    loop = asyncio.get_running_loop()
+
+    with pytest.raises(RuntimeError, match="ws close failed"):
+        await provider._close_ws_models_for_loop(loop, [first, second], loop)
+
+    assert first.closed and second.closed


### PR DESCRIPTION
## Problem

`OpenAIProvider._close_models` and the threadsafe branch of `_close_ws_models_for_loop` (`src/agents/models/openai_provider.py`) awaited each `model.close()` in a bare loop, so the first failing close aborted cleanup and leaked every remaining cached websocket model. `OpenAIProvider.aclose()` had the same shape one level up: a loop whose close failed skipped closing the remaining event loops' models and left their `_ws_model_cache_by_loop` entries behind.

This is the same cleanup contract `MultiProvider.aclose()` landed with #4438 — close all children, preserve the first failure — applied to the websocket model cache paths.

## Changes

- `_close_models`: close every model even when one `close()` raises, then raise the first error (`CancelledError` still propagates immediately).
- `_close_ws_models_for_loop` threadsafe branch: same per-model error collection around `run_coroutine_threadsafe(...)`/`wrap_future`.
- `aclose()`: a failing loop no longer prevents the remaining loops from being closed and their cache entries cleared; the first error is raised after the sweep.

Behavior on the single-model / all-healthy paths is unchanged.

## Testing

New `tests/models/test_openai_provider_ws_close.py` (hermetic fake models):

- first model's `close()` raises → the second model is still closed, and the first error is raised (fails on `main`: the second model leaks)
- second model also failing → both closed, first error raised
- all healthy → all closed
- `_close_ws_models_for_loop` same-loop branch → resilient close

```
$ pytest tests/models/test_openai_provider_ws_close.py -q
4 passed

$ pytest tests/models/ -q        # full models suite
816 passed, 11 skipped

$ ruff check && ruff format --check   # repo-pinned ruff 0.9.2
All checks passed / 2 files already formatted
```
