### PR TITLE
fix(tracing): respect model-data logging redaction for record_model_error_on_span

### DIFF
--- a/src/agents/util/_error_tracing.py
+++ b/src/agents/util/_error_tracing.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from .. import _debug
 from ..exceptions import ModelTimeoutError
-from ..logger import logger
+from ..logger import log_model_action_warning, logger
 from ..tracing import Span, SpanError, get_current_span
 
 REDACTED_TRACE_ERROR_MESSAGE = "Error details are redacted."
@@ -114,8 +114,12 @@ def record_model_error_on_span(
                 },
             ),
         )
-    except Exception:
-        logger.warning("Could not record the model error on the span", exc_info=True)
+    except Exception as tracing_error:
+        log_model_action_warning(
+            logger,
+            "Could not record the model error on the span",
+            tracing_error,
+        )
 
 
 @contextlib.contextmanager

--- a/tests/test_model_error_logging_redaction.py
+++ b/tests/test_model_error_logging_redaction.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import pytest
+
+from agents import _debug
+from agents.tracing import Span
+from agents.util._error_tracing import record_model_error_on_span
+
+
+class _FailingSpan:
+    def set_error(self, _error: Any) -> None:
+        raise RuntimeError("span-annotation-secret")
+
+
+def test_model_error_annotation_failure_respects_log_redaction(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(_debug, "DONT_LOG_MODEL_DATA", True)
+
+    with caplog.at_level(logging.WARNING, logger="openai.agents"):
+        record_model_error_on_span(
+            cast(Span[Any], _FailingSpan()),
+            message="Error getting response",
+            error=RuntimeError("model-secret"),
+            trace_include_sensitive_data=False,
+        )
+
+    assert "span-annotation-secret" not in caplog.text
+    assert "model-secret" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)


### PR DESCRIPTION
### Summary
- route model-span annotation failures through the SDK's model-data-aware logging helper
- avoid attaching traceback or exception data when model-data logging is disabled
- preserve diagnostic exception logging when model-data logging is enabled

`record_model_error_on_span()` is best-effort and should never turn tracing into a data leak. Previously its fallback `logger.warning(..., exc_info=True)` bypassed the SDK logging redaction policy.

### Test plan
- added focused regression coverage in `tests/test_model_error_logging_redaction.py`
- GitHub Actions

### Issue number
N/A