### PR TITLE
fix(schema): preserve Griffe logger inheritance

### DIFF
--- a/src/agents/function_schema.py
+++ b/src/agents/function_schema.py
@@ -139,7 +139,7 @@ def _detect_docstring_style(doc: str) -> DocstringStyle:
 def _suppress_griffe_logging():
     # Suppresses warnings about missing annotations for params
     logger = logging.getLogger("griffe")
-    previous_level = logger.getEffectiveLevel()
+    previous_level = logger.level
     logger.setLevel(logging.ERROR)
     try:
         yield

--- a/tests/test_function_schema_logger_restore.py
+++ b/tests/test_function_schema_logger_restore.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+
+from agents.function_schema import _suppress_griffe_logging
+
+
+def test_suppress_griffe_logging_restores_configured_notset_level() -> None:
+    logger = logging.getLogger("griffe")
+    root_logger = logging.getLogger()
+    previous_logger_level = logger.level
+    previous_root_level = root_logger.level
+
+    try:
+        logger.setLevel(logging.NOTSET)
+        root_logger.setLevel(logging.WARNING)
+        assert logger.getEffectiveLevel() == logging.WARNING
+
+        with _suppress_griffe_logging():
+            assert logger.level == logging.ERROR
+
+        assert logger.level == logging.NOTSET
+        assert logger.getEffectiveLevel() == logging.WARNING
+    finally:
+        logger.setLevel(previous_logger_level)
+        root_logger.setLevel(previous_root_level)


### PR DESCRIPTION
### Summary
- restore the Griffe logger's configured level after docstring parsing
- preserve `NOTSET` inheritance instead of replacing it with the inherited effective level
- keep warning suppression during parsing unchanged

`_suppress_griffe_logging()` captured `logger.getEffectiveLevel()`. When the `griffe` logger inherited its level via `NOTSET`, leaving the context permanently replaced `NOTSET` with the inherited numeric level and changed future logging configuration.

### Test plan
- added focused regression coverage in `tests/test_function_schema_logger_restore.py`
- GitHub Actions

### Issue number
N/A