### PR TITLE
Use sys.executable instead of tee for the stdio placeholder command

### DIFF
--- a/tests/mcp/helpers.py
+++ b/tests/mcp/helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-import shutil
+import sys
 from typing import Any
 
 from mcp import Tool as MCPToolType
@@ -24,8 +24,7 @@ from agents.tool import ToolErrorFunction
 
 from .model_compat import ListResourceTemplatesResult, Tool as MCPTool
 
-tee = shutil.which("tee") or ""
-assert tee, "tee not found"
+tee = sys.executable
 
 
 # Added dummy stream classes for patching stdio_client to avoid real I/O during tests


### PR DESCRIPTION
### Summary

`tests/mcp/helpers.py` resolved `tee` at import time and asserted on the result:

```python
tee = shutil.which("tee") or ""
assert tee, "tee not found"
```

`tee` is a Unix utility. It is not on `PATH` on a default Windows install, so the assert fires during collection and takes down every module that imports this helper. That is 11 modules, seven under `tests/mcp/` plus `tests/voice/test_pipeline.py`, `tests/test_agent_as_tool.py`, `tests/test_process_model_response.py` and `tests/test_tool_origin.py`.

The value is only ever used as `MCPServerStdio(params={"command": tee})`, and those tests patch `mcp.client.stdio.stdio_client` with `DummyStreamsContextManager`, so the command is never executed. It only has to be a path that exists. `sys.executable` satisfies that on every platform by definition.

CI does not see this because GitHub's `windows-latest` image ships Git for Windows with its `usr/bin` on `PATH`, which provides `tee.EXE`. A Windows machine without that directory on `PATH` does not have it.

### Test plan

Same checkout, same machine, only `PATH` differing, on Windows 11 / Python 3.13.11:

```
without C:\Program Files\Git\usr\bin on PATH, before this change
  $ uv run pytest tests/mcp tests/voice/test_pipeline.py tests/test_agent_as_tool.py \
      tests/test_process_model_response.py tests/test_tool_origin.py
  Interrupted: 10 errors during collection
  ERROR tests/mcp/test_caching.py - AssertionError: tee not found

with that directory on PATH (what a GitHub runner has), before this change
  shutil.which("tee") -> C:\Program Files\Git\usr\bin\tee.EXE
  6 passed

without it on PATH, after this change
  622 passed, 24 skipped in 89.40s
```

`uv run ruff format --check` and `uv run ruff check` are clean on the changed file.

`make typecheck` reports three errors on this machine, all in `src/agents/sandbox/`, none touched here. They are platform-conditional rather than caused by this change: `mypy src` gives 3 errors and `mypy --platform linux src` gives `Success: no issues found` on the same checkout. The typecheck job runs on `ubuntu-latest`, so CI does not see them either. Filed separately as #4477 rather than folded in here.

### Issue number

n/a

### Checks

- [ ] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

The verification script is a shell script and this was verified on Windows, so I ran the underlying commands directly rather than through it. No new tests: this restores collection of existing ones, and the pass count above is the check.
