### PR TITLE
fix(core): reject ignored explicit-client options for OpenAIProvider

### DIFF
--- a/src/agents/models/openai_provider.py
+++ b/src/agents/models/openai_provider.py
@@ -88,10 +88,13 @@ class OpenAIProvider(ModelProvider):
                 chunk semantics are not reliable enough for incremental processing.
         """
         if openai_client is not None:
-            if api_key is not None or base_url is not None or websocket_base_url is not None:
+            if any(
+                value is not None
+                for value in (api_key, base_url, websocket_base_url, organization, project)
+            ):
                 raise UserError(
-                    "Don't provide api_key, base_url, or websocket_base_url if you provide "
-                    "openai_client"
+                    "Don't provide api_key, base_url, websocket_base_url, organization, or project "
+                    "if you provide openai_client"
                 )
             self._client: AsyncOpenAI | None = openai_client
         else:

--- a/tests/test_openai_provider_client_options.py
+++ b/tests/test_openai_provider_client_options.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from openai import AsyncOpenAI
+
+from agents.exceptions import UserError
+from agents.models.openai_provider import OpenAIProvider
+
+
+@pytest.mark.parametrize(
+    "client_option",
+    [
+        {"organization": "org-test"},
+        {"project": "proj-test"},
+    ],
+)
+def test_openai_provider_rejects_ignored_options_with_explicit_client(
+    client_option: dict[str, str],
+) -> None:
+    client = cast(AsyncOpenAI, object())
+
+    with pytest.raises(UserError, match="organization, or project"):
+        OpenAIProvider(
+            openai_client=client,
+            **cast(dict[str, Any], client_option),
+        )


### PR DESCRIPTION
### Summary
- reject `organization` and `project` when `openai_client` is supplied
- align them with existing rejection of `api_key`, `base_url`, and `websocket_base_url`
- prevent documented client-construction options from being silently ignored

When an explicit `AsyncOpenAI` client is supplied, client-construction options cannot affect that client. Failing fast avoids configuration that appears to be applied but is actually discarded.

### Test plan
- added focused regression coverage in `tests/test_openai_provider_client_options.py`
- GitHub Actions

### Issue number
N/A