### PR TITLE
fix(asyncio): preserve producer failures while draining consumers

### DIFF
--- a/src/agents/util/_asyncio_tasks.py
+++ b/src/agents/util/_asyncio_tasks.py
@@ -139,7 +139,7 @@ async def run_producer_consumer(
         try:
             producer_result = producer_task.result()
         except BaseException:
-            await consumer_task
+            await asyncio.gather(consumer_task, return_exceptions=True)
             raise
 
         consumer_result = await consumer_task

--- a/tests/test_asyncio_tasks_primary_error.py
+++ b/tests/test_asyncio_tasks_primary_error.py
@@ -16,6 +16,7 @@ async def test_run_producer_consumer_preserves_producer_failure_when_consumer_al
         pass
 
     producer_failed = asyncio.Event()
+    allow_consumer_failure = asyncio.Event()
     consumer_failed = asyncio.Event()
 
     async def producer() -> None:
@@ -23,11 +24,17 @@ async def test_run_producer_consumer_preserves_producer_failure_when_consumer_al
         raise ProducerError("producer failed")
 
     async def consumer() -> None:
-        await producer_failed.wait()
+        await allow_consumer_failure.wait()
         consumer_failed.set()
         raise ConsumerError("consumer failed while draining")
 
+    task = asyncio.create_task(run_producer_consumer(producer(), consumer()))
+    await producer_failed.wait()
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    allow_consumer_failure.set()
     with pytest.raises(ProducerError, match="producer failed"):
-        await run_producer_consumer(producer(), consumer())
+        await task
 
     assert consumer_failed.is_set()

--- a/tests/test_asyncio_tasks_primary_error.py
+++ b/tests/test_asyncio_tasks_primary_error.py
@@ -31,6 +31,7 @@ async def test_run_producer_consumer_preserves_producer_failure_when_consumer_al
     task = asyncio.create_task(run_producer_consumer(producer(), consumer()))
     await producer_failed.wait()
     await asyncio.sleep(0)
+    await asyncio.sleep(0)
     assert not task.done()
 
     allow_consumer_failure.set()

--- a/tests/test_asyncio_tasks_primary_error.py
+++ b/tests/test_asyncio_tasks_primary_error.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agents.util._asyncio_tasks import run_producer_consumer
+
+
+@pytest.mark.asyncio
+async def test_run_producer_consumer_preserves_producer_failure_when_consumer_also_fails() -> None:
+    class ProducerError(Exception):
+        pass
+
+    class ConsumerError(Exception):
+        pass
+
+    producer_failed = asyncio.Event()
+    consumer_failed = asyncio.Event()
+
+    async def producer() -> None:
+        producer_failed.set()
+        raise ProducerError("producer failed")
+
+    async def consumer() -> None:
+        await producer_failed.wait()
+        consumer_failed.set()
+        raise ConsumerError("consumer failed while draining")
+
+    with pytest.raises(ProducerError, match="producer failed"):
+        await run_producer_consumer(producer(), consumer())
+
+    assert consumer_failed.is_set()


### PR DESCRIPTION
### Summary
- preserve the producer exception when the consumer also fails during producer-failure draining
- continue waiting for the consumer task to settle before propagating the producer failure
- keep consumer-first failure and parent-cancellation behaviour unchanged

`run_producer_consumer()` documents producer failures as primary while the consumer drains. Previously a secondary consumer exception raised during that drain replaced the producer exception.

### Test plan
- added focused regression coverage in `tests/test_asyncio_tasks_primary_error.py`
- GitHub Actions

### Issue number
N/A