### PR TITLE
fix(tools): normalize custom data copy errors

### DIFF
--- a/src/agents/util/_custom_data.py
+++ b/src/agents/util/_custom_data.py
@@ -26,8 +26,8 @@ def normalize_custom_data(value: Mapping[str, Any] | None) -> dict[str, Any] | N
     if not all(isinstance(key, str) for key in value):
         raise UserError("custom_data_extractor must return a mapping with string keys.")
 
-    copied = copy.deepcopy(dict(value))
     try:
+        copied = copy.deepcopy(dict(value))
         return cast(dict[str, Any], json.loads(json.dumps(copied, allow_nan=False)))
     except (TypeError, ValueError) as exc:
         raise UserError("custom_data_extractor must return JSON-compatible data.") from exc

--- a/tests/test_custom_data_copy_error.py
+++ b/tests/test_custom_data_copy_error.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from agents.exceptions import UserError
+from agents.util._custom_data import normalize_custom_data
+
+
+def test_normalize_custom_data_wraps_deepcopy_type_error() -> None:
+    values = (value for value in [1, 2, 3])
+
+    with pytest.raises(
+        UserError,
+        match="custom_data_extractor must return JSON-compatible data",
+    ):
+        normalize_custom_data({"values": values})


### PR DESCRIPTION
### Summary
- include defensive copying inside the custom-data normalization error boundary
- convert non-copyable custom-data values into the same `UserError` used for other non-JSON-compatible payloads
- preserve existing behaviour for valid mappings and JSON serialization failures

This prevents implementation-specific `copy.deepcopy()` errors from escaping a public custom-data extractor boundary.

### Test plan
- added focused regression coverage in `tests/test_custom_data_copy_error.py`
- GitHub Actions

### Issue number
N/A