### PR TITLE
fix(sandbox): require file operations and add lines in the apply_patch grammar

### DIFF
--- a/src/agents/sandbox/capabilities/tools/apply_patch_tool.py
+++ b/src/agents/sandbox/capabilities/tools/apply_patch_tool.py
@@ -88,11 +88,11 @@ jump to the right context. For instance:
 [3 lines of post-context]
 
 The full grammar definition is below:
-Patch := Begin { FileOp } End
+Patch := Begin FileOp { FileOp } End
 Begin := "*** Begin Patch" NEWLINE
 End := "*** End Patch" NEWLINE
 FileOp := AddFile | DeleteFile | UpdateFile
-AddFile := "*** Add File: " path NEWLINE { "+" line NEWLINE }
+AddFile := "*** Add File: " path NEWLINE "+" line NEWLINE { "+" line NEWLINE }
 DeleteFile := "*** Delete File: " path NEWLINE
 UpdateFile := "*** Update File: " path NEWLINE [ MoveTo ] Hunk { Hunk }
 MoveTo := "*** Move to: " newPath NEWLINE

--- a/tests/sandbox/capabilities/test_apply_patch_tool.py
+++ b/tests/sandbox/capabilities/test_apply_patch_tool.py
@@ -662,3 +662,60 @@ async def _execute_custom_tool_call(
         config=RunConfig(),
     )
     return result
+
+
+class TestApplyPatchDescriptionMatchesRuntime:
+    """The model-facing grammar must not advertise shapes the runtime rejects."""
+
+    def test_description_requires_at_least_one_file_operation(self) -> None:
+        tool = SandboxApplyPatchTool(session=scripted_sandbox_session())
+
+        description = tool.tool_config["description"]
+        assert isinstance(description, str)
+        assert "Patch := Begin FileOp { FileOp } End" in description
+
+        grammar = cast(dict[str, Any], tool.tool_config["format"])["definition"]
+        assert isinstance(grammar, str)
+        start_rule = next(line for line in grammar.splitlines() if line.startswith("start:"))
+        assert start_rule == "start: begin_patch hunk+ end_patch"
+
+    def test_description_requires_at_least_one_add_line(self) -> None:
+        tool = SandboxApplyPatchTool(session=scripted_sandbox_session())
+
+        description = tool.tool_config["description"]
+        assert isinstance(description, str)
+        assert (
+            'AddFile := "*** Add File: " path NEWLINE "+" line NEWLINE { "+" line NEWLINE }'
+            in description
+        )
+
+        grammar = cast(dict[str, Any], tool.tool_config["format"])["definition"]
+        assert isinstance(grammar, str)
+        add_rule = next(line for line in grammar.splitlines() if line.startswith("add_hunk:"))
+        assert add_rule == 'add_hunk: "*** Add File: " filename LF add_line+'
+
+    @pytest.mark.asyncio
+    async def test_runtime_rejects_a_patch_with_no_file_operations(self) -> None:
+        tool = SandboxApplyPatchTool(session=scripted_sandbox_session())
+
+        result = await _execute_custom_tool_call(
+            tool,
+            context_wrapper=make_context_wrapper(),
+            raw_input="*** Begin Patch\n*** End Patch\n",
+        )
+
+        assert isinstance(result, ToolCallOutputItem)
+        assert "must include at least one file operation" in result.output
+
+    @pytest.mark.asyncio
+    async def test_runtime_rejects_an_add_file_without_lines(self) -> None:
+        tool = SandboxApplyPatchTool(session=scripted_sandbox_session())
+
+        result = await _execute_custom_tool_call(
+            tool,
+            context_wrapper=make_context_wrapper(),
+            raw_input="*** Begin Patch\n*** Add File: notes.txt\n*** End Patch\n",
+        )
+
+        assert isinstance(result, ToolCallOutputItem)
+        assert "must include at least one + line" in result.output


### PR DESCRIPTION
### Summary

#4470 fixed the `UpdateFile` production so the model-facing grammar stops advertising a shape the runtime rejects. Two productions in the same description still do.

```
Patch := Begin { FileOp } End
AddFile := "*** Add File: " path NEWLINE { "+" line NEWLINE }
```

`{ }` is zero-or-more in this description, so both say the shape is optional. The runtime disagrees in both cases:

- `_parse_apply_patch_input` raises `apply_patch input must include at least one file operation` (`apply_patch_tool.py:350`)
- `_parse_add_file` raises `Add File patch for {path} must include at least one + line` (`apply_patch_tool.py:365`)

The lark grammar that is actually sent as the constraint already agrees with the runtime, `start: begin_patch hunk+ end_patch` and `add_hunk: ... add_line+`, so only the description was out of step. This is the same defect #4468 described, on the two operations #4470 did not touch.

This aligns both productions using the shape #4470 introduced for `UpdateFile`:

```
Patch := Begin FileOp { FileOp } End
AddFile := "*** Add File: " path NEWLINE "+" line NEWLINE { "+" line NEWLINE }
```

Nothing else changes. The lark grammar, the runtime parser, and the accepted patch shapes are all untouched; this only stops the description promising the model two shapes that cannot parse.

### Test plan

- `test_description_requires_at_least_one_file_operation` and `test_description_requires_at_least_one_add_line` assert the corrected productions and pin the matching lark rules alongside them, so the two can no longer drift apart. Both fail against `main`.
- `test_runtime_rejects_a_patch_with_no_file_operations` and `test_runtime_rejects_an_add_file_without_lines` pin the runtime side, mirroring the `test_runtime_rejects_updates_without_diff` coverage added in #4470. These pass before and after by design: they are what establishes which side of the mismatch is correct.
- `uv run pytest tests/sandbox/capabilities/test_apply_patch_tool.py`: 29 passed.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck and the full test run all pass.
- CI here needs a maintainer to approve the workflow for a fork PR, so the above is the local run.

### Issue number

Same class as #4468, which #4470 fixed for `UpdateFile` only.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

worth saying plainly: I found this by re-reading #4470 right after it merged and checking whether the same mismatch survived elsewhere in the file, so the credit for the diagnosis is really that PR's. if you consider `{ }` in this prose loose enough that only `UpdateFile` was worth tightening, close it and I will take the point. freshman in college, still learning how literally these descriptions are meant to be read :)
