### PR TITLE
fix(tracing): clean up processors after tracing is disabled

### DIFF
--- a/src/agents/tracing/provider.py
+++ b/src/agents/tracing/provider.py
@@ -507,10 +507,6 @@ class DefaultTraceProvider(TraceProvider):
             log_model_and_tool_action_error(logger, "Error flushing trace provider", e)
 
     def shutdown(self, timeout: float | None = None) -> None:
-        self._refresh_disabled_flag()
-        if self._disabled:
-            return
-
         try:
             _safe_debug("Shutting down trace provider")
             self._multi_processor.shutdown(timeout=timeout)

--- a/tests/test_disabled_trace_provider_shutdown.py
+++ b/tests/test_disabled_trace_provider_shutdown.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from agents.tracing.provider import DefaultTraceProvider
+
+
+def test_disabled_trace_provider_still_shuts_down_registered_processors() -> None:
+    provider = DefaultTraceProvider()
+    processor = MagicMock()
+    provider.register_processor(processor)
+    provider.set_disabled(True)
+
+    provider.shutdown()
+
+    processor.shutdown.assert_called_once_with()


### PR DESCRIPTION
### Summary
- always run `DefaultTraceProvider.shutdown()` for registered processors
- keep shutdown independent from whether new tracing is currently disabled
- ensure processors created before or while tracing is disabled can release worker and client resources

`DefaultTraceProvider.shutdown()` previously returned early when the provider's disabled flag was set. Disabling tracing controls creation of new trace data, but registered processors can already own resources and still require shutdown. This is especially relevant for the default batch processor, which owns a worker thread and exporter client.

### Test plan
- added focused regression coverage in `tests/test_disabled_trace_provider_shutdown.py`
- GitHub Actions

### Issue number
N/A