### PR TITLE
docs: correct Agent.clone list attribute semantics

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -548,11 +548,18 @@ class Agent(AgentBase, Generic[TContext]):
     def clone(self, **kwargs: Any) -> Agent[TContext]:
         """Make a copy of the agent, with the given arguments changed.
         Notes:
-            - Uses `dataclasses.replace`, which performs a **shallow copy**.
-            - Mutable attributes like `tools` and `handoffs` are shallow-copied:
-              new list objects are created only if overridden, but their contents
-              (tool functions and handoff objects) are shared with the original.
-            - To modify these independently, pass new lists when calling `clone()`.
+            - Uses `dataclasses.replace`, which performs a **shallow copy** and never copies a
+              list attribute such as `tools`, `handoffs`, `mcp_servers`, `input_guardrails`, or
+              `output_guardrails`. Each of those attributes is whatever the merged arguments hold.
+            - An attribute you do not pass arrives as the original agent's own list, so both
+              agents hold that one list and its entries. Appending through either agent, for
+              example `cloned.tools.append(extra_tool)`, therefore also changes the other.
+            - An attribute you do pass is used exactly as given, so it shares a list or an entry
+              with the original agent only where you reused one. `agent.clone(tools=agent.tools)`
+              still shares that list, while `agent.clone(tools=[other_tool])` shares nothing.
+            - To give the clone a list that no other agent holds, pass a new one, for example
+              `agent.clone(tools=[*agent.tools, extra_tool])`. The entries copied into it remain
+              the same objects the original agent holds.
         Example:
             ```python
             new_agent = agent.clone(instructions="New instructions")

--- a/src/agents/realtime/agent.py
+++ b/src/agents/realtime/agent.py
@@ -103,11 +103,18 @@ class RealtimeAgent(AgentBase, Generic[TContext]):
         """Make a copy of the agent, with the given arguments changed.
 
         Notes:
-            - Uses `dataclasses.replace`, which performs a **shallow copy**.
-            - Mutable attributes like `tools` and `handoffs` are shallow-copied:
-              new list objects are created only if overridden, but their contents
-              (tool functions and handoff objects) are shared with the original.
-            - To modify these independently, pass new lists when calling `clone()`.
+            - Uses `dataclasses.replace`, which performs a **shallow copy** and never copies a
+              list attribute such as `tools`, `handoffs`, `mcp_servers`, or `output_guardrails`.
+              Each of those attributes is whatever the merged arguments hold.
+            - An attribute you do not pass arrives as the original agent's own list, so both
+              agents hold that one list and its entries. Appending through either agent, for
+              example `cloned.tools.append(extra_tool)`, therefore also changes the other.
+            - An attribute you do pass is used exactly as given, so it shares a list or an entry
+              with the original agent only where you reused one. `agent.clone(tools=agent.tools)`
+              still shares that list, while `agent.clone(tools=[other_tool])` shares nothing.
+            - To give the clone a list that no other agent holds, pass a new one, for example
+              `agent.clone(tools=[*agent.tools, extra_tool])`. The entries copied into it remain
+              the same objects the original agent holds.
 
         Example:
             ```python

--- a/tests/test_agent_clone_shallow_copy.py
+++ b/tests/test_agent_clone_shallow_copy.py
@@ -30,3 +30,52 @@ def test_agent_clone_shallow_copy():
     assert cloned.tools[0] is original.tools[0], "Tool objects should be same instance"
     assert cloned.handoffs is not original.handoffs, "Handoffs should be different list"
     assert cloned.handoffs[0] is original.handoffs[0], "Handoff objects should be same instance"
+
+
+def test_agent_clone_keeps_list_attributes_it_is_not_given():
+    """An attribute that clone() is not given arrives as the original agent's own list."""
+    target_agent = Agent(name="Target")
+    original = Agent(name="Original", tools=[greet], handoffs=[handoff(target_agent)])
+
+    cloned = original.clone(name="Cloned")
+
+    assert cloned.tools is original.tools
+    assert cloned.handoffs is original.handoffs
+
+
+def test_agent_clone_uses_a_given_list_as_is():
+    """An attribute passed to clone() is used exactly as given, entries included."""
+
+    @function_tool
+    def farewell(name: str) -> str:
+        return f"Goodbye, {name}!"
+
+    original = Agent(name="Original", tools=[greet])
+    supplied = [farewell]
+
+    cloned = original.clone(name="Cloned", tools=supplied)
+
+    assert cloned.tools is supplied
+    assert original.tools == [greet]
+    # Passing a list does not by itself share entries with the original agent.
+    assert all(tool is not greet for tool in cloned.tools)
+
+
+def test_agent_clone_still_shares_when_given_the_original_list():
+    """Passing the original agent's own list keeps both agents on that one list."""
+    original = Agent(name="Original", tools=[greet])
+
+    cloned = original.clone(name="Cloned", tools=original.tools)
+
+    assert cloned.tools is original.tools
+
+
+def test_agent_clone_shared_list_mutation_affects_both_agents():
+    """Appending through either agent changes the other while they hold one list."""
+    original = Agent(name="Original", tools=[greet])
+    cloned = original.clone(name="Cloned")
+
+    cloned.tools.append(greet)
+
+    assert original.tools == cloned.tools
+    assert len(original.tools) == 2


### PR DESCRIPTION
### Summary

The `Agent.clone()` docstring added in #1296 makes two claims that the implementation does not hold, both about how list attributes are copied. It currently says:

> Mutable attributes like `tools` and `handoffs` are shallow-copied: new list objects are created only if overridden, but their contents (tool functions and handoff objects) are shared with the original.

Neither half is reliable. `clone()` calls `dataclasses.replace`, which never copies a list at all, so what the clone gets is whatever the merged arguments hold:

```
CLAIM 1: "new list objects are created only if overridden"
  omitted                      -> cloned.tools is original.tools     True
  overridden with the SAME list -> cloned.tools is original.tools     True
  overridden with a NEW list    -> cloned.tools is the supplied list  True

