### PR TITLE
fix(models): copy multi-provider mappings

### DIFF
--- a/src/agents/models/multi_provider.py
+++ b/src/agents/models/multi_provider.py
@@ -31,7 +31,7 @@ class MultiProviderMap:
 
     def set_mapping(self, mapping: dict[str, ModelProvider]):
         """Overwrites the current mapping with a new one."""
-        self._mapping = mapping
+        self._mapping = mapping.copy()
 
     def get_provider(self, prefix: str) -> ModelProvider | None:
         """Returns the ModelProvider for the given prefix.

--- a/tests/models/test_multi_provider_map.py
+++ b/tests/models/test_multi_provider_map.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from agents.models.interface import Model, ModelProvider
+from agents.models.multi_provider import MultiProviderMap
+
+
+class _TestProvider(ModelProvider):
+    def get_model(self, model_name: str | None) -> Model:
+        raise NotImplementedError
+
+
+def test_set_mapping_copies_caller_owned_mapping() -> None:
+    provider = _TestProvider()
+    mapping = {"custom": provider}
+    provider_map = MultiProviderMap()
+
+    provider_map.set_mapping(mapping)
+    mapping.clear()
+
+    assert provider_map.get_provider("custom") is provider


### PR DESCRIPTION
### Summary
- copy dictionaries passed to `MultiProviderMap.set_mapping()`
- prevent later mutation of a caller-owned dictionary from silently changing provider routing
- add focused regression coverage for mapping isolation

This matches `get_mapping()`, which already returns a copy rather than exposing the internal mapping directly.

### Test plan
- added focused coverage in `tests/models/test_multi_provider_map.py`
- GitHub Actions

### Issue number
N/A