### PR TITLE
fix(agent-tools) reject invalid input builder results

### DIFF
--- a/src/agents/agent_tool_input.py
+++ b/src/agents/agent_tool_input.py
@@ -99,7 +99,10 @@ async def resolve_agent_tool_input(
             result = await result
         if isinstance(result, str) or isinstance(result, list):
             return result
-        return cast(StructuredToolInputResult, result)
+        raise TypeError(
+            "Agent tool input builder must return a string or list of response input items, "
+            f"got {type(result).__name__}"
+        )
 
     if is_agent_tool_input(params) and _has_only_input_field(params):
         return cast(str, params["input"])

--- a/tests/test_agent_tool_input_invalid_builder.py
+++ b/tests/test_agent_tool_input_invalid_builder.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from agents.agent_tool_input import StructuredToolInputBuilder, resolve_agent_tool_input
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_tool_input_rejects_invalid_builder_result() -> None:
+    def invalid_builder(_options: Any) -> Any:
+        return {"input": "invalid"}
+
+    with pytest.raises(
+        TypeError,
+        match="Agent tool input builder must return a string or list of response input items, got dict",
+    ):
+        await resolve_agent_tool_input(
+            params={"input": "ignored"},
+            input_builder=cast(StructuredToolInputBuilder, invalid_builder),
+        )

--- a/tests/test_agent_tool_input_invalid_builder.py
+++ b/tests/test_agent_tool_input_invalid_builder.py
@@ -12,10 +12,7 @@ async def test_resolve_agent_tool_input_rejects_invalid_builder_result() -> None
     def invalid_builder(_options: Any) -> Any:
         return {"input": "invalid"}
 
-    with pytest.raises(
-        TypeError,
-        match="Agent tool input builder must return a string or list of response input items, got dict",
-    ):
+    with pytest.raises(TypeError, match="must return a string or list.*got dict"):
         await resolve_agent_tool_input(
             params={"input": "ignored"},
             input_builder=cast(StructuredToolInputBuilder, invalid_builder),


### PR DESCRIPTION
### Summary
- validate custom structured agent-tool input builder results at the API boundary
- raise a clear `TypeError` when a builder returns an unsupported runtime type
- preserve existing string, list, and awaitable builder behaviour

This prevents invalid builder values from being silently cast and failing later in the run pipeline.

### Test plan
- added focused regression coverage in `tests/test_agent_tool_input_invalid_builder.py`
- GitHub Actions

### Issue number
N/A