### PR TITLE
fix(output): isolate returned JSON schemas

### DIFF
--- a/src/agents/agent_output.py
+++ b/src/agents/agent_output.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 from dataclasses import dataclass
 from typing import Any, cast, get_args, get_origin
 
@@ -137,7 +138,7 @@ class AgentOutputSchema(AgentOutputSchemaBase):
         """The JSON schema of the output type."""
         if self.is_plain_text():
             raise UserError("Output type is plain text, so no JSON schema is available")
-        return self._output_schema
+        return copy.deepcopy(self._output_schema)
 
     def validate_json(self, json_str: str) -> Any:
         """Validate a JSON string against the output type. Returns the validated object, or raises

--- a/tests/test_agent_output_schema_copy.py
+++ b/tests/test_agent_output_schema_copy.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from agents.agent_output import AgentOutputSchema
+
+
+class _Output(BaseModel):
+    value: str
+
+
+def test_agent_output_json_schema_returns_isolated_copy() -> None:
+    output_schema = AgentOutputSchema(_Output)
+
+    first = output_schema.json_schema()
+    first["properties"]["value"]["type"] = "integer"
+
+    second = output_schema.json_schema()
+    assert second["properties"]["value"]["type"] == "string"


### PR DESCRIPTION
### Summary
- return a deep copy from `AgentOutputSchema.json_schema()`
- prevent caller mutation of a returned schema from changing the schema retained by the output contract
- preserve the existing plain-text error behaviour

`json_schema()` exposes a nested mutable dictionary. Returning the internal object lets an inspection or downstream modification silently alter later model-facing schema reads from the same `AgentOutputSchema` instance.

### Test plan
- added focused regression coverage in `tests/test_agent_output_schema_copy.py`
- GitHub Actions

### Issue number
N/A