### PR TITLE
fix: keep Codex verification for development sandboxed

### DIFF
--- a/.agents/skills/code-change-verification/SKILL.md
+++ b/.agents/skills/code-change-verification/SKILL.md
@@ -12,12 +12,13 @@ Ensure work is only marked complete after formatting, linting, type checking, an
 ## Quick start
 
 1. Keep this skill at `./.agents/skills/code-change-verification` so it loads automatically for the repository.
-2. macOS/Linux: `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`.
-3. Windows: `powershell -ExecutionPolicy Bypass -File .agents/skills/code-change-verification/scripts/run.ps1`.
-4. The scripts run `make format` first, then run `make lint`, `make typecheck`, and `make tests` in parallel with fail-fast semantics.
-5. While the parallel steps are still running, the scripts emit periodic heartbeat updates so you can tell that work is still in progress.
-6. If any command fails, fix the issue, rerun the script, and report the failing output.
-7. Confirm completion only when all commands succeed with no remaining issues.
+2. Codex on macOS/Linux: `/usr/bin/env -u OPENAI_API_KEY OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1 UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`.
+3. Other macOS/Linux environments: `env UV_DEFAULT_INDEX=https://pypi.org/simple bash .agents/skills/code-change-verification/scripts/run.sh`.
+4. Windows: `powershell -ExecutionPolicy Bypass -File .agents/skills/code-change-verification/scripts/run.ps1`.
+5. The scripts run `make format` first, then run `make lint`, `make typecheck`, and `make tests` in parallel with fail-fast semantics.
+6. While the parallel steps are still running, the scripts emit periodic heartbeat updates so you can tell that work is still in progress.
+7. If any command fails, fix the issue, rerun the script, and report the failing output.
+8. Confirm completion only when all commands succeed with no remaining issues.
 
 ## Start condition and host capacity
 
@@ -28,20 +29,11 @@ Ensure work is only marked complete after formatting, linting, type checking, an
 
 ## Codex execution policy
 
-The full test suite exercises `UnixLocalSandboxSession`, which starts its own macOS sandbox. A
-nested run inside the Codex filesystem sandbox fails with
-`sandbox-exec: sandbox_apply: Operation not permitted` even when the implementation is correct.
+Repository verification and all child processes must remain in the normal Codex workspace sandbox. Never request elevated sandbox permissions for the verification wrapper, and never retry the wrapper with broader host access after a failure.
 
-When Codex invokes the macOS/Linux verification command:
+On macOS, tests marked `requires_native_macos_sandbox` need to start their own `sandbox-exec` process. The Codex command sets `OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1`, which skips only that marker before nested sandbox creation. All other tests remain enabled. Ordinary local and CI runs do not set this variable and therefore keep the marked tests enabled.
 
-- Use the exact command from Quick start so it matches the persistent command allow rule.
-- Set `sandbox_permissions=require_escalated` on the first invocation. The matching allow rule makes
-  this non-interactive; it does not require a new user approval.
-- Do not first run the suite inside the Codex sandbox and retry after the expected UnixLocal
-  failures.
-
-This execution policy changes only where the verification process runs. The SDK sandbox tests must
-remain enabled and unchanged.
+The marked tests run separately on a disposable GitHub-hosted macOS runner. If that trusted runner is unavailable, report the missing native-macOS coverage; do not compensate by weakening the Codex sandbox boundary.
 
 ## Environment setup
 

--- a/.agents/skills/code-change-verification/agents/openai.yaml
+++ b/.agents/skills/code-change-verification/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Change Verification"
   short_description: "Run the required local verification stack"
-  default_prompt: "Use $code-change-verification to run the required local verification stack. On macOS/Linux, invoke its canonical env command outside the Codex sandbox on the first attempt so nested UnixLocal sandbox tests run without an approval retry. Report any failures."
+  default_prompt: "Use $code-change-verification to run the required local verification stack inside the normal Codex workspace sandbox. On macOS/Linux, use the documented Codex command so only tests that require a native macOS sandbox are skipped locally. Never request elevated sandbox permissions or retry with broader host access. Report any failures."

--- a/.github/scripts/detect-changes.sh
+++ b/.github/scripts/detect-changes.sh
@@ -46,7 +46,7 @@ changed_files=$(git diff --name-only "$base_sha" "$head_sha" || true)
 
 case "$mode" in
   code)
-    pattern='^(src/|tests/|integration_tests/|examples/|\.agents/skills/(examples-auto-run|examples-run-analysis|integration-tests)/|\.github/scripts/(detect-changes\.sh|run_examples\.sh|run_integration_tests\.py|update_released_api_contract\.py)$|\.github/workflows/tests\.yml$|pyproject.toml$|uv.lock$|Makefile$)'
+    pattern='^(src/|tests/|integration_tests/|examples/|\.agents/skills/(code-change-verification|examples-auto-run|examples-run-analysis|integration-tests)/|\.github/scripts/(detect-changes\.sh|run_examples\.sh|run_integration_tests\.py|update_released_api_contract\.py)$|\.github/workflows/tests\.yml$|pyproject.toml$|uv.lock$|Makefile$)'
     ;;
   docs)
     pattern='^(docs/|mkdocs.yml$)'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,6 +158,36 @@ jobs:
         if: steps.changes.outputs.run != 'true'
         run: echo "Skipping tests for non-code changes."
 
+  native-macos-sandbox:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    env:
+      OPENAI_API_KEY: fake-for-tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Detect code changes
+        id: changes
+        run: ./.github/scripts/detect-changes.sh code "${{ github.event.pull_request.base.sha || github.event.before }}" "${{ github.sha }}"
+      - name: Setup uv
+        if: steps.changes.outputs.run == 'true'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # setup-uv v9.0.0; uv 0.11.14
+        with:
+          version: "0.11.14"
+          enable-cache: false
+          python-version: "3.14"
+      - name: Install dependencies
+        if: steps.changes.outputs.run == 'true'
+        run: make sync
+      - name: Run native macOS sandbox tests
+        if: steps.changes.outputs.run == 'true'
+        run: uv run pytest -m requires_native_macos_sandbox
+      - name: Skip native macOS sandbox tests
+        if: steps.changes.outputs.run != 'true'
+        run: echo "Skipping native macOS sandbox tests for non-code changes."
+
   mcp-v1-compat:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ filterwarnings = [
 ]
 markers = [
   "allow_call_model_methods: mark test as allowing calls to real model implementations",
+  "requires_native_macos_sandbox: mark test as requiring its own macOS sandbox-exec process",
   "review_optional: mark a slow subsystem-specific test that an unrelated iterative review check may omit",
   "serial: mark test as requiring exclusive execution after all xdist workers exit",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 
 import pytest
 
@@ -24,6 +24,8 @@ _PROXY_ENVIRONMENT_VARIABLES = (
     "https_proxy",
 )
 _PROXY_OPT_IN_ENVIRONMENT_VARIABLE = "OPENAI_AGENTS_TEST_USE_PROXY"
+_CODEX_SANDBOX_ENVIRONMENT_VARIABLE = "OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX"
+_NATIVE_MACOS_SANDBOX_MARKER = "requires_native_macos_sandbox"
 
 
 def _remove_ambient_proxy_environment(environment: MutableMapping[str, str]) -> None:
@@ -40,6 +42,25 @@ def _remove_ambient_proxy_environment(environment: MutableMapping[str, str]) -> 
 
 
 _remove_ambient_proxy_environment(os.environ)
+
+
+def _running_in_nested_codex_macos_sandbox(
+    *, platform: str, environment: Mapping[str, str]
+) -> bool:
+    return platform == "darwin" and environment.get(_CODEX_SANDBOX_ENVIRONMENT_VARIABLE) == "1"
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    if not _running_in_nested_codex_macos_sandbox(platform=sys.platform, environment=os.environ):
+        return
+
+    skip_native_macos_sandbox = pytest.mark.skip(
+        reason="requires a native macOS sandbox and cannot run inside the Codex outer sandbox"
+    )
+    for item in items:
+        if item.get_closest_marker(_NATIVE_MACOS_SANDBOX_MARKER) is not None:
+            item.add_marker(skip_native_macos_sandbox)
+
 
 collect_ignore: list[str] = []
 

--- a/tests/sandbox/_filesystem_test_session.py
+++ b/tests/sandbox/_filesystem_test_session.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import tempfile
+import uuid
+from pathlib import Path
+from typing import cast
+
+from agents.sandbox.errors import (
+    ExecNonZeroError,
+    WorkspaceArchiveReadError,
+    WorkspaceArchiveWriteError,
+    WorkspaceReadNotFoundError,
+)
+from agents.sandbox.files import EntryKind, FileEntry
+from agents.sandbox.manifest import Manifest
+from agents.sandbox.sandboxes.unix_local import (
+    UnixLocalSandboxClient,
+    UnixLocalSandboxSessionState,
+)
+from agents.sandbox.session import SandboxSession
+from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
+from agents.sandbox.session.sandbox_session_state import SandboxSessionState
+from agents.sandbox.snapshot import NoopSnapshot, SnapshotBase, SnapshotSpec
+from agents.sandbox.types import ExecResult, Permissions, User
+
+
+class FilesystemTestSandboxSession(BaseSandboxSession):
+    """Host-filesystem test double with no process-execution implementation."""
+
+    def __init__(self, state: UnixLocalSandboxSessionState) -> None:
+        self.state = state
+        self._running = False
+
+    async def start(self) -> None:
+        Path(self.state.manifest.root).mkdir(parents=True, exist_ok=True)
+        self._running = True
+        self.state.workspace_root_ready = True
+
+    async def stop(self) -> None:
+        self._running = False
+
+    async def shutdown(self) -> None:
+        self._running = False
+
+    async def _exec_internal(
+        self,
+        *command: str | Path,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        _ = timeout
+        command_parts = tuple(str(part) for part in command)
+        if len(command_parts) == 3 and command_parts[:2] in {("test", "-d"), ("test", "-f")}:
+            path = Path(command_parts[2])
+            exists = path.is_dir() if command_parts[1] == "-d" else path.is_file()
+            return ExecResult(stdout=b"", stderr=b"", exit_code=0 if exists else 1)
+        raise AssertionError(f"Unexpected filesystem test command: {command_parts!r}")
+
+    @staticmethod
+    def _reject_user(user: str | User | None) -> None:
+        if user is not None:
+            raise AssertionError(
+                "FilesystemTestSandboxSession does not support user-scoped filesystem operations"
+            )
+
+    async def read(self, path: Path, *, user: str | User | None = None) -> io.IOBase:
+        self._reject_user(user)
+        workspace_path = self.normalize_path(path)
+        try:
+            return workspace_path.open("rb")
+        except FileNotFoundError as error:
+            raise WorkspaceReadNotFoundError(path=path, cause=error) from error
+        except OSError as error:
+            raise WorkspaceArchiveReadError(path=path, cause=error) from error
+
+    async def write(
+        self,
+        path: Path,
+        data: io.IOBase,
+        *,
+        user: str | User | None = None,
+    ) -> None:
+        self._reject_user(user)
+        workspace_path = self.normalize_path(path, for_write=True)
+        try:
+            workspace_path.parent.mkdir(parents=True, exist_ok=True)
+            with workspace_path.open("wb") as stream:
+                shutil.copyfileobj(data, stream)
+        except OSError as error:
+            raise WorkspaceArchiveWriteError(path=path, cause=error) from error
+
+    async def ls(
+        self,
+        path: Path | str,
+        *,
+        user: str | User | None = None,
+    ) -> list[FileEntry]:
+        self._reject_user(user)
+        workspace_path = self.normalize_path(path)
+        try:
+            with os.scandir(workspace_path) as entries:
+                listed: list[FileEntry] = []
+                for entry in entries:
+                    stat_result = entry.stat(follow_symlinks=False)
+                    if entry.is_symlink():
+                        kind = EntryKind.SYMLINK
+                    elif entry.is_dir(follow_symlinks=False):
+                        kind = EntryKind.DIRECTORY
+                    elif entry.is_file(follow_symlinks=False):
+                        kind = EntryKind.FILE
+                    else:
+                        kind = EntryKind.OTHER
+                    listed.append(
+                        FileEntry(
+                            path=entry.path,
+                            permissions=Permissions.from_mode(stat_result.st_mode),
+                            owner=str(stat_result.st_uid),
+                            group=str(stat_result.st_gid),
+                            size=stat_result.st_size,
+                            kind=kind,
+                        )
+                    )
+                return listed
+        except OSError as error:
+            raise ExecNonZeroError(
+                ExecResult(stdout=b"", stderr=str(error).encode(), exit_code=1),
+                command=("ls", "-la", "--", str(workspace_path)),
+                cause=error,
+            ) from error
+
+    async def mkdir(
+        self,
+        path: Path | str,
+        *,
+        parents: bool = False,
+        user: str | User | None = None,
+    ) -> None:
+        self._reject_user(user)
+        self.normalize_path(path, for_write=True).mkdir(parents=parents, exist_ok=True)
+
+    async def rm(
+        self,
+        path: Path | str,
+        *,
+        recursive: bool = False,
+        user: str | User | None = None,
+    ) -> None:
+        self._reject_user(user)
+        workspace_path = self.normalize_path(path, for_write=True)
+        if workspace_path.is_dir() and not workspace_path.is_symlink():
+            if recursive:
+                shutil.rmtree(workspace_path)
+            else:
+                workspace_path.rmdir()
+        else:
+            workspace_path.unlink()
+
+    async def running(self) -> bool:
+        return self._running
+
+    async def persist_workspace(self) -> io.IOBase:
+        raise AssertionError("FilesystemTestSandboxSession does not support workspace persistence")
+
+    async def hydrate_workspace(self, data: io.IOBase) -> None:
+        _ = data
+        raise AssertionError("FilesystemTestSandboxSession does not support workspace hydration")
+
+
+class FilesystemTestSandboxClient(UnixLocalSandboxClient):
+    """Client test double that creates ``FilesystemTestSandboxSession`` instances."""
+
+    async def create(
+        self,
+        *,
+        snapshot: SnapshotSpec | SnapshotBase | None = None,
+        manifest: Manifest | None = None,
+        options: object | None = None,
+    ) -> SandboxSession:
+        _ = (snapshot, options)
+        resolved_manifest = manifest if manifest is not None else Manifest()
+        workspace_root_owned = resolved_manifest.root == Manifest().root
+        if workspace_root_owned:
+            workspace_root = tempfile.mkdtemp(prefix="filesystem-test-workspace-")
+            resolved_manifest = resolved_manifest.model_copy(
+                update={"root": workspace_root},
+                deep=True,
+            )
+        state = UnixLocalSandboxSessionState(
+            session_id=uuid.uuid4(),
+            manifest=resolved_manifest,
+            snapshot=NoopSnapshot(id=str(uuid.uuid4())),
+            workspace_root_owned=workspace_root_owned,
+        )
+        return self._wrap_session(
+            FilesystemTestSandboxSession(state=state),
+            instrumentation=self._instrumentation,
+        )
+
+    async def delete(self, session: SandboxSession) -> SandboxSession:
+        inner = cast(FilesystemTestSandboxSession, session._inner)
+        if inner.state.workspace_root_owned:
+            shutil.rmtree(inner.state.manifest.root, ignore_errors=True)
+        return session
+
+    async def resume(self, state: SandboxSessionState) -> SandboxSession:
+        unix_state = cast(UnixLocalSandboxSessionState, state)
+        return self._wrap_session(
+            FilesystemTestSandboxSession(state=unix_state),
+            instrumentation=self._instrumentation,
+        )

--- a/tests/sandbox/integration_tests/_helpers.py
+++ b/tests/sandbox/integration_tests/_helpers.py
@@ -145,10 +145,12 @@ class MockExternalTools:
 def install_mock_external_tools(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    *,
+    writable_root: Path,
 ) -> MockExternalTools:
     bin_dir = tmp_path / "mock-bin"
     bin_dir.mkdir()
-    log_path = tmp_path / "mock-tool-calls.tsv"
+    log_path = writable_root / "mock-tool-calls.tsv"
     log_path.write_text("", encoding="utf-8")
 
     for name in MOCK_TOOL_NAMES:

--- a/tests/sandbox/integration_tests/test_runner_pause_resume.py
+++ b/tests/sandbox/integration_tests/test_runner_pause_resume.py
@@ -23,16 +23,22 @@ from tests.sandbox.integration_tests.test_model import TestModel
 
 @pytest.mark.asyncio
 @pytest.mark.review_optional
+@pytest.mark.requires_native_macos_sandbox
 async def test_runner_preserves_unix_local_lifecycle_state_across_pause_and_resume(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    install_mock_external_tools(monkeypatch, tmp_path)
     source_root = create_local_sources(tmp_path)
+    mock_tools = install_mock_external_tools(
+        monkeypatch,
+        tmp_path,
+        writable_root=source_root,
+    )
     manifest = build_manifest_with_all_entry_types(
         workspace_root=Path("/workspace"),
         source_root=source_root,
     )
+    assert mock_tools.log_path.parent == source_root
     events: list[SandboxSessionEvent] = []
     client = UnixLocalSandboxClient(
         instrumentation=Instrumentation(

--- a/tests/sandbox/test_memory.py
+++ b/tests/sandbox/test_memory.py
@@ -74,9 +74,9 @@ from agents.sandbox.memory.storage import (
     _updated_at_sort_key,
 )
 from agents.sandbox.runtime import _stream_memory_input_override
-from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient
 from agents.sandbox.workspace_paths import SandboxWorkspaceScope
 from agents.testing import ScriptedModel
+from tests.sandbox._filesystem_test_session import FilesystemTestSandboxClient
 from tests.test_responses import get_final_output_message, get_text_message
 from tests.utils.hitl import make_shell_call
 
@@ -92,7 +92,7 @@ class _DeclaredProviderMemoryGenerateConfig(MemoryGenerateConfig):
     phase_two_model_settings: _DeclaredProviderModelSettings | None = None
 
 
-class _DeleteTrackingUnixLocalSandboxClient(UnixLocalSandboxClient):
+class _DeleteTrackingFilesystemTestSandboxClient(FilesystemTestSandboxClient):
     def __init__(self) -> None:
         super().__init__()
         self.deleted_roots: list[Path] = []
@@ -215,7 +215,7 @@ def _raw_memory_record(
 
 
 async def _cleanup_session(
-    client: UnixLocalSandboxClient,
+    client: FilesystemTestSandboxClient,
     session: Any,
     *,
     close: bool = True,
@@ -600,7 +600,7 @@ def test_updated_at_sort_key_places_unknown_timestamps_last() -> None:
 
 @pytest.mark.asyncio
 async def test_phase_two_selection_tracks_added_retained_and_removed_rollouts() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
 
     try:
@@ -649,7 +649,7 @@ async def test_runner_memory_generation_sanitizes_and_truncates_phase_one_prompt
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(phase_one_module, "_PHASE_ONE_ROLLOUT_TOKEN_LIMIT", 1000)
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     phase_one_model = ScriptedModel(steps=[[_phase_one_message()]])
     memory = _memory_config(phase_one_model=phase_one_model)
@@ -721,7 +721,7 @@ async def test_runner_memory_generation_sanitizes_and_truncates_phase_one_prompt
 
 @pytest.mark.asyncio
 async def test_sandbox_agent_without_memory_capability_skips_memory_generation() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     agent = SandboxAgent(
         name="worker",
@@ -746,7 +746,7 @@ async def test_sandbox_agent_without_memory_capability_skips_memory_generation()
 
 @pytest.mark.asyncio
 async def test_memory_capability_returns_none_without_memory_summary() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     capability = Memory(generate=None)
 
@@ -937,7 +937,7 @@ def test_memory_generate_config_rejects_too_many_raw_memories() -> None:
 async def test_memory_capability_injects_truncated_memory_summary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     capability = Memory(generate=None)
 
@@ -966,7 +966,7 @@ async def test_memory_capability_injects_truncated_memory_summary(
 
 @pytest.mark.asyncio
 async def test_memory_capability_live_update_instructions() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     capability = Memory(generate=None)
 
@@ -992,7 +992,7 @@ async def test_memory_capability_live_update_instructions() -> None:
 
 @pytest.mark.asyncio
 async def test_memory_capability_renders_session_owned_paths_as_absolute_with_run_cwd() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     capability = Memory(generate=None)
 
@@ -1025,7 +1025,7 @@ async def test_memory_capability_renders_session_owned_paths_as_absolute_with_ru
 async def test_memory_capability_preserves_layout_spelling_without_run_cwd(
     memories_dir: str,
 ) -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     capability = Memory(
         layout=MemoryLayoutConfig(memories_dir=memories_dir),
@@ -1053,7 +1053,7 @@ async def test_memory_capability_preserves_layout_spelling_without_run_cwd(
 @pytest.mark.asyncio
 async def test_memory_capability_uses_typed_layout_path_with_run_cwd() -> None:
     memories_dir = r"team\memory"
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     capability = Memory(
         layout=MemoryLayoutConfig(memories_dir=memories_dir),
@@ -1085,7 +1085,7 @@ async def test_memory_capability_uses_typed_layout_path_with_run_cwd() -> None:
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_writes_rollouts_and_memory_files() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     phase_one_model = ScriptedModel(steps=[[_phase_one_message()]])
     phase_two_model = ScriptedModel(
@@ -1161,7 +1161,7 @@ async def test_sandbox_memory_writes_rollouts_and_memory_files() -> None:
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_uses_custom_layout() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     phase_two_model = ScriptedModel(
         steps=[
@@ -1211,7 +1211,7 @@ async def test_sandbox_memory_uses_custom_layout() -> None:
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_supports_multiple_generating_layouts_in_one_session() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     phase_two_model_a = ScriptedModel(
         steps=[
@@ -1282,7 +1282,7 @@ async def test_sandbox_memory_supports_multiple_generating_layouts_in_one_sessio
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_rejects_different_generate_configs_for_same_layout() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     memory = _memory_config()
     different_memory = _memory_config(
@@ -1300,7 +1300,7 @@ async def test_sandbox_memory_rejects_different_generate_configs_for_same_layout
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_rollout_payload_uses_validated_rollout_id() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     memory = _memory_config()
 
@@ -1327,7 +1327,7 @@ async def test_sandbox_memory_rollout_payload_uses_validated_rollout_id() -> Non
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_rejects_different_sessions_dirs_for_same_memories_dir() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     first_memory = _memory_config(
         layout=MemoryLayoutConfig(memories_dir="shared_memory", sessions_dir="sessions_a")
@@ -1347,7 +1347,7 @@ async def test_sandbox_memory_rejects_different_sessions_dirs_for_same_memories_
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_rejects_shared_sessions_dir_for_different_memories_dirs() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     first_memory = _memory_config(
         layout=MemoryLayoutConfig(memories_dir="memory_a", sessions_dir="shared_sessions")
@@ -1367,7 +1367,7 @@ async def test_sandbox_memory_rejects_shared_sessions_dir_for_different_memories
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_groups_segments_by_sdk_session_until_close() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     phase_one_model = ScriptedModel(steps=[[_phase_one_message(raw_memory="joined raw\n")]])
     phase_two_model = ScriptedModel(
@@ -1450,7 +1450,7 @@ async def test_sandbox_memory_groups_segments_by_sdk_session_until_close() -> No
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_fallback_does_not_mutate_run_config() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     agent_model = ScriptedModel()
     agent_model.extend(
@@ -1490,7 +1490,7 @@ async def test_sandbox_memory_fallback_does_not_mutate_run_config() -> None:
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_uses_conversation_id_when_sdk_session_is_absent() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     agent = SandboxAgent(
         name="worker",
@@ -1518,7 +1518,7 @@ async def test_sandbox_memory_uses_conversation_id_when_sdk_session_is_absent() 
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_uses_group_id_when_sdk_session_is_absent() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     agent_model = ScriptedModel()
     agent_model.extend(
@@ -1555,7 +1555,7 @@ async def test_sandbox_memory_uses_group_id_when_sdk_session_is_absent() -> None
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_uses_per_run_conversation_when_no_conversation_id() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     agent_model = ScriptedModel()
     agent_model.extend(
@@ -1588,7 +1588,7 @@ async def test_sandbox_memory_uses_per_run_conversation_when_no_conversation_id(
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_caps_phase_two_selection_and_surfaces_removed_rollouts() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     phase_one_model = ScriptedModel()
     phase_one_model.extend(
@@ -1670,7 +1670,7 @@ async def test_sandbox_memory_caps_phase_two_selection_and_surfaces_removed_roll
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_runs_phase_one_and_phase_two_on_session_close() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     phase_one_model = ScriptedModel(steps=[[_phase_one_message()]])
     phase_two_model = ScriptedModel(
@@ -1712,7 +1712,7 @@ async def test_sandbox_memory_runs_phase_one_and_phase_two_on_session_close() ->
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_unregisters_manager_on_session_close() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     memory = _memory_config()
 
@@ -1744,7 +1744,7 @@ async def test_sandbox_memory_flush_propagates_worker_base_exception_without_han
     monkeypatch: pytest.MonkeyPatch,
     worker_error: BaseException,
 ) -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     memory = _memory_config()
     manager = get_or_create_memory_generation_manager(session=session, memory=memory)
@@ -1781,7 +1781,7 @@ async def test_sandbox_memory_flush_propagates_worker_base_exception_without_han
 async def test_sandbox_memory_flush_parent_cancellation_stops_worker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     memory = _memory_config()
     manager = get_or_create_memory_generation_manager(session=session, memory=memory)
@@ -1862,7 +1862,7 @@ async def test_sandbox_memory_enqueue_failure_follows_both_data_policies(
     monkeypatch.setattr(_debug, "DONT_LOG_TOOL_DATA", tool_redacted)
     caplog.set_level(logging.WARNING)
 
-    client = _DeleteTrackingUnixLocalSandboxClient()
+    client = _DeleteTrackingFilesystemTestSandboxClient()
     agent = SandboxAgent(
         name="worker",
         model=ScriptedModel(steps=[[get_final_output_message("done")]]),
@@ -1907,7 +1907,7 @@ async def test_sandbox_memory_enqueue_failure_follows_both_data_policies(
 
 @pytest.mark.asyncio
 async def test_sandbox_memory_marks_interrupted_runs_in_phase_one_prompt() -> None:
-    client = UnixLocalSandboxClient()
+    client = FilesystemTestSandboxClient()
     session = await client.create(manifest=Manifest())
     phase_one_model = ScriptedModel(steps=[[_phase_one_message()]])
     phase_two_model = ScriptedModel(

--- a/tests/sandbox/test_run_cwd.py
+++ b/tests/sandbox/test_run_cwd.py
@@ -41,6 +41,8 @@ _IMAGE_BY_TASK = {
     "task-b": ("image/svg+xml", _SVG_BYTES),
 }
 
+pytestmark = pytest.mark.requires_native_macos_sandbox
+
 
 async def _read_bytes(session: BaseSandboxSession, path: str) -> bytes:
     file_obj = await session.read(Path(path))

--- a/tests/sandbox/test_runtime.py
+++ b/tests/sandbox/test_runtime.py
@@ -2809,20 +2809,23 @@ async def test_unix_local_persist_workspace_excludes_mounted_directory_contents(
 
 
 @pytest.mark.asyncio
-async def test_runner_allows_fresh_unix_local_sessions_without_options() -> None:
+async def test_runner_allows_fresh_sessions_for_clients_with_default_options() -> None:
     agent = SandboxAgent(
         name="sandbox",
         model=ScriptedModel(steps=[[get_final_output_message("done")]]),
         instructions="Base instructions.",
+        default_manifest=Manifest(),
     )
+    client = _ManifestSessionClient()
 
     result = await Runner.run(
         agent,
         "hello",
-        run_config=_unix_local_run_config(),
+        run_config=RunConfig(sandbox=SandboxRunConfig(client=client)),
     )
 
     assert result.final_output == "done"
+    assert len(client.created_manifests) == 1
 
 
 @pytest.mark.asyncio
@@ -3139,6 +3142,7 @@ async def test_runner_rejects_unix_local_manifest_user_and_group_provisioning() 
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_runner_persists_workspace_and_tool_choice_state_across_sandbox_resume() -> None:
     client = UnixLocalSandboxClient()
     file_capability = _SessionFileCapability()
@@ -3239,6 +3243,7 @@ async def test_runner_persists_workspace_and_tool_choice_state_across_sandbox_re
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_runner_restores_all_sandbox_agents_from_run_state_across_handoffs() -> None:
     client = UnixLocalSandboxClient()
     file_capability = _SessionFileCapability()
@@ -3345,6 +3350,7 @@ async def test_runner_restores_all_sandbox_agents_from_run_state_across_handoffs
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_runner_serializes_unique_sandbox_resume_keys_for_duplicate_agent_names() -> None:
     client = UnixLocalSandboxClient()
     file_capability = _SessionFileCapability()
@@ -4818,6 +4824,7 @@ async def test_session_manager_restores_duplicate_name_sessions_when_only_sandbo
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_runner_restores_duplicate_name_sandbox_sessions_after_json_roundtrip() -> None:
     client = UnixLocalSandboxClient()
     file_capability = _SessionFileCapability()
@@ -4917,6 +4924,7 @@ async def test_runner_restores_duplicate_name_sandbox_sessions_after_json_roundt
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_runner_restores_legacy_current_sandbox_payload_after_json_roundtrip() -> None:
     client = UnixLocalSandboxClient()
 
@@ -4995,6 +5003,7 @@ async def test_runner_restores_legacy_current_sandbox_payload_after_json_roundtr
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 @pytest.mark.skipif(
     sys.platform != "darwin" or shutil.which("sandbox-exec") is None,
     reason="sandbox-exec is only available on macOS when installed",

--- a/tests/sandbox/test_session_sinks.py
+++ b/tests/sandbox/test_session_sinks.py
@@ -36,6 +36,7 @@ from agents.sandbox.session.sandbox_session import _read_with_expected_span_erro
 from agents.sandbox.snapshot import LocalSnapshot
 from agents.sandbox.types import ExecResult
 from agents.tracing import custom_span, trace
+from tests.sandbox._filesystem_test_session import FilesystemTestSandboxSession
 from tests.testing_processor import fetch_normalized_spans, fetch_ordered_spans
 
 
@@ -60,7 +61,37 @@ def _build_unix_local_session(
     return UnixLocalSandboxSession.from_state(state)
 
 
+def _build_filesystem_test_session(
+    tmp_path: Path,
+    *,
+    manifest: Manifest | None = None,
+) -> FilesystemTestSandboxSession:
+    workspace = tmp_path / "workspace"
+    session_manifest = (
+        manifest.model_copy(update={"root": str(workspace)}, deep=True)
+        if manifest is not None
+        else Manifest(root=str(workspace))
+    )
+    state = UnixLocalSandboxSessionState(
+        manifest=session_manifest,
+        snapshot=LocalSnapshot(id=str(uuid.uuid4()), base_path=tmp_path),
+    )
+    return FilesystemTestSandboxSession(state=state)
+
+
 @pytest.mark.asyncio
+async def test_filesystem_test_session_rejects_process_backed_operations(tmp_path: Path) -> None:
+    session = _build_filesystem_test_session(tmp_path)
+
+    assert session.supports_pty() is False
+    with pytest.raises(NotImplementedError, match="PTY execution is not supported"):
+        await session.pty_exec_start("echo hi")
+    with pytest.raises(AssertionError, match="user-scoped filesystem operations"):
+        await session.write(Path("x.txt"), io.BytesIO(b"hello"), user="sandbox-user")
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_sandbox_session_exec_emits_stdout_when_enabled(tmp_path: Path) -> None:
     events: list[SandboxSessionEvent] = []
     instrumentation = Instrumentation(
@@ -91,7 +122,7 @@ async def test_sandbox_session_write_does_not_include_bytes_when_disabled(
         payload_policy=EventPayloadPolicy(include_write_len=False),
     )
 
-    inner = _build_unix_local_session(tmp_path)
+    inner = _build_filesystem_test_session(tmp_path)
     async with SandboxSession(inner, instrumentation=instrumentation) as session:
         await session.write(Path("x.txt"), io.BytesIO(b"hello"))
 
@@ -198,6 +229,7 @@ async def test_chained_sink_runs_in_order(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_workspace_jsonl_sink_writes_into_workspace_and_persists(tmp_path: Path) -> None:
     inner = _build_unix_local_session(tmp_path)
     instrumentation = Instrumentation(
@@ -219,6 +251,7 @@ async def test_workspace_jsonl_sink_writes_into_workspace_and_persists(tmp_path:
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_workspace_jsonl_sink_supports_session_id_template(tmp_path: Path) -> None:
     inner = _build_unix_local_session(tmp_path)
     relpath = Path("logs/events-{session_id}.jsonl")
@@ -245,7 +278,7 @@ async def test_workspace_jsonl_sink_supports_session_id_template(tmp_path: Path)
 
 @pytest.mark.asyncio
 async def test_workspace_jsonl_sink_preserves_preexisting_outbox_contents(tmp_path: Path) -> None:
-    inner = _build_unix_local_session(tmp_path)
+    inner = _build_filesystem_test_session(tmp_path)
     relpath = Path(f"logs/events-{inner.state.session_id}.jsonl")
     old_line = b'{"old":true}\n'
 
@@ -285,7 +318,7 @@ async def test_workspace_jsonl_sink_preserves_preexisting_outbox_contents(tmp_pa
 async def test_workspace_jsonl_sink_does_not_duplicate_lines_across_flushes(
     tmp_path: Path,
 ) -> None:
-    inner = _build_unix_local_session(tmp_path)
+    inner = _build_filesystem_test_session(tmp_path)
     relpath = Path(f"logs/events-{inner.state.session_id}.jsonl")
 
     async with inner:
@@ -310,7 +343,7 @@ async def test_workspace_jsonl_sink_does_not_duplicate_lines_across_flushes(
 
 @pytest.mark.asyncio
 async def test_workspace_jsonl_sink_clears_flushed_buffer(tmp_path: Path) -> None:
-    inner = _build_unix_local_session(tmp_path)
+    inner = _build_filesystem_test_session(tmp_path)
     relpath = Path(f"logs/events-{inner.state.session_id}.jsonl")
 
     async with inner:
@@ -335,6 +368,7 @@ async def test_workspace_jsonl_sink_clears_flushed_buffer(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_workspace_jsonl_sink_ephemeral_excludes_runtime_outbox_with_existing_parent(
     tmp_path: Path,
 ) -> None:
@@ -373,6 +407,7 @@ async def test_workspace_jsonl_sink_ephemeral_excludes_runtime_outbox_with_exist
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_workspace_jsonl_sink_flushes_on_stop_when_flush_every_gt_one(
     tmp_path: Path,
 ) -> None:
@@ -403,6 +438,7 @@ async def test_workspace_jsonl_sink_flushes_on_stop_when_flush_every_gt_one(
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_callback_sink_receives_bound_inner_session(tmp_path: Path) -> None:
     inner = _build_unix_local_session(tmp_path)
     seen: list[tuple[str, BaseSandboxSession]] = []
@@ -467,7 +503,7 @@ async def test_sandbox_session_error_events_and_traces_include_retryability(
     instrumentation = Instrumentation(
         sinks=[CallbackSink(lambda e, _sess: events.append(e), mode="sync")]
     )
-    inner = _build_unix_local_session(tmp_path)
+    inner = _build_filesystem_test_session(tmp_path)
 
     with trace("sandbox_retryability_test"):
         async with SandboxSession(inner, instrumentation=instrumentation) as session:
@@ -506,7 +542,7 @@ async def test_expected_read_span_error_is_call_scoped_and_preserves_audit_failu
     instrumentation = Instrumentation(
         sinks=[CallbackSink(lambda e, _sess: events.append(e), mode="sync")]
     )
-    inner = _build_unix_local_session(tmp_path)
+    inner = _build_filesystem_test_session(tmp_path)
     expected_path = Path("expected-missing.txt")
     ordinary_path = Path("ordinary-missing.txt")
 
@@ -561,7 +597,7 @@ async def test_expected_read_span_records_finish_sink_failure(tmp_path: Path) ->
     instrumentation = Instrumentation(
         sinks=[CallbackSink(fail_read_finish, mode="sync", on_error="raise")]
     )
-    inner = _build_unix_local_session(tmp_path)
+    inner = _build_filesystem_test_session(tmp_path)
 
     with trace("sandbox_expected_read_sink_failure_test"):
         async with SandboxSession(inner, instrumentation=instrumentation) as session:
@@ -583,6 +619,7 @@ async def test_expected_read_span_records_finish_sink_failure(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_exec_span_records_cancellation_during_finish_sink_delivery(tmp_path: Path) -> None:
     finish_delivery_started = asyncio.Event()
     completed_exit_codes: list[int] = []
@@ -622,6 +659,7 @@ async def test_exec_span_records_cancellation_during_finish_sink_delivery(tmp_pa
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_sandbox_session_ops_nest_under_sdk_trace_and_events_carry_trace_ids(
     tmp_path: Path,
 ) -> None:
@@ -885,6 +923,7 @@ async def test_sandbox_session_ops_nest_under_sdk_trace_and_events_carry_trace_i
 
 
 @pytest.mark.asyncio
+@pytest.mark.requires_native_macos_sandbox
 async def test_sandbox_session_events_fallback_to_audit_ids_under_disabled_parent_span(
     tmp_path: Path,
 ) -> None:
@@ -916,7 +955,7 @@ async def test_sandbox_session_events_fallback_to_audit_ids_under_disabled_paren
 
 @pytest.mark.asyncio
 async def test_sandbox_session_aclose_flushes_best_effort_sink_tasks(tmp_path: Path) -> None:
-    inner = _build_unix_local_session(tmp_path)
+    inner = _build_filesystem_test_session(tmp_path)
     seen: list[tuple[str, str]] = []
 
     async def _callback(event: SandboxSessionEvent, _session: BaseSandboxSession) -> None:

--- a/tests/sandbox/test_unix_local.py
+++ b/tests/sandbox/test_unix_local.py
@@ -111,6 +111,7 @@ class TestUnixLocalPty:
         assert session._fd_close_tasks == set()
 
     @pytest.mark.asyncio
+    @pytest.mark.requires_native_macos_sandbox
     async def test_pty_exec_write_poll_and_unknown_session_errors(self, tmp_path: Path) -> None:
         client = UnixLocalSandboxClient()
         manifest = Manifest(root=str(tmp_path / "workspace"))
@@ -144,6 +145,7 @@ class TestUnixLocalPty:
                 await session.pty_write_stdin(session_id=999_999, chars="")
 
     @pytest.mark.asyncio
+    @pytest.mark.requires_native_macos_sandbox
     async def test_pty_ctrl_c_interrupts_long_running_process(self, tmp_path: Path) -> None:
         client = UnixLocalSandboxClient()
         manifest = Manifest(root=str(tmp_path / "workspace"))
@@ -188,6 +190,7 @@ class TestUnixLocalPty:
         ],
     )
     @pytest.mark.asyncio
+    @pytest.mark.requires_native_macos_sandbox
     async def test_pty_terminal_signals_interrupt_even_if_parent_ignores_signal(
         self, tmp_path: Path, signum: signal.Signals, chars: str
     ) -> None:
@@ -221,6 +224,7 @@ class TestUnixLocalPty:
             signal.signal(signum, previous_handler)
 
     @pytest.mark.asyncio
+    @pytest.mark.requires_native_macos_sandbox
     async def test_non_tty_pty_session_rejects_stdin_and_can_still_be_polled(
         self, tmp_path: Path
     ) -> None:
@@ -260,6 +264,7 @@ class TestUnixLocalPty:
                 await session.pty_write_stdin(session_id=started.process_id, chars="")
 
     @pytest.mark.asyncio
+    @pytest.mark.requires_native_macos_sandbox
     async def test_stop_terminates_active_pty_sessions(self, tmp_path: Path) -> None:
         client = UnixLocalSandboxClient()
         manifest = Manifest(root=str(tmp_path / "workspace"))

--- a/tests/test_code_change_verification_policy.py
+++ b/tests/test_code_change_verification_policy.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import _running_in_nested_codex_macos_sandbox
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_SKILL_PATH = _REPOSITORY_ROOT / ".agents/skills/code-change-verification/SKILL.md"
+_PROMPT_PATH = _REPOSITORY_ROOT / ".agents/skills/code-change-verification/agents/openai.yaml"
+_CHANGE_DETECTOR_PATH = _REPOSITORY_ROOT / ".github/scripts/detect-changes.sh"
+
+
+def test_code_change_verification_keeps_codex_execution_sandboxed() -> None:
+    skill = _SKILL_PATH.read_text(encoding="utf-8")
+    prompt = _PROMPT_PATH.read_text(encoding="utf-8")
+    combined = f"{skill}\n{prompt}"
+
+    assert "sandbox_permissions=require_escalated" not in combined
+    assert "persistent command allow rule" not in combined
+    assert "outside the Codex sandbox" not in combined
+    assert "retry with broader host access" in combined
+    assert (
+        "/usr/bin/env -u OPENAI_API_KEY OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX=1 "
+        "UV_DEFAULT_INDEX=https://pypi.org/simple"
+    ) in skill
+
+
+def test_code_change_detection_includes_verification_skill() -> None:
+    detector = _CHANGE_DETECTOR_PATH.read_text(encoding="utf-8")
+    code_pattern = re.search(r"^\s*pattern='([^']+)'$", detector, flags=re.MULTILINE)
+
+    assert code_pattern is not None
+    assert re.match(
+        code_pattern.group(1),
+        ".agents/skills/code-change-verification/SKILL.md",
+    )
+
+
+@pytest.mark.parametrize(
+    ("platform", "environment", "expected"),
+    [
+        pytest.param("darwin", {"OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX": "1"}, True),
+        pytest.param("darwin", {}, False),
+        pytest.param("darwin", {"OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX": "0"}, False),
+        pytest.param("linux", {"OPENAI_AGENTS_TEST_IN_CODEX_SANDBOX": "1"}, False),
+    ],
+)
+def test_native_macos_sandbox_skip_requires_explicit_nested_mode(
+    platform: str, environment: dict[str, str], expected: bool
+) -> None:
+    assert (
+        _running_in_nested_codex_macos_sandbox(
+            platform=platform,
+            environment=environment,
+        )
+        is expected
+    )


### PR DESCRIPTION
This pull request fixes a verification policy that instructed Codex to execute repository-controlled verification outside its workspace sandbox.

It keeps the verification wrapper and its child processes sandboxed, skips only explicitly marked tests that require a native macOS sandbox when running under Codex, and executes those tests on a disposable macOS CI runner.

It also keeps the native pause/resume test's mock-tool log within its existing writable grant and replaces incidental `UnixLocalSandboxSession` usage in backend-neutral memory and event-sink tests with a process-free filesystem test session. Real `UnixLocalSandboxSession` coverage remains reserved for tests that intentionally validate native confinement and lifecycle behavior.

Regression coverage verifies the sandboxed command, collection policy, native marker boundary, and process-free test-session behavior.