### PR TITLE
fix(tracing): detach serialized trace metadata

### DIFF
--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import contextvars
+import copy
 import hashlib
 import threading
 from collections import OrderedDict
@@ -178,7 +179,7 @@ class Trace(abc.ABC):
         exported = self.export()
         if exported is None:
             return None
-        payload = dict(exported)
+        payload = copy.deepcopy(exported)
         if include_tracing_api_key and self.tracing_api_key:
             payload["tracing_api_key"] = self.tracing_api_key
         return payload

--- a/tests/test_trace_json_isolation.py
+++ b/tests/test_trace_json_isolation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from agents.tracing.provider import SynchronousMultiTracingProcessor
+from agents.tracing.traces import TraceImpl
+
+
+def test_trace_to_json_detaches_nested_metadata() -> None:
+    trace = TraceImpl(
+        name="workflow",
+        trace_id="trace_test",
+        group_id=None,
+        metadata={"nested": {"value": "original"}},
+        processor=SynchronousMultiTracingProcessor(),
+    )
+
+    payload = trace.to_json()
+    assert payload is not None
+    payload["metadata"]["nested"]["value"] = "changed"
+
+    assert trace.metadata == {"nested": {"value": "original"}}


### PR DESCRIPTION
### Summary
- deep-copy exported trace data in `Trace.to_json()`
- keep nested metadata in persistence and transport payloads isolated from the live trace
- preserve existing tracing API-key serialization behaviour

The previous top-level `dict()` copy left nested metadata shared, so mutating a serialized payload could silently mutate the trace object it came from.

### Test plan
- added focused regression coverage in `tests/test_trace_json_isolation.py`
- GitHub Actions

### Issue number
N/A