### PR TITLE
ci(tests): run Windows tests on Python 3.10 and 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -267,6 +267,12 @@ jobs:
   tests-windows:
     runs-on: windows-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.13"
     env:
       OPENAI_API_KEY: fake-for-tests
     steps:
@@ -283,7 +289,7 @@ jobs:
           version: "0.11.14"
           enable-cache: true
           prune-cache: true
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'
         run: uv sync --all-extras --all-packages --group dev


### PR DESCRIPTION
### Summary

`tests-windows` pins a single Python version (3.13), which is exactly the version where the Windows clock became fine-grained — so the whole class of coarse-clock bug (e.g. #4392, 37 tests failing on a clean checkout while CI stayed green) is invisible on Windows for the other supported versions. This matrices the job across `"3.10"` (the declared minimum, on the coarse-clock side) and `"3.13"` (what runs today), using the shape suggested in the issue: 2x the current Windows runner cost instead of 5x. `fail-fast: false` keeps both legs reporting, and the `detect-changes` gate is preserved unchanged. `packaged-contract-windows` is intentionally untouched (packaging smoke, not test coverage).

### Test plan

Workflow-only change; verified locally:
- `tests.yml` parses as valid YAML and the `tests-windows` job carries `strategy.matrix.python-version == ["3.10", "3.13"]` with `fail-fast: false`, and `Setup uv` consumes `${{ matrix.python-version }}` (asserted programmatically).
- The matrix shape mirrors the existing Linux `tests` job, and no other job references the changed keys.

Final proof is CI itself: this PR's checks page should show two `tests-windows` legs (3.10 and 3.13), both honoring the `detect-changes` gate.

### Issue number

Fixes #4472

### Checks

- [ ] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification-stack checkboxes are left unchecked honestly: this diff touches only a CI workflow file, and the applicable verification is the YAML/structure check described in the test plan plus the workflow legs on this PR.
