### PR TITLE
fix(sandbox): enforce Windows mypy compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,41 @@ jobs:
         if: steps.changes.outputs.run != 'true'
         run: echo "Skipping typecheck for non-code changes."
 
+  mypy-win32:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Detect code changes
+        id: changes
+        run: ./.github/scripts/detect-changes.sh code "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
+      - name: Setup uv
+        if: steps.changes.outputs.run == 'true'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # setup-uv v9.0.0; uv 0.11.14
+        with:
+          version: "0.11.14"
+          enable-cache: true
+          prune-cache: true
+          python-version: "3.14"
+      - name: Restore mypy cache
+        if: steps.changes.outputs.run == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .mypy_cache
+          key: mypy-win32-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('uv.lock', 'pyproject.toml', 'Makefile') }}-${{ github.sha }}
+          restore-keys: |
+            mypy-win32-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('uv.lock', 'pyproject.toml', 'Makefile') }}-
+      - name: Install dependencies
+        if: steps.changes.outputs.run == 'true'
+        run: make sync
+      - name: Run mypy for Windows
+        if: steps.changes.outputs.run == 'true'
+        run: uv run mypy --platform win32 src
+      - name: Skip Windows mypy
+        if: steps.changes.outputs.run != 'true'
+        run: echo "Skipping Windows mypy for non-code changes."
+
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/src/agents/sandbox/sandboxes/docker.py
+++ b/src/agents/sandbox/sandboxes/docker.py
@@ -1427,7 +1427,7 @@ class DockerSandboxSession(BaseSandboxSession):
             archive.seek(0)
             await self._stream_into_exec(
                 cmd=["tar", "-x", "-C", root.as_posix()],
-                stream=archive,
+                stream=cast(io.IOBase, archive),
                 error_path=error_root,
             )
 

--- a/src/agents/sandbox/sandboxes/unix_local.py
+++ b/src/agents/sandbox/sandboxes/unix_local.py
@@ -336,8 +336,8 @@ class UnixLocalSandboxSession(BaseSandboxSession):
             else:
                 with suppress(OSError):
                     os.close(secondary_fd)
-            entry = _UnixPtyProcessEntry(process=process, tty=True, primary_fd=primary_fd)
-            entry.pump_tasks = [asyncio.create_task(self._pump_pty_primary_fd(entry))]
+                entry = _UnixPtyProcessEntry(process=process, tty=True, primary_fd=primary_fd)
+                entry.pump_tasks = [asyncio.create_task(self._pump_pty_primary_fd(entry))]
         else:
             process = await asyncio.create_subprocess_exec(
                 *exec_command,

--- a/src/agents/sandbox/util/tar_utils.py
+++ b/src/agents/sandbox/util/tar_utils.py
@@ -8,6 +8,7 @@ import tarfile
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import cast
 
 
 class UnsafeTarMemberError(ValueError):
@@ -158,7 +159,7 @@ def strip_tar_member_prefix(data: io.IOBase, *, prefix: str | Path) -> io.IOBase
         with tarfile.open(fileobj=out, mode="r:*") as tar:
             validate_tarfile(tar)
         out.seek(0)
-        return out
+        return cast(io.IOBase, out)
     except Exception:
         out.close()
         raise


### PR DESCRIPTION
This pull request fixes Windows-targeted mypy errors in the sandbox implementation and adds a dedicated `mypy-win32` CI job that runs in parallel with the existing typecheck job.

It preserves the source corrections from #4482, removes the runtime-only regression tests that pass against the unfixed base, and checks the complete `src` tree with `mypy --platform win32`. The new job uses an isolated mypy cache key so Windows-targeted results cannot collide with the existing Linux cache.

Resolves https://github.com/openai/openai-agents-python/issues/4477