### PR TITLE
docs: document the minimum uv version for development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ The OpenAI Agents Python repository provides the Python Agents SDK, examples, an
 ### Prerequisites
 
 - Python 3.10+.
-- `uv` installed for dependency management (`uv sync`) and `uv run` for Python commands.
+- `uv` 0.9.25 or newer installed for dependency management (`uv sync`) and `uv run` for Python commands. Older versions cannot parse the repository's current project and lockfile configuration.
 - `make` available to run repository tasks.
 
 ### Development Workflow

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ For voice support, install with the optional `voice` group: `pip install 'openai
 
 If you're familiar with [uv](https://docs.astral.sh/uv/), installing the package would be even easier:
 
+For repository development, use `uv` 0.9.25 or newer. Older versions cannot parse the repository's current project and lockfile configuration.
+
 ```bash
 uv init
 uv add openai-agents


### PR DESCRIPTION
### Summary

`uv` versions older than 0.9.25 cannot parse this repository's current `pyproject.toml` and `uv.lock`, so `make sync` reports misleading TOML errors from the checkout. This pull request documents 0.9.25 as the minimum development version in the contributor guide and README.

### Test plan

- `uv sync --all-extras --all-packages --group dev` — passed with uv 0.12.5; 202 packages resolved.
- `mingw32-make.exe format` — passed.
- `mingw32-make.exe lint` — passed.
- `uv run mkdocs build` — passed; existing documentation warnings remain.
- `uv run mypy src` — blocked by existing errors in `unix_local.py`, `docker.py`, and `tar_utils.py`.
- `uv run pyright --project pyrightconfig.json --threads 4` — blocked by the existing `tar_utils.py` return-type error.
- `mingw32-make.exe typecheck` — the aggregate target cannot run under the Windows shell because it uses Unix-shell syntax; the underlying mypy and Pyright commands were run directly.
- `uv run pytest -n auto --maxprocesses=9 --dist worksteal -m "not serial"` — 7,403 passed and 82 skipped; 19 failures and 135 collection errors were caused by the Windows environment and existing platform assumptions (`tee`, symlink behavior, and the system GBK locale).

The repository-wide verification checklist is left incomplete because of those unrelated baseline/environment failures.

### Issue number

Closes #4476

### Checks

- [x] I've added new tests, if relevant
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.ps1`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR