### PR TITLE
fix(sandbox): require apply_patch update hunks

### DIFF
--- a/src/agents/sandbox/capabilities/tools/apply_patch_tool.py
+++ b/src/agents/sandbox/capabilities/tools/apply_patch_tool.py
@@ -28,7 +28,7 @@ end_patch: "*** End Patch" LF?
 hunk: add_hunk | delete_hunk | update_hunk
 add_hunk: "*** Add File: " filename LF add_line+
 delete_hunk: "*** Delete File: " filename LF
-update_hunk: "*** Update File: " filename LF change_move? change?
+update_hunk: "*** Update File: " filename LF change_move? change
 
 filename: /(.+)/
 add_line: "+" /(.*)/ LF -> line
@@ -94,7 +94,7 @@ End := "*** End Patch" NEWLINE
 FileOp := AddFile | DeleteFile | UpdateFile
 AddFile := "*** Add File: " path NEWLINE { "+" line NEWLINE }
 DeleteFile := "*** Delete File: " path NEWLINE
-UpdateFile := "*** Update File: " path NEWLINE [ MoveTo ] { Hunk }
+UpdateFile := "*** Update File: " path NEWLINE [ MoveTo ] Hunk { Hunk }
 MoveTo := "*** Move to: " newPath NEWLINE
 Hunk := "@@" [ header ] NEWLINE { HunkLine } [ "*** End of File" NEWLINE ]
 HunkLine := (" " | "-" | "+") text NEWLINE

--- a/tests/sandbox/capabilities/test_apply_patch_tool.py
+++ b/tests/sandbox/capabilities/test_apply_patch_tool.py
@@ -41,6 +41,20 @@ class TestSandboxApplyPatchTool:
         assert tool.tool_config["format"]["type"] == "grammar"
         assert tool.tool_config["format"]["syntax"] == "lark"
 
+    def test_grammar_requires_update_diff_after_optional_move(self) -> None:
+        tool = SandboxApplyPatchTool(session=scripted_sandbox_session())
+
+        grammar = cast(dict[str, Any], tool.tool_config["format"])["definition"]
+        assert isinstance(grammar, str)
+        update_rule = next(line for line in grammar.splitlines() if line.startswith("update_hunk:"))
+        assert update_rule == 'update_hunk: "*** Update File: " filename LF change_move? change'
+
+        description = tool.tool_config["description"]
+        assert isinstance(description, str)
+        assert (
+            'UpdateFile := "*** Update File: " path NEWLINE [ MoveTo ] Hunk { Hunk }' in description
+        )
+
     def test_converter_uses_sandbox_custom_apply_patch_tool_config(self) -> None:
         tool = SandboxApplyPatchTool(session=scripted_sandbox_session())
 
@@ -54,6 +68,30 @@ class TestSandboxApplyPatchTool:
         assert "A full patch can combine several operations" in description
         tool_format = cast(dict[str, Any], converted.tools[0]["format"])
         assert tool_format["syntax"] == "lark"
+        assert tool_format["definition"] == tool.tool_config["format"]["definition"]
+
+    @pytest.mark.parametrize(
+        "update_body",
+        [
+            "",
+            "*** Move to: moved.txt\n",
+        ],
+        ids=["empty", "move-only"],
+    )
+    @pytest.mark.asyncio
+    async def test_runtime_rejects_updates_without_diff(self, update_body: str) -> None:
+        tool = SandboxApplyPatchTool(session=scripted_sandbox_session())
+
+        result = await _execute_custom_tool_call(
+            tool,
+            context_wrapper=make_context_wrapper(),
+            raw_input=(
+                f"*** Begin Patch\n*** Update File: notes.txt\n{update_body}*** End Patch\n"
+            ),
+        )
+
+        assert isinstance(result, ToolCallOutputItem)
+        assert "Update File patch for notes.txt must include a hunk" in result.output
 
     def test_needs_approval_exposes_operation_typed_setting(self) -> None:
         async def needs_approval(


### PR DESCRIPTION
### Summary

The custom `apply_patch` grammar currently allows an `Update File` operation without any diff lines, even though the runtime parser rejects that input. This pull request requires at least one change after the optional `Move to` directive and aligns the model-facing EBNF description with the runtime contract.

It also adds regression coverage that:
- compares the complete `update_hunk` production so the old `change?` rule cannot pass
- verifies the converter forwards the validated grammar definition
- confirms empty and move-only updates retain the runtime rejection

### Test plan

- `env NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`
- All formatting, lint, type checking, and test steps passed on Python 3.12.

### Issue number

Closes #4468

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
