### PR TITLE
fix: pin mypy target platform to linux in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ convention = "google"
 "tests/**/*.py" = ["ASYNC", "RUF006", "RUF012", "RUF100"]
 
 [tool.mypy]
+platform = "linux"
 strict = true
 disallow_incomplete_defs = false
 disallow_untyped_defs = false


### PR DESCRIPTION
This pull request fixes make typecheck behavior on Windows contributor setups by pinning platform = linux in pyproject.toml.

### Background
Running make typecheck or uv run mypy src on Windows previously surfaced 3 platform-specific type errors in src/agents/sandbox/ because mypy used the host OS (win32) instead of the target Linux platform enforced in CI (ubuntu-latest). Setting platform = linux ensures mypy output is deterministic across all OS environments.

This pull request resolves #4477.