### PR TITLE
fix(usage): isolate aggregated request usage entries

### DIFF
--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -297,7 +297,7 @@ class Usage:
         # (this preserves nested token details that would otherwise be discarded
         # when synthesizing an entry from only the top-level fields).
         if other.request_usage_entries:
-            self.request_usage_entries.extend(other.request_usage_entries)
+            self.request_usage_entries.extend(copy.deepcopy(other.request_usage_entries))
         elif other.requests == 1 and other.total_tokens > 0:
             # Otherwise, if the other Usage represents a single request with tokens, record it.
             input_details = other.input_tokens_details or _make_input_tokens_details()

--- a/src/agents/usage.py
+++ b/src/agents/usage.py
@@ -306,8 +306,8 @@ class Usage:
                 input_tokens=other.input_tokens,
                 output_tokens=other.output_tokens,
                 total_tokens=other.total_tokens,
-                input_tokens_details=input_details,
-                output_tokens_details=output_details,
+                input_tokens_details=copy.deepcopy(input_details),
+                output_tokens_details=copy.deepcopy(output_details),
             )
             self.request_usage_entries.append(request_usage)
 

--- a/tests/test_usage_copy_isolation.py
+++ b/tests/test_usage_copy_isolation.py
@@ -34,3 +34,26 @@ def test_usage_add_copies_preexisting_request_entries() -> None:
     assert copied_entry.input_tokens == 3
     assert copied_entry.input_tokens_details.cached_tokens == 1
     assert entry.output_tokens_details.reasoning_tokens == 2
+
+
+def test_usage_add_copies_synthesized_request_details() -> None:
+    source = Usage(
+        requests=1,
+        input_tokens=3,
+        output_tokens=4,
+        total_tokens=7,
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 1}
+        ),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=2),
+    )
+    aggregate = Usage()
+
+    aggregate.add(source)
+
+    copied_entry = aggregate.request_usage_entries[0]
+    source.input_tokens_details.cached_tokens = 99
+    copied_entry.output_tokens_details.reasoning_tokens = 77
+
+    assert copied_entry.input_tokens_details.cached_tokens == 1
+    assert source.output_tokens_details.reasoning_tokens == 2

--- a/tests/test_usage_copy_isolation.py
+++ b/tests/test_usage_copy_isolation.py
@@ -1,0 +1,36 @@
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from agents.usage import RequestUsage, Usage
+
+
+def test_usage_add_copies_preexisting_request_entries() -> None:
+    entry = RequestUsage(
+        input_tokens=3,
+        output_tokens=4,
+        total_tokens=7,
+        input_tokens_details=InputTokensDetails.model_validate(
+            {"cache_write_tokens": 0, "cached_tokens": 1}
+        ),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=2),
+    )
+    source = Usage(
+        requests=1,
+        input_tokens=3,
+        output_tokens=4,
+        total_tokens=7,
+        request_usage_entries=[entry],
+    )
+    aggregate = Usage()
+
+    aggregate.add(source)
+
+    copied_entry = aggregate.request_usage_entries[0]
+    assert copied_entry is not entry
+
+    entry.input_tokens = 99
+    entry.input_tokens_details.cached_tokens = 99
+    copied_entry.output_tokens_details.reasoning_tokens = 77
+
+    assert copied_entry.input_tokens == 3
+    assert copied_entry.input_tokens_details.cached_tokens == 1
+    assert entry.output_tokens_details.reasoning_tokens == 2


### PR DESCRIPTION
### Summary
- detach existing `request_usage_entries` when aggregating `Usage` values
- detach nested token-detail objects when synthesizing a per-request entry
- add regression coverage for mutations in both directions

This keeps the aggregate's per-request history independent from the source `Usage` object after `Usage.add()` returns.

### Test plan
- added focused regression tests in `tests/test_usage_copy_isolation.py`
- GitHub Actions

### Issue number
N/A