### PR TITLE
fix(retry): reject negative retry counts

### DIFF
--- a/src/agents/retry.py
+++ b/src/agents/retry.py
@@ -210,7 +210,7 @@ def retry_policy_retries_all_transient_errors(policy: RetryPolicy | None) -> boo
 class ModelRetrySettings:
     """Opt-in runner-managed retry settings for model calls."""
 
-    max_retries: int | None = None
+    max_retries: int | None = Field(default=None, ge=0)
     """Retries allowed after the initial model request."""
 
     backoff: ModelRetryBackoffInput | None = None

--- a/tests/test_retry_count_validation.py
+++ b/tests/test_retry_count_validation.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agents.retry import ModelRetrySettings
+
+
+def test_model_retry_settings_rejects_negative_max_retries() -> None:
+    with pytest.raises(ValidationError):
+        ModelRetrySettings(max_retries=-1)
+
+
+def test_model_retry_settings_allows_zero_max_retries() -> None:
+    settings = ModelRetrySettings(max_retries=0)
+    assert settings.max_retries == 0


### PR DESCRIPTION
### Summary
- constrain `ModelRetrySettings.max_retries` to non-negative values
- preserve `0` as the explicit no-retry configuration
- fail during settings validation instead of silently treating negative counts as an exhausted retry budget

The setting represents retries allowed after the initial request, so negative values are not meaningful. The backoff settings already use Pydantic numeric constraints; this applies the same validation boundary to the retry count.

### Test plan
- added focused regression coverage in `tests/test_retry_count_validation.py`
- GitHub Actions

### Issue number
N/A