### PR TITLE
fix(mcp) ignore whitespace-only tool metadata

### DIFF
--- a/src/agents/_mcp_tool_metadata.py
+++ b/src/agents/_mcp_tool_metadata.py
@@ -20,7 +20,7 @@ def _get_mapping_or_attr(value: Any, key: str) -> Any:
 
 
 def _get_non_empty_string(value: Any) -> str | None:
-    if isinstance(value, str) and value:
+    if isinstance(value, str) and value.strip():
         return value
     return None
 

--- a/tests/test_mcp_tool_metadata_whitespace.py
+++ b/tests/test_mcp_tool_metadata_whitespace.py
@@ -1,0 +1,30 @@
+from agents._mcp_tool_metadata import (
+    collect_mcp_list_tools_metadata,
+    resolve_mcp_tool_description_for_model,
+    resolve_mcp_tool_title,
+)
+
+
+def test_mcp_tool_title_skips_whitespace_explicit_title() -> None:
+    tool = {"title": "   ", "annotations": {"title": "Annotated"}}
+    assert resolve_mcp_tool_title(tool) == "Annotated"
+
+
+def test_mcp_model_description_skips_whitespace_description() -> None:
+    tool = {"description": "\t ", "title": "Short"}
+    assert resolve_mcp_tool_description_for_model(tool) == "Short"
+
+
+def test_mcp_metadata_collection_skips_whitespace_identifiers() -> None:
+    items = [
+        {
+            "type": "mcp_list_tools",
+            "server_label": "github",
+            "tools": [
+                {"name": "   ", "description": "ignored"},
+                {"name": "search", "description": "kept"},
+            ],
+        }
+    ]
+
+    assert list(collect_mcp_list_tools_metadata(items)) == [("github", "search")]


### PR DESCRIPTION
### Summary
- treat whitespace-only MCP strings as empty metadata
- allow useful annotation titles to win when an explicit title is blank whitespace
- let model-facing descriptions fall back to titles when descriptions contain only whitespace
- skip whitespace-only MCP server labels and tool names during metadata collection

The helper already models non-empty string semantics; this makes that behaviour consistent with other schema-description handling in the SDK.

### Test plan
- added focused regression coverage in `tests/test_mcp_tool_metadata_whitespace.py`
- GitHub Actions

### Issue number
N/A