### PR TITLE
fix(sandbox): validate normalized cwd separators

### DIFF
--- a/src/agents/sandbox/workspace_paths.py
+++ b/src/agents/sandbox/workspace_paths.py
@@ -73,12 +73,12 @@ def normalize_sandbox_cwd(cwd: str | PurePath) -> PurePosixPath:
     if isinstance(cwd, PurePath):
         raw_cwd = cwd.as_posix()
     elif isinstance(cwd, str):
-        if "\\" in cwd:
-            raise ValueError("sandbox.cwd must use POSIX path separators")
         raw_cwd = cwd
     else:
         raise ValueError("sandbox.cwd must be a string or Path")
 
+    if "\\" in raw_cwd:
+        raise ValueError("sandbox.cwd must use POSIX path separators")
     if not raw_cwd.strip():
         raise ValueError("sandbox.cwd must be non-empty")
     if windows_absolute_path(cwd) is not None:

--- a/tests/sandbox/test_sandbox_cwd_path_validation.py
+++ b/tests/sandbox/test_sandbox_cwd_path_validation.py
@@ -1,0 +1,16 @@
+from pathlib import PurePosixPath, PureWindowsPath
+
+import pytest
+
+from agents.sandbox.workspace_paths import normalize_sandbox_cwd
+
+
+def test_normalize_sandbox_cwd_rejects_backslash_in_pure_posix_path() -> None:
+    with pytest.raises(ValueError, match="POSIX path separators"):
+        normalize_sandbox_cwd(PurePosixPath(r"tasks\child"))
+
+
+def test_normalize_sandbox_cwd_normalizes_relative_pure_windows_path() -> None:
+    assert normalize_sandbox_cwd(PureWindowsPath(r"tasks\child")) == PurePosixPath(
+        "tasks/child"
+    )


### PR DESCRIPTION
### Summary
- apply the existing POSIX-separator validation after normalizing `PurePath` inputs
- reject backslashes embedded in `PurePosixPath` values just like equivalent string inputs
- preserve relative `PureWindowsPath` support through its existing POSIX normalization
- add focused regression coverage

This removes a representation-dependent validation gap in `normalize_sandbox_cwd()` without changing the policy for raw Windows-style string paths.

### Test plan
- added focused coverage in `tests/sandbox/test_sandbox_cwd_path_validation.py`
- GitHub Actions

### Issue number
N/A