### PR TITLE
fix(tracing): make trace finish idempotent

### DIFF
--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -497,6 +497,7 @@ class TraceImpl(Trace):
         "_prev_context_token",
         "_processor",
         "_started",
+        "_finished",
     )
 
     def __init__(
@@ -516,6 +517,7 @@ class TraceImpl(Trace):
         self._prev_context_token: contextvars.Token[Trace | None] | None = None
         self._processor = processor
         self._started = False
+        self._finished = False
 
     @property
     def trace_id(self) -> str:
@@ -544,7 +546,9 @@ class TraceImpl(Trace):
         if not self._started:
             return
 
-        self._processor.on_trace_end(self)
+        if not self._finished:
+            self._processor.on_trace_end(self)
+            self._finished = True
 
         if reset_current and self._prev_context_token is not None:
             Scope.reset_current_trace(self._prev_context_token)

--- a/tests/test_trace_finish_idempotent.py
+++ b/tests/test_trace_finish_idempotent.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from agents.tracing.scope import Scope
+from agents.tracing.traces import TraceImpl
+
+
+def test_trace_finish_notifies_processor_once_and_can_reset_later() -> None:
+    processor = MagicMock()
+    trace = TraceImpl(
+        name="workflow",
+        trace_id="trace_test",
+        group_id=None,
+        metadata=None,
+        processor=processor,
+    )
+
+    trace.start(mark_as_current=True)
+    trace.finish()
+    trace.finish(reset_current=True)
+
+    processor.on_trace_end.assert_called_once_with(trace)
+    assert Scope.get_current_trace() is None


### PR DESCRIPTION
### Summary
- make `TraceImpl.finish()` notify processors at most once
- preserve the ability to reset a trace context on a later `finish(reset_current=True)` call
- align trace lifecycle behaviour with the existing idempotent span finish path

Calling `finish()` more than once currently emits duplicate `on_trace_end` events, which can enqueue and export the same trace multiple times. The finished state is recorded after the processor callback succeeds, before any optional context reset.

### Test plan
- added focused regression coverage in `tests/test_trace_finish_idempotent.py`
- GitHub Actions

### Issue number
N/A