### PR TITLE
fix(sandbox): make typecheck pass on Windows

### DIFF
--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -1427,7 +1427,7 @@ class DockerSandboxSession(BaseSandboxSession):
             archive.seek(0)
             await self._stream_into_exec(
                 cmd=["tar", "-x", "-C", root.as_posix()],
-                stream=archive,
+                stream=cast(io.IOBase, archive),
                 error_path=error_root,
             )
 

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -336,8 +336,8 @@ class UnixLocalSandboxSession(BaseSandboxSession):
             else:
                 with suppress(OSError):
                     os.close(secondary_fd)
-            entry = _UnixPtyProcessEntry(process=process, tty=True, primary_fd=primary_fd)
-            entry.pump_tasks = [asyncio.create_task(self._pump_pty_primary_fd(entry))]
+                entry = _UnixPtyProcessEntry(process=process, tty=True, primary_fd=primary_fd)
+                entry.pump_tasks = [asyncio.create_task(self._pump_pty_primary_fd(entry))]
         else:
             process = await asyncio.create_subprocess_exec(
                 *exec_command,

--- a/src/agents/sandbox/util/tar_utils.py
+++ b/src/agents/sandbox/util/tar_utils.py
@@ -8,6 +8,7 @@ import tarfile
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import cast
 
 
 class UnsafeTarMemberError(ValueError):
@@ -158,7 +159,7 @@ def strip_tar_member_prefix(data: io.IOBase, *, prefix: str | Path) -> io.IOBase
         with tarfile.open(fileobj=out, mode="r:*") as tar:
             validate_tarfile(tar)
         out.seek(0)
-        return out
+        return cast(io.IOBase, out)
     except Exception:
         out.close()
         raise

--- a/tests/sandbox/test_windows_tempfile_iobase.py
+++ b/tests/sandbox/test_windows_tempfile_iobase.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import tempfile
+
+from agents.sandbox.util.tar_utils import strip_tar_member_prefix
+
+
+def _prefixed_workspace_tar() -> io.BytesIO:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        directory = tarfile.TarInfo("workspace")
+        directory.type = tarfile.DIRTYPE
+        tar.addfile(directory)
+        payload = b"hello"
+        member = tarfile.TarInfo("workspace/hello.txt")
+        member.size = len(payload)
+        tar.addfile(member, io.BytesIO(payload))
+    buf.seek(0)
+    return buf
+
+
+def test_strip_tar_member_prefix_returns_seekable_stream() -> None:
+    """Windows TemporaryFile wrappers must remain usable as binary IO streams."""
+
+    stream = strip_tar_member_prefix(_prefixed_workspace_tar(), prefix="workspace")
+    stream.seek(0)
+    with tarfile.open(fileobj=stream, mode="r:*") as tar:
+        assert tar.getnames() == [".", "hello.txt"]
+
+
+def test_temporary_file_supports_hydrate_style_copy() -> None:
+    """Docker hydrate copies the archive through TemporaryFile, then seeks it."""
+
+    payload = b"ustar-payload"
+    with tempfile.TemporaryFile() as archive:
+        archive.write(payload)
+        archive.seek(0)
+        assert archive.read() == payload


### PR DESCRIPTION
### Summary

`make typecheck` reports three mypy errors on Windows and none on Linux. On win32, typeshed types `tempfile.TemporaryFile()` as `_TemporaryFileWrapper[bytes]`, which is not an `IOBase` subclass, so `strip_tar_member_prefix` and Docker hydrate fail. Windows mypy also treats `process` as unbound after the PTY `try`/`except`/`else` in `unix_local`.

Cast the TemporaryFile objects to `io.IOBase` at those two sites, and create the PTY session entry inside the `else` branch where `process` is defined. No public types are widened.

### Test plan

- [x] `uv run mypy --platform win32 --follow-imports=silent` on the three affected modules
- [x] the same command with `--platform linux` stays clean
- [x] `tests/sandbox/test_windows_tempfile_iobase.py` covers the seekable-stream contract

### Issue number

Fixes #4477