CLAIM 2: "their contents are shared with the original"
  overridden with [other_tool] -> any entry shared with original      False
```

So `agent.clone(tools=agent.tools)` is an override that creates no new list, and `agent.clone(tools=[other_tool])` shares no contents. Overriding is not what decides either outcome; what the caller passes is.

The distinction that does hold, and that the docstring is right to warn about, is between passing an attribute and not passing it. When you do not pass one, the clone receives the original agent's own list, so appending through either agent changes the other.

This is easy to get backwards. The reporter in #1293 asserted `clone.tools is not original.tools` and the test failed in review for exactly this reason. The regression test added alongside that docstring works around the behavior rather than pinning it: `test_agent_clone_shallow_copy` passes `tools=original.tools.copy()`, and its own docstring calls that "the tools.copy() workaround". Nothing in the suite covered the un-passed case, which is why the inaccuracy survived.

The equivalent JSDoc in the JS SDK was corrected in openai/openai-agents-js#1705, where automated review flagged these same two claims. This change brings the Python docstring to the same description so both SDKs document one contract.

### Fix

Docstring and tests only. No behavior change and no API change.

The note now leads with the mechanism, that `dataclasses.replace` never copies a list attribute, and lets the cases follow from it rather than asserting an outcome per case. It names the affected attributes (`tools`, `handoffs`, `mcp_servers`, `input_guardrails`, `output_guardrails`), separates passing an attribute from omitting it, gives both of the counterexamples above, and keeps the existing guidance on how to get an independently owned list.

### Test plan

Four tests added to `tests/test_agent_clone_shallow_copy.py`, each pinning one behavior the docstring now describes:

- `test_agent_clone_keeps_list_attributes_it_is_not_given`
- `test_agent_clone_uses_a_given_list_as_is`
- `test_agent_clone_still_shares_when_given_the_original_list`
- `test_agent_clone_shared_list_mutation_affects_both_agents`

They pin current behavior, so they pass before and after. To confirm they are load bearing rather than tautological, I temporarily made `clone()` copy its list attributes when they are not passed, which is the behavior the old docstring described, and two of the four failed:

```
FAILED tests/test_agent_clone_shallow_copy.py::test_agent_clone_keeps_list_attributes_it_is_not_given
FAILED tests/test_agent_clone_shallow_copy.py::test_agent_clone_shared_list_mutation_affects_both_agents
2 failed, 3 passed
```

Then reverted that experiment. The pre-existing `test_agent_clone_shallow_copy` is left untouched.

Commands run locally on Windows. `make` is unavailable in this environment, so the Makefile targets were invoked directly through `uv`:

- `uv run pytest tests/test_agent_clone_shallow_copy.py`: 5 passed
- `uv run ruff format`: 905 files left unchanged
- `uv run ruff check`: all checks passed
- `uv run python .github/scripts/check_optional_truthiness.py src/agents`: passed
- `uv run pytest -n auto --maxprocesses=9 --dist worksteal -m "not serial"`: 17 failed, 7847 passed, 82 skipped
- The same command on unmodified `main`: 17 failed, 7843 passed, 82 skipped. The failure set is identical; all 17 are pre-existing on this platform, failing in `os.symlink` with `OSError: [WinError 1314] A required privilege is not held by the client`, in `tests/sandbox/test_tar_utils.py`, `tests/sandbox/test_workspace_paths.py`, and `tests/sandbox/test_docker.py`. The only difference is the four tests this PR adds, all passing.
- `uv run mypy src`: 3 errors, all pre-existing and all in files this PR does not touch (`sandbox/util/tar_utils.py`, `sandbox/sandboxes/unix_local.py`, `sandbox/sandboxes/docker.py`)
- `uv run pyright --project pyrightconfig.json`: 1 error, in `sandbox/util/tar_utils.py`. Confirmed pre-existing by stashing this change and re-running on clean `main`, which reports the identical error.

One note on methodology, in case it saves anyone a repeat: an earlier full-suite run of mine reported 6 extra failures in `tests/extensions/memory/test_advanced_sqlite_session.py`, all of them multiprocess contention tests. That was host contention from running the suite and the typecheckers concurrently, not this change. Run on its own, that file reports 128 passed.

### Issue number

N/A. Follows up #1293 and #1296, and aligns with openai/openai-agents-js#1705.

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh` (`make` is unavailable here; the equivalent commands are listed above)
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
