### PR TITLE
fix: handle non-UTF8 Codex stderr

### DIFF
--- a/src/agents/extensions/experimental/codex/exec.py
+++ b/src/agents/extensions/experimental/codex/exec.py
@@ -200,7 +200,7 @@ class CodexExec:
 
             if process.returncode not in (0, None):
                 await stderr_task
-                stderr_text = b"".join(stderr_chunks).decode("utf-8")
+                stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
                 raise RuntimeError(
                     f"Codex exec exited with code {process.returncode}: {stderr_text}"
                 )

--- a/tests/extensions/experiemental/codex/test_codex_exec_thread.py
+++ b/tests/extensions/experiemental/codex/test_codex_exec_thread.py
@@ -471,6 +471,26 @@ async def test_codex_exec_run_raises_on_non_zero_exit(
 
 
 @pytest.mark.asyncio
+async def test_codex_exec_run_handles_non_utf8_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess(stdout_lines=[], stderr_chunks=[b"bad:\xff"], returncode=2)
+
+    async def fake_create_subprocess_exec(*args: Any, **kwargs: Any) -> FakeProcess:
+        return process
+
+    monkeypatch.setattr(exec_module.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    exec_client = exec_module.CodexExec(executable_path="/bin/codex")
+    args = exec_module.CodexExecArgs(input="hello")
+
+    with pytest.raises(RuntimeError, match="exited with code 2") as exc_info:
+        async for _ in exec_client.run(args):
+            pass
+    assert "bad:\ufffd" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_codex_exec_run_raises_without_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
     process = FakeProcess(stdout_lines=[], stdin_present=False)
 


### PR DESCRIPTION
### Summary

Failed Codex subprocesses currently decode stderr strictly as UTF-8 before raising their `RuntimeError`. If stderr contains an invalid byte, `UnicodeDecodeError` masks the subprocess exit code and diagnostic output.

This change replacement-decodes stderr only on the existing nonzero-exit path, so callers still receive the original `RuntimeError` shape with the exit code and readable diagnostic text. Successful executions and stdout decoding are unchanged.

### Test plan

- Added a regression for a nonzero Codex subprocess exit with non-UTF-8 stderr.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`; format, lint, type checking, and the full test suite passed.

### Issue number

N/A

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
