### PR TITLE
fix(sessions): count the compaction request when the provider omits usage

### DIFF
--- a/src/agents/memory/openai_responses_compaction_session.py
+++ b/src/agents/memory/openai_responses_compaction_session.py
@@ -11,7 +11,7 @@ from ..items import TResponseInputItem
 from ..logger import log_model_and_tool_action_warning
 from ..models._openai_shared import get_default_openai_client
 from ..run_internal.items import normalize_input_items_for_api
-from ..usage import _response_usage_to_usage
+from ..usage import Usage, _response_usage_to_usage
 from .openai_conversations_session import OpenAIConversationsSession
 from .session import (
     OpenAIResponsesCompactionArgs,
@@ -238,8 +238,14 @@ class OpenAIResponsesCompactionSession(SessionABC, OpenAIResponsesCompactionAwar
         compacted = await self.client.responses.compact(**compact_kwargs)
 
         compacted_usage = getattr(compacted, "usage", None)
-        if wrapper is not None and compacted_usage is not None:
-            wrapper.usage.add(_response_usage_to_usage(compacted_usage))
+        if wrapper is not None:
+            # The compaction call is billed, so it counts even when the provider reports no
+            # usage. Recorded without synthesizing token counts that never arrived.
+            wrapper.usage.add(
+                _response_usage_to_usage(compacted_usage)
+                if compacted_usage is not None
+                else Usage(requests=1)
+            )
 
         output_items = _strip_orphaned_assistant_ids(
             _normalize_compaction_output_items(compacted.output or [])

--- a/tests/memory/test_openai_responses_compaction_session.py
+++ b/tests/memory/test_openai_responses_compaction_session.py
@@ -1496,6 +1496,38 @@ class TestOpenAIResponsesCompactionSession:
         assert any(isinstance(item, dict) and item.get("type") == "compaction" for item in items)
 
     @pytest.mark.asyncio
+    async def test_compaction_request_counts_when_provider_omits_usage(self) -> None:
+        """The compaction call is billed, so it counts even without a usage payload.
+
+        OpenAI-compatible endpoints behind a custom `base_url` can answer `responses.compact`
+        with no usage. Dropping the request entirely understates `Usage.requests`, which is the
+        accounting the issue behind #4446 was about.
+        """
+        underlying = SimpleListSession()
+        compacted = SimpleNamespace(
+            output=[{"type": "compaction", "encrypted_content": "enc"}],
+            usage=None,
+        )
+        mock_client = MagicMock()
+        mock_client.responses.compact = AsyncMock(return_value=compacted)
+
+        session = OpenAIResponsesCompactionSession(
+            session_id="demo",
+            underlying_session=underlying,
+            client=mock_client,
+            should_trigger_compaction=lambda ctx: True,
+        )
+
+        model = ScriptedModel(steps=[[get_text_message("ok")]])
+        result = await Runner.run(Agent(name="assistant", model=model), "hello", session=session)
+
+        mock_client.responses.compact.assert_awaited_once()
+        # One model call plus the compaction call.
+        assert result.context_wrapper.usage.requests == 2
+        # No usage payload is synthesized, so token counts stay at zero.
+        assert result.context_wrapper.usage.total_tokens == 0
+
+    @pytest.mark.asyncio
     async def test_compaction_skips_when_tool_outputs_present(self) -> None:
         underlying = SimpleListSession()
         mock_client = MagicMock()


### PR DESCRIPTION
### Summary

`run_compaction` makes a real, billed `responses.compact` call, then only records it when the response carries usage (`openai_responses_compaction_session.py:239`):

```python
compacted_usage = getattr(compacted, "usage", None)
if wrapper is not None and compacted_usage is not None:
    wrapper.usage.add(_response_usage_to_usage(compacted_usage))
```

If the provider reports no usage, the whole request disappears from `Usage.requests`, not just its token counts. That is the accounting #4446 set out to fix for #4434, and it is the same gap #4453 closed for the Responses adapter, where the rule landed as "the request completed, so it counts even when the provider omits usage."

Reproduced on `main` with one model call plus one compaction whose response has `usage=None`:

```
result.context_wrapper.usage.requests == 1   # expected 2
```

The compaction call happened and will be billed, but the run reports a single request. `OpenAIResponsesCompactionSession` takes a caller-supplied `client`, so this is the same OpenAI-compatible-endpoint population that motivated #4290 and #4453, and the code already anticipates the shape by checking `usage is not None` before using it.

This records one request when the payload is absent. Token counts stay at zero rather than being synthesized, so nothing reports numbers that never arrived, and the existing path is unchanged whenever usage is present.

### Test plan

- `test_compaction_request_counts_when_provider_omits_usage`, placed next to the existing `test_compaction_runs_during_runner_flow` so the two read as a pair: same Runner flow, same mocked `responses.compact`, one with a usage payload and one without. It fails against `main` with `assert 1 == 2` and passes here.
- `uv run pytest tests/memory/`: 204 passed.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck and the full test run all pass.
- CI here needs a maintainer to approve the workflow for a fork PR, so the above is the local run.

### Issue number

Same accounting as #4434, which #4446 fixed for the case where the provider does report usage.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

small note in case it reads as nitpicking a fix that just landed: I only went looking here because #4453 taught me this exact shape, and I checked the compaction path last since it is the one billed call that does not go through a model adapter. if you would rather compaction stayed out of `requests` entirely, that is a reasonable call too and I will close this. freshman in college, still calibrating what counts as worth a PR :)
