### PR TITLE
fix(config): reject invalid default OpenAI API values

### DIFF
--- a/src/agents/_config.py
+++ b/src/agents/_config.py
@@ -25,6 +25,10 @@ def set_default_openai_client(client: AsyncOpenAI, use_for_tracing: bool) -> Non
 
 
 def set_default_openai_api(api: Literal["chat_completions", "responses"]) -> None:
+    if api not in {"chat_completions", "responses"}:
+        raise ValueError(
+            "Invalid OpenAI API. Expected one of: 'chat_completions', 'responses'."
+        )
     if api == "chat_completions":
         _openai_shared.set_use_responses_by_default(False)
     else:

--- a/tests/test_default_openai_api_validation.py
+++ b/tests/test_default_openai_api_validation.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from agents import _config
+from agents.models import _openai_shared
+
+
+def test_set_default_openai_api_rejects_invalid_runtime_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[bool] = []
+    monkeypatch.setattr(_openai_shared, "set_use_responses_by_default", calls.append)
+
+    with pytest.raises(
+        ValueError,
+        match="Invalid OpenAI API",
+    ):
+        _config.set_default_openai_api(cast(Any, "chat_completion"))
+
+    assert calls == []


### PR DESCRIPTION
### Summary
- validate runtime values passed to `set_default_openai_api()`
- reject unsupported API names instead of silently selecting the Responses API
- avoid changing the provider default when validation fails

The function is annotated with a `Literal`, but runtime callers can still pass arbitrary strings. Previously every value other than `"chat_completions"` was treated as `"responses"`.

### Test plan
- added focused regression coverage in `tests/test_default_openai_api_validation.py`
- GitHub Actions

### Issue number
N/A