### PR TITLE
docs: note that Agent.clone shares non-list mutable attributes

### DIFF
--- a/src/agents/agent.py
+++ b/src/agents/agent.py
@@ -560,6 +560,16 @@ class Agent(AgentBase, Generic[TContext]):
             - To give the clone a list that no other agent holds, pass a new one, for example
               `agent.clone(tools=[*agent.tools, extra_tool])`. The entries copied into it remain
               the same objects the original agent holds.
+            - The same applies to the mutable attributes that are not lists, `model_settings` and
+              `mcp_config`. An omitted one arrives as the original agent's own object, so
+              `cloned.model_settings.temperature = 0.9` also changes the original. Pass a
+              replacement to keep them separate, for example
+              `agent.clone(model_settings=dataclasses.replace(agent.model_settings,
+              temperature=0.9))`.
+            - Overriding `model` alone does not give the clone its own `model_settings`. Fresh
+              settings are substituted only when the current ones still match the implicit
+              defaults for the current model, so an agent carrying any explicit setting keeps
+              sharing that object across `agent.clone(model=...)`.
         Example:
             ```python
             new_agent = agent.clone(instructions="New instructions")

--- a/tests/test_agent_clone_shallow_copy.py
+++ b/tests/test_agent_clone_shallow_copy.py
@@ -1,4 +1,4 @@
-from agents import Agent, function_tool, handoff
+from agents import Agent, ModelSettings, function_tool, handoff
 
 
 @function_tool
@@ -79,3 +79,32 @@ def test_agent_clone_shared_list_mutation_affects_both_agents():
 
     assert original.tools == cloned.tools
     assert len(original.tools) == 2
+
+
+def test_agent_clone_shares_non_list_mutable_attributes():
+    """`model_settings` and `mcp_config` are shared too, which the list wording does not cover."""
+    agent = Agent(
+        name="Original",
+        model="gpt-4o",
+        model_settings=ModelSettings(temperature=0.1),
+        mcp_config={"convert_schemas_to_strict": True},
+    )
+
+    cloned = agent.clone(instructions="Changed")
+
+    assert cloned.model_settings is agent.model_settings
+    assert cloned.mcp_config is agent.mcp_config
+
+    cloned.model_settings.temperature = 0.9
+    cloned.mcp_config["convert_schemas_to_strict"] = False
+    assert agent.model_settings.temperature == 0.9
+    assert agent.mcp_config["convert_schemas_to_strict"] is False
+
+
+def test_agent_clone_with_only_model_override_keeps_shared_model_settings():
+    """Overriding `model` alone does not detach explicit settings from the original."""
+    agent = Agent(name="Original", model="gpt-4o", model_settings=ModelSettings(temperature=0.1))
+
+    cloned = agent.clone(model="gpt-4o-mini")
+
+    assert cloned.model_settings is agent.model_settings


### PR DESCRIPTION
### Summary

#4474 fixed the `Agent.clone()` docstring for list attributes. Its wording is list-only, though, so a reader now reasonably concludes that anything which is not a list gets copied:

> ...never copies a **list** attribute such as `tools`, `handoffs`, `mcp_servers`, `input_guardrails`, or `output_guardrails`

`Agent` has two mutable attributes that are not lists, and `dataclasses.replace` shares both exactly the same way. On current `main`:

```
mcp_config shared            : True
  original now               : {'convert_schemas_to_strict': False}
model_settings shared        : True
  original temperature now   : 0.9
model= only, settings shared : True
```

So the surprise #4474 set out to document still bites through `model_settings` and `mcp_config`, and the advice it gives ("pass a new one, for example `agent.clone(tools=[*agent.tools, extra_tool])`") does not translate to either.

The last line is the part I did not expect. Overriding `model` alone does **not** give the clone its own settings: `clone()` substitutes fresh ones only when `_model_settings_match_implicit_model_defaults(self.model, self.model_settings)` holds, so an agent carrying any explicit setting keeps sharing that `ModelSettings` object across `agent.clone(model=...)`.

This documents both, in the same shape #4474 used, and leaves the behavior alone. `RealtimeAgent` needs nothing: it has no `model_settings` or `mcp_config`, so its list-only wording is already complete.

### Test plan

- Two tests added to `tests/test_agent_clone_shallow_copy.py`, next to the coverage #4474 added: one asserts both non-list attributes are shared and that mutating them through the clone changes the original, one asserts `clone(model=...)` alone keeps the shared settings. They pin the behavior the docstring describes, in the same way #4474's tests do, rather than pinning the prose.
- `uv run pytest tests/test_agent_clone_shallow_copy.py`: 7 passed.
- Ran `.agents/skills/code-change-verification/scripts/run.sh`: format, lint, typecheck and the full test run all pass.
- CI here needs a maintainer to approve the workflow for a fork PR, so the above is the local run.

### Issue number

None. Follow-up to #4474, which corrected the list half of the same docstring.

### Checks

- [x] I've added new tests, if relevant
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR

---

context so this does not look like second-guessing a PR that just landed: I had measured the same sharing and left a note about it on #4474 rather than opening a competing change, and it merged without that half, so this is the leftover rather than a disagreement. #4474's version of the list wording is better than what I would have written. if you would rather the docstring stay list-only and treat `model_settings` as obvious, close it and I will take that. freshman in college, still calibrating what belongs in a docstring :)
