### PR TITLE
fix(tracing): make no-op starts idempotent

### DIFF
--- a/src/agents/tracing/spans.py
+++ b/src/agents/tracing/spans.py
@@ -222,11 +222,12 @@ class NoOpSpan(Span[TSpanData]):
         span_data: The operation-specific data for this span.
     """
 
-    __slots__ = ("_span_data", "_prev_span_token")
+    __slots__ = ("_span_data", "_prev_span_token", "_started")
 
     def __init__(self, span_data: TSpanData):
         self._span_data = span_data
         self._prev_span_token: contextvars.Token[Span[TSpanData] | None] | None = None
+        self._started = False
 
     @property
     def trace_id(self) -> str:
@@ -245,6 +246,10 @@ class NoOpSpan(Span[TSpanData]):
         return None
 
     def start(self, mark_as_current: bool = False):
+        if self._started:
+            return
+
+        self._started = True
         if mark_as_current:
             self._prev_span_token = Scope.set_current_span(self)
 

--- a/src/agents/tracing/traces.py
+++ b/src/agents/tracing/traces.py
@@ -429,7 +429,6 @@ class NoOpTrace(Trace):
                 logger.error("Trace already started but no context token set")
             return self
 
-        self._started = True
         self.start(mark_as_current=True)
 
         return self
@@ -441,6 +440,10 @@ class NoOpTrace(Trace):
             self.finish(reset_current=True)
 
     def start(self, mark_as_current: bool = False):
+        if self._started:
+            return
+
+        self._started = True
         if mark_as_current:
             self._prev_context_token = Scope.set_current_trace(self)
 

--- a/tests/test_noop_tracing_start_idempotent.py
+++ b/tests/test_noop_tracing_start_idempotent.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from agents.tracing.scope import Scope
+from agents.tracing.span_data import AgentSpanData
+from agents.tracing.spans import NoOpSpan
+from agents.tracing.traces import NoOpTrace
+
+
+def test_noop_trace_repeated_start_does_not_overwrite_context_token() -> None:
+    trace = NoOpTrace()
+    try:
+        trace.start(mark_as_current=True)
+        trace.start(mark_as_current=True)
+        trace.finish(reset_current=True)
+
+        assert Scope.get_current_trace() is None
+    finally:
+        Scope.set_current_trace(None)
+
+
+def test_noop_span_repeated_start_does_not_overwrite_context_token() -> None:
+    span = NoOpSpan(AgentSpanData(name="test"))
+    try:
+        span.start(mark_as_current=True)
+        span.start(mark_as_current=True)
+        span.finish(reset_current=True)
+
+        assert Scope.get_current_span() is None
+    finally:
+        Scope.set_current_span(None)


### PR DESCRIPTION
### Summary
- make repeated `NoOpTrace.start()` calls idempotent
- make repeated `NoOpSpan.start()` calls idempotent
- prevent a second `mark_as_current=True` start from overwriting the original ContextVar token

Normal trace and span implementations already ignore repeated starts. The no-op implementations did not, so a second start replaced the saved token with one whose previous value was the no-op object itself. A single `finish(reset_current=True)` then restored that object as current instead of clearing it, leaking tracing context when tracing is disabled.

### Test plan
- added focused regression coverage in `tests/test_noop_tracing_start_idempotent.py`
- GitHub Actions

### Issue number
N/A